### PR TITLE
Restore accepting X-Requested-With for non-GET requests

### DIFF
--- a/lib_static/open_project/authentication/strategies/warden/session.rb
+++ b/lib_static/open_project/authentication/strategies/warden/session.rb
@@ -51,13 +51,19 @@ module OpenProject
 
             # For all other requests, to mitigate CSRF vectors,
             # require browser indication that this was a same-origin request
-            same_origin?
+            # we also allow the legacy X-Requested-With header in addition to that, since Sec-Fetch-Site
+            # is only sent via HTTPS (specifically: Only to "potentially trustworty origin"s)
+            same_origin? || (!Setting.https? && xml_request_header_set?)
           end
 
           def authenticate!
             user = user_id ? User.find(user_id) : User.anonymous
 
             success! user
+          end
+
+          def xml_request_header_set?
+            request.env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest"
           end
 
           def same_origin?

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -100,6 +100,26 @@ RSpec.describe "API V3 Authentication" do
           expect(last_response).to have_http_status :unauthorized
         end
       end
+
+      context "and when there is an X-Requested-With: XMLHttpRequest header when HTTPS is enabled",
+              with_settings: { https: true } do
+        let(:add_additional_headers) { header "X-Requested-With", "XMLHttpRequest" }
+
+        # in HTTPS setups we ignore this header, because the safer alternative is available
+        it "is not authenticated" do
+          expect(last_response).to have_http_status :unauthorized
+        end
+      end
+
+      context "and when there is an X-Requested-With: XMLHttpRequest header when HTTPS is disabled",
+              with_settings: { https: false } do
+        let(:add_additional_headers) { header "X-Requested-With", "XMLHttpRequest" }
+
+        # in HTTP setups we still accept the header for backwards-compatibility
+        it "authenticates successfully" do
+          expect(last_response).to have_http_status :created
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This is necessary to support HTTP (read: not HTTPS) deployments of OpenProject.

# Ticket
https://community.openproject.org/wp/OP-19499

# References

* https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-site-header
* https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-url
* Problem originally introduced via https://github.com/opf/openproject/pull/22549