### PR TITLE
Do not generate $PORT variables for overmind processes in `bin/dev`

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 if command -v overmind &> /dev/null; then
-  overmind start -f Procfile.dev
+  # Start Procfile.dev and do not generate a $PORT env var, as this overrides our $FE_PORT, as the new version of
+  # `ng serve` seems to pick the $ENV var over the CLI arg, which causes the FE to fail to start on the expected port.
+  overmind start -f Procfile.dev -N
 elif command -v foreman &> /dev/null; then
   foreman start -f Procfile.dev
 else

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -184,7 +184,7 @@
     "build": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --configuration production --named-chunks --source-map",
     "build:watch": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --watch --named-chunks",
     "ci:plugins:register_frontend": "node ci-plugins-generator.js",
-    "serve": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng serve --host ${FE_HOST:-localhost} --port ${FE_PORT:-4200} --serve-path ${RAILS_RELATIVE_URL_ROOT}/assets/frontend",
+    "serve": "PORT=${FE_PORT:-4200} node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng serve --host ${FE_HOST:-localhost} --port ${FE_PORT:-4200} --serve-path ${RAILS_RELATIVE_URL_ROOT}/assets/frontend",
     "test": "ng test --watch=false",
     "test:watch": "ng test --watch=true",
     "lint": "ng lint",


### PR DESCRIPTION
With the recent update to Angular 22 (#23588) it seems that `ng serve` is given the `$PORT` env variable precedent over the command line argument `--port`. 

So, when we run `Procfile.dev` with `overmind`, overmind automatically generates a $PORT for each process (web=3000, angular=3100) and passes this as as `$PORT` to the processes and the new `ng serve` uses this port, while the backend expects the angular server to run on `$FE_PORT`.

This PR fixes the call to overmind to skip the automatic `$PORT` generation.

---

Also, we explicitly set `$PORT` for the frontend to `$FE_PORT` as the previous fix still broke when explicitly setting an ENV var for the port and this was "leaked" through overmind