### PR TITLE
Bug/op 19472 custom actions rejected for conflicting change if clicked after changing something

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
@@ -79,6 +79,9 @@ export class WpCustomActionComponent extends UntilDestroyedMixin implements OnIn
 
     void this.halResourceService
       .get<CustomActionResource>(this.action.href)
+      .pipe(
+        this.untilDestroyed(),
+      )
       .subscribe((action) => {
         this.action = action;
       });

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -45,9 +45,6 @@ import {
 import {
   WorkPackageNotificationService,
 } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
-import {
-  take,
-} from 'rxjs/operators';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -138,10 +135,14 @@ export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
    * Needs to be run explicitly by descendants.
    *
    * Note: this.workPackageId may be a semantic identifier (e.g. "PROJ-7")
-   * from the route param. The API resolves it correctly, but the cache key
-   * would be "PROJ-7" while list queries cache the same WP under "42".
-   * After the first load we normalize to the numeric PK to prevent
-   * dual cache entries.
+   * from the route param. In that case the initial load and stream are
+   * keyed under the semantic id, but cache writes elsewhere (e.g.
+   * cache.updateWorkPackage on save) key by the numeric PK on wp.id.
+   * If they differ, we open a parallel subscription on the numeric slot
+   * after the first emission so subsequent updates reach us — otherwise
+   * this.workPackage would freeze at the initial load. In classic mode
+   * (route param == numeric PK) no parallel subscription is opened, so
+   * the emission count is unchanged from the original behavior.
    */
   protected observeWorkPackage():void {
     this
@@ -151,29 +152,42 @@ export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
       .requireAndStream()
       .pipe(this.untilDestroyed())
       .subscribe((wp:WorkPackageResource) => {
-        // Normalize semantic route param (e.g. "PROJ-7") to numeric PK
-        // for cache coherence — downstream code uses this.workPackageId
-        // as a cache key, and the canonical key is always numeric.
-        if (this.workPackageId !== wp.id && wp.id) {
+        if (wp.id && this.workPackageId !== wp.id) {
           this.workPackageId = wp.id;
+          this.subscribeToNumericCacheSlot(wp.id);
         }
 
-        if (!this.workPackage) {
-          this.workPackage = wp;
-          this.init();
-        } else {
-          this.workPackage = wp;
-        }
-
-        if (this.routedFromAngular) {
-          // Push the current title
-          this.titleService.setFirstPart(this.workPackage.subjectWithType(-1));
-        }
-
-        this.cdRef.detectChanges();
+        this.applyWorkPackage(wp);
       }, (error) => {
         this.handleLoadingError(error);
       });
+  }
+
+  private subscribeToNumericCacheSlot(numericId:string):void {
+    this
+      .apiV3Service
+      .work_packages
+      .cache
+      .state(numericId)
+      .values$()
+      .pipe(this.untilDestroyed())
+      .subscribe((nextWp:WorkPackageResource) => this.applyWorkPackage(nextWp));
+  }
+
+  private applyWorkPackage(wp:WorkPackageResource):void {
+    if (!this.workPackage) {
+      this.workPackage = wp;
+      this.init();
+    } else {
+      this.workPackage = wp;
+    }
+
+    if (this.routedFromAngular) {
+      // Push the current title
+      this.titleService.setFirstPart(this.workPackage.subjectWithType(-1));
+    }
+
+    this.cdRef.detectChanges();
   }
 
   /**

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -572,4 +572,44 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
       edit_ca_page.expect_action(multi_user_custom_field.name, [other_member_user.name])
     end
   end
+
+  context "when staying on the page for multiple changes (Bug#OP-19472)",
+          with_settings: { work_packages_identifier: "semantic" } do
+    let!(:unassign_ca) do
+      create(:custom_action,
+             actions: [CustomActions::Actions::AssignedTo.new(nil)],
+             name: "Unassign")
+    end
+
+    let!(:responsible_ca) do
+      create(:member,
+             principal: admin,
+             project: project,
+             roles: [role])
+      create(:custom_action,
+             actions: [CustomActions::Actions::Responsible.new("current_user")],
+             name: "Be responsible")
+    end
+
+    before do
+      # This is done to fix the id that breaks because the wp is created outside of the
+      # semantic identifier scope.
+      previous_identifier = project.identifier
+      project.update!(identifier: "RENAMED")
+      project.handle_semantic_rename(previous_identifier)
+    end
+
+    it "works when clicking two buttons" do
+      wp_page.visit!
+
+      wp_page.click_custom_action(unassign_ca.name, expect_success: true)
+
+      wp_page.click_custom_action(responsible_ca.name, expect_success: true)
+
+      wp_page.expect_attributes(
+        assignee: "-",
+        responsible: admin.name
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19472

# What are you trying to accomplish?

Fix clicking a custom action after modifications on the work package page have already been done (e.g., clicking another custom action or any other attribute change).

The action before would sent the patch to the backend updating the work package and its lockVersion. That response is correctly returned to the frontend. But the change is not correctly listened to by the subscription in WorkPackageSingleViewBase. The subscription will always be registered using the semantic identifier (if it is active) but the api's response will update the cache using the canonical id. The fact that `this.workPackageId` gets the canonical id assigned does not change the subscription being with the semantic identifier.

This problem then propagates down to components having `workPackage` as their input like WpCustomActionComponent. 

The fix is to only take the first value (possibly listening to the semantic identifiers there) and only then subscribing after the id listened to (`this.workPackageId`) has been set to the canonical id.

# Merge checklist

- [x] Added/updated tests
