### PR TITLE
Feature/STC-746: Adapt meeting PDF exports for semantic identifiers

### DIFF
--- a/modules/meeting/app/workers/meetings/pdf/common/agenda.rb
+++ b/modules/meeting/app/workers/meetings/pdf/common/agenda.rb
@@ -61,10 +61,14 @@ module Meetings::PDF::Common::Agenda
     make_link_href(
       href,
       prawn_table_cell_inline_formatting_data(
-        "#{work_package.type.name} ##{work_package.id} #{work_package.subject}",
+        work_package_title_text(work_package),
         { styles: [:underline] }
       )
     )
+  end
+
+  def work_package_title_text(work_package)
+    "#{work_package.type.name} #{work_package.formatted_id} #{work_package.subject}"
   end
 
   def agenda_wp_title_row(agenda_item)
@@ -109,7 +113,7 @@ module Meetings::PDF::Common::Agenda
 
   def write_visible_work_package_outcome(work_package)
     href = url_helpers.work_package_url(work_package)
-    link_text = "#{work_package.type.name} ##{work_package.id} #{work_package.subject}"
+    link_text = work_package_title_text(work_package)
     status_text = " (#{work_package.status.name})"
     base_style = styles.outcome_work_package
     pdf.formatted_text([

--- a/modules/meeting/spec/workers/meetings/pdf/default/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/pdf/default/exporter_spec.rb
@@ -250,6 +250,52 @@ RSpec.describe Meetings::PDF::Default::Exporter do
         expect(subject).to eq expected_document
       end
     end
+
+    context "with semantic work package identifiers",
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:options) do
+        {
+          participants: "0",
+          outcomes: "0",
+          backlog: "0",
+          attachments: "0"
+        }
+      end
+      let(:wp_agenda_item) do
+        create(:wp_meeting_agenda_item,
+               meeting:,
+               meeting_section: meeting_section_second,
+               work_package:,
+               duration_in_minutes: 10,
+               notes: "<mention class=\"mention\" data-id=\"#{work_package.id}\" data-type=\"work_package\" " \
+                      "data-text=\"##{work_package.id}\">##{work_package.id}</mention>")
+      end
+
+      before do
+        work_package.update_columns(identifier: "MEET-1", sequence_number: 1)
+      end
+
+      it "renders the semantic identifier for the agenda item and the mention in its notes" do
+        expected_document = [
+          *expected_cover_page,
+          *meeting_head,
+
+          "Untitled section", "  ", "15 mins",
+          "Agenda Item TOP 1", "  ", "15 mins", "  ", "Export User",
+          "foo",
+
+          "Second section", "  ", "10 mins",
+          "Task", "MEET-1", "Important task", " (Workin' on it)", "  ", "10 mins",
+          "MEET-1",
+
+          "1", # Page number
+          export_time_formatted,
+          project.name
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
   end
 
   context "with a meeting with special work package agenda item" do
@@ -361,6 +407,32 @@ RSpec.describe Meetings::PDF::Default::Exporter do
         ].join(" ")
 
         expect(subject).to eq expected_document
+      end
+
+      context "with semantic work package identifiers",
+              with_settings: { work_packages_identifier: "semantic" } do
+        before do
+          outcome_work_package.update_columns(identifier: "MEET-1", sequence_number: 1)
+        end
+
+        it "renders the work package outcome with the semantic identifier" do
+          expected_document = [
+            *expected_cover_page,
+            *meeting_head,
+
+            "Section with outcomes", "  ", "15 mins",
+            "Agenda Item", "  ", "15 mins", "  ", "Export User",
+            "Agenda item notes",
+            "✓   Outcome",
+            "Task", "MEET-1", "Outcome WP", " (In Progress)",
+
+            "1", # Page number
+            export_time_formatted,
+            project.name
+          ].join(" ")
+
+          expect(subject).to eq expected_document
+        end
       end
     end
 

--- a/modules/meeting/spec/workers/meetings/pdf/minutes/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/pdf/minutes/exporter_spec.rb
@@ -258,6 +258,50 @@ RSpec.describe Meetings::PDF::Minutes::Exporter do
         expect(subject).to eq expected_document
       end
     end
+
+    context "with semantic work package identifiers",
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:options) do
+        default_options.merge(
+          {
+            first_page_header_left: "",
+            outcomes: "0",
+            author: ""
+          }
+        )
+      end
+      let(:wp_agenda_item) do
+        create(:wp_meeting_agenda_item,
+               meeting:,
+               meeting_section: meeting_section_second,
+               work_package:,
+               duration_in_minutes: 10,
+               notes: "<mention class=\"mention\" data-id=\"#{work_package.id}\" data-type=\"work_package\" " \
+                      "data-text=\"##{work_package.id}\">##{work_package.id}</mention>")
+      end
+
+      before do
+        work_package.update_columns(identifier: "MEET-1", sequence_number: 1)
+      end
+
+      it "renders the semantic identifier for the agenda item and the mention in its notes" do
+        expected_document = [
+          meeting.title,
+          *meeting_info,
+          "1. Untitled section", "  ", "15 mins",
+          "1.1. Agenda Item TOP 1",
+          "foo",
+
+          "2. Second section", "  ", "10 mins",
+          "2.1. Task", "MEET-1", "Important task", " (Workin' on it)",
+          "MEET-1",
+
+          *expected_footer
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
   end
 
   context "with a meeting with special work package agenda item" do
@@ -351,6 +395,29 @@ RSpec.describe Meetings::PDF::Minutes::Exporter do
         ].join(" ")
 
         expect(subject).to eq expected_document
