### PR TITLE
[OP-19362] Migrate Stimulus controllers to `useAngularServices` mixin

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-field-role-assignment.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-field-role-assignment.controller.spec.ts
@@ -1,0 +1,125 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type CustomFieldRoleAssignmentControllerType from './custom-field-role-assignment.controller';
+
+describe('Custom field role assignment controller', () => {
+  let ctx:StimulusTestContext;
+  let CustomFieldRoleAssignmentController:typeof CustomFieldRoleAssignmentControllerType;
+  let request:Mock;
+  let previewCustomFieldRoleAssignmentDialog:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: CustomFieldRoleAssignmentController } = await import('./custom-field-role-assignment.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    previewCustomFieldRoleAssignmentDialog = vi.fn().mockReturnValue('/custom_fields/7/preview_role_assignment');
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { request },
+          pathHelperService: { previewCustomFieldRoleAssignmentDialog },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'admin--custom-field-role-assignment': CustomFieldRoleAssignmentController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderAssignment() {
+    await ctx.mount(`
+      <div data-controller="admin--custom-field-role-assignment"
+           data-admin--custom-field-role-assignment-initial-role-value="1"
+           data-admin--custom-field-role-assignment-custom-field-id-value="7"></div>
+    `);
+    return ctx.getController<CustomFieldRoleAssignmentControllerType>('admin--custom-field-role-assignment');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderAssignment();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('requests the preview dialog turbo stream', async () => {
+    const controller = await renderAssignment();
+
+    void controller.showPreviewModal();
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/custom_fields/7/preview_role_assignment',
+        { headers: { Accept: 'text/vnd.turbo-stream.html' } },
+      );
+    });
+  });
+
+  it('does not request when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderAssignment();
+    const root = ctx.container.querySelector('[data-controller="admin--custom-field-role-assignment"]')!;
+
+    void controller.showPreviewModal();
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { request },
+        pathHelperService: { previewCustomFieldRoleAssignmentDialog },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-field-role-assignment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-field-role-assignment.controller.ts
@@ -29,10 +29,11 @@
  */
 
 import { ApplicationController } from 'stimulus-use';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class CustomFieldRoleAssignmentController extends ApplicationController {
+  static services:ServiceKey[] = ['turboRequests', 'pathHelperService'];
+
   static values = {
     initialRole: Number,
     customFieldId: Number
@@ -49,13 +50,11 @@ export default class CustomFieldRoleAssignmentController extends ApplicationCont
   declare readonly previewHintBoxTarget:HTMLDivElement;
   declare readonly hasPreviewHintBoxTarget:boolean;
 
-  protected turboRequests:TurboRequestsService;
-  protected pathHelper:PathHelperService;
+  declare services:Promise<PickedServices<'turboRequests'|'pathHelperService'>>;
 
-  async connect() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
   }
 
   changeRole(event:Event):void {
@@ -67,11 +66,11 @@ export default class CustomFieldRoleAssignmentController extends ApplicationCont
     this.previewHintBoxTarget.classList.toggle('d-none', this.currentRoleValue === this.initialRoleValue);
   }
 
-  showPreviewModal():void {
-    void this
-      .turboRequests
+  async showPreviewModal() {
+    const { turboRequests, pathHelperService } = await this.services;
+    void turboRequests
       .request(
-        this.pathHelper.previewCustomFieldRoleAssignmentDialog(this.customFieldIdValue, this.currentRoleValue),
+        pathHelperService.previewCustomFieldRoleAssignmentDialog(this.customFieldIdValue, this.currentRoleValue),
         {
           headers: {
             Accept: 'text/vnd.turbo-stream.html',

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.spec.ts
@@ -1,0 +1,121 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type CustomFieldsControllerType from './custom-fields.controller';
+
+class FakeAutoscroll {
+  static constructedWith:unknown[][] = [];
+
+  constructor(...args:unknown[]) {
+    FakeAutoscroll.constructedWith.push(args);
+  }
+}
+
+describe('Admin custom fields controller', () => {
+  let ctx:StimulusTestContext;
+  let CustomFieldsController:typeof CustomFieldsControllerType;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({ classes: { DomAutoscrollService: FakeAutoscroll } });
+
+  beforeAll(async () => {
+    ({ default: CustomFieldsController } = await import('./custom-fields.controller'));
+  });
+
+  beforeEach(async () => {
+    FakeAutoscroll.constructedWith = [];
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve(pluginContext()),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'admin--custom-fields': CustomFieldsController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderOptions() {
+    await ctx.mount(`
+      <div data-controller="admin--custom-fields">
+        <table>
+          <tbody data-admin--custom-fields-target="dragContainer">
+            <tr data-admin--custom-fields-target="customOptionRow"><td>one</td></tr>
+            <tr data-admin--custom-fields-target="customOptionRow"><td>two</td></tr>
+          </tbody>
+        </table>
+      </div>
+    `);
+    return ctx.getController<CustomFieldsControllerType>('admin--custom-fields');
+  }
+
+  it('sets up autoscroll once connected', async () => {
+    await renderOptions();
+
+    await waitFor(() => {
+      expect(FakeAutoscroll.constructedWith).toHaveLength(1);
+    });
+  });
+
+  it('moves a custom option row up', async () => {
+    const controller = await renderOptions();
+    const rows = ctx.container.querySelectorAll('tr');
+
+    controller.moveRowUp({ target: rows[1].querySelector('td')! });
+
+    const cells = Array.from(ctx.container.querySelectorAll('td')).map((cell) => cell.textContent);
+    expect(cells).toEqual(['two', 'one']);
+  });
+
+  it('does not set up autoscroll when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderOptions();
+    const root = ctx.container.querySelector('[data-controller="admin--custom-fields"]')!;
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext(pluginContext());
+    await ctx.nextFrame();
+
+    expect(FakeAutoscroll.constructedWith).toHaveLength(0);
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -29,7 +29,9 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import dragula from 'dragula';
+import dragula, { Drake } from 'dragula';
+import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { useAngularServices } from 'core-stimulus/mixins/use-angular-services';
 
 export default class CustomFieldsController extends Controller {
   static targets = [
@@ -50,6 +52,12 @@ export default class CustomFieldsController extends Controller {
 
   declare readonly customOptionDefaultsTargets:HTMLInputElement[];
   declare readonly customOptionRowTargets:HTMLTableRowElement[];
+
+  declare pluginContext:Promise<OpenProjectPluginContext>;
+
+  initialize() {
+    useAngularServices(this);
+  }
 
   connect() {
     if (this.hasDragContainerTarget) {
@@ -172,19 +180,22 @@ export default class CustomFieldsController extends Controller {
       ignoreInputTextSelection: true,
     });
 
-    // Setup autoscroll
-    void window.OpenProject.getPluginContext().then((pluginContext) => {
-      new pluginContext.classes.DomAutoscrollService(
-        [
-          document.getElementById('content-body')!,
-        ],
-        {
-          margin: 25,
-          maxSpeed: 10,
-          scrollWhenOutside: true,
-          autoScroll: () => drake.dragging,
-        },
-      );
-    });
+    void this.setupAutoscroll(drake);
+  }
+
+  private async setupAutoscroll(drake:Drake) {
+    const { classes } = await this.pluginContext;
+
+    new classes.DomAutoscrollService(
+      [
+        document.getElementById('content-body')!,
+      ],
+      {
+        margin: 25,
+        maxSpeed: 10,
+        scrollWhenOutside: true,
+        autoScroll: () => drake.dragging,
+      },
+    );
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/jira-import.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/jira-import.controller.spec.ts
@@ -1,0 +1,112 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type JiraImportControllerType from './jira-import.controller';
+
+describe('Admin JIRA import controller', () => {
+  let ctx:StimulusTestContext;
+  let JiraImportController:typeof JiraImportControllerType;
+  let addError:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: JiraImportController } = await import('./jira-import.controller'));
+  });
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+
+    addError = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { notifications: { addError } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'admin--jira-import': JiraImportController },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderPolling() {
+    await ctx.mount(`
+      <div data-controller="admin--jira-import"
+           data-admin--jira-import-url-value="/admin/jira_import/status">
+        <div data-admin--jira-import-target="poll"></div>
+      </div>
+    `);
+    return ctx.getController<JiraImportControllerType>('admin--jira-import');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderPolling();
+
+    await expect(controller.services).resolves.toMatchObject({
+      notifications: { addError },
+    });
+  });
+
+  it('reports a failed status poll as an error notification', async () => {
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    await renderPolling();
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(addError).toHaveBeenCalledWith(new Error('network down'));
+  });
+
+  it('does not notify when disconnected before the plugin context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    await renderPolling();
+    const element = ctx.container.querySelector('[data-controller="admin--jira-import"]')!;
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    element.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { notifications: { addError } } });
+    await ctx.nextFrame();
+
+    expect(addError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/jira-import.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/jira-import.controller.ts
@@ -31,8 +31,11 @@
 import {Controller} from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
 import {HttpErrorResponse} from '@angular/common/http';
+import {useAngularServices, type PickedServices, type ServiceKey} from 'core-stimulus/mixins/use-angular-services';
 
 export default class extends Controller {
+    static services:ServiceKey[] = ['notifications'];
+
     static targets = ['finished', 'poll'];
     static values = {
         url: String
@@ -40,14 +43,20 @@ export default class extends Controller {
 
     private pollingInterval = 3000;
 
+    declare services:Promise<PickedServices<'notifications'>>;
+
     declare urlValue:string;
 
     interval?:ReturnType<typeof setInterval>;
 
+    initialize() {
+        useAngularServices(this);
+    }
+
     pollTargetConnected() {
         this.interval ??= setInterval(() => {
             this.reload()
-                .catch((error) => this.handleError(error as HttpErrorResponse));
+                .catch((error) => { void this.handleError(error as HttpErrorResponse); });
         }, this.pollingInterval);
     }
 
@@ -76,9 +85,8 @@ export default class extends Controller {
         }
     }
 
-    private handleError(error:HttpErrorResponse) {
-        void window.OpenProject.getPluginContext().then((pluginContext) => {
-            pluginContext.services.notifications.addError(error);
-        });
+    private async handleError(error:HttpErrorResponse) {
+        const {notifications} = await this.services;
+        notifications.addError(error);
     }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.spec.ts
@@ -1,0 +1,147 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type TypeFormConfigurationControllerType from './main.controller';
+
+interface QueryEditorConfig {
+  currentQuery:unknown;
+  callback:(queryProps:unknown) => void;
+  disabledTabs:Record<string, string>;
+}
+
+describe('Type form configuration controller', () => {
+  let ctx:StimulusTestContext;
+  let TypeFormConfigurationController:typeof TypeFormConfigurationControllerType;
+  let request:Mock;
+  let show:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: TypeFormConfigurationController } = await import('./main.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    show = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { request },
+          externalRelationQueryConfiguration: { show },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'admin--type-form-configuration--main': TypeFormConfigurationController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderConfiguration() {
+    await ctx.mount(`
+      <div data-controller="admin--type-form-configuration--main"
+           data-admin--type-form-configuration--main-add-group-url-value="/types/1/form_configuration/groups"
+           data-admin--type-form-configuration--main-no-filter-query-value="{}"
+           data-admin--type-form-configuration--main-groups-url-value="/types/1/form_configuration/groups">
+        <div data-admin--type-form-configuration--main-target="groupsContainer"></div>
+      </div>
+    `);
+    return ctx.getController<TypeFormConfigurationControllerType>('admin--type-form-configuration--main');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderConfiguration();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+      externalRelationQueryConfiguration: { show },
+    });
+  });
+
+  it('opens the query editor and posts the new group from its callback', async () => {
+    const controller = await renderConfiguration();
+
+    controller.addQueryGroup(new CustomEvent('click'));
+
+    await waitFor(() => {
+      expect(show).toHaveBeenCalled();
+    });
+
+    const config = show.mock.calls[0][0] as QueryEditorConfig;
+    expect(config.currentQuery).toEqual({});
+
+    config.callback({ filters: [] });
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/types/1/form_configuration/groups',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    const body = (request.mock.calls[0][1] as { body:URLSearchParams }).body;
+    expect(body.get('group_type')).toBe('query');
+    expect(body.get('query')).toBe(JSON.stringify({ filters: [] }));
+  });
+
+  it('does not open the query editor when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderConfiguration();
+    const root = ctx.container.querySelector('[data-controller="admin--type-form-configuration--main"]')!;
+
+    controller.addQueryGroup(new CustomEvent('click'));
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { request },
+        externalRelationQueryConfiguration: { show },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(show).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.ts
@@ -29,12 +29,11 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import {
-  ExternalRelationQueryConfigurationService,
-} from 'core-app/features/work-packages/components/wp-table/external-configuration/external-relation-query-configuration.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class TypeFormConfigurationController extends Controller {
+  static services:ServiceKey[] = ['turboRequests', 'externalRelationQueryConfiguration'];
+
   static targets = ['groupsContainer', 'inactiveContainer'];
 
   declare readonly groupsContainerTarget:HTMLElement;
@@ -50,18 +49,10 @@ export default class TypeFormConfigurationController extends Controller {
   declare readonly noFilterQueryValue:string;
   declare readonly groupsUrlValue:string;
 
-  private turboRequests:TurboRequestsService;
-  private externalRelationQueryConfiguration:ExternalRelationQueryConfigurationService;
-  private servicesInitialization?:Promise<void>;
+  declare services:Promise<PickedServices<'turboRequests'|'externalRelationQueryConfiguration'>>;
 
-  connect() {
-    this.servicesInitialization ??= this.initializeServices();
-  }
-
-  private async initializeServices() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.externalRelationQueryConfiguration = context.services.externalRelationQueryConfiguration;
+  initialize() {
+    useAngularServices(this);
   }
 
   addQueryGroup(event:Event) {
@@ -99,7 +90,7 @@ export default class TypeFormConfigurationController extends Controller {
   }
 
   private async postNewGroup(groupType:'attribute'|'query', queryProps?:unknown):Promise<void> {
-    await this.servicesInitialization;
+    const { turboRequests } = await this.services;
 
     const body = new URLSearchParams({
       group_type: groupType,
@@ -109,7 +100,7 @@ export default class TypeFormConfigurationController extends Controller {
       body.set('query', JSON.stringify(queryProps));
     }
 
-    await this.turboRequests.request(this.addGroupUrlValue, {
+    await turboRequests.request(this.addGroupUrlValue, {
       method: 'POST',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
@@ -119,9 +110,9 @@ export default class TypeFormConfigurationController extends Controller {
   }
 
   private async postQueryUpdate(groupKey:string, queryProps:unknown):Promise<boolean> {
-    await this.servicesInitialization;
+    const { turboRequests } = await this.services;
 
-    await this.turboRequests.request(`${this.groupsUrlValue}/${encodeURIComponent(groupKey)}/update_query`, {
+    await turboRequests.request(`${this.groupsUrlValue}/${encodeURIComponent(groupKey)}/update_query`, {
       method: 'PATCH',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
@@ -135,7 +126,7 @@ export default class TypeFormConfigurationController extends Controller {
   }
 
   private async openQueryEditor(queryJson:string, callback:(queryProps:unknown) => void) {
-    await this.servicesInitialization;
+    const { externalRelationQueryConfiguration } = await this.services;
 
     const currentQuery = JSON.parse(queryJson) as unknown;
     const disabledTabs = {
@@ -143,9 +134,7 @@ export default class TypeFormConfigurationController extends Controller {
       timelines: I18n.t('js.work_packages.table_configuration.embedded_tab_disabled'),
     };
 
-    if (!this.element.isConnected) return;
-
-    this.externalRelationQueryConfiguration.show({
+    externalRelationQueryConfiguration.show({
       currentQuery,
       callback,
       disabledTabs,

--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts
@@ -1,0 +1,147 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { Subject } from 'rxjs';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type BacklogsControllerType from './backlogs.controller';
+
+interface HalEvent {
+  eventType:string;
+}
+
+describe('Backlogs controller', () => {
+  let ctx:StimulusTestContext;
+  let BacklogsController:typeof BacklogsControllerType;
+  let events$:Subject<HalEvent[]>;
+  let aggregated$:Mock;
+  let reload:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({
+    services: { halEvents: { aggregated$ } },
+  });
+
+  beforeAll(async () => {
+    ({ default: BacklogsController } = await import('./backlogs.controller'));
+  });
+
+  beforeEach(async () => {
+    events$ = new Subject<HalEvent[]>();
+    aggregated$ = vi.fn(() => events$);
+    reload = vi.fn(() => Promise.resolve());
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve(pluginContext()),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { backlogs: BacklogsController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderBacklogs() {
+    await ctx.mount(`
+      <div data-controller="backlogs">
+        <turbo-frame id="backlogs_container"></turbo-frame>
+      </div>
+    `);
+    const frame = ctx.container.querySelector('#backlogs_container')!;
+    (frame as unknown as { reload:Mock }).reload = reload;
+    return ctx.getController<BacklogsControllerType>('backlogs');
+  }
+
+  it('subscribes to aggregated work package events once connected', async () => {
+    await renderBacklogs();
+
+    await waitFor(() => {
+      expect(aggregated$).toHaveBeenCalledWith('WorkPackage');
+    });
+  });
+
+  it('reloads the list frame on an updated event', async () => {
+    await renderBacklogs();
+    await waitFor(() => { expect(aggregated$).toHaveBeenCalled(); });
+
+    events$.next([{ eventType: 'updated' }]);
+
+    await waitFor(() => {
+      expect(reload).toHaveBeenCalled();
+    });
+  });
+
+  it('ignores event batches without an update', async () => {
+    await renderBacklogs();
+    await waitFor(() => { expect(aggregated$).toHaveBeenCalled(); });
+
+    events$.next([{ eventType: 'created' }]);
+    await ctx.nextFrame();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('stops reloading once disconnected', async () => {
+    await renderBacklogs();
+    await waitFor(() => { expect(aggregated$).toHaveBeenCalled(); });
+
+    const root = ctx.container.querySelector('[data-controller="backlogs"]')!;
+    root.remove();
+    await ctx.nextFrame();
+
+    events$.next([{ eventType: 'updated' }]);
+    await ctx.nextFrame();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderBacklogs();
+    const root = ctx.container.querySelector('[data-controller="backlogs"]')!;
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext(pluginContext());
+    await ctx.nextFrame();
+
+    expect(aggregated$).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
@@ -31,16 +31,20 @@ import { FrameElement } from '@hotwired/turbo';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { filter, Subscription } from 'rxjs';
 
+import { useAngularServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
+
 export default class BacklogsController extends Controller<HTMLElement> {
-  private service:HalEventsService|null = null;
+  static services:ServiceKey[] = ['halEvents'];
+  declare halEvents:HalEventsService;
+
   private subscription:Subscription|null = null;
 
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  async connect() {
-    const { services: { halEvents } } = await window.OpenProject.getPluginContext();
+  initialize() {
+    useAngularServices(this);
+  }
 
-    this.service = halEvents;
-    this.subscription = this.service.aggregated$('WorkPackage')
+  servicesConnected() {
+    this.subscription = this.halEvents.aggregated$('WorkPackage')
       .pipe(filter((events) => events.some((event) => event.eventType === 'updated')))
       .subscribe(() => { this.refreshList(); });
   }
@@ -48,7 +52,6 @@ export default class BacklogsController extends Controller<HTMLElement> {
   disconnect() {
     this.subscription?.unsubscribe();
     this.subscription = null;
-    this.service = null;
   }
 
   private refreshList() {

--- a/frontend/src/stimulus/controllers/dynamic/costs/export.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/costs/export.controller.spec.ts
@@ -1,0 +1,112 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type ExportControllerType from './export.controller';
+
+describe('Costs export controller', () => {
+  let ctx:StimulusTestContext;
+  let ExportController:typeof ExportControllerType;
+  let addError:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: ExportController } = await import('./export.controller'));
+  });
+
+  beforeEach(async () => {
+    addError = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { notifications: { addError } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'costs--export': ExportController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderLink() {
+    await ctx.mount(`
+      <a href="/cost_reports/export.xls"
+         data-controller="costs--export"
+         data-costs--export-job-status-dialog-url-value="/job_statuses/_job_uuid_/dialog">Export</a>
+    `);
+    return ctx.getController<ExportControllerType>('costs--export');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderLink();
+
+    await expect(controller.services).resolves.toMatchObject({
+      notifications: { addError },
+    });
+  });
+
+  it('reports a failed export request as an error notification', async () => {
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    const controller = await renderLink();
+
+    controller.download(new CustomEvent('click'));
+
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalledWith(new Error('network down'));
+    });
+  });
+
+  it('does not notify when disconnected before the plugin context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    const controller = await renderLink();
+    const link = ctx.container.querySelector('a')!;
+
+    controller.download(new CustomEvent('click'));
+    await ctx.nextFrame();
+
+    link.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { notifications: { addError } } });
+    await ctx.nextFrame();
+
+    expect(addError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/costs/export.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/costs/export.controller.ts
@@ -31,13 +31,22 @@
 import { Controller } from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
 import { HttpErrorResponse } from '@angular/common/http';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class ExportController extends Controller<HTMLLinkElement> {
+  static services:ServiceKey[] = ['notifications'];
+
   static values = {
     jobStatusDialogUrl: String,
   };
 
+  declare services:Promise<PickedServices<'notifications'>>;
+
   declare jobStatusDialogUrlValue:string;
+
+  initialize() {
+    useAngularServices(this);
+  }
 
   jobModalUrl(job_id:string):string {
     return this.jobStatusDialogUrlValue.replace('_job_uuid_', job_id);
@@ -79,12 +88,11 @@ export default class ExportController extends Controller<HTMLLinkElement> {
     evt.preventDefault(); // Don't follow the href
     this.requestExport(this.href)
       .then((job_id) => this.showJobModal(job_id))
-      .catch((error:HttpErrorResponse) => this.handleError(error));
+      .catch((error:HttpErrorResponse) => { void this.handleError(error); });
   }
 
-  private handleError(error:HttpErrorResponse) {
-    void window.OpenProject.getPluginContext().then((pluginContext) => {
-      pluginContext.services.notifications.addError(error);
-    });
+  private async handleError(error:HttpErrorResponse) {
+    const { notifications } = await this.services;
+    notifications.addError(error);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
@@ -28,8 +28,11 @@
  * ++
  */
 
+import { waitFor } from '@testing-library/dom';
+import { vi } from 'vitest';
+
 import GenericDragAndDropController from './generic-drag-and-drop.controller';
-import { createControllerInstance } from 'core-stimulus/test-helpers';
+import { createControllerInstance, setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 
 describe('GenericDragAndDropController', () => {
   let controller:GenericDragAndDropController;
@@ -139,6 +142,106 @@ describe('GenericDragAndDropController', () => {
       setValue('handleSelectorValue', '.DragHandle');
 
       expect(callAriaPressedTarget(row)).toBe(handle);
+    });
+  });
+
+  describe('autoscroll setup through the plugin context', () => {
+    class FakeAutoscroll {
+      static constructedWith:unknown[][] = [];
+
+      static instances:FakeAutoscroll[] = [];
+
+      destroy = vi.fn();
+
+      constructor(...args:unknown[]) {
+        FakeAutoscroll.constructedWith.push(args);
+        FakeAutoscroll.instances.push(this);
+      }
+    }
+
+    let ctx:StimulusTestContext;
+    let originalOpenProject:typeof window.OpenProject;
+
+    const pluginContext = () => ({ classes: { DomAutoscrollService: FakeAutoscroll } });
+
+    beforeEach(async () => {
+      FakeAutoscroll.constructedWith = [];
+      FakeAutoscroll.instances = [];
+      originalOpenProject = window.OpenProject;
+      window.OpenProject = {
+        getPluginContext: () => Promise.resolve(pluginContext()),
+      } as unknown as typeof window.OpenProject;
+
+      ctx = await setupStimulusTest({
+        controllers: { 'generic-drag-and-drop': GenericDragAndDropController },
+      });
+    });
+
+    afterEach(() => {
+      ctx.dispose();
+      window.OpenProject = originalOpenProject;
+      vi.restoreAllMocks();
+    });
+
+    async function renderLists() {
+      await ctx.mount(`
+        <div data-controller="generic-drag-and-drop">
+          <div data-generic-drag-and-drop-target="scrollContainer">
+            <ul data-generic-drag-and-drop-target="container"></ul>
+          </div>
+        </div>
+      `);
+      return ctx.getController<GenericDragAndDropController>('generic-drag-and-drop');
+    }
+
+    it('exposes the full plugin context as a promise', async () => {
+      const mounted = await renderLists();
+
+      await expect(mounted.pluginContext).resolves.toMatchObject({
+        classes: { DomAutoscrollService: FakeAutoscroll },
+      });
+    });
+
+    it('sets up autoscroll on the scroll containers once connected', async () => {
+      await renderLists();
+
+      await waitFor(() => {
+        expect(FakeAutoscroll.constructedWith).toHaveLength(1);
+      });
+      const scrollContainer = ctx.container.querySelector('[data-generic-drag-and-drop-target="scrollContainer"]');
+      expect(FakeAutoscroll.constructedWith[0][0]).toEqual([scrollContainer]);
+    });
+
+    it('destroys the autoscroll instance on disconnect', async () => {
+      await renderLists();
+      const root = ctx.container.querySelector('[data-controller="generic-drag-and-drop"]')!;
+
+      await waitFor(() => {
+        expect(FakeAutoscroll.instances).toHaveLength(1);
+      });
+
+      root.remove();
+      await ctx.nextFrame();
+
+      expect(FakeAutoscroll.instances[0].destroy).toHaveBeenCalled();
+    });
+
+    it('does not set up autoscroll when disconnected before the context resolves', async () => {
+      let resolveContext!:(context:unknown) => void;
+      window.OpenProject = {
+        getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+      } as unknown as typeof window.OpenProject;
+
+      await renderLists();
+      const root = ctx.container.querySelector('[data-controller="generic-drag-and-drop"]')!;
+
+      root.remove();
+      await ctx.nextFrame();
+
+      resolveContext(pluginContext());
+      await ctx.nextFrame();
+
+      expect(FakeAutoscroll.constructedWith).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -33,6 +33,8 @@ import { FetchRequest } from '@rails/request.js';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 import type { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-autoscroll.service';
+import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { useAngularServices } from 'core-stimulus/mixins/use-angular-services';
 import dragula, { Drake } from 'dragula';
 import invariant from 'tiny-invariant';
 
@@ -58,12 +60,18 @@ export default class GenericDragAndDropController extends Controller {
   declare readonly handleSelectorValue:string;
   declare readonly positionModeValue:string;
 
+  declare pluginContext:Promise<OpenProjectPluginContext>;
+
   private drake:Drake|null = null;
   private autoscroll:DomAutoscrollService|null = null;
   private containers:HTMLElement[] = [];
   private targetConfigs:TargetConfig[] = [];
   private dragOriginSource:Element|null = null;
   private dragOriginNextSibling:Element|null = null;
+
+  initialize() {
+    useAngularServices(this);
+  }
 
   connect() {
     this.autoscroll?.destroy();
@@ -148,24 +156,25 @@ export default class GenericDragAndDropController extends Controller {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       .on('drop', this.drop.bind(this));
 
-    // Setup autoscroll
-    void window.OpenProject.getPluginContext().then((pluginContext) => {
-      if (!this.element.isConnected) return;
+    void this.setupAutoscroll();
+  }
 
-      const scrollTargets:Element[] = this.scrollContainerTargets.length > 0
-        ? this.scrollContainerTargets
-        : [document.getElementById('content-body')!];
+  private async setupAutoscroll() {
+    const { classes } = await this.pluginContext;
 
-      this.autoscroll = new pluginContext.classes.DomAutoscrollService(
-        scrollTargets,
-        {
-          margin: 25,
-          maxSpeed: 10,
-          scrollWhenOutside: true,
-          autoScroll: () => this.drake?.dragging,
-        },
-      );
-    });
+    const scrollTargets:Element[] = this.scrollContainerTargets.length > 0
+      ? this.scrollContainerTargets
+      : [document.getElementById('content-body')!];
+
+    this.autoscroll = new classes.DomAutoscrollService(
+      scrollTargets,
+      {
+        margin: 25,
+        maxSpeed: 10,
+        scrollWhenOutside: true,
+        autoScroll: () => this.drake?.dragging,
+      },
+    );
   }
 
   accepts(el:Element, target:Element, _source:Element|null, _sibling:Element|null) {

--- a/frontend/src/stimulus/controllers/dynamic/job-dialog.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/job-dialog.controller.spec.ts
@@ -1,0 +1,171 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import { TurboHelpers } from 'core-turbo/helpers';
+import type AsyncJobDialogControllerType from './job-dialog.controller';
+
+describe('Job dialog controller', () => {
+  let ctx:StimulusTestContext;
+  let AsyncJobDialogController:typeof AsyncJobDialogControllerType;
+  let addError:Mock;
+  let jobStatusModalPath:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: AsyncJobDialogController } = await import('./job-dialog.controller'));
+  });
+
+  beforeEach(async () => {
+    addError = vi.fn();
+    jobStatusModalPath = vi.fn().mockReturnValue('/job_statuses/abc/dialog');
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          notifications: { addError },
+          pathHelperService: { jobStatusModalPath },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'job-dialog': AsyncJobDialogController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderLink() {
+    await ctx.mount('<a href="/exports/run" data-controller="job-dialog">Run export</a>');
+    return ctx.container.querySelector('a')!;
+  }
+
+  it('binds the declared services after connect', async () => {
+    await renderLink();
+    const controller = ctx.getController<AsyncJobDialogControllerType>('job-dialog');
+
+    await expect(controller.services).resolves.toMatchObject({
+      notifications: { addError },
+      pathHelperService: { jobStatusModalPath },
+    });
+  });
+
+  it('requests the job and consults the job status modal path on click', async () => {
+    vi.spyOn(window, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ job_id: 'abc' }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        statusText: 'nope',
+      } as unknown as Response);
+    const link = await renderLink();
+
+    link.click();
+
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalledWith(new Error('nope'));
+    });
+    expect(jobStatusModalPath).toHaveBeenCalledWith('abc');
+  });
+
+  it('runs a click arriving before the plugin context resolves once it does', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const fetchSpy = vi.spyOn(window, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ job_id: 'abc' }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    const link = await renderLink();
+
+    const notPrevented = link.dispatchEvent(new MouseEvent('click', { cancelable: true }));
+
+    expect(notPrevented).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    resolveContext({
+      services: {
+        notifications: { addError },
+        pathHelperService: { jobStatusModalPath },
+      },
+    });
+
+    await waitFor(() => {
+      expect(jobStatusModalPath).toHaveBeenCalledWith('abc');
+    });
+  });
+
+  it('leaves the progress bar alone when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const showProgressBar = vi.spyOn(TurboHelpers, 'showProgressBar');
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ job_id: 'abc' }),
+    } as unknown as Response);
+    const link = await renderLink();
+
+    link.click();
+
+    link.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        notifications: { addError },
+        pathHelperService: { jobStatusModalPath },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(showProgressBar).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(jobStatusModalPath).not.toHaveBeenCalled();
+    expect(addError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/job-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/job-dialog.controller.ts
@@ -32,39 +32,52 @@ import { ApplicationController } from 'stimulus-use';
 import { renderStreamMessage } from '@hotwired/turbo';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TurboHelpers } from 'core-turbo/helpers';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class AsyncJobDialogController extends ApplicationController {
+    static services:ServiceKey[] = ['pathHelperService', 'notifications'];
+
     static values = {
         closeDialogId: String,
     };
 
-    declare closeDialogIdValue:string;
-    protected pathHelper:PathHelperService;
+    declare services:Promise<PickedServices<'pathHelperService'|'notifications'>>;
 
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    async connect(){
-        const context = await window.OpenProject.getPluginContext();
-        this.pathHelper = context.services.pathHelperService;
+    declare closeDialogIdValue:string;
+
+    initialize() {
+        super.initialize();
+        useAngularServices(this);
+    }
+
+    connect() {
         this.element.addEventListener('click', (e) => {
             e.preventDefault();
-            TurboHelpers.showProgressBar();
-            this.closePreviousDialog();
-            this.requestJob()
-                .then((job_id) => {
-                    if (job_id) {
-                        return this.showJobModal(job_id);
-                    }
-                    this.handleError(I18n.t('js.no_job_id'));
-                    return null;
-                })
-                .catch((error:unknown) => {
-                    this.handleError(error);
-                })
-                .finally(() => {
-                    TurboHelpers.hideProgressBar();
-                });
+            void this.triggerJob();
         });
+    }
+
+    // The services must be resolved before anything that needs cleanup in the
+    // finally block: their promise never settles after a disconnect, so an
+    // await on it inside the try would strand the progress bar.
+    private async triggerJob() {
+        const { pathHelperService, notifications } = await this.services;
+
+        TurboHelpers.showProgressBar();
+        this.closePreviousDialog();
+
+        try {
+            const jobId = await this.requestJob();
+            if (jobId) {
+                await this.showJobModal(pathHelperService.jobStatusModalPath(jobId));
+            } else {
+                notifications.addError(I18n.t('js.no_job_id'));
+            }
+        } catch (error) {
+            notifications.addError(error as string | HttpErrorResponse);
+        } finally {
+            TurboHelpers.hideProgressBar();
+        }
     }
 
     closePreviousDialog() {
@@ -91,8 +104,8 @@ export default class AsyncJobDialogController extends ApplicationController {
         return result.job_id;
     }
 
-    async showJobModal(job_id:string) {
-        const response = await fetch(this.pathHelper.jobStatusModalPath(job_id), {
+    async showJobModal(url:string) {
+        const response = await fetch(url, {
             method: 'GET',
             headers: { Accept: 'text/vnd.turbo-stream.html' },
         });
@@ -101,12 +114,6 @@ export default class AsyncJobDialogController extends ApplicationController {
         } else {
             throw new Error(response.statusText);
         }
-    }
-
-    handleError(error:unknown):void {
-        void window.OpenProject.getPluginContext().then((pluginContext) => {
-            pluginContext.services.notifications.addError(error as string | HttpErrorResponse);
-        });
     }
 
     get href() {

--- a/frontend/src/stimulus/controllers/dynamic/meetings/export/form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/export/form.controller.spec.ts
@@ -1,0 +1,114 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type FormControllerType from './form.controller';
+
+describe('Meetings export form controller', () => {
+  let ctx:StimulusTestContext;
+  let FormController:typeof FormControllerType;
+  let addError:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: FormController } = await import('./form.controller'));
+  });
+
+  beforeEach(async () => {
+    addError = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { notifications: { addError } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'meetings--export--form': FormController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form action="/meetings/export.json"
+            data-controller="meetings--export--form"
+            data-meetings--export--form-job-status-dialog-url-value="/job_statuses/_job_uuid_/dialog">
+        <input type="hidden" name="format" value="pdf">
+      </form>
+    `);
+    return ctx.getController<FormControllerType>('meetings--export--form');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      notifications: { addError },
+    });
+  });
+
+  it('reports a failed export request as an error notification', async () => {
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    const controller = await renderForm();
+
+    controller.submitForm(new CustomEvent('submit'));
+
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalledWith(new Error('network down'));
+    });
+  });
+
+  it('does not notify when disconnected before the plugin context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    const controller = await renderForm();
+    const form = ctx.container.querySelector('form')!;
+
+    controller.submitForm(new CustomEvent('submit'));
+    await ctx.nextFrame();
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { notifications: { addError } } });
+    await ctx.nextFrame();
+
+    expect(addError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/meetings/export/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/export/form.controller.ts
@@ -1,16 +1,25 @@
 import {Controller} from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
 import {HttpErrorResponse} from '@angular/common/http';
+import {useAngularServices, type PickedServices, type ServiceKey} from 'core-stimulus/mixins/use-angular-services';
 
 export default class FormController extends Controller<HTMLFormElement> {
+    static services:ServiceKey[] = ['notifications'];
+
     static values = {
         jobStatusDialogUrl: String,
     };
 
     static targets = ['inputGroups'];
 
+    declare services:Promise<PickedServices<'notifications'>>;
+
     declare jobStatusDialogUrlValue:string;
     declare inputGroupsTargets:HTMLElement[];
+
+    initialize() {
+        useAngularServices(this);
+    }
 
     jobModalUrl(job_id:string):string {
         return this.jobStatusDialogUrlValue.replace('_job_uuid_', job_id);
@@ -57,15 +66,14 @@ export default class FormController extends Controller<HTMLFormElement> {
         this.requestExport(this.generateExportURL(formData))
             .then((job_id) => this.showJobModal(job_id))
             .catch((error:unknown) => {
-                this.handleError(error);
+                void this.handleError(error);
             });
         return true;
     }
 
-    private handleError(error:unknown) {
-        void window.OpenProject.getPluginContext().then((pluginContext) => {
-            pluginContext.services.notifications.addError(error as HttpErrorResponse);
-        });
+    private async handleError(error:unknown) {
+        const {notifications} = await this.services;
+        notifications.addError(error as HttpErrorResponse);
     }
 
     private getExportParams(formData:FormData):string {

--- a/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.spec.ts
@@ -1,0 +1,125 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type FormControllerType from './form.controller';
+
+describe('Meetings form controller', () => {
+  let ctx:StimulusTestContext;
+  let FormController:typeof FormControllerType;
+  let request:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: FormController } = await import('./form.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { request },
+          pathHelperService: { staticBase: '/op' },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'meetings--form': FormController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form data-controller="meetings--form">
+        <input name="meeting[start_date]" value="2026-06-11">
+        <input name="meeting[start_time_hour]" value="10:00">
+      </form>
+    `);
+    return ctx.getController<FormControllerType>('meetings--form');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('requests the timezone turbo stream with the form values', async () => {
+    const controller = await renderForm();
+
+    void controller.updateTimezoneText();
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalled();
+    });
+    const url = request.mock.calls[0][0] as string;
+    expect(url).toContain('/op/meetings/fetch_timezone?');
+    expect(url).toContain(encodeURIComponent('meeting[start_date]'));
+    expect(url).toContain('2026-06-11');
+  });
+
+  it('does not request when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderForm();
+    const form = ctx.container.querySelector('form')!;
+
+    void controller.updateTimezoneText();
+    await ctx.nextFrame();
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { request },
+        pathHelperService: { staticBase: '/op' },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
@@ -29,20 +29,19 @@
  */
 
 import { ApplicationController } from 'stimulus-use';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class extends ApplicationController {
-  protected turboRequests:TurboRequestsService;
-  protected pathHelper:PathHelperService;
+  static services:ServiceKey[] = ['turboRequests', 'pathHelperService'];
 
-  async connect() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
+  declare services:Promise<PickedServices<'turboRequests'|'pathHelperService'>>;
+
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
   }
 
-  updateTimezoneText():void {
+  async updateTimezoneText() {
     const data = new FormData(this.element as HTMLFormElement);
     const urlSearchParams = new URLSearchParams();
     let key:string;
@@ -52,10 +51,10 @@ export default class extends ApplicationController {
       urlSearchParams.append(key, data.get(key) as string);
     });
 
-    void this
-      .turboRequests
+    const { turboRequests, pathHelperService } = await this.services;
+    void turboRequests
       .request(
-        `${this.pathHelper.staticBase}/meetings/fetch_timezone?${urlSearchParams.toString()}`,
+        `${pathHelperService.staticBase}/meetings/fetch_timezone?${urlSearchParams.toString()}`,
         {
           headers: {
             Accept: 'text/vnd.turbo-stream.html',

--- a/frontend/src/stimulus/controllers/dynamic/meetings/submit.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/submit.controller.spec.ts
@@ -1,0 +1,119 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type SubmitControllerType from './submit.controller';
+
+describe('Meetings submit controller', () => {
+  let ctx:StimulusTestContext;
+  let SubmitController:typeof SubmitControllerType;
+  let request:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: SubmitController } = await import('./submit.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { turboRequests: { request } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'meetings--submit': SubmitController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderActions() {
+    await ctx.mount(`
+      <div data-controller="meetings--submit">
+        <a data-href="/meetings/1/change_state" data-method="PUT">Close meeting</a>
+      </div>
+    `);
+    return ctx.getController<SubmitControllerType>('meetings--submit');
+  }
+
+  function fakeClick(target:Element):Event {
+    return { preventDefault: vi.fn(), currentTarget: target } as unknown as Event;
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderActions();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('sends the intercepted action as a turbo stream request', async () => {
+    const controller = await renderActions();
+    const link = ctx.container.querySelector('a')!;
+
+    controller.intercept(fakeClick(link));
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalled();
+    });
+    const [url, options] = request.mock.calls[0] as [string, { method:string }];
+    expect(url).toContain('/meetings/1/change_state');
+    expect(options.method).toBe('PUT');
+  });
+
+  it('does not send when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderActions();
+    const root = ctx.container.querySelector('[data-controller="meetings--submit"]')!;
+    const link = ctx.container.querySelector('a')!;
+
+    controller.intercept(fakeClick(link));
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { turboRequests: { request } } });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/meetings/submit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/submit.controller.ts
@@ -29,13 +29,16 @@
  */
 
 import { ApplicationController, useMeta } from 'stimulus-use';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 import { BeforeunloadController } from '../../beforeunload.controller';
 import { appendCollapsedState } from '../../../helpers/meetings-helpers';
 import { hasUnsavedChanges } from '../../../helpers/meetings-helpers';
 
 export default class extends ApplicationController {
-  private turboRequests:TurboRequestsService;
+  static services:ServiceKey[] = ['turboRequests'];
+
+  declare services:Promise<PickedServices<'turboRequests'>>;
+
   private beforeUnloadController:BeforeunloadController;
   private boundBeforeUnloadHandler = this.beforeUnloadHandler.bind(this);
 
@@ -45,18 +48,16 @@ export default class extends ApplicationController {
 
   private isSubmittingOutcomeForm = false;
 
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
+  }
+
   connect():void {
     useMeta(this, { suffix: false });
 
     window.addEventListener('beforeunload', this.boundBeforeUnloadHandler);
     this.beforeUnloadController = this.application.getControllerForElementAndIdentifier(document.body, 'beforeunload') as BeforeunloadController;
-
-    void this.initializeTurboRequests();
-  }
-
-  private async initializeTurboRequests():Promise<void> {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
   }
 
   interceptOutcomeFormSubmission(event:SubmitEvent):void {
@@ -79,13 +80,18 @@ export default class extends ApplicationController {
 
     this.isSubmittingOutcomeForm = true;
 
-    void this.turboRequests.request(form.action, {
-      method: form.method.toUpperCase(),
+    void this.submitOutcomeForm(form.action, form.method.toUpperCase(), new FormData(form));
+  }
+
+  private async submitOutcomeForm(url:string, method:string, body:FormData):Promise<void> {
+    const { turboRequests } = await this.services;
+    void turboRequests.request(url, {
+      method,
       headers: {
         'X-CSRF-Token': this.csrfToken,
         Accept: 'text/vnd.turbo-stream.html',
       },
-      body: new FormData(form),
+      body,
     }).finally(() => {
       this.isSubmittingOutcomeForm = false;
     });
@@ -113,10 +119,10 @@ export default class extends ApplicationController {
     if (hasUnsavedChanges()) {
       if (window.confirm(I18n.t('js.text_are_you_sure_to_cancel'))) {
         window.OpenProject.pageState = 'pristine';
-        this.sendRequest(url, method);
+        void this.sendRequest(url, method);
       }
     } else {
-      this.sendRequest(url, method);
+      void this.sendRequest(url, method);
     }
   }
 
@@ -126,8 +132,9 @@ export default class extends ApplicationController {
     }
   }
 
-  private sendRequest(url:string, method:string):void {
-    void this.turboRequests.request(url, {
+  private async sendRequest(url:string, method:string):Promise<void> {
+    const { turboRequests } = await this.services;
+    void turboRequests.request(url, {
       method: method,
       headers: {
         'X-CSRF-Token': this.csrfToken,

--- a/frontend/src/stimulus/controllers/dynamic/menus/main-toggle.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/menus/main-toggle.controller.spec.ts
@@ -1,0 +1,112 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type MainToggleControllerType from './main-toggle.controller';
+
+describe('Main menu toggle controller', () => {
+  let ctx:StimulusTestContext;
+  let MainToggleController:typeof MainToggleControllerType;
+  let initializeMenu:Mock;
+  let toggleNavigation:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({
+    injector: { get: () => ({ initializeMenu, toggleNavigation }) },
+  });
+
+  beforeAll(async () => {
+    ({ default: MainToggleController } = await import('./main-toggle.controller'));
+  });
+
+  beforeEach(async () => {
+    initializeMenu = vi.fn();
+    toggleNavigation = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve(pluginContext()),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'menus--main-toggle': MainToggleController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderToggle() {
+    await ctx.mount('<button data-controller="menus--main-toggle"></button>');
+    return ctx.getController<MainToggleControllerType>('menus--main-toggle');
+  }
+
+  it('initializes the menu service after connect', async () => {
+    await renderToggle();
+
+    await waitFor(() => {
+      expect(initializeMenu).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('delegates navigation toggles to the menu service', async () => {
+    const controller = await renderToggle();
+    await waitFor(() => {
+      expect(initializeMenu).toHaveBeenCalled();
+    });
+
+    const event = new CustomEvent('click');
+    controller.toggleNavigation(event);
+
+    expect(toggleNavigation).toHaveBeenCalledWith(event);
+  });
+
+  it('does not initialize the menu when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderToggle();
+    const button = ctx.container.querySelector('button')!;
+
+    button.remove();
+    await ctx.nextFrame();
+
+    resolveContext(pluginContext());
+    await ctx.nextFrame();
+
+    expect(initializeMenu).not.toHaveBeenCalled();
+    expect(controller.pluginContext).toBeInstanceOf(Promise);
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/menus/main-toggle.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/menus/main-toggle.controller.ts
@@ -1,18 +1,19 @@
 import { Controller } from '@hotwired/stimulus';
 import { MainMenuToggleService } from 'core-app/core/main-menu/main-menu-toggle.service';
+import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { useAngularServices } from 'core-stimulus/mixins/use-angular-services';
 
 export default class MainToggleController extends Controller {
+  declare pluginContext:Promise<OpenProjectPluginContext>;
+
   mainMenuService:MainMenuToggleService|undefined;
 
-  connect() {
-    window.OpenProject.getPluginContext()
-      .then((pluginContext) => pluginContext.injector.get(MainMenuToggleService))
-      .then((service) => {
-        if (!this.element.isConnected) return;
-        this.mainMenuService = service;
-        this.mainMenuService.initializeMenu();
-      })
-      .catch(() => { /* Do nothing */ });
+  initialize() {
+    useAngularServices(this);
+  }
+
+  servicesConnected() {
+    void this.connectMenuService();
   }
 
   disconnect() {
@@ -21,5 +22,16 @@ export default class MainToggleController extends Controller {
 
   toggleNavigation(e:Event) {
     this.mainMenuService?.toggleNavigation(e);
+  }
+
+  private async connectMenuService() {
+    try {
+      const { injector } = await this.pluginContext;
+      this.mainMenuService = injector.get(MainMenuToggleService);
+      this.mainMenuService.initializeMenu();
+    } catch {
+      // Keep swallowing injector failures, as the previous chain did — the
+      // toggle then stays inert instead of erroring on every page.
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/menus/main.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/menus/main.controller.spec.ts
@@ -1,0 +1,112 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type MainMenuControllerType from './main.controller';
+
+describe('Main menu controller', () => {
+  let ctx:StimulusTestContext;
+  let MainMenuController:typeof MainMenuControllerType;
+  let next:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({
+    injector: { get: () => ({ navigationEvents$: { next } }) },
+  });
+
+  beforeAll(async () => {
+    ({ default: MainMenuController } = await import('./main.controller'));
+  });
+
+  beforeEach(async () => {
+    next = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve(pluginContext()),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'menus--main': MainMenuController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderMenu() {
+    await ctx.mount(`
+      <div data-controller="menus--main">
+        <div data-menus--main-target="sidebar"></div>
+        <ul data-menus--main-target="root">
+          <li data-name="overview" class="open"><a class="toggler">Overview</a></li>
+        </ul>
+      </div>
+    `);
+    return ctx.getController<MainMenuControllerType>('menus--main');
+  }
+
+  it('exposes the full plugin context as a promise', async () => {
+    const controller = await renderMenu();
+
+    await expect(controller.pluginContext).resolves.toMatchObject({
+      injector: expect.anything() as unknown,
+    });
+  });
+
+  it('publishes the active menu entry on initialize', async () => {
+    await renderMenu();
+
+    await waitFor(() => {
+      expect(next).toHaveBeenCalledWith('overview');
+    });
+  });
+
+  it('publishes nothing when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderMenu();
+    const root = ctx.container.querySelector('[data-controller="menus--main"]')!;
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext(pluginContext());
+    await ctx.nextFrame();
+
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/menus/main.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/menus/main.controller.ts
@@ -1,5 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { MainMenuNavigationService } from 'core-app/core/main-menu/main-menu-navigation.service';
+import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { useAngularServices } from 'core-stimulus/mixins/use-angular-services';
 
 export default class MainMenuController extends Controller {
   static targets = [
@@ -12,14 +14,19 @@ export default class MainMenuController extends Controller {
   declare readonly rootTarget:HTMLElement;
   declare readonly itemTargets:HTMLElement[];
 
+  declare pluginContext:Promise<OpenProjectPluginContext>;
+
   initialize() {
+    // Must come first: markActive() below already reads this.pluginContext.
+    useAngularServices(this);
+
     if (this.rootTarget.classList.contains('closed')) {
       this.sidebarTarget.classList.add('-hidden');
     }
 
     const active = this.getActiveMenuName();
     if (active) {
-      this.markActive(active);
+      void this.markActive(active);
     }
   }
 
@@ -34,7 +41,7 @@ export default class MainMenuController extends Controller {
     targetLi.querySelector<HTMLElement>('li > a, .tree-menu--title')?.focus();
 
     targetLi.querySelector<HTMLElement>('.main-menu--arrow-left-to-project')?.focus();
-    this.markActive(targetLi.dataset.name!);
+    void this.markActive(targetLi.dataset.name!);
   }
 
   ascend(event:MouseEvent) {
@@ -56,10 +63,9 @@ export default class MainMenuController extends Controller {
     return (activeItem || activeRoot)?.dataset.name;
   }
 
-  private markActive(active:string):void {
-    void window.OpenProject.getPluginContext()
-      .then((pluginContext) => pluginContext.injector.get(MainMenuNavigationService))
-      .then((service) => service.navigationEvents$.next(active));
+  private async markActive(active:string) {
+    const { injector } = await this.pluginContext;
+    injector.get(MainMenuNavigationService).navigationEvents$.next(active);
   }
 
   private toggleMenuState(item:HTMLElement) {

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.spec.ts
@@ -1,0 +1,157 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { type ActionEvent } from '@hotwired/stimulus';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type MyTimeTrackingControllerType from './time-tracking.controller';
+
+describe('My time tracking controller', () => {
+  let ctx:StimulusTestContext;
+  let MyTimeTrackingController:typeof MyTimeTrackingControllerType;
+  let request:Mock;
+  let myTimeTrackingRefresh:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: MyTimeTrackingController } = await import('./time-tracking.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    myTimeTrackingRefresh = vi.fn().mockReturnValue('/my/time_tracking/refresh?date=2026-06-01');
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { request },
+          pathHelperService: {
+            timeEntryDialog: () => '/time_entries/dialog',
+            myTimeTrackingRefresh,
+          },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'my--time-tracking': MyTimeTrackingController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  // The calendar view needs FullCalendar; the list view exercises the
+  // service wiring without it.
+  async function renderListView() {
+    await ctx.mount(`
+      <div data-controller="my--time-tracking"
+           data-my--time-tracking-view-mode-value="list"
+           data-my--time-tracking-mode-value="week"></div>
+    `);
+    return ctx.getController<MyTimeTrackingControllerType>('my--time-tracking');
+  }
+
+  function dialogClosed(detail:object) {
+    document.dispatchEvent(new CustomEvent('dialog:close', { detail }));
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderListView();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('requests the time entry dialog for a new time entry', async () => {
+    const controller = await renderListView();
+
+    void controller.newTimeEntry({ params: { date: '2026-06-01' } } as unknown as ActionEvent);
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/time_entries/dialog?onlyMe=true&date=2026-06-01',
+        { method: 'GET' },
+      );
+    });
+  });
+
+  it('refreshes the list when the time entry dialog was submitted', async () => {
+    const controller = await renderListView();
+    await waitFor(() => { expect(controller.turboRequests).toBeDefined(); });
+
+    dialogClosed({
+      dialog: { id: 'time-entry-dialog' },
+      additional: { spent_on: '2026-06-01' },
+      submitted: true,
+    });
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('/my/time_tracking/refresh?date=2026-06-01', { method: 'GET' });
+    });
+    expect(myTimeTrackingRefresh).toHaveBeenCalledWith('2026-06-01', 'list', 'week');
+  });
+
+  it('ignores dialog close events arriving before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderListView();
+    const root = ctx.container.querySelector('[data-controller="my--time-tracking"]')!;
+
+    dialogClosed({
+      dialog: { id: 'time-entry-dialog' },
+      additional: { spent_on: '2026-06-01' },
+      submitted: true,
+    });
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { request },
+        pathHelperService: {
+          timeEntryDialog: () => '/time_entries/dialog',
+          myTimeTrackingRefresh,
+        },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -5,8 +5,8 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import momentTimezonePlugin from '@fullcalendar/moment-timezone';
 import { toMoment } from '@fullcalendar/moment';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import type { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import type { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import moment from 'moment';
 import allLocales from '@fullcalendar/core/locales-all';
 import { renderStreamMessage } from '@hotwired/turbo';
@@ -14,10 +14,14 @@ import { opStopwatchStopIconData, toDOMString } from '@openproject/octicons-angu
 import { useMeta } from 'stimulus-use';
 import { html, render, TemplateResult } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class MyTimeTrackingController extends Controller {
-  private turboRequests:TurboRequestsService;
-  private pathHelper:PathHelperService;
+  static services:ServiceKey[] = ['turboRequests', 'pathHelperService'];
+
+  declare turboRequests:TurboRequestsService;
+  declare pathHelperService:PathHelperService;
+  declare services:Promise<PickedServices<'turboRequests'|'pathHelperService'>>;
 
   static targets = ['calendar'];
 
@@ -58,12 +62,15 @@ export default class MyTimeTrackingController extends Controller {
   private DEFAULT_TIMED_EVENT_DURATION = '01:00';
   private boundListener = this.dialogCloseListener.bind(this);
 
-  async connect() {
-    useMeta(this, { suffix: false });
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
+  initialize() {
+    useAngularServices(this);
+  }
 
+  connect() {
+    useMeta(this, { suffix: false });
+  }
+
+  servicesConnected() {
     if (this.hasCalendarTarget && this.viewModeValue === 'calendar') {
       this.initializeCalendar();
 
@@ -143,7 +150,7 @@ export default class MyTimeTrackingController extends Controller {
         }
 
         void this.turboRequests.request(
-          `${this.pathHelper.timeEntryDialog()}?${dialogParams}`,
+          `${this.pathHelperService.timeEntryDialog()}?${dialogParams}`,
           { method: 'GET' },
         );
       },
@@ -225,7 +232,7 @@ export default class MyTimeTrackingController extends Controller {
         }
 
         void this.turboRequests.request(
-          `${this.pathHelper.timeEntryEditDialog(info.event.id)}?onlyMe=true`,
+          `${this.pathHelperService.timeEntryEditDialog(info.event.id)}?onlyMe=true`,
           { method: 'GET' },
         );
       },
@@ -266,7 +273,7 @@ export default class MyTimeTrackingController extends Controller {
       <div class="fc-event-title-container">
         <div class="fc-event-title fc-event-wp" title="${info.event.extendedProps.workPackageSubject}">
           <a class="Link--primary Link"
-             href="${this.pathHelper.workPackageShortPath(info.event.extendedProps.workPackageId as string)}">
+             href="${this.pathHelperService.workPackageShortPath(info.event.extendedProps.workPackageId as string)}">
             ${info.event.extendedProps.workPackageSubject}
           </a>
         </div>
@@ -387,7 +394,7 @@ export default class MyTimeTrackingController extends Controller {
   }
 
   updateTimeEntry(timeEntryId:string, spentOn:string, startTime:string|null, hours:number, revertFunction:() => void) {
-    fetch(this.pathHelper.timeEntryUpdate(timeEntryId), {
+    fetch(this.pathHelperService.timeEntryUpdate(timeEntryId), {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -475,11 +482,12 @@ export default class MyTimeTrackingController extends Controller {
     return hiddenDays;
   }
 
-  newTimeEntry(event:ActionEvent) {
+  async newTimeEntry(event:ActionEvent) {
     const dialogParams = `onlyMe=true&date=${event.params.date}`;
 
-    void this.turboRequests.request(
-      `${this.pathHelper.timeEntryDialog()}?${dialogParams}`,
+    const { turboRequests, pathHelperService } = await this.services;
+    void turboRequests.request(
+      `${pathHelperService.timeEntryDialog()}?${dialogParams}`,
       { method: 'GET' },
     );
   }
@@ -504,7 +512,7 @@ export default class MyTimeTrackingController extends Controller {
     if (this.viewModeValue === 'list') {
       // we don't know what date we clicked, so we need to reload the whole page
       if (additional?.spent_on) {
-        void this.turboRequests.request(this.pathHelper.myTimeTrackingRefresh(additional.spent_on, this.viewModeValue, this.modeValue), { method: 'GET' });
+        void this.turboRequests.request(this.pathHelperService.myTimeTrackingRefresh(additional.spent_on, this.viewModeValue, this.modeValue), { method: 'GET' });
       } else {
         window.location.reload();
       }

--- a/frontend/src/stimulus/controllers/dynamic/openid-connect/match-preview-dialog.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/openid-connect/match-preview-dialog.controller.spec.ts
@@ -1,0 +1,122 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type MatchPreviewDialogControllerType from './match-preview-dialog.controller';
+
+describe('Match preview dialog controller', () => {
+  let ctx:StimulusTestContext;
+  let MatchPreviewDialogController:typeof MatchPreviewDialogControllerType;
+  let request:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: MatchPreviewDialogController } = await import('./match-preview-dialog.controller'));
+  });
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { turboRequests: { request } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'openid-connect--match-preview-dialog': MatchPreviewDialogController },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderDialog() {
+    await ctx.mount(`
+      <dialog data-controller="openid-connect--match-preview-dialog"
+              data-openid-connect--match-preview-dialog-update-url-value="/oidc/match_preview">
+        <input data-openid-connect--match-preview-dialog-target="regexpInput" value="^op-.*$">
+        <input data-openid-connect--match-preview-dialog-target="groupNamesInput" value="op-admins">
+      </dialog>
+    `);
+    return ctx.getController<MatchPreviewDialogControllerType>('openid-connect--match-preview-dialog');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderDialog();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('posts the match preview after the input debounce', async () => {
+    await renderDialog();
+    const regexpInput = ctx.container.querySelector<HTMLInputElement>('input')!;
+
+    regexpInput.dispatchEvent(new Event('input'));
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const [url, options] = request.mock.calls[0] as [string, { method:string, body:string }];
+    expect(url).toBe('/oidc/match_preview');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual({
+      preview_group_names: 'op-admins',
+      preview_regular_expressions: '^op-.*$',
+    });
+  });
+
+  it('does not post when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderDialog();
+    const dialog = ctx.container.querySelector('dialog')!;
+    const regexpInput = ctx.container.querySelector<HTMLInputElement>('input')!;
+
+    regexpInput.dispatchEvent(new Event('input'));
+    await vi.advanceTimersByTimeAsync(500);
+
+    dialog.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { turboRequests: { request } } });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/openid-connect/match-preview-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/openid-connect/match-preview-dialog.controller.ts
@@ -29,10 +29,7 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { from, Observable, of } from 'rxjs';
-import { tap } from 'rxjs/operators';
-
-import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export interface MatchPreviewDialogSubmittedEvent {
   detail:{
@@ -42,6 +39,8 @@ export interface MatchPreviewDialogSubmittedEvent {
 }
 
 export default class MatchPreviewDialogController extends Controller {
+  static services:ServiceKey[] = ['turboRequests'];
+
   static targets = [
     'regexpInput',
     'groupNamesInput',
@@ -56,9 +55,13 @@ export default class MatchPreviewDialogController extends Controller {
 
   declare dialog:HTMLDialogElement;
   declare updateUrlValue:string;
+  declare services:Promise<PickedServices<'turboRequests'>>;
+
   private updateMatchTimeout:number|null = null;
 
-  private pluginContextData:OpenProjectPluginContext|null = null;
+  initialize() {
+    useAngularServices(this);
+  }
 
   connect() {
     this.dialog = this.element as HTMLDialogElement;
@@ -87,34 +90,23 @@ export default class MatchPreviewDialogController extends Controller {
       window.clearTimeout(this.updateMatchTimeout);
     }
 
-    this.updateMatchTimeout = window.setTimeout(() => { this.doUpdateMatchPreview(); }, 500);
+    this.updateMatchTimeout = window.setTimeout(() => { void this.doUpdateMatchPreview(); }, 500);
   }
 
-  private doUpdateMatchPreview() {
-    this.pluginContext.subscribe((context) => {
-      void context.services.turboRequests.request(this.updateUrlValue, {
-        method: 'POST',
-        headers: {
-          Accept: 'text/vnd.turbo-stream.html',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          preview_group_names: this.groupNamesInputTarget.value,
-          preview_regular_expressions: this.regexpInputTarget.value,
-        }),
-      });
+  private async doUpdateMatchPreview() {
+    const body = JSON.stringify({
+      preview_group_names: this.groupNamesInputTarget.value,
+      preview_regular_expressions: this.regexpInputTarget.value,
     });
-  }
 
-  private get pluginContext():Observable<OpenProjectPluginContext> {
-    if (this.pluginContextData === null) {
-      return from(window.OpenProject.getPluginContext()).pipe(
-        tap((context) => {
-          this.pluginContextData = context;
-        }),
-      );
-    }
-
-    return of(this.pluginContextData);
+    const { turboRequests } = await this.services;
+    void turboRequests.request(this.updateUrlValue, {
+      method: 'POST',
+      headers: {
+        Accept: 'text/vnd.turbo-stream.html',
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycle-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycle-form.controller.spec.ts
@@ -1,0 +1,122 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type ProjectLifeCycleFormControllerType from './project-life-cycle-form.controller';
+
+describe('Project life cycle form controller', () => {
+  let ctx:StimulusTestContext;
+  let ProjectLifeCycleFormController:typeof ProjectLifeCycleFormControllerType;
+  let utcDateToISODateString:Mock;
+  let timezone:{ utcDateToISODateString:Mock };
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: ProjectLifeCycleFormController } = await import('./project-life-cycle-form.controller'));
+  });
+
+  beforeEach(async () => {
+    utcDateToISODateString = vi.fn((date:Date) => date.toISOString().slice(0, 10));
+    timezone = { utcDateToISODateString };
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { timezone } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'overview--project-life-cycle-form': ProjectLifeCycleFormController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form data-controller="overview--project-life-cycle-form" action="/projects/1/life_cycle">
+        <input type="text" data-overview--project-life-cycle-form-target="startDate" value="">
+        <input type="text" data-overview--project-life-cycle-form-target="finishDate" value="">
+        <input type="text" data-overview--project-life-cycle-form-target="duration" value="">
+      </form>
+    `);
+    return ctx.getController<ProjectLifeCycleFormControllerType>('overview--project-life-cycle-form');
+  }
+
+  function flatpickrDatesChanged(dates:Date[]) {
+    document.dispatchEvent(new CustomEvent('date-picker:flatpickr-dates-changed', { detail: { dates } }));
+  }
+
+  it('binds the declared timezone service after connect', async () => {
+    const controller = await renderForm();
+
+    await waitFor(() => { expect(controller.timezone).toBe(timezone); });
+  });
+
+  it('writes the changed flatpickr dates into the date fields', async () => {
+    const controller = await renderForm();
+    await waitFor(() => { expect(controller.timezone).toBe(timezone); });
+
+    flatpickrDatesChanged([new Date('2026-06-01'), new Date('2026-06-11')]);
+
+    const [startDate, finishDate] = Array.from(ctx.container.querySelectorAll('input'));
+    expect(startDate.value).toBe('2026-06-01');
+    expect(finishDate.value).toBe('2026-06-11');
+    expect(startDate.classList.contains('op-datepicker-modal--date-field_current')).toBe(true);
+  });
+
+  it('ignores flatpickr events when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderForm();
+    const form = ctx.container.querySelector('form')!;
+    const startDate = ctx.container.querySelector('input')!;
+
+    flatpickrDatesChanged([new Date('2026-06-01'), new Date('2026-06-11')]);
+    expect(startDate.value).toBe('');
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { timezone } });
+    await ctx.nextFrame();
+
+    flatpickrDatesChanged([new Date('2026-06-01'), new Date('2026-06-11')]);
+
+    expect(startDate.value).toBe('');
+    expect(utcDateToISODateString).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycle-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycle-form.controller.ts
@@ -28,7 +28,7 @@
  * ++
  */
 
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import type { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import FormPreviewController from '../../form-preview.controller';
 import {
@@ -36,9 +36,13 @@ import {
   DebouncedFunc,
 } from 'lodash';
 import { type TurboBeforeMorphAttributeEvent } from '@hotwired/turbo';
+import { useAngularServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class ProjectLifeCycleFormController extends FormPreviewController {
-  private timezoneService:TimezoneService;
+  static services:ServiceKey[] = ['timezone'];
+
+  declare timezone:TimezoneService;
+
   private deviceService:DeviceService;
   private handleFlatpickrDatesChangedBound = this.handleFlatpickrDatesChanged.bind(this);
   private updateFlatpickrCalendarBound = this.updateFlatpickrCalendar.bind(this);
@@ -53,7 +57,12 @@ export default class ProjectLifeCycleFormController extends FormPreviewControlle
 
   private readonly CURRENT_FIELD_CLASS_NAME = 'op-datepicker-modal--date-field_current';
 
-  async connect() {
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
+  }
+
+  connect() {
     super.connect();
 
     this.previewForm = debounce(() => {
@@ -62,10 +71,12 @@ export default class ProjectLifeCycleFormController extends FormPreviewControlle
       }
     }, 300);
 
-    const context = await window.OpenProject.getPluginContext();
-    this.timezoneService = context.services.timezone;
     this.deviceService = new DeviceService();
+  }
 
+  // The flatpickr listener reads the timezone service synchronously, so it may
+  // only start listening once the service is bound.
+  servicesConnected() {
     document.addEventListener('date-picker:flatpickr-dates-changed', this.handleFlatpickrDatesChangedBound);
     document.addEventListener('turbo:before-stream-render', this.updateFlatpickrCalendarBound);
     document.addEventListener('turbo:before-morph-attribute', this.preventValueMorphingActiveElementBound);
@@ -195,7 +206,7 @@ export default class ProjectLifeCycleFormController extends FormPreviewControlle
 
   private dateToIso(date:Date|null):string {
     if (date) {
-      return this.timezoneService.utcDateToISODateString(date);
+      return this.timezone.utcDateToISODateString(date);
     }
     return '';
   }

--- a/frontend/src/stimulus/controllers/dynamic/primer-to-angular-modal.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/primer-to-angular-modal.controller.spec.ts
@@ -1,0 +1,111 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type PrimerToAngularModalControllerType from './primer-to-angular-modal.controller';
+
+describe('Primer to Angular modal controller', () => {
+  let ctx:StimulusTestContext;
+  let PrimerToAngularModalController:typeof PrimerToAngularModalControllerType;
+  let closeMe:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({
+    services: { opModalService: { activeModalInstance$: { value: { closeMe } } } },
+  });
+
+  beforeAll(async () => {
+    ({ default: PrimerToAngularModalController } = await import('./primer-to-angular-modal.controller'));
+  });
+
+  beforeEach(async () => {
+    closeMe = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve(pluginContext()),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'primer-to-angular-modal': PrimerToAngularModalController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderModal() {
+    await ctx.mount('<div data-controller="primer-to-angular-modal"></div>');
+    return ctx.getController<PrimerToAngularModalControllerType>('primer-to-angular-modal');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderModal();
+
+    await expect(controller.services).resolves.toMatchObject({
+      opModalService: { activeModalInstance$: { value: { closeMe } } },
+    });
+  });
+
+  it('closes the active Angular modal', async () => {
+    const controller = await renderModal();
+    const event = new CustomEvent('click');
+
+    void controller.close(event);
+
+    await waitFor(() => {
+      expect(closeMe).toHaveBeenCalledWith(event);
+    });
+  });
+
+  it('does not close when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderModal();
+    const root = ctx.container.querySelector('[data-controller="primer-to-angular-modal"]')!;
+
+    void controller.close(new CustomEvent('click'));
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext(pluginContext());
+    await ctx.nextFrame();
+
+    expect(closeMe).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/primer-to-angular-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/primer-to-angular-modal.controller.ts
@@ -29,17 +29,21 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { from, filter, take } from 'rxjs';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class PrimerToAngularModalController extends Controller {
-  close(event:CustomEvent):void {
-    from(window.OpenProject.getPluginContext())
-      .pipe(
-        take(1),
-        filter((context) => context.services.opModalService?.activeModalInstance$ !== null),
-      )
-      .subscribe((context) => {
-        context.services.opModalService.activeModalInstance$.value?.closeMe(event);
-      });
+  static services:ServiceKey[] = ['opModalService'];
+
+  declare services:Promise<PickedServices<'opModalService'>>;
+
+  initialize() {
+    useAngularServices(this);
+  }
+
+  async close(event:CustomEvent) {
+    const { opModalService } = await this.services;
+    if (opModalService.activeModalInstance$ !== null) {
+      opModalService.activeModalInstance$.value?.closeMe(event);
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.spec.ts
@@ -1,0 +1,134 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { of } from 'rxjs';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type ProjectStorageFormControllerType from './project-storage-form.controller';
+
+describe('Project storage form controller', () => {
+  let ctx:StimulusTestContext;
+  let ProjectStorageFormController:typeof ProjectStorageFormControllerType;
+  let show:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({ services: { opModalService: { show } } });
+
+  beforeAll(async () => {
+    ({ default: ProjectStorageFormController } = await import('./project-storage-form.controller'));
+  });
+
+  beforeEach(async () => {
+    show = vi.fn().mockReturnValue(of({
+      closingEvent: of({ submitted: true, location: { id: '99', name: 'Shared folder' } }),
+    }));
+    vi.spyOn(window, 'fetch').mockResolvedValue({
+      json: () => Promise.resolve({ _links: { authorizationState: { href: 'connected' } } }),
+    } as unknown as Response);
+
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve(pluginContext()),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'project-storage-form': ProjectStorageFormController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <div data-controller="project-storage-form"
+           data-project-storage-form-folder-mode-value="manual"
+           data-project-storage-form-placeholder-folder-name-value="(none)"
+           data-project-storage-form-not-logged-in-validation-value="Login required"
+           data-project-storage-form-last-project-folders-value='{"manual":"","automatic":""}'>
+        <span data-project-storage-form-target="storage"
+              data-storage='{"_links":{"self":{"href":"/api/v3/storages/1"}}}'></span>
+        <button type="button" data-project-storage-form-target="selectProjectFolderButton"></button>
+        <button type="button" data-project-storage-form-target="loginButton"></button>
+        <section data-project-storage-form-target="projectFolderSection"></section>
+        <input data-project-storage-form-target="projectFolderIdInput" value="">
+        <span data-project-storage-form-target="projectFolderIdValidation"></span>
+        <span data-project-storage-form-target="selectedFolderText"></span>
+      </div>
+    `);
+    return ctx.getController<ProjectStorageFormControllerType>('project-storage-form');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      opModalService: { show },
+    });
+  });
+
+  it('opens the location picker and applies the chosen folder', async () => {
+    const controller = await renderForm();
+
+    void controller.selectProjectFolder(new CustomEvent('click'));
+
+    await waitFor(() => {
+      expect(show).toHaveBeenCalled();
+    });
+    const folderText = ctx.container.querySelector<HTMLElement>('[data-project-storage-form-target="selectedFolderText"]')!;
+    const folderIdInput = ctx.container.querySelector<HTMLInputElement>('[data-project-storage-form-target="projectFolderIdInput"]')!;
+    expect(folderText.innerText).toBe('Shared folder');
+    expect(folderIdInput.value).toBe('99');
+  });
+
+  it('does not open the picker when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderForm();
+    const root = ctx.container.querySelector('[data-controller="project-storage-form"]')!;
+
+    void controller.selectProjectFolder(new CustomEvent('click'));
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext(pluginContext());
+    await ctx.nextFrame();
+
+    expect(show).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
@@ -43,14 +43,16 @@ import {
 
 import { IStorage } from 'core-app/core/state/storages/storage.model';
 import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
-import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import {
   LocationPickerModalComponent,
 } from 'core-app/shared/components/storages/location-picker-modal/location-picker-modal.component';
 import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outlet-target.enum';
 import { storageConnected } from 'core-app/shared/components/storages/storages-constants.const';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class ProjectStorageFormController extends Controller {
+  static services:ServiceKey[] = ['opModalService'];
+
   static targets = [
     'projectFolderSection',
     'projectFolderIdInput',
@@ -84,6 +86,12 @@ export default class ProjectStorageFormController extends Controller {
   declare readonly hasProjectFolderIdValidationTarget:boolean;
   declare readonly hasProjectFolderSectionTarget:boolean;
 
+  declare services:Promise<PickedServices<'opModalService'>>;
+
+  initialize() {
+    useAngularServices(this);
+  }
+
   connect():void {
     combineLatest([
       this.fetchStorageAuthorizationState(),
@@ -95,30 +103,27 @@ export default class ProjectStorageFormController extends Controller {
     });
   }
 
-  selectProjectFolder(_evt:Event):void {
+  async selectProjectFolder(_evt:Event) {
     const locals = {
       projectFolderHref: this.projectFolderHref,
       createFolderHref: `${this.storage._links.self.href}/folders`,
       storage: this.storage,
     };
 
-    this.pluginContext.subscribe((context) => {
-      context.runInZone(() => {
-        context.services.opModalService
-          .show(LocationPickerModalComponent, 'global', locals, false, false, this.OutletTarget)
-          .pipe(
-            switchMap((modal) => modal.closingEvent),
-            filter((modal) => modal.submitted),
-          )
-          .subscribe((modal) => {
-            if (this.hasProjectFolderIdValidationTarget) {
-              this.projectFolderIdValidationTarget.style.display = 'none';
-            }
-            this.selectedFolderTextTarget.innerText = modal.location.name;
-            this.projectFolderIdInputTarget.value = modal.location.id as string;
-          });
+    const { opModalService } = await this.services;
+    opModalService
+      .show(LocationPickerModalComponent, 'global', locals, false, false, this.OutletTarget)
+      .pipe(
+        switchMap((modal) => modal.closingEvent),
+        filter((modal) => modal.submitted),
+      )
+      .subscribe((modal) => {
+        if (this.hasProjectFolderIdValidationTarget) {
+          this.projectFolderIdValidationTarget.style.display = 'none';
+        }
+        this.selectedFolderTextTarget.innerText = modal.location.name;
+        this.projectFolderIdInputTarget.value = modal.location.id as string;
       });
-    });
   }
 
   updateForm(evt:InputEvent):void {
@@ -146,10 +151,6 @@ export default class ProjectStorageFormController extends Controller {
     this.folderModeValue = mode;
     this.toggleFolderDisplay(mode);
     this.setProjectFolderModeQueryParam(mode);
-  }
-
-  protected get pluginContext():Observable<OpenProjectPluginContext> {
-    return from(window.OpenProject.getPluginContext());
   }
 
   protected get OutletTarget():PortalOutletTarget {

--- a/frontend/src/stimulus/controllers/dynamic/projects/wizard.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/projects/wizard.controller.spec.ts
@@ -1,0 +1,130 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type WizardControllerType from './wizard.controller';
+
+describe('Projects wizard controller', () => {
+  let ctx:StimulusTestContext;
+  let WizardController:typeof WizardControllerType;
+  let requestStream:Mock;
+  let projectCreationWizardHelpTextPath:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: WizardController } = await import('./wizard.controller'));
+  });
+
+  beforeEach(async () => {
+    requestStream = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    projectCreationWizardHelpTextPath = vi.fn().mockReturnValue('/projects/wizard/help_text/42');
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { requestStream },
+          pathHelperService: { projectCreationWizardHelpTextPath },
+          currentProject: { identifier: 'my-project' },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'projects--wizard': WizardController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderWizard() {
+    await ctx.mount(`
+      <div data-controller="projects--wizard">
+        <div data-custom-field-id="42">
+          <input type="text">
+        </div>
+      </div>
+    `);
+    return ctx.getController<WizardControllerType>('projects--wizard');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderWizard();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { requestStream },
+      currentProject: { identifier: 'my-project' },
+    });
+  });
+
+  it('requests the help text for the focused custom field', async () => {
+    const controller = await renderWizard();
+    const input = ctx.container.querySelector('input')!;
+
+    controller.handleFieldFocus({ target: input } as unknown as FocusEvent);
+
+    await waitFor(() => {
+      expect(requestStream).toHaveBeenCalledWith('/projects/wizard/help_text/42');
+    });
+    expect(projectCreationWizardHelpTextPath).toHaveBeenCalledWith('my-project', '42');
+  });
+
+  it('does not request help text when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderWizard();
+    const root = ctx.container.querySelector('[data-controller="projects--wizard"]')!;
+    const input = ctx.container.querySelector('input')!;
+
+    controller.handleFieldFocus({ target: input } as unknown as FocusEvent);
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { requestStream },
+        pathHelperService: { projectCreationWizardHelpTextPath },
+        currentProject: { identifier: 'my-project' },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(requestStream).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/projects/wizard.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/projects/wizard.controller.ts
@@ -29,23 +29,17 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class WizardController extends Controller {
+  static services:ServiceKey[] = ['turboRequests', 'pathHelperService', 'currentProject'];
+
+  declare services:Promise<PickedServices<'turboRequests'|'pathHelperService'|'currentProject'>>;
+
   private currentFieldId:string|null = null;
 
-  private turboRequests:TurboRequestsService;
-  private pathHelper:PathHelperService;
-  private currentProject:CurrentProjectService;
-
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  async connect() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
-    this.currentProject = context.services.currentProject;
+  initialize() {
+    useAngularServices(this);
   }
 
   handleFieldFocus(event:FocusEvent):void {
@@ -68,8 +62,9 @@ export default class WizardController extends Controller {
     return null;
   }
 
-  private updateHelpText(customFieldId:string) {
-    const url = this.pathHelper.projectCreationWizardHelpTextPath(this.currentProject.identifier!, customFieldId);
-    void this.turboRequests.requestStream(url);
+  private async updateHelpText(customFieldId:string) {
+    const { turboRequests, pathHelperService, currentProject } = await this.services;
+    const url = pathHelperService.projectCreationWizardHelpTextPath(currentProject.identifier!, customFieldId);
+    void turboRequests.requestStream(url);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.spec.ts
@@ -1,0 +1,125 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type RecurringMeetingsFormControllerType from './form.controller';
+
+describe('Recurring meetings form controller', () => {
+  let ctx:StimulusTestContext;
+  let RecurringMeetingsFormController:typeof RecurringMeetingsFormControllerType;
+  let request:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: RecurringMeetingsFormController } = await import('./form.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { request },
+          pathHelperService: { staticBase: '/op' },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'recurring-meetings--form': RecurringMeetingsFormController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form data-controller="recurring-meetings--form">
+        <input name="meeting[start_date]" value="2026-06-11">
+        <input name="meeting[frequency]" value="weekly">
+      </form>
+    `);
+    return ctx.getController<RecurringMeetingsFormControllerType>('recurring-meetings--form');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('requests the humanized schedule with the form values', async () => {
+    const controller = await renderForm();
+
+    void controller.updateFrequencyText();
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalled();
+    });
+    const url = request.mock.calls[0][0] as string;
+    expect(url).toContain('/op/recurring_meetings/humanize_schedule?');
+    expect(url).toContain('2026-06-11');
+    expect(url).toContain('weekly');
+  });
+
+  it('does not request when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderForm();
+    const form = ctx.container.querySelector('form')!;
+
+    void controller.updateFrequencyText();
+    await ctx.nextFrame();
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { request },
+        pathHelperService: { staticBase: '/op' },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
@@ -7,7 +7,7 @@ export default class OpRecurringMeetingsFormController extends OpMeetingsFormCon
 
   declare persistedValue:boolean;
 
-  updateFrequencyText():void {
+  async updateFrequencyText() {
     const data = new FormData(this.element as HTMLFormElement);
     const urlSearchParams = new URLSearchParams();
     [
@@ -24,10 +24,10 @@ export default class OpRecurringMeetingsFormController extends OpMeetingsFormCon
       urlSearchParams.append(key, data.get(key) as string);
     });
 
-    void this
-      .turboRequests
+    const { turboRequests, pathHelperService } = await this.services;
+    void turboRequests
       .request(
-        `${this.pathHelper.staticBase}/recurring_meetings/humanize_schedule?${urlSearchParams.toString()}`,
+        `${pathHelperService.staticBase}/recurring_meetings/humanize_schedule?${urlSearchParams.toString()}`,
         {
           headers: {
             Accept: 'text/vnd.turbo-stream.html',
@@ -36,12 +36,12 @@ export default class OpRecurringMeetingsFormController extends OpMeetingsFormCon
       );
   }
 
-  updateTimezoneText() {
+  async updateTimezoneText() {
     // We don't update the timezone text on editing recurring meetings
     if (this.persistedValue) {
       return;
     }
 
-    super.updateTimezoneText();
+    await super.updateTimezoneText();
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/repository-navigation.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/repository-navigation.controller.spec.ts
@@ -1,0 +1,126 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { of } from 'rxjs';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type RepositoryNavigationControllerType from './repository-navigation.controller';
+
+describe('Repository navigation controller', () => {
+  let ctx:StimulusTestContext;
+  let RepositoryNavigationController:typeof RepositoryNavigationControllerType;
+  let get:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: RepositoryNavigationController } = await import('./repository-navigation.controller'));
+  });
+
+  beforeEach(async () => {
+    get = vi.fn().mockReturnValue(of('<div class="loaded-entry"></div>'));
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { http: { get } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'repository-navigation': RepositoryNavigationController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderBrowser() {
+    await ctx.mount(`
+      <div data-controller="repository-navigation">
+        <input data-repository-navigation-target="revision" value="">
+        <div data-repository-navigation-target="repoBrowser">
+          <a data-element="entry-1" data-url="/repository/dir?path=sub"
+             data-action="repository-navigation#toggleDirectory">sub/</a>
+          <div id="entry-1"></div>
+        </div>
+      </div>
+    `);
+    return ctx.getController<RepositoryNavigationControllerType>('repository-navigation');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderBrowser();
+
+    await expect(controller.services).resolves.toMatchObject({
+      http: { get },
+    });
+  });
+
+  it('loads and expands a directory on toggle', async () => {
+    const controller = await renderBrowser();
+    const link = ctx.container.querySelector('a')!;
+    const content = ctx.container.querySelector<HTMLElement>('#entry-1')!;
+
+    controller.toggleDirectory({ target: link } as unknown as MouseEvent);
+
+    expect(content.classList.contains('loading')).toBe(true);
+
+    await waitFor(() => {
+      expect(get).toHaveBeenCalledWith('/repository/dir?path=sub', { responseType: 'text' });
+    });
+    await waitFor(() => {
+      expect(content.classList.contains('open')).toBe(true);
+    });
+    expect(content.classList.contains('loading')).toBe(false);
+    expect(ctx.container.querySelector('.loaded-entry')).not.toBeNull();
+  });
+
+  it('does not load when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderBrowser();
+    const root = ctx.container.querySelector('[data-controller="repository-navigation"]')!;
+    const link = ctx.container.querySelector('a')!;
+
+    controller.toggleDirectory({ target: link } as unknown as MouseEvent);
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { http: { get } } });
+    await ctx.nextFrame();
+
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/repository-navigation.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/repository-navigation.controller.ts
@@ -29,9 +29,11 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { HttpClient } from '@angular/common/http';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class RepositoryNavigationController extends Controller {
+  static services:ServiceKey[] = ['http'];
+
   static targets = [
     'revision',
     'branch',
@@ -54,16 +56,17 @@ export default class RepositoryNavigationController extends Controller {
 
   declare readonly repoBrowserTarget:HTMLFormElement;
 
-  private http:HttpClient;
+  declare services:Promise<PickedServices<'http'>>;
 
-  async connect() {
+  initialize() {
+    useAngularServices(this);
+  }
+
+  connect() {
     // If we're viewing a tag or branch, don't display it in the revision box
     if (this.tagSelected || this.branchSelected) {
       this.revisionTarget.value = '';
     }
-
-    const context = await window.OpenProject.getPluginContext();
-    this.http = context.services.http;
   }
 
   sendForm() {
@@ -100,15 +103,19 @@ export default class RepositoryNavigationController extends Controller {
     if (this.expandDir(content)) {
       content.classList.add('loading');
 
-      this
-        .http
-        .get(el.dataset.url!, { responseType: 'text' })
-        .subscribe((response:string) => {
-          content.insertAdjacentHTML('afterend', response);
-          content.classList.remove('loading');
-          this.expandItem(content);
-        });
+      void this.loadDirectory(el.dataset.url!, content);
     }
+  }
+
+  private async loadDirectory(url:string, content:HTMLElement) {
+    const { http } = await this.services;
+    http
+      .get(url, { responseType: 'text' })
+      .subscribe((response:string) => {
+        content.insertAdjacentHTML('afterend', response);
+        content.classList.remove('loading');
+        this.expandItem(content);
+      });
   }
 
   private get branchSelected():boolean {

--- a/frontend/src/stimulus/controllers/dynamic/time-entry.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/time-entry.controller.spec.ts
@@ -1,0 +1,127 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type TimeEntryControllerType from './time-entry.controller';
+
+describe('Time entry controller', () => {
+  let ctx:StimulusTestContext;
+  let TimeEntryController:typeof TimeEntryControllerType;
+  let request:Mock;
+  let timeEntriesUserTimezoneCaption:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: TimeEntryController } = await import('./time-entry.controller'));
+  });
+
+  beforeEach(async () => {
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    timeEntriesUserTimezoneCaption = vi.fn().mockReturnValue('/time_entries/user_timezone_caption/5');
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: {
+          turboRequests: { request },
+          pathHelperService: { timeEntriesUserTimezoneCaption },
+        },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'time-entry': TimeEntryController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <div data-controller="time-entry">
+        <form data-time-entry-target="form" data-refresh-form-url="/time_entries/refresh_form">
+          <input name="time_entry[user_id]" value="5">
+        </form>
+      </div>
+    `);
+    return ctx.getController<TimeEntryControllerType>('time-entry');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('requests the timezone caption when the user changes', async () => {
+    const controller = await renderForm();
+    const input = ctx.container.querySelector('input')!;
+
+    void controller.userChanged({ currentTarget: input } as unknown as InputEvent);
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('/time_entries/user_timezone_caption/5', { method: 'GET' });
+    });
+    expect(timeEntriesUserTimezoneCaption).toHaveBeenCalledWith('5');
+  });
+
+  it('does not request when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderForm();
+    const root = ctx.container.querySelector('[data-controller="time-entry"]')!;
+    const input = ctx.container.querySelector('input')!;
+
+    void controller.userChanged({ currentTarget: input } as unknown as InputEvent);
+    await ctx.nextFrame();
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: {
+        turboRequests: { request },
+        pathHelperService: { timeEntriesUserTimezoneCaption },
+      },
+    });
+    await ctx.nextFrame();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/time-entry.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/time-entry.controller.ts
@@ -29,12 +29,13 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { useMeta } from 'stimulus-use';
 import { durationStringToSeconds, formattedHour } from 'core-stimulus/helpers/chronic-duration-helper';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class TimeEntryController extends Controller {
+  static services:ServiceKey[] = ['turboRequests', 'pathHelperService'];
+
   static targets = ['startTimeInput', 'endTimeInput', 'hoursInput', 'hoursHiddenInput', 'form'];
 
   declare readonly formTarget:HTMLFormElement;
@@ -50,31 +51,31 @@ export default class TimeEntryController extends Controller {
 
   declare readonly csrfToken:string;
 
-  private turboRequests:TurboRequestsService;
-  private pathHelper:PathHelperService;
+  declare services:Promise<PickedServices<'turboRequests'|'pathHelperService'>>;
 
-  async connect() {
+  initialize() {
+    useAngularServices(this);
+  }
+
+  connect() {
     useMeta(this, { suffix: false });
-
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
 
     const workPackageAutocompleter = document.querySelector('opce-autocompleter[data-input-name*="time_entry[entity_id]"]');
     if (workPackageAutocompleter) {
-      this.oldWorkPackageId = (workPackageAutocompleter as HTMLElement).dataset.inputValue || '';
+      this.oldWorkPackageId = (workPackageAutocompleter as HTMLElement).dataset.inputValue ?? '';
     }
   }
 
-  userChanged(event:InputEvent) {
+  async userChanged(event:InputEvent) {
     const userId = (event.currentTarget as HTMLInputElement).value;
-    void this.turboRequests.request(
-      this.pathHelper.timeEntriesUserTimezoneCaption(userId),
+    const { turboRequests, pathHelperService } = await this.services;
+    void turboRequests.request(
+      pathHelperService.timeEntriesUserTimezoneCaption(userId),
       { method: 'GET' },
     );
   }
 
-  entityChanged(event:InputEvent) {
+  async entityChanged(event:InputEvent) {
     const target = event.currentTarget as HTMLInputElement;
     const newValue = target.value;
 
@@ -84,7 +85,8 @@ export default class TimeEntryController extends Controller {
       const url = this.formTarget.dataset.refreshFormUrl!;
       const formData = new FormData(this.formTarget);
       formData.delete('_method'); // remove the override method as this will submit to the wrong action
-      void this.turboRequests.request(url, {
+      const { turboRequests } = await this.services;
+      void turboRequests.request(url, {
         method: 'post',
         body: formData,
         headers: {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.spec.ts
@@ -1,0 +1,122 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type LazyPageControllerType from './lazy-page.controller';
+import type IndexController from './index.controller';
+
+describe('Activities tab lazy page controller', () => {
+  let ctx:StimulusTestContext;
+  let LazyPageController:typeof LazyPageControllerType;
+  let requestStream:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: LazyPageController } = await import('./lazy-page.controller'));
+  });
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+    requestStream = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { turboRequests: { requestStream } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'work-packages--activities-tab--lazy-page': LazyPageController },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderPage() {
+    await ctx.mount(`
+      <div data-controller="work-packages--activities-tab--lazy-page"
+           data-work-packages--activities-tab--lazy-page-url-value="/work_packages/1/activities/page"
+           data-work-packages--activities-tab--lazy-page-page-value="2"></div>
+    `);
+    const controller = ctx.getController<LazyPageControllerType>('work-packages--activities-tab--lazy-page');
+    // The index outlet lives outside this fixture; stub the part the URL
+    // builder reads.
+    controller.indexOutlet = { filterValue: 'all' } as unknown as IndexController;
+    return controller;
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderPage();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { requestStream },
+    });
+  });
+
+  it('loads the page stream after appearing in the viewport', async () => {
+    const controller = await renderPage();
+
+    controller.appear();
+    await vi.advanceTimersByTimeAsync(300);
+
+    // The intersection observer can fire appear() a second time, so only the
+    // request URL is asserted.
+    expect(requestStream).toHaveBeenCalled();
+    const url = requestStream.mock.calls[0][0] as string;
+    expect(url).toContain('/work_packages/1/activities/page');
+    expect(url).toContain('page=2');
+    expect(url).toContain('filter=all');
+  });
+
+  it('does not load when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderPage();
+    const root = ctx.container.querySelector('[data-controller="work-packages--activities-tab--lazy-page"]')!;
+
+    controller.appear();
+    await vi.advanceTimersByTimeAsync(300);
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { turboRequests: { requestStream } } });
+    await ctx.nextFrame();
+
+    expect(requestStream).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
@@ -28,11 +28,13 @@
  * ++
  */
 
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { useIntersection } from 'stimulus-use';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 import BaseController from './base.controller';
 
 export default class LazyPageController extends BaseController {
+  static services:ServiceKey[] = ['turboRequests'];
+
   static values = {
     url: String,
     page: { type: Number, default: 1 },
@@ -45,15 +47,20 @@ export default class LazyPageController extends BaseController {
   declare isLoadedValue:boolean;
   declare loadDelayMsValue:number;
 
-  private turboRequests:TurboRequestsService;
+  declare services:Promise<PickedServices<'turboRequests'>>;
+
   private stopObserving?:() => void;
   private loadTimeout?:number;
+
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
+  }
 
   connect() {
     if (this.isLoadedValue) return;
 
     super.connect();
-    void this.initializeTurboRequestService();
     this.startObserving();
   }
 
@@ -91,9 +98,10 @@ export default class LazyPageController extends BaseController {
     this.stopObserving = unobserve;
   }
 
-  private fetchPageStream():Promise<{ html:string, headers:Headers }> {
+  private async fetchPageStream():Promise<{ html:string, headers:Headers }> {
     const url = this.preparePageStreamsUrl();
-    return this.turboRequests.requestStream(url);
+    const { turboRequests } = await this.services;
+    return turboRequests.requestStream(url);
   }
 
   private preparePageStreamsUrl():string {
@@ -104,11 +112,6 @@ export default class LazyPageController extends BaseController {
     url.searchParams.set('filter', this.indexOutlet.filterValue);
 
     return url.toString();
-  }
-
-  private async initializeTurboRequestService() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
   }
 
   private cancelPendingLoad() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.spec.ts
@@ -1,0 +1,142 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type PollingControllerType from './polling.controller';
+import type IndexController from './index.controller';
+
+describe('Activities tab polling controller', () => {
+  let ctx:StimulusTestContext;
+  let PollingController:typeof PollingControllerType;
+  let request:Mock;
+  let resolveContext:(context:unknown) => void;
+  let originalOpenProject:typeof window.OpenProject;
+
+  const pluginContext = () => ({
+    services: { turboRequests: { request }, apiV3Service: {} },
+  });
+
+  beforeAll(async () => {
+    ({ default: PollingController } = await import('./polling.controller'));
+  });
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] });
+
+    request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    // The outlets must be stubbed before the context resolves, so resolution
+    // stays manual in every test. One shared promise serves all accesses.
+    const contextPromise = new Promise((resolve) => { resolveContext = resolve; });
+    window.OpenProject = {
+      getPluginContext: () => contextPromise,
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'work-packages--activities-tab--polling': PollingController },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderPolling() {
+    await ctx.mount(`
+      <div data-controller="work-packages--activities-tab--polling"
+           data-work-packages--activities-tab--polling-last-server-timestamp-value="2026-06-11T10:00:00Z"
+           data-work-packages--activities-tab--polling-update-streams-path-value="/work_packages/1/activities/update_streams"></div>
+    `);
+    const controller = ctx.getController<PollingControllerType>('work-packages--activities-tab--polling');
+
+    // The index and sibling outlets live outside this fixture; stub the parts
+    // the polling paths read.
+    controller.indexOutlet = {
+      workPackageIdValue: 1,
+      userIdValue: 2,
+      sortingValue: 'asc',
+      filterValue: 'all',
+    } as unknown as IndexController;
+    Object.defineProperty(controller, 'workPackagesActivitiesTabAutoScrollingOutlet', {
+      value: {
+        isJournalsContainerScrolledToBottom: () => false,
+        performAutoScrollingOnStreamsUpdate: vi.fn(),
+      },
+      configurable: true,
+    });
+    Object.defineProperty(controller, 'workPackagesActivitiesTabStemsOutlet', {
+      value: { handleStemVisibility: vi.fn() },
+      configurable: true,
+    });
+
+    return controller;
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderPolling();
+
+    resolveContext(pluginContext());
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { request },
+    });
+  });
+
+  it('polls the update streams path once connected', async () => {
+    await renderPolling();
+
+    resolveContext(pluginContext());
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const url = request.mock.calls[0][0] as string;
+    expect(url).toContain('/work_packages/1/activities/update_streams');
+    expect(url).toContain('sortBy=asc');
+    expect(url).toContain('filter=all');
+  });
+
+  it('stops polling on disconnect', async () => {
+    await renderPolling();
+    const root = ctx.container.querySelector('[data-controller="work-packages--activities-tab--polling"]')!;
+
+    resolveContext(pluginContext());
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    root.remove();
+    await ctx.nextFrame();
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.ts
@@ -28,13 +28,16 @@
  * ++
  */
 
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import type { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import type { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 import type AutoScrollingController from './auto-scrolling.controller';
 import BaseController from './base.controller';
 import type StemsController from './stems.controller';
 
 export default class PollingController extends BaseController {
+  static services:ServiceKey[] = ['turboRequests', 'apiV3Service'];
+
   static outlets = ['work-packages--activities-tab--auto-scrolling', 'work-packages--activities-tab--stems'];
   declare readonly workPackagesActivitiesTabAutoScrollingOutlet:AutoScrollingController;
   declare readonly workPackagesActivitiesTabStemsOutlet:StemsController;
@@ -57,19 +60,20 @@ export default class PollingController extends BaseController {
   declare readonly editFormTargets:HTMLFormElement[];
   declare readonly reactionButtonTargets:HTMLElement[];
 
+  declare turboRequests:TurboRequestsService;
+  declare apiV3Service:ApiV3Service;
+  declare services:Promise<PickedServices<'turboRequests'|'apiV3Service'>>;
+
   private updateInProgress = false;
   private intervallId:number;
-  private turboRequests:TurboRequestsService;
-  private apiV3Service:ApiV3Service;
   private abortController = new AbortController();
 
-  async connect() {
-    super.connect();
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
+  }
 
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.apiV3Service = context.services.apiV3Service;
-
+  servicesConnected() {
     this.setupEventListeners();
     this.safeUpdateWorkPackageFormsWithStateChecks();
     this.setLatestKnownChangesetUpdatedAt();

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.spec.ts
@@ -1,0 +1,110 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type CreateDialogControllerType from './create-dialog.controller';
+
+describe('Work package create dialog controller', () => {
+  let ctx:StimulusTestContext;
+  let CreateDialogController:typeof CreateDialogControllerType;
+  let submitForm:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: CreateDialogController } = await import('./create-dialog.controller'));
+  });
+
+  beforeEach(async () => {
+    submitForm = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { turboRequests: { submitForm } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'work-packages--create-dialog': CreateDialogController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form data-controller="work-packages--create-dialog"
+            data-work-packages--create-dialog-refresh-url-value="/work_packages/dialog/refresh"></form>
+    `);
+    return ctx.getController<CreateDialogControllerType>('work-packages--create-dialog');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      turboRequests: { submitForm },
+    });
+  });
+
+  it('submits the form to the refresh URL', async () => {
+    const controller = await renderForm();
+    const form = ctx.container.querySelector('form')!;
+
+    void controller.refreshForm();
+
+    await waitFor(() => {
+      expect(submitForm).toHaveBeenCalledWith(form, null, '/work_packages/dialog/refresh');
+    });
+  });
+
+  it('does not submit when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const controller = await renderForm();
+    const form = ctx.container.querySelector('form')!;
+
+    void controller.refreshForm();
+    await ctx.nextFrame();
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { turboRequests: { submitForm } } });
+    await ctx.nextFrame();
+
+    expect(submitForm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
@@ -29,24 +29,26 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class CreateDialogController extends Controller<HTMLFormElement> {
-  private turboRequests:TurboRequestsService;
+  static services:ServiceKey[] = ['turboRequests'];
 
   static values = {
     refreshUrl: String,
   };
 
+  declare services:Promise<PickedServices<'turboRequests'>>;
+
   declare refreshUrlValue:string;
 
-  async connect() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
+  initialize() {
+    useAngularServices(this);
   }
 
-  refreshForm() {
-    void this.turboRequests.submitForm(
+  async refreshForm() {
+    const { turboRequests } = await this.services;
+    void turboRequests.submitForm(
       this.element,
       null,
       this.refreshUrlValue,

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.spec.ts
@@ -1,0 +1,125 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type PreviewControllerType from './preview.controller';
+
+describe('Date picker preview controller', () => {
+  let ctx:StimulusTestContext;
+  let PreviewController:typeof PreviewControllerType;
+  let utcDateToISODateString:Mock;
+  let timezone:{ utcDateToISODateString:Mock, utcDatesToISODateStrings:Mock };
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: PreviewController } = await import('./preview.controller'));
+  });
+
+  beforeEach(async () => {
+    utcDateToISODateString = vi.fn((date:Date) => date.toISOString().slice(0, 10));
+    timezone = {
+      utcDateToISODateString,
+      utcDatesToISODateStrings: vi.fn((dates:Date[]) => dates.map((date) => date.toISOString().slice(0, 10))),
+    };
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { timezone } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'work-packages--date-picker--preview': PreviewController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderDialog() {
+    await ctx.mount(`
+      <div data-controller="work-packages--date-picker--preview">
+        <form action="/work_packages/dialog" data-work-packages--date-picker--preview-target="form">
+          <input type="text" id="work_package_start_date" name="work_package[start_date]" value=""
+                 data-work-packages--date-picker--preview-target="fieldInput">
+        </form>
+      </div>
+    `);
+    return ctx.getController<PreviewControllerType>('work-packages--date-picker--preview');
+  }
+
+  function flatpickrDatesChanged(dates:Date[]) {
+    document.dispatchEvent(new CustomEvent('date-picker:flatpickr-dates-changed', { detail: { dates } }));
+  }
+
+  it('binds the declared timezone service after connect', async () => {
+    const controller = await renderDialog();
+
+    await waitFor(() => { expect(controller.timezone).toBe(timezone); });
+  });
+
+  it('writes the changed flatpickr date into the start date field', async () => {
+    const controller = await renderDialog();
+    await waitFor(() => { expect(controller.timezone).toBe(timezone); });
+
+    flatpickrDatesChanged([new Date('2026-06-11')]);
+
+    const input = ctx.container.querySelector<HTMLInputElement>('#work_package_start_date')!;
+    expect(input.value).toBe('2026-06-11');
+    expect(utcDateToISODateString).toHaveBeenCalled();
+  });
+
+  it('ignores flatpickr events when disconnected before the context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    await renderDialog();
+    const root = ctx.container.querySelector('[data-controller="work-packages--date-picker--preview"]')!;
+    const input = ctx.container.querySelector<HTMLInputElement>('#work_package_start_date')!;
+
+    flatpickrDatesChanged([new Date('2026-06-11')]);
+    expect(input.value).toBe('');
+
+    root.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { timezone } });
+    await ctx.nextFrame();
+
+    flatpickrDatesChanged([new Date('2026-06-11')]);
+
+    expect(input.value).toBe('');
+    expect(utcDateToISODateString).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -29,13 +29,16 @@
  */
 
 import { DialogPreviewController } from '../dialog/preview.controller';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import type { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import {
   debounce,
   DebouncedFunc,
 } from 'lodash';
+import { useAngularServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class PreviewController extends DialogPreviewController {
+  static services:ServiceKey[] = ['timezone'];
+
   static values = {
     dateMode: String,
     triggeringField: String,
@@ -46,7 +49,8 @@ export default class PreviewController extends DialogPreviewController {
   declare triggeringFieldValue:string;
   declare scheduleManuallyValue:boolean;
 
-  private timezoneService:TimezoneService;
+  declare timezone:TimezoneService;
+
   private highlightedField:HTMLInputElement|null = null;
 
   // The field values currently used by the controller
@@ -62,7 +66,11 @@ export default class PreviewController extends DialogPreviewController {
   private debouncedDelayedPreview:DebouncedFunc<(input:HTMLInputElement) => void>;
   private debouncedImmediatePreview:DebouncedFunc<(input:HTMLInputElement) => void>;
 
-  async connect() {
+  initialize() {
+    useAngularServices(this);
+  }
+
+  connect() {
     // if the debounce value is changed, the following test helper must be kept
     // in sync: `spec/support/edit_fields/progress_edit_field.rb`, method `#wait_for_preview_to_complete`
     this.debouncedDelayedPreview = debounce((input:HTMLInputElement) => {
@@ -74,10 +82,11 @@ export default class PreviewController extends DialogPreviewController {
 
     this.readInitialValues();
     super.connect();
+  }
 
-    const context = await window.OpenProject.getPluginContext();
-    this.timezoneService = context.services.timezone;
-
+  // The flatpickr listener reads the timezone service synchronously, so it may
+  // only start listening once the service is bound.
+  servicesConnected() {
     document.addEventListener('date-picker:flatpickr-dates-changed', this.handleFlatpickrDatesChangedBound);
     this.focusOnOpen();
   }
@@ -266,13 +275,13 @@ export default class PreviewController extends DialogPreviewController {
   }
 
   private lastClickedDate(changedDates:Date[]):Date|null {
-    const flatPickrDates = this.timezoneService.utcDatesToISODateStrings(changedDates);
+    const flatPickrDates = this.timezone.utcDatesToISODateStrings(changedDates);
     if (flatPickrDates.length === 1) {
       return this.toDate(flatPickrDates[0]);
     }
 
     const fieldDates = _.compact([this.currentStartDate, this.currentDueDate])
-                        .map((date) => this.timezoneService.utcDateToISODateString(date));
+                        .map((date) => this.timezone.utcDateToISODateString(date));
     const diff = _.difference(flatPickrDates, fieldDates);
     return this.toDate(diff[0]);
   }
@@ -416,7 +425,7 @@ export default class PreviewController extends DialogPreviewController {
     if (targetFieldID) {
       const inputField = document.getElementById(targetFieldID);
       if (inputField) {
-        (inputField as HTMLInputElement).value = this.timezoneService.utcDateToISODateString(new Date(Date.now()));
+        (inputField as HTMLInputElement).value = this.timezone.utcDateToISODateString(new Date(Date.now()));
         inputField.dispatchEvent(new Event('input'));
       }
     }
@@ -424,7 +433,7 @@ export default class PreviewController extends DialogPreviewController {
 
   private datetoIso(date:Date|null):string {
     if (date) {
-      return this.timezoneService.utcDateToISODateString(date);
+      return this.timezone.utcDateToISODateString(date);
     }
     return '';
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.spec.ts
@@ -1,0 +1,114 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type FormControllerType from './form.controller';
+
+describe('Work package export form controller', () => {
+  let ctx:StimulusTestContext;
+  let FormController:typeof FormControllerType;
+  let addError:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: FormController } = await import('./form.controller'));
+  });
+
+  beforeEach(async () => {
+    addError = vi.fn();
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({ services: { notifications: { addError } } }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'work-packages--export--form': FormController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form action="/work_packages/export.json"
+            data-controller="work-packages--export--form"
+            data-work-packages--export--form-job-status-dialog-url-value="/job_statuses/_job_uuid_/dialog">
+        <input type="hidden" name="format" value="csv">
+      </form>
+    `);
+    return ctx.getController<FormControllerType>('work-packages--export--form');
+  }
+
+  it('binds the declared services after connect', async () => {
+    const controller = await renderForm();
+
+    await expect(controller.services).resolves.toMatchObject({
+      notifications: { addError },
+    });
+  });
+
+  it('reports a failed export request as an error notification', async () => {
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    const controller = await renderForm();
+
+    controller.submitForm(new CustomEvent('submit'));
+
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalledWith(new Error('network down'));
+    });
+  });
+
+  it('does not notify when disconnected before the plugin context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network down'));
+    const controller = await renderForm();
+    const form = ctx.container.querySelector('form')!;
+
+    controller.submitForm(new CustomEvent('submit'));
+    await ctx.nextFrame();
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({ services: { notifications: { addError } } });
+    await ctx.nextFrame();
+
+    expect(addError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
@@ -1,15 +1,24 @@
 import { Controller } from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
 import { HttpErrorResponse } from '@angular/common/http';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class FormController extends Controller<HTMLFormElement> {
+  static services:ServiceKey[] = ['notifications'];
+
   static values = {
     jobStatusDialogUrl: String,
     jobStatusDialogId: String,
   };
 
+  declare services:Promise<PickedServices<'notifications'>>;
+
   declare jobStatusDialogUrlValue:string;
   declare jobStatusDialogIdValue:string;
+
+  initialize() {
+    useAngularServices(this);
+  }
 
   jobModalUrl(job_id:string):string {
     return this.jobStatusDialogUrlValue.replace('_job_uuid_', job_id);
@@ -66,7 +75,7 @@ export default class FormController extends Controller<HTMLFormElement> {
 
     this.requestExport(this.generateExportURL(formData))
       .then((job_id) => this.showJobModal(job_id))
-      .catch((error:HttpErrorResponse) => this.handleError(error));
+      .catch((error:HttpErrorResponse) => { void this.handleError(error); });
 
     const dialog = document.getElementById(this.jobStatusDialogIdValue) as HTMLDialogElement;
     if (dialog) {
@@ -76,10 +85,9 @@ export default class FormController extends Controller<HTMLFormElement> {
     return true;
   }
 
-  private handleError(error:HttpErrorResponse) {
-    void window.OpenProject.getPluginContext().then((pluginContext) => {
-      pluginContext.services.notifications.addError(error);
-    });
+  private async handleError(error:HttpErrorResponse) {
+    const { notifications } = await this.services;
+    notifications.addError(error);
   }
 
   private findCurrentVisibleColumnSelection(formData:FormData):HTMLElement|null {

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
@@ -1,0 +1,146 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type RequirePasswordConfirmationControllerType from './require-password-confirmation.controller';
+
+describe('Require password confirmation controller', () => {
+  let ctx:StimulusTestContext;
+  let RequirePasswordConfirmationController:typeof RequirePasswordConfirmationControllerType;
+  let myPasswordConfirmationDialogPath:Mock;
+  let fetchSpy:Mock;
+  let originalOpenProject:typeof window.OpenProject;
+
+  beforeAll(async () => {
+    ({ default: RequirePasswordConfirmationController } = await import('./require-password-confirmation.controller'));
+  });
+
+  beforeEach(async () => {
+    myPasswordConfirmationDialogPath = vi.fn().mockReturnValue('/my/password_confirmation_dialog');
+    fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
+      headers: new Headers({ 'Content-Type': 'text/vnd.turbo-stream.html' }),
+      text: () => Promise.resolve(''),
+    } as unknown as Response);
+
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = {
+      getPluginContext: () => Promise.resolve({
+        services: { pathHelperService: { myPasswordConfirmationDialogPath } },
+      }),
+    } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'require-password-confirmation': RequirePasswordConfirmationController },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function renderForm() {
+    await ctx.mount(`
+      <form data-controller="require-password-confirmation" action="/my/account" method="post">
+        <button type="submit">Save</button>
+      </form>
+    `);
+    return ctx.container.querySelector('form')!;
+  }
+
+  it('binds the declared services after connect', async () => {
+    await renderForm();
+    const controller = ctx.getController<RequirePasswordConfirmationControllerType>('require-password-confirmation');
+
+    await expect(controller.services).resolves.toMatchObject({
+      pathHelperService: { myPasswordConfirmationDialogPath },
+    });
+  });
+
+  it('intercepts the submit and requests the confirmation dialog', async () => {
+    const form = await renderForm();
+
+    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/my/password_confirmation_dialog',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+  });
+
+  it('appends the confirmed password and resubmits the form', async () => {
+    const form = await renderForm();
+    const requestSubmit = vi.fn();
+    form.requestSubmit = requestSubmit;
+
+    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    document.dispatchEvent(new CustomEvent('password-confirmation-dialog:submit', { detail: 'secret' }));
+
+    const input = form.querySelector<HTMLInputElement>('#hidden_password_confirmation')!;
+    expect(input.value).toBe('secret');
+    expect(input.name).toBe('_password_confirmation');
+    expect(requestSubmit).toHaveBeenCalled();
+  });
+
+  it('intercepts submits arriving before the plugin context resolves', async () => {
+    let resolveContext!:(context:unknown) => void;
+    window.OpenProject = {
+      getPluginContext: () => new Promise((resolve) => { resolveContext = resolve; }),
+    } as unknown as typeof window.OpenProject;
+
+    const form = await renderForm();
+
+    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+
+    form.remove();
+    await ctx.nextFrame();
+
+    resolveContext({
+      services: { pathHelperService: { myPasswordConfirmationDialogPath } },
+    });
+    await ctx.nextFrame();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
@@ -29,26 +29,30 @@
  */
 
 import { ApplicationController } from 'stimulus-use';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { renderStreamMessage } from '@hotwired/turbo';
+import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
 export default class RequirePasswordConfirmationController extends ApplicationController {
+  static services:ServiceKey[] = ['pathHelperService'];
+
+  declare services:Promise<PickedServices<'pathHelperService'>>;
+
   private formListener:(evt:SubmitEvent) => unknown = this.onFormSubmit.bind(this);
   private dialogCloseListener:(evt:Event) => unknown = this.onDialogClose.bind(this);
   private dialogSubmitListener:(evt:CustomEvent) => unknown = this.onConfirmationSubmit.bind(this);
-
-  private pathHelper:PathHelperService;
 
   private activeDialog = false;
   private submitButton:HTMLButtonElement|null;
   private submitDialogId:string|undefined;
   private previousSubmitter:HTMLElement|null;
 
-  async connect() {
-    super.connect();
+  initialize() {
+    super.initialize();
+    useAngularServices(this);
+  }
 
-    const context = await window.OpenProject.getPluginContext();
-    this.pathHelper = context.services.pathHelperService;
+  connect() {
+    super.connect();
 
     this.element.addEventListener('submit', this.formListener);
     document.addEventListener('password-confirmation-dialog:close', this.dialogCloseListener);
@@ -87,7 +91,8 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
     }
     this.activeDialog = true;
 
-    void fetch(this.pathHelper.myPasswordConfirmationDialogPath(), {
+    const { pathHelperService } = await this.services;
+    void fetch(pathHelperService.myPasswordConfirmationDialogPath(), {
       method: 'GET',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',

--- a/frontend/src/stimulus/mixins/use-angular-services.spec.ts
+++ b/frontend/src/stimulus/mixins/use-angular-services.spec.ts
@@ -1,0 +1,250 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi } from 'vitest';
+import { Controller } from '@hotwired/stimulus';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import { useAngularServices, type ServiceKey } from './use-angular-services';
+
+interface Deferred<T> {
+  promise:Promise<T>;
+  resolve:(value:T) => void;
+}
+
+function deferred<T>():Deferred<T> {
+  let resolve!:(value:T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+class TestController extends Controller<HTMLElement> {
+  static services:ServiceKey[] = ['halEvents', 'i18n'];
+
+  declare halEvents:unknown;
+  declare i18n:unknown;
+  declare services:Promise<Record<string, unknown>>;
+  declare pluginContext:Promise<unknown>;
+
+  servicesConnectedCount = 0;
+
+  initialize() {
+    useAngularServices(this);
+  }
+
+  servicesConnected() {
+    this.servicesConnectedCount += 1;
+  }
+}
+
+class BadServiceController extends Controller<HTMLElement> {
+  static services = ['unknownService'] as unknown as ServiceKey[];
+
+  initialize() {
+    useAngularServices(this);
+  }
+}
+
+class PlainController extends Controller<HTMLElement> {
+  declare services:Promise<Record<string, unknown>>;
+
+  initialize() {
+    useAngularServices(this);
+  }
+}
+
+describe('useAngularServices', () => {
+  let ctx:StimulusTestContext;
+  let originalOpenProject:typeof window.OpenProject;
+  let halEvents:{ service:string };
+  let i18n:{ service:string };
+  let timezone:{ service:string };
+  let pluginContext:{ services:Record<string, unknown> };
+
+  function stubPluginContext(getPluginContext:() => Promise<unknown>) {
+    window.OpenProject = { getPluginContext } as unknown as typeof window.OpenProject;
+  }
+
+  beforeEach(async () => {
+    halEvents = { service: 'halEvents' };
+    i18n = { service: 'i18n' };
+    timezone = { service: 'timezone' };
+    pluginContext = { services: { halEvents, i18n, timezone } };
+
+    originalOpenProject = window.OpenProject;
+    stubPluginContext(() => Promise.resolve(pluginContext));
+
+    ctx = await setupStimulusTest({
+      controllers: {
+        'use-services-test': TestController,
+        'use-services-bad': BadServiceController,
+        'use-services-plain': PlainController,
+      },
+    });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  async function mountController<T extends Controller>(identifier:string):Promise<{ controller:T, element:HTMLElement }> {
+    await ctx.mount(`<div data-controller="${identifier}"></div>`);
+    const element = ctx.container.querySelector<HTMLElement>(`[data-controller="${identifier}"]`)!;
+    const controller = ctx.getController<T>(identifier, element);
+    return { controller, element };
+  }
+
+  it('binds the declared services on the controller and then calls servicesConnected', async () => {
+    const { controller } = await mountController<TestController>('use-services-test');
+
+    await waitFor(() => { expect(controller.servicesConnectedCount).toBe(1); });
+
+    expect(controller.halEvents).toBe(halEvents);
+    expect(controller.i18n).toBe(i18n);
+  });
+
+  it('calls servicesConnected again on every reconnect', async () => {
+    const { controller, element } = await mountController<TestController>('use-services-test');
+    await waitFor(() => { expect(controller.servicesConnectedCount).toBe(1); });
+
+    element.remove();
+    await ctx.nextFrame();
+    ctx.container.append(element);
+
+    await waitFor(() => { expect(controller.servicesConnectedCount).toBe(2); });
+  });
+
+  it('does not call servicesConnected when disconnected before the context resolves', async () => {
+    const context = deferred<unknown>();
+    stubPluginContext(() => context.promise);
+
+    const { controller, element } = await mountController<TestController>('use-services-test');
+
+    element.remove();
+    await ctx.nextFrame();
+
+    context.resolve(pluginContext);
+    await ctx.nextFrame();
+
+    expect(controller.servicesConnectedCount).toBe(0);
+    expect(controller.halEvents).toBeUndefined();
+  });
+
+  it('ignores a stale resolution from before a reconnect', async () => {
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    const getPluginContext = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    stubPluginContext(getPluginContext as () => Promise<unknown>);
+
+    const { controller, element } = await mountController<TestController>('use-services-test');
+
+    element.remove();
+    await ctx.nextFrame();
+    ctx.container.append(element);
+    await waitFor(() => { expect(getPluginContext).toHaveBeenCalledTimes(2); });
+
+    second.resolve(pluginContext);
+    await waitFor(() => { expect(controller.servicesConnectedCount).toBe(1); });
+
+    first.resolve(pluginContext);
+    await ctx.nextFrame();
+
+    expect(controller.servicesConnectedCount).toBe(1);
+  });
+
+  it('exposes a services promise resolving to the declared subset', async () => {
+    const { controller } = await mountController<TestController>('use-services-test');
+
+    const services = await controller.services;
+
+    expect(services).toEqual({ halEvents, i18n });
+  });
+
+  it('never resolves a pending services promise after disconnect', async () => {
+    const context = deferred<unknown>();
+    stubPluginContext(() => context.promise);
+
+    const { controller, element } = await mountController<TestController>('use-services-test');
+
+    const resolved = vi.fn();
+    void controller.services.then(resolved);
+
+    element.remove();
+    await ctx.nextFrame();
+
+    context.resolve(pluginContext);
+    await ctx.nextFrame();
+
+    expect(resolved).not.toHaveBeenCalled();
+  });
+
+  it('never resolves a services promise obtained after disconnect', async () => {
+    const context = deferred<unknown>();
+    stubPluginContext(() => context.promise);
+
+    const { controller, element } = await mountController<TestController>('use-services-test');
+
+    element.remove();
+    await ctx.nextFrame();
+
+    const resolved = vi.fn();
+    void controller.services.then(resolved);
+
+    context.resolve(pluginContext);
+    await ctx.nextFrame();
+
+    expect(resolved).not.toHaveBeenCalled();
+  });
+
+  it('exposes a pluginContext promise resolving to the full context', async () => {
+    const { controller } = await mountController<TestController>('use-services-test');
+
+    await expect(controller.pluginContext).resolves.toBe(pluginContext);
+  });
+
+  it('reports an error when a declared service does not exist', async () => {
+    const handleError = vi.fn();
+    ctx.application.handleError = handleError;
+
+    await mountController<BadServiceController>('use-services-bad');
+
+    await waitFor(() => { expect(handleError).toHaveBeenCalled(); });
+    expect((handleError.mock.calls[0][0] as Error).message).toContain('unknownService');
+  });
+
+  it('works without a static services list and without a servicesConnected hook', async () => {
+    const { controller } = await mountController<PlainController>('use-services-plain');
+
+    await expect(controller.services).resolves.toEqual({});
+  });
+});

--- a/frontend/src/stimulus/mixins/use-angular-services.spec.ts
+++ b/frontend/src/stimulus/mixins/use-angular-services.spec.ts
@@ -226,6 +226,27 @@ describe('useAngularServices', () => {
     expect(resolved).not.toHaveBeenCalled();
   });
 
+  it('never resolves a services promise requested while disconnected once reconnected', async () => {
+    const context = deferred<unknown>();
+    stubPluginContext(() => context.promise);
+
+    const { controller, element } = await mountController<TestController>('use-services-test');
+
+    element.remove();
+    await ctx.nextFrame();
+
+    const resolved = vi.fn();
+    void controller.services.then(resolved);
+
+    ctx.container.append(element);
+    await ctx.nextFrame();
+
+    context.resolve(pluginContext);
+    await ctx.nextFrame();
+
+    expect(resolved).not.toHaveBeenCalled();
+  });
+
   it('exposes a pluginContext promise resolving to the full context', async () => {
     const { controller } = await mountController<TestController>('use-services-test');
 

--- a/frontend/src/stimulus/mixins/use-angular-services.ts
+++ b/frontend/src/stimulus/mixins/use-angular-services.ts
@@ -1,0 +1,144 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import type { Controller } from '@hotwired/stimulus';
+import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+
+export type ServiceKey = keyof OpenProjectPluginContext['services'];
+
+export type PickedServices<K extends ServiceKey = ServiceKey> = Pick<OpenProjectPluginContext['services'], K>;
+
+interface ServiceConsumer {
+  servicesConnected?:() => void;
+}
+
+/**
+ * Binds Angular plugin context services to a Stimulus controller, owning all
+ * the `window.OpenProject.getPluginContext()` boilerplate and its
+ * disconnect-before-resolve races.
+ *
+ * Usage:
+ *
+ *     export default class ListRefreshController extends Controller<HTMLElement> {
+ *       static services:ServiceKey[] = ['halEvents'];
+ *       declare halEvents:HalEventsService;
+ *
+ *       initialize() {
+ *         useAngularServices(this);
+ *       }
+ *
+ *       // Fires after every connect(), once the context has resolved and the
+ *       // element is still connected.
+ *       servicesConnected() {
+ *         this.subscription = this.halEvents.aggregated$('WorkPackage')...
+ *       }
+ *     }
+ *
+ * For use outside `servicesConnected()` (e.g. event handlers), the mixin also
+ * defines two promise properties on the controller (add matching `declare`
+ * lines to get typing):
+ *
+ * - `this.services` — resolves to the declared subset of context services
+ * - `this.pluginContext` — resolves to the full `OpenProjectPluginContext`,
+ *   the escape hatch for `classes`, `helpers` and `injector`
+ *
+ * Both promises never settle while the controller is disconnected at context
+ * resolution time — whether obtained before or after the disconnect — so code
+ * after an `await` cannot act on a dead element.
+ */
+export function useAngularServices(controller:Controller):void {
+  const declaredServices = (controller.constructor as unknown as { services?:ServiceKey[] }).services ?? [];
+
+  // Each disconnect invalidates anything still pending from the previous
+  // connection — replaces the per-controller Symbol-token pattern.
+  let epoch = 0;
+
+  const guarded = <T>(map:(context:OpenProjectPluginContext) => T):Promise<T> => {
+    const token = epoch;
+    return window.OpenProject.getPluginContext().then((context) => {
+      if (token !== epoch || !controller.element.isConnected) {
+        return new Promise<T>(() => {
+          // Disconnected while pending — never settle (see doc block above).
+        });
+      }
+      return map(context);
+    });
+  };
+
+  const pickServices = (context:OpenProjectPluginContext):Record<string, unknown> => {
+    const picked:Record<string, unknown> = {};
+    declaredServices.forEach((key) => {
+      if (!(key in context.services)) {
+        throw new Error(`useAngularServices: unknown plugin context service "${key}"`);
+      }
+      picked[key] = context.services[key];
+    });
+    return picked;
+  };
+
+  const connectServices = async () => {
+    const token = epoch;
+    try {
+      const context = await window.OpenProject.getPluginContext();
+      if (token !== epoch || !controller.element.isConnected) {
+        return;
+      }
+      Object.assign(controller, pickServices(context));
+      (controller as ServiceConsumer).servicesConnected?.();
+    } catch (error) {
+      controller.application.handleError(
+        error as Error,
+        `Error connecting plugin context services for "${controller.identifier}"`,
+        {},
+      );
+    }
+  };
+
+  const originalConnect = controller.connect.bind(controller);
+  const originalDisconnect = controller.disconnect.bind(controller);
+
+  controller.connect = () => {
+    originalConnect();
+    void connectServices();
+  };
+
+  controller.disconnect = () => {
+    epoch += 1;
+    originalDisconnect();
+  };
+
+  Object.defineProperty(controller, 'services', {
+    get: () => guarded(pickServices),
+    configurable: true,
+  });
+
+  Object.defineProperty(controller, 'pluginContext', {
+    get: () => guarded((context) => context),
+    configurable: true,
+  });
+}

--- a/frontend/src/stimulus/mixins/use-angular-services.ts
+++ b/frontend/src/stimulus/mixins/use-angular-services.ts
@@ -67,16 +67,20 @@ interface ServiceConsumer {
  * - `this.pluginContext` — resolves to the full `OpenProjectPluginContext`,
  *   the escape hatch for `classes`, `helpers` and `injector`
  *
- * Both promises never settle while the controller is disconnected at context
- * resolution time — whether obtained before or after the disconnect — so code
- * after an `await` cannot act on a dead element.
+ * Both promises never settle once the controller disconnects — whether they
+ * were obtained before the disconnect or while disconnected — so code after
+ * an `await` cannot act on a dead element. Only promises obtained from the
+ * current connection resolve.
  */
 export function useAngularServices(controller:Controller):void {
   const declaredServices = (controller.constructor as unknown as { services?:ServiceKey[] }).services ?? [];
 
   // Each disconnect invalidates anything still pending from the previous
-  // connection — replaces the per-controller Symbol-token pattern.
+  // connection, and a reconnect invalidates anything requested while
+  // disconnected — replaces the per-controller Symbol-token pattern. The
+  // first connect must not bump: initialize() may already hold promises.
   let epoch = 0;
+  let disconnected = false;
 
   const guarded = <T>(map:(context:OpenProjectPluginContext) => T):Promise<T> => {
     const token = epoch;
@@ -123,12 +127,17 @@ export function useAngularServices(controller:Controller):void {
   const originalDisconnect = controller.disconnect.bind(controller);
 
   controller.connect = () => {
+    if (disconnected) {
+      epoch += 1;
+      disconnected = false;
+    }
     originalConnect();
     void connectServices();
   };
 
   controller.disconnect = () => {
     epoch += 1;
+    disconnected = true;
     originalDisconnect();
   };
 

--- a/frontend/src/stimulus/test-helpers.ts
+++ b/frontend/src/stimulus/test-helpers.ts
@@ -97,6 +97,10 @@ export async function setupStimulusTest(options:SetupOptions):Promise<StimulusTe
     },
 
     dispose() {
+      // Unload before stopping: stop() kills the DOM observer, so controllers
+      // would never disconnect and document-level listeners would leak into
+      // the next test. unload() disconnects them synchronously.
+      application.unload(Object.keys(options.controllers));
       application.stop();
       container.remove();
       if (stimulusErrors.length > 0) {


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/75299

# What are you trying to accomplish?

Every Stimulus controller that reached into Angular via `window.OpenProject.getPluginContext()` now declares its services through the `useAngularServices` mixin, which owns the async context resolution and its disconnect races centrally; `this.pluginContext` covers the `classes`/`injector` consumers. This includes the Backlogs controller, the last remaining consumer, migrated as the final commit. When Angular is removed, one mixin changes instead of every controller. Each migrated controller gains a skeleton spec.

Deliberate behavior changes:

- The password confirmation form and the job dialog attach their listeners directly on connect, so early submits/clicks no longer slip past them while the Angular context is still resolving.
- Pending context promises never settle on disconnected controllers, which removes stray match-preview POSTs and modal closes on dead elements.

Pre-existing issues spotted but left for follow-ups (so they are not mistaken for regressions): the activities-tab polling controller reuses one AbortController across reconnects, the job dialog re-adds its click listener per reconnect, the admin custom-fields autoscroll instance is never destroyed, and the storage form's connect subscription is never unsubscribed.

# What approach did you choose and why?

One commit per controller group, mechanical shapes first, so each behavioral argument (lazy `await this.services` in handlers vs. the `servicesConnected()` hook for connect-time subscriptions, listener timing) is reviewable in isolation. The mixin gained one fix surfaced by the rollout: guarded promises also check `element.isConnected` at resolution time, closing the case where a handler obtains `this.services` only after disconnect.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
