### PR TITLE
hocuspocus: Add provider/server wire-protocol integration test with CI version-skew guard

### DIFF
--- a/.github/workflows/hocuspocus-version-skew.yml
+++ b/.github/workflows/hocuspocus-version-skew.yml
@@ -1,0 +1,51 @@
+name: "Hocuspocus / Version skew"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'frontend/package.json'
+      - 'extensions/op-blocknote-hocuspocus/package.json'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  pull-requests: write # to comment on the PR
+
+jobs:
+  version-skew:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Compare Hocuspocus client and server major versions
+        id: skew
+        run: ./script/ci/hocuspocus_version_skew.sh
+
+      - name: Add comment if versions skew
+        if: steps.skew.outputs.skew == 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: hocuspocus-version-skew
+          message: |
+            > [!WARNING]
+            > The Hocuspocus client and server are on different major versions.
+
+            - `@hocuspocus/provider` (client, frontend): **${{ steps.skew.outputs.provider_range }}**
+            - `@hocuspocus/server` (server, op-blocknote-hocuspocus extension): **${{ steps.skew.outputs.server_range }}**
+
+            The client ships with the core app; the server ships as the separately deployed
+            `openproject/hocuspocus` image, so they can drift independently.
+
+            A one-major skew is supported by Hocuspocus in both directions and is fine as a
+            temporary state while the two halves are realigned. Two or more majors apart is not
+            supported. Please confirm this skew is intentional, or bump the lagging side.
+      - name: Skew check passed
+        if: steps.skew.outputs.skew != 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: hocuspocus-version-skew
+          delete: true

--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -20,7 +20,7 @@
         "@eslint/js": "^9.35.0",
         "@eslint/json": "^1.2.0",
         "@hocuspocus/provider": "^4.2.0",
-        "@hocuspocus/provider-prev": "npm:@hocuspocus/provider@^3",
+        "@hocuspocus/provider-prev-test-only": "npm:@hocuspocus/provider@^3",
         "@stylistic/eslint-plugin": "^5.3.1",
         "@types/node": "^25.0.2",
         "eslint": "^9.35.0",
@@ -1006,7 +1006,7 @@
         "yjs": "^13.6.8"
       }
     },
-    "node_modules/@hocuspocus/provider-prev": {
+    "node_modules/@hocuspocus/provider-prev-test-only": {
       "name": "@hocuspocus/provider",
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-3.4.4.tgz",
@@ -1024,7 +1024,7 @@
         "yjs": "^13.6.8"
       }
     },
-    "node_modules/@hocuspocus/provider-prev/node_modules/@hocuspocus/common": {
+    "node_modules/@hocuspocus/provider-prev-test-only/node_modules/@hocuspocus/common": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-3.4.4.tgz",
       "integrity": "sha512-RykIJ0tsHHMP4Xk+4UCbc7SO5LgGxGUSTdbh6anJEsaALAyqinf1Nn5HYuMjLPolAmsar1v++m9zufR09NLpXA==",

--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -19,6 +19,8 @@
         "@blocknote/core": "^0.51.3",
         "@eslint/js": "^9.35.0",
         "@eslint/json": "^1.2.0",
+        "@hocuspocus/provider": "^4.2.0",
+        "@hocuspocus/provider-prev": "npm:@hocuspocus/provider@^3",
         "@stylistic/eslint-plugin": "^5.3.1",
         "@types/node": "^25.0.2",
         "eslint": "^9.35.0",
@@ -988,6 +990,60 @@
         "@hocuspocus/server": "^4.2.0"
       }
     },
