### PR TITLE
[#69801] Real-time collaboration admin page: save button visible on read-only non-editable form

### DIFF
--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
@@ -61,7 +61,7 @@
           placeholder: Setting.collaborative_editing_hocuspocus_secret.present? ? "••••••••••••••••" : nil
         )
 
-        form.submit
+        form.submit unless none_writable_settings?
       end
     end
   else

--- a/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
@@ -186,6 +186,10 @@ RSpec.describe "Document collaboration settings admin",
                                  with: "",
                                  disabled: true)
     end
+
+    it "does not show a save button" do
+      expect(page).to have_no_button(I18n.t("button_save"))
+    end
   end
 
   context "with non-admin user" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/STC-588

# What are you trying to accomplish?

On the real-time collaboration admin settings page, the **Save** button was unconditionally rendered even when all settings (`hocuspocus_url` and `hocuspocus_secret`) are locked via environment variables, making the form fully read-only. The button was non-functional in that state (no editable fields exist) and misleading to administrators.

This fix hides the Save button when `none_writable_settings?` is `true` — i.e., when every tracked setting is overridden by an environment variable — and adds a feature spec asserting this behaviour.

## Screenshots

Before:
<img width="1317" height="579" alt="Screenshot 2026-06-13 at 19 47 54" src="https://github.com/user-attachments/assets/f01aee94-f371-46cb-b807-7321bc365733" />

After:
<img width="1311" height="529" alt="Screenshot 2026-06-13 at 19 46 36" src="https://github.com/user-attachments/assets/d0e4141d-43da-43da-b779-1bd9f3bc1821" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)