### PR TITLE
Replace bare URLs in formatted text

### DIFF
--- a/lib/open_project/text_formatting/filters/link_replacement_filter.rb
+++ b/lib/open_project/text_formatting/filters/link_replacement_filter.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::TextFormatting
+  module Filters
+    ##
+    # A filter that replaces links with a rich representation. It's supposed to only replace bare links that would expose the
+    # full URL in the formatted text. Deliberately named links will not be replaced.
+    class LinkReplacementFilter < HTML::Pipeline::Filter
+      class << self
+        # Register a handler class to deal with URL replacements. A new handler will be instantiated per document. Instances are
+        # expected to implement `match?` method, accepting a URI and deciding whether it will be replaced and
+        # a `html_for` method, accepting a URI and returning the HTML it should be replaced with.
+        # If `html_for` returns `nil` after a match occured, no replacement will happen,
+        # but no other handler will be tried as well.
+        def register_handler(handler)
+          handlers << handler
+        end
+
+        def handlers
+          @handlers ||= []
+        end
+      end
+
+      def call
+        links.each do |node|
+          next unless plain_link?(node)
+
+          url = parse_url(node["href"])
+          next unless url
+
+          handler = handlers.find { |h| h.match?(url) }
+          next unless handler
+
+          replacement = handler.html_for(url)
+          node.replace(replacement) if replacement
+        end
+
+        doc
+      end
+
+      private
+
+      def links
+        doc.css("a")
+      end
+
+      def parse_url(string)
+        URI.parse(string)
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def handlers
+        @handlers ||= self.class.handlers.map(&:new)
+      end
+
+      def plain_link?(node)
+        node.text == node["href"]
+      end
+    end
+  end
+end

--- a/lib/open_project/text_formatting/formats/markdown/formatter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/formatter.rb
@@ -44,6 +44,7 @@ module OpenProject::TextFormatting::Formats::Markdown
       OpenProject::TextFormatting::Filters::AttachmentFilter,
       OpenProject::TextFormatting::Filters::AutolinkFilter,
       OpenProject::TextFormatting::Filters::AutolinkCustomProtocolsFilter,
+      OpenProject::TextFormatting::Filters::LinkReplacementFilter,
       OpenProject::TextFormatting::Filters::RelativeLinkFilter,
       OpenProject::TextFormatting::Filters::LinkAttributeFilter,
       OpenProject::TextFormatting::Filters::ExternalLinkCaptureFilter,

--- a/modules/wikis/app/services/wikis/text_formatting/wiki_url_handler.rb
+++ b/modules/wikis/app/services/wikis/text_formatting/wiki_url_handler.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  module TextFormatting
+    class WikiUrlHandler
+      include Dry::Monads[:result]
+
+      def match?(uri)
+        page_info_for_url(uri).present?
+      end
+
+      def html_for(uri)
+        page_info = page_info_for_url(uri)
+        return nil if page_info.nil?
+
+        # We only render successful macro components, in case of a failure we fallback to leaving the link as it was originally
+        # pasted into the document.
+        InlinePageLinkMacroComponent.new(Success(page_info)).render_in(view_context)
+      end
+
+      private
+
+      def providers
+        @providers ||= Provider.visible.enabled.to_a
+      end
+
+      def page_info_for_url(uri)
+        return nil unless scheme_valid?(uri)
+        return cached_page_infos[uri] if cached_page_infos.key?(uri)
+
+        Adapters::Input::PageInfoForUrl.build(url: uri.to_s).bind do |input_data|
+          providers.each do |provider|
+            provider_page_info_for_url(input_data:, provider:) do |page_info|
+              cached_page_infos[uri] = page_info
+              return page_info
+            end
+          end
+        end
+
+        cached_page_infos[uri] = nil
+        nil
+      end
+
+      def provider_page_info_for_url(input_data:, provider:, &)
+        provider.auth_strategy_for(user).bind do |auth_strategy|
+          provider.resolve("queries.page_info_for_url").call(input_data:, auth_strategy:).bind(&)
+        end
+      end
+
+      # The expected lifecycle of the handler is the parsing of a single document. Using the cache prevents
+      # double requests for calls between #match? and #html_for, as well as when a link appears twice in the same document.
+      def cached_page_infos
+        @cached_page_infos ||= {}
+      end
+
+      def user = User.current
+
+      def scheme_valid?(uri) = %w[http https].include?(uri.scheme)
+
+      def view_context
+        @view_context ||= ApplicationController.new.view_context
+      end
+    end
+  end
+end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -60,6 +60,7 @@ module OpenProject::Wikis
       )
 
       OpenProject::TextFormatting::Filters::PatternMatcherFilter.append_matcher ::Wikis::TextFormatting::WikiLinkMatcher
