### PR TITLE
[STC-222] Update text on Notification settings for clarity

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3874,8 +3874,8 @@ en:
         submit_button: "Update alerts"
     notifications:
       participating:
+        description: "You will always receive a notification whenever you are mentioned, and for changes to work packages you are watching. These cannot be disabled. However, you can choose to enable or disable receiving notifications for changes to work packages that concern you (where you are assignee, accountable or are shared with you)."
         title: "Participating"
-        description: "Notifications for all activities in work packages you are involved in (assignee, accountable or watcher)."
         submit_button: "Update preferences"
         mentioned: "Mentioned"
         watched: "Watching"
@@ -3883,8 +3883,8 @@ en:
         responsible: "Accountable"
         shared: "Shared with me"
       date_alerts:
+        description: "You can configure date alerts for work packages where you are assignee, accountable and/or watcher to be automatically notified a few days prior to approaching or overdue deadlines."
         title: "Date alerts"
-        description: "Automatic notifications when important dates are approaching for open work packages you are involved in (assignee, accountable or watcher)."
         submit_button: "Update date alerts"
         start_date: "Start date"
         due_date: "Finish date"
@@ -3898,8 +3898,8 @@ en:
           three_days_after: "3 days after"
           seven_days_after: "7 days after"
       non_participating:
+        description: "You can additionally choose to be notified of any of the following activities for all projects."
         title: "Non-participating"
-        description: "Additional notifications for activities in all projects."
         submit_button: "Update preferences"
         work_package_created: "New work packages"
         work_package_commented: "All new comments"
@@ -3907,8 +3907,8 @@ en:
         work_package_prioritized: "All priority changes"
         work_package_scheduled: "All date changes"
       project_specific_settings:
-        title: "Project-specific notification settings"
-        description: "These project-specific settings override default settings above."
+        description: "You can fine-tune your notification settings to only be notified of certain events in specific projects. Add a project below and choose which events should trigger a notification for you. These project-specific settings override default settings above."
+        title: "Project-specific notifications"
         add_button: "Add project-specific notifications"
         dialog_title: "Add project-specific notifications"
         list_header: "Projects with specific notifications"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/STC-222

# What are you trying to accomplish?

Users reported that the helper text under each section header in **Account settings → Notifications** was unclear and had not been updated since the Date alerts feature was introduced. This PR updates the five affected strings in the English locale file to be more accurate and user-friendly:

## Screenshots
Before:
<img width="895" height="1068" alt="Screenshot 2026-06-15 at 9 48 33" src="https://github.com/user-attachments/assets/d6534778-5aae-4889-ac34-003991ba5b64" />

After:
<img width="1101" height="1117" alt="Screenshot 2026-06-15 at 9 48 10" src="https://github.com/user-attachments/assets/915582cd-a1ef-4ebf-9f72-80ecf83ed6c4" />

# What approach did you choose and why?

All five changes are confined to a single place: `config/locales/en.yml` under `my_account.notifications`. Because all components (`participating_form.rb`, `date_alerts_form.rb`, `non_participating_form.rb`, and the show-page template) reference these keys dynamically, no Ruby, ERB, or TypeScript files required modification.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)