### PR TITLE
[Dream-719] Allow configuration for WP types to show project attributes

### DIFF
--- a/app/components/work_package_types/project_attributes/index_component.html.erb
+++ b/app/components/work_package_types/project_attributes/index_component.html.erb
@@ -22,12 +22,13 @@
         end
       end
 
-      @project_custom_field_sections.each do |project_custom_field_section|
+      @project_custom_field_sections.each do |project_custom_field_section, project_custom_fields|
         flex.with_row do
           render(
             WorkPackageTypes::ProjectAttributes::SectionComponent.new(
               type: @type,
-              project_custom_field_section:
+              project_custom_field_section:,
+              project_custom_fields:
             )
           )
         end

--- a/app/components/work_package_types/project_attributes/index_component.html.erb
+++ b/app/components/work_package_types/project_attributes/index_component.html.erb
@@ -15,8 +15,8 @@
             show_clear_button: true,
             clear_button_id: clear_button_id,
             data: {
-              action: "input->projects--settings--border-box-filter#filterLists",
-              "projects--settings--border-box-filter-target": "filter"
+              action: "input->filter--filter-list#filterLists",
+              "filter--filter-list-target": "filter"
             }
           )
         end

--- a/app/components/work_package_types/project_attributes/index_component.html.erb
+++ b/app/components/work_package_types/project_attributes/index_component.html.erb
@@ -1,0 +1,37 @@
+<%=
+  component_wrapper(data: wrapper_data_attributes) do
+    flex_layout do |flex|
+      flex.with_row do
+        render(Primer::OpenProject::SubHeader.new) do |subheader|
+          subheader.with_filter_input(
+            name: "border-box-filter",
+            label: t("types.edit.project_attributes.filter"),
+            visually_hide_label: true,
+            placeholder: t("types.edit.project_attributes.filter"),
+            leading_visual: {
+              icon: :search,
+              size: :small
+            },
+            show_clear_button: true,
+            clear_button_id: clear_button_id,
+            data: {
+              action: "input->projects--settings--border-box-filter#filterLists",
+              "projects--settings--border-box-filter-target": "filter"
+            }
+          )
+        end
+      end
+
+      @project_custom_field_sections.each do |project_custom_field_section|
+        flex.with_row do
+          render(
+            WorkPackageTypes::ProjectAttributes::SectionComponent.new(
+              type: @type,
+              project_custom_field_section:
+            )
+          )
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_package_types/project_attributes/index_component.rb
+++ b/app/components/work_package_types/project_attributes/index_component.rb
@@ -28,8 +28,8 @@ module WorkPackageTypes
 
       def wrapper_data_attributes
         {
-          controller: "projects--settings--border-box-filter",
-          "projects--settings--border-box-filter-clear-button-id-value": clear_button_id
+          controller: "filter--filter-list",
+          "filter--filter-list-clear-button-id-value": clear_button_id
         }
       end
 

--- a/app/components/work_package_types/project_attributes/index_component.rb
+++ b/app/components/work_package_types/project_attributes/index_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module ProjectAttributes
+    class IndexComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
+
+      def initialize(type:, project_custom_field_sections:)
+        super
+
+        @type = type
+        @project_custom_field_sections = project_custom_field_sections
+      end
+
+      private
+
+      def wrapper_data_attributes
+        {
+          controller: "projects--settings--border-box-filter",
+          "projects--settings--border-box-filter-clear-button-id-value": clear_button_id
+        }
+      end
+
+      def clear_button_id
+        "project-attributes-filter-clear-button"
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/project_attributes/row_component.html.erb
+++ b/app/components/work_package_types/project_attributes/row_component.html.erb
@@ -1,0 +1,44 @@
+<%=
+  component_wrapper do
+    flex_layout(
+      align_items: :center, justify_content: :space_between, classes: "op-project-custom-field", data: {
+        test_selector: "type-project-attribute-#{@project_custom_field.id}"
+      }
+    ) do |custom_field_container|
+      custom_field_container.with_column(flex_layout: true) do |title_container|
+        title_container.with_column(pt: 1, mr: 2) do
+          render(Primer::Beta::Text.new(classes: "filter-target-visible-text")) do
+            @project_custom_field.name
+          end
+        end
+        title_container.with_column(pt: 1, mr: 2, data: { test_selector: "custom-field-type" }) do
+          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+            helpers.label_for_custom_field_format(@project_custom_field.field_format)
+          end
+        end
+        if @project_custom_field.required?
+          title_container.with_column(pt: 1) do
+            render(Primer::Beta::Label.new(scheme: :attention, size: :medium)) do
+              ProjectCustomField.human_attribute_name(:required)
+            end
+          end
+        end
+      end
+
+      custom_field_container.with_column(py: 1, mr: 2) do
+        render(
+          Primer::Alpha::ToggleSwitch.new(
+            src: toggle_path,
+            csrf_token: form_authenticity_token,
+            data: toggle_data_attributes,
+            checked: active_for_type?,
+            enabled: true,
+            size: :small,
+            status_label_position: :start,
+            classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"
+          )
+        )
+      end
+    end
+  end
+%>

