### PR TITLE
[STC-162] Open attachment links from activity tab in a new tab

### DIFF
--- a/lib/open_project/journal_formatter/attachment.rb
+++ b/lib/open_project/journal_formatter/attachment.rb
@@ -69,7 +69,7 @@ class OpenProject::JournalFormatter::Attachment < JournalFormatter::Base
 
   def format_html_attachment_detail(key, value)
     if value.present? && a = Attachment.find_by(id: key.to_i)
-      link_to_attachment(a, only_path: false)
+      link_to_attachment(a, only_path: false, target: "_blank")
     elsif value.present?
       value
     end

--- a/lib/open_project/journal_formatter/file_link.rb
+++ b/lib/open_project/journal_formatter/file_link.rb
@@ -86,7 +86,7 @@ class OpenProject::JournalFormatter::FileLink < JournalFormatter::Base
 
   def format_html_file_link_detail(key, value)
     if file_link = file_link_for(key, value)
-      link_to_file_link(file_link, only_path: false)
+      link_to_file_link(file_link, only_path: false, target: "_blank")
     elsif value.present?
       value
     end

--- a/spec/lib/open_project/journal_formatter/attachment_spec.rb
+++ b/spec/lib/open_project/journal_formatter/attachment_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe OpenProject::JournalFormatter::Attachment do
         expect(instance.render(key, [nil, attachment.filename.to_s]))
           .to eq(I18n.t(:text_journal_attachment_added,
                         label: "<strong>#{I18n.t(:"activerecord.models.attachment")}</strong>",
-                        value: "<a href=\"#{link}\">#{attachment.filename}</a>"))
+                        value: "<a target=\"_blank\" href=\"#{link}\">#{attachment.filename}</a>"))
       end
 
       context "WITH a relative_url_root" do
@@ -71,7 +71,7 @@ RSpec.describe OpenProject::JournalFormatter::Attachment do
           expect(instance.render(key, [nil, attachment.filename.to_s]))
             .to eq(I18n.t(:text_journal_attachment_added,
                           label: "<strong>#{I18n.t(:"activerecord.models.attachment")}</strong>",
-                          value: "<a href=\"#{link}\">#{attachment.filename}</a>"))
+                          value: "<a target=\"_blank\" href=\"#{link}\">#{attachment.filename}</a>"))
         end
       end
     end

--- a/spec/lib/open_project/journal_formatter/file_link_spec.rb
+++ b/spec/lib/open_project/journal_formatter/file_link_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe OpenProject::JournalFormatter::FileLink do
         expect(instance.render(key, [nil, changes]))
           .to eq(I18n.t(:text_journal_file_link_added,
                         label: "<strong>#{I18n.t('activerecord.models.file_link')}</strong>",
-                        value: "<a href=\"#{link}\">#{file_link.origin_name}</a>",
+                        value: "<a target=\"_blank\" href=\"#{link}\">#{file_link.origin_name}</a>",
                         storage: file_link.storage.name))
       end
 
@@ -83,7 +83,7 @@ RSpec.describe OpenProject::JournalFormatter::FileLink do
           expect(instance.render(key, [nil, changes]))
             .to eq(I18n.t(:text_journal_file_link_added,
                           label: "<strong>#{I18n.t('activerecord.models.file_link')}</strong>",
-                          value: "<a href=\"#{link}\">#{file_link.origin_name}</a>",
+                          value: "<a target=\"_blank\" href=\"#{link}\">#{file_link.origin_name}</a>",
                           storage: file_link.storage.name))
         end
 
@@ -95,7 +95,7 @@ RSpec.describe OpenProject::JournalFormatter::FileLink do
             expect(instance.render(key, [nil, changes]))
               .to eq(I18n.t(:text_journal_file_link_added,
                             label: "<strong>#{I18n.t('activerecord.models.file_link')}</strong>",
-                            value: "<a href=\"#{link}\">#{file_link.origin_name}</a>",
+                            value: "<a target=\"_blank\" href=\"#{link}\">#{file_link.origin_name}</a>",
                             storage: file_link.storage.name))
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/59942/activity

# What are you trying to accomplish?

Attachment links and storage file links shown in the Activity tab now open in a new browser tab, matching the behaviour of the Files tab.

Previously, clicking an attachment link in the Activity/Journal tab navigated the current tab away from the work package, requiring a browser back action to return. The Files tab already rendered those same links with `target="_blank"`. This inconsistency was reported and confirmed as a bug; the team decision is that any link to an external resource (file content, storage file) should open in a new tab throughout the application.

## Screenshots
Before:
<img width="1850" height="848" alt="Kapture 2026-06-12 at 17 06 03" src="https://github.com/user-attachments/assets/b2deb41a-1b38-4d02-b120-ffabefed371d" />

After:
<img width="1850" height="848" alt="Kapture 2026-06-12 at 17 04 02" src="https://github.com/user-attachments/assets/af1e6e3a-8597-4067-b73f-5c1b84c1f70a" />

# What approach did you choose and why?

The journal formatters for attachments (`OpenProject::JournalFormatter::Attachment`) and storage file links (`OpenProject::JournalFormatter::FileLink`) each call a `link_to`-based helper — `link_to_attachment` and `link_to_file_link` respectively — to produce the anchor tag. Both helpers already forward arbitrary HTML options to Rails' `link_to`, so adding `target: "_blank"` at the two call sites is sufficient.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)