### PR TITLE
Code maintenance/STC-834: Bump Hocuspocus client & server to v4.2.0 (lockstep)

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -10,8 +10,8 @@
       "license": "GPLv3",
       "dependencies": {
         "@blocknote/server-util": "^0.51.3",
-        "@hocuspocus/extension-logger": "^3.4.4",
-        "@hocuspocus/server": "^3.4.0",
+        "@hocuspocus/extension-logger": "^4.2.0",
+        "@hocuspocus/server": "^4.2.0",
         "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
         "tsx": "^4.21.0"
       },
@@ -971,35 +971,37 @@
       }
     },
     "node_modules/@hocuspocus/common": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-3.4.4.tgz",
-      "integrity": "sha512-RykIJ0tsHHMP4Xk+4UCbc7SO5LgGxGUSTdbh6anJEsaALAyqinf1Nn5HYuMjLPolAmsar1v++m9zufR09NLpXA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.2.0.tgz",
+      "integrity": "sha512-031clELz+rW7MpmpFUFN7+vE52Gtk1wkrSVHyqydZgKSLf5AtrorliCf38cH65mGGltLR2/JrydzqOk2bVQhjw==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.87"
       }
     },
     "node_modules/@hocuspocus/extension-logger": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-3.4.4.tgz",
-      "integrity": "sha512-GEnjmvQlrDlr5hoTQ8NHStZkzpL42wkwZ5XOBMkEX/TgqcnEtKCK1SOK0xj+px9tEHaflDLtCq6f5oy4gOCkPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-4.2.0.tgz",
+      "integrity": "sha512-zLJJnl+5WR2wg5PSVPPdTrHOsV+7P8uZrF7Y1AnvOp48CAK+PjRJ5N/K07Rpbzx6GwWQKOUAcdnqeJ+n0a1jRw==",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^3.4.4"
+        "@hocuspocus/server": "^4.2.0"
       }
     },
     "node_modules/@hocuspocus/server": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-3.4.4.tgz",
-      "integrity": "sha512-UV+oaONAejOzeYgUygNcgsc8RdZvSokVvAxluZJIisLACpRO/VsseQ5lWKDRwLd7Fn6+rHWDH3hGuQ1fdX1Ycg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.2.0.tgz",
+      "integrity": "sha512-D3OjjH/62G2M6FDfJMJDtAgV3VdUcq1V4MNLjuVaUpdhWkRy5OdzC6Zwo9hfFmtoolDzAy+WUK+xFPN/FljtYw==",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^3.4.4",
-        "async-lock": "^1.3.1",
+        "@hocuspocus/common": "^4.2.0",
         "async-mutex": "^0.5.0",
+        "crossws": "^0.4.4",
         "kleur": "^4.1.4",
-        "lib0": "^0.2.47",
-        "ws": "^8.5.0"
+        "lib0": "^0.2.47"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "y-protocols": "^1.0.6",
@@ -2428,12 +2430,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/async-lock": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
-      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
-      "license": "MIT"
-    },
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -2624,6 +2620,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.6.tgz",
+      "integrity": "sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
       }
     },
     "node_modules/css-color-keywords": {

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@blocknote/server-util": "^0.51.3",
-    "@hocuspocus/extension-logger": "^3.4.4",
-    "@hocuspocus/server": "^3.4.0",
+    "@hocuspocus/extension-logger": "^4.2.0",
+    "@hocuspocus/server": "^4.2.0",
     "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
     "tsx": "^4.21.0"
   },

--- a/extensions/op-blocknote-hocuspocus/src/extensions/openProjectApi.ts
+++ b/extensions/op-blocknote-hocuspocus/src/extensions/openProjectApi.ts
@@ -41,7 +41,7 @@ export class OpenProjectApi implements Extension {
       throw new Error('Unauthorized: Missing auth params');
     }
 
-    const requestOrigin = data.request?.headers?.origin;
+    const requestOrigin = data.requestHeaders?.get("origin") ?? undefined;
     const result = await decryptAndValidateToken(token, resourceUrl, requestOrigin);
 
     const tokenExpiresAtDate = new Date(result.tokenExpiresAt);
