### PR TITLE
Address collaborative document presence change detection and debounce

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
@@ -36,7 +36,7 @@ import { ApplicationController, useDebounce } from 'stimulus-use';
 interface LiveUser {id:string, name:string, avatarUrl:string}
 
 export default class extends ApplicationController {
-  static debounces = ['triggerUpdateUI'];
+  static debounces = ['triggerUpdateUsersUI'];
   static targets = ['users', 'popover'];
 
   declare readonly usersTarget:HTMLElement;
@@ -96,9 +96,9 @@ export default class extends ApplicationController {
   private updateUsers(states:onAwarenessUpdateParameters['states']) {
     const nextState = new Map<number, LiveUser>();
 
-    states.forEach((state, clientId) => {
+    states.forEach((state) => {
       if (state.user) {
-        nextState.set(clientId, state.user as LiveUser);
+        nextState.set(state.clientId, state.user as LiveUser);
       }
     });
 


### PR DESCRIPTION
Two latent bugs in the collaborative-document presence controller (`live-events.controller.ts`), which renders connected-user avatars from the Yjs awareness protocol. The change-detector keyed its presence map by array index instead of `state.clientId`, so it only noticed when the user *count* changed and missed same-count membership swaps (one peer leaving as another joins) — leaving stale avatars; and the refresh debounce named a non-existent method (`triggerUpdateUI` vs the real `triggerUpdateUsersUI`), so every awareness frame fetched immediately instead of throttling to 1s. Both fixed by keying on the real client id and pointing the debounce at the correct method.
