### PR TITLE
Work Package Card: normalize priority label width

### DIFF
--- a/app/components/open_project/common/work_package_card_component.html.erb
+++ b/app/components/open_project/common/work_package_card_component.html.erb
@@ -60,10 +60,10 @@ See COPYRIGHT and LICENSE files for more details.
       <%= render(
             Primer::Beta::Text.new(
               tag: :span,
-              classes: "__hl_inline_priority_#{work_package.priority.id} __hl_inline__small_dot no-wrap"
+              classes: "op-work-package-card--priority __hl_inline_priority_#{work_package.priority.id} __hl_inline__small_dot no-wrap"
             )
           ) do %>
-        <span class="op-work-package-card--priority-name"><%= work_package.priority.name %></span>
+        <span class="op-work-package-card--priority-name ml-1"><%= work_package.priority.name %></span>
       <% end %>
     <% end %>
 

--- a/app/components/open_project/common/work_package_card_component.html.erb
+++ b/app/components/open_project/common/work_package_card_component.html.erb
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
               classes: "op-work-package-card--priority __hl_inline_priority_#{work_package.priority.id} __hl_inline__small_dot no-wrap"
             )
           ) do %>
-        <span class="op-work-package-card--priority-name ml-1"><%= work_package.priority.name %></span>
+        <span class="op-work-package-card--priority-name"><%= work_package.priority.name %></span>
       <% end %>
     <% end %>
 

--- a/app/components/open_project/common/work_package_card_component.sass
+++ b/app/components/open_project/common/work_package_card_component.sass
@@ -38,16 +38,15 @@
   margin-bottom: var(--base-size-4)
   container-type: inline-size
 
-  .op-work-package-card--priority
+  &--priority
     display: inline-flex
     align-items: center
 
-    &-name
-      display: inline-block
-      width: 90px
-      overflow: hidden
-      text-overflow: ellipsis
-      white-space: nowrap
+  &--priority-name
+    display: inline-block
+    margin-left: 4px
+    width: 5rem
+    @include text_shortener
 
   &_with-footer
     grid-template-rows: auto auto auto

--- a/app/components/open_project/common/work_package_card_component.sass
+++ b/app/components/open_project/common/work_package_card_component.sass
@@ -38,6 +38,17 @@
   margin-bottom: var(--base-size-4)
   container-type: inline-size
 
+  .op-work-package-card--priority
+    display: inline-flex
+    align-items: center
+
+    &-name
+      display: inline-block
+      width: 90px
+      overflow: hidden
+      text-overflow: ellipsis
+      white-space: nowrap
+
   &_with-footer
     grid-template-rows: auto auto auto
     grid-template-areas: "info_line actions" "subject subject" "footer footer"

--- a/app/components/open_project/common/work_package_card_component.sass
+++ b/app/components/open_project/common/work_package_card_component.sass
@@ -44,7 +44,7 @@
 
   &--priority-name
     display: inline-block
-    margin-left: 4px
+    margin-left: var(--base-size-4)
     width: 5rem
     @include text_shortener
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-281

# What are you trying to accomplish?
Cuts off after a certain threshold.

Using a fixed width leads to a more structured and calm visual design. The price is that a bit of space is wasted for priorities with shorter names.

As fixed width, I chose 90 px as it could hold "Immediate", which is the longest predefined priority in English - and then add 10 pixels of additional buffer space. It might not work as well for other languages (or different font settings and sizes), but we have to choose _some_ width if we want to go with this general approach.

I briefly considered using the `ch` unit instead of `px`, but it does not seem like we use it anywhere else in OP. Hence, I stuck to `px`.

## Screenshots

### Before
<img width="1400" height="912" alt="image" src="https://github.com/user-attachments/assets/c0330820-2fed-4199-8c27-e423fc983ec6" />


### After
<img width="1400" height="912" alt="image" src="https://github.com/user-attachments/assets/f106d5a5-c1dd-406f-ba7f-c94d5b156693" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
