### PR TITLE
[DREAM-720] Show project attributes in separate tab in the WP view

### DIFF
--- a/app/components/work_packages/project_attributes_tab_component.html.erb
+++ b/app/components/work_packages/project_attributes_tab_component.html.erb
@@ -1,0 +1,19 @@
+<turbo-frame id="work-package-project-attributes-tab-content">
+  <%=
+    component_wrapper do
+      if project_custom_fields_grouped_by_section.any?
+        render(Primer::OpenProject::SidePanel.new(spacious: true)) do |panel|
+          project_custom_fields_grouped_by_section.each do |project_custom_field_section, project_custom_fields|
+            panel.with_section(
+              Overviews::ProjectCustomFields::SectionComponent.new(
+                project: @project,
+                project_custom_field_section:,
+                project_custom_fields:
+              )
+            )
+          end
+        end
+      end
+    end
+  %>
+</turbo-frame>

--- a/app/components/work_packages/project_attributes_tab_component.html.erb
+++ b/app/components/work_packages/project_attributes_tab_component.html.erb
@@ -2,10 +2,10 @@
   <%=
     component_wrapper do
       if project_custom_fields_grouped_by_section.any?
-        render(Primer::OpenProject::SidePanel.new(spacious: true)) do |panel|
+        render(Primer::OpenProject::SidePanel.new) do |panel|
           project_custom_fields_grouped_by_section.each do |project_custom_field_section, project_custom_fields|
             panel.with_section(
-              Overviews::ProjectCustomFields::SectionComponent.new(
+              WorkPackages::ProjectCustomFields::SectionComponent.new(
                 project: @project,
                 project_custom_field_section:,
                 project_custom_fields:

--- a/app/components/work_packages/project_attributes_tab_component.rb
+++ b/app/components/work_packages/project_attributes_tab_component.rb
@@ -48,6 +48,8 @@ class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
   def project_custom_fields_grouped_by_section
     @project_custom_fields_grouped_by_section ||=
       @project.available_custom_fields
+              .joins(:project_custom_field_type_mappings)
+              .where(project_custom_field_type_mappings: { type_id: @work_package.type_id })
               .group_by(&:project_custom_field_section)
   end
 end

--- a/app/components/work_packages/project_attributes_tab_component.rb
+++ b/app/components/work_packages/project_attributes_tab_component.rb
@@ -47,9 +47,8 @@ class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
 
   def project_custom_fields_grouped_by_section
     @project_custom_fields_grouped_by_section ||=
-      @project.available_custom_fields
-              .joins(:project_custom_field_type_mappings)
-              .where(project_custom_field_type_mappings: { type_id: @work_package.type_id })
-              .group_by(&:project_custom_field_section)
+      ProjectCustomFieldSection.grouped_in_order(
+        @project.available_custom_fields_for_type(@work_package.type_id)
+      )
   end
 end

--- a/app/components/work_packages/project_attributes_tab_component.rb
+++ b/app/components/work_packages/project_attributes_tab_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
+  include OpPrimer::ComponentHelpers
+  include OpTurbo::Streamable
+
+  def initialize(work_package:)
+    super
+
+    @work_package = work_package
+    @project = work_package.project
+  end
+
+  private
+
+  def project_custom_fields_grouped_by_section
+    @project_custom_fields_grouped_by_section ||=
+      @project.available_custom_fields
+              .group_by(&:project_custom_field_section)
+  end
+end

--- a/app/components/work_packages/project_custom_fields/section_component.html.erb
+++ b/app/components/work_packages/project_custom_fields/section_component.html.erb
@@ -1,0 +1,28 @@
+<%=
+  component_wrapper do
+    render(
+      Primer::OpenProject::SidePanel::Section.new(
+        test_selector: "wp-project-attribute-section-#{@project_custom_field_section.id}"
+      )
+    ) do |section|
+      section.with_title { @project_custom_field_section.name }
+
+      flex_layout(classes: "gap-2") do |flex|
+        @project_custom_fields.each do |project_custom_field|
+          flex.with_row do
+            render(
+              OpenProject::Common::InplaceEditFieldComponent.new(
+                model: @project,
+                attribute: project_custom_field.attribute_name.to_sym,
+                open_in_dialog: false,
+                truncated: false,
+                test_selector: "wp-project-attribute-#{project_custom_field.id}",
+                display_classes: "op-project-custom-field-container"
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/project_custom_fields/section_component.rb
+++ b/app/components/work_packages/project_custom_fields/section_component.rb
@@ -28,26 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
+class WorkPackages::ProjectCustomFields::SectionComponent < ApplicationComponent
+  include ApplicationHelper
   include OpPrimer::ComponentHelpers
   include OpTurbo::Streamable
 
-  def initialize(work_package:)
+  def initialize(project:, project_custom_field_section:, project_custom_fields:)
     super
 
-    @work_package = work_package
-    @project = work_package.project
-  end
-
-  def render?
-    project_custom_fields_grouped_by_section.any?
-  end
-
-  private
-
-  def project_custom_fields_grouped_by_section
-    @project_custom_fields_grouped_by_section ||=
-      @project.available_custom_fields
-              .group_by(&:project_custom_field_section)
+    @project = project
+    @project_custom_field_section = project_custom_field_section
+    @project_custom_fields = project_custom_fields
   end
 end

--- a/app/components/work_packages/project_custom_fields/section_component.rb
+++ b/app/components/work_packages/project_custom_fields/section_component.rb
@@ -29,7 +29,6 @@
 #++
 
 class WorkPackages::ProjectCustomFields::SectionComponent < ApplicationComponent
-  include ApplicationHelper
   include OpPrimer::ComponentHelpers
   include OpTurbo::Streamable
 

--- a/app/controllers/work_packages/project_attributes_tab_controller.rb
+++ b/app/controllers/work_packages/project_attributes_tab_controller.rb
@@ -31,6 +31,7 @@
 class WorkPackages::ProjectAttributesTabController < ApplicationController
   before_action :find_work_package
   before_action :authorize
+  before_action :authorize_project_attributes_visibility
 
   def index
     render(WorkPackages::ProjectAttributesTabComponent.new(work_package: @work_package))
@@ -43,5 +44,9 @@ class WorkPackages::ProjectAttributesTabController < ApplicationController
     @project = @work_package.project
   rescue ActiveRecord::RecordNotFound
     render_404
+  end
+
+  def authorize_project_attributes_visibility
+    do_authorize(:view_project_attributes)
   end
 end

--- a/app/controllers/work_packages/project_attributes_tab_controller.rb
+++ b/app/controllers/work_packages/project_attributes_tab_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class WorkPackages::ProjectAttributesTabController < ApplicationController
+  before_action :find_work_package
+  before_action :authorize
+
+  def index
+    render(WorkPackages::ProjectAttributesTabComponent.new(work_package: @work_package))
+  end
+
+  private
+
+  def find_work_package
+    @work_package = WorkPackage.visible.find(params.expect(:id))
+    @project = @work_package.project
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+end

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -50,6 +50,12 @@ module Projects::CustomFields
       all_visible_custom_fields.where(id: project_custom_field_project_mappings.select(:custom_field_id))
     end
 
+    def available_custom_fields_for_type(type_id)
+      available_custom_fields
+        .joins(:project_custom_field_type_mappings)
+        .where(project_custom_field_type_mappings: { type_id: })
+    end
+
     # Note:
     #
     # The UI allows the enabled attributes only via the project_custom_field_project_mappings.

--- a/app/views/work_package_types/project_attributes_tab/edit.html.erb
+++ b/app/views/work_package_types/project_attributes_tab/edit.html.erb
@@ -12,6 +12,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<p><%= I18n.t("types.edit.project_attributes.description") %></p>
 
 <%= render WorkPackageTypes::ProjectAttributes::IndexComponent.new(
       type: @type,

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -314,7 +314,8 @@ Rails.application.reloader.to_prepare do
                        "work_packages/menus": %i[show],
                        "work_packages/hover_card": %i[show],
                        work_package_relations_tab: %i[index],
-                       "work_packages/reminders": %i[modal_body create update destroy]
+                       "work_packages/reminders": %i[modal_body create update destroy],
+                       "work_packages/project_attributes_tab": %i[index]
                      },
                      permissible_on: %i[work_package project],
                      contract_actions: { work_packages: %i[read] }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1503,6 +1503,7 @@ en:
         actions:
           label_disable_all: "Disable all"
           label_enable_all: "Enable all"
+        description: "Select the project attributes that you want to enable for this work package type. Enabled project attributes are displayed in a separate tab in work packages of this type. Users with the necessary permissions can view and edit these attributes there."
         filter: "Search by section or name"
         tab: "Project attributes"
       projects:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -971,11 +971,12 @@ en:
         relation_filters:
           filter_work_packages_by_relation_type: "Filter work packages by relation type"
       tabs:
-        overview: Overview
         activity: Activity
+        files: Files
+        project_attributes: Project attributes
+        overview: Overview
         relations: Relations
         watchers: Watchers
-        files: Files
       time_relative:
         days: "days"
         weeks: "weeks"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -973,8 +973,8 @@ en:
       tabs:
         activity: Activity
         files: Files
-        project_attributes: Project attributes
         overview: Overview
+        project_attributes: Project attributes
         relations: Relations
         watchers: Watchers
       time_relative:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -962,6 +962,7 @@ Rails.application.routes.draw do
     concerns :shareable
 
     get "hover_card" => "work_packages/hover_card#show", on: :member
+    get "project_attributes" => "work_packages/project_attributes_tab#index", on: :member
 
     get "generate_pdf_dialog" => "work_packages#generate_pdf_dialog", on: :member
     post "generate_pdf" => "work_packages#generate_pdf", on: :member

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -45,6 +45,10 @@ allOf:
       readonly:
         type: boolean
         description: If true, the work package is in a readonly status so with the exception of the status, no other property can be altered.
+      hasProjectAttributes:
+        type: boolean
+        description: If true, the work package's type has at least one project custom field activated and visible to the current user.
+        readOnly: true
       startDate:
         type:
           - "string"

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -166,6 +166,8 @@ export class WorkPackageBaseResource extends HalResource {
 
   public lockVersion:number;
 
+  public hasProjectAttributes:boolean;
+
   public description:any;
 
   public activities:CollectionResource;

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.html
@@ -1,0 +1,13 @@
+<div id="work-package-project-attributes-container">
+  <turbo-frame [src]="turboFrameSrc" id="work-package-project-attributes-tab-content" loading="lazy">
+    <op-content-loader viewBox="0 0 100 100">
+      <svg:rect x="0" y="0" width="70" height="5" rx="1" />
+
+      <svg:rect x="75" y="0" width="25" height="5" rx="1" />
+
+      <svg:rect x="0" y="10" width="100" height="8" rx="1" />
+
+      <svg:rect x="0" y="25" width="100" height="12" rx="1" />
+    </op-content-loader>
+  </turbo-frame>
+</div>

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.ts
@@ -1,0 +1,71 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  Input,
+  OnInit,
+} from '@angular/core';
+
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { UIRouterGlobals } from '@uirouter/core';
+
+@Component({
+  selector: 'op-project-attributes-tab',
+  templateUrl: './op-project-attributes-tab.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class WorkPackageProjectAttributesTabComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly pathHelper = inject(PathHelperService);
+
+  public turboFrameSrc:string;
+  public workPackageId:string;
+
+  @Input() public workPackage:WorkPackageResource;
+
+  ngOnInit() {
+    const { workPackageId } = this.uiRouterGlobals.params as unknown as { workPackageId:string };
+    this.workPackageId = (this.workPackage.id!) || workPackageId;
+
+    this.turboFrameSrc = this.buildTurboFrameSrc();
+  }
+
+  protected buildTurboFrameSrc():string {
+    const baseUrl = window.location.origin;
+    const url = new URL(`${this.pathHelper.staticBase}/work_packages/${this.workPackageId}/project_attributes`, baseUrl);
+
+    return url.toString();
+  }
+}

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
@@ -73,4 +73,23 @@ describe('WpTabsService', () => {
       expect(displayableTabs[0].id).toEqual(notDisplayableTab.id);
     });
   });
+
+  describe('project_attributes tab', () => {
+    beforeEach(() => {
+      // Reset to default tabs so the built-in project_attributes tab is present
+      (service as any).registeredTabs = (service as any).buildDefaultTabs();
+    });
+
+    it('is hidden when hasProjectAttributes is false', () => {
+      const wp:any = { hasProjectAttributes: false };
+      const tabs = service.getDisplayableTabs(wp);
+      expect(tabs.find((t) => t.id === 'project_attributes')).toBeUndefined();
+    });
+
+    it('is visible when hasProjectAttributes is true', () => {
+      const wp:any = { hasProjectAttributes: true };
+      const tabs = service.getDisplayableTabs(wp);
+      expect(tabs.find((t) => t.id === 'project_attributes')).toBeDefined();
+    });
+  });
 });

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -151,6 +151,7 @@ export class WorkPackageTabsService {
         id: 'project_attributes',
         component: WorkPackageProjectAttributesTabComponent,
         name: I18n.t('js.work_packages.tabs.project_attributes'),
+        displayable: (workPackage) => !!workPackage.hasProjectAttributes,
       },
       {
         id: 'files',

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -59,6 +59,7 @@ import {
 import {
   workPackageFilesCount,
 } from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-files-count.function';
+import { WorkPackageProjectAttributesTabComponent } from 'core-app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component';
 
 @Injectable({
   providedIn: 'root',
@@ -145,6 +146,11 @@ export class WorkPackageTabsService {
         name: I18n.t('js.work_packages.tabs.activity'),
         count: workPackageNotificationsCount,
         showCountAsBubble: true,
+      },
+      {
+        id: 'project_attributes',
+        component: WorkPackageProjectAttributesTabComponent,
+        name: I18n.t('js.work_packages.tabs.project_attributes'),
       },
       {
         id: 'files',

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -409,6 +409,7 @@ import { WorkPackageFullViewEntryComponent } from 'core-app/features/work-packag
 import {
   WorkPackageSplitCreateEntryComponent,
 } from 'core-app/features/work-packages/routing/wp-split-create/wp-split-create-entry.component';
+import { WorkPackageProjectAttributesTabComponent } from 'core-app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component';
 
 @NgModule({
   imports: [
@@ -588,6 +589,9 @@ import {
 
     // Files tab
     WorkPackageFilesTabComponent,
+
+    // Project attributes tab
+    WorkPackageProjectAttributesTabComponent,
 
     // Split view
     WorkPackageDetailsViewButtonComponent,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -494,7 +496,14 @@ module API
                  as: :hasProjectAttributes,
                  writable: false,
                  uncacheable: true,
-                 getter: ->(*) { project&.available_custom_fields&.any? || false }
+                 getter: ->(*) do
+                   fields = project
+                              &.available_custom_fields
+                              &.joins(:project_custom_field_type_mappings)
+                   fields
+                     &.where(project_custom_field_type_mappings: { type_id: })
+                     &.any? || false
+                 end
 
         associated_resource :category
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -490,6 +490,12 @@ module API
                    status_id && status.is_readonly?
                  end
 
+        property :has_project_attributes,
+                 as: :hasProjectAttributes,
+                 writable: false,
+                 uncacheable: true,
+                 getter: ->(*) { project&.available_custom_fields&.any? || false }
+
         associated_resource :category
 
         associated_resource :type

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -497,12 +497,7 @@ module API
                  writable: false,
                  uncacheable: true,
                  getter: ->(*) do
-                   fields = project
-                              &.available_custom_fields
-                              &.joins(:project_custom_field_type_mappings)
-                   fields
-                     &.where(project_custom_field_type_mappings: { type_id: })
-                     &.any? || false
+                   project&.available_custom_fields_for_type(type_id)&.any? || false
                  end
 
         associated_resource :category

--- a/spec/components/work_packages/project_attributes_tab_component_spec.rb
+++ b/spec/components/work_packages/project_attributes_tab_component_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe WorkPackages::ProjectAttributesTabComponent, type: :component do
   include Rails.application.routes.url_helpers
 
   let(:project) { create(:project) }
-  let(:work_package) { build_stubbed(:work_package, project:) }
+  let(:type) { create(:type) }
+  let(:work_package) { build_stubbed(:work_package, project:, type:) }
   let(:user) { build_stubbed(:admin) }
 
   current_user { user }
@@ -43,31 +44,54 @@ RSpec.describe WorkPackages::ProjectAttributesTabComponent, type: :component do
     render_inline(described_class.new(work_package:))
   end
 
+  def create_field_for(wp_type, section:)
+    create(:project_custom_field, project_custom_field_section: section, projects: [project]).tap do |f|
+      wp_type.project_custom_fields << f
+    end
+  end
+
   context "when the project has no custom fields" do
     it "renders nothing" do
       expect(rendered_component.to_html).to be_empty
     end
   end
 
-  context "when the project has custom fields but the user has no permission to view them" do
+  context "when the project has custom fields mapped to the type but the user has no permission to view them" do
     let(:user) { build_stubbed(:user) }
     let(:section) { create(:project_custom_field_section) }
-    let!(:fields) { create_list(:project_custom_field, 2, project_custom_field_section: section, projects: [project]) }
+    let!(:fields) { Array.new(2) { create_field_for(type, section:) } }
 
     it "renders nothing" do
       expect(rendered_component.to_html).to be_empty
     end
   end
 
-  context "when the project has custom fields in multiple sections" do
+  context "when the project has custom fields in multiple sections mapped to the type" do
     let(:section_a) { create(:project_custom_field_section) }
     let(:section_b) { create(:project_custom_field_section) }
-    let!(:fields_a) { create_list(:project_custom_field, 2, project_custom_field_section: section_a, projects: [project]) }
-    let!(:fields_b) { create_list(:project_custom_field, 1, project_custom_field_section: section_b, projects: [project]) }
+    let!(:fields_a) { Array.new(2) { create_field_for(type, section: section_a) } }
+    let!(:fields_b) { [create_field_for(type, section: section_b)] }
 
     it "renders one section component per custom field section" do
       expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_a.id}")
       expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_b.id}")
+    end
+  end
+
+  context "when the project has custom fields with type mappings" do
+    let(:section) { create(:project_custom_field_section) }
+    let(:other_type) { create(:type) }
+    let!(:field_for_type) { create_field_for(type, section:) }
+    let!(:field_for_other_type) { create_field_for(other_type, section:) }
+    let!(:field_without_mapping) do
+      create(:project_custom_field, project_custom_field_section: section, projects: [project])
+    end
+
+    it "only renders fields mapped to the work package type" do
+      expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section.id}")
+      expect(rendered_component).to have_text(field_for_type.name)
+      expect(rendered_component).to have_no_text(field_for_other_type.name)
+      expect(rendered_component).to have_no_text(field_without_mapping.name)
     end
   end
 end

--- a/spec/components/work_packages/project_attributes_tab_component_spec.rb
+++ b/spec/components/work_packages/project_attributes_tab_component_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::ProjectAttributesTabComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:project) { create(:project) }
+  let(:work_package) { build_stubbed(:work_package, project:) }
+  let(:user) { build_stubbed(:admin) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(work_package:))
+  end
+
+  context "when the project has no custom fields" do
+    it "renders nothing" do
+      expect(rendered_component.to_html).to be_empty
+    end
+  end
+
+  context "when the project has custom fields but the user has no permission to view them" do
+    let(:user) { build_stubbed(:user) }
+    let(:section) { create(:project_custom_field_section) }
+    let!(:fields) { create_list(:project_custom_field, 2, project_custom_field_section: section, projects: [project]) }
+
+    it "renders nothing" do
+      expect(rendered_component.to_html).to be_empty
+    end
+  end
+
+  context "when the project has custom fields in multiple sections" do
+    let(:section_a) { create(:project_custom_field_section) }
+    let(:section_b) { create(:project_custom_field_section) }
+    let!(:fields_a) { create_list(:project_custom_field, 2, project_custom_field_section: section_a, projects: [project]) }
+    let!(:fields_b) { create_list(:project_custom_field, 1, project_custom_field_section: section_b, projects: [project]) }
+
+    it "renders one section component per custom field section" do
+      expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_a.id}")
+      expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_b.id}")
+    end
+  end
+end

--- a/spec/components/work_packages/project_custom_fields/section_component_spec.rb
+++ b/spec/components/work_packages/project_custom_fields/section_component_spec.rb
@@ -28,26 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
-  include OpPrimer::ComponentHelpers
-  include OpTurbo::Streamable
+require "rails_helper"
 
-  def initialize(work_package:)
-    super
+RSpec.describe WorkPackages::ProjectCustomFields::SectionComponent, type: :component do
+  include Rails.application.routes.url_helpers
 
-    @work_package = work_package
-    @project = work_package.project
+  let(:project) { build(:project) }
+  let(:project_custom_field_section) { build(:project_custom_field_section, name: "Special Section") }
+  let(:project_custom_fields) { create_list(:project_custom_field, 2, projects: [project]) }
+  let(:user) { build_stubbed(:user) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(project:, project_custom_field_section:, project_custom_fields:))
   end
 
-  def render?
-    project_custom_fields_grouped_by_section.any?
+  it "renders the section with the correct title" do
+    expect(rendered_component).to have_section "Special Section"
   end
 
-  private
-
-  def project_custom_fields_grouped_by_section
-    @project_custom_fields_grouped_by_section ||=
-      @project.available_custom_fields
-              .group_by(&:project_custom_field_section)
+  it "renders a field container for each custom field" do
+    expect(rendered_component).to have_css ".op-project-custom-field-container", count: 2
   end
 end

--- a/spec/controllers/work_packages/project_attributes_tab_controller_spec.rb
+++ b/spec/controllers/work_packages/project_attributes_tab_controller_spec.rb
@@ -28,25 +28,46 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject
-  module InplaceEdit
-    module Handlers
-      class ProjectUpdate
-        def self.call(model:, params:, user:)
-          contract_options = project_attributes_only?(params) ? { project_attributes_only: true } : {}
+require "spec_helper"
 
-          call = ::Projects::UpdateService
-                   .new(model:, user:, contract_options:)
-                   .call(params)
+RSpec.describe WorkPackages::ProjectAttributesTabController do
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
 
-          call.success?
-        end
+  let(:role_with_both_permissions) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes])
+  end
+  let(:role_without_project_attributes) do
+    create(:project_role, permissions: %i[view_work_packages])
+  end
 
-        def self.project_attributes_only?(params)
-          params.keys.all? { |k| k.to_s.start_with?("custom_field_", "custom_comment") }
-        end
-        private_class_method :project_attributes_only?
-      end
+  before do
+    allow(User).to receive(:current).and_return(user)
+    work_package
+  end
+
+  describe "#index" do
+    subject do
+      get :index, params: { id: work_package.id }
+      response
+    end
+
+    context "when the user has view_work_packages and view_project_attributes" do
+      let(:user) { create(:user, member_with_roles: { project => role_with_both_permissions }) }
+
+      it { is_expected.to be_successful }
+    end
+
+    context "when the user has view_work_packages but not view_project_attributes" do
+      let(:user) { create(:user, member_with_roles: { project => role_without_project_attributes }) }
+
+      it { is_expected.to be_forbidden }
+    end
+
+    context "when the user has no access to the project" do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be_not_found }
     end
   end
 end

--- a/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
+++ b/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package project attributes tab", :js do
+  shared_let(:project) { create(:project) }
+  shared_let(:section) { create(:project_custom_field_section, name: "Details") }
+  shared_let(:string_field) do
+    create(:string_project_custom_field,
+           name: "Project info",
+           project_custom_field_section: section,
+           projects: [project]) do |field|
+      create(:custom_value, customized: project, custom_field: field, value: "Initial value")
+    end
+  end
+
+  shared_let(:edit_role) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes edit_project_attributes edit_project])
+  end
+  shared_let(:view_role) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes])
+  end
+
+  let(:work_package) { create(:work_package, project:) }
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+  let(:inplace_field) { Components::Common::InplaceEditField.new(project, string_field.attribute_name.to_sym) }
+  let(:input_field) { FormFields::Primerized::InputField.new(string_field) }
+
+  context "as a user with view and edit permissions" do
+    let(:user) { create(:user, member_with_roles: { project => edit_role }) }
+
+    before do
+      login_as user
+      wp_page.visit_tab! "activity"
+      expect_angular_frontend_initialized
+      wait_for_turbo_frame { click_on I18n.t("js.work_packages.tabs.project_attributes") }
+    end
+
+    it "displays the section and field" do
+      expect(page).to have_test_selector("wp-project-attribute-section-#{section.id}")
+      expect(page).to have_test_selector("wp-project-attribute-#{string_field.id}")
+    end
+
+    it "allows editing a string field" do
+      wait_for_turbo_stream { inplace_field.open_field }
+
+      input_field.fill_in(with: "Updated value")
+      inplace_field.submit
+      inplace_field.expect_close
+
+      within_test_selector("wp-project-attribute-#{string_field.id}") do
+        expect(page).to have_text "Updated value"
+      end
+    end
+  end
+
+  context "as a user with view permission only" do
+    let(:user) { create(:user, member_with_roles: { project => view_role }) }
+
+    before do
+      login_as user
+      wp_page.visit_tab! "activity"
+      expect_angular_frontend_initialized
+      wait_for_turbo_frame { click_on I18n.t("js.work_packages.tabs.project_attributes") }
+    end
+
+    it "displays the field but does not allow editing" do
+      expect(page).to have_test_selector("wp-project-attribute-#{string_field.id}")
+
+      within_test_selector("wp-project-attribute-#{string_field.id}") do
+        expect(page).to have_no_css(".op-inplace-edit--display-field_clickable")
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
+++ b/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
@@ -32,12 +32,14 @@ require "spec_helper"
 
 RSpec.describe "Work package project attributes tab", :js do
   shared_let(:project) { create(:project) }
