### PR TITLE
[#67316] Highlighted comments: Bottom border is sligthly narrower than the rest of the borders

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -28,3 +28,4 @@
             border-top: none
             border-left: none
             border-right: none
+            border-bottom: none


### PR DESCRIPTION
🤖 AI-generated PR! Please review it for accuracy and then remove this line.

**Work package:** https://community.openproject.org/work_packages/67316 — plan & discussion in the comments.

# Ticket

https://community.openproject.org/work_packages/67316

# What are you trying to accomplish?

When a comment is deep-linked via a URL anchor the Stimulus auto-scrolling controller adds `--anchor-highlighted` to the surrounding `Primer::Beta::BorderBox`, applying a 2 px accent border on all four sides. The existing SASS already removes `border-top`, `border-left`, and `border-right` from `.Box-header` to avoid a double-border, but `border-bottom` was left out. This residual 1 px header separator made the bottom highlight border appear narrower than the other three sides. For internal (restricted) comments the effect was more visible because Primer's `--header__internal-comment` modifier also applies a different `border-color` to `.Box-header`, causing the bottom border to appear in a mismatched colour.

The fix adds the missing `border-bottom: none` to complete the four-side suppression.

# What approach did you choose and why?

The simplest correct fix is to add one line to the existing four-property block inside the `--anchor-highlighted` context — no restructuring, no new selectors. The rule's specificity (two classes + one element, 0,2,1) already beats Primer's default `.Box-header` (0,1,0) and the `--header__internal-comment` variant (0,1,0), so no specificity hacks are needed.

Removing the separator for the duration of the highlight is acceptable: the header/body sections remain visually distinguishable via their background-colour difference, and the separator reappears as soon as the highlight is cleared.

## Screenshots

N/A

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)