### PR TITLE
Pin shared Yjs stack across client and server for lockstep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,12 +23,12 @@ updates:
         patterns:
           - 'angular-eslint'
           - '@angular-eslint/*'
+      appsignal:
+        patterns:
+          - '@appsignal/*'
       blocknote:
         patterns:
           - '@blocknote/*'
-      fullcalendar:
-        patterns:
-          - '@fullcalendar/*'
       eslint:
         patterns:
           - 'eslint'
@@ -36,9 +36,9 @@ updates:
           - '@eslint/*'
           - '@stylistic/eslint-plugin'
           - 'globals'
-      html-eslint:
+      fullcalendar:
         patterns:
-          - '@html-eslint/*'
+          - '@fullcalendar/*'
       hocuspocus:
         patterns:
           - '@hocuspocus/*'
@@ -46,6 +46,9 @@ updates:
         patterns:
           - '@hotwired/turbo'
           - '@hotwired/turbo-rails'
+      html-eslint:
+        patterns:
+          - '@html-eslint/*'
       jquery:
         patterns:
           - 'jquery'
@@ -56,9 +59,6 @@ updates:
       ng-select:
         patterns:
           - '@ng-select/*'
-      appsignal:
-        patterns:
-          - '@appsignal/*'
       react:
         patterns:
           - 'react'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,16 @@ updates:
         patterns:
           - 'vitest'
           - '@vitest/*'
+      yjs:
+        # Keep the shared Yjs CRDT/sync layer aligned between the
+        # collab client (/frontend) and server (the extension). These
+        # are pinned as direct deps in both manifests so Dependabot
+        # tracks them; group-by: dependency-name merges each into a
+        # single cross-directory PR rather than one PR per directory.
+        group-by: dependency-name
+        patterns:
+          - 'yjs'
+          - 'y-protocols'
     ignore:
       - dependency-name: "@angular/*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directories:
+      - "/"
+      - "/frontend"
+      - "/extensions/op-blocknote-hocuspocus"
     schedule:
       interval: "daily"
     target-branch: "dev"
@@ -88,6 +91,7 @@ updates:
       - dependency-name: "@openproject/primer-view-components"
       - dependency-name: "@primer/primitives"
       - dependency-name: "@primer/css"
+
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -106,27 +110,7 @@ updates:
       - dependency-name: "openproject-octicons"
       - dependency-name: "openproject-octicons_helper"
       - dependency-name: "openproject-primer_view_components"
-  - package-ecosystem: "npm"
-    directory: "/extensions/op-blocknote-hocuspocus"
-    schedule:
-      interval: "weekly"
-    target-branch: "dev"
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 5
-    commit-message:
-      prefix: "deps(hocuspocus)"
-    labels:
-      - "dependencies"
-    groups:
-      npm-minor-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
       html-eslint:
         patterns:
           - '@html-eslint/*'
+      hocuspocus:
+        patterns:
+          - '@hocuspocus/*'
       hotwired:
         patterns:
           - '@hotwired/turbo'

--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -13,7 +13,9 @@
         "@hocuspocus/extension-logger": "^3.4.4",
         "@hocuspocus/server": "^3.4.0",
         "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.27"
       },
       "devDependencies": {
         "@blocknote/core": "^0.51.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -27,7 +27,9 @@
     "@hocuspocus/extension-logger": "^3.4.4",
     "@hocuspocus/server": "^3.4.0",
     "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.27"
   },
   "devDependencies": {
     "@blocknote/core": "^0.51.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -124,7 +124,9 @@
         "turbo_power": "^0.7.1",
         "typedjson": "^1.5.1",
         "urijs": "^1.19.11",
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.0",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.27"
       },
       "devDependencies": {
         "@angular-builders/custom-esbuild": "^22.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -170,7 +170,9 @@
     "turbo_power": "^0.7.1",
     "typedjson": "^1.5.1",
     "urijs": "^1.19.11",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.27"
   },
   "optionalDependencies": {
     "fsevents": "*"


### PR DESCRIPTION
> [!NOTE]
> This PR is based off #23782

# Ticket

Stacked on #23782 · Related: #23755

# What are you trying to accomplish?
Follow-up to #23782. Keeps the shared **Yjs** layer (`yjs` + `y-protocols`) aligned between the collaboration client (`/frontend`) and server (`/extensions/op-blocknote-hocuspocus`), which is the layer both artifacts actually serialize to each other.

Both reach `yjs`/`y-protocols` transitively via BlockNote — not via the `@hocuspocus/*` packages, which only share `lib0`/`@hocuspocus/common` (and `common` is locked to the hocuspocus major, so it can't be pinned independently). The packages are declared as direct deps in both manifests so Dependabot tracks them, and a new `yjs` group uses `group-by: dependency-name` to merge each into a **single cross-directory PR** instead of one per directory.

# What approach did you choose and why?
`group-by: dependency-name` only merges a dependency of the *same name* across directories — which is exactly the case here once `yjs`/`y-protocols` are direct deps in both manifests. This is distinct from #23782's `@hocuspocus/*` grouping, which can't span directories (different names).

Caveats reviewers should weigh:
- This aligns the Yjs stack, not the `@hocuspocus/*` packages themselves — those still bump in separate PRs.
- These are effectively pinned direct deps we don't import directly; ranges are kept compatible with what BlockNote requires (resolution is unchanged — the lockfile updates only record them as direct).
- npm support for `group-by` is still beta and has been reported to fall back to per-directory PRs; the runtime version-skew guard in #23755 remains the real compatibility safety net.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)