### PR TITLE
[AGILE-275] Ensure sprint is cleared when bucket is set and vice versa

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/patches/set_attributes_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/set_attributes_service_patch.rb
@@ -57,11 +57,14 @@ module OpenProject::Backlogs::Patches::SetAttributesServicePatch
     # A work package may only have either a sprint *or* a bucket assigned. Not both at the
     # same time. Instead of throwing a validation error and making the user resolve it,
     # we resolve it implicitly: whichever attribute was just changed wins, the other is cleared.
-    def clear_conflicting_sprint_or_bucket # rubocop:disable Metrics/AbcSize
-      if model.backlog_bucket_id_changed? && model.backlog_bucket_id.present? && model.sprint_id.present?
-        model.sprint = nil
-      elsif model.sprint_id_changed? && model.sprint_id.present? && model.backlog_bucket_id.present?
+    def clear_conflicting_sprint_or_bucket
+      # No conflict to resolve? Abort.
+      return unless model.backlog_bucket_id? && model.sprint_id?
+
+      if model.sprint_id_changed?
         model.backlog_bucket = nil
+      else
+        model.sprint = nil
       end
     end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/set_attributes_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/set_attributes_service_patch.rb
@@ -50,6 +50,19 @@ module OpenProject::Backlogs::Patches::SetAttributesServicePatch
           model.sprint = nil
         end
       end
+
+      clear_conflicting_sprint_or_bucket
+    end
+
+    # A work package may only have either a sprint *or* a bucket assigned. Not both at the
+    # same time. Instead of throwing a validation error and making the user resolve it,
+    # we resolve it implicitly: whichever attribute was just changed wins, the other is cleared.
+    def clear_conflicting_sprint_or_bucket # rubocop:disable Metrics/AbcSize
+      if model.backlog_bucket_id_changed? && model.backlog_bucket_id.present? && model.sprint_id.present?
+        model.sprint = nil
+      elsif model.sprint_id_changed? && model.sprint_id.present? && model.backlog_bucket_id.present?
+        model.backlog_bucket = nil
+      end
     end
 
     def moved_to_another_project?

--- a/modules/backlogs/lib/open_project/backlogs/patches/set_attributes_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/set_attributes_service_patch.rb
@@ -59,7 +59,12 @@ module OpenProject::Backlogs::Patches::SetAttributesServicePatch
     # we resolve it implicitly: whichever attribute was just changed wins, the other is cleared.
     def clear_conflicting_sprint_or_bucket
       # No conflict to resolve? Abort.
-      return unless model.backlog_bucket_id? && model.sprint_id?
+      return unless model.sprint_id? && model.backlog_bucket_id?
+
+      # Both attributes were set at the same time. It is unknown what the users
+      # intentions are here. We should not clear a previously set value in this case
+      # and let the user deal with the validation error.
+      return if model.sprint_id_changed? && model.backlog_bucket_id_changed?
 
       if model.sprint_id_changed?
         model.backlog_bucket = nil

--- a/modules/backlogs/spec/features/work_packages/sprints_on_wp_view_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/sprints_on_wp_view_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Sprint displayed and selectable on work package view", :js do
   end
 
   context "when attempting to assign the wp to a bucket" do
-    let!(:bucket) { create(:backlog_bucket, name: "Bucket", project:) }
+    shared_let(:bucket) { create(:backlog_bucket, name: "Bucket", project:) }
 
     it "clears the sprint (and the other way around) instead of throwing an error" do
       wp_page.visit!

--- a/modules/backlogs/spec/features/work_packages/sprints_on_wp_view_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/sprints_on_wp_view_spec.rb
@@ -65,6 +65,38 @@ RSpec.describe "Sprint displayed and selectable on work package view", :js do
     wp_page.expect_attributes sprint: next_sprint.name
   end
 
+  context "when attempting to assign the wp to a bucket" do
+    let!(:bucket) { create(:backlog_bucket, name: "Bucket", project:) }
+
+    it "clears the sprint (and the other way around) instead of throwing an error" do
+      wp_page.visit!
+
+      wp_page.expect_attributes sprint: sprint.name, backlog_bucket: nil
+
+      # Assign to bucket
+      field = wp_page.work_package_field(:backlog_bucket)
+      field.activate!
+      field.autocomplete(bucket.name, select: true)
+      wp_page.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)
+
+      # Sprint was unassigned, bucket is assigned
+      wp_page.expect_attributes sprint: nil, backlog_bucket: bucket.name
+      wp_page.visit!
+      wp_page.expect_attributes sprint: nil, backlog_bucket: bucket.name
+
+      # Assign to sprint
+      field = wp_page.work_package_field(:sprint)
+      field.activate!
+      field.autocomplete(sprint.name, select: true)
+      wp_page.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)
+
+      # Bucket was unassigned, sprint is assigned
+      wp_page.expect_attributes sprint: sprint.name, backlog_bucket: nil
+      wp_page.visit!
+      wp_page.expect_attributes sprint: sprint.name, backlog_bucket: nil
+    end
+  end
+
   context "when lacking the permission to see sprints" do
     let(:permissions) { %i(view_work_packages) }
 

