### PR TITLE
[#59757] Focus is not on text input when editing a comment

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/edit.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/edit.rb
@@ -55,7 +55,10 @@ module WorkPackages
 
         def wrapper_data_attributes
           {
-            internal_comment_stimulus_controller("-is-internal-value") => journal.internal?
+            internal_comment_stimulus_controller("-is-internal-value") => journal.internal?,
+            controller: "ckeditor-focus",
+            "ckeditor-focus-autofocus-value": true,
+            "ckeditor-focus-target": "editor"
           }
         end
       end

--- a/frontend/src/stimulus/controllers/ckeditor-focus.controller.ts
+++ b/frontend/src/stimulus/controllers/ckeditor-focus.controller.ts
@@ -38,14 +38,48 @@ export default class extends Controller {
   static targets = ['editor'];
   declare readonly editorTarget:HTMLElement;
 
+  private focusObserver?:MutationObserver;
+
   connect():void {
     if (this.autofocusValue) {
-      setTimeout(() => { this.focusInput(); }, 100);
+      this.tryFocusOrObserve();
     }
+  }
+
+  disconnect():void {
+    this.focusObserver?.disconnect();
+    this.focusObserver = undefined;
   }
 
   focusInput():void {
     this.element.scrollIntoView({ block: 'center' });
     retrieveCkEditorInstance(this.editorTarget)?.editing.view.focus();
+  }
+
+  private tryFocusOrObserve():void {
+    setTimeout(() => {
+      if (this.tryFocus()) return;
+
+      const observer = new MutationObserver(() => {
+        if (this.tryFocus()) {
+          observer.disconnect();
+          if (this.focusObserver === observer) {
+            this.focusObserver = undefined;
+          }
+        }
+      });
+      this.focusObserver = observer;
+      observer.observe(this.editorTarget, { childList: true, subtree: true });
+    }, 100);
+  }
+
+  private tryFocus():boolean {
+    const instance = retrieveCkEditorInstance(this.editorTarget);
+    if (!instance) return false;
+    setTimeout(() => {
+      this.element.scrollIntoView({ block: 'center' });
+      retrieveCkEditorInstance(this.editorTarget)?.editing.view.focus();
+    });
+    return true;
   }
 }

--- a/spec/features/activities/work_package/activity_tab_comment_editor_spec.rb
+++ b/spec/features/activities/work_package/activity_tab_comment_editor_spec.rb
@@ -139,6 +139,25 @@ RSpec.describe "Work package activity tab comment editor",
     end
   end
 
+  describe "Editing a comment" do
+    let!(:journal) { create(:work_package_journal, journable: work_package, notes: "Original text", user: admin, version: 2) }
+
+    current_user { admin }
+
+    before do
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "places focus on the editor when edit is clicked" do
+      activity_tab.within_journal_entry(journal) do
+        page.find_test_selector("op-wp-journal-#{journal.id}-action-menu").click
+        page.find_test_selector("op-wp-journal-#{journal.id}-edit").click
+      end
+      activity_tab.expect_focus_on_editor
+    end
+  end
+
   describe "Attachments" do
     let(:image_fixture) { UploadedFile.load_from("spec/fixtures/files/image.png") }
     let(:editor) { Components::WysiwygEditor.new }


### PR DESCRIPTION
🤖 AI-generated PR! Please review it for accuracy and then remove this line.

**Work package:** https://community.openproject.org/work_packages/59757 — plan & discussion in the comments.

# Ticket

https://community.openproject.org/work_packages/59757

# What are you trying to accomplish?

When a user clicks "Edit" on an existing work package comment, the CKEditor rich text field did not receive focus automatically. The user had to click inside the editor before they could start typing, making the edit flow unnecessarily awkward.

The fix ensures the editor is focused immediately after the edit form is rendered via Turbo Stream, matching the behaviour of the new-comment form.

# What approach did you choose and why?

**Root cause**: `ItemComponent::Edit` rendered the edit form without wiring any autofocus mechanism. The Stimulus controller `CkeditorFocusController` (`ckeditor-focus`) already solves this exact problem for inplace-edit rich-text fields, but it was not connected to the comment edit form.

**Two-part fix:**

1. **`edit.rb`** — Added `ckeditor-focus` Stimulus controller data to `wrapper_data_attributes`, setting `autofocus-value: true` and declaring the wrapper element as the `editor` target. This makes the controller root and the CKEditor host the same element, which is valid in Stimulus and consistent with how `rich_text_area_component.rb` uses the same controller.

2. **`ckeditor-focus.controller.ts`** — The original `connect()` ran a single `setTimeout(..., 100)` and silently dropped the focus attempt if CKEditor had not yet finished initialising (the `?.` chain swallowed the miss). For a fresh Turbo Stream insertion, Angular initialises CKEditor asynchronously and the 100 ms window is not always sufficient. The controller now falls back to a `MutationObserver` that watches for the editable element to appear and retries focus when it does — mirroring the pattern already used in `editor.controller.ts#setEditorDataWhenReady`. The observer is stored on the instance and disconnected in `disconnect()` to prevent memory leaks if the component is torn down before CKEditor finishes loading.

Alternative considered: calling `focusEditor()` directly from the Turbo Stream response handler in `ActivitiesTabController#edit`. Rejected because it would duplicate focus logic that already belongs in the Stimulus layer, and would not benefit other consumers of `CkeditorFocusController`.

## Screenshots

N/A

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)