### PR TITLE
Drop deprecated @stylistic overrides.arrow option

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -194,16 +194,19 @@ export default defineConfig([
       // Disable indentation rule as it breaks in edge cases and is covered by editorconfig
       '@stylistic/indent': 'off',
 
-      // Whitespace configuration
+      // Whitespace configuration: spaces around the function-type `=>`
+      // (defaults), but tight colons. Colon spacing lives in
+      // `overrides.colon` because the rule's `overrides.arrow` option is
+      // deprecated; keeping the base spaced preserves `() => void` style.
       '@stylistic/type-annotation-spacing': [
         'error',
         {
-          before: false,
-          after: false,
+          before: true,
+          after: true,
           overrides: {
-            arrow: {
-              before: true,
-              after: true,
+            colon: {
+              before: false,
+              after: false,
             },
           },
         },


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

# What are you trying to accomplish?

`@stylistic/type-annotation-spacing` deprecated its `overrides.arrow` option, so every ESLint run printed a deprecation warning.

# What approach did you choose and why?

The deprecation message suggests `arrow-spacing`, but that rule only covers arrow *expressions* (`(x) => x`), not type-level `() => void`. The config needs tight colons (`x:any`) combined with spaced type arrows, which previously relied on `overrides.arrow`. Moving the tight-colon rule into the non-deprecated `overrides.colon` and letting the base options carry the spaced `=>` style preserves the exact existing formatting while removing the deprecated option.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)