--- a/modules/backlogs/spec/services/work_packages/update_service_sprint_bucket_xor_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/update_service_sprint_bucket_xor_spec.rb
@@ -84,4 +84,68 @@ RSpec.describe WorkPackages::UpdateService, "sprint and bucket mutual exclusivit
       expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: nil)
     end
   end
+
+  context "when only sprint changes (no bucket involved)" do
+    context "when the work package has no sprint" do
+      let(:work_package) { create(:work_package, project:) }
+
+      it "sets the sprint without clearing the bucket" do
+        result = instance.call(sprint:)
+
+        expect(result).to be_success
+        expect(work_package.reload).to have_attributes(sprint:, backlog_bucket: nil)
+      end
+    end
+
+    context "when the work package already has a sprint" do
+      let(:other_sprint) { create(:sprint, project:) }
+      let(:work_package) { create(:work_package, project:, sprint:) }
+
+      it "changes the sprint without clearing the bucket" do
+        result = instance.call(sprint: other_sprint)
+
+        expect(result).to be_success
+        expect(work_package.reload).to have_attributes(sprint: other_sprint, backlog_bucket: nil)
+      end
+
+      it "clears the sprint without clearing the bucket" do
+        result = instance.call(sprint: nil)
+
+        expect(result).to be_success
+        expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: nil)
+      end
+    end
+  end
+
+  context "when only bucket changes (no sprint involved)" do
+    context "when the work package has no bucket" do
+      let(:work_package) { create(:work_package, project:) }
+
+      it "sets the bucket without clearing the sprint" do
+        result = instance.call(backlog_bucket: bucket)
+
+        expect(result).to be_success
+        expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: bucket)
+      end
+    end
+
+    context "when the work package already has a bucket" do
+      let(:other_bucket) { create(:backlog_bucket, project:) }
+      let(:work_package) { create(:work_package, project:, backlog_bucket: bucket) }
+
+      it "changes the bucket without clearing the sprint" do
+        result = instance.call(backlog_bucket: other_bucket)
+
+        expect(result).to be_success
+        expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: other_bucket)
+      end
+
+      it "clears the bucket without clearing the sprint" do
+        result = instance.call(backlog_bucket: nil)
+
+        expect(result).to be_success
+        expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: nil)
+      end
+    end
+  end
 end

--- a/modules/backlogs/spec/services/work_packages/update_service_sprint_bucket_xor_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/update_service_sprint_bucket_xor_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::UpdateService, "sprint and bucket mutual exclusivity", type: :model do
+  let(:project) { create(:project, enabled_module_names: %i[backlogs work_package_tracking]) }
+
+  let(:permissions) do
+    %i[
+      view_work_packages
+      edit_work_packages
+      view_sprints
+      manage_sprint_items
+    ]
+  end
+
+  let(:user) { create(:user, member_with_permissions: { project => permissions }) }
+
+  let(:sprint) { create(:sprint, project:) }
+  let(:bucket) { create(:backlog_bucket, project:) }
+
+  let(:instance) { described_class.new(user:, model: work_package) }
+
+  current_user { user }
+
+  context "when the work package has a sprint assigned" do
+    let(:work_package) { create(:work_package, project:, sprint:) }
+
+    it "clears the sprint when a bucket is assigned" do
+      result = instance.call(backlog_bucket: bucket)
+
+      expect(result).to be_success
+      expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: bucket)
+    end
+  end
+
+  context "when the work package has a bucket assigned" do
+    let(:work_package) { create(:work_package, project:, backlog_bucket: bucket) }
+
+    it "clears the bucket when a sprint is assigned" do
+      result = instance.call(sprint:)
+
+      expect(result).to be_success
+      expect(work_package.reload).to have_attributes(sprint:, backlog_bucket: nil)
+    end
+  end
+
+  context "when sprint and bucket are both set in the same call" do
+    let(:work_package) { create(:work_package, project:) }
+
+    it "returns a validation error rather than silently clearing one" do
+      result = instance.call(sprint:, backlog_bucket: bucket)
+
+      expect(result).to be_failure
+      expect(result.errors.symbols_for(:base)).to include(:backlog_bucket_xor_sprint)
+      expect(work_package.reload).to have_attributes(sprint: nil, backlog_bucket: nil)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-275

# What are you trying to accomplish?
Unassign the Bucket (when assigning a Sprint) or the Sprint (when assigning a Bucket) automatically to avoid a validation error when both are set at the same time.

## Screenshots
https://github.com/user-attachments/assets/46402c4e-f2b7-4133-b7ca-eb94321b0e3e

# What approach did you choose and why?
Added the fix after `SetAttributesService#set_attributes` as this is where the attributes have been set on the WP but before the contract is validated. The contract will still ensure that sprints and buckets aren't set at the same time (e.g., if the attributes are set by other means).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