@@ -103,7 +103,7 @@ export class OpenProjectApi implements Extension {
     * Store data to the API. The data is a YDoc update
     */
   async onStoreDocument(data: onStoreDocumentPayload): Promise<void> {
-    const { resourceUrl, readonly } = data.context;
+    const { resourceUrl, readonly } = data.lastContext;
 
     if (!resourceUrl) {
       console.warn("Missing parameters in context. Skipping store.");
@@ -124,7 +124,7 @@ export class OpenProjectApi implements Extension {
     const editorData = editor.yXmlFragmentToBlocks(tempFragment);
     const markdownData = await editor.blocksToMarkdownLossy(editorData);
 
-    const response = await fetchResource(resourceUrl, data.context.token, {
+    const response = await fetchResource(resourceUrl, data.lastContext.token, {
       method: "PATCH",
       body: JSON.stringify({
         content_binary: base64Data,
@@ -137,7 +137,7 @@ export class OpenProjectApi implements Extension {
       return;
     }
 
-    data.document.connections.forEach(({ connection }) => connection.sendStateless("storeEvent"));
+    data.document.broadcastStateless("storeEvent");
   }
 
   /**

--- a/extensions/op-blocknote-hocuspocus/test/extensions/openProjectApi.test.ts
+++ b/extensions/op-blocknote-hocuspocus/test/extensions/openProjectApi.test.ts
@@ -37,11 +37,9 @@ describe("OpenProjectApi", () => {
         new OpenProjectApi().onAuthenticate({
           token: "Yjo1x80JGIjrK8J6IDOuRn5kIOGvaAUw8C1so+dJJq7cgkllf3dQnw6d8bgiKbHXw8ZaMYE4IyOI1KQgX2ZRmx1mKBkxtb/fc7eCpGyTKGTA2Y1r/q7VJYiJZlpX7gx3nu569joEl/k=--mUkLaPiK0E82vGT9--gj1ZnTNlydL9j+Xw8+YFAA==",
           documentName: "https://test.api/api/v3/documents/1",
-          request: {
-            headers: {
-              origin: "https://different.origin",
-            },
-          },
+          requestHeaders: new Headers({
+            origin: "https://different.origin",
+          }),
         } as unknown as onAuthenticatePayload)
       ).rejects.toThrowError("Unauthorized: Token origin does not match request origin.");
     });
@@ -269,20 +267,22 @@ describe("OpenProjectApi", () => {
       // @ts-expect-error BlockNote types are complicated
       editor.blocksToYXmlFragment(blocks, fragment);
 
+      const broadcastStateless = vi.fn();
       const data = {
-        context: {
+        lastContext: {
           token: "superValidToken",
           resourceUrl: "https://test.api/api/v3/documents/121",
           readonly: false,
           tokenExpiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5 min from now
         },
-        document: { ...document, connections: [] } as unknown as Document,
-      } as onStoreDocumentPayload;
+        document: { ...document, broadcastStateless } as unknown as Document,
+      } as unknown as onStoreDocumentPayload;
 
       const api = new OpenProjectApi();
       await api.onStoreDocument(data);
 
       await expect(body).resolves.toContain("content_binary");
+      expect(broadcastStateless).toHaveBeenCalledWith("storeEvent");
     });
   });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "@fullcalendar/resource-timeline": "^6.1.20",
         "@fullcalendar/timegrid": "^6.1.20",
         "@github/webauthn-json": "^2.1.1",
-        "@hocuspocus/provider": "^4.1.0",
+        "@hocuspocus/provider": "^4.2.0",
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo": "^8.0.23",
         "@hotwired/turbo-rails": "^8.0.23",
@@ -3539,12 +3539,12 @@
       }
     },
     "node_modules/@hocuspocus/provider": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-4.1.0.tgz",
-      "integrity": "sha512-K80V2yX4AMdpqgjIkexJioyI2Oq8pu8hjdFqY0INXKSpH8TQv9NMaDzJmlrZMYmUeKyRO2t7VhGyFK9jZQPnNw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-4.2.0.tgz",
+      "integrity": "sha512-w38vvgYBs4NDonMkxb4R//n+CgBJ+K/03RMXcr8yHx1I3TY8HYpTlRqOUWdIJpmgw2ZyuM9EdbJwwRPrZF7iEA==",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^4.1.0",
+        "@hocuspocus/common": "^4.2.0",
         "@lifeomic/attempt": "^3.0.2",
         "lib0": "^0.2.87"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
     "@fullcalendar/resource-timeline": "^6.1.20",
     "@fullcalendar/timegrid": "^6.1.20",
     "@github/webauthn-json": "^2.1.1",
-    "@hocuspocus/provider": "^4.1.0",
+    "@hocuspocus/provider": "^4.2.0",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo": "^8.0.23",
     "@hotwired/turbo-rails": "^8.0.23",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-834

Server-side follow-up to the `@hocuspocus/provider` v4 client bump in #23570.

# What are you trying to accomplish?

#23570 moves the frontend client `@hocuspocus/provider` to v4. The collaboration server in `op-blocknote-hocuspocus` was still on v3. The two talk over a versioned wire protocol and ship as independent artifacts — the server is the separately built `openproject/hocuspocus` image — so a one-major skew is tolerated, but the goal is to bring the server up to v4 as well so both halves run the current major.

This PR bumps `@hocuspocus/server` and `@hocuspocus/extension-logger` to v4 and applies the API changes the major introduces.

## What v4 changes, and how it's applied here

v4 is a cross-runtime release that standardizes the server hook payloads on web-standard primitives and restructures a couple of hook shapes ([v4.0.0 release notes](https://github.com/ueberdosis/hocuspocus/releases/tag/v4.0.0), [full diff](https://github.com/ueberdosis/hocuspocus/compare/v3.4.4...v4.0.0)). Three of those touch our `OpenProjectApi` extension:

- **Request headers are now a web-standard `Headers` object** — upgrade guide §2 *Request and Headers (Breaking)*. `onAuthenticate` previously read the request origin off a plain object (`data.request.headers.origin`). v4 exposes it as `Headers`, accessed with `.get()`:

  ```ts
  // before (v3)
  const requestOrigin = data.request?.headers?.origin;
  // after (v4)
  const requestOrigin = data.requestHeaders?.get("origin") ?? undefined;
  ```

  This matters beyond a rename: against v4 the old plain-object access would silently return `undefined`, quietly weakening the origin check passed to `decryptAndValidateToken`.

- **The store hook's context is renamed `context` → `lastContext`** — upgrade guide §3 *`onStoreDocument` Payload (Breaking)*. `onStoreDocument` reads the resource URL, readonly flag, and token from the snapshot of the last connection context:

  ```ts
  // before (v3): data.context
  // after (v4):  data.lastContext
  const { resourceUrl, readonly } = data.lastContext;
  ```

- **Broadcasting to connected clients goes through `Document#broadcastStateless`.** In v4 `Document.connections` is a `Map<Connection, { clients }>`, so the old `connections.forEach(({ connection }) => connection.sendStateless(...))` no longer typechecks. `broadcastStateless` is the supported helper for this ([CHANGELOG, client-initiated broadcastStateless #1103](https://github.com/ueberdosis/hocuspocus/blob/main/CHANGELOG.md)):

  ```ts
  // before (v3)
  data.document.connections.forEach(({ connection }) => connection.sendStateless("storeEvent"));
  // after (v4)
  data.document.broadcastStateless("storeEvent");
  ```

The rest of the extension is unchanged: `onTokenSync`, `connection.close({ code, reason })`, `connectionConfig.readOnly`, and the ad-hoc `context` writes all compile and behave the same under v4. `@hocuspocus/common` resolves to v4 transitively; `closeEvents.ts` already uses the v4-narrowed `{ code, reason }` CloseEvent shape (upgrade guide §11 *`CloseEvent` Shape*), so no change was needed there.

### References

- v4.0.0 release notes & v3→v4 upgrade guide: https://github.com/ueberdosis/hocuspocus/releases/tag/v4.0.0
- Full changelog: https://github.com/ueberdosis/hocuspocus/blob/main/CHANGELOG.md
- v3.4.4 → v4.0.0 diff: https://github.com/ueberdosis/hocuspocus/compare/v3.4.4...v4.0.0

A standing assertion of the client/server compatibility, plus a CI guard against future major drift, lands in the follow-up #23755.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (n/a)
- [x] Tested major browsers (live smoke test in Chrome)
