### PR TITLE
[STC-337] Fix rendered date of edited comments

### DIFF
--- a/app/components/work_packages/activities_tab/shared_helpers.rb
+++ b/app/components/work_packages/activities_tab/shared_helpers.rb
@@ -57,13 +57,13 @@ module WorkPackages
                    "#{auto_scrolling_controller}-anchor-name-param": activity_anchor_name
                  }
                )) do
-          journal_updated_at_formatted_time(journal)
+          journal_created_at_formatted_time(journal)
         end
       end
 
-      def journal_updated_at_formatted_time(journal)
+      def journal_created_at_formatted_time(journal)
         render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) do
-          format_time(journal.updated_at)
+          format_time(journal.created_at)
         end
       end
 

--- a/spec/components/work_packages/activities_tab/journals/item_component_spec.rb
+++ b/spec/components/work_packages/activities_tab/journals/item_component_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Minimal wrapper to test SharedHelpers#journal_created_at_formatted_time
+# without the routing dependencies of the full ItemComponent template.
+class JournalCreatedAtFormattedTimeTestComponent < ApplicationComponent
+  include ApplicationHelper
+  include WorkPackages::ActivitiesTab::SharedHelpers
+
+  def initialize(journal)
+    super(nil)
+    @journal = journal
+  end
+
+  def call
+    journal_created_at_formatted_time(@journal)
+  end
+end
+
+RSpec.describe WorkPackages::ActivitiesTab::Journals::ItemComponent, type: :component do
+  include Redmine::I18n
+
+  describe "activity anchor link date" do
+    let(:created_at) { 3.days.ago.beginning_of_minute }
+    let(:updated_at) { 1.day.ago.beginning_of_minute }
+    let(:journal) { build_stubbed(:work_package_journal, created_at:, updated_at:) }
+
+    context "when a journal has been edited (updated_at differs from created_at)" do
+      it "shows created_at rather than updated_at in the header link" do
+        expect(format_time(created_at)).not_to eq(format_time(updated_at))
+
+        render_inline(JournalCreatedAtFormattedTimeTestComponent.new(journal))
+
+        expect(page).to have_text(format_time(created_at))
+        expect(page).to have_no_text(format_time(updated_at))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64251

# What are you trying to accomplish?

Fix a bug where the date shown in a comment's activity-tab headline reflects the _last edit time_ instead of the _original creation time_. After editing a comment, `journal.updated_at` is bumped, causing the header timestamp to silently change and mislead users into thinking the comment was written at a later date.

# What approach did you choose and why?

The root cause is a one-liner in `shared_helpers.rb`: `journal_updated_at_formatted_time` (used to render the header date) called `format_time(journal.updated_at)` instead of `format_time(journal.created_at)`.

**Changes made:**

1. **`app/components/work_packages/activities_tab/shared_helpers.rb`** — Changed `journal.updated_at` → `journal.created_at` inside the formatting helper. Renamed the method from `journal_updated_at_formatted_time` to `journal_created_at_formatted_time` to accurately reflect its corrected semantics, and updated its single call site in `activity_anchor_link` accordingly.

   The `journal-with-changeset-updated-at` data attribute in `details.html.erb` intentionally keeps `updated_at` — it is used by the Stimulus controller for change-tracking state and is not a display timestamp; it was left unchanged.

2. **`spec/components/work_packages/activities_tab/journals/item_component_spec.rb`** — Added 68 lines of new spec coverage for the `ItemComponent`. The new context simulates an edited journal (`updated_at` ≠ `created_at`) and asserts that the rendered header shows `format_time(journal.created_at)` and does **not** show `format_time(journal.updated_at)`.

**Why this approach:** The inconsistency was already acknowledged implicitly in the codebase — the mobile comment header in `item_component.html.erb` independently used `journal.created_at`. Aligning the desktop helper to the same field is the minimal, correct fix. No database, API, or serialisation layer is involved.

## Screenshots

Before:
<img width="651" height="285" alt="Screenshot 2026-06-12 at 16 34 16" src="https://github.com/user-attachments/assets/c4de2708-0b9d-41b5-b32b-b63aad7d4252" />
After:
<img width="653" height="275" alt="Screenshot 2026-06-12 at 16 33 58" src="https://github.com/user-attachments/assets/934393c8-b5f8-48f4-a445-8af144323870" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)