+      end
+
+      context "with semantic work package identifiers",
+              with_settings: { work_packages_identifier: "semantic" } do
+        before do
+          outcome_work_package.update_columns(identifier: "MEET-1", sequence_number: 1)
+        end
+
+        it "renders the work package outcome with the semantic identifier" do
+          expected_document = [
+            meeting.title,
+            *meeting_info,
+            *meeting_info_custom,
+            "1. Section with outcomes", "  ", "15 mins",
+            "1.1. Agenda Item",
+            "Agenda item notes",
+            "✓   Outcome",
+            "Task", "MEET-1", "Outcome WP", " (In Progress)",
+            *expected_header_footer
+          ].join(" ")
+
+          expect(subject).to eq expected_document
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-746

# What are you trying to accomplish?

On instances configured with project-based work package identifiers, meeting PDF exports still showed the numeric database id. This PR makes the agenda and minutes templates render the configured identifier instead, so a work package agenda item exports as `Task PROD-42 Improve onboarding flow` rather than `Task #39 Improve onboarding flow`. The same applies to work package outcomes. Work package mentions inside agenda item notes already resolved to the configured identifier through the shared markdown-to-PDF pipeline, and the meeting exporter specs now cover that path too.

## Screenshots

**Before (classic identifiers)**

<img width="595" height="842" alt="stc746-minutes-classic-before" src="https://github.com/user-attachments/assets/7e4965c1-e1a7-4e70-8fb8-6ea6e297f6fe" />

[stc746-minutes-classic-before.pdf](https://github.com/user-attachments/files/28876688/stc746-minutes-classic-before.pdf)

**After (semantic identifiers)**

<img width="595" height="842" alt="stc746-minutes-semantic-after" src="https://github.com/user-attachments/assets/d6699ca2-d86b-4e79-9039-8bde73a001fc" />

[stc746-minutes-semantic-after.pdf](https://github.com/user-attachments/files/28876689/stc746-minutes-semantic-after.pdf)

<!-- drop stc746-minutes-semantic-after.png here -->

# What approach did you choose and why?

The agenda title and outcome lines built their label with the raw numeric id, while the rest of the application (the meeting page itself, the work package PDF exports, mention expansion) renders identifiers through `formatted_id`, which returns the hash-prefixed numeric id in classic mode and the project-based identifier in semantic mode. The fix is to build the meeting PDF labels the same way, through a single helper shared by the agenda item title and the outcome line. Link URLs needed no change since URL helpers already resolve to the configured identifier.

Undisclosed work package references (where the viewer lacks permission) keep showing the numeric id, consistent with how the meeting page renders them.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
