### PR TITLE
[STC-356] Disallow setting journal aggregation period to >2 hours

### DIFF
--- a/app/contracts/settings/update_params_contract.rb
+++ b/app/contracts/settings/update_params_contract.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Settings
+  class UpdateParamsContract < ::ParamsContract
+    include RequiresAdminGuard
+
+    validate :journal_aggregation_time_minutes_is_within_bounds
+
+    protected
+
+    def journal_aggregation_time_minutes_is_within_bounds
+      value = params[:journal_aggregation_time_minutes]
+      return if value.nil?
+
+      allowed = Settings::Definition[:journal_aggregation_time_minutes].allowed
+      unless allowed.cover?(value.to_i)
+        errors.add :base, :journal_aggregation_time_minutes_is_out_of_bounds, min: allowed.min, max: allowed.max
+      end
+    end
+  end
+end

--- a/app/forms/admin/settings/aggregation_settings_form/journal_aggregation_time_minutes_caption.html.erb
+++ b/app/forms/admin/settings/aggregation_settings_form/journal_aggregation_time_minutes_caption.html.erb
@@ -1,5 +1,9 @@
 <%= render(Primer::Beta::Text.new(tag: :p)) do %>
-  <%= link_translate("admin.journal_aggregation.caption", links: { webhook_link: url_helpers.admin_outgoing_webhooks_path }) %>
+  <%= link_translate(
+        "admin.journal_aggregation.caption_with_maximum",
+        i18n_args: { max: ::Settings::Definition[:journal_aggregation_time_minutes].allowed.max },
+        links: { webhook_link: url_helpers.admin_outgoing_webhooks_path }
+      ) %>
 <% end %>
 <%= render(Primer::OpenProject::InlineMessage.new(scheme: :warning, size: :small)) do %>
   <%= render(Primer::Beta::Text.new(tag: :p)) do %>

--- a/app/services/settings/update_service.rb
+++ b/app/services/settings/update_service.rb
@@ -34,6 +34,13 @@ class Settings::UpdateService < BaseServices::BaseContracted
           contract_class: Settings::UpdateContract)
   end
 
