### PR TITLE
Chore: Make the flaky-spec Copilot prompt request a standalone PR off dev

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -105,9 +105,10 @@ jobs:
               printf '<details>\n<summary>🤖 Ask Copilot to investigate</summary>\n\n'
               printf 'Copy the prompt below into a new comment on this PR to delegate the investigation to GitHub Copilot. It will look into the flakiness and open a separate pull request with you as reviewer.\n\n'
               printf '```\n'
-              printf '@copilot The following spec(s) were detected as flaky on PR #%s:\n\n' "$PR_NUMBER"
+              printf '@copilot The following spec(s) are flaky in CI (first seen on PR #%s, linked for reference only):\n\n' "$PR_NUMBER"
               printf '%s\n\n' "$specs"
-              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to investigate the root cause and apply a fix. Open a separate pull request with the change and request a review from @%s.\n' "$PR_AUTHOR"
+              printf 'Treat this as a standalone task, unrelated to PR #%s. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #%s or reuse that branch.\n\n' "$PR_NUMBER" "$PR_NUMBER"
+              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the flakiness. Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause and how the change resolves it. Request a review from @%s.\n' "$PR_AUTHOR"
               printf '```\n\n'
               printf '</details>\n'
             } > tmp/flaky_comment.md


### PR DESCRIPTION
When the flaky-spec reporter's `@copilot` prompt said "open a separate pull request", Copilot read "separate" as a follow-up stacked on the triggering PR ([example](https://github.com/opf/openproject/pull/23784)): it echoed that PR's title, based its branch on it, and framed the work as merging back into it. That coupling also meant the agent session died once the triggering PR merged, since its base ref disappeared. The prompt now states the task is standalone, unrelated to the triggering PR, to branch from `origin/dev` and target `dev`, to title the PR after the spec(s) it fixes, and to use the PR description for the root cause and the fix. The triggering PR number stays only as a backlink for traceability.

No work package — follow-up to the flaky-spec Copilot delegation merged in #23773.

### Preview

How the posted comment renders — expand for the refined prompt:

***

> [!WARNING]
> Flaky specs

- `rspec ./spec/features/projects/create_spec.rb[1:12:3:2:1]`
- `rspec ./spec/features/work_packages/table/switch_types_spec.rb[1:1:2]`

<details>
<summary>🤖 Ask Copilot to investigate</summary>

Copy the prompt below into a new comment on this PR to delegate the investigation to GitHub Copilot. It will look into the flakiness and open a separate pull request with you as reviewer.

```
@copilot The following spec(s) are flaky in CI (first seen on PR #23755, linked for reference only):

- `rspec ./spec/features/projects/create_spec.rb[1:12:3:2:1]`
- `rspec ./spec/features/work_packages/table/switch_types_spec.rb[1:1:2]`

Treat this as a standalone task, unrelated to PR #23755. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #23755 or reuse that branch.

Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the flakiness. Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause and how the change resolves it. Request a review from @akabiru.
```

</details>

***