+    "node_modules/@hocuspocus/provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-4.2.0.tgz",
+      "integrity": "sha512-w38vvgYBs4NDonMkxb4R//n+CgBJ+K/03RMXcr8yHx1I3TY8HYpTlRqOUWdIJpmgw2ZyuM9EdbJwwRPrZF7iEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^4.2.0",
+        "@lifeomic/attempt": "^3.0.2",
+        "lib0": "^0.2.87"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@hocuspocus/provider-prev": {
+      "name": "@hocuspocus/provider",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-3.4.4.tgz",
+      "integrity": "sha512-KbsMAfdYcIJD8eMU/5QnpXcSOvIWAcCNI33FSRSaKCIpYBFtAwkYIwWnZJmPZ8a1BMAtqQc+uvy9+UQf7GHnGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^3.4.4",
+        "@lifeomic/attempt": "^3.0.2",
+        "lib0": "^0.2.87",
+        "ws": "^8.17.1"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@hocuspocus/provider-prev/node_modules/@hocuspocus/common": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-3.4.4.tgz",
+      "integrity": "sha512-RykIJ0tsHHMP4Xk+4UCbc7SO5LgGxGUSTdbh6anJEsaALAyqinf1Nn5HYuMjLPolAmsar1v++m9zufR09NLpXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.87"
+      }
+    },
+    "node_modules/@hocuspocus/provider/node_modules/@hocuspocus/common": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.2.0.tgz",
+      "integrity": "sha512-031clELz+rW7MpmpFUFN7+vE52Gtk1wkrSVHyqydZgKSLf5AtrorliCf38cH65mGGltLR2/JrydzqOk2bVQhjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.87"
+      }
+    },
     "node_modules/@hocuspocus/server": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.2.0.tgz",
@@ -1175,6 +1231,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lifeomic/attempt": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@lifeomic/attempt/-/attempt-3.1.0.tgz",
+      "integrity": "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==",
       "dev": true,
       "license": "MIT"
     },

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -34,7 +34,7 @@
     "@eslint/js": "^9.35.0",
     "@eslint/json": "^1.2.0",
     "@hocuspocus/provider": "^4.2.0",
-    "@hocuspocus/provider-prev": "npm:@hocuspocus/provider@^3",
+    "@hocuspocus/provider-prev-test-only": "npm:@hocuspocus/provider@^3",
     "@stylistic/eslint-plugin": "^5.3.1",
     "@types/node": "^25.0.2",
     "eslint": "^9.35.0",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -33,6 +33,8 @@
     "@blocknote/core": "^0.51.3",
     "@eslint/js": "^9.35.0",
     "@eslint/json": "^1.2.0",
+    "@hocuspocus/provider": "^4.2.0",
+    "@hocuspocus/provider-prev": "npm:@hocuspocus/provider@^3",
     "@stylistic/eslint-plugin": "^5.3.1",
     "@types/node": "^25.0.2",
     "eslint": "^9.35.0",

--- a/extensions/op-blocknote-hocuspocus/test/integration/provider-server-sync.test.ts
+++ b/extensions/op-blocknote-hocuspocus/test/integration/provider-server-sync.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Server } from "@hocuspocus/server";
 import { HocuspocusProvider } from "@hocuspocus/provider";
-import { HocuspocusProvider as HocuspocusProviderPrev } from "@hocuspocus/provider-prev";
+import { HocuspocusProvider as HocuspocusProviderPrev } from "@hocuspocus/provider-prev-test-only";
 import * as Y from "yjs";
 import { ws } from "msw";
 import { readFileSync } from "node:fs";
@@ -61,7 +61,7 @@ type ProviderConstructor = new (config: ProviderConfig) => ProviderInstance;
 
 const providers = [
   { label: `v${CURRENT_MAJOR} (current)`, pkg: "@hocuspocus/provider", major: CURRENT_MAJOR, Provider: HocuspocusProvider as unknown as ProviderConstructor },
-  { label: `v${PREVIOUS_MAJOR} (previous)`, pkg: "@hocuspocus/provider-prev", major: PREVIOUS_MAJOR, Provider: HocuspocusProviderPrev as unknown as ProviderConstructor },
+  { label: `v${PREVIOUS_MAJOR} (previous)`, pkg: "@hocuspocus/provider-prev-test-only", major: PREVIOUS_MAJOR, Provider: HocuspocusProviderPrev as unknown as ProviderConstructor },
 ] as const;
 
 let hocuspocus: Server;
@@ -88,7 +88,7 @@ it("provider matrix stays within Hocuspocus's one-major skew window", () => {
   }
   expect(
     CURRENT_MAJOR - PREVIOUS_MAJOR,
-    "the matrix must stay exactly one major apart; bump the @hocuspocus/provider-prev alias in package.json",
+    "the matrix must stay exactly one major apart; bump the @hocuspocus/provider-prev-test-only alias in package.json",
   ).toBe(1);
 });
 

