### PR TITLE
Chore: Spell out Angular CLI entry path for Node 22.22.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
   frontend:
     build:
       <<: *frontend-build
-    command: "node --max_old_space_size=8096 ./node_modules/@angular/cli/bin/ng serve --host 0.0.0.0"
+    command: "node --max_old_space_size=8096 ./node_modules/@angular/cli/bin/ng.js serve --host 0.0.0.0"
     volumes:
       - ".:/home/dev/openproject"
       - "${CKEDITOR_BUILD_DIR:-./frontend/src/vendor/ckeditor/}:/home/dev/openproject/frontend/src/vendor/ckeditor/"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -183,10 +183,10 @@
   },
   "scripts": {
     "analyze": "ng build --configuration production --stats-json && npx esbuild-visualizer --metadata ../public/assets/frontend/stats.json",
-    "build": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --configuration production --named-chunks --source-map",
-    "build:watch": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --watch --named-chunks",
+    "build": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng.js build --configuration production --named-chunks --source-map",
+    "build:watch": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng.js build --watch --named-chunks",
     "ci:plugins:register_frontend": "node ci-plugins-generator.js",
-    "serve": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng serve --host ${FE_HOST:-localhost} --port ${FE_PORT:-4200} --serve-path ${RAILS_RELATIVE_URL_ROOT}/assets/frontend",
+    "serve": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng.js serve --host ${FE_HOST:-localhost} --port ${FE_PORT:-4200} --serve-path ${RAILS_RELATIVE_URL_ROOT}/assets/frontend",
     "test": "ng test --watch=false",
     "test:watch": "ng test --watch=true",
     "lint": "ng lint",


### PR DESCRIPTION
# Ticket
No work package. Follow-up to #23588 ([OP-19470] Upgrade Angular to v22), which surfaced this.

# What are you trying to accomplish?
On a fresh install, the Docker dev `frontend` container crashes with:

```
Error: Cannot find module '/home/dev/openproject/frontend/node_modules/@angular/cli/bin/ng'
```

The frontend launch commands invoke the Angular CLI through an **extensionless** path — `node ./node_modules/@angular/cli/bin/ng`. Node used to auto-append `.js` to the main-module argument, so this resolved for years even though the actual file has always been `bin/ng.js`. Node 22.22.3 dropped that fallback, so the extensionless path now fails to resolve.

#23588 bumped the frontend Docker base image from `node:22.21.0` to `node:22.22.3` — the trigger. It didn't touch these invocation paths, and it didn't touch `docker-compose.yml` at all, so the breakage only shows up once `node_modules` is reinstalled against the new image.

The fix spells out `bin/ng.js` everywhere the CLI is launched by explicit path:

- `docker-compose.yml` — the `frontend` service `command`
- `frontend/package.json` — the `build`, `build:watch`, and `serve` scripts

The `analyze`, `test`, and `lint` scripts call the bare `ng`, which resolves through the `node_modules/.bin/ng` symlink, so they were never affected and stay as-is. `Procfile.dev` runs `npm run serve`, so it inherits the fix.

# What approach did you choose and why?
These commands use `node --max_old_space_size=… <path>` to pass a V8 heap flag to the process running the CLI, so they need an explicit file path rather than the bare `ng` on PATH. Pointing them at the published entry `bin/ng.js` is the direct, intended target and is robust across Node versions. Routing through the `.bin/ng` symlink would also work but adds indirection for no gain.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)