### PR TITLE
[STC-564] Fix rendering on double separator in enumeration component 

### DIFF
--- a/app/components/admin/enumerations/item_component.rb
+++ b/app/components/admin/enumerations/item_component.rb
@@ -55,18 +55,18 @@ module Admin
       end
 
       def build_enumeration_menu(menu)
-        edit_enumeration(menu)
-        menu.with_divider
-        if !first_item?
-          move_to_top_enumeration(menu)
-          move_up_enumeration(menu)
+        with_item_group(menu) { edit_enumeration(menu) }
+        with_item_group(menu) do
+          unless first_item?
+            move_to_top_enumeration(menu)
+            move_up_enumeration(menu)
+          end
+          unless last_item?
+            move_down_enumeration(menu)
+            move_to_bottom_enumeration(menu)
+          end
         end
-        if !last_item?
-          move_down_enumeration(menu)
-          move_to_bottom_enumeration(menu)
-        end
-        menu.with_divider
-        deletion_enumeration(menu)
+        with_item_group(menu) { deletion_enumeration(menu) }
       end
 
       def edit_enumeration(menu)

--- a/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Document types admin", :js do
       expect(page).to have_no_button(I18n.t(:label_sort_higher))
       expect(page).to have_no_button(I18n.t(:label_sort_lower))
       expect(page).to have_no_button(I18n.t(:label_sort_lowest))
-      expect(page).to have_css("li[role='separator']", count: 1)
+      expect(page).to have_css("li.ActionList-sectionDivider", count: 1)
     end
   end
 

--- a/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
@@ -187,6 +187,26 @@ RSpec.describe "Document types admin", :js do
     end
   end
 
+  context "with a single document type" do
+    let!(:only_type) { create(:document_type, name: "Only type") }
+
+    it "shows a single separator (no duplicate) in the more menu" do
+      visit admin_settings_document_types_path
+
+      within_enumeration_item(only_type) do
+        click_on accessible_name: "Document type actions"
+      end
+
+      expect(page).to have_link("Edit")
+      expect(page).to have_link("Delete")
+      expect(page).to have_no_button(I18n.t(:label_sort_highest))
+      expect(page).to have_no_button(I18n.t(:label_sort_higher))
+      expect(page).to have_no_button(I18n.t(:label_sort_lower))
+      expect(page).to have_no_button(I18n.t(:label_sort_lowest))
+      expect(page).to have_css("li[role='separator']", count: 1)
+    end
+  end
+
   context "with non-admin user" do
     current_user { create(:user) }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/69518

# What are you trying to accomplish?

When the Documents administration "Types" page has only a single document type, the three-dot more menu displays a double separator line between the "Edit" and "Delete" items. This is caused by two unconditional `menu.with_divider` calls in `Admin::Enumerations::ItemComponent#build_enumeration_menu` that were intended to bracket the "move" actions (Move to top / Move up / Move down / Move to bottom). When only one type exists, `first_item?` and `last_item?` are both true, so no move actions are rendered — but both dividers still appear, producing two consecutive horizontal separator lines.

## What approach did you choose and why?

Tweak the conditional that dictates when separators get rendered.

The fix lives in the base class `Admin::Enumerations::ItemComponent`, which is shared by all enumeration admin pages (document types, issue priorities, time entry activities, etc.), so all of them benefit from the correction without any additional changes.

## Screenshots

N/A

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)