### PR TITLE
[#71747] Cursor not placed correctly when quoting comment in activity tab

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
@@ -20,6 +20,10 @@ export interface CKEditorDomEventData {
   keyCode:number;
 }
 
+// Opaque handle for a parsed CKEditor model fragment (DocumentFragment).
+// We never inspect its internals, only pass it from data.parse to model.insertContent.
+export type CKEditorModelFragment = unknown;
+
 export interface ICKEditorInstance {
   id:string;
 
@@ -39,9 +43,13 @@ export interface ICKEditorInstance {
 
   listenTo(node:unknown, key:string, callback:(evt:CKEditorEvent, data:CKEditorDomEventData) => unknown, options:CKEditorListenOptions):void;
 
+  data:{
+    parse(data:string):CKEditorModelFragment;
+  };
   model:{
     on(ev:string, callback:() => unknown):void
     fire(ev:string, data:unknown):void
+    insertContent(content:CKEditorModelFragment):void
     document:{
       on(ev:string, callback:() => unknown):void
     };

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
@@ -65,19 +65,19 @@ export default class QuoteCommentController extends Controller {
       .join('');
 
     // if we ever change CKEditor or how @mentions work this will break
-    return `<mention class="mention" data-id="${userId}" data-type="user" data-text="@${userName}">@${userName}</mention> ${textWrote}:\n\n${quoted}`;
+    return `<mention class="mention" data-id="${userId}" data-type="user" data-text="@${userName}">@${userName}</mention> ${textWrote}:\n\n${quoted}\n\n`;
   }
 
   private insertQuoteOnExistingEditor(quotedText:string) {
-    if (this.ckEditorInstance) {
-      const editorData = this.ckEditorInstance.getData({ trim: false });
+    const editor = this.ckEditorInstance;
+    if (!editor) return;
 
-      if (editorData.endsWith('<br>') || editorData.endsWith('\n')) {
-        this.ckEditorInstance.setData(`${editorData}${quotedText}`);
-      } else {
-        this.ckEditorInstance.setData(`${editorData}\n\n${quotedText}`);
-      }
-    }
+    // insert at the current cursor position (preserved by CKEditor across blur/focus),
+    // then place focus so the user can type immediately after the blockquote
+    const fragment = editor.data.parse(quotedText);
+    editor.model.insertContent(fragment);
+
+    this.workPackagesActivitiesTabEditorOutlet.focusEditor();
   }
 
   private setCommentRestriction(isInternal:boolean) {

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -919,6 +919,9 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
 
         # expect the quoted comment to be shown
         activity_tab.ckeditor.expect_include_value("@A Member wrote:\nFirst comment by member")
+
+        # expect the editor to be focused so the user can type immediately
+        activity_tab.expect_focus_on_editor
       end
     end
 
@@ -937,8 +940,11 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
         # quote other user's comment
         activity_tab.quote_comment(first_comment_by_member)
 
-        # expect the original comment and quote are shown
+        # expect the original comment and quote are shown (quote appended after existing content)
         activity_tab.ckeditor.expect_include_value("Partial message:\n@A Member wrote:\nFirst comment by member")
+
+        # expect the editor to be focused so the user can type immediately
+        activity_tab.expect_focus_on_editor
       end
     end
   end


### PR DESCRIPTION
**Work package:** https://community.openproject.org/work_packages/71747 — plan & discussion in the comments.

# Ticket

https://community.openproject.org/work_packages/71747

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Fix three related UX bugs in the "Quote this comment" feature of the activities tab:

1. **No empty paragraph after the blockquote** — after quoting a comment the cursor landed inside the blockquote block, requiring two extra Enter keypresses to escape it and begin typing a reply.
2. **Editor not focused after quoting** — clicking "Quote this comment" inserted the quote but left focus elsewhere, forcing a manual click before the user could type.
3. **Quote always appended at end** — when the editor was already open with content and the cursor positioned mid-text, quoting always appended to the end of the document instead of inserting at the cursor location.

## What approach did you choose and why?

**Bug 1 (trailing empty paragraph):** `quotedText()` already appended `\n\n` at the end of the blockquote string, which causes CKEditor to render an empty paragraph after the blockquote. No additional change was needed here — the fix arrives implicitly because the insertion method was changed (see Bug 3).

**Bug 3 (insert at cursor):** Replaced the `getData()` + `setData()` round-trip in `insertQuoteOnExistingEditor()` with CKEditor 5's `editor.data.parse()` + `editor.model.insertContent()`. `insertContent()` inserts at the current model selection, which CKEditor preserves across blur/focus cycles. This also means the cursor is automatically placed at the end of the inserted fragment (i.e., in the trailing empty paragraph), making a separate selection-move step unnecessary.

**Bug 2 (focus):** After `insertContent()` a call to the existing `focusEditor()` method on the `EditorController` outlet is all that is needed. This was already wired as a public outlet method — no new interface surface was required.

The `getData()`/`setData()` approach was discarded because it replaces the entire document, destroying the user's cursor position and requiring a manual selection-restore step. `insertContent()` is the idiomatic CKEditor 5 API for this use case.

## Screenshots

N/A

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)