### PR TITLE
[STC-820/STC-828] Update Hocuspocus to TypeScript 6.0

### DIFF
--- a/.github/workflows/hocuspocus-test.yml
+++ b/.github/workflows/hocuspocus-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.19'
+          node-version: '22.22.3'
           package-manager-cache: false
           cache: npm
           cache-dependency-path: extensions/op-blocknote-hocuspocus/package-lock.json

--- a/docker/dev/hocuspocus/docker-compose.override.example.yml
+++ b/docker/dev/hocuspocus/docker-compose.override.example.yml
@@ -5,7 +5,7 @@ services:
   hocuspocus:
     # In case of MacOS you need to specify the platform in your `docker/dev/hocuspocus/docker-compose.override.yml`:
     # platform: linux/amd64
-    image: node:22-alpine
+    image: node:22.22.3-alpine
     working_dir: /app
     command: sh -c "npm run dev"
     volumes:

--- a/extensions/op-blocknote-hocuspocus/Dockerfile
+++ b/extensions/op-blocknote-hocuspocus/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.18
+FROM node:22.22.3
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --omit=dev

--- a/extensions/op-blocknote-hocuspocus/eslint.config.mjs
+++ b/extensions/op-blocknote-hocuspocus/eslint.config.mjs
@@ -6,6 +6,9 @@ import { defineConfig } from "eslint/config";
 import stylistic from "@stylistic/eslint-plugin";
 
 export default defineConfig([
+  {
+    ignores: ["package-lock.json"],
+  },
   tseslint.configs.recommended,
   {
     files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
@@ -25,6 +28,12 @@ export default defineConfig([
       "@stylistic/semi": ["warn", "always"],
       "@stylistic/indent": ["warn", 2],
     }
+  },
+  {
+    files: ["**/*.ts"],
+    rules: {
+      "no-undef": "off",
+    },
   },
   {
     files: ["**/*.json"],

--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -24,11 +24,12 @@
         "eslint": "^9.35.0",
         "globals": "^17.3.0",
         "msw": "^2.12.7",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.48.1",
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=22.18"
+        "node": "^22.22.3 || ^24.15.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -5174,7 +5175,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/opf/openproject/tree/dev/extensions/op-blocknote-hocuspocus#readme",
   "engines": {
-    "node": ">=22.18"
+    "node": "^22.22.3 || ^24.15.0"
   },
   "dependencies": {
     "@blocknote/server-util": "^0.51.3",
@@ -38,6 +38,7 @@
     "eslint": "^9.35.0",
     "globals": "^17.3.0",
     "msw": "^2.12.7",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.48.1",
     "vitest": "^4.1.0"
   }

--- a/extensions/op-blocknote-hocuspocus/src/extensions/openProjectApi.ts
+++ b/extensions/op-blocknote-hocuspocus/src/extensions/openProjectApi.ts
@@ -122,7 +122,6 @@ export class OpenProjectApi implements Extension {
     Y.applyUpdate(tempYdoc, Y.encodeStateAsUpdate(data.document));
     const tempFragment = tempYdoc.getXmlFragment("document-store");
     const editorData = editor.yXmlFragmentToBlocks(tempFragment);
-    // @ts-expect-error BlockNote types are complicated
     const markdownData = await editor.blocksToMarkdownLossy(editorData);
 
     const response = await fetchResource(resourceUrl, data.context.token, {

--- a/extensions/op-blocknote-hocuspocus/tsconfig.json
+++ b/extensions/op-blocknote-hocuspocus/tsconfig.json
@@ -4,13 +4,17 @@
       "es2024",
       "ESNext.Array",
       "ESNext.Collection",
-      "ESNext.Iterator"
+      "ESNext.Iterator",
+      "DOM"
     ],
-    "module": "nodenext",
+    "module": "esnext",
     "target": "es2022",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": [
+      "node"
+    ]
   }
 }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-820
https://community.openproject.org/wp/STC-828

# What are you trying to accomplish?

Update the Hocuspocus extension to the same Node baseline as OpenProject core and make the OpenProject API extension compile cleanly with TypeScript 6.

Related core upgrade: https://github.com/opf/openproject/pull/23588

## Screenshots

No visible changes.

# What approach did you choose and why?

The runtime metadata, Docker base images, and Hocuspocus test workflow now use the core Node range/version. TypeScript is an explicit dev dependency, the extension tsconfig keeps bundler-style imports while satisfying TypeScript 6, and the stale BlockNote suppression in openProjectApi.ts was removed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
