### PR TITLE
[#SSI-466] remove unescaping logic from nextcloud rename command

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/commands/rename_file_command.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/commands/rename_file_command.rb
@@ -65,12 +65,12 @@ module Storages
               source_path = UrlBuilder.url(@storage.uri,
                                            "remote.php/dav/files",
                                            user,
-                                           CGI.unescape(file_info.location))
+                                           file_info.location)
 
               destination = UrlBuilder.path(@storage.uri.path,
                                             "remote.php/dav/files",
                                             user,
-                                            CGI.unescape(target_path(file_info, name)))
+                                            target_path(file_info, name))
 
               Authentication[auth_strategy].call(storage: @storage) do |http|
                 handle_response http.request("MOVE", source_path, headers: { "Destination" => destination, "Overwrite" => "F" })
@@ -78,7 +78,7 @@ module Storages
             end
 
             def target_path(info, name)
-              info.location.gsub(CGI.escapeURIComponent(info.name), CGI.escapeURIComponent(name))
+              info.location.gsub(info.name, name)
             end
 
             def handle_response(response)


### PR DESCRIPTION
# Ticket
[OP#SSI-466](https://community.openproject.org/wp/SSI-466)

# What are you trying to accomplish?
- AMPF sync must succeed

# What approach did you choose and why?
- remove breaking unescaping calls from the rename file command