+      OpenProject::TextFormatting::Filters::LinkReplacementFilter.register_handler ::Wikis::TextFormatting::WikiUrlHandler
 
       # Registering queries and filters
       ::Queries::Register.register(::Queries::Wikis::PageLinks::PageLinkQuery) do

--- a/modules/wikis/spec/services/wikis/text_formatting/wiki_url_handler_spec.rb
+++ b/modules/wikis/spec/services/wikis/text_formatting/wiki_url_handler_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Wikis::TextFormatting::WikiUrlHandler do
+  let(:handler) { described_class.new }
+  let(:url) { URI.parse("https://example.com") }
+
+  let(:provider) { create(:internal_wiki_provider) }
+  let(:auth_strategy) { instance_double(Wikis::Adapters::Providers::Internal::Authentication::UserBound, call: nil) }
+  let(:query) { instance_double(Wikis::Adapters::BaseQuery, call: query_result) }
+  let(:query_result) { Success(page_info) }
+  let(:page_info) { Wikis::Adapters::Results::PageInfo.new(identifier: "abc", provider:, title: "A page", href: url.to_s) }
+
+  before do
+    provider
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Wikis::Provider).to receive(:auth_strategy_for).and_return(Success(auth_strategy))
+    allow_any_instance_of(Wikis::Provider).to receive(:resolve).with("queries.page_info_for_url").and_return(query)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe "#match?" do
+    subject { handler.match?(url) }
+
+    it { is_expected.to be_truthy }
+
+    it "passes the URL to the query" do
+      subject
+      expect(query).to have_received(:call).with(input_data: having_attributes(url: url.to_s), auth_strategy:)
+    end
+
+    context "when the provider finds no page" do
+      let(:query_result) { Failure(Wikis::Adapters::Results::Error.new(code: :not_found, source: self)) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the provider returns an unexpected error" do
+      let(:query_result) { Failure(Wikis::Adapters::Results::Error.new(code: :banana, source: self)) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when a matching provider is disabled" do
+      let(:provider) { create(:internal_wiki_provider, enabled: false) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when a non-https URL is passed" do
+      let(:url) { URI.parse("data:,Hello%2C%20World%21") }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when asking for two different URLs" do
+      let(:second_url) { URI.parse("https://other.example.com") }
+
+      it "calls the provider query twice" do
+        subject
+        handler.match?(second_url)
+
+        expect(query).to have_received(:call).twice
+        expect(query).to have_received(:call).with(input_data: having_attributes(url: url.to_s), auth_strategy:)
+        expect(query).to have_received(:call).with(input_data: having_attributes(url: second_url.to_s), auth_strategy:)
+      end
+    end
+
+    context "when asking for the same URL twice" do
+      it "calls the provider query once" do
+        subject
+        handler.match?(url)
+
+        expect(query).to have_received(:call).once
+      end
+    end
+  end
+
+  describe "#html_for" do
+    subject { handler.html_for(url) }
+
+    it "returns a formatted link to the URL" do
+      component = Capybara.string(subject)
+      expect(component).to have_css(".op-inline-macro")
+      expect(component).to have_css(%{a[href="#{url}"]})
+    end
+
+    context "when the provider finds no page" do
+      let(:query_result) { Failure(Wikis::Adapters::Results::Error.new(code: :not_found, source: self)) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the provider returns an unexpected error" do
+      let(:query_result) { Failure(Wikis::Adapters::Results::Error.new(code: :banana, source: self)) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when a matching provider is disabled" do
+      let(:provider) { create(:internal_wiki_provider, enabled: false) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when a non-https URL is passed" do
+      let(:url) { URI.parse("data:,Hello%2C%20World%21") }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when asking for two different URLs" do
+      let(:second_url) { URI.parse("https://other.example.com") }
+
+      it "calls the provider query twice" do
+        subject
+        handler.html_for(second_url)
+
+        expect(query).to have_received(:call).twice
+        expect(query).to have_received(:call).with(input_data: having_attributes(url: url.to_s), auth_strategy:)
+        expect(query).to have_received(:call).with(input_data: having_attributes(url: second_url.to_s), auth_strategy:)
+      end
+    end
+
+    context "when asking for the same URL twice" do
+      it "calls the provider query once" do
+        subject
+        handler.html_for(url)
+
+        expect(query).to have_received(:call).once
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/text_formatting/filters/link_replacement_filter_spec.rb
+++ b/spec/lib/open_project/text_formatting/filters/link_replacement_filter_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# rubocop:disable RSpec/VerifiedDoubles
+RSpec.describe OpenProject::TextFormatting::Filters::LinkReplacementFilter do
+  let(:filter) { described_class.new(html, context) }
+  let(:context) { {} }
+  let(:html) do
+    '<a href="https://example.com">https://example.com</a> and ' \
+      '<a href="https://example.com/foo">https://example.com/foo</a> are great websites.'
+  end
+  let(:handlers) { [double(new: handler), double(new: second_handler)] }
+  let(:handler) do
+    double("URL handler", match?: true).tap do |h|
+      allow(h).to receive(:html_for) { |uri| %{<a class="fancy" href="#{uri}">a fancy link</a>} }
+    end
+  end
+  let(:second_handler) { double("URL handler", match?: false) }
+
+  before do
+    allow(described_class).to receive(:handlers).and_return(handlers)
+  end
+
+  describe "#call" do
+    subject(:result) { filter.call }
+
+    it "replaces links according to handler" do
+      expect(result.to_html).to eq(
+        '<a class="fancy" href="https://example.com">a fancy link</a> and ' \
+        '<a class="fancy" href="https://example.com/foo">a fancy link</a> are great websites.'
+      )
+    end
+
+    it "calls the handler with all links found in the document" do
+      subject
+
+      expect(handler).to have_received(:match?).twice
+      expect(handler).to have_received(:match?).with(URI.parse("https://example.com"))
+      expect(handler).to have_received(:match?).with(URI.parse("https://example.com/foo"))
+
+      expect(handler).to have_received(:html_for).twice
+      expect(handler).to have_received(:html_for).with(URI.parse("https://example.com"))
+      expect(handler).to have_received(:html_for).with(URI.parse("https://example.com/foo"))
+    end
+
+    it "does not look for other handlers" do
+      subject
+
+      expect(second_handler).not_to have_received(:match?)
+    end
+
+    context "when handler does not match a link" do
+      before do
+        allow(handler).to receive(:match?).and_return(false)
+      end
+
+      it "does not replace the link" do
+        expect(result.to_html).to eq(html)
+      end
+
+      it "looks for other handlers" do
+        subject
+
+        expect(second_handler).to have_received(:match?).twice
+      end
+    end
+
+    context "when a link has a custom text" do
+      let(:html) do
+        'The documentation can be found <a href="https://example.com">here</a>.'
+      end
+
+      it "does not replace the link" do
+        expect(result.to_html).to eq(html)
+      end
+
+      it "does not call the handler about it" do
+        subject
+
+        expect(handler).not_to have_received(:match?)
+        expect(handler).not_to have_received(:html_for)
+      end
+    end
+
+    context "when multiple handlers match a link" do
+      before do
+        allow(second_handler).to receive_messages(match?: true, html_for: "link stolen")
+      end
+
+      it "replaces using the first handler" do
+        expect(result.to_html).to eq(
+          '<a class="fancy" href="https://example.com">a fancy link</a> and ' \
+          '<a class="fancy" href="https://example.com/foo">a fancy link</a> are great websites.'
+        )
+      end
+
+      it "does not look for other handlers" do
+        subject
+
+        expect(second_handler).not_to have_received(:match?)
+      end
+    end
+
+    context "when a matching handler returns no replacement" do
+      before do
+        allow(handler).to receive(:html_for).and_return(nil)
+      end
+
+      it "does not replace the link" do
+        expect(result.to_html).to eq(html)
+      end
+
+      it "does not look for other handlers" do
+        subject
+
+        expect(second_handler).not_to have_received(:match?)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/VerifiedDoubles


### PR DESCRIPTION
For now intended to replace links to wiki pages with their corresponding macro, this could also be used to replace links to work packages or other OpenProject resources with a nicer representation.

# Ticket
https://community.openproject.org/wp/XWI-38