### PR TITLE
[OP-19423] Hide "my meetings" and "favourited projects" widgets for anonymous users

### DIFF
--- a/modules/grids/app/components/grids/widgets/favorite_projects.rb
+++ b/modules/grids/app/components/grids/widgets/favorite_projects.rb
@@ -40,6 +40,10 @@ module Grids
       def favorite_projects
         @favorite_projects ||= Project.visible.active.favorited_by(current_user).order(name: :asc).to_a
       end
+
+      def render?
+        current_user.logged?
+      end
     end
   end
 end

--- a/modules/grids/spec/components/grids/widgets/favorite_projects_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/favorite_projects_spec.rb
@@ -33,11 +33,11 @@ require "rails_helper"
 RSpec.describe Grids::Widgets::FavoriteProjects, type: :component do
   include Rails.application.routes.url_helpers
 
-  shared_let(:admin) { create(:admin) }
+  shared_let(:user) { create(:admin) }
 
-  current_user { admin }
+  current_user { user }
 
-  subject(:rendered_component) { render_inline(described_class.new(current_user: admin)) }
+  subject(:rendered_component) { render_inline(described_class.new(current_user: user)) }
 
   context "with no favorite projects" do
     let!(:visible_project) { create(:project, name: "Visible project") }
@@ -57,7 +57,7 @@ RSpec.describe Grids::Widgets::FavoriteProjects, type: :component do
     let!(:visible_project) { create(:project, name: "Visible project") }
 
     before do
-      create(:favorite, user: admin, favorited: favorite_project)
+      create(:favorite, user:, favorited: favorite_project)
     end
 
     it "renders only favorite projects and a link to all projects" do
@@ -73,23 +73,32 @@ RSpec.describe Grids::Widgets::FavoriteProjects, type: :component do
     end
 
     context "when a favorited project is not visible to the user" do
-      let(:user) { create(:user) }
+      let(:non_admin) { create(:user) }
       let!(:favorite_project) { create(:public_project, name: "Visible favorite project") }
       let!(:invisible_favorite_project) { create(:private_project, name: "Invisible favorite project") }
 
-      current_user { user }
+      current_user { non_admin }
 
       subject(:rendered_component) { render_inline(described_class.new(current_user: user)) }
 
       before do
-        create(:favorite, user:, favorited: favorite_project)
-        create(:favorite, user:, favorited: invisible_favorite_project)
+        create(:favorite, user: non_admin, favorited: favorite_project)
+        create(:favorite, user: non_admin, favorited: invisible_favorite_project)
       end
 
       it "only renders visible favorite projects" do
         expect(rendered_component).to have_link(favorite_project.name, href: project_path(favorite_project))
         expect(rendered_component).to have_no_link(invisible_favorite_project.name)
       end
+    end
+  end
+
+  context "when being an anonymous user" do
+    let!(:project) { create(:public_project, name: "Visible favorite project") }
+    let(:user) { create(:anonymous) }
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
     end
   end
 end

--- a/modules/meeting/app/components/meetings/widgets/meetings.rb
+++ b/modules/meeting/app/components/meetings/widgets/meetings.rb
@@ -64,7 +64,7 @@ module Meetings
       end
 
       def render?
-        global_scoped? || project.module_enabled?("meetings")
+        current_user.logged? && (global_scoped? || project.module_enabled?("meetings"))
       end
 
       private

--- a/modules/meeting/spec/components/meetings/widgets/meetings_spec.rb
+++ b/modules/meeting/spec/components/meetings/widgets/meetings_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe Meetings::Widgets::Meetings, type: :component do
 
   subject(:rendered_component) { render_component(project) }
 
+  before { login_as user }
+
   shared_examples "empty-state without action" do
     it "renders empty blankslate without action" do
       expect(rendered_component).to have_test_selector("meetings-widget-empty")
@@ -162,5 +164,14 @@ RSpec.describe Meetings::Widgets::Meetings, type: :component do
 
     # User has only view_meetings permission now
     it_behaves_like "empty-state without action"
+  end
+
+  context "when being an anonymous user" do
+    let(:project) { project_red }
+    let(:user) { create(:anonymous) }
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19423

# What are you trying to accomplish?
Hide meetings & favorited widgets when the user is not logged in

