### PR TITLE
[OP-19545] Replace lodash equality/clone helpers

### DIFF
--- a/frontend/src/app/core/apiv3/endpoints/work_packages/work-package.cache.ts
+++ b/frontend/src/app/core/apiv3/endpoints/work_packages/work-package.cache.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { MultiInputState } from '@openproject/reactivestates';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { Injectable, Injector } from '@angular/core';
@@ -88,7 +89,7 @@ export class WorkPackageCache extends StateCacheService<WorkPackageResource> {
       // so that no consumer needs to call schema#$load manually
       void this.schemaCacheService.ensureLoaded(wp).then(() => {
         // Check if the work package has changed
-        if (skipOnIdentical && state.hasValue() && _.isEqual(state.value!.$source, wp.$source)) {
+        if (skipOnIdentical && state.hasValue() && isEqual(state.value!.$source, wp.$source)) {
           debugLog('Skipping identical work package from updating');
           return;
         }

--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { StateDeclaration, StateService, Transition, TransitionService, UIRouter } from '@uirouter/core';
 import { IToast, ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -129,7 +130,7 @@ export function uiRouterConfiguration(uiRouter:UIRouter, injector:Injector, modu
       raw: true,
       dynamic: true,
       is: (val:unknown) => typeof (val) === 'string',
-      equals: (a:any, b:any) => _.isEqual(a, b),
+      equals: (a:unknown, b:unknown) => isEqual(a, b),
     },
   );
 
@@ -142,7 +143,7 @@ export function uiRouterConfiguration(uiRouter:UIRouter, injector:Injector, modu
       raw: true,
       dynamic: true,
       is: (val:unknown) => typeof (val) === 'string',
-      equals: (a:unknown, b:unknown) => _.isEqual(a, b),
+      equals: (a:unknown, b:unknown) => isEqual(a, b),
     },
   );
 }
@@ -228,7 +229,7 @@ export function initializeUiRouterListeners(injector:Injector) {
     const hasProjectRoutes = toStateObject?.includes?.root;
     const projectIdentifier = toParams.projectPath as string || currentProject.identifier;
     if (hasProjectRoutes && !toParams.projects && projectIdentifier) {
-      const newParams = _.clone(toParams);
+      const newParams = { ...toParams };
       Object.assign(newParams, { projectPath: projectIdentifier, projects: 'projects' });
       return $state.target(toState, newParams, { location: 'replace' });
     }

--- a/frontend/src/app/features/hal/hal-link/hal-link.ts
+++ b/frontend/src/app/features/hal/hal-link/hal-link.ts
@@ -102,7 +102,7 @@ export class HalLink implements HalLinkInterface {
       throw new Error(`The link ${this.href} is not templated.`);
     }
 
-    let href = _.clone(this.href) || '';
+    let href = this.href ?? '';
     Object.entries(templateValues).forEach(([key, value]) => {
       const regexp = new RegExp(`{${key}}`);
       href = href.replace(regexp, value);

--- a/frontend/src/app/features/hal/resources/hal-resource.ts
+++ b/frontend/src/app/features/hal/resources/hal-resource.ts
@@ -35,6 +35,7 @@ import { LazyInject } from 'core-app/shared/helpers/angular/lazy-inject.decorato
 import { HalLinkInterface } from 'core-app/features/hal/hal-link/hal-link';
 import { ICKEditorContext } from 'core-app/shared/components/editor/components/ckeditor/ckeditor.types';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
+import { cloneDeep } from 'lodash-es';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 
 export type HalResourceClass<T extends HalResource = HalResource> = new(
@@ -176,7 +177,10 @@ export class HalResource {
   }
 
   public $plain():any {
-    return _.cloneDeep(this.$source);
+    // Use a deep clone (not structuredClone) because $source may contain
+    // HalResource instances (e.g. filter values), which carry functions and
+    // injector state that structuredClone cannot clone (DataCloneError).
+    return cloneDeep(this.$source);
   }
 
   public get $isHal():boolean {

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, OnInit, Output, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -183,7 +184,7 @@ export class OpBaselineComponent extends UntilDestroyedMixin implements OnInit {
     this.wpTableBaseline
       .pristine$()
       .subscribe((timestamps) => {
-        if (_.isEqual(timestamps, [DEFAULT_TIMESTAMP])) {
+        if (isEqual(timestamps, [DEFAULT_TIMESTAMP])) {
           this.resetSelection();
           this.wpTableBaseline.disable();
         }

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/child-relations-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/child-relations-render-pass.ts
@@ -21,7 +21,7 @@ export class ChildRelationsRenderPass extends RelationsRenderPass {
     }
 
     // Render for each original row, clone it since we're modifying the tablepass
-    const rendered = _.clone(this.tablePass.renderedOrder);
+    const rendered = [...this.tablePass.renderedOrder];
     const missingChildIds:string[] = [];
 
     rendered.forEach((row:RowRenderInfo) => {

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/relations-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/relations-render-pass.ts
@@ -57,7 +57,7 @@ export class RelationsRenderPass {
     }
 
     // Render for each original row, clone it since we're modifying the tablepass
-    const rendered = _.clone(this.tablePass.renderedOrder);
+    const rendered = [...this.tablePass.renderedOrder];
     rendered.forEach((row:RowRenderInfo) => {
       // We only care for rows that are natural work packages
       if (!row.workPackage) {

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
@@ -172,7 +172,7 @@ describe('UrlParamsHelper', () => {
         pageSize: 100,
       };
 
-      expect(_.isEqual(decodedQueryParams, expected)).toBeTruthy();
+      expect(decodedQueryParams).toEqual(expected);
     });
   });
 
@@ -264,7 +264,7 @@ describe('UrlParamsHelper', () => {
         timestamps: 'PT0S',
       };
 
-      expect(_.isEqual(v3Params, expected)).toBeTruthy();
+      expect(v3Params).toEqual(expected);
     });
 
     it('decodes custom options filters', () => {
@@ -324,7 +324,7 @@ describe('UrlParamsHelper', () => {
         timestamps: 'PT0S',
       };
 
-      expect(_.isEqual(v3Params, expected)).toBeTruthy();
+      expect(v3Params).toEqual(expected);
     });
   });
 });

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input, OnInit, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { BehaviorSubject, combineLatest } from 'rxjs';
@@ -173,7 +174,7 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
       .pipe(
         this.untilDestroyed(),
         map((resource) => this.contextFrom(resource)),
-        distinctUntilChanged<ResourceContextChange>((a, b) => _.isEqual(a, b)),
+        distinctUntilChanged<ResourceContextChange>((a, b) => isEqual(a, b)),
         map(() => this.halEditing.changeFor(this.workPackage)),
       )
       .subscribe((changeset:WorkPackageChangeset) => this.refresh(changeset));

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/timelines-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/timelines-tab.component.ts
@@ -87,7 +87,7 @@ export class WpTableConfigurationTimelinesTabComponent implements TabComponent, 
 
     // Current label models
     const { labels } = this.wpTableTimeline;
-    this.labels = _.clone(labels);
+    this.labels = { ...labels };
     this.availableLabels = Object.keys(this.labels);
 
     // Available labels

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { Injectable, inject } from '@angular/core';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { States } from 'core-app/core/states/states.service';
@@ -148,7 +149,7 @@ export class WorkPackageViewBaselineService extends WorkPackageQueryStateService
   }
 
   public hasChanged(query:QueryResource) {
-    return !_.isEqual(query.timestamps, this.current);
+    return !isEqual(query.timestamps, this.current);
   }
 
   public applyToQuery(query:QueryResource):boolean {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { States } from 'core-app/core/states/states.service';
 import { Injectable, inject } from '@angular/core';
@@ -51,7 +52,7 @@ export class WorkPackageViewColumnsService extends WorkPackageQueryStateService<
   public isCurrentlyEqualTo(a:QueryColumn[]) {
     const comparer = (columns:QueryColumn[]) => columns.map((c) => c.href);
 
-    return _.isEqual(
+    return isEqual(
       comparer(a),
       comparer(this.getColumns()),
     );

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { Injectable, inject } from '@angular/core';
 import { combine, input, InputState } from '@openproject/reactivestates';
 import { States } from 'core-app/core/states/states.service';
@@ -208,7 +209,7 @@ export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<
   public hasChanged(query:QueryResource) {
     const comparer = (filter:HalResource[]) => filter.map((el) => el.$source);
 
-    return !_.isEqual(
+    return !isEqual(
       comparer(query.filters),
       comparer(this.rawFilters),
     );

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { States } from 'core-app/core/states/states.service';
 import { Injectable, inject } from '@angular/core';
@@ -45,7 +46,7 @@ export class WorkPackageViewGroupByService extends WorkPackageQueryStateService<
   public hasChanged(query:QueryResource) {
     const comparer = (groupBy:QueryColumn|HalResource|null|undefined) => (groupBy ? groupBy.href : null);
 
-    return !_.isEqual(
+    return !isEqual(
       comparer(query.groupBy),
       comparer(this.current),
     );

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service.ts
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash-es';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { Injectable, inject } from '@angular/core';
 import { States } from 'core-app/core/states/states.service';
@@ -63,7 +64,7 @@ export class WorkPackageViewHighlightingService extends WorkPackageQueryStateSer
 
   public hasChanged(query:QueryResource) {
     return query.highlightingMode !== this.current.mode
-      || !_.isEqual(query.highlightedAttributes, this.current.selectedAttributes);
+      || !isEqual(query.highlightedAttributes, this.current.selectedAttributes);
   }
 
   public applyToQuery(query:QueryResource):boolean {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { combine } from '@openproject/reactivestates';
 import { mapTo } from 'rxjs/operators';
 import { Injectable, inject } from '@angular/core';
@@ -57,7 +58,7 @@ export class WorkPackageViewSortByService extends WorkPackageQueryStateService<Q
   public hasChanged(query:QueryResource) {
     const comparer = (sortBy:QuerySortByResource[]) => sortBy.map((el) => el.href);
 
-    return !_.isEqual(
+    return !isEqual(
       comparer(query.sortBy),
       comparer(this.current),
     );

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { isEqual } from 'lodash-es';
 import { Injectable } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { input } from '@openproject/reactivestates';
@@ -59,7 +60,7 @@ export class WorkPackageViewTimelineService extends WorkPackageQueryStateService
   public hasChanged(query:QueryResource) {
     const visibilityChanged = this.isVisible !== query.timelineVisible;
     const zoomLevelChanged = this.zoomLevel !== query.timelineZoomLevel;
-    const labelsChanged = !_.isEqual(this.current.labels, query.timelineLabels);
+    const labelsChanged = !isEqual(this.current.labels, query.timelineLabels);
 
     return visibilityChanged || zoomLevelChanged || labelsChanged;
   }

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { omitBy } from 'lodash-es';
+import { isEqual, omitBy } from 'lodash-es';
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
@@ -41,7 +41,6 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import _ from 'lodash';
 
 export type DateMode = 'single'|'range';
 
@@ -164,7 +163,7 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
   private isDifferentFromDatePickerSelectedDates(isoDates:string[]):boolean {
     const datePickerSelectedDates = this.datePickerInstance.datepickerInstance.selectedDates;
     const isoDatePickerSelectedDates = datePickerSelectedDates.map((date) => this.timezoneService.formattedISODate(date));
-    return !_.isEqual(isoDates, isoDatePickerSelectedDates);
+    return !isEqual(isoDates, isoDatePickerSelectedDates);
   }
 
   // set dates on flatpickr, trying to avoid jumping to a different month when possible

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -296,7 +296,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   private setupAttachmentRemovalSignal(editor:ICKEditorInstance) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-    this.attachments = _.clone((this.halResource as HalResource).attachments.elements);
+    this.attachments = [...(this.halResource as HalResource).attachments.elements];
 
     this
       .states
@@ -317,7 +317,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
           editor.model.fire('op:attachment-removed', removedUrls);
         }
 
-        this.attachments = _.clone(resource.attachments.elements);
+        this.attachments = [...resource.attachments.elements];
       });
   }
 

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -31,6 +31,7 @@ import {
   InputState,
 } from '@openproject/reactivestates';
 import { take } from 'rxjs/operators';
+import { cloneDeep } from 'lodash-es';
 
 import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
@@ -425,9 +426,9 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
       // to let all default values be transmitted (type, status, etc.)
       // We clone the object to avoid later manipulations to affect the original resource.
       if (this.form$.value) {
-        payload = _.cloneDeep(this.form$.value.payload.$source);
+        payload = cloneDeep((this.form$.value.payload as HalResource).$source) as typeof payload;
       } else {
-        payload = _.cloneDeep(this.pristineResource.$source);
+        payload = cloneDeep(this.pristineResource.$source) as typeof payload;
       }
 
       // Add attachments to be assigned.

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -426,7 +426,7 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
       // to let all default values be transmitted (type, status, etc.)
       // We clone the object to avoid later manipulations to affect the original resource.
       if (this.form$.value) {
-        payload = cloneDeep((this.form$.value.payload as HalResource).$source) as typeof payload;
+        payload = cloneDeep((this.form$.value.payload as { $source:unknown }).$source) as typeof payload;
       } else {
         payload = cloneDeep(this.pristineResource.$source) as typeof payload;
       }


### PR DESCRIPTION
> [!NOTE]
> Lodash-removal series (parent #65621). Merge #23732 before this PR. Order: #23730 → #23732 → **#23733 (this)** → #23728 → #23736 (last). (#23729, which also added `lodash-es`, is already merged.)

# Ticket

https://community.openproject.org/wp/OP-19545

# What are you trying to accomplish?

Continues removing lodash from the frontend (parent: OP-17486 / WP 65621). This is the **equality / clone** bucket: `clone`, `cloneDeep`, `isEqual`, `isEqualWith` (~27 call sites) move off the global `_`.

The global `_` deliberately stays — `lodash` is still required by the remaining buckets and is removed only in the final cleanup ticket.

## Screenshots

No visual changes.

# What approach did you choose and why?

- **`clone`** → native shallow copy chosen per type: `{ ...obj }`, `[...arr]`, and a no-op for the one `clone(string)` case.
- **`cloneDeep`** → `lodash-es` `cloneDeep` (**not** `structuredClone`). The three sites deep-clone a HAL `$source`. It is usually plain JSON, but a query filter's `$source` can hold live `HalLink` instances (set via the UI when filtering by project/user), and those carry a `requestMethod` **function** — so `structuredClone` throws `DataCloneError` when a query is saved (`cloneFilters()` → `$copy()` → `$plain()`). `lodash-es` `cloneDeep` reproduces the original `_.cloneDeep` behaviour exactly while still dropping the global `_`.
- **`isEqual` / `isEqualWith`** → `lodash-es` named imports. There is no safe native deep-equality, and reimplementing one is riskier than keeping the exact lodash implementation; this matches the lodash-es bucket's approach for helpers with no native equivalent. Adds `lodash-es` + `@types/lodash-es` (the same dependency that PR introduces — trivial rebase if it merges first).
- Three `expect(_.isEqual(a, b)).toBeTruthy()` spec assertions become idiomatic `expect(a).toEqual(b)`.

`tsc --noEmit` passes; the full vitest suite passes (including `hal-resource.spec`, which covers the `cloneDeep` path, and `url-params-helper.spec`, whose assertions were upgraded here).

# Merge checklist

- [x] Added/updated tests <!-- spec assertions upgraded to toEqual; cloneDeep path covered by hal-resource.spec -->
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) <!-- no visual change; full vitest suite green -->
