### PR TITLE
[STC-549] Correct label in new document type form

### DIFF
--- a/app/components/admin/enumerations/item_form.rb
+++ b/app/components/admin/enumerations/item_form.rb
@@ -61,7 +61,8 @@ module Admin
           form.check_box(
             name: :is_default,
             label: I18n.t(:label_default),
-            caption: I18n.t(:"priorities.admin.default.caption"),
+            caption: I18n.t(:enumeration_default_value_caption,
+                            model: object.class.model_name.human.downcase),
             data: { action: "admin--enumerations#lockstepActive",
                     "admin--enumerations-target": "default" }
           )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1388,9 +1388,6 @@ en:
       priority_color_text: |
         Click to assign or change the color of this priority.
         It can be used for highlighting work packages in the table.
-    admin:
-      default:
-        caption: Making this priority default will override the previous default priority.
 
   reactions:
     action_title: "React"
@@ -3375,10 +3372,11 @@ en:
       enabled: "Disable"
 
   enumeration_activities: "Time tracking activities"
-  enumeration_work_package_priorities: "Work package priorities"
-  enumeration_reported_project_statuses: "Reported status"
   enumeration_caption_order_changed: "Order successfully changed."
   enumeration_could_not_be_moved: "Enumeration could not be moved."
+  enumeration_default_value_caption: "Making this %{model} the default will override the previous default %{model}."
+  enumeration_reported_project_statuses: "Reported status"
+  enumeration_work_package_priorities: "Work package priorities"
 
   enterprise_trials:
     dialog_component:

--- a/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe "Document types admin", :js do
 
       click_link "Documentation"
 
+      expect(page).to have_text("Making this document type the default")
+      expect(page).to have_no_text("priority")
+
       fill_in "Name", with: "Report"
       click_on("Save")
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69304

# What are you trying to accomplish?

The "Default" checkbox caption on the admin document types edit form incorrectly reads "Making this priority default will override the previous default priority." — wording copied from the issue priorities form — instead of document-type-specific text.

# What approach did you choose and why?
Migrate to a shared parametrized translation string.


## Screenshots

Before:
<img width="473" height="351" alt="Screenshot 2026-06-15 at 18 30 35" src="https://github.com/user-attachments/assets/5fc4d1db-e7e8-4633-8c49-9f16f0b259d0" />
After:
<img width="567" height="345" alt="Screenshot 2026-06-15 at 18 30 17" src="https://github.com/user-attachments/assets/83bc0af7-a7a6-4e9e-b031-ec6bc541f8b9" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)