--- a/extensions/op-blocknote-hocuspocus/test/integration/provider-server-sync.test.ts
+++ b/extensions/op-blocknote-hocuspocus/test/integration/provider-server-sync.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Server } from "@hocuspocus/server";
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { HocuspocusProvider as HocuspocusProviderPrev } from "@hocuspocus/provider-prev";
+import * as Y from "yjs";
+import { ws } from "msw";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { OpenProjectApi } from "../../src/extensions/openProjectApi";
+import { createTestToken } from "../helpers/tokenHelper";
+import { server as apiMock } from "../mocks/node";
+
+// Proves a real @hocuspocus/provider completes the connect -> authenticate -> load -> sync
+// handshake against our server over the actual wire protocol. The server boots in-process so
+// the existing msw mocks intercept its outbound Rails calls.
+const PORT = 9678;
+// Must equal the token's resource_url: onAuthenticate sets resourceUrl = documentName
+// and validates they match. createTestToken() defaults to this URL.
+const DOC_NAME = "https://test.api/api/v3/documents/1";
+
+// setup.ts runs msw with onUnhandledRequest:'error', which also patches the global
+// WebSocket. Passthrough the connection to the in-process server so the real client
+// transport is exercised; Rails calls to test.api stay mocked by the default handlers.
+const socketLink = ws.link(`ws://127.0.0.1:${PORT}`);
+
+// Expected provider majors, declared statically so a version bump forces a conscious edit
+// here as well as in package.json (the previous major is a manual `npm:` alias that won't
+// move on its own). The guard test below cross-checks these against the installed versions
+// and enforces the one-major gap Hocuspocus supports.
+const CURRENT_MAJOR = 4;
+const PREVIOUS_MAJOR = 3;
+
+// The installed manifest is the source of truth — package.json's `^3` range only states
+// intent, not what npm resolved. Read the file directly rather than require()-ing it: these
+// packages' `exports` maps don't expose ./package.json, so require('<pkg>/package.json')
+// throws ERR_PACKAGE_PATH_NOT_EXPORTED. Path is anchored to this file so cwd doesn't matter.
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const installedMajor = (pkg: string): number => {
+  const { version } = JSON.parse(
+    readFileSync(join(packageRoot, "node_modules", pkg, "package.json"), "utf8"),
+  ) as { version: string };
+  return Number(version.split(".")[0]);
+};
+
+// The two provider majors have incompatible constructor/config types, so the matrix drives
+// both through this minimal duck-typed shape (hence the `as unknown as` casts below). If a
+// future major renames `synced`/`destroy` or changes the config, update this shape — TS can't
+// see through the cast, so the only symptom would be the sync poll silently timing out.
+interface ProviderConfig {
+  url: string;
+  name: string;
+  token: string;
+  document: Y.Doc;
+}
+interface ProviderInstance {
+  synced: boolean;
+  destroy(): void;
+}
+type ProviderConstructor = new (config: ProviderConfig) => ProviderInstance;
+
+const providers = [
+  { label: `v${CURRENT_MAJOR} (current)`, pkg: "@hocuspocus/provider", major: CURRENT_MAJOR, Provider: HocuspocusProvider as unknown as ProviderConstructor },
+  { label: `v${PREVIOUS_MAJOR} (previous)`, pkg: "@hocuspocus/provider-prev", major: PREVIOUS_MAJOR, Provider: HocuspocusProviderPrev as unknown as ProviderConstructor },
+] as const;
+
+let hocuspocus: Server;
+
+beforeAll(async () => {
+  hocuspocus = new Server({ port: PORT, quiet: true, extensions: [new OpenProjectApi()] });
+  await hocuspocus.listen();
+});
+
+afterAll(async () => {
+  await hocuspocus?.destroy();
+});
+
+beforeEach(() => {
+  apiMock.use(socketLink.addEventListener("connection", ({ server }) => server.connect()));
+});
+
+it("provider matrix stays within Hocuspocus's one-major skew window", () => {
+  for (const { pkg, major } of providers) {
+    expect(
+      installedMajor(pkg),
+      `${pkg} resolved to a different major than declared — update CURRENT_MAJOR/PREVIOUS_MAJOR and package.json together`,
+    ).toBe(major);
+  }
+  expect(
+    CURRENT_MAJOR - PREVIOUS_MAJOR,
+    "the matrix must stay exactly one major apart; bump the @hocuspocus/provider-prev alias in package.json",
+  ).toBe(1);
+});
+
+describe.each(providers)("@hocuspocus/provider ($label) <-> server", ({ Provider }) => {
+  it("connects, authenticates, and syncs", async () => {
+    const provider = new Provider({
+      url: `ws://127.0.0.1:${PORT}`,
+      name: DOC_NAME,
+      token: createTestToken(),
+      document: new Y.Doc(),
+    });
+
+    // finally so a failed/timed-out poll still tears down the socket and reconnect timers,
+    // which would otherwise leak handles and hang the run.
+    try {
+      await expect.poll(() => provider.synced, { timeout: 10000 }).toBe(true);
+    } finally {
+      provider.destroy();
+    }
+  });
+});