+  shared_let(:type) { create(:type) }
   shared_let(:section) { create(:project_custom_field_section, name: "Details") }
   shared_let(:string_field) do
     create(:string_project_custom_field,
            name: "Project info",
            project_custom_field_section: section,
            projects: [project]) do |field|
+      type.project_custom_fields << field
       create(:custom_value, customized: project, custom_field: field, value: "Initial value")
     end
   end
@@ -49,7 +51,7 @@ RSpec.describe "Work package project attributes tab", :js do
     create(:project_role, permissions: %i[view_work_packages view_project_attributes])
   end
 
-  let(:work_package) { create(:work_package, project:) }
+  let(:work_package) { create(:work_package, project:, type:) }
   let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:inplace_field) { Components::Common::InplaceEditField.new(project, string_field.attribute_name.to_sym) }
   let(:input_field) { FormFields::Primerized::InputField.new(string_field) }

--- a/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
+++ b/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe "Work package project attributes tab", :js do
   shared_let(:edit_role) do
     create(:project_role, permissions: %i[view_work_packages view_project_attributes edit_project_attributes edit_project])
   end
+  shared_let(:edit_project_attributes_only_role) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes edit_project_attributes])
+  end
   shared_let(:view_role) do
     create(:project_role, permissions: %i[view_work_packages view_project_attributes])
   end
