### PR TITLE
test: cover blank work-package journal values in meeting activity formatter

### DIFF
--- a/modules/meeting/spec/lib/open_project/journal_formatter/meeting_work_package_id_spec.rb
+++ b/modules/meeting/spec/lib/open_project/journal_formatter/meeting_work_package_id_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe OpenProject::JournalFormatter::MeetingWorkPackageId do
       end
     end
 
+    context "when one side of the change is blank" do
+      # Regression for an activities-page crash: a work-package association
+      # journal holds a blank value for the absent side when the link is added
+      # or removed, and resolving it must not trip the find_by semantic-id guard.
+      before do
+        allow(WorkPackage).to receive(:visible).and_return(WorkPackage.where(id: new_work_package.id))
+      end
+
+      it "renders the visible side and an undisclosed label for the blank side" do
+        result = instance.render("work_package_id", ["", new_work_package.id], html: true)
+
+        expect(result).to include("New task")
+        expect(result).to include(I18n.t(:label_agenda_item_undisclosed_wp, id: ""))
+      end
+    end
+
     context "when work package names contain HTML" do
       let(:old_work_package) { create(:work_package, project:, subject: "Safe task") }
       let(:new_work_package) { create(:work_package, project:, subject: "<img src=x onerror=alert(1)>") }


### PR DESCRIPTION
Regression coverage for an `UnsupportedLookup` on the activity stream: a meeting agenda-item journal holds a blank value for the absent side of a work-package link, and rendering it must show the undisclosed label rather than trip the `find_by` semantic-id guard. Test-only — the predicate-level fix already landed in #23213.