### PR TITLE
Consolidate Dependabot npm config and group hocuspocus deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,12 +23,12 @@ updates:
         patterns:
           - 'angular-eslint'
           - '@angular-eslint/*'
+      appsignal:
+        patterns:
+          - '@appsignal/*'
       blocknote:
         patterns:
           - '@blocknote/*'
-      fullcalendar:
-        patterns:
-          - '@fullcalendar/*'
       eslint:
         patterns:
           - 'eslint'
@@ -36,9 +36,9 @@ updates:
           - '@eslint/*'
           - '@stylistic/eslint-plugin'
           - 'globals'
-      html-eslint:
+      fullcalendar:
         patterns:
-          - '@html-eslint/*'
+          - '@fullcalendar/*'
       hocuspocus:
         patterns:
           - '@hocuspocus/*'
@@ -46,6 +46,9 @@ updates:
         patterns:
           - '@hotwired/turbo'
           - '@hotwired/turbo-rails'
+      html-eslint:
+        patterns:
+          - '@html-eslint/*'
       jquery:
         patterns:
           - 'jquery'
@@ -56,9 +59,6 @@ updates:
       ng-select:
         patterns:
           - '@ng-select/*'
-      appsignal:
-        patterns:
-          - '@appsignal/*'
       react:
         patterns:
           - 'react'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directories:
+      - "/"
+      - "/frontend"
+      - "/extensions/op-blocknote-hocuspocus"
     schedule:
       interval: "daily"
     target-branch: "dev"
@@ -88,6 +91,7 @@ updates:
       - dependency-name: "@openproject/primer-view-components"
       - dependency-name: "@primer/primitives"
       - dependency-name: "@primer/css"
+
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -106,27 +110,7 @@ updates:
       - dependency-name: "openproject-octicons"
       - dependency-name: "openproject-octicons_helper"
       - dependency-name: "openproject-primer_view_components"
-  - package-ecosystem: "npm"
-    directory: "/extensions/op-blocknote-hocuspocus"
-    schedule:
-      interval: "weekly"
-    target-branch: "dev"
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 5
-    commit-message:
-      prefix: "deps(hocuspocus)"
-    labels:
-      - "dependencies"
-    groups:
-      npm-minor-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
       html-eslint:
         patterns:
           - '@html-eslint/*'
+      hocuspocus:
+        patterns:
+          - '@hocuspocus/*'
       hotwired:
         patterns:
           - '@hotwired/turbo'


### PR DESCRIPTION
# Ticket
Related: #23755

# What are you trying to accomplish?
Tidies the Dependabot npm configuration. The standalone `op-blocknote-hocuspocus` entry is folded into the main npm entry's `directories` list, a new `hocuspocus` group keeps `@hocuspocus/server` and `@hocuspocus/extension-logger` bumping together, and the group definitions are sorted alphabetically.

Client (`@hocuspocus/provider`, frontend) and server (extension) still land in separate PRs — Dependabot cannot lockstep differently-named packages across directories (`group-by: dependency-name` only merges the *same* dependency name). _The CI version-skew guard in #23755 is what actually keeps client/server compatible._

References: 
- GitHub blog: [Dependabot can group updates by dependency name across multiple directories](https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/)
- https://github.com/dependabot/dependabot-core/issues/13284

# What approach did you choose and why?

Grouping was chosen over `group-by` after confirming `group-by: dependency-name` does not apply here. The group still earns its place by coupling the server packages within the extension directory's PR.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)