--- a/app/components/work_package_types/project_attributes/row_component.rb
+++ b/app/components/work_package_types/project_attributes/row_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module ProjectAttributes
+    class RowComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
+
+      def initialize(type:, project_custom_field:)
+        super
+
+        @type = type
+        @project_custom_field = project_custom_field
+        @project_custom_field_type_mappings = type.project_custom_field_type_mappings
+      end
+
+      private
+
+      def wrapper_uniq_by
+        @project_custom_field.id
+      end
+
+      def active_for_type?
+        @project_custom_field_type_mappings.any? do |mapping|
+          mapping.custom_field_id == @project_custom_field.id
+        end
+      end
+
+      def toggle_path
+        toggle_type_project_attributes_path(
+          @type,
+          project_custom_field_type_mapping: {
+            type_id: @type.id,
+            custom_field_id: @project_custom_field.id
+          }
+        )
+      end
+
+      def toggle_data_attributes
+        {
+          "turbo-method": :post,
+          "turbo-stream": true,
+          test_selector: "toggle-type-project-attribute-#{@project_custom_field.id}"
+        }
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/project_attributes/section_component.html.erb
+++ b/app/components/work_package_types/project_attributes/section_component.html.erb
@@ -1,0 +1,83 @@
+<%=
+  component_wrapper do
+    render(
+      border_box_container(
+        mb: 3, classes: "op-project-custom-field-section", data: {
+          test_selector: "type-project-attribute-section-#{@project_custom_field_section.id}"
+        }
+      )
+    ) do |component|
+      component.with_header(font_weight: :bold, py: 2) do
+        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
+          section_header_container.with_column(py: 2) do
+            render(Primer::Beta::Text.new(font_weight: :bold)) do
+              @project_custom_field_section.name
+            end
+          end
+          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
+            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
+              render(
+                Primer::Beta::Button.new(
+                  tag: :a,
+                  href: enable_all_of_section_type_project_attributes_path(
+                    @type,
+                    project_custom_field_type_mapping: {
+                      type_id: @type.id,
+                      custom_field_section_id: @project_custom_field_section.id
+                    }
+                  ),
+                  scheme: :invisible,
+                  font_weight: :bold,
+                  color: :subtle,
+                  "aria-label": t("types.edit.project_attributes.actions.label_enable_all"),
+                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-type-project-attributes-#{@project_custom_field_section.id}" }
+                )
+              ) do |button|
+                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+                t("types.edit.project_attributes.actions.label_enable_all")
+              end
+            end
+            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
+              render(
+                Primer::Beta::Button.new(
+                  tag: :a,
+                  href: disable_all_of_section_type_project_attributes_path(
+                    @type,
+                    project_custom_field_type_mapping: {
+                      type_id: @type.id,
+                      custom_field_section_id: @project_custom_field_section.id
+                    }
+                  ),
+                  scheme: :invisible,
+                  font_weight: :bold,
+                  color: :subtle,
+                  "aria-label": t("types.edit.project_attributes.actions.label_disable_all"),
+                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-type-project-attributes-#{@project_custom_field_section.id}" }
+                )
+              ) do |button|
+                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+                t("types.edit.project_attributes.actions.label_disable_all")
+              end
+            end
+          end
+        end
+      end
+      if @project_custom_fields.empty?
+        component.with_row do
+          render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
+        end
+      else
+        @project_custom_fields.each do |project_custom_field|
+          component.with_row(data: { "projects--settings--border-box-filter-target": "searchItem" }) do
+            render(
+              WorkPackageTypes::ProjectAttributes::RowComponent.new(
+                type: @type,
+                project_custom_field:
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_package_types/project_attributes/section_component.html.erb
+++ b/app/components/work_package_types/project_attributes/section_component.html.erb
@@ -1,74 +1,61 @@
-<%=
-  component_wrapper do
+<%= component_wrapper do %>
+  <%=
     render(
-      border_box_container(
-        mb: 3, classes: "op-project-custom-field-section", data: {
-          test_selector: "type-project-attribute-section-#{@project_custom_field_section.id}"
-        }
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "type-project-attribute-section-#{@project_custom_field_section.id}",
+        mb: 3,
+        classes: "op-project-custom-field-section",
+        test_selector: "type-project-attribute-section-#{@project_custom_field_section.id}"
       )
-    ) do |component|
-      component.with_header(font_weight: :bold, py: 2) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(py: 2) do
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              @project_custom_field_section.name
-            end
-          end
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: enable_all_of_section_type_project_attributes_path(
-                    @type,
-                    project_custom_field_type_mapping: {
-                      type_id: @type.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("types.edit.project_attributes.actions.label_enable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-type-project-attributes-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                t("types.edit.project_attributes.actions.label_enable_all")
-              end
-            end
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: disable_all_of_section_type_project_attributes_path(
-                    @type,
-                    project_custom_field_type_mapping: {
-                      type_id: @type.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("types.edit.project_attributes.actions.label_disable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-type-project-attributes-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                t("types.edit.project_attributes.actions.label_disable_all")
-              end
-            end
-          end
+    ) do |list|
+      list.with_header(
+        title: @project_custom_field_section.name,
+        title_arguments: { font_weight: :bold }
+      ) do |header|
+        header.with_action_button(
+          tag: :a,
+          href: enable_all_path,
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("types.edit.project_attributes.actions.label_enable_all"),
+          data: {
+            "turbo-method": :put,
+            "turbo-stream": true,
+            test_selector: "enable-all-type-project-attributes-#{@project_custom_field_section.id}"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+          t("types.edit.project_attributes.actions.label_enable_all")
+        end
+
+        header.with_action_button(
+          tag: :a,
+          href: disable_all_path,
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("types.edit.project_attributes.actions.label_disable_all"),
+          data: {
+            "turbo-method": :put,
+            "turbo-stream": true,
+            test_selector: "disable-all-type-project-attributes-#{@project_custom_field_section.id}"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+          t("types.edit.project_attributes.actions.label_disable_all")
         end
       end
+
       if @project_custom_fields.empty?
-        component.with_row do
-          render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
+        list.with_item do
+          render(Primer::Beta::Text.new(color: :subtle)) do
+            t("settings.project_attributes.label_no_project_custom_fields")
+          end
         end
       else
         @project_custom_fields.each do |project_custom_field|
-          component.with_row(data: { "filter--filter-list-target": "searchItem" }) do
+          list.with_item(data: { "filter--filter-list-target": "searchItem" }) do
             render(
               WorkPackageTypes::ProjectAttributes::RowComponent.new(
                 type: @type,
@@ -79,5 +66,5 @@
         end
       end
     end
-  end
-%>
+  %>
+<% end %>

--- a/app/components/work_package_types/project_attributes/section_component.html.erb
+++ b/app/components/work_package_types/project_attributes/section_component.html.erb
@@ -15,7 +15,7 @@
             end
           end
           section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
+            actions_container.with_column do
               render(
                 Primer::Beta::Button.new(
                   tag: :a,
@@ -37,7 +37,7 @@
                 t("types.edit.project_attributes.actions.label_enable_all")
               end
             end
-            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
+            actions_container.with_column do
               render(
                 Primer::Beta::Button.new(
                   tag: :a,
@@ -68,7 +68,7 @@
         end
       else
         @project_custom_fields.each do |project_custom_field|
-          component.with_row(data: { "projects--settings--border-box-filter-target": "searchItem" }) do
+          component.with_row(data: { "filter--filter-list-target": "searchItem" }) do
             render(
               WorkPackageTypes::ProjectAttributes::RowComponent.new(
                 type: @type,

--- a/app/components/work_package_types/project_attributes/section_component.rb
+++ b/app/components/work_package_types/project_attributes/section_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module ProjectAttributes
+    class SectionComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
+
+      def initialize(type:, project_custom_field_section:)
+        super
+
+        @type = type
+        @project_custom_field_section = project_custom_field_section
+        @project_custom_fields = project_custom_field_section.custom_fields
+      end
+
+      private
+
+      def wrapper_uniq_by
+        @project_custom_field_section.id
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/project_attributes/section_component.rb
+++ b/app/components/work_package_types/project_attributes/section_component.rb
@@ -27,6 +27,27 @@ module WorkPackageTypes
 
       private
 
+      def enable_all_path
+        enable_all_of_section_type_project_attributes_path(
+          @type,
+          project_custom_field_type_mapping: bulk_action_params
+        )
+      end
+
+      def disable_all_path
+        disable_all_of_section_type_project_attributes_path(
+          @type,
+          project_custom_field_type_mapping: bulk_action_params
+        )
+      end
+
+      def bulk_action_params
+        {
+          type_id: @type.id,
+          custom_field_section_id: @project_custom_field_section.id
+        }
+      end
+
       def wrapper_uniq_by
         @project_custom_field_section.id
       end

--- a/app/components/work_package_types/project_attributes/section_component.rb
+++ b/app/components/work_package_types/project_attributes/section_component.rb
@@ -17,12 +17,12 @@ module WorkPackageTypes
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 
-      def initialize(type:, project_custom_field_section:)
+      def initialize(type:, project_custom_field_section:, project_custom_fields:)
         super
 
         @type = type
         @project_custom_field_section = project_custom_field_section
-        @project_custom_fields = project_custom_field_section.custom_fields
+        @project_custom_fields = project_custom_fields
       end
 
       private

--- a/app/components/work_packages/project_attributes_tab_component.html.erb
+++ b/app/components/work_packages/project_attributes_tab_component.html.erb
@@ -1,0 +1,19 @@
+<turbo-frame id="work-package-project-attributes-tab-content">
+  <%=
+    component_wrapper do
+      if project_custom_fields_grouped_by_section.any?
+        render(Primer::OpenProject::SidePanel.new(spacious: true)) do |panel|
+          project_custom_fields_grouped_by_section.each do |project_custom_field_section, project_custom_fields|
+            panel.with_section(
+              Overviews::ProjectCustomFields::SectionComponent.new(
+                project: @project,
+                project_custom_field_section:,
+                project_custom_fields:
+              )
+            )
+          end
+        end
+      end
+    end
+  %>
+</turbo-frame>

--- a/app/components/work_packages/project_attributes_tab_component.html.erb
+++ b/app/components/work_packages/project_attributes_tab_component.html.erb
@@ -2,10 +2,10 @@
   <%=
     component_wrapper do
       if project_custom_fields_grouped_by_section.any?
-        render(Primer::OpenProject::SidePanel.new(spacious: true)) do |panel|
+        render(Primer::OpenProject::SidePanel.new) do |panel|
           project_custom_fields_grouped_by_section.each do |project_custom_field_section, project_custom_fields|
             panel.with_section(
-              Overviews::ProjectCustomFields::SectionComponent.new(
+              WorkPackages::ProjectCustomFields::SectionComponent.new(
                 project: @project,
                 project_custom_field_section:,
                 project_custom_fields:

--- a/app/components/work_packages/project_attributes_tab_component.rb
+++ b/app/components/work_packages/project_attributes_tab_component.rb
@@ -48,6 +48,8 @@ class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
   def project_custom_fields_grouped_by_section
     @project_custom_fields_grouped_by_section ||=
       @project.available_custom_fields
+              .joins(:project_custom_field_type_mappings)
+              .where(project_custom_field_type_mappings: { type_id: @work_package.type_id })
               .group_by(&:project_custom_field_section)
   end
 end

--- a/app/components/work_packages/project_attributes_tab_component.rb
+++ b/app/components/work_packages/project_attributes_tab_component.rb
@@ -47,9 +47,8 @@ class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
 
   def project_custom_fields_grouped_by_section
     @project_custom_fields_grouped_by_section ||=
-      @project.available_custom_fields
-              .joins(:project_custom_field_type_mappings)
-              .where(project_custom_field_type_mappings: { type_id: @work_package.type_id })
-              .group_by(&:project_custom_field_section)
+      ProjectCustomFieldSection.grouped_in_order(
+        @project.available_custom_fields_for_type(@work_package.type_id)
+      )
   end
 end

--- a/app/components/work_packages/project_attributes_tab_component.rb
+++ b/app/components/work_packages/project_attributes_tab_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
+  include OpPrimer::ComponentHelpers
+  include OpTurbo::Streamable
+
+  def initialize(work_package:)
+    super
+
+    @work_package = work_package
+    @project = work_package.project
+  end
+
+  private
+
+  def project_custom_fields_grouped_by_section
+    @project_custom_fields_grouped_by_section ||=
+      @project.available_custom_fields
+              .group_by(&:project_custom_field_section)
+  end
+end

--- a/app/components/work_packages/project_custom_fields/section_component.html.erb
+++ b/app/components/work_packages/project_custom_fields/section_component.html.erb
@@ -1,0 +1,28 @@
+<%=
+  component_wrapper do
+    render(
+      Primer::OpenProject::SidePanel::Section.new(
+        test_selector: "wp-project-attribute-section-#{@project_custom_field_section.id}"
+      )
+    ) do |section|
+      section.with_title { @project_custom_field_section.name }
+
+      flex_layout(classes: "gap-2") do |flex|
+        @project_custom_fields.each do |project_custom_field|
+          flex.with_row do
+            render(
+              OpenProject::Common::InplaceEditFieldComponent.new(
+                model: @project,
+                attribute: project_custom_field.attribute_name.to_sym,
+                open_in_dialog: false,
+                truncated: false,
+                test_selector: "wp-project-attribute-#{project_custom_field.id}",
+                display_classes: "op-project-custom-field-container"
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/project_custom_fields/section_component.rb
+++ b/app/components/work_packages/project_custom_fields/section_component.rb
@@ -28,26 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
+class WorkPackages::ProjectCustomFields::SectionComponent < ApplicationComponent
+  include ApplicationHelper
   include OpPrimer::ComponentHelpers
   include OpTurbo::Streamable
 
-  def initialize(work_package:)
+  def initialize(project:, project_custom_field_section:, project_custom_fields:)
     super
 
-    @work_package = work_package
-    @project = work_package.project
-  end
-
-  def render?
-    project_custom_fields_grouped_by_section.any?
-  end
-
-  private
-
-  def project_custom_fields_grouped_by_section
-    @project_custom_fields_grouped_by_section ||=
-      @project.available_custom_fields
-              .group_by(&:project_custom_field_section)
+    @project = project
+    @project_custom_field_section = project_custom_field_section
+    @project_custom_fields = project_custom_fields
   end
 end

--- a/app/components/work_packages/project_custom_fields/section_component.rb
+++ b/app/components/work_packages/project_custom_fields/section_component.rb
@@ -29,7 +29,6 @@
 #++
 
 class WorkPackages::ProjectCustomFields::SectionComponent < ApplicationComponent
-  include ApplicationHelper
   include OpPrimer::ComponentHelpers
   include OpTurbo::Streamable
 

--- a/app/contracts/project_custom_field_type_mappings/base_contract.rb
+++ b/app/contracts/project_custom_field_type_mappings/base_contract.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectCustomFieldTypeMappings
+  class BaseContract < ::ModelContract
+    attribute :type_id
+    attribute :custom_field_id
+
+    validate :admin_permission
+    validate :project_custom_field
+
+    private
+
+    def admin_permission
+      errors.add :base, :error_unauthorized unless user.admin?
+    end
+
+    def project_custom_field
+      return if model.project_custom_field.is_a?(ProjectCustomField)
+
+      errors.add :custom_field_id, :invalid
+    end
+  end
+end

--- a/app/contracts/project_custom_field_type_mappings/update_contract.rb
+++ b/app/contracts/project_custom_field_type_mappings/update_contract.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectCustomFieldTypeMappings
+  class UpdateContract < BaseContract
+  end
+end

--- a/app/controllers/concerns/work_package_types/project_attributes_component_streams.rb
+++ b/app/controllers/concerns/work_package_types/project_attributes_component_streams.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes::ProjectAttributesComponentStreams
+  extend ActiveSupport::Concern
+
+  included do
+    def update_project_attribute_sections_via_turbo_stream(
+      type: @type,
+      project_custom_field_sections: @project_custom_field_sections
+    )
+      update_via_turbo_stream(
+        component: ::WorkPackageTypes::ProjectAttributes::IndexComponent.new(
+          type:,
+          project_custom_field_sections:
+        )
+      )
+    end
+  end
+end

--- a/app/controllers/work_package_types/project_attributes_tab_controller.rb
+++ b/app/controllers/work_package_types/project_attributes_tab_controller.rb
@@ -75,9 +75,8 @@ module WorkPackageTypes
         eager_load_project_custom_field_data
         update_project_attribute_sections_via_turbo_stream
       else
-        render_error_flash_message_via_turbo_stream(
-          message: call.message.presence || I18n.t(:notice_unsuccessful_update)
-        )
+        error_message = call.message.presence || I18n.t(:notice_unsuccessful_update)
+        render_error_flash_message_via_turbo_stream(message: error_message)
       end
 
       respond_with_turbo_streams(status: call.success? ? :ok : :unprocessable_entity)

--- a/app/controllers/work_package_types/project_attributes_tab_controller.rb
+++ b/app/controllers/work_package_types/project_attributes_tab_controller.rb
@@ -48,12 +48,7 @@ module WorkPackageTypes
 
     def eager_load_project_custom_field_data
       @project_custom_field_sections =
-        ProjectCustomFieldSection
-          .joins(:custom_fields)
-          .includes(:custom_fields)
-          .merge(ProjectCustomField.visible)
-          .group(:id, "custom_fields.id")
-          .order(:position, :position_in_custom_field_section)
+        ProjectCustomFieldSection.grouped_in_order(ProjectCustomField.visible)
     end
 
     def set_project_custom_field_section

--- a/app/controllers/work_package_types/project_attributes_tab_controller.rb
+++ b/app/controllers/work_package_types/project_attributes_tab_controller.rb
@@ -51,6 +51,7 @@ module WorkPackageTypes
         ProjectCustomFieldSection
           .joins(:custom_fields)
           .includes(:custom_fields)
+          .merge(ProjectCustomField.visible)
           .group(:id, "custom_fields.id")
           .order(:position, :position_in_custom_field_section)
     end
@@ -73,6 +74,10 @@ module WorkPackageTypes
       if call.success?
         eager_load_project_custom_field_data
         update_project_attribute_sections_via_turbo_stream
+      else
+        render_error_flash_message_via_turbo_stream(
+          message: call.message.presence || I18n.t(:notice_unsuccessful_update)
+        )
       end
 
       respond_with_turbo_streams(status: call.success? ? :ok : :unprocessable_entity)
@@ -84,11 +89,10 @@ module WorkPackageTypes
           type_id
           custom_field_id
           custom_field_section_id
-          value
         ]
       ).to_h
 
-      permitted_params[:value] = params[:value] if params.key?(:value)
+      permitted_params[:value] = params.permit(:value)[:value] if params.key?(:value)
 
       permitted_params
     end

--- a/app/controllers/work_package_types/project_attributes_tab_controller.rb
+++ b/app/controllers/work_package_types/project_attributes_tab_controller.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  class ProjectAttributesTabController < BaseTabController
+    include OpTurbo::ComponentStream
+    include WorkPackageTypes::ProjectAttributesComponentStreams
+
+    current_menu_item [:edit, :toggle, :enable_all_of_section, :disable_all_of_section] do
+      :types
+    end
+
+    before_action :eager_load_project_custom_field_data
+    before_action :set_project_custom_field_section, only: %i[enable_all_of_section disable_all_of_section]
+
+    def edit; end
+
+    def toggle
+      call = ProjectCustomFieldTypeMappings::ToggleService
+        .new(user: current_user)
+        .call(project_custom_field_type_mapping_params)
+
+      if call.success?
+        render json: {}, status: :ok
+      else
+        render json: {}, status: :unprocessable_entity
+      end
+    end
+
+    def enable_all_of_section
+      bulk_update_section(:enable)
+    end
+
+    def disable_all_of_section
+      bulk_update_section(:disable)
+    end
+
+    private
+
+    def eager_load_project_custom_field_data
+      @project_custom_field_sections =
+        ProjectCustomFieldSection
+          .joins(:custom_fields)
+          .includes(:custom_fields)
+          .group(:id, "custom_fields.id")
+          .order(:position, :position_in_custom_field_section)
+    end
+
+    def set_project_custom_field_section
+      @project_custom_field_section = ProjectCustomFieldSection.find(
+        project_custom_field_type_mapping_params[:custom_field_section_id]
+      )
+    end
+
+    def bulk_update_section(action)
+      call = ProjectCustomFieldTypeMappings::BulkUpdateService
+        .new(
+          user: current_user,
+          type: @type,
+          project_custom_field_section: @project_custom_field_section
+        )
+        .call(action:)
+
+      if call.success?
+        eager_load_project_custom_field_data
+        update_project_attribute_sections_via_turbo_stream
+      end
+
+      respond_with_turbo_streams(status: call.success? ? :ok : :unprocessable_entity)
+    end
+
+    def project_custom_field_type_mapping_params
+      permitted_params = params.expect(
+        project_custom_field_type_mapping: %i[
+          type_id
+          custom_field_id
+          custom_field_section_id
+          value
+        ]
+      ).to_h
+
+      permitted_params[:value] = params[:value] if params.key?(:value)
+
+      permitted_params
+    end
+  end
+end

--- a/app/controllers/work_packages/project_attributes_tab_controller.rb
+++ b/app/controllers/work_packages/project_attributes_tab_controller.rb
@@ -31,6 +31,7 @@
 class WorkPackages::ProjectAttributesTabController < ApplicationController
   before_action :find_work_package
   before_action :authorize
+  before_action :authorize_project_attributes_visibility
 
   def index
     render(WorkPackages::ProjectAttributesTabComponent.new(work_package: @work_package))
@@ -43,5 +44,9 @@ class WorkPackages::ProjectAttributesTabController < ApplicationController
     @project = @work_package.project
   rescue ActiveRecord::RecordNotFound
     render_404
+  end
+
+  def authorize_project_attributes_visibility
+    do_authorize(:view_project_attributes)
   end
 end

--- a/app/controllers/work_packages/project_attributes_tab_controller.rb
+++ b/app/controllers/work_packages/project_attributes_tab_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class WorkPackages::ProjectAttributesTabController < ApplicationController
+  before_action :find_work_package
+  before_action :authorize
+
+  def index
+    render(WorkPackages::ProjectAttributesTabComponent.new(work_package: @work_package))
+  end
+
+  private
+
+  def find_work_package
+    @work_package = WorkPackage.visible.find(params.expect(:id))
+    @project = @work_package.project
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -45,6 +45,11 @@ module ::TypesHelper
         label: I18n.t("types.edit.form_configuration.tab")
       },
       {
+        name: "project_attributes",
+        path: edit_type_project_attributes_path(@type),
+        label: I18n.t("types.edit.project_attributes.tab")
+      },
+      {
         name: "subject_configuration",
         path: edit_type_subject_configuration_path(type_id: @type.id),
         label: I18n.t("types.edit.subject_configuration.tab"),

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -75,7 +75,7 @@ class ProjectCustomField < CustomField
       ).first
     end
 
-    def toggleable_ids_in_type_settings(custom_field_section_id)
+    def custom_field_ids_in_section(custom_field_section_id)
       where(custom_field_section_id:).pluck(:id)
     end
 

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -36,6 +36,9 @@ class ProjectCustomField < CustomField
   has_many :project_custom_field_project_mappings, class_name: "ProjectCustomFieldProjectMapping", foreign_key: :custom_field_id,
                                                    dependent: :destroy, inverse_of: :project_custom_field
   has_many :projects, through: :project_custom_field_project_mappings
+  has_many :project_custom_field_type_mappings, class_name: "ProjectCustomFieldTypeMapping", foreign_key: :custom_field_id,
+                                                dependent: :destroy, inverse_of: :project_custom_field
+  has_many :types, through: :project_custom_field_type_mappings
 
   after_save :activate_required_field_in_all_projects, if: :is_for_all?
 
@@ -70,6 +73,10 @@ class ProjectCustomField < CustomField
         custom_field_section_id:,
         options: { is_for_all: false }
       ).first
+    end
+
+    def toggleable_ids_in_type_settings(custom_field_section_id)
+      where(custom_field_section_id:).pluck(:id)
     end
 
     def toggleable_ids_in_creation_wizard_settings(project, custom_field_section_id)

--- a/app/models/project_custom_field_type_mapping.rb
+++ b/app/models/project_custom_field_type_mapping.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ProjectCustomFieldTypeMapping < ApplicationRecord
+  belongs_to :type
+  belongs_to :project_custom_field, class_name: "ProjectCustomField", foreign_key: "custom_field_id",
+                                    inverse_of: :project_custom_field_type_mappings
+
+  validates :custom_field_id, uniqueness: { scope: :type_id }
+end

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -50,6 +50,12 @@ module Projects::CustomFields
       all_visible_custom_fields.where(id: project_custom_field_project_mappings.select(:custom_field_id))
     end
 
+    def available_custom_fields_for_type(type_id)
+      available_custom_fields
+        .joins(:project_custom_field_type_mappings)
+        .where(project_custom_field_type_mappings: { type_id: })
+    end
+
     # Note:
     #
     # The UI allows the enabled attributes only via the project_custom_field_project_mappings.

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -46,6 +46,9 @@ class Type < ApplicationRecord
   belongs_to :color, optional: true, class_name: "Color"
 
   has_many :work_packages
+  has_many :project_custom_field_type_mappings, dependent: :destroy
+  has_many :project_custom_fields, through: :project_custom_field_type_mappings,
+                                   class_name: "ProjectCustomField"
   has_many :workflows, dependent: :delete_all do
     def copy_from_type(source_type)
       Workflow.copy(source_type, nil, proxy_association.owner, nil)

--- a/app/services/project_custom_field_type_mappings/bulk_update_service.rb
+++ b/app/services/project_custom_field_type_mappings/bulk_update_service.rb
@@ -37,13 +37,15 @@ module ProjectCustomFieldTypeMappings
     end
 
     def perform_bulk_edit(service_call, params)
-      custom_field_ids = ProjectCustomField.toggleable_ids_in_type_settings(@project_custom_field_section.id)
+      custom_field_ids = ProjectCustomField.custom_field_ids_in_section(@project_custom_field_section.id)
 
       case params[:action]
       when :enable
         enable_custom_fields(custom_field_ids)
       when :disable
         disable_custom_fields(custom_field_ids)
+      else
+        raise ArgumentError, "Unsupported bulk update action: #{params[:action].inspect}"
       end
 
       service_call

--- a/app/services/project_custom_field_type_mappings/bulk_update_service.rb
+++ b/app/services/project_custom_field_type_mappings/bulk_update_service.rb
@@ -45,7 +45,7 @@ module ProjectCustomFieldTypeMappings
       when :disable
         disable_custom_fields(custom_field_ids)
       else
-        raise ArgumentError, "Unsupported bulk update action: #{params[:action].inspect}"
+        raise ArgumentError, "Unsupported bulk update action: #{params[:action]}"
       end
 
       service_call

--- a/app/services/project_custom_field_type_mappings/bulk_update_service.rb
+++ b/app/services/project_custom_field_type_mappings/bulk_update_service.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectCustomFieldTypeMappings
+  class BulkUpdateService < ::BaseServices::BaseCallable
+    def initialize(user:, type:, project_custom_field_section:)
+      super()
+      @user = user
+      @type = type
+      @project_custom_field_section = project_custom_field_section
+    end
+
+    def perform
+      service_call = validate_permissions
+      service_call = perform_bulk_edit(service_call, params) if service_call.success?
+
+      service_call
+    end
+
+    private
+
+    def validate_permissions
+      if @user.admin?
+        ServiceResult.success
+      else
+        ServiceResult.failure(errors: { base: :error_unauthorized })
+      end
+    end
+
+    def perform_bulk_edit(service_call, params)
+      custom_field_ids = ProjectCustomField.toggleable_ids_in_type_settings(@project_custom_field_section.id)
+
+      case params[:action]
+      when :enable
+        enable_custom_fields(custom_field_ids)
+      when :disable
+        disable_custom_fields(custom_field_ids)
+      end
+
+      service_call
+    rescue StandardError => e
+      service_call.success = false
+      service_call.errors = e.message
+      service_call
+    end
+
+    def enable_custom_fields(custom_field_ids)
+      new_mapping_ids = custom_field_ids - existing_mappings(custom_field_ids)
+
+      create_mappings(new_mapping_ids) if new_mapping_ids.any?
+    end
+
+    def disable_custom_fields(custom_field_ids)
+      @type.project_custom_field_type_mappings
+        .where(custom_field_id: custom_field_ids)
+        .delete_all
+
+      reset_associations
+    end
+
+    def existing_mappings(custom_field_ids)
+      @type.project_custom_field_type_mappings
+        .where(custom_field_id: custom_field_ids)
+        .pluck(:custom_field_id)
+    end
+
+    def create_mappings(custom_field_ids)
+      @type.project_custom_field_type_mappings
+        .insert_all(
+          custom_field_ids.map { |id| { custom_field_id: id } },
+          unique_by: %i[type_id custom_field_id]
+        )
+
+      reset_associations
+    end
+
+    def reset_associations
+      @type.project_custom_field_type_mappings.reset
+      @type.project_custom_fields.reset
+    end
+  end
+end

--- a/app/services/project_custom_field_type_mappings/set_attributes_service.rb
+++ b/app/services/project_custom_field_type_mappings/set_attributes_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectCustomFieldTypeMappings
+  class SetAttributesService < ::BaseServices::SetAttributes
+  end
+end

--- a/app/services/project_custom_field_type_mappings/toggle_service.rb
+++ b/app/services/project_custom_field_type_mappings/toggle_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectCustomFieldTypeMappings
+  class ToggleService < ::BaseServices::Write
+    def persist(service_result)
+      if ActiveModel::Type::Boolean.new.cast(params[:value])
+        create_mapping(service_result)
+      else
+        destroy_mapping(service_result)
+      end
+
+      service_result
+    end
+
+    def create_mapping(service_result)
+      return if service_result.result.persisted?
+
+      unless service_result.result.save
+        service_result.errors = service_result.result.errors
+        service_result.success = false
+      end
+    end
+
+    def destroy_mapping(service_result)
+      return unless service_result.result.persisted?
+
+      service_result.result.destroy!
+    rescue StandardError => e
+      service_result.errors = e.message
+      service_result.success = false
+    end
+
+    def instance(params)
+      instance_class.find_or_initialize_by(
+        type_id: params[:type_id],
+        custom_field_id: params[:custom_field_id]
+      )
+    end
+
+    def set_attributes_params(_params)
+      {}
+    end
+
+    def default_contract_class
+      ProjectCustomFieldTypeMappings::UpdateContract
+    end
+  end
+end

--- a/app/services/project_custom_field_type_mappings/toggle_service.rb
+++ b/app/services/project_custom_field_type_mappings/toggle_service.rb
@@ -22,6 +22,23 @@ module ProjectCustomFieldTypeMappings
       service_result
     end
 
+    def instance(params)
+      instance_class.find_or_initialize_by(
+        type_id: params[:type_id],
+        custom_field_id: params[:custom_field_id]
+      )
+    end
+
+    def set_attributes_params(_params)
+      {}
+    end
+
+    def default_contract_class
+      ProjectCustomFieldTypeMappings::UpdateContract
+    end
+
+    private
+
     def create_mapping(service_result)
       return if service_result.result.persisted?
 
@@ -38,21 +55,6 @@ module ProjectCustomFieldTypeMappings
     rescue StandardError => e
       service_result.errors = e.message
       service_result.success = false
-    end
-
-    def instance(params)
-      instance_class.find_or_initialize_by(
-        type_id: params[:type_id],
-        custom_field_id: params[:custom_field_id]
-      )
-    end
-
-    def set_attributes_params(_params)
-      {}
-    end
-
-    def default_contract_class
-      ProjectCustomFieldTypeMappings::UpdateContract
     end
   end
 end

--- a/app/views/work_package_types/project_attributes_tab/edit.html.erb
+++ b/app/views/work_package_types/project_attributes_tab/edit.html.erb
@@ -1,0 +1,19 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
+
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+
+<%= render WorkPackageTypes::ProjectAttributes::IndexComponent.new(
+      type: @type,
+      project_custom_field_sections: @project_custom_field_sections
+    ) %>

--- a/app/views/work_package_types/project_attributes_tab/edit.html.erb
+++ b/app/views/work_package_types/project_attributes_tab/edit.html.erb
@@ -12,6 +12,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<p><%= I18n.t("types.edit.project_attributes.description") %></p>
 
 <%= render WorkPackageTypes::ProjectAttributes::IndexComponent.new(
       type: @type,

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -314,7 +314,8 @@ Rails.application.reloader.to_prepare do
                        "work_packages/menus": %i[show],
                        "work_packages/hover_card": %i[show],
                        work_package_relations_tab: %i[index],
-                       "work_packages/reminders": %i[modal_body create update destroy]
+                       "work_packages/reminders": %i[modal_body create update destroy],
+                       "work_packages/project_attributes_tab": %i[index]
                      },
                      permissible_on: %i[work_package project],
                      contract_actions: { work_packages: %i[read] }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1504,6 +1504,12 @@ en:
         enable_all: Enable for all projects
         select_projects: Select projects
         select_projects_description: Select the projects in which you would like to use this type.
+      project_attributes:
+        tab: "Project attributes"
+        filter: "Search by section or name"
+        actions:
+          label_enable_all: "Enable all"
+          label_disable_all: "Disable all"
       settings:
         tab: "Settings"
         type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1467,49 +1467,49 @@ en:
       no_results_content_text: Create a new type
     edit:
       form_configuration:
-        tab: "Form configuration"
-        label_group: "Section"
-        reset_to_defaults: "Reset form"
         add_attribute_group: "Section"
         add_query_group: "Related work packages table"
+        blankslate_description: "Add groups using the button above or drag attributes from the left panel."
+        blankslate_title: "No groups yet"
+        builtin_field: "Built-in field"
+        confirm_delete_group: "Are you sure you want to delete this section? This action cannot be automatically reversed."
+        confirm_reset: "Are you sure you want to reset the form configuration?"
+        custom_field: "Custom field"
         delete_group: "Delete section"
-        remove_attribute: "Remove from section"
         drag_to_activate: "Drag fields from here to activate them"
         drag_to_reorder: "Drag to reorder"
         edit_query: "Edit query"
-        custom_field: "Custom field"
-        filter_inactive: "Filter attributes"
-        inactive_attributes_heading: "Inactive attributes"
-        no_inactive_attributes: "No inactive attributes"
-        blankslate_title: "No groups yet"
-        blankslate_description: "Add groups using the button above or drag attributes from the left panel."
-        group_actions: "Section actions"
-        rename_group: "Rename section"
-        confirm_delete_group: "Are you sure you want to delete this section? This action cannot be automatically reversed."
-        group_name_label: "Section name"
-        row_actions: "Row actions"
-        query_group_label: "Related work packages table"
         empty_group_hint: "Drag attributes here"
+        filter_inactive: "Filter attributes"
+        group_actions: "Section actions"
+        group_name_label: "Section name"
+        inactive_attributes_heading: "Inactive attributes"
         invalid_attribute_groups: "The form configuration payload is invalid."
         invalid_query: "The embedded query configuration is invalid."
+        label_group: "Section"
+        no_inactive_attributes: "No inactive attributes"
         not_found: "The requested form configuration item could not be found."
-        untitled_group: "Untitled group"
-        reset_title: "Reset form configuration"
-        confirm_reset: "Are you sure you want to reset the form configuration?"
-        builtin_field: "Built-in field"
+        query_group_label: "Related work packages table"
+        remove_attribute: "Remove from section"
+        rename_group: "Rename section"
         reset_description: >
           This will reset the attributes to their default group and disable ALL custom fields.
+        reset_title: "Reset form configuration"
+        reset_to_defaults: "Reset form"
+        row_actions: "Row actions"
+        tab: "Form configuration"
+        untitled_group: "Untitled group"
+      project_attributes:
+        actions:
+          label_disable_all: "Disable all"
+          label_enable_all: "Enable all"
+        filter: "Search by section or name"
+        tab: "Project attributes"
       projects:
-        tab: Projects
         enable_all: Enable for all projects
         select_projects: Select projects
         select_projects_description: Select the projects in which you would like to use this type.
-      project_attributes:
-        tab: "Project attributes"
-        filter: "Search by section or name"
-        actions:
-          label_enable_all: "Enable all"
-          label_disable_all: "Disable all"
+        tab: Projects
       settings:
         tab: "Settings"
         type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1503,6 +1503,7 @@ en:
         actions:
           label_disable_all: "Disable all"
           label_enable_all: "Enable all"
+        description: "Select the project attributes that you want to enable for this work package type. Enabled project attributes are displayed in a separate tab in work packages of this type. Users with the necessary permissions can view and edit these attributes there."
         filter: "Search by section or name"
         tab: "Project attributes"
       projects:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -971,11 +971,12 @@ en:
         relation_filters:
           filter_work_packages_by_relation_type: "Filter work packages by relation type"
       tabs:
-        overview: Overview
         activity: Activity
+        files: Files
+        project_attributes: Project attributes
+        overview: Overview
         relations: Relations
         watchers: Watchers
-        files: Files
       time_relative:
         days: "days"
         weeks: "weeks"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -973,8 +973,8 @@ en:
       tabs:
         activity: Activity
         files: Files
-        project_attributes: Project attributes
         overview: Overview
+        project_attributes: Project attributes
         relations: Relations
         watchers: Watchers
       time_relative:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -962,6 +962,7 @@ Rails.application.routes.draw do
     concerns :shareable
 
     get "hover_card" => "work_packages/hover_card#show", on: :member
+    get "project_attributes" => "work_packages/project_attributes_tab#index", on: :member
 
     get "generate_pdf_dialog" => "work_packages#generate_pdf_dialog", on: :member
     post "generate_pdf" => "work_packages#generate_pdf", on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,11 @@ Rails.application.routes.draw do
         post :enable_all, to: "projects_tab#enable_all_projects"
       end
     end
+    resource :project_attributes, controller: "project_attributes_tab", only: %i[edit] do
+      post :toggle
+      put :enable_all_of_section
+      put :disable_all_of_section
+    end
     resource :settings, controller: "settings_tab", only: %i[update edit]
     resource :subject_configuration, controller: "subject_configuration_tab", only: %i[update edit]
 

--- a/db/migrate/20260615120000_create_project_custom_field_type_mappings.rb
+++ b/db/migrate/20260615120000_create_project_custom_field_type_mappings.rb
@@ -3,7 +3,7 @@
 class CreateProjectCustomFieldTypeMappings < ActiveRecord::Migration[8.1]
   def change
     create_table :project_custom_field_type_mappings do |t|
-      t.references :type, null: false, foreign_key: true
+      t.references :type, null: false, foreign_key: true, index: false
       t.references :custom_field, null: false, foreign_key: true,
                                   index: { name: "index_project_cf_type_mappings_on_custom_field_id" }
 

--- a/db/migrate/20260615120000_create_project_custom_field_type_mappings.rb
+++ b/db/migrate/20260615120000_create_project_custom_field_type_mappings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateProjectCustomFieldTypeMappings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :project_custom_field_type_mappings do |t|
+      t.references :type, null: false, foreign_key: true
+      t.references :custom_field, null: false, foreign_key: true,
+                                  index: { name: "index_project_cf_type_mappings_on_custom_field_id" }
+
+      t.timestamps
+
+      t.index %i[type_id custom_field_id],
+              unique: true,
+              name: "index_project_custom_field_type_mappings_unique"
+    end
+  end
+end

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -45,6 +45,10 @@ allOf:
       readonly:
         type: boolean
         description: If true, the work package is in a readonly status so with the exception of the status, no other property can be altered.
+      hasProjectAttributes:
+        type: boolean
+        description: If true, the work package's type has at least one project custom field activated and visible to the current user.
+        readOnly: true
       startDate:
         type:
           - "string"

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -166,6 +166,8 @@ export class WorkPackageBaseResource extends HalResource {
 
   public lockVersion:number;
 
+  public hasProjectAttributes:boolean;
+
   public description:any;
 
   public activities:CollectionResource;

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.html
@@ -1,0 +1,13 @@
+<div id="work-package-project-attributes-container">
+  <turbo-frame [src]="turboFrameSrc" id="work-package-project-attributes-tab-content" loading="lazy">
+    <op-content-loader viewBox="0 0 100 100">
+      <svg:rect x="0" y="0" width="70" height="5" rx="1" />
+
+      <svg:rect x="75" y="0" width="25" height="5" rx="1" />
+
+      <svg:rect x="0" y="10" width="100" height="8" rx="1" />
+
+      <svg:rect x="0" y="25" width="100" height="12" rx="1" />
+    </op-content-loader>
+  </turbo-frame>
+</div>

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component.ts
@@ -1,0 +1,71 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  Input,
+  OnInit,
+} from '@angular/core';
+
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { UIRouterGlobals } from '@uirouter/core';
+
+@Component({
+  selector: 'op-project-attributes-tab',
+  templateUrl: './op-project-attributes-tab.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class WorkPackageProjectAttributesTabComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly pathHelper = inject(PathHelperService);
+
+  public turboFrameSrc:string;
+  public workPackageId:string;
+
+  @Input() public workPackage:WorkPackageResource;
+
+  ngOnInit() {
+    const { workPackageId } = this.uiRouterGlobals.params as unknown as { workPackageId:string };
+    this.workPackageId = (this.workPackage.id!) || workPackageId;
+
+    this.turboFrameSrc = this.buildTurboFrameSrc();
+  }
+
+  protected buildTurboFrameSrc():string {
+    const baseUrl = window.location.origin;
+    const url = new URL(`${this.pathHelper.staticBase}/work_packages/${this.workPackageId}/project_attributes`, baseUrl);
+
+    return url.toString();
+  }
+}

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
@@ -73,4 +73,23 @@ describe('WpTabsService', () => {
       expect(displayableTabs[0].id).toEqual(notDisplayableTab.id);
     });
   });
+
+  describe('project_attributes tab', () => {
+    beforeEach(() => {
+      // Reset to default tabs so the built-in project_attributes tab is present
+      (service as any).registeredTabs = (service as any).buildDefaultTabs();
+    });
+
+    it('is hidden when hasProjectAttributes is false', () => {
+      const wp:any = { hasProjectAttributes: false };
+      const tabs = service.getDisplayableTabs(wp);
+      expect(tabs.find((t) => t.id === 'project_attributes')).toBeUndefined();
+    });
+
+    it('is visible when hasProjectAttributes is true', () => {
+      const wp:any = { hasProjectAttributes: true };
+      const tabs = service.getDisplayableTabs(wp);
+      expect(tabs.find((t) => t.id === 'project_attributes')).toBeDefined();
+    });
+  });
 });

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -151,6 +151,7 @@ export class WorkPackageTabsService {
         id: 'project_attributes',
         component: WorkPackageProjectAttributesTabComponent,
         name: I18n.t('js.work_packages.tabs.project_attributes'),
+        displayable: (workPackage) => !!workPackage.hasProjectAttributes,
       },
       {
         id: 'files',

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -59,6 +59,7 @@ import {
 import {
   workPackageFilesCount,
 } from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-files-count.function';
+import { WorkPackageProjectAttributesTabComponent } from 'core-app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component';
 
 @Injectable({
   providedIn: 'root',
@@ -145,6 +146,11 @@ export class WorkPackageTabsService {
         name: I18n.t('js.work_packages.tabs.activity'),
         count: workPackageNotificationsCount,
         showCountAsBubble: true,
+      },
+      {
+        id: 'project_attributes',
+        component: WorkPackageProjectAttributesTabComponent,
+        name: I18n.t('js.work_packages.tabs.project_attributes'),
       },
       {
         id: 'files',

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -409,6 +409,7 @@ import { WorkPackageFullViewEntryComponent } from 'core-app/features/work-packag
 import {
   WorkPackageSplitCreateEntryComponent,
 } from 'core-app/features/work-packages/routing/wp-split-create/wp-split-create-entry.component';
+import { WorkPackageProjectAttributesTabComponent } from 'core-app/features/work-packages/components/wp-single-view-tabs/project-attributes-tab/op-project-attributes-tab.component';
 
 @NgModule({
   imports: [
@@ -588,6 +589,9 @@ import {
 
     // Files tab
     WorkPackageFilesTabComponent,
+
+    // Project attributes tab
+    WorkPackageProjectAttributesTabComponent,
 
     // Split view
     WorkPackageDetailsViewButtonComponent,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -494,7 +496,14 @@ module API
                  as: :hasProjectAttributes,
                  writable: false,
                  uncacheable: true,
-                 getter: ->(*) { project&.available_custom_fields&.any? || false }
+                 getter: ->(*) do
+                   fields = project
+                              &.available_custom_fields
+                              &.joins(:project_custom_field_type_mappings)
+                   fields
+                     &.where(project_custom_field_type_mappings: { type_id: })
+                     &.any? || false
+                 end
 
         associated_resource :category
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -490,6 +490,12 @@ module API
                    status_id && status.is_readonly?
                  end
 
+        property :has_project_attributes,
+                 as: :hasProjectAttributes,
+                 writable: false,
+                 uncacheable: true,
+                 getter: ->(*) { project&.available_custom_fields&.any? || false }
+
         associated_resource :category
 
         associated_resource :type

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -497,12 +497,7 @@ module API
                  writable: false,
                  uncacheable: true,
                  getter: ->(*) do
-                   fields = project
-                              &.available_custom_fields
-                              &.joins(:project_custom_field_type_mappings)
-                   fields
-                     &.where(project_custom_field_type_mappings: { type_id: })
-                     &.any? || false
+                   project&.available_custom_fields_for_type(type_id)&.any? || false
                  end
 
         associated_resource :category

--- a/spec/components/work_packages/project_attributes_tab_component_spec.rb
+++ b/spec/components/work_packages/project_attributes_tab_component_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe WorkPackages::ProjectAttributesTabComponent, type: :component do
   include Rails.application.routes.url_helpers
 
   let(:project) { create(:project) }
-  let(:work_package) { build_stubbed(:work_package, project:) }
+  let(:type) { create(:type) }
+  let(:work_package) { build_stubbed(:work_package, project:, type:) }
   let(:user) { build_stubbed(:admin) }
 
   current_user { user }
@@ -43,31 +44,54 @@ RSpec.describe WorkPackages::ProjectAttributesTabComponent, type: :component do
     render_inline(described_class.new(work_package:))
   end
 
+  def create_field_for(wp_type, section:)
+    create(:project_custom_field, project_custom_field_section: section, projects: [project]).tap do |f|
+      wp_type.project_custom_fields << f
+    end
+  end
+
   context "when the project has no custom fields" do
     it "renders nothing" do
       expect(rendered_component.to_html).to be_empty
     end
   end
 
-  context "when the project has custom fields but the user has no permission to view them" do
+  context "when the project has custom fields mapped to the type but the user has no permission to view them" do
     let(:user) { build_stubbed(:user) }
     let(:section) { create(:project_custom_field_section) }
-    let!(:fields) { create_list(:project_custom_field, 2, project_custom_field_section: section, projects: [project]) }
+    let!(:fields) { Array.new(2) { create_field_for(type, section:) } }
 
     it "renders nothing" do
       expect(rendered_component.to_html).to be_empty
     end
   end
 
-  context "when the project has custom fields in multiple sections" do
+  context "when the project has custom fields in multiple sections mapped to the type" do
     let(:section_a) { create(:project_custom_field_section) }
     let(:section_b) { create(:project_custom_field_section) }
-    let!(:fields_a) { create_list(:project_custom_field, 2, project_custom_field_section: section_a, projects: [project]) }
-    let!(:fields_b) { create_list(:project_custom_field, 1, project_custom_field_section: section_b, projects: [project]) }
+    let!(:fields_a) { Array.new(2) { create_field_for(type, section: section_a) } }
+    let!(:fields_b) { [create_field_for(type, section: section_b)] }
 
     it "renders one section component per custom field section" do
       expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_a.id}")
       expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_b.id}")
+    end
+  end
+
+  context "when the project has custom fields with type mappings" do
+    let(:section) { create(:project_custom_field_section) }
+    let(:other_type) { create(:type) }
+    let!(:field_for_type) { create_field_for(type, section:) }
+    let!(:field_for_other_type) { create_field_for(other_type, section:) }
+    let!(:field_without_mapping) do
+      create(:project_custom_field, project_custom_field_section: section, projects: [project])
+    end
+
+    it "only renders fields mapped to the work package type" do
+      expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section.id}")
+      expect(rendered_component).to have_text(field_for_type.name)
+      expect(rendered_component).to have_no_text(field_for_other_type.name)
+      expect(rendered_component).to have_no_text(field_without_mapping.name)
     end
   end
 end

--- a/spec/components/work_packages/project_attributes_tab_component_spec.rb
+++ b/spec/components/work_packages/project_attributes_tab_component_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::ProjectAttributesTabComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:project) { create(:project) }
+  let(:work_package) { build_stubbed(:work_package, project:) }
+  let(:user) { build_stubbed(:admin) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(work_package:))
+  end
+
+  context "when the project has no custom fields" do
+    it "renders nothing" do
+      expect(rendered_component.to_html).to be_empty
+    end
+  end
+
+  context "when the project has custom fields but the user has no permission to view them" do
+    let(:user) { build_stubbed(:user) }
+    let(:section) { create(:project_custom_field_section) }
+    let!(:fields) { create_list(:project_custom_field, 2, project_custom_field_section: section, projects: [project]) }
+
+    it "renders nothing" do
+      expect(rendered_component.to_html).to be_empty
+    end
+  end
+
+  context "when the project has custom fields in multiple sections" do
+    let(:section_a) { create(:project_custom_field_section) }
+    let(:section_b) { create(:project_custom_field_section) }
+    let!(:fields_a) { create_list(:project_custom_field, 2, project_custom_field_section: section_a, projects: [project]) }
+    let!(:fields_b) { create_list(:project_custom_field, 1, project_custom_field_section: section_b, projects: [project]) }
+
+    it "renders one section component per custom field section" do
+      expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_a.id}")
+      expect(rendered_component).to have_test_selector("wp-project-attribute-section-#{section_b.id}")
+    end
+  end
+end

--- a/spec/components/work_packages/project_custom_fields/section_component_spec.rb
+++ b/spec/components/work_packages/project_custom_fields/section_component_spec.rb
@@ -28,26 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class WorkPackages::ProjectAttributesTabComponent < ApplicationComponent
-  include OpPrimer::ComponentHelpers
-  include OpTurbo::Streamable
+require "rails_helper"
 
-  def initialize(work_package:)
-    super
+RSpec.describe WorkPackages::ProjectCustomFields::SectionComponent, type: :component do
+  include Rails.application.routes.url_helpers
 
-    @work_package = work_package
-    @project = work_package.project
+  let(:project) { build(:project) }
+  let(:project_custom_field_section) { build(:project_custom_field_section, name: "Special Section") }
+  let(:project_custom_fields) { create_list(:project_custom_field, 2, projects: [project]) }
+  let(:user) { build_stubbed(:user) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(project:, project_custom_field_section:, project_custom_fields:))
   end
 
-  def render?
-    project_custom_fields_grouped_by_section.any?
+  it "renders the section with the correct title" do
+    expect(rendered_component).to have_section "Special Section"
   end
 
-  private
-
-  def project_custom_fields_grouped_by_section
-    @project_custom_fields_grouped_by_section ||=
-      @project.available_custom_fields
-              .group_by(&:project_custom_field_section)
+  it "renders a field container for each custom field" do
+    expect(rendered_component).to have_css ".op-project-custom-field-container", count: 2
   end
 end

--- a/spec/contracts/project_custom_field_type_mappings/base_contract_spec.rb
+++ b/spec/contracts/project_custom_field_type_mappings/base_contract_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe ProjectCustomFieldTypeMappings::BaseContract do
+  include_context "ModelContract shared context"
+
+  let(:user) { build_stubbed(:admin) }
+  let(:type) { build_stubbed(:type) }
+  let(:project_custom_field) { build_stubbed(:project_custom_field) }
+  let(:mapping) { ProjectCustomFieldTypeMapping.new(type:, project_custom_field:) }
+  let(:contract) { described_class.new(mapping, user) }
+
+  it_behaves_like "contract is valid"
+
+  context "with a non-admin user" do
+    let(:user) { build_stubbed(:user) }
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+
+  context "with a work package custom field" do
+    let(:work_package_custom_field) { create(:wp_custom_field) }
+    let(:mapping) do
+      ProjectCustomFieldTypeMapping.new(
+        type:,
+        custom_field_id: work_package_custom_field.id
+      )
+    end
+
+    it_behaves_like "contract is invalid", custom_field_id: :invalid
+  end
+
+  include_examples "contract reuses the model errors"
+end

--- a/spec/contracts/project_custom_field_type_mappings/update_contract_spec.rb
+++ b/spec/contracts/project_custom_field_type_mappings/update_contract_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe ProjectCustomFieldTypeMappings::UpdateContract do
+  include_context "ModelContract shared context"
+
+  let(:user) { build_stubbed(:admin) }
+  let(:type) { build_stubbed(:type) }
+  let(:project_custom_field) { build_stubbed(:project_custom_field) }
+  let(:mapping) { ProjectCustomFieldTypeMapping.new(type:, project_custom_field:) }
+  let(:contract) { described_class.new(mapping, user) }
+
+  it_behaves_like "contract is valid"
+
+  context "with a non-admin user" do
+    let(:user) { build_stubbed(:user) }
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+
+  context "with a work package custom field" do
+    let(:work_package_custom_field) { create(:wp_custom_field) }
+    let(:mapping) do
+      ProjectCustomFieldTypeMapping.new(
+        type:,
+        custom_field_id: work_package_custom_field.id
+      )
+    end
+
+    it_behaves_like "contract is invalid", custom_field_id: :invalid
+  end
+
+  include_examples "contract reuses the model errors"
+end

--- a/spec/controllers/work_package_types/project_attributes_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/project_attributes_tab_controller_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe WorkPackageTypes::ProjectAttributesTabController do
 
       it { expect(response).to have_http_status(:forbidden) }
     end
+
+    describe "POST toggle" do
+      before do
+        post :toggle,
+             params: {
+               type_id: type.id,
+               value: "1",
+               project_custom_field_type_mapping: {
+                 type_id: type.id,
+                 custom_field_id: project_custom_field.id
+               }
+             }
+      end
+
+      it "does not enable the project attribute" do
+        expect(response).to have_http_status(:forbidden)
+        expect(type.reload.project_custom_fields).to be_empty
+      end
+    end
   end
 
   context "with admin access" do
@@ -81,6 +100,57 @@ RSpec.describe WorkPackageTypes::ProjectAttributesTabController do
 
         expect(response).to have_http_status(:ok)
         expect(type.reload.project_custom_fields).to contain_exactly(project_custom_field)
+      end
+    end
+
+    describe "PUT disable_all_of_section" do
+      let(:params) do
+        {
+          type_id: type.id,
+          project_custom_field_type_mapping: {
+            type_id: type.id,
+            custom_field_section_id: project_custom_field_section.id
+          }
+        }
+      end
+
+      before do
+        type.project_custom_fields << project_custom_field
+      end
+
+      it "disables all project attributes of the section" do
+        put :disable_all_of_section, params: params, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(type.reload.project_custom_fields).to be_empty
+      end
+    end
+
+    describe "a failed bulk update" do
+      let(:params) do
+        {
+          type_id: type.id,
+          project_custom_field_type_mapping: {
+            type_id: type.id,
+            custom_field_section_id: project_custom_field_section.id
+          }
+        }
+      end
+
+      let(:service) { instance_double(ProjectCustomFieldTypeMappings::BulkUpdateService) }
+
+      before do
+        allow(ProjectCustomFieldTypeMappings::BulkUpdateService).to receive(:new).and_return(service)
+        allow(service).to receive(:call).and_return(
+          ServiceResult.failure(message: "Project attributes could not be updated.")
+        )
+      end
+
+      it "shows an error message" do
+        put :enable_all_of_section, params: params, format: :turbo_stream
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("Project attributes could not be updated.")
       end
     end
   end

--- a/spec/controllers/work_package_types/project_attributes_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/project_attributes_tab_controller_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackageTypes::ProjectAttributesTabController do
+  let(:type) { create(:type) }
+  let(:project_custom_field_section) { create(:project_custom_field_section) }
+  let!(:project_custom_field) { create(:project_custom_field, project_custom_field_section:) }
+
+  before do
+    login_as user
+  end
+
+  context "without admin access" do
+    let(:user) { create(:user) }
+
+    describe "GET edit" do
+      before do
+        get :edit, params: { type_id: type.id }
+      end
+
+      it { expect(response).to have_http_status(:forbidden) }
+    end
+  end
+
+  context "with admin access" do
+    let(:user) { create(:admin) }
+
+    describe "GET edit" do
+      before do
+        get :edit, params: { type_id: type.id }
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template "edit" }
+    end
+
+    describe "POST toggle" do
+      let(:params) do
+        {
+          type_id: type.id,
+          value: "1",
+          project_custom_field_type_mapping: {
+            type_id: type.id,
+            custom_field_id: project_custom_field.id
+          }
+        }
+      end
+
+      it "enables the project attribute for the type" do
+        post :toggle, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(type.reload.project_custom_fields).to contain_exactly(project_custom_field)
+      end
+    end
+
+    describe "PUT enable_all_of_section" do
+      let(:params) do
+        {
+          type_id: type.id,
+          project_custom_field_type_mapping: {
+            type_id: type.id,
+            custom_field_section_id: project_custom_field_section.id
+          }
+        }
+      end
+
+      it "enables all project attributes of the section" do
+        put :enable_all_of_section, params: params, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(type.reload.project_custom_fields).to contain_exactly(project_custom_field)
+      end
+    end
+  end
+end

--- a/spec/controllers/work_packages/project_attributes_tab_controller_spec.rb
+++ b/spec/controllers/work_packages/project_attributes_tab_controller_spec.rb
@@ -28,25 +28,46 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject
-  module InplaceEdit
-    module Handlers
-      class ProjectUpdate
-        def self.call(model:, params:, user:)
-          contract_options = project_attributes_only?(params) ? { project_attributes_only: true } : {}
+require "spec_helper"
 
-          call = ::Projects::UpdateService
-                   .new(model:, user:, contract_options:)
-                   .call(params)
+RSpec.describe WorkPackages::ProjectAttributesTabController do
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
 
-          call.success?
-        end
+  let(:role_with_both_permissions) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes])
+  end
+  let(:role_without_project_attributes) do
+    create(:project_role, permissions: %i[view_work_packages])
+  end
 
-        def self.project_attributes_only?(params)
-          params.keys.all? { |k| k.to_s.start_with?("custom_field_", "custom_comment") }
-        end
-        private_class_method :project_attributes_only?
-      end
+  before do
+    allow(User).to receive(:current).and_return(user)
+    work_package
+  end
+
+  describe "#index" do
+    subject do
+      get :index, params: { id: work_package.id }
+      response
+    end
+
+    context "when the user has view_work_packages and view_project_attributes" do
+      let(:user) { create(:user, member_with_roles: { project => role_with_both_permissions }) }
+
+      it { is_expected.to be_successful }
+    end
+
+    context "when the user has view_work_packages but not view_project_attributes" do
+      let(:user) { create(:user, member_with_roles: { project => role_without_project_attributes }) }
+
+      it { is_expected.to be_forbidden }
+    end
+
+    context "when the user has no access to the project" do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be_not_found }
     end
   end
 end

--- a/spec/features/types/project_attributes_spec.rb
+++ b/spec/features/types/project_attributes_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package type project attributes", :js do
+  shared_let(:admin) { create(:admin) }
+
+  let(:type) { create(:type, name: "Project order") }
+  let(:other_type) { create(:type, name: "Milestone") }
+
+  let!(:input_section) { create(:project_custom_field_section, name: "Input fields") }
+  let!(:select_section) { create(:project_custom_field_section, name: "Select fields") }
+
+  let!(:boolean_project_custom_field) do
+    create(:boolean_project_custom_field,
+           name: "Boolean field",
+           project_custom_field_section: input_section)
+  end
+
+  let!(:string_project_custom_field) do
+    create(:string_project_custom_field,
+           name: "String field",
+           project_custom_field_section: input_section)
+  end
+
+  let!(:list_project_custom_field) do
+    create(:list_project_custom_field,
+           name: "List field",
+           project_custom_field_section: select_section,
+           possible_values: ["Option 1", "Option 2"])
+  end
+
+  before do
+    login_as(admin)
+  end
+
+  it "shows all project attributes deactivated by default" do
+    visit edit_type_project_attributes_path(type)
+
+    expect(page).to have_link("Project attributes")
+
+    within_project_attribute_section_container(input_section) do
+      within_project_attribute_container(boolean_project_custom_field) do
+        expect(page).to have_text("Boolean field")
+        expect_type("Bool")
+        expect_unchecked_state
+      end
+
+      within_project_attribute_container(string_project_custom_field) do
+        expect(page).to have_text("String field")
+        expect_type("Text")
+        expect_unchecked_state
+      end
+    end
+
+    within_project_attribute_section_container(select_section) do
+      within_project_attribute_container(list_project_custom_field) do
+        expect(page).to have_text("List field")
+        expect_type("List")
+        expect_unchecked_state
+      end
+    end
+  end
+
+  it "toggles a project attribute for the current type" do
+    visit edit_type_project_attributes_path(type)
+
+    within_project_attribute_container(boolean_project_custom_field) do
+      expect_unchecked_state
+
+      toggle_type_project_attribute(boolean_project_custom_field)
+
+      expect_checked_state
+    end
+
+    visit edit_type_project_attributes_path(type)
+
+    within_project_attribute_container(boolean_project_custom_field) do
+      expect_checked_state
+    end
+
+    visit edit_type_project_attributes_path(other_type)
+
+    within_project_attribute_container(boolean_project_custom_field) do
+      expect_unchecked_state
+    end
+  end
+
+  it "enables and disables all project attributes of a section" do
+    visit edit_type_project_attributes_path(type)
+
+    within_project_attribute_section_container(input_section) do
+      page.find_test_selector("enable-all-type-project-attributes-#{input_section.id}").click
+
+      within_project_attribute_container(boolean_project_custom_field) do
+        expect_checked_state
+      end
+
+      within_project_attribute_container(string_project_custom_field) do
+        expect_checked_state
+      end
+    end
+
+    within_project_attribute_section_container(select_section) do
+      within_project_attribute_container(list_project_custom_field) do
+        expect_unchecked_state
+      end
+    end
+
+    expect(type.reload.project_custom_fields).to contain_exactly(boolean_project_custom_field, string_project_custom_field)
+
+    within_project_attribute_section_container(input_section) do
+      page.find_test_selector("disable-all-type-project-attributes-#{input_section.id}").click
+
+      within_project_attribute_container(boolean_project_custom_field) do
+        expect_unchecked_state
+      end
+
+      within_project_attribute_container(string_project_custom_field) do
+        expect_unchecked_state
+      end
+    end
+
+    expect(type.reload.project_custom_fields).to be_empty
+  end
+
+  it "filters the project attributes by name with given user input" do
+    visit edit_type_project_attributes_path(type)
+
+    fill_in "border-box-filter", with: "Boolean"
+
+    within_project_attribute_section_container(input_section) do
+      expect(page).to have_text("Boolean field")
+      expect(page).to have_no_text("String field")
+    end
+
+    within_project_attribute_section_container(select_section) do
+      expect(page).to have_no_text("List field")
+    end
+  end
+
+  it "shows sections and project attributes in the configured order" do
+    visit edit_type_project_attributes_path(type)
+
+    sections = page.all(".op-project-custom-field-section")
+
+    expect(sections.size).to eq(2)
+    expect(sections[0].text).to include("Input fields")
+    expect(sections[1].text).to include("Select fields")
+
+    within_project_attribute_section_container(input_section) do
+      custom_fields = page.all(".op-project-custom-field")
+
+      expect(custom_fields.size).to eq(2)
+      expect(custom_fields[0].text).to include("Boolean field")
+      expect(custom_fields[1].text).to include("String field")
+    end
+
+    input_section.move_to_bottom
+    boolean_project_custom_field.move_to_bottom
+
+    visit edit_type_project_attributes_path(type)
+
+    sections = page.all(".op-project-custom-field-section")
+
+    expect(sections.size).to eq(2)
+    expect(sections[0].text).to include("Select fields")
+    expect(sections[1].text).to include("Input fields")
+
+    within_project_attribute_section_container(input_section) do
+      custom_fields = page.all(".op-project-custom-field")
+
+      expect(custom_fields.size).to eq(2)
+      expect(custom_fields[0].text).to include("String field")
+      expect(custom_fields[1].text).to include("Boolean field")
+    end
+  end
+
+  def toggle_type_project_attribute(project_custom_field)
+    page
+      .find("[data-test-selector='toggle-type-project-attribute-#{project_custom_field.id}'] > button")
+      .click
+  end
+
+  def expect_type(type)
+    within "[data-test-selector='custom-field-type']" do
+      expect(page).to have_text(type)
+    end
+  end
+
+  def expect_checked_state
+    expect(page).to have_css(".ToggleSwitch-statusOn")
+  end
+
+  def expect_unchecked_state
+    expect(page).to have_css(".ToggleSwitch-statusOff")
+  end
+
+  def within_project_attribute_section_container(section, &)
+    within("[data-test-selector='type-project-attribute-section-#{section.id}']", &)
+  end
+
+  def within_project_attribute_container(project_custom_field, &)
+    within("[data-test-selector='type-project-attribute-#{project_custom_field.id}']", &)
+  end
+end

--- a/spec/features/types/project_attributes_spec.rb
+++ b/spec/features/types/project_attributes_spec.rb
@@ -116,7 +116,9 @@ RSpec.describe "Work package type project attributes", :js do
   it "enables and disables all project attributes of a section" do
     project_attributes_page.within_section(input_section) do
       page.find_test_selector("enable-all-type-project-attributes-#{input_section.id}").click
+    end
 
+    project_attributes_page.within_section(input_section) do
       project_attributes_page.within_attribute(boolean_project_custom_field) do
         project_attributes_page.expect_checked_state
       end
@@ -136,7 +138,9 @@ RSpec.describe "Work package type project attributes", :js do
 
     project_attributes_page.within_section(input_section) do
       page.find_test_selector("disable-all-type-project-attributes-#{input_section.id}").click
+    end
 
+    project_attributes_page.within_section(input_section) do
       project_attributes_page.within_attribute(boolean_project_custom_field) do
         project_attributes_page.expect_unchecked_state
       end

--- a/spec/features/types/project_attributes_spec.rb
+++ b/spec/features/types/project_attributes_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Work package type project attributes", :js do
     end
 
     input_section.move_to_bottom
-    boolean_project_custom_field.move_to_bottom
+    input_section.move_in_order(boolean_project_custom_field.column_name, :lowest)
 
     project_attributes_page.visit!
 

--- a/spec/features/types/project_attributes_spec.rb
+++ b/spec/features/types/project_attributes_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Work package type project attributes", :js do
 
   let(:type) { create(:type, name: "Project order") }
   let(:other_type) { create(:type, name: "Milestone") }
+  let(:project_attributes_page) { Pages::Types::ProjectAttributes.new(type) }
 
   let!(:input_section) { create(:project_custom_field_section, name: "Input fields") }
   let!(:select_section) { create(:project_custom_field_section, name: "Select fields") }
@@ -60,92 +61,88 @@ RSpec.describe "Work package type project attributes", :js do
 
   before do
     login_as(admin)
+    project_attributes_page.visit!
   end
 
   it "shows all project attributes deactivated by default" do
-    visit edit_type_project_attributes_path(type)
-
     expect(page).to have_link("Project attributes")
 
-    within_project_attribute_section_container(input_section) do
-      within_project_attribute_container(boolean_project_custom_field) do
+    project_attributes_page.within_section(input_section) do
+      project_attributes_page.within_attribute(boolean_project_custom_field) do
         expect(page).to have_text("Boolean field")
-        expect_type("Bool")
-        expect_unchecked_state
+        project_attributes_page.expect_type("Bool")
+        project_attributes_page.expect_unchecked_state
       end
 
-      within_project_attribute_container(string_project_custom_field) do
+      project_attributes_page.within_attribute(string_project_custom_field) do
         expect(page).to have_text("String field")
-        expect_type("Text")
-        expect_unchecked_state
+        project_attributes_page.expect_type("Text")
+        project_attributes_page.expect_unchecked_state
       end
     end
 
-    within_project_attribute_section_container(select_section) do
-      within_project_attribute_container(list_project_custom_field) do
+    project_attributes_page.within_section(select_section) do
+      project_attributes_page.within_attribute(list_project_custom_field) do
         expect(page).to have_text("List field")
-        expect_type("List")
-        expect_unchecked_state
+        project_attributes_page.expect_type("List")
+        project_attributes_page.expect_unchecked_state
       end
     end
   end
 
   it "toggles a project attribute for the current type" do
-    visit edit_type_project_attributes_path(type)
+    project_attributes_page.within_attribute(boolean_project_custom_field) do
+      project_attributes_page.expect_unchecked_state
 
-    within_project_attribute_container(boolean_project_custom_field) do
-      expect_unchecked_state
+      project_attributes_page.toggle(boolean_project_custom_field)
 
-      toggle_type_project_attribute(boolean_project_custom_field)
-
-      expect_checked_state
+      project_attributes_page.expect_checked_state
     end
 
-    visit edit_type_project_attributes_path(type)
+    project_attributes_page.visit!
 
-    within_project_attribute_container(boolean_project_custom_field) do
-      expect_checked_state
+    project_attributes_page.within_attribute(boolean_project_custom_field) do
+      project_attributes_page.expect_checked_state
     end
 
-    visit edit_type_project_attributes_path(other_type)
+    other_type_page = Pages::Types::ProjectAttributes.new(other_type)
+    other_type_page.visit!
 
-    within_project_attribute_container(boolean_project_custom_field) do
-      expect_unchecked_state
+    other_type_page.within_attribute(boolean_project_custom_field) do
+      other_type_page.expect_unchecked_state
     end
   end
 
   it "enables and disables all project attributes of a section" do
-    visit edit_type_project_attributes_path(type)
-
-    within_project_attribute_section_container(input_section) do
+    project_attributes_page.within_section(input_section) do
       page.find_test_selector("enable-all-type-project-attributes-#{input_section.id}").click
 
-      within_project_attribute_container(boolean_project_custom_field) do
-        expect_checked_state
+      project_attributes_page.within_attribute(boolean_project_custom_field) do
+        project_attributes_page.expect_checked_state
       end
 
-      within_project_attribute_container(string_project_custom_field) do
-        expect_checked_state
+      project_attributes_page.within_attribute(string_project_custom_field) do
+        project_attributes_page.expect_checked_state
       end
     end
 
-    within_project_attribute_section_container(select_section) do
-      within_project_attribute_container(list_project_custom_field) do
-        expect_unchecked_state
+    project_attributes_page.within_section(select_section) do
+      project_attributes_page.within_attribute(list_project_custom_field) do
+        project_attributes_page.expect_unchecked_state
       end
     end
 
     expect(type.reload.project_custom_fields).to contain_exactly(boolean_project_custom_field, string_project_custom_field)
 
-    within_project_attribute_section_container(input_section) do
+    project_attributes_page.within_section(input_section) do
       page.find_test_selector("disable-all-type-project-attributes-#{input_section.id}").click
 
-      within_project_attribute_container(boolean_project_custom_field) do
-        expect_unchecked_state
+      project_attributes_page.within_attribute(boolean_project_custom_field) do
+        project_attributes_page.expect_unchecked_state
       end
 
-      within_project_attribute_container(string_project_custom_field) do
-        expect_unchecked_state
+      project_attributes_page.within_attribute(string_project_custom_field) do
+        project_attributes_page.expect_unchecked_state
       end
     end
 
@@ -153,30 +150,26 @@ RSpec.describe "Work package type project attributes", :js do
   end
 
   it "filters the project attributes by name with given user input" do
-    visit edit_type_project_attributes_path(type)
-
     fill_in "border-box-filter", with: "Boolean"
 
-    within_project_attribute_section_container(input_section) do
+    project_attributes_page.within_section(input_section) do
       expect(page).to have_text("Boolean field")
       expect(page).to have_no_text("String field")
     end
 
-    within_project_attribute_section_container(select_section) do
+    project_attributes_page.within_section(select_section) do
       expect(page).to have_no_text("List field")
     end
   end
 
   it "shows sections and project attributes in the configured order" do
-    visit edit_type_project_attributes_path(type)
-
     sections = page.all(".op-project-custom-field-section")
 
     expect(sections.size).to eq(2)
     expect(sections[0].text).to include("Input fields")
     expect(sections[1].text).to include("Select fields")
 
-    within_project_attribute_section_container(input_section) do
+    project_attributes_page.within_section(input_section) do
       custom_fields = page.all(".op-project-custom-field")
 
       expect(custom_fields.size).to eq(2)
@@ -187,7 +180,7 @@ RSpec.describe "Work package type project attributes", :js do
     input_section.move_to_bottom
     boolean_project_custom_field.move_to_bottom
 
-    visit edit_type_project_attributes_path(type)
+    project_attributes_page.visit!
 
     sections = page.all(".op-project-custom-field-section")
 
@@ -195,40 +188,12 @@ RSpec.describe "Work package type project attributes", :js do
     expect(sections[0].text).to include("Select fields")
     expect(sections[1].text).to include("Input fields")
 
-    within_project_attribute_section_container(input_section) do
+    project_attributes_page.within_section(input_section) do
       custom_fields = page.all(".op-project-custom-field")
 
       expect(custom_fields.size).to eq(2)
       expect(custom_fields[0].text).to include("String field")
       expect(custom_fields[1].text).to include("Boolean field")
     end
-  end
-
-  def toggle_type_project_attribute(project_custom_field)
-    page
-      .find("[data-test-selector='toggle-type-project-attribute-#{project_custom_field.id}'] > button")
-      .click
-  end
-
-  def expect_type(type)
-    within "[data-test-selector='custom-field-type']" do
-      expect(page).to have_text(type)
-    end
-  end
-
-  def expect_checked_state
-    expect(page).to have_css(".ToggleSwitch-statusOn")
-  end
-
-  def expect_unchecked_state
-    expect(page).to have_css(".ToggleSwitch-statusOff")
-  end
-
-  def within_project_attribute_section_container(section, &)
-    within("[data-test-selector='type-project-attribute-section-#{section.id}']", &)
-  end
-
-  def within_project_attribute_container(project_custom_field, &)
-    within("[data-test-selector='type-project-attribute-#{project_custom_field.id}']", &)
   end
 end

--- a/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
+++ b/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package project attributes tab", :js do
+  shared_let(:project) { create(:project) }
+  shared_let(:section) { create(:project_custom_field_section, name: "Details") }
+  shared_let(:string_field) do
+    create(:string_project_custom_field,
+           name: "Project info",
+           project_custom_field_section: section,
+           projects: [project]) do |field|
+      create(:custom_value, customized: project, custom_field: field, value: "Initial value")
+    end
+  end
+
+  shared_let(:edit_role) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes edit_project_attributes edit_project])
+  end
+  shared_let(:view_role) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes])
+  end
+
+  let(:work_package) { create(:work_package, project:) }
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+  let(:inplace_field) { Components::Common::InplaceEditField.new(project, string_field.attribute_name.to_sym) }
+  let(:input_field) { FormFields::Primerized::InputField.new(string_field) }
+
+  context "as a user with view and edit permissions" do
+    let(:user) { create(:user, member_with_roles: { project => edit_role }) }
+
+    before do
+      login_as user
+      wp_page.visit_tab! "activity"
+      expect_angular_frontend_initialized
+      wait_for_turbo_frame { click_on I18n.t("js.work_packages.tabs.project_attributes") }
+    end
+
+    it "displays the section and field" do
+      expect(page).to have_test_selector("wp-project-attribute-section-#{section.id}")
+      expect(page).to have_test_selector("wp-project-attribute-#{string_field.id}")
+    end
+
+    it "allows editing a string field" do
+      wait_for_turbo_stream { inplace_field.open_field }
+
+      input_field.fill_in(with: "Updated value")
+      inplace_field.submit
+      inplace_field.expect_close
+
+      within_test_selector("wp-project-attribute-#{string_field.id}") do
+        expect(page).to have_text "Updated value"
+      end
+    end
+  end
+
+  context "as a user with view permission only" do
+    let(:user) { create(:user, member_with_roles: { project => view_role }) }
+
+    before do
+      login_as user
+      wp_page.visit_tab! "activity"
+      expect_angular_frontend_initialized
+      wait_for_turbo_frame { click_on I18n.t("js.work_packages.tabs.project_attributes") }
+    end
+
+    it "displays the field but does not allow editing" do
+      expect(page).to have_test_selector("wp-project-attribute-#{string_field.id}")
+
+      within_test_selector("wp-project-attribute-#{string_field.id}") do
+        expect(page).to have_no_css(".op-inplace-edit--display-field_clickable")
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
+++ b/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
@@ -32,12 +32,14 @@ require "spec_helper"
 
 RSpec.describe "Work package project attributes tab", :js do
   shared_let(:project) { create(:project) }
+  shared_let(:type) { create(:type) }
   shared_let(:section) { create(:project_custom_field_section, name: "Details") }
   shared_let(:string_field) do
     create(:string_project_custom_field,
            name: "Project info",
            project_custom_field_section: section,
            projects: [project]) do |field|
+      type.project_custom_fields << field
       create(:custom_value, customized: project, custom_field: field, value: "Initial value")
     end
   end
@@ -49,7 +51,7 @@ RSpec.describe "Work package project attributes tab", :js do
     create(:project_role, permissions: %i[view_work_packages view_project_attributes])
   end
 
-  let(:work_package) { create(:work_package, project:) }
+  let(:work_package) { create(:work_package, project:, type:) }
   let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:inplace_field) { Components::Common::InplaceEditField.new(project, string_field.attribute_name.to_sym) }
   let(:input_field) { FormFields::Primerized::InputField.new(string_field) }

--- a/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
+++ b/spec/features/work_packages/tabs/project_attributes_tab_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe "Work package project attributes tab", :js do
   shared_let(:edit_role) do
     create(:project_role, permissions: %i[view_work_packages view_project_attributes edit_project_attributes edit_project])
   end
+  shared_let(:edit_project_attributes_only_role) do
+    create(:project_role, permissions: %i[view_work_packages view_project_attributes edit_project_attributes])
+  end
   shared_let(:view_role) do
     create(:project_role, permissions: %i[view_work_packages view_project_attributes])
   end
@@ -69,6 +72,29 @@ RSpec.describe "Work package project attributes tab", :js do
     it "displays the section and field" do
       expect(page).to have_test_selector("wp-project-attribute-section-#{section.id}")
       expect(page).to have_test_selector("wp-project-attribute-#{string_field.id}")
+    end
+
+    it "allows editing a string field" do
+      wait_for_turbo_stream { inplace_field.open_field }
+
+      input_field.fill_in(with: "Updated value")
+      inplace_field.submit
+      inplace_field.expect_close
+
+      within_test_selector("wp-project-attribute-#{string_field.id}") do
+        expect(page).to have_text "Updated value"
+      end
+    end
+  end
+
+  context "as a user with edit_project_attributes but without edit_project" do
+    let(:user) { create(:user, member_with_roles: { project => edit_project_attributes_only_role }) }
+
+    before do
+      login_as user
+      wp_page.visit_tab! "activity"
+      expect_angular_frontend_initialized
+      wait_for_turbo_frame { click_on I18n.t("js.work_packages.tabs.project_attributes") }
     end
 
     it "allows editing a string field" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -203,6 +203,29 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
       end
     end
 
+    describe "hasProjectAttributes" do
+      context "when the project has no visible custom fields" do
+        before do
+          allow(workspace).to receive(:available_custom_fields).and_return([])
+        end
+
+        it "renders as false" do
+          expect(subject).to be_json_eql(false.to_json).at_path("hasProjectAttributes")
+        end
+      end
+
+      context "when the project has visible custom fields" do
+        before do
+          allow(workspace).to receive(:available_custom_fields)
+            .and_return(instance_double(Array, any?: true, reject: []))
+        end
+
+        it "renders as true" do
+          expect(subject).to be_json_eql(true.to_json).at_path("hasProjectAttributes")
+        end
+      end
+    end
+
     describe "startDate" do
       it_behaves_like "has ISO 8601 date only" do
         let(:date) { start_date }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -204,21 +204,22 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
     end
 
     describe "hasProjectAttributes" do
-      context "when the project has no visible custom fields" do
-        before do
-          allow(workspace).to receive(:available_custom_fields).and_return([])
-        end
+      let(:type_fields_exist) { false }
 
+      before do
+        fields = instance_double(ActiveRecord::Relation, any?: type_fields_exist)
+        allow(fields).to receive_messages(reject: [], joins: fields, where: fields)
+        allow(workspace).to receive(:available_custom_fields).and_return(fields)
+      end
+
+      context "when no custom fields are mapped to the type" do
         it "renders as false" do
           expect(subject).to be_json_eql(false.to_json).at_path("hasProjectAttributes")
         end
       end
 
-      context "when the project has visible custom fields" do
-        before do
-          allow(workspace).to receive(:available_custom_fields)
-            .and_return(instance_double(Array, any?: true, reject: []))
-        end
+      context "when custom fields are mapped to the type" do
+        let(:type_fields_exist) { true }
 
         it "renders as true" do
           expect(subject).to be_json_eql(true.to_json).at_path("hasProjectAttributes")

--- a/spec/models/project_custom_field_type_mapping_spec.rb
+++ b/spec/models/project_custom_field_type_mapping_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe ProjectCustomFieldTypeMapping do
+  describe "uniqueness by type" do
+    let(:type) { create(:type) }
+    let(:project_custom_field) { create(:project_custom_field) }
+
+    it "maps a project custom field to a type only once" do
+      type.project_custom_fields << project_custom_field
+
+      expect(described_class).to exist(custom_field_id: project_custom_field.id,
+                                       type_id: type.id)
+
+      expect do
+        type.project_custom_fields << project_custom_field
+      end.to raise_error(ActiveRecord::RecordInvalid, /Custom field has already been taken/)
+    end
+  end
+end

--- a/spec/services/project_custom_field_type_mappings/bulk_update_service_spec.rb
+++ b/spec/services/project_custom_field_type_mappings/bulk_update_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ProjectCustomFieldTypeMappings::BulkUpdateService do
       result = instance.call(action: :unsupported)
 
       expect(result).to be_failure
-      expect(result.errors).to eq("Unsupported bulk update action: :unsupported")
+      expect(result.errors).to eq("Unsupported bulk update action: unsupported")
       expect(type.reload.project_custom_fields).to be_empty
     end
   end

--- a/spec/services/project_custom_field_type_mappings/bulk_update_service_spec.rb
+++ b/spec/services/project_custom_field_type_mappings/bulk_update_service_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe ProjectCustomFieldTypeMappings::BulkUpdateService do
 
       expect(type.reload.project_custom_fields).to contain_exactly(other_project_custom_field)
     end
+
+    it "fails for an unsupported action" do
+      result = instance.call(action: :unsupported)
+
+      expect(result).to be_failure
+      expect(result.errors).to eq("Unsupported bulk update action: :unsupported")
+      expect(type.reload.project_custom_fields).to be_empty
+    end
   end
 
   context "without admin permissions" do

--- a/spec/services/project_custom_field_type_mappings/bulk_update_service_spec.rb
+++ b/spec/services/project_custom_field_type_mappings/bulk_update_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe ProjectCustomFieldTypeMappings::BulkUpdateService do
+  let(:type) { create(:type) }
+  let(:project_custom_field_section) { create(:project_custom_field_section) }
+  let(:other_section) { create(:project_custom_field_section) }
+
+  let!(:project_custom_field) do
+    create(:project_custom_field,
+           name: "First field",
+           project_custom_field_section:)
+  end
+
+  let!(:other_project_custom_field) do
+    create(:project_custom_field,
+           name: "Other field",
+           project_custom_field_section: other_section)
+  end
+
+  let(:instance) { described_class.new(user:, type:, project_custom_field_section:) }
+
+  context "with admin permissions" do
+    let(:user) { create(:admin) }
+
+    it "bulk enables and disables all project attributes of the section" do
+      expect(instance.call(action: :enable)).to be_success
+
+      expect(type.reload.project_custom_fields).to contain_exactly(project_custom_field)
+
+      type.project_custom_fields << other_project_custom_field
+
+      expect(instance.call(action: :disable)).to be_success
+
+      expect(type.reload.project_custom_fields).to contain_exactly(other_project_custom_field)
+    end
+  end
+
+  context "without admin permissions" do
+    let(:user) { create(:user) }
+
+    it "does not bulk enable project attributes" do
+      expect(instance.call(action: :enable)).to be_failure
+
+      expect(type.reload.project_custom_fields).to be_empty
+    end
+  end
+end

--- a/spec/services/project_custom_field_type_mappings/toggle_service_spec.rb
+++ b/spec/services/project_custom_field_type_mappings/toggle_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe ProjectCustomFieldTypeMappings::ToggleService do
+  let(:type) { create(:type) }
+  let(:project_custom_field) { create(:project_custom_field) }
+  let(:instance) { described_class.new(user:) }
+
+  let(:params) do
+    {
+      type_id: type.id,
+      custom_field_id: project_custom_field.id
+    }
+  end
+
+  context "with admin permissions" do
+    let(:user) { create(:admin) }
+
+    it "toggles a project custom field for the type" do
+      expect(type.project_custom_fields).to be_empty
+
+      2.times do
+        expect(instance.call(**params, value: "1")).to be_success
+
+        expect(type.reload.project_custom_fields).to contain_exactly(project_custom_field)
+      end
+
+      2.times do
+        expect(instance.call(**params, value: "0")).to be_success
+
+        expect(type.reload.project_custom_fields).to be_empty
+      end
+    end
+  end
+
+  context "without admin permissions" do
+    let(:user) { create(:user) }
+
+    it "does not toggle project custom fields for the type" do
+      expect(instance.call(**params, value: "1")).to be_failure
+
+      expect(type.reload.project_custom_fields).to be_empty
+    end
+  end
+end

--- a/spec/services/project_custom_field_type_mappings/toggle_service_spec.rb
+++ b/spec/services/project_custom_field_type_mappings/toggle_service_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe ProjectCustomFieldTypeMappings::ToggleService do
         expect(type.reload.project_custom_fields).to be_empty
       end
     end
+
+    it "does not map a work package custom field to the type" do
+      work_package_custom_field = create(:wp_custom_field)
+
+      result = instance.call(
+        type_id: type.id,
+        custom_field_id: work_package_custom_field.id,
+        value: "1"
+      )
+
+      expect(result).to be_failure
+      expect(ProjectCustomFieldTypeMapping).not_to exist(
+        type_id: type.id,
+        custom_field_id: work_package_custom_field.id
+      )
+    end
   end
 
   context "without admin permissions" do

--- a/spec/support/pages/types/project_attributes.rb
+++ b/spec/support/pages/types/project_attributes.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module Types
+    class ProjectAttributes < ::Pages::Page
+      def initialize(type)
+        super()
+
+        @type = type
+      end
+
+      def path
+        edit_type_project_attributes_path(@type)
+      end
+
+      def toggle(project_custom_field)
+        page
+          .find("[data-test-selector='toggle-type-project-attribute-#{project_custom_field.id}'] > button")
+          .click
+      end
+
+      def expect_type(type)
+        within "[data-test-selector='custom-field-type']" do
+          expect(page).to have_text(type)
+        end
+      end
+
+      def expect_checked_state
+        expect(page).to have_css(".ToggleSwitch-statusOn")
+      end
+
+      def expect_unchecked_state
+        expect(page).to have_css(".ToggleSwitch-statusOff")
+      end
+
+      def within_section(section, &)
+        within("[data-test-selector='type-project-attribute-section-#{section.id}']", &)
+      end
+
+      def within_attribute(project_custom_field, &)
+        within("[data-test-selector='type-project-attribute-#{project_custom_field.id}']", &)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-719

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add configuration for Project attributes on work package types.
This introduces a new `Project attributes` tab under: `Administration > Work packages > Types > :type`

The tab shows the globally configured project attribute sections and attributes in the same order as `Administration > Projects > Project attributes`. For each work package type, admins can decide which project attributes should be shown for work packages of that type.
Initially, no project attributes are enabled for a type. Attributes can be enabled individually with a toggle, or in bulk per section with `Enable all` / `Disable all`.


## Screenshots
<img width="1222" height="918" alt="Screenshot 2026-06-16 at 16 19 23" src="https://github.com/user-attachments/assets/94004c68-fa58-4c0b-a82b-049717c5bc2d" />

# What approach did you choose and why?
The type-project-attributes is stored in a join table between work package types and project custom fields: `project_custom_field_type_mappings`
The UI follows the existing Project settings > Project attributes

# Merge checklist

- [X] Added/updated tests