### PR TITLE
Update op-blocknote-extensions to 0.1.3

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^3.4.4",
         "@hocuspocus/server": "^3.4.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.3/op-blocknote-extensions-0.1.3.tgz",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -4216,9 +4216,9 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.2",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
-      "integrity": "sha512-6uGRJ2SlIVq0LwNnb8KZXhX09fvwXzrkrtsoRVZUrZKKsRFCVd15bgOu/3DyOCvwztXj4h+6VP2N6PkzeCBpUA==",
+      "version": "0.1.3",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.3/op-blocknote-extensions-0.1.3.tgz",
+      "integrity": "sha512-8jW540tDhJqKw+ot+xMBYd8aXEw5oP/UwOAL+YiGjjVjRIv0NvRo4RvKiD2qjJOcAGF2ZDqjkWFtKK9tL02L3g==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^3.4.4",
     "@hocuspocus/server": "^3.4.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.3/op-blocknote-extensions-0.1.3.tgz",
     "tsx": "^4.21.0"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.3.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.3/op-blocknote-extensions-0.1.3.tgz",
         "openapi-explorer": "^2.4.799",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -13811,9 +13811,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.2",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
-      "integrity": "sha512-6uGRJ2SlIVq0LwNnb8KZXhX09fvwXzrkrtsoRVZUrZKKsRFCVd15bgOu/3DyOCvwztXj4h+6VP2N6PkzeCBpUA==",
+      "version": "0.1.3",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.3/op-blocknote-extensions-0.1.3.tgz",
+      "integrity": "sha512-8jW540tDhJqKw+ot+xMBYd8aXEw5oP/UwOAL+YiGjjVjRIv0NvRo4RvKiD2qjJOcAGF2ZDqjkWFtKK9tL02L3g==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -153,7 +153,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.3.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.3/op-blocknote-extensions-0.1.3.tgz",
     "openapi-explorer": "^2.4.799",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -104,15 +104,13 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
     context "when inserting work package links into the editor" do
       let(:status) { create(:status, name: "Open") }
       let(:type) { create(:type, name: "Life Goals") }
-      let(:work_package) do
+      let!(:work_package) do
         create(:work_package,
                project: document.project,
                subject: "pet a tiger",
                status:,
                type:)
       end
-
-      before { work_package } # force eager creation before visiting the page
 
       it "inserts link work package cards with slash command" do
         visit document_path(document)
@@ -128,7 +126,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         # Capybara's have_link seems not to work in a shadow dom, so it's tested via the property
         expect(editor.element.find_link(text: "pet a tiger").native.property("href")).to end_with("/wp/#{work_package.id}")
 
-        editor.wait_for_autosave { document.reload.description&.include?("##{work_package.id}") }
+        editor.wait_for_autosave { document.reload.description&.include?("[####{work_package.id}](https://openproject.local/wp/#{work_package.id})") }
       end
 
       it "inserts an xxs inline link via # notation" do
@@ -144,7 +142,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         expect(editor.element.text).to match(/##{work_package.display_id}/)
         # xxs chip shows only the ID — no title link
 
-        editor.wait_for_autosave { document.reload.description&.include?("##{work_package.id}") }
+        editor.wait_for_autosave { document.reload.description&.include?("[##{work_package.id}](https://openproject.local/wp/#{work_package.id})") }
       end
 
       it "inserts an xs inline link via ## notation" do
@@ -162,7 +160,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         expect(editor.element.find_link(text: "pet a tiger").native.property("href"))
           .to end_with("/wp/#{work_package.id}")
 
-        editor.wait_for_autosave { document.reload.description&.include?("##{work_package.id}") }
+        editor.wait_for_autosave { document.reload.description&.include?("[###{work_package.id}](https://openproject.local/wp/#{work_package.id})") }
       end
 
       it "inserts an s inline link via ### notation" do
@@ -180,7 +178,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         expect(editor.element.find_link(text: "pet a tiger").native.property("href"))
           .to end_with("/wp/#{work_package.id}")
 
-        editor.wait_for_autosave { document.reload.description&.include?("##{work_package.id}") }
+        editor.wait_for_autosave { document.reload.description&.include?("####{work_package.id}") }
       end
 
       describe "CTRL-Z undo behavior" do


### PR DESCRIPTION
This includes:
- [BNE-93] Semantic ID and markdown support for copy-paste
- [BNE-108] Dragging a work package link reloads the data via the network
- [#74978] split surrounding sentence when promoting inline chip to block
- New translations
- [BNE-84] Remove getSideMenuExtension workaround

# Ticket
https://community.openproject.org/projects/STC/work_packages/BNE-93 amongst others

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
