### PR TITLE
[#75690] Documents: work package link text and surrounding text not vertically aligned

### DIFF
--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -278,7 +278,9 @@ $scrollbar-size: 10px
 
 @mixin macro--text-style
   @media screen
-    display: inline
+    display: inline-flex
+    align-items: center
+    vertical-align: middle
     background: var(--bgColor-muted)
     border-radius: var(--borderRadius-default)
     // 2px vertical ensures that line-height is not overflowed excessively


### PR DESCRIPTION
**Work package:** https://community.openproject.org/work_packages/75690 — plan & discussion in the comments.

# Ticket

https://community.openproject.org/work_packages/75690

# What are you trying to accomplish?

Work package mention chips (inserted via `#` in the Documents editor) were not vertically aligned with the surrounding inline text. The chip sat above the text baseline in both Chrome and Firefox, making inline mentions visually jarring.

The root cause was that the `macro--text-style` mixin set the host custom element to `display: inline`. Because inline elements derive their baseline from their deepest descendant, and the chip's inner `<display-field>` children render as `inline-block`, the chip's perceived baseline ended up misaligned with the surrounding text's baseline.

# What approach did you choose and why?

In `_mixins.sass`, the `macro--text-style` mixin's `@media screen` block was changed from `display: inline` to `display: inline-flex`, and two new declarations were added:

- `align-items: center` — vertically centres the chip's internal children (type badge, subject text, anchor) within the flex container, regardless of their individual line heights.
- `vertical-align: middle` — aligns the chip's vertical midpoint with the surrounding text's x-height midpoint, producing the expected inline alignment.

`inline-flex` was preferred over `inline-block` because it exposes `align-items`, which correctly handles the varying heights of the chip's child elements without requiring fixed heights or negative margins.

The existing `&:has(.-multiline)` branch (used by `attribute-macro` when a multiline custom field is rendered inside the chip) already specified `display: inline-flex`, so it is now a no-op for the `display` property and causes no regression. The fix applies equally to both `work-package-quickinfo-macro` and `attribute-macro` since both include this shared mixin. No HTML or JavaScript changes are required.

## Screenshots

N/A

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)