### PR TITLE
[STC-563] Fix label of new document type button in admin

### DIFF
--- a/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
@@ -37,12 +37,12 @@
           subheader.with_action_button(
             scheme: :primary,
             leading_icon: :plus,
-            label: t(:button_add),
+            label: t("documents.button_add_type"),
             tag: :a,
             href: helpers.url_for(action: :new),
             test_selector: "add-document-type-button"
           ) do
-            I18n.t(:button_add)
+            I18n.t("documents.button_add_type")
           end
         end
       end

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -58,6 +58,8 @@ en:
   enumeration_doc_categories: "Document categories"
 
   documents:
+    button_add_type: "Type"
+
     page_header:
       heading: "All documents"
       action_menu:

--- a/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Document types admin", :js do
       end
 
       within_test_selector("admin-document-types-subheader") do
-        click_on "Add"
+        click_on "Type"
       end
 
       fill_in "Name", with: "Documentation"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/69498/activity

# What are you trying to accomplish?

The "+Add" button on the Documents admin Types page (`admin/settings/document_types`) displayed the generic "Add" label instead of the context-specific "Type" label. The button renders a leading `+` icon automatically, so the full visible label should be "+Type" — not "+Add".

## Screenshots
Before:
<img width="1029" height="803" alt="Screenshot 2026-06-12 at 16 10 53" src="https://github.com/user-attachments/assets/87e99c0f-307b-4116-ab48-576dd6b1e85d" />

After:
<img width="1033" height="753" alt="Screenshot 2026-06-12 at 16 10 39" src="https://github.com/user-attachments/assets/102b80bd-9bec-487f-bdd5-10b404b8f93c" />



# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)