### PR TITLE
Remove @types/uuid@11.0.0 stub

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -153,7 +153,6 @@
         "@types/react-dom": "^19.2.3",
         "@types/resize-observer-browser": "^0.1.4",
         "@types/urijs": "^1.19.26",
-        "@types/uuid": "^11.0.0",
         "@types/webpack-env": "^1.16.0",
         "@typescript-eslint/eslint-plugin": "8.60.1",
         "@typescript-eslint/parser": "8.60.1",
@@ -7118,16 +7117,6 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/webpack-env": {
       "version": "1.18.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
     "@types/react-dom": "^19.2.3",
     "@types/resize-observer-browser": "^0.1.4",
     "@types/urijs": "^1.19.26",
-    "@types/uuid": "^11.0.0",
     "@types/webpack-env": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "8.60.1",
     "@typescript-eslint/parser": "8.60.1",


### PR DESCRIPTION
Fixes warning on `npm ci`:

    "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed."

# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
