### PR TITLE
Fix rubocop offenses in wikis module

### DIFF
--- a/modules/wikis/app/controllers/wikis/admin/health_status_controller.rb
+++ b/modules/wikis/app/controllers/wikis/admin/health_status_controller.rb
@@ -85,7 +85,7 @@ module Wikis
       end
 
       def find_provider
-        @provider = ::Wikis::Provider.visible.find(params[:wiki_provider_id])
+        @provider = ::Wikis::Provider.visible.find(params.expect(:wiki_provider_id))
       end
 
       def create_and_store_report

--- a/modules/wikis/app/controllers/wikis/admin/oauth_clients_controller.rb
+++ b/modules/wikis/app/controllers/wikis/admin/oauth_clients_controller.rb
@@ -99,7 +99,7 @@ module Wikis
       end
 
       def find_wiki_provider
-        @wiki_provider = Wikis::Provider.visible.find(params[:wiki_provider_id])
+        @wiki_provider = Wikis::Provider.visible.find(params.expect(:wiki_provider_id))
       end
 
       def respond_for_success

--- a/modules/wikis/app/controllers/wikis/admin/wiki_providers_controller.rb
+++ b/modules/wikis/app/controllers/wikis/admin/wiki_providers_controller.rb
@@ -150,13 +150,13 @@ module Wikis
       end
 
       def find_wiki_provider
-        @wiki_provider = editable_wiki_providers.find(params[:id])
+        @wiki_provider = editable_wiki_providers.find(params.expect(:id))
       end
 
       def continue_from_wizard_params
         return if params[:continue_wizard].blank?
 
-        editable_wiki_providers.find(params[:continue_wizard])
+        editable_wiki_providers.find(params.expect(:continue_wizard))
       end
 
       def wiki_provider_params

--- a/modules/wikis/app/controllers/work_package_wikis_tab_controller.rb
+++ b/modules/wikis/app/controllers/work_package_wikis_tab_controller.rb
@@ -49,6 +49,6 @@ class WorkPackageWikisTabController < ApplicationController
   private
 
   def set_work_package
-    @work_package = @project.work_packages.visible.find(params[:work_package_id])
+    @work_package = @project.work_packages.visible.find(params.expect(:work_package_id))
   end
 end


### PR DESCRIPTION
Those sneaked in most likely due to a Rubocop update. Fixing them all at once, bringing the wikis module back to formall no offenses.

# Ticket
none