--- a/script/ci/hocuspocus_version_skew.sh
+++ b/script/ci/hocuspocus_version_skew.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Compares the major version of the Hocuspocus client (@hocuspocus/provider, in
+# the frontend) against the server (@hocuspocus/server, in the op-blocknote-hocuspocus
+# extension). The client ships with the core app; the server ships as the separately
+# built and deployed openproject/hocuspocus image, and the two live in separate
+# dependabot ecosystems that can never be grouped — so they bump independently and
+# can silently drift. This flags a major mismatch for human review. It never fails
+# the build: Hocuspocus supports a one-major skew in both directions, so a mismatch
+# is a heads-up, not a blocker.
+
+set -e
+
+PROVIDER_RANGE=$(jq -r '.dependencies["@hocuspocus/provider"] // empty' frontend/package.json)
+SERVER_RANGE=$(jq -r '.dependencies["@hocuspocus/server"] // empty' extensions/op-blocknote-hocuspocus/package.json)
+
+if [ -z "$PROVIDER_RANGE" ] || [ -z "$SERVER_RANGE" ]; then
+  echo "::warning::Could not read @hocuspocus/provider or @hocuspocus/server version; skipping skew check."
+  exit 0
+fi
+
+# Strip a leading range operator (^, ~, >=, etc.) and take the major version.
+major() {
+  echo "$1" | sed -E 's/^[^0-9]*//' | cut -d. -f1
+}
+
+PROVIDER_MAJOR=$(major "$PROVIDER_RANGE")
+SERVER_MAJOR=$(major "$SERVER_RANGE")
+
+echo "@hocuspocus/provider (client): ${PROVIDER_RANGE} (major ${PROVIDER_MAJOR})"
+echo "@hocuspocus/server (server):   ${SERVER_RANGE} (major ${SERVER_MAJOR})"
+
+{
+  echo "provider_range=${PROVIDER_RANGE}"
+  echo "server_range=${SERVER_RANGE}"
+  echo "provider_major=${PROVIDER_MAJOR}"
+  echo "server_major=${SERVER_MAJOR}"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+if [ "$PROVIDER_MAJOR" != "$SERVER_MAJOR" ]; then
+  echo "Major version skew detected between Hocuspocus client and server."
+  echo "skew=true" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+else
+  echo "Hocuspocus client and server are on the same major version."
+  echo "skew=false" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+fi


### PR DESCRIPTION
https://community.openproject.org/wp/STC-834 · Follows  #23754 (Hocuspocus v4.2.0 lockstep bump)

The Hocuspocus client and server live in separate dependabot ecosystems and ship as independently deployed artifacts, so they can drift apart in version on future bumps — with nothing testing that the real `@hocuspocus/provider` ↔ server wire protocol still holds across that drift.

This adds a failsafe on two fronts: a vitest integration test that boots the server in-process and connects a real provider, asserting the connect/auth/load/sync handshake across adjacent provider majors so the supported skew stays proven; and a soft-warning CI check that flags whenever the client and server majors diverge, since only a single major of drift is supported (two or more is not).

The check never blocks the build, and the test runs in the existing `npm test` with no workflow change.
