### PR TITLE
Fix WP description edit scrolling to page bottom on activation

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
@@ -90,6 +90,11 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   public destroyed = false;
 
   public setActive(active = true):void {
+    if (active && !this.active) {
+      this.preserveWrapperHeight();
+    } else if (!active) {
+      this.clearWrapperHeight();
+    }
     this.active = active;
     if (!this.componentDestroyed) {
       this.cdRef.detectChanges();
@@ -217,6 +222,28 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     this.deactivate();
   }
 
+  // When switching to edit mode, the display container collapses immediately
+  // (display:none) while the edit portal renders asynchronously. This shrinks
+  // the page height and the browser clamps scroll to the new maximum, causing
+  // the page to jump to the bottom (observed in Firefox). Preserve the wrapper
+  // height to prevent this.
+  // Note: min-height must be set on the block wrapper div, not the host element
+  // (op-editable-attribute-field is display:inline and ignores min-height).
+  private preserveWrapperHeight():void {
+    const wrapperEl = this.displayContainer.nativeElement.parentElement;
+    const height = this.displayContainer.nativeElement.offsetHeight;
+    if (wrapperEl && height > 0) {
+      wrapperEl.style.minHeight = `${height}px`;
+    }
+  }
+
+  private clearWrapperHeight():void {
+    const wrapperEl = this.displayContainer.nativeElement.parentElement;
+    if (wrapperEl) {
+      wrapperEl.style.minHeight = '';
+    }
+  }
+
   private get schema() {
     if (this.halEditing.typedState(this.resource).hasValue()) {
       const val = this.halEditing.typedState(this.resource).value as { schema:SchemaResource };
@@ -226,4 +253,3 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     return this.schemaCache.of(this.resource);
   }
 }
-


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19226

# What are you trying to accomplish?

Fix a Firefox-specific bug where clicking the description field to enter inline edit mode causes the page to jump to the bottom, leaving the description out of view.

The bug only triggers when the description top is scrolled off-screen and the page has enough fields to make the description tall enough that its absence would shrink the page significantly.

## Screenshots

See ticket, there is a GIF reproducing the issue.

# What approach did you choose and why?

Bug fixed with assistance of Claude AI.

**How the bug is triggered:**

1. User scrolls down so the description top is off-screen
2. User clicks the description to enter edit mode
3. `setActive(true)` runs in `editable-attribute-field.component.ts`
4. `[hidden]="active"` hides the display container — the tall read-only description text disappears from the layout instantly (`display:none`)
5. `[hidden]="!active"` shows the edit container — but it is empty, the Angular portal that renders CKEditor resolves asynchronously
6. `cdRef.detectChanges()` flushes both changes synchronously
7. The page height collapses by the full height of the description text
8. The browser sees that `window.scrollY` now exceeds the new page maximum and clamps it to the new bottom
9. CKEditor finishes rendering asynchronously — page height recovers
10. But `window.scrollY` is already clamped at the bottom and stays there => feels like it scrolled to the bottom

Seen on Firefox. Chrome does not exhibit this behaviour; Safari was not tested.

**How the fix works**

Before step 4, the fix measures the display container's `offsetHeight` and sets it as `min-height` on the parent wrapper `<div>`. The page height never collapses during steps 4–9, so the browser has no reason to clamp the scroll position. Once CKEditor is rendered and the field is eventually deactivated, `min-height` is cleared.

**Why the wrapper div and not the host element:** `op-editable-attribute-field` is a custom element with `display:inline` by default, which ignores `min-height`. The inner `<div>` wrapper is `display:block` and respects it.

**Alternatives considered:**
- Saving and restoring `window.scrollY` around `detectChanges()` — works but feels fragile; any intervening async scroll would be clobbered.
- Delaying `detectChanges()` until CKEditor is ready — would introduce a visible lag before the edit form appears.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [~] Tested major browsers (Chrome, Firefox, Edge, ...)
  - Tested on Firefox and Chrome
  - Edge and Safari not tested
