### PR TITLE
Add 15min timeout to frontend unit test jobs

### DIFF
--- a/.github/workflows/test-frontend-unit.yml
+++ b/.github/workflows/test-frontend-unit.yml
@@ -29,6 +29,7 @@ jobs:
   unit:
     name: Units (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION

# Ticket

n/a

# What are you trying to accomplish?

Caps each matrix browser job so a hung run cannot consume the default 6-hour ceiling. 

# What approach did you choose and why?

Specs normally finish in a couple minutes; 15 leaves ample margin.

