### PR TITLE
[STC-729] Support semantic identifiers in Excel and CSV exports

### DIFF
--- a/app/models/work_package/exports/formatters/id.rb
+++ b/app/models/work_package/exports/formatters/id.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackage::Exports
+  module Formatters
+    # Exports the user-facing work package identifier: the semantic
+    # identifier (e.g. "PROJ-42") in semantic mode, the numeric database
+    # ID in classic mode.
+    class Id < ::Exports::Formatters::Default
+      def self.apply?(attribute, export_format)
+        attribute.to_sym == :id && export_format == :csv
+      end
+
+      protected
+
+      def retrieve_value(object)
+        object.display_id
+      end
+    end
+  end
+end

--- a/config/initializers/export_formats.rb
+++ b/config/initializers/export_formats.rb
@@ -47,6 +47,7 @@ Rails.application.configure do |application|
       formatter WorkPackage, WorkPackage::Exports::Formatters::PDF::Days
       formatter WorkPackage, WorkPackage::Exports::Formatters::XLS::DoneRatio
       formatter WorkPackage, WorkPackage::Exports::Formatters::PDF::Hours
+      formatter WorkPackage, WorkPackage::Exports::Formatters::Id
       formatter WorkPackage, WorkPackage::Exports::Formatters::ProjectPhase
       formatter WorkPackage, WorkPackage::Exports::Formatters::SpentUnits
 

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -246,6 +246,25 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
     end
   end
 
+  context "with semantic work package identifiers",
+          with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "XLSPROJ") }
+    let(:work_package) do
+      create(:work_package,
+             project:,
+             type: project.types.first)
+    end
+    let(:work_packages) { [work_package] }
+    let(:column_names) { %w[id subject] }
+
+    it "exports the semantic identifier in the ID column" do
+      expect(sheet.rows.size).to eq(1 + 1)
+
+      expect(work_package.identifier).to match(/\AXLSPROJ-\d+\z/)
+      expect(sheet.rows[1][0]).to eq work_package.identifier
+    end
+  end
+
   context "with underscore in subject" do
     let(:work_package) do
       create(:work_package,

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -134,6 +134,30 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
     end
   end
 
+  context "with semantic work package identifiers",
+          with_settings: { work_packages_identifier: "semantic" } do
+    let(:semantic_project) do
+      create(:project,
+             identifier: "CSVPROJ",
+             member_with_permissions: { user => %i[view_work_packages] })
+    end
+    let!(:work_package) { create(:work_package, project: semantic_project) }
+    let(:options) { {} }
+    let(:query) do
+      create(:query, project: semantic_project, user:, column_names: %i(id subject))
+    end
+
+    it "exports the semantic identifier in the ID column" do
+      headers, values = CSV.parse instance.export!.content
+      pairs = headers.zip(values).to_h
+
+      expect(work_package.identifier).to match(/\ACSVPROJ-\d+\z/)
+      # the leading ID header is downcased by the exporter to avoid SYLK detection
+      expect(pairs["#{byte_order_mark}id"]).to eq work_package.identifier
+      expect(pairs["Subject"]).to eq work_package.subject
+    end
+  end
+
   context "with multiple work packages" do
     shared_let(:wp1) { create(:work_package, project:, done_ratio: 25, subject: "WP1", type: type_a, id: 1) }
     shared_let(:wp2) { create(:work_package, project:, done_ratio: 0, subject: "WP2", type: type_a, id: 2) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/STC-729


# What are you trying to accomplish?
CSV and XLS exports have been rendering the ID field in the numeric form, even in the semantic mode.

(More accurately, XLS _partially_ supports semantic mode, because the project and parent WP links already _do_ show the semantic version).

Let's patch this.

## Screenshots
[xls_old.xls](https://github.com/user-attachments/files/28851434/xls_old.xls) vs. [xls_fixed.xls](https://github.com/user-attachments/files/28851433/xls_fixed.xls)

<img width="2037" height="1061" alt="Screenshot 2026-06-11 at 21 01 47" src="https://github.com/user-attachments/assets/82df19ee-ceec-4337-8be1-5f76ad155e69" />

[csv_old.csv](https://github.com/user-attachments/files/28851443/csv_old.csv) vs. [csv_fixed.csv](https://github.com/user-attachments/files/28851442/csv_fixed.csv)

<img width="2263" height="889" alt="Screenshot 2026-06-11 at 21 04 11" src="https://github.com/user-attachments/assets/fa36835b-16ae-44c5-a0f8-fa4b07d6b450" />



# What approach did you choose and why?
Add a standalone ID formatter for CSV and XLS, similarly to other fields like `project_phase` and `spent_units`.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