+  def validate_params
+    contract = Settings::UpdateParamsContract.new(model, user, params:)
+    ServiceResult.new success: contract.valid?,
+                      errors: contract.errors,
+                      result: model
+  end
+
   def persist(call)
     params.each do |name, value|
       set_setting_value(name, value)

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -697,7 +697,8 @@ module Settings
         default: 7
       },
       journal_aggregation_time_minutes: {
-        default: 5
+        default: 5,
+        allowed: 0..120
       },
       ldap_force_no_page: {
         description: "Force LDAP to respond as a single page, in case paged responses do not work with your server.",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,8 +137,8 @@ en:
         trial: "Trial"
     jemalloc_allocator: Jemalloc memory allocator
     journal_aggregation:
-      caption: >
-        User actions on a work package (changing description, status, values, or writing comments) are grouped if performed within this period. It also controls notification and [webhook](webhook_link) delays.
+      caption_with_maximum: >
+        User actions on a work package (changing description, status, values, or writing comments) are grouped if performed within this period. It also controls notification and [webhook](webhook_link) delays. The maximum is %{max} minutes.
     import:
       title: "Import"
     jira:
@@ -2471,11 +2471,12 @@ en:
         setting:
           attributes:
             base:
-              working_days_are_missing: "At least one day of the week must be defined as a working day."
-              previous_working_day_changes_unprocessed: "The previous changes to the working days configuration have not been applied yet."
-              hours_per_day_are_missing: "The number of hours per day must be defined."
               durations_are_not_positive_numbers: "The durations must be positive numbers."
+              hours_per_day_are_missing: "The number of hours per day must be defined."
               hours_per_day_is_out_of_bounds: "Hours per day can't be more than 24"
+              journal_aggregation_time_minutes_is_out_of_bounds: "Aggregation period must be between %{min} and %{max} minutes."
+              previous_working_day_changes_unprocessed: "The previous changes to the working days configuration have not been applied yet."
+              working_days_are_missing: "At least one day of the week must be defined as a working day."
         status:
           attributes:
             default_done_ratio:

--- a/spec/contracts/settings/update_params_contract_spec.rb
+++ b/spec/contracts/settings/update_params_contract_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,51 +26,43 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
-#
+#++
 
 require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
 
-RSpec.shared_context "with update service setup" do
-  let(:instance) do
-    described_class.new(user:)
-  end
-  let(:user) { build_stubbed(:admin) }
+RSpec.describe Settings::UpdateParamsContract do
+  include_context "ModelContract shared context"
+
+  let(:current_user) { build_stubbed(:admin) }
+  let(:params) { { journal_aggregation_time_minutes: "5" } }
   let(:contract) do
-    instance_double(Settings::UpdateContract,
-                    validate: contract_success,
-                    errors: instance_double(ActiveModel::Error))
+    described_class.new(nil, current_user, params:)
   end
-  let(:contract_success) { true }
-  let(:setting_definition) do
-    instance_double(Settings::Definition)
-  end
-  let(:setting_name) { :a_setting_name }
-  let(:new_setting_value) { "a_new_setting_value" }
-  let(:previous_setting_value) { "the_previous_setting_value" }
-  let(:params) { { setting_name => new_setting_value } }
 
-  before do
-    # stub a setting definition
-    allow(Settings::Definition)
-      .to receive(:[])
-            .and_call_original
-    allow(Settings::Definition)
-      .to receive(:[])
-            .with(setting_name)
-            .and_return(setting_definition)
-    allow(Setting)
-      .to receive(:[])
-            .and_call_original
-    allow(Setting)
-      .to receive(:[]).with(setting_name)
-                      .and_return(previous_setting_value)
-    allow(Setting)
-      .to receive(:[]=)
+  it_behaves_like "contract is valid for active admins and invalid for regular users"
 
-    # stub contract
-    allow(Settings::UpdateContract)
-      .to receive(:new)
-            .and_return(contract)
+  describe "journal_aggregation_time_minutes validation" do
+    [0, 5, 120].each do |valid_value|
+      context "with value #{valid_value}" do
+        let(:params) { { journal_aggregation_time_minutes: valid_value.to_s } }
+
+        it_behaves_like "contract is valid"
+      end
+    end
+
+    [121, 9_999_999, -1].each do |invalid_value|
+      context "with value #{invalid_value}" do
+        let(:params) { { journal_aggregation_time_minutes: invalid_value.to_s } }
+
+        it_behaves_like "contract is invalid", base: :journal_aggregation_time_minutes_is_out_of_bounds
+      end
+    end
+
+    context "when not present in params" do
+      let(:params) { {} }
+
+      it_behaves_like "contract is valid"
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/65108/activity

# What are you trying to accomplish?

Administrators could enter an arbitrarily large value in the "User actions aggregated within" field under Administration → Emails and notifications → Aggregation. When a value large enough to overflow PostgreSQL's `timestamp` range was stored (e.g. `9999999999`), every subsequent call to `Notifications::WorkflowJob` crashed with:

```
PG::DatetimeFieldOverflow: ERROR: timestamp out of range: "677347521-07-22 12:03:56"
```

This blocked notification delivery for all users on the affected instance.

Let's cap this to a reasonable value -- I'm going with 2 hours, but open to further suggestions.

# What approach did you choose and why?

* **UI constraint** (`AggregationSettingsForm`): Added `max: 3600` (and `min: 0`) to the number input so the browser enforces the allowed range before a form submission is even made.

* **Server-side contract validation** (`Settings::UpdateContract`): Added a `journal_aggregation_time_minutes_range` validation that rejects any value outside `0..3600`. This is the authoritative guard — it runs regardless of how the setting is written (UI, API, console).


# Screenshots

Before:
<img width="1261" height="451" alt="Screenshot 2026-06-12 at 15 32 41" src="https://github.com/user-attachments/assets/424b4663-6078-4d68-ab83-b644ccb4198a" />

After:
<img width="1243" height="541" alt="Screenshot 2026-06-12 at 16 01 07" src="https://github.com/user-attachments/assets/88d4b8f0-7cb0-40e7-b76d-f2ff2f83eed7" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)