@@ -69,6 +72,29 @@ RSpec.describe "Work package project attributes tab", :js do
     it "displays the section and field" do
       expect(page).to have_test_selector("wp-project-attribute-section-#{section.id}")
       expect(page).to have_test_selector("wp-project-attribute-#{string_field.id}")
+    end
+
+    it "allows editing a string field" do
+      wait_for_turbo_stream { inplace_field.open_field }
+
+      input_field.fill_in(with: "Updated value")
+      inplace_field.submit
+      inplace_field.expect_close
+
+      within_test_selector("wp-project-attribute-#{string_field.id}") do
+        expect(page).to have_text "Updated value"
+      end
+    end
+  end
+
+  context "as a user with edit_project_attributes but without edit_project" do
+    let(:user) { create(:user, member_with_roles: { project => edit_project_attributes_only_role }) }
+
+    before do
+      login_as user
+      wp_page.visit_tab! "activity"
+      expect_angular_frontend_initialized
+      wait_for_turbo_frame { click_on I18n.t("js.work_packages.tabs.project_attributes") }
     end
 
     it "allows editing a string field" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -203,6 +203,29 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
       end
     end
 
+    describe "hasProjectAttributes" do
+      context "when the project has no visible custom fields" do
+        before do
+          allow(workspace).to receive(:available_custom_fields).and_return([])
+        end
+
+        it "renders as false" do
+          expect(subject).to be_json_eql(false.to_json).at_path("hasProjectAttributes")
+        end
+      end
+
+      context "when the project has visible custom fields" do
+        before do
+          allow(workspace).to receive(:available_custom_fields)
+            .and_return(instance_double(Array, any?: true, reject: []))
+        end
+
+        it "renders as true" do
+          expect(subject).to be_json_eql(true.to_json).at_path("hasProjectAttributes")
+        end
+      end
+    end
+
     describe "startDate" do
       it_behaves_like "has ISO 8601 date only" do
         let(:date) { start_date }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -204,21 +204,22 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
     end
 
     describe "hasProjectAttributes" do
