### PR TITLE
[OP-19541] Replace `_.get` with optional chaining

### DIFF
--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -47,19 +47,19 @@ export class ConfigurationService {
   }
 
   public commentsSortedInDescendingOrder():boolean {
-    return this.userPreference('commentSortDescending');
+    return this.configuration.userPreferences.commentSortDescending;
   }
 
   public disableKeyboardShortcuts():boolean {
-    return this.userPreference('disableKeyboardShortcuts');
+    return this.configuration.userPreferences.disableKeyboardShortcuts;
   }
 
   public warnOnLeavingUnsaved():boolean {
-    return this.userPreference('warnOnLeavingUnsaved');
+    return this.configuration.userPreferences.warnOnLeavingUnsaved;
   }
 
   public autoHidePopups():boolean {
-    return this.userPreference('autoHidePopups');
+    return this.configuration.userPreferences.autoHidePopups;
   }
 
   public isTimezoneSet():boolean {
@@ -71,98 +71,91 @@ export class ConfigurationService {
   }
 
   public timezone():string {
-    return this.userPreference('timeZone');
+    return this.configuration.userPreferences.timeZone;
   }
 
   public isDirectUploads():boolean {
     return !!this.prepareAttachmentURL;
   }
 
-  public get prepareAttachmentURL():string {
-    return this.configuration?.prepareAttachment?.href as string;
+  public get prepareAttachmentURL():string|undefined {
+    return this.configuration.prepareAttachment?.href;
   }
 
   public get maximumAttachmentFileSize():number {
-    return this.systemPreference('maximumAttachmentFileSize');
+    return this.configuration.maximumAttachmentFileSize;
   }
 
   public get maximumApiV3PageSize():number {
-    return this.systemPreference('maximumAPIV3PageSize');
+    return this.configuration.maximumAPIV3PageSize;
   }
 
   public get perPageOptions():number[] {
-    return this.systemPreference('perPageOptions');
+    return this.configuration.perPageOptions;
   }
 
   public get allowedLinkProtocols():string[]|null {
-    return this.systemPreference('allowedLinkProtocols') || null;
+    return this.configuration.allowedLinkProtocols ?? null;
   }
 
   public dateFormatPresent():boolean {
-    return !!this.systemPreference('dateFormat');
+    return !!this.dateFormat();
   }
 
   public dateFormat():string {
-    return this.systemPreference('dateFormat');
+    return this.configuration.dateFormat ?? '';
   }
 
   public durationFormat():DurationFormat {
-    return this.systemPreference('durationFormat');
+    return this.configuration.durationFormat;
   }
 
   public hoursPerDay():number {
-    return this.systemPreference('hoursPerDay');
-  }
-
-  public hoursPerWeek():number {
-    return this.systemPreference('hoursPerWeek');
+    return this.configuration.hoursPerDay;
   }
 
   public daysPerMonth():number {
-    return this.systemPreference('daysPerMonth');
+    return this.configuration.daysPerMonth;
   }
 
   public timeFormatPresent():boolean {
-    return !!this.systemPreference('timeFormat');
+    return !!this.timeFormat();
   }
 
   public timeFormat():string {
-    return this.systemPreference('timeFormat');
+    return this.configuration.timeFormat ?? '';
   }
 
   public defaultTimezone():string {
-    return this.systemPreference('userDefaultTimezone');
-  }
-
-  public startOfWeekPresent():boolean {
-    return !!this.systemPreference('startOfWeek');
+    return this.configuration.userDefaultTimezone ?? '';
   }
 
   public startOfWeek():number {
-    if (this.startOfWeekPresent()) {
-      return this.systemPreference('startOfWeek');
+    const startOfWeek = this.configuration.startOfWeek;
+    if (startOfWeek !== null) {
+      return startOfWeek;
     }
     return moment.localeData(I18n.locale).firstDayOfWeek();
   }
 
   public get wikisAvailable():boolean {
-    return this.systemPreference('wikisAvailable');
+    return this.configuration.wikisAvailable;
   }
 
   public get hostName():string {
-    return this.systemPreference('hostName');
+    return this.configuration.hostName;
   }
 
   public get activeFeatureFlags():string[] {
-    return this.systemPreference<string[]>('activeFeatureFlags');
+    return this.configuration.activeFeatureFlags;
   }
 
   public get availableFeatures():string[] {
-    return this.systemPreference<string[]>('availableFeatures');
+    return this.configuration.availableFeatures;
   }
 
   public get triallingFeatures():string[] {
-    return this.systemPreference<string[]>('triallingFeatures');
+    return this.configuration.triallingFeatures;
   }
 
   private loadConfiguration() {
@@ -174,13 +167,5 @@ export class ConfigurationService {
       .then((configuration:ConfigurationResource) => {
         this.configuration = configuration;
       });
-  }
-
-  private userPreference<T>(pref:string):T {
-    return this.configuration?.userPreferences?.[pref] as T;
-  }
-
-  private systemPreference<T>(pref:string):T {
-    return this.configuration?.[pref] as T;
   }
 }

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -79,7 +79,7 @@ export class ConfigurationService {
   }
 
   public get prepareAttachmentURL():string {
-    return _.get(this.configuration, ['prepareAttachment', 'href']) as string;
+    return this.configuration?.prepareAttachment?.href as string;
   }
 
   public get maximumAttachmentFileSize():number {
@@ -177,10 +177,10 @@ export class ConfigurationService {
   }
 
   private userPreference<T>(pref:string):T {
-    return _.get(this.configuration, ['userPreferences', pref]) as T;
+    return this.configuration?.userPreferences?.[pref] as T;
   }
 
   private systemPreference<T>(pref:string):T {
-    return _.get(this.configuration, pref) as T;
+    return this.configuration?.[pref] as T;
   }
 }

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -27,6 +27,7 @@
 //++
 
 import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import moment from 'moment';
 
 import { ConfigurationResource } from 'core-app/features/hal/resources/configuration-resource';
@@ -158,14 +159,7 @@ export class ConfigurationService {
     return this.configuration.triallingFeatures;
   }
 
-  private loadConfiguration() {
-    return this
-      .apiV3Service
-      .configuration
-      .get()
-      .toPromise()
-      .then((configuration:ConfigurationResource) => {
-        this.configuration = configuration;
-      });
+  private async loadConfiguration():Promise<void> {
+    this.configuration = await firstValueFrom(this.apiV3Service.configuration.get());
   }
 }

--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -40,6 +40,11 @@ import {
   redirectToMobileAlternative,
 } from 'core-app/shared/helpers/routing/mobile-guard.helper';
 
+interface RouteStateData {
+  bodyClasses?:string[]|string|null;
+  menuItem?:string;
+}
+
 export const OPENPROJECT_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'root',
@@ -168,7 +173,7 @@ export function initializeUiRouterListeners(injector:Injector) {
 
     // Re-apply the body classes if the turbo load event is on the same page (e.g. when creating a child from the relations tab)
     if (stateService.href(uiRouter.globals.current) === window.location.pathname + window.location.search) {
-      bodyClass(_.get(uiRouter.globals.current, 'data.bodyClasses'), 'add');
+      bodyClass((uiRouter.globals.current?.data as RouteStateData|undefined)?.bodyClasses, 'add');
     }
   });
 
@@ -191,17 +196,21 @@ export function initializeUiRouterListeners(injector:Injector) {
   // however the second parameter has the currently (e.g., parent) entering state chain.
   $transitions.onEnter({}, (transition:Transition, state:StateDeclaration) => {
     // Add body class when entering this state
-    bodyClass(_.get(state, 'data.bodyClasses'), 'add');
-    if (transition.from().data && _.get(state, 'data.menuItem') !== transition.from().data.menuItem) {
-      updateMenuItem(_.get(state, 'data.menuItem'), 'add');
+    const stateData = state?.data as RouteStateData|undefined;
+    const fromData = transition.from().data as RouteStateData|undefined;
+    bodyClass(stateData?.bodyClasses, 'add');
+    if (fromData && stateData?.menuItem !== fromData.menuItem) {
+      updateMenuItem(stateData?.menuItem, 'add');
     }
   });
 
   $transitions.onExit({}, (transition:Transition, state:StateDeclaration) => {
     // Remove body class when leaving this state
-    bodyClass(_.get(state, 'data.bodyClasses'), 'remove');
-    if (transition.to().data && _.get(state, 'data.menuItem') !== transition.to().data.menuItem) {
-      updateMenuItem(_.get(state, 'data.menuItem'), 'remove');
+    const stateData = state?.data as RouteStateData|undefined;
+    const toData = transition.to().data as RouteStateData|undefined;
+    bodyClass(stateData?.bodyClasses, 'remove');
+    if (toData && stateData?.menuItem !== toData.menuItem) {
+      updateMenuItem(stateData?.menuItem, 'remove');
     }
   });
 
@@ -255,7 +264,7 @@ export function initializeUiRouterListeners(injector:Injector) {
 
     // Remove and add any body class definitions for entering
     // and exiting states.
-    bodyClass(_.get(toState, 'data.bodyClasses'), 'add');
+    bodyClass((toState?.data as RouteStateData|undefined)?.bodyClasses, 'add');
 
     // We need to distinguish between actions that should run on the initial page load
     // (ie. openining a new tab in the details view should focus on the element in the table)

--- a/frontend/src/app/core/state/attachments/attachments.service.ts
+++ b/frontend/src/app/core/state/attachments/attachments.service.ts
@@ -193,7 +193,7 @@ export class AttachmentsResourceService extends ResourceStoreService<IAttachment
     }
 
     if (isNewResource(resource)) {
-      return this.configurationService.prepareAttachmentURL;
+      return this.configurationService.prepareAttachmentURL ?? null;
     }
 
     return null;

--- a/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
@@ -41,7 +41,7 @@ export class BoardVersionActionService extends CachedBoardActionService {
   localizedName = this.I18n.t('js.work_packages.properties.version');
 
   public canAddToQuery(query:QueryResource):Promise<boolean> {
-    const formLink = _.get(query, 'results.createWorkPackage.href', null);
+    const formLink = (query?.results?.createWorkPackage as { href?:string }|undefined)?.href ?? null;
 
     if (!formLink) {
       return Promise.resolve(false);

--- a/frontend/src/app/features/hal/helpers/hal-resource-builder.ts
+++ b/frontend/src/app/features/hal/helpers/hal-resource-builder.ts
@@ -184,7 +184,8 @@ export function initializeHalProperties<T extends HalResource>(halResourceServic
       if (isArray) {
         halResource.$source._embedded[linkName] = (val).map((el) => el.$source);
       } else {
-        halResource.$source._embedded[linkName] = _.get(val, '$source', val);
+        const source:unknown = (val as HalResource | undefined)?.$source;
+        (halResource.$source as { _embedded:Record<string, unknown> })._embedded[linkName] = source === undefined ? val : source;
       }
     }
 

--- a/frontend/src/app/features/hal/resources/configuration-resource.ts
+++ b/frontend/src/app/features/hal/resources/configuration-resource.ts
@@ -27,8 +27,38 @@
 //++
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { type DurationFormat } from 'core-app/shared/helpers/chronic_duration';
+
+export interface ConfigurationUserPreferences {
+  timeZone:string;
+  commentSortDescending:boolean;
+  disableKeyboardShortcuts:boolean;
+  warnOnLeavingUnsaved:boolean;
+  autoHidePopups:boolean;
+}
 
 export class ConfigurationResource extends HalResource {
+  // Embedded `_embedded.userPreferences`, exposed as a property by the HAL initializer
+  public userPreferences:ConfigurationUserPreferences;
+
+  // `_links.prepareAttachment`, present only when direct uploads are enabled
+  public prepareAttachment?:{ href:string };
+
+  // Top-level body attributes
+  public maximumAttachmentFileSize:number;
+  public maximumAPIV3PageSize:number;
   public perPageOptions:number[];
   public allowedLinkProtocols?:string[];
+  public dateFormat:string|null;
+  public timeFormat:string|null;
+  public durationFormat:DurationFormat;
+  public hoursPerDay:number;
+  public daysPerMonth:number;
+  public userDefaultTimezone:string|null;
+  public startOfWeek:number|null;
+  public wikisAvailable:boolean;
+  public hostName:string;
+  public activeFeatureFlags:string[];
+  public availableFeatures:string[];
+  public triallingFeatures:string[];
 }

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -279,7 +279,7 @@ export class WorkPackageBaseResource extends HalResource {
     this.attachments = new AttachmentCollectionResource(
       this.injector,
       // Attachments MAY be an array if we're building from a form
-      _.get(attachments, '$source', attachments),
+      (attachments as { $source?:unknown }).$source ?? attachments,
       false,
       this.halInitializer,
       'HalResource',

--- a/frontend/src/app/features/hal/services/hal-resource-notification.service.ts
+++ b/frontend/src/app/features/hal/services/hal-resource-notification.service.ts
@@ -129,7 +129,7 @@ export class HalResourceNotificationService {
     }
 
     // Some older response may have a data attribute
-    if (_.get(response, 'data._type') === 'Error') {
+    if ((response as { data?:{ _type?:string } } | null)?.data?._type === 'Error') {
       errorBody = (response as any).data;
     }
 

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -202,12 +202,12 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   }
 
   private get isUserResource() {
-    const type = _.get(this.filter.currentSchema, 'values.type', null) as string;
-    return type && type.indexOf('User') > 0;
+    const type = this.filter.currentSchema?.values?.type;
+    return !!type && type.indexOf('User') > 0;
   }
 
   private get isVersionResource() {
-    const type = _.get(this.filter.currentSchema, 'values.type', null) as string;
-    return type && type.indexOf('Version') > 0;
+    const type = this.filter.currentSchema?.values?.type;
+    return !!type && type.indexOf('Version') > 0;
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.component.ts
@@ -86,7 +86,7 @@ export class WorkPackageBreadcrumbParentComponent {
   public updateParent(newParent:WorkPackageResource|null) {
     this.close();
     const newParentId = newParent ? newParent.id : null;
-    if (_.get(this.parent, 'id', null) === newParentId) {
+    if ((this.parent?.id ?? null) === newParentId) {
       return;
     }
 

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
@@ -139,7 +139,7 @@ export class UrlParamsHelperService {
     const paramsData:QueryProps = {
       c: query.columns.map((column) => column.id),
       hi: !!query.showHierarchies,
-      g: _.get(query.groupBy, 'id', ''),
+      g: query.groupBy?.id ?? '',
       dr: query.displayRepresentation,
       is: query.includeSubprojects,
       ...this.encodeSums(query),
@@ -291,7 +291,7 @@ export class UrlParamsHelperService {
       queryData.showHierarchies = properties.hi;
     }
 
-    queryData.groupBy = _.get(properties, 'g', '');
+    queryData.groupBy = properties.g ?? '';
 
     // Filters
     if (properties.f) {
@@ -364,7 +364,7 @@ export class UrlParamsHelperService {
 
     queryData.includeSubprojects = !!query.includeSubprojects;
     queryData.showHierarchies = !!query.showHierarchies;
-    queryData.groupBy = _.get(query.groupBy, 'id', '');
+    queryData.groupBy = query.groupBy?.id ?? '';
 
     // Filters
     queryData.filters = this.buildV3GetFiltersAsJson(query.filters, contextual);

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -164,13 +164,14 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
         this.cdRef.markForCheck();
         return query;
       })
-      .catch((error) => {
+      .catch((error:unknown) => {
+        const message = (error as { message?:unknown } | null | undefined)?.message;
         this.error = this.I18n.t(
           'js.error.embedded_table_loading',
-          { message: _.get(error, 'message', error) },
+          { message: message !== undefined ? message : error },
         );
         this.cdRef.markForCheck();
-        this.onError.emit(error);
+        this.onError.emit(error as string);
       });
 
     if (visible) {

--- a/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.spec.ts
@@ -85,7 +85,9 @@ describe('wpTablePagination Directive', () => {
         WorkPackageViewPaginationService,
         HalResourceService,
         { provide: WeekdayService, useValue: WeekdayServiceStub },
-        ConfigurationService,
+        // PaginationService reads perPageOptions from ConfigurationService in its
+        // constructor; in production the service is initialized before injection.
+        { provide: ConfigurationService, useValue: { perPageOptions: [10, 50] } as unknown as ConfigurationService },
         IsolatedQuerySpace,
         I18nService,
         provideHttpClient(withXhr(), withInterceptorsFromDi()),

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-relation-columns.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-relation-columns.service.ts
@@ -118,7 +118,7 @@ this.relationsForColumn(workPackage, relations, column),
         const denormalized = relation.denormalized(workPackage);
         const target = this.apiV3Service.work_packages.cache.state(denormalized.targetId).value;
 
-        return _.get(target, 'type.href') === typeHref;
+        return target?.type?.href === typeHref;
       });
     }
 

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -256,7 +256,7 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
    * @param attribute
    */
   public humanName(attribute:string):string {
-    return _.get(this.schema, `${attribute}.name`, attribute);
+    return (this.schema?.[attribute] as { name?:string }|undefined)?.name ?? attribute;
   }
 
   /**
@@ -487,7 +487,7 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
 
       return links;
     }
-    return { href: _.get(val, 'href', null) };
+    return { href: (val as { href?:string }|null|undefined)?.href ?? null };
   }
 
   /**

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
@@ -73,11 +73,11 @@ export class CustomTextEditFieldService extends EditFieldHandler {
   }
 
   public get rawText() {
-    return _.get(this.textValue, 'raw', '');
+    return (this.textValue as { raw?:string } | null)?.raw ?? '';
   }
 
   public get htmlText() {
-    return _.get(this.textValue, 'html', '');
+    return (this.textValue as { html?:string } | null)?.html ?? '';
   }
 
   public get textValue() {

--- a/frontend/src/app/shared/components/table-pagination/pagination-service.ts
+++ b/frontend/src/app/shared/components/table-pagination/pagination-service.ts
@@ -89,11 +89,11 @@ export class PaginationService {
   }
 
   public getMaxVisiblePageOptions() {
-    return _.get(this.paginationOptions, 'maxVisiblePageOptions', DEFAULT_PAGINATION_OPTIONS.maxVisiblePageOptions);
+    return this.paginationOptions.maxVisiblePageOptions;
   }
 
   public getOptionsTruncationSize() {
-    return _.get(this.paginationOptions, 'optionsTruncationSize', DEFAULT_PAGINATION_OPTIONS.optionsTruncationSize);
+    return this.paginationOptions.optionsTruncationSize;
   }
 
   public setPerPage(perPage:number) {

--- a/frontend/src/app/shared/helpers/angular/tracking-functions.ts
+++ b/frontend/src/app/shared/helpers/angular/tracking-functions.ts
@@ -19,15 +19,11 @@ export function compareByName<T extends HalResource>(a:T|undefined|null, b:T|und
 
 export function trackByHrefAndProperty(propertyName:string) {
   return (i:number, item:HalResource) => {
-    const href:string = _.get(item, 'href') || '';
-    const prop:string = _.get(item, propertyName, 'none');
+    const href:string = item.href ?? '';
+    const prop:string = (item as Record<string, string|undefined>)[propertyName] ?? 'none';
 
     return `${href}#${propertyName}=${prop}`;
   };
-}
-
-export function trackByTrackingIdentifier(i:number, item:any) {
-  return _.get(item, 'trackingIdentifier', item?.href);
 }
 
 export function compareByHref<T extends HalResource>(a:T|undefined|null, b:T|undefined|null):boolean {


### PR DESCRIPTION
> [!NOTE]
> Lodash-removal series (parent #65621). Merge #23733 before this PR. Order: #23730 → #23732 → #23733 → **#23728 (this)** → #23736 (last).

# Ticket

https://community.openproject.org/wp/OP-19541

# What are you trying to accomplish?

First step towards removing lodash from the frontend, starting with `_.get`. All 24 `_.get` call sites are replaced by native optional chaining / nullish coalescing, preserving the lodash default-on-`undefined` semantics. The global `_` stays for now as other lodash helpers (`filter`, `debounce`, ...) remain in use.

While migrating, `ConfigurationService` and `ConfigurationResource` are properly typed (declared attributes verified against the live `/api/v3/configuration` response, including nullable fields), removing the `any` access that `_.get` was masking. The configuration loader also switches off the deprecated `Observable.toPromise()` to `firstValueFrom`.

## Screenshots

no visual changes

# What approach did you choose and why?

Removing the `[attribute:string]:any` index signature from `HalResource` wholesale is out of scope (it underpins runtime-attached HAL properties across the app); `ConfigurationResource` is typed here as a contained proof of the per-resource pattern. A couple of dead helpers surfaced during the migration (`trackByTrackingIdentifier`, `hoursPerWeek`) and were removed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
