### PR TITLE
Keep CKEditor floating UI inside open dialogs so autocomplete is usable

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.spec.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.spec.ts
@@ -1,0 +1,122 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { CKEditorSetupService } from 'core-app/shared/components/editor/components/ckeditor/ckeditor-setup.service';
+
+// watchTopLayer moves the ck-body-wrapper into the open dialog and back out on close.
+describe('CKEditorSetupService#watchTopLayer', () => {
+  const flushMutations = ():Promise<void> =>
+    new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+
+  const addWrapper = ():HTMLElement => {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('ck-body-wrapper');
+    document.body.appendChild(wrapper);
+    return wrapper;
+  };
+
+  // mirrors the turbo dialog dom: <dialog-helper><dialog>
+  const openDialog = (id:string):HTMLDialogElement => {
+    const helper = document.createElement('dialog-helper');
+    const dialog = document.createElement('dialog');
+    dialog.id = id;
+    helper.appendChild(dialog);
+    document.body.appendChild(helper);
+    dialog.showModal();
+    return dialog;
+  };
+
+  beforeAll(() => {
+    // watchTopLayer uses no instance state, so call it on the prototype
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (CKEditorSetupService.prototype as any).watchTopLayer.call({});
+  });
+
+  afterEach(() => {
+    document
+      .querySelectorAll('.ck-body-wrapper, dialog-helper')
+      .forEach((el) => el.remove());
+  });
+
+  it('moves an already-present body wrapper into a dialog opened afterwards', async () => {
+    const wrapper = addWrapper();
+
+    expect(wrapper.parentElement).toBe(document.body);
+
+    const dialog = openDialog('create-work-package-dialog');
+    await flushMutations();
+
+    expect(wrapper.parentElement).toBe(dialog);
+  });
+
+  it('moves a wrapper created while a dialog is already open into that dialog', async () => {
+    const dialog = openDialog('create-work-package-dialog');
+    await flushMutations();
+
+    const wrapper = addWrapper();
+    await flushMutations();
+
+    expect(wrapper.parentElement).toBe(dialog);
+  });
+
+  it('restores the wrapper to document.body when the dialog closes', async () => {
+    const wrapper = addWrapper();
+    const dialog = openDialog('create-work-package-dialog');
+    await flushMutations();
+
+    expect(wrapper.parentElement).toBe(dialog);
+
+    dialog.close();
+    await flushMutations();
+    // closing removes the `open` attribute
+    // the observer restores the wrapper on a microtask before teardown
+    expect(wrapper.parentElement).toBe(document.body);
+  });
+
+  it('keeps the wrapper in the still-open dialog when a stacked inner dialog closes', async () => {
+    const wrapper = addWrapper();
+    const outer = openDialog('outer-dialog');
+    await flushMutations();
+    const inner = openDialog('inner-dialog');
+    await flushMutations();
+
+    expect(wrapper.parentElement).toBe(inner);
+
+    inner.close();
+    await flushMutations();
+
+    expect(wrapper.parentElement).toBe(outer);
+
+    outer.close();
+    await flushMutations();
+
+    expect(wrapper.parentElement).toBe(document.body);
+  });
+});

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
@@ -201,29 +201,40 @@ export class CKEditorSetupService {
   }
 
   private watchTopLayer() {
-    const targetClassNames = ['ck-body-wrapper', 'ck-inspector-'];
+    const floatingUi = () => document.querySelectorAll<HTMLElement>('.ck-body-wrapper, [class*="ck-inspector-"]');
 
-    const observer = new MutationObserver((mutations) => {
-      const dialog = document.querySelector('dialog[open]');
-      if (!dialog) {
-        return;
-      }
+    // querySelectorAll preserves document order
+    const frontMostOpenDialog = ():HTMLElement|null => {
+      const open = document.querySelectorAll<HTMLDialogElement>('dialog[open]');
+      return open.length ? open[open.length - 1] : null;
+    };
 
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
-          if (!(node instanceof HTMLElement)) {
-            return;
-          }
-
-          if (targetClassNames.some((className) => node.classList.contains(className))) {
-            dialog.append(node);
-          }
-        });
+    // wrapper lives inside the modal while one is open and returns to document.body afterwards
+    const place = () => {
+      const target = frontMostOpenDialog() ?? document.body;
+      floatingUi().forEach((node) => {
+        if (node.parentElement !== target) {
+          target.appendChild(node);
+        }
       });
-    });
+    };
 
-    observer.observe(document.body, {
-      childList: true,
+    // wrapper and <dialog-helper> are child of document.body
+    const isRelevantChild = (nodes:NodeList):boolean => Array.from(nodes).some((node) => (
+      node instanceof HTMLElement
+      && node.matches('.ck-body-wrapper, [class*="ck-inspector-"], dialog, dialog-helper')
+    ));
+    const childObserver = new MutationObserver((mutations) => {
+      if (mutations.some((mutation) => isRelevantChild(mutation.addedNodes) || isRelevantChild(mutation.removedNodes))) {
+        place();
+      }
     });
+    childObserver.observe(document.body, { childList: true });
+
+    // `open` attribute toggled by dialog opening/closing
+    const openAttrObserver = new MutationObserver(place);
+    openAttrObserver.observe(document.body, { attributes: true, attributeFilter: ['open'], subtree: true });
+
+    place();
   }
 }


### PR DESCRIPTION
Fixes https://community.openproject.org/work_packages/76021

## Context

CKEditor renders its floating UI (the small list that appears near the cursor after typing `#` or `@`) into a single `.ck-body-wrapper` appended to `document.body`. When an editor is inside a native `<dialog>` opened with `showModal()` (for example after clicking `Create new child` in the `Relations` tab of a work package), the dialog is in the top layer, so anything in `document.body` is painted behind it and can't be interacted with (whatwg/html#9936).

`watchTopLayer` (from #15277) already moved the wrapper into an open dialog, but only when the wrapper was added while a dialog was open. On a work-package page the wrapper already exists, created by the page editors, so opening a dialog reused it and nothing moved it. It also never moved the wrapper back.

## Changes

`watchTopLayer` now keeps `.ck-body-wrapper` inside the front-most open dialog, and returns it to `document.body` when none is open. Two observers on `document.body`: a `childList` one (no subtree) for the wrapper and dialogs being added or removed, and an attribute one scoped to the dialog `open` attribute.

Restore-on-close uses the `open` attribute mutation, which fires on a microtask, before the close-event task where Turbo removes the dialog. The dialog `close` event does not reach `document` listeners, so a close handler is not an option. Same idea as the existing hover-card and date-picker top-layer handling.

No CSS or z-index change.

## Before / after

`#` typed in the Description field of the create child dialog.

Before:

![before](https://community.openproject.org/api/v3/attachments/921980/content)

After:

![after](https://community.openproject.org/api/v3/attachments/921981/content)

## Verifications

- [x] Manual: `#` and `@` work above the dialog, and the page editors still work after closing it (Cancel and Escape).