-      context "when the project has no visible custom fields" do
-        before do
-          allow(workspace).to receive(:available_custom_fields).and_return([])
-        end
+      let(:type_fields_exist) { false }
 
+      before do
+        fields = instance_double(ActiveRecord::Relation, any?: type_fields_exist)
+        allow(fields).to receive_messages(reject: [], joins: fields, where: fields)
+        allow(workspace).to receive(:available_custom_fields).and_return(fields)
+      end
+
+      context "when no custom fields are mapped to the type" do
         it "renders as false" do
           expect(subject).to be_json_eql(false.to_json).at_path("hasProjectAttributes")
         end
       end
 
-      context "when the project has visible custom fields" do
-        before do
-          allow(workspace).to receive(:available_custom_fields)
-            .and_return(instance_double(Array, any?: true, reject: []))
-        end
+      context "when custom fields are mapped to the type" do
+        let(:type_fields_exist) { true }
 
         it "renders as true" do
           expect(subject).to be_json_eql(true.to_json).at_path("hasProjectAttributes")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-720

# What are you trying to accomplish?
Add a tab for project attributes within the WP view

**ToDo**

- [x] Create new tab called "Project attributes"
- [x] Render the project attribute of that project in the tab
  - [x] activate inline editing
  - [x] Limit to those active for that type
  - [x] Hide the tab when there are no attributes active/visible for this type
- [x] Add tests
- [x] Permission checks


## Screenshots

<img width="2147" height="888" alt="Bildschirmfoto 2026-06-12 um 14 37 29" src="https://github.com/user-attachments/assets/05a22c62-e670-42f0-8b83-0a1afd56eda1" />
