### PR TITLE
Implementation/STC-783: Adapt PDF export of timesheets for semantic identifiers

### DIFF
--- a/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
+++ b/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
@@ -224,7 +224,7 @@ class CostQuery::PDF::TimesheetGenerator
 
     href = url_helpers.work_package_url(entry.entity)
     {
-      content: "#{make_link_href(href, "##{entry.entity.id}")} #{entry.entity.subject || ''}",
+      content: "#{make_link_href(href, entry.entity.formatted_id)} #{entry.entity.subject || ''}",
       inline_format: true
     }
   end

--- a/modules/reporting/spec/workers/cost_query/pdf/timesheet_generator_spec.rb
+++ b/modules/reporting/spec/workers/cost_query/pdf/timesheet_generator_spec.rb
@@ -227,4 +227,16 @@ RSpec.describe CostQuery::PDF::TimesheetGenerator do
       expect(subject).to eq expected_document(false)
     end
   end
+
+  context "with semantic work package identifiers",
+          with_settings: { work_packages_identifier: "semantic", allow_tracking_start_and_end_times: false } do
+    before do
+      user_time_entry.entity.update_columns(identifier: "PROD-42", sequence_number: 42)
+    end
+
+    it "renders the semantic identifier in the work package column" do
+      expect(subject).to include("PROD-42")
+      expect(subject).not_to include("##{user_time_entry.entity.id}")
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-783

# What are you trying to accomplish?

On instances configured with project-based work package identifiers, the timesheet PDF export still showed the numeric database id in the work package column. The column now renders the configured identifier, so an entry exports as `PROD-42 Improve onboarding flow` rather than `#65 Improve onboarding flow`.

## Screenshots

**Before (classic identifiers)**

<img width="595" height="842" alt="stc783-timesheet-classic-before" src="https://github.com/user-attachments/assets/fc9e9a1d-f1cf-4c57-b077-00f9239b8488" />

[stc783-timesheet-classic-before.pdf](https://github.com/user-attachments/files/28877090/stc783-timesheet-classic-before.pdf)

**After (semantic identifiers)**

<img width="595" height="842" alt="stc783-timesheet-semantic-after" src="https://github.com/user-attachments/assets/d1f0a9a5-e0a9-4e2a-ae68-00fe7f432402" />

[stc783-timesheet-semantic-after.pdf](https://github.com/user-attachments/files/28877088/stc783-timesheet-semantic-after.pdf)

# What approach did you choose and why?

Same approach as the meeting PDF exports (#23708): the work package cell built its label from the raw numeric id, while the rest of the application renders identifiers through `formatted_id`, which returns the hash-prefixed numeric id in classic mode and the project-based identifier in semantic mode. The cell label now goes through that method; classic-mode output is unchanged, and the link URL already resolved to the configured identifier through the URL helpers.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
