### PR TITLE
Chore: Surface a Copilot fix-delegation prompt in the flaky-spec reporter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ See [AGENTS.md](../AGENTS.md) for all agent instructions.
 #### Parallel Test Failures
 - Tests run in parallel on CI with different random seeds per group
 - Check `tmp/parallel_runtime.log` for execution times
-- **Flaky specs**: Some tests may fail randomly; see `docs/development/running-tests/` for handling flaky tests
+- **Flaky specs**: Some tests may fail randomly; see [`docs/development/testing/handling-flaky-tests/README.md`](../docs/development/testing/handling-flaky-tests/README.md) for the full playbook, including the Turbo-aware waiting helpers and a pattern→fix table for feature specs
   - Use `script/bulk_run_rspec` to run tests multiple times to identify flaky behavior
 
 ### Extended Details

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -92,12 +92,26 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
         if [ -f tmp/retried_specs.txt ]; then
           echo "## Flaky specs" >> "$GITHUB_STEP_SUMMARY"
           cat tmp/retried_specs.txt >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$PR_NUMBER" ]; then
-            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(printf '> [!WARNING]\n> Flaky specs\n\n'; cat tmp/retried_specs.txt)"
+            specs="$(cat tmp/retried_specs.txt)"
+            {
+              printf '> [!WARNING]\n> Flaky specs\n\n'
+              printf '%s\n\n' "$specs"
+              printf '<details>\n<summary>🤖 Ask Copilot to investigate</summary>\n\n'
+              printf 'Copy the prompt below into a new comment on this PR to delegate the investigation to GitHub Copilot. It will look into the flakiness and open a separate pull request with you as reviewer.\n\n'
+              printf '```\n'
+              printf '@copilot The following spec(s) were detected as flaky on PR #%s:\n\n' "$PR_NUMBER"
+              printf '%s\n\n' "$specs"
+              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to investigate the root cause and apply a fix. Open a separate pull request with the change and request a review from @%s.\n' "$PR_AUTHOR"
+              printf '```\n\n'
+              printf '</details>\n'
+            } > tmp/flaky_comment.md
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file tmp/flaky_comment.md
           fi
         fi
     - name: Save CI image to cache

--- a/docs/development/testing/handling-flaky-tests/README.md
+++ b/docs/development/testing/handling-flaky-tests/README.md
@@ -287,6 +287,33 @@ Get flaky fixes with:
 git log --grep=flaky --no-merges
 ```
 
+### Common feature-spec flake patterns and their fixes
+
+The most frequent root cause is **Turbo's asynchronous rendering**. `wait_for_network_idle` only waits for the HTTP response to arrive, but Turbo updates the DOM *after* that:
+
+1. HTTP response received → network idle
+2. Turbo dispatches `turbo:before-stream-render` (or `turbo:before-render` for Drive)
+3. Turbo awaits the next repaint
+4. DOM is updated
+
+An assertion running between steps 1 and 4 sees stale content and fails intermittently. The helpers below (in `spec/support/shared/cuprite_helpers.rb` and `spec/support/toasts/expectations.rb`) register their JS event listeners *before* yielding the block, so they are race-condition-safe. Wrap only the triggering action — never the assertion.
+
+| Helper | Use when the action triggers… | Example |
+|--------|-------------------------------|---------|
+| `wait_for_turbo_stream { action }` | a **Turbo Stream** response (partial DOM replacement: dialog updates, list item changes). Waits for `op:turbo-stream-rendered`. | `wait_for_turbo_stream { share_dialog.toggle_public }` |
+| `wait_for_turbo { action }` | a **Turbo Drive** navigation (form submit, POST → redirect). Waits for `turbo:load`. | `wait_for_turbo { click_on "Complete" }` |
+| `wait_for_turbo_frame { action }` | a **Turbo Frame** load/update. Waits for `turbo:frame-load`. | `wait_for_turbo_frame { projects_page.remove_column("Status") }` |
+| `wait_for_network_idle` | a plain AJAX/Angular request with **no** Turbo rendering to wait for. | `columns.remove("Priority"); wait_for_network_idle` |
+| `dismiss_specific_toaster!(message:)` | **multiple** toasts may appear in sequence and `dismiss_toaster!` could close the wrong one. | `dismiss_specific_toaster!(message: "Saved successfully")` |
+| `have_test_selector(sel, text:)` | the container itself may be **replaced** by a Turbo Stream (stale node). Re-queries the DOM on each retry, unlike `within_test_selector`. | `expect(page).to have_test_selector("agenda-items-list", text: "No notes")` |
+| `retry_block { action }` | page state is **non-deterministic** after navigation (e.g. `go_back` re-initialises asynchronously). | `retry_block { click_on "Calendar event" }` |
+| `have_button("Label", wait: 20)` | an Angular custom element sets its label asynchronously in `ngOnInit` and the default wait is too short on slow CI. | `expect(page).to have_button("Nextcloud login", wait: 20)` |
+| `expect_active!` (not `activate!`) | a field is **already** in edit mode (e.g. auto-opened after a failed save). | `subject_field.expect_active!` |
+
+A frequent trap: a helper method call (`field.open_field`) followed by a bare `wait_for_network_idle` on the next line. The HTTP request finishes but Turbo hasn't applied the stream yet — replace it with `wait_for_turbo_stream { field.open_field }`. Wrapping a helper that internally calls `wait_for_network_idle` is safe, because the outer listener is registered before the block runs.
+
+To pick the right wait when unsure, check the controller action: `render turbo_stream:` / `format.turbo_stream` → `wait_for_turbo_stream`; `redirect_to` → `wait_for_turbo`; a `<turbo-frame>` update → `wait_for_turbo_frame`.
+
 ### Is the failure authentic?
 
 Flakiness can also be reversed: a test passes sometimes, but actually, given the code state, it should always fail.


### PR DESCRIPTION
The CI flaky-spec reporter used to post a plain warning listing the retried specs, leaving whoever read it to work out a fix from scratch. The comment now includes a collapsible `<details>` block with a ready-to-copy `@copilot` prompt — pasting it into a new comment delegates the investigation to GitHub Copilot, which opens a separate PR and requests review from the PR author. The mention lives inside a code fence so it is copyable but inert, meaning it does not auto-trigger Copilot (or ping the author) on every flaky run; a human decides when to delegate.

The prompt points Copilot at `docs/development/testing/handling-flaky-tests/README.md`, which now documents the Turbo-aware waiting helpers and a pattern→fix table for feature specs. Since Copilot's coding agent loads `.github/copilot-instructions.md` automatically, that file's previously-broken link into the testing docs is fixed to reach the same playbook, so the agent and humans share one source of truth for the OpenProject-specific guidance.

No work package — CI tooling and docs improvement.

### Preview

How the posted comment renders — the *Ask Copilot* section is collapsed by default; expand it for the copyable prompt:

***

> [!WARNING]
> Flaky specs

- `rspec ./spec/features/work_packages/table/columns_spec.rb[1:2:3]`

<details>
<summary>🤖 Ask Copilot to investigate</summary>

Copy the prompt below into a new comment on this PR to delegate the investigation to GitHub Copilot. It will look into the flakiness and open a separate pull request with you as reviewer.

```
@copilot The following spec(s) were detected as flaky on PR #23754:

- `rspec ./spec/features/work_packages/table/columns_spec.rb[1:2:3]`

Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to investigate the root cause and apply a fix. Open a separate pull request with the change and request a review from @akabiru.
```

</details>

***