### PR TITLE
[STC-289] Improve labels for dismissal of new comments in Activity tab

### DIFF
--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -93,7 +93,7 @@
                       data: { action: "click->#{editor_stimulus_controller}#closeEditor" }
                     )
                   ) do
-                    t("button_cancel")
+                    t("activities.work_packages.activity_tab.label_dismiss_comment")
                   end
                 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
         label_activity_show_all: "Show everything"
         label_activity_show_only_comments: "Show comments only"
         label_activity_show_only_changes: "Show changes only"
+        label_dismiss_comment: "Dismiss"
         label_sort_asc: "Newest at the bottom"
         label_sort_desc: "Newest on top"
         label_type_to_comment: "Add a comment. Type @ to notify people."
@@ -52,7 +53,7 @@ en:
         commented: "commented"
         internal_comment: Internal comment
         internal_journal: Internal comments are visible to a limited group of members.
-        unsaved_changes_confirmation_message: You have unsaved changes. Are you sure you want to close the editor?
+        unsaved_changes_confirmation_message: "Are you sure you want to dismiss your comment? The content that you have written will be lost."
         internal_comment_confirmation:
           title: "Make this comment public?"
           heading: "Make this comment public?"

--- a/spec/features/activities/work_package/activity_tab_comment_editor_spec.rb
+++ b/spec/features/activities/work_package/activity_tab_comment_editor_spec.rb
@@ -55,7 +55,17 @@ RSpec.describe "Work package activity tab comment editor",
         end
       end
 
-      it "is dismissable via Cancel button" do
+      it "shows a Dismiss button (not Cancel) for new comments" do
+        activity_tab.add_comment(text: "Sample text", save: false)
+        activity_tab.clear_comment
+
+        page.within_test_selector("op-work-package-journal-form") do
+          expect(page).to have_button("Dismiss")
+          expect(page).to have_no_button("Cancel")
+        end
+      end
+
+      it "is dismissable via Dismiss button" do
         expect_editor_to_be_dismissed do
           activity_tab.dismiss_comment_editor_with_cancel_button
         end
@@ -80,10 +90,22 @@ RSpec.describe "Work package activity tab comment editor",
           end
         end
 
-        it "requires confirmation to dismiss via Cancel button" do
+        it "requires confirmation to dismiss via Dismiss button" do
           expect_editor_to_be_dismissed_with_confirmation do
             activity_tab.dismiss_comment_editor_with_cancel_button
           end
+        end
+
+        it "shows the updated confirmation message when dismissing a new comment" do
+          activity_tab.add_comment(text: "Sample text", save: false)
+          activity_tab.expect_focus_on_editor
+
+          expected_message = "Are you sure you want to dismiss your comment? The content that you have written will be lost."
+          accept_alert(expected_message) do
+            activity_tab.dismiss_comment_editor_with_cancel_button
+          end
+
+          expect(page).not_to have_test_selector("op-work-package-journal-form-element")
         end
 
         def expect_editor_to_be_dismissed_with_confirmation(&)

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -355,7 +355,7 @@ module Components
 
       def dismiss_comment_editor_with_cancel_button
         page.within_test_selector("op-work-package-journal-form") do
-          click_on "Cancel"
+          click_on "Dismiss"
         end
       end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/62513

# What are you trying to accomplish?

When a user starts typing a new work-package comment and then wants to abort, two things were confusing:

1. **The button was labelled "Cancel"**, which is ambiguous — "Cancel" implies undoing an edit, whereas the user is discarding a not-yet-submitted message. "Dismiss" is more accurate for this action.
2. **The confirmation dialog showed a generic message**: _"You have unsaved changes. Are you sure you want to close the editor?"_ — "unsaved changes", "editor", and "closing" are all technical abstractions that mean nothing to a user who just wants to throw away a comment they were drafting.

This PR improves both touchpoints on the **new-comment form only**. The existing-comment edit form retains "Cancel" / "Save" because "Cancel" correctly describes undoing an in-progress edit.

## Screenshots
Before:
<img width="641" height="277" alt="Screenshot 2026-06-13 at 20 10 54" src="https://github.com/user-attachments/assets/462709b5-ab5e-4b70-b96e-10b7b71f097c" />
<img width="415" height="197" alt="Screenshot 2026-06-13 at 20 10 59" src="https://github.com/user-attachments/assets/e347aa36-6edc-4f07-a3b2-fd640888ca24" />
After:
<img width="643" height="271" alt="Screenshot 2026-06-13 at 20 10 01" src="https://github.com/user-attachments/assets/e9555143-e818-4b9c-8791-a9674dbbffaa" />
<img width="425" height="189" alt="Screenshot 2026-06-13 at 20 10 06" src="https://github.com/user-attachments/assets/13611001-b172-47de-95ba-10e9800248af" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)