### PR TITLE
[OP-19544] Replace lodash set/dedup helpers with native

### DIFF
--- a/frontend/src/app/core/apiv3/endpoints/relations/apiv3-relations-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/relations/apiv3-relations-paths.ts
@@ -57,7 +57,7 @@ export class ApiV3RelationsPaths extends ApiV3ResourceCollection<RelationResourc
       const chunks = chunk(workPackageIds, MAGIC_RELATION_SIZE);
       return forkJoin(chunks.map((chunk) => this.loadInvolved(chunk)))
         .pipe(
-          map((results) => _.flatten(results)),
+          map((results) => results.flat()),
         );
     }
 

--- a/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
@@ -70,7 +70,7 @@ export class ApiV3WorkPackagesPaths extends ApiV3Collection<WorkPackageResource,
 
     return new Promise<undefined>((resolve, reject) => {
       this
-        .loadCollectionsFor(_.uniq(ids))
+        .loadCollectionsFor(Array.from(new Set(ids)))
         .then((pagedResults:WorkPackageCollectionResource[]) => {
           _.each(pagedResults, (results) => {
             if (results.schemas) {

--- a/frontend/src/app/features/hal/resources/error-resource.ts
+++ b/frontend/src/app/features/hal/resources/error-resource.ts
@@ -94,20 +94,20 @@ export class ErrorResource extends HalResource {
   }
 
   public getInvolvedAttributes():string[] {
-    let columns = [];
+    let columns:ErrorResource[] = [];
 
     if (this.details) {
-      columns = [{ details: this.details }];
+      columns = [{ details: this.details as { attribute:string } } as ErrorResource];
     } else if (this.errors) {
-      columns = this.errors;
+      columns = this.errors as ErrorResource[];
     }
 
-    return _.flatten(columns.map((resource:ErrorResource) => {
+    return columns.map((resource:ErrorResource):string => {
       if (resource.errorIdentifier === v3ErrorIdentifierMultipleErrors) {
         return this.extractMultiError(resource)[0];
       }
-      return resource.details.attribute;
-    }));
+      return (resource.details as { attribute:string }).attribute;
+    }).flat();
   }
 
   public getMessagesPerAttribute():Record<string, string[]> {

--- a/frontend/src/app/features/hal/resources/hal-resource.ts
+++ b/frontend/src/app/features/hal/resources/hal-resource.ts
@@ -287,7 +287,7 @@ export class HalResource {
    */
   public $embeddableKeys():string[] {
     const properties = Object.keys(this.$source);
-    return _.without(properties, '_links', '_embedded', 'id');
+    return properties.filter((property) => !['_links', '_embedded', 'id'].includes(property));
   }
 
   /**
@@ -296,6 +296,6 @@ export class HalResource {
    */
   public $linkableKeys():string[] {
     const properties = Object.keys(this.$links);
-    return _.without(properties, 'self');
+    return properties.filter((property) => property !== 'self');
   }
 }

--- a/frontend/src/app/features/hal/resources/project-resource.ts
+++ b/frontend/src/app/features/hal/resources/project-resource.ts
@@ -51,6 +51,6 @@ export class ProjectResource extends HalResource {
    * Exclude the schema _link from the linkable Resources.
    */
   public $linkableKeys():string[] {
-    return _.without(super.$linkableKeys(), 'schema');
+    return super.$linkableKeys().filter((key) => key !== 'schema');
   }
 }

--- a/frontend/src/app/features/hal/resources/time-entry-resource.ts
+++ b/frontend/src/app/features/hal/resources/time-entry-resource.ts
@@ -56,7 +56,7 @@ export class TimeEntryResource extends HalResource {
    * Exclude the schema _link from the linkable Resources.
    */
   public $linkableKeys():string[] {
-    return _.without(super.$linkableKeys(), 'schema');
+    return super.$linkableKeys().filter((key) => key !== 'schema');
   }
 }
 

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -297,7 +297,7 @@ export class WorkPackageBaseResource extends HalResource {
    * Exclude the schema _link from the linkable Resources.
    */
   public $linkableKeys():string[] {
-    return _.without(super.$linkableKeys(), 'schema');
+    return super.$linkableKeys().filter((key) => key !== 'schema');
   }
 
   /**

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
@@ -69,6 +69,6 @@ export class InAppNotificationActorsLineComponent implements OnInit {
       })
       .filter((actor) => actor !== null) as PrincipalLike[];
 
-    this.actors = _.uniqBy(actors, (item) => item.href);
+    this.actors = actors.filter((item, index, self) => index === self.findIndex((other) => other.href === item.href));
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
@@ -133,7 +133,7 @@ export class WorkPackageCardDragAndDropService {
    * Update current order
    */
   private updateOrder(newOrder:string[]) {
-    newOrder = _.uniq(newOrder);
+    newOrder = Array.from(new Set(newOrder));
 
     Promise
       .all(newOrder.map((id) => this

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -132,7 +132,12 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
         // Append all new elements
         elements = elements.concat(newElements);
         // Remove duplicates (Regression #29652)
-        this.deferred[parent.id!] = _.uniqBy(elements, (el) => el.id!);
+        const seen = new Set<string>();
+        this.deferred[parent.id!] = elements.filter((el) => {
+          if (seen.has(el.id!)) { return false; }
+          seen.add(el.id!);
+          return true;
+        });
         return true;
       }
       // Otherwise, continue the chain upwards

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/child-relations-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/child-relations-render-pass.ts
@@ -72,7 +72,7 @@ export class ChildRelationsRenderPass extends RelationsRenderPass {
   }
 
   private loadMissingTargets(ids:string[]) {
-    const uniqueIds = _.uniq(ids);
+    const uniqueIds = Array.from(new Set(ids));
 
     if (uniqueIds.length === 0 || this.loadingMissingTargets) {
       return;

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
@@ -168,7 +168,7 @@ export class DragAndDropTransformer {
    * Update current rendered order
    */
   private async updateRenderedOrder(order:string[]) {
-    order = _.uniq(order);
+    order = Array.from(new Set(order));
 
     const mappedOrder = await Promise.all(
       order.map(

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/wp-activity.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/wp-activity.service.ts
@@ -70,7 +70,7 @@ export class WorkPackagesActivityService extends WorkPackageLinkedResourceCache<
   }
 
   protected sortedActivityList(activities:HalResource[], attr = 'createdAt'):HalResource[] {
-    const sorted = sortBy(_.flatten(activities), attr);
+    const sorted = sortBy(activities.flat(), attr);
 
     if (this.isReversed) {
       return sorted.reverse();

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
@@ -91,7 +91,7 @@ export class WpTableConfigurationSortByTabComponent implements TabComponent, OnI
 
         // For whatever reason, even though the UI doesn't implement it,
         // QuerySortByResources are doubled for each column (one for asc/desc direction)
-        this.allColumns = _.uniqBy(allColumns, 'href');
+        this.allColumns = allColumns.filter((col, index, self) => index === self.findIndex((other) => other.href === col.href));
 
         this.getManualSortingOption();
 
@@ -123,7 +123,7 @@ export class WpTableConfigurationSortByTabComponent implements TabComponent, OnI
       .filter((o) => o.column !== null)
       .map((object:SortModalObject) => object.column);
 
-    this.availableColumns = sortBy(_.differenceBy(this.allColumns, usedColumns, 'href'), 'name');
+    this.availableColumns = sortBy(this.allColumns.filter((col) => !usedColumns.some((used) => used.href === col.href)), 'name');
   }
 
   public updateSortingMode(mode:SortingMode) {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cells-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cells-renderer.ts
@@ -120,7 +120,7 @@ export class WorkPackageTimelineCellsRenderer {
       newCells.push(identifier);
     });
 
-    _.difference(currentlyActive, newCells).forEach((identifier:string) => {
+    currentlyActive.filter((identifier) => !newCells.includes(identifier)).forEach((identifier:string) => {
       this.cells[identifier].clear();
       delete this.cells[identifier];
     });

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service.ts
@@ -73,7 +73,7 @@ export class WorkPackageViewAdditionalElementsService {
       this.requireWorkPackageShares(workPackageIds),
       this.requireSumsSchema(results),
     ]).then((wpResults:string[][]) => {
-      this.loadAdditional(_.flatten(wpResults));
+      this.loadAdditional(wpResults.flat());
     });
   }
 
@@ -103,7 +103,7 @@ export class WorkPackageViewAdditionalElementsService {
       .requireAll(rows)
       .then(() => {
         const ids = this.getInvolvedWorkPackages(rows.map((id) => this.wpRelations.state(id).value!));
-        return _.flatten(ids);
+        return ids.flat();
       });
   }
 
@@ -116,9 +116,7 @@ export class WorkPackageViewAdditionalElementsService {
       return Promise.resolve([]);
     }
 
-    const ids = _.flatten(
-      rows.map((el) => el.children?.map((child) => child.id!) || []),
-    );
+    const ids = rows.map((el) => el.children?.map((child) => child.id!) || []).flat();
 
     return Promise.resolve(ids);
   }
@@ -134,7 +132,7 @@ export class WorkPackageViewAdditionalElementsService {
     }
 
     const resultIds = rows.map((el:WorkPackageResource) => (el.id as string | number).toString());
-    const ids = _.flatten(rows.map((el) => el.ancestorIds))
+    const ids = rows.map((el) => el.ancestorIds).flat()
       .filter((id) => !resultIds.includes(id));
 
     return Promise.resolve(ids);
@@ -184,7 +182,7 @@ export class WorkPackageViewAdditionalElementsService {
         map((elements) => {
           const shares = elements as ShareResource[];
 
-          const sharedWpIds = _.uniq(shares.map((share) => share.entity.id!));
+          const sharedWpIds = Array.from(new Set(shares.map((share) => share.entity.id!)));
 
           sharedWpIds.forEach((wpId) => {
             this

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
@@ -65,7 +65,7 @@ export class WorkPackageViewColumnsService extends WorkPackageQueryStateService<
     query.columns = cloneHalResourceCollection<QueryColumn>(toApply);
 
     // We can avoid reloading even with relation columns if we only removed columns
-    const onlyRemoved = _.difference(newColumns, oldColumns).length === 0;
+    const onlyRemoved = newColumns.filter((column) => !oldColumns.includes(column)).length === 0;
 
     // Reload the table visibly if adding relation or share columns.
     return !onlyRemoved && (this.hasRelationColumns() || this.hasShareColumn());
@@ -283,7 +283,8 @@ export class WorkPackageViewColumnsService extends WorkPackageQueryStateService<
    * Get columns not yet selected
    */
   public get unused():QueryColumn[] {
-    return _.differenceBy(this.all, this.getColumns(), '$href');
+    const columns = this.getColumns();
+    return this.all.filter((column) => !columns.some((other) => other.$href === column.$href));
   }
 
   /**

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -313,7 +313,7 @@ export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<
    * Get all filters that are not in the current active set
    */
   private remainingFilters(filters = this.rawFilters) {
-    return _.differenceBy(this.availableFilters, filters, (filter) => filter.id);
+    return this.availableFilters.filter((available) => !filters.some((filter) => filter.id === available.id));
   }
 
   isAvailable(el:QueryFilterInstanceResource):boolean {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service.ts
@@ -91,7 +91,7 @@ export class WorkPackageViewHierarchyIdentationService {
     // get the first element of the ancestor chain that workPackage is not in
     const predecessor = await firstValueFrom(this.apiV3Service.work_packages.id(predecessorId).get());
 
-    const difference = _.difference(predecessor.ancestorIds, workPackage.ancestorIds);
+    const difference = predecessor.ancestorIds.filter((id) => !workPackage.ancestorIds.includes(id));
     if (difference && difference.length > 0) {
       newParentId = difference[0];
     }

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -128,7 +128,15 @@ export class UserAutocompleterComponent extends OpAutocompleterComponent<IUserAu
       .http
       .get<IHALCollection<IUser>>(filteredURL.toString())
       .pipe(
-        map((res) => _.uniqBy(res._embedded.elements, (el) => el._links.self?.href || el.id)),
+        map((res) => {
+          const seen = new Set<string|number>();
+          return res._embedded.elements.filter((el) => {
+            const key = el._links.self?.href || el.id;
+            if (seen.has(key)) { return false; }
+            seen.add(key);
+            return true;
+          });
+        }),
         map((users) => {
           const mapped:IUserAutocompleteItem[] = users.map((user) => {
               return { id: user.id, name: user.name, href: user._links.self?.href, email: user.email };

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -307,11 +307,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
         filter((resource) => !!resource),
       )
       .subscribe((resource:HalResource&{ attachments:AttachmentCollectionResource }) => {
-        const missingAttachments = _.differenceBy(
-          this.attachments,
-          resource.attachments.elements,
-          (attachment:HalResource) => attachment.id,
-        );
+        const presentIds = new Set<string|null>(resource.attachments.elements.map((other:HalResource) => other.id));
+        const missingAttachments = this.attachments.filter((attachment:HalResource) => !presentIds.has(attachment.id));
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return
         const removedUrls = missingAttachments.map((attachment) => attachment.downloadLocation.href);

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -327,7 +327,14 @@ export class SearchableProjectListService {
     return forkJoin(extraFetches).pipe(
       map((collections) => collections.map((collection) => collection._embedded.elements)),
       map((collections) => projects.concat(...collections)),
-      map((allProjects) => _.uniqBy(allProjects, (p) => p.id)),
+      map((allProjects) => {
+        const seen = new Set<ID>();
+        return allProjects.filter((p) => {
+          if (seen.has(p.id)) { return false; }
+          seen.add(p.id);
+          return true;
+        });
+      }),
     );
   }
 

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -75,10 +75,10 @@ export class WorkPackageEmbeddedGraphComponent implements OnChanges {
   }
 
   private updateChartData() {
-    let uniqLabels = _.uniq(this.datasets.reduce((array, dataset) => {
+    let uniqLabels = Array.from(new Set(this.datasets.reduce((array, dataset) => {
       const groups = (dataset.groups || []).map((group) => group.value) as any;
       return array.concat(groups);
-    }, [])) as string[];
+    }, []))) as string[];
 
     const labelCountMaps = this.datasets.map((dataset) => {
       const countMap = (dataset.groups || []).reduce<any>((hash, group) => ({

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -563,11 +563,11 @@ export default class FiltersFormController extends Controller {
     if (operator && this.daysOperators.includes(operator)) {
       const dateValue = this.findTargetByName(filterName, this.daysTargets)?.value;
 
-      value = _.without([dateValue], '');
+      value = [dateValue].filter((v) => v !== '');
     } else if (operator === this.onDateOperator) {
       const dateValue = this.findTargetById(filterName, this.singleDayTargets)?.value;
 
-      value = _.without([dateValue], '');
+      value = [dateValue].filter((v) => v !== '');
     } else if (operator === this.betweenDatesOperator) {
       const rangeValue = this.findTargetById(filterName, this.dateRangeTargets)?.value;
       const [fromValue, toValue] = rangeValue?.split(' - ') ?? [];

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -282,7 +282,7 @@ export default class PreviewController extends DialogPreviewController {
 
     const fieldDates = [this.currentStartDate, this.currentDueDate].filter((x):x is NonNullable<typeof x> => Boolean(x))
                         .map((date) => this.timezone.utcDateToISODateString(date));
-    const diff = _.difference(flatPickrDates, fieldDates);
+    const diff = flatPickrDates.filter((date) => !fieldDates.includes(date));
     return this.toDate(diff[0]);
   }
 

--- a/modules/gitlab_integration/frontend/module/hal/resources/gitlab-issue-resource.ts
+++ b/modules/gitlab_integration/frontend/module/hal/resources/gitlab-issue-resource.ts
@@ -38,6 +38,6 @@ export class GitlabIssueResource extends HalResource {
    * Exclude the schema _link from the linkable Resources.
    */
   public $linkableKeys():string[] {
-    return _.without(super.$linkableKeys(), 'schema');
+    return super.$linkableKeys().filter((key) => key !== 'schema');
   }
 }

--- a/modules/gitlab_integration/frontend/module/hal/resources/gitlab-merge-request-resource.ts
+++ b/modules/gitlab_integration/frontend/module/hal/resources/gitlab-merge-request-resource.ts
@@ -38,6 +38,6 @@ export class GitlabMergeRequestResource extends HalResource {
    * Exclude the schema _link from the linkable Resources.
    */
   public $linkableKeys():string[] {
-    return _.without(super.$linkableKeys(), 'schema');
+    return super.$linkableKeys().filter((key) => key !== 'schema');
   }
 }

--- a/modules/gitlab_integration/frontend/module/hal/resources/gitlab-user-resource.ts
+++ b/modules/gitlab_integration/frontend/module/hal/resources/gitlab-user-resource.ts
@@ -38,6 +38,6 @@ export class GitlabUserResource extends HalResource {
    * Exclude the schema _link from the linkable Resources.
    */
   public $linkableKeys():string[] {
-    return _.without(super.$linkableKeys(), 'schema');
+    return super.$linkableKeys().filter((key) => key !== 'schema');
   }
 }

--- a/modules/gitlab_integration/frontend/module/tab-issue/wp-gitlab-issue.service.ts
+++ b/modules/gitlab_integration/frontend/module/tab-issue/wp-gitlab-issue.service.ts
@@ -46,6 +46,6 @@ export class WorkPackagesGitlabIssueService extends WorkPackageLinkedResourceCac
   }
 
   protected sortList(gitlabIssue:HalResource[], attr = 'createdAt'):HalResource[] {
-    return sortBy(_.flatten(gitlabIssue), attr);
+    return sortBy(gitlabIssue.flat(), attr);
   }
 }

--- a/modules/gitlab_integration/frontend/module/tab-mrs/wp-gitlab-mrs.service.ts
+++ b/modules/gitlab_integration/frontend/module/tab-mrs/wp-gitlab-mrs.service.ts
@@ -46,6 +46,6 @@ export class WorkPackagesGitlabMrsService extends WorkPackageLinkedResourceCache
   }
 
   protected sortList(mergeRequests:HalResource[], attr = 'createdAt'):HalResource[] {
-    return sortBy(_.flatten(mergeRequests), attr);
+    return sortBy(mergeRequests.flat(), attr);
   }
 }


### PR DESCRIPTION
> [!NOTE]
> Lodash-removal series (parent #65621). Merge #23730 before this PR. Order: #23730 → **#23732 (this)** → #23733 → #23728 → #23736 (last).

# Ticket

https://community.openproject.org/wp/OP-19544

# What are you trying to accomplish?

Continues removing lodash from the frontend (parent: OP-17486 / WP 65621). This is the **set / dedup / difference** bucket: `flatten`, `uniq`, `without`, `uniqBy`, `difference`, `differenceBy` (~33 call sites) move from the global `_` to native operations.

The global `_` deliberately stays — `lodash` is still required by the remaining buckets and is removed only in the final cleanup ticket.

## Screenshots

No visual changes.

# What approach did you choose and why?

- `flatten(a)` → `a.flat()` (lodash `flatten` is one-level, matching `flat()`).
- `uniq(a)` → `Array.from(new Set(a))`.
- `without(a, ...vals)` → `a.filter(x => x !== val)` / `!… .includes(x)`.
- `difference(a, b)` → `a.filter(x => !b.includes(x))`.
- `uniqBy(a, key)` → `a.filter((x, i, self) => i === self.findIndex(y => key(y) === key(x)))`.
- `differenceBy(a, b, key)` → `a.filter(x => !b.some(y => key(y) === key(x)))`.

The one behavioural subtlety: `uniqBy` keeps the **first** occurrence of each key, which the `findIndex` form preserves — a `Map`-based dedup would keep the last. `tsc --noEmit` passes; the full vitest suite passes (including `wp-view-hierarchy-indentation.service.spec`, which covers one of the `difference` conversions).

No dedicated spec added — these conversions live in DI-heavy services/HAL resources with no clean pure seam, and are exercised by the existing suite.

# Merge checklist

- [ ] Added/updated tests <!-- covered by existing suite; no clean pure seam to add to -->
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) <!-- no visual change; full vitest suite green -->
