### PR TITLE
Feature/AGILE-235 filtering by backlog bucket in work package list

### DIFF
--- a/lib/api/v3/queries/schemas/backlog_bucket_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/backlog_bucket_filter_dependency_representer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Queries
+      module Schemas
+        class BacklogBucketFilterDependencyRepresenter < FilterDependencyRepresenter
+          def json_cache_key
+            super + [filter.project&.id].compact
+          end
+
+          def href_callback
+            query_params = "sortBy=#{to_query [%i(name asc)]}&pageSize=-1"
+
+            if filter.project.nil?
+              "#{api_v3_paths.backlog_buckets}?#{query_params}"
+            else
+              "#{api_v3_paths.project_backlog_buckets(filter.project.id)}?#{query_params}"
+            end
+          end
+
+          private
+
+          def type
+            "[]BacklogBucket"
+          end
+
+          def to_query(param)
+            CGI.escape(::JSON.dump(param))
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/app/models/queries/work_packages/filter/backlog_bucket_filter.rb
+++ b/modules/backlogs/app/models/queries/work_packages/filter/backlog_bucket_filter.rb
@@ -46,10 +46,6 @@ module Queries::WorkPackages::Filter
       :backlog_bucket_id
     end
 
-    def human_name
-      WorkPackage.human_attribute_name(:backlog_bucket)
-    end
-
     def ar_object_filter?
       true
     end

--- a/modules/backlogs/app/models/queries/work_packages/filter/backlog_bucket_filter.rb
+++ b/modules/backlogs/app/models/queries/work_packages/filter/backlog_bucket_filter.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Queries::WorkPackages::Filter
+  class BacklogBucketFilter < ::Queries::WorkPackages::Filter::WorkPackageFilter
+    def allowed_values
+      @allowed_values ||= backlog_buckets.pluck(:id).map { |id| [id.to_s] * 2 }
+    end
+
+    def available?
+      allowed?
+    end
+
+    def type
+      :list_optional
+    end
+
+    def self.key
+      :backlog_bucket_id
+    end
+
+    def human_name
+      WorkPackage.human_attribute_name(:backlog_bucket)
+    end
+
+    def ar_object_filter?
+      true
+    end
+
+    def value_objects
+      available_buckets = backlog_buckets.index_by(&:id)
+
+      values.filter_map { |id| available_buckets[id.to_i] }
+    end
+
+    private
+
+    def allowed?
+      if project.present?
+        User.current.allowed_in_project?(:view_sprints, project)
+      else
+        User.current.allowed_in_any_project?(:view_sprints)
+      end
+    end
+
+    def backlog_buckets
+      @backlog_buckets ||= begin
+        scope = BacklogBucket.visible
+        project ? scope.where(project:) : scope
+      end
+    end
+  end
+end

--- a/modules/backlogs/app/models/queries/work_packages/filter/sprint_filter.rb
+++ b/modules/backlogs/app/models/queries/work_packages/filter/sprint_filter.rb
@@ -46,10 +46,6 @@ module Queries::WorkPackages::Filter
       :sprint_id
     end
 
-    def human_name
-      WorkPackage.human_attribute_name(:sprint)
-    end
-
     def ar_object_filter?
       true
     end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -244,6 +244,7 @@ module OpenProject::Backlogs
       ::Type.add_default_mapping(:details, :backlog_bucket)
 
       ::Queries::Register.register(::Query) do
+        filter Queries::WorkPackages::Filter::BacklogBucketFilter
         filter Queries::WorkPackages::Filter::SprintFilter
 
         select OpenProject::Backlogs::QueryBacklogsSelect

--- a/modules/backlogs/spec/features/work_packages/filter_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/filter_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe "Filter work packages by backlog filters", :js do
   shared_let(:work_package_in_own_sprint) { create(:work_package, type: task_type, project:, sprint: own_sprint) }
   shared_let(:work_package_in_shared_sprint) { create(:work_package, type: task_type, project:, sprint: shared_sprint) }
 
+  shared_let(:bucket_a) { create(:backlog_bucket, project:) }
+  shared_let(:bucket_b) { create(:backlog_bucket, project:) }
+  shared_let(:work_package_in_bucket_a) { create(:work_package, type: task_type, project:, backlog_bucket: bucket_a) }
+  shared_let(:work_package_in_bucket_b) { create(:work_package, type: task_type, project:, backlog_bucket: bucket_b) }
+
   let(:user) do
     create(:user,
            member_with_permissions: {
@@ -124,6 +129,69 @@ RSpec.describe "Filter work packages by backlog filters", :js do
       let(:wp_table) { Pages::WorkPackagesTable.new }
 
       include_examples "filtering on sprints"
+    end
+  end
+
+  context "on the backlog bucket" do
+    shared_examples_for "filtering on backlog buckets" do
+      it "allows filtering by backlog bucket" do
+        filters.open
+
+        filters.add_filter_by("Backlog bucket", "is (OR)", bucket_a.name, "backlogBucket")
+
+        wp_table.expect_work_package_listed work_package_in_bucket_a
+        wp_table.ensure_work_package_not_listed! work_package_in_bucket_b,
+                                                 work_package_with_story_type,
+                                                 work_package_with_task_type
+
+        filters.clear_filter_value "backlogBucket"
+        filters.set_filter("Backlog bucket", "is (OR)", bucket_b.name, "backlogBucket")
+
+        wp_table.expect_work_package_listed work_package_in_bucket_b
+        wp_table.ensure_work_package_not_listed! work_package_in_bucket_a,
+                                                 work_package_with_story_type,
+                                                 work_package_with_task_type
+
+        filters.clear_filter_value "backlogBucket"
+        filters.set_filter("Backlog bucket", "is (OR)", [bucket_a.name, bucket_b.name], "backlogBucket")
+
+        wp_table.expect_work_package_listed work_package_in_bucket_a,
+                                            work_package_in_bucket_b
+        wp_table.ensure_work_package_not_listed! work_package_with_story_type,
+                                                 work_package_with_task_type
+
+        filters.clear_filter_value "backlogBucket"
+        filters.set_filter("Backlog bucket", "is not", bucket_b.name, "backlogBucket")
+
+        wp_table.expect_work_package_listed work_package_in_bucket_a,
+                                            work_package_with_story_type,
+                                            work_package_with_task_type
+        wp_table.ensure_work_package_not_listed! work_package_in_bucket_b
+
+        filters.set_operator "Backlog bucket", "is empty", "backlogBucket"
+
+        wp_table.expect_work_package_listed work_package_with_story_type,
+                                            work_package_with_task_type
+        wp_table.ensure_work_package_not_listed! work_package_in_bucket_a,
+                                                 work_package_in_bucket_b
+
+        filters.set_operator "Backlog bucket", "is not empty", "backlogBucket"
+
+        wp_table.expect_work_package_listed work_package_in_bucket_a,
+                                            work_package_in_bucket_b
+        wp_table.ensure_work_package_not_listed! work_package_with_story_type,
+                                                 work_package_with_task_type
+      end
+    end
+
+    context "when filtering inside a project" do
+      include_examples "filtering on backlog buckets"
+    end
+
+    context "when filtering globally" do
+      let(:wp_table) { Pages::WorkPackagesTable.new }
+
+      include_examples "filtering on backlog buckets"
     end
   end
 end

--- a/modules/backlogs/spec/lib/api/v3/queries/schemas/backlog_bucket_filter_dependency_representer_spec.rb
+++ b/modules/backlogs/spec/lib/api/v3/queries/schemas/backlog_bucket_filter_dependency_representer_spec.rb
@@ -30,12 +30,12 @@
 
 require "spec_helper"
 
-RSpec.describe API::V3::Queries::Schemas::SprintFilterDependencyRepresenter do
+RSpec.describe API::V3::Queries::Schemas::BacklogBucketFilterDependencyRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }
   let(:query) { build_stubbed(:query, project:) }
-  let(:filter) { Queries::WorkPackages::Filter::SprintFilter.create!(context: query) }
+  let(:filter) { Queries::WorkPackages::Filter::BacklogBucketFilter.create!(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do
@@ -48,7 +48,7 @@ RSpec.describe API::V3::Queries::Schemas::SprintFilterDependencyRepresenter do
 
   describe "rendering" do
     let(:path) { "values" }
-    let(:type) { "[]Sprint" }
+    let(:type) { "[]BacklogBucket" }
     let(:order) { "sortBy=#{CGI.escape(JSON.dump([%i(name asc)]))}&pageSize=-1" }
 
     context "for operator 'Queries::Operators::All'" do
@@ -65,7 +65,7 @@ RSpec.describe API::V3::Queries::Schemas::SprintFilterDependencyRepresenter do
 
     context "within a project context" do
       let(:href) do
-        "#{api_v3_paths.project_sprints(project.id)}?#{order}"
+        "#{api_v3_paths.project_backlog_buckets(project.id)}?#{order}"
       end
 
       context "for operator 'Queries::Operators::Equals'" do
@@ -84,7 +84,7 @@ RSpec.describe API::V3::Queries::Schemas::SprintFilterDependencyRepresenter do
     context "within a global context" do
       let(:project) { nil }
       let(:href) do
-        "#{api_v3_paths.sprints}?#{order}"
+        "#{api_v3_paths.backlog_buckets}?#{order}"
       end
 
       context "for operator 'Queries::Operators::Equals'" do

--- a/modules/backlogs/spec/models/queries/work_packages/filter/backlog_bucket_filter_spec.rb
+++ b/modules/backlogs/spec/models/queries/work_packages/filter/backlog_bucket_filter_spec.rb
@@ -30,73 +30,65 @@
 
 require "spec_helper"
 
-RSpec.describe Queries::WorkPackages::Filter::SprintFilter do
-  let(:scope_class) do
-    Class.new do
-      def for_project(_project); end
-
-      def pluck(*_args); end
-    end
-  end
-  let(:sprint) { build_stubbed(:sprint) }
+RSpec.describe Queries::WorkPackages::Filter::BacklogBucketFilter do
+  let(:bucket) { build_stubbed(:backlog_bucket) }
 
   it_behaves_like "basic query filter" do
     let(:type) { :list_optional }
-    let(:class_key) { :sprint_id }
-    let(:values) { [sprint.id.to_s] }
+    let(:class_key) { :backlog_bucket_id }
+    let(:values) { [bucket.id.to_s] }
     let(:model) { WorkPackage }
 
-    let(:visible_scope) { instance_double(scope_class) }
-    let(:scope) { instance_double(scope_class) }
+    let(:visible_scope) { instance_double(ActiveRecord::Relation) }
+    let(:scoped_to_project) { instance_double(ActiveRecord::Relation) }
     let(:project_permissions) { [:view_sprints] }
 
     current_user { build_stubbed(:user) }
 
     before do
-      allow(Sprint)
+      allow(BacklogBucket)
         .to receive(:visible)
         .and_return(visible_scope)
 
       if project
         allow(visible_scope)
-          .to receive(:for_project)
-          .with(project)
-          .and_return(scope)
+          .to receive(:where)
+          .with(project:)
+          .and_return(scoped_to_project)
 
-        allow(scope).to receive(:pluck).with(:id).and_return([sprint.id])
+        allow(scoped_to_project).to receive(:pluck).with(:id).and_return([bucket.id])
       else
-        allow(visible_scope).to receive(:pluck).with(:id).and_return([sprint.id])
+        allow(visible_scope).to receive(:pluck).with(:id).and_return([bucket.id])
       end
 
       mock_permissions_for current_user do |mock|
         if project
           mock.allow_in_project(*project_permissions, project:)
         else
-          # To mock having permissions for the `allowed_in_any_project?` check
           mock.allow_in_project(*project_permissions, project: build_stubbed(:project))
         end
       end
     end
 
     describe "#allowed_values" do
-      let(:sprint2) { build_stubbed(:sprint) }
+      let(:bucket2) { build_stubbed(:backlog_bucket) }
 
       before do
-        allow(scope).to receive(:pluck).with(:id).and_return([sprint.id, sprint2.id])
+        allow(scoped_to_project).to receive(:pluck).with(:id).and_return([bucket.id, bucket2.id])
       end
 
-      it "returns id pairs for sprints visible in the project" do
+      it "returns id pairs for buckets visible in the project" do
         expect(instance.allowed_values).to contain_exactly(
-          [sprint.id.to_s, sprint.id.to_s],
-          [sprint2.id.to_s, sprint2.id.to_s]
+          [bucket.id.to_s, bucket.id.to_s],
+          [bucket2.id.to_s, bucket2.id.to_s]
         )
       end
 
       context "when outside a project" do
         let(:project) { nil }
 
-        it "returns id pairs for all visible sprints" do
-          expect(instance.allowed_values).to contain_exactly([sprint.id.to_s, sprint.id.to_s])
+        it "returns id pairs for all visible buckets" do
+          expect(instance.allowed_values).to contain_exactly([bucket.id.to_s, bucket.id.to_s])
         end
       end
     end
@@ -141,29 +133,29 @@ RSpec.describe Queries::WorkPackages::Filter::SprintFilter do
     end
 
     describe "dependency representer" do
-      it "maps to the sprint dependency representer" do
+      it "maps to the backlog bucket dependency representer" do
         dependency = API::V3::Queries::Schemas::FilterDependencyRepresenterFactory
           .create(instance, Queries::Operators::Equals)
 
-        expect(dependency).to be_a(API::V3::Queries::Schemas::SprintFilterDependencyRepresenter)
+        expect(dependency).to be_a(API::V3::Queries::Schemas::BacklogBucketFilterDependencyRepresenter)
       end
     end
 
     describe "#value_objects" do
-      let(:sprint1) { build_stubbed(:sprint) }
-      let(:sprint2) { build_stubbed(:sprint) }
+      let(:bucket1) { build_stubbed(:backlog_bucket) }
+      let(:bucket2) { build_stubbed(:backlog_bucket) }
 
       before do
         allow(visible_scope)
-          .to receive(:for_project)
-          .with(project)
-          .and_return([sprint1, sprint2])
+          .to receive(:where)
+          .with(project:)
+          .and_return([bucket1, bucket2])
 
-        instance.values = [sprint1.id.to_s]
+        instance.values = [bucket1.id.to_s]
       end
 
-      it "returns an array of sprints" do
-        expect(instance.value_objects).to contain_exactly(sprint1)
+      it "returns an array of backlog buckets matching the set values" do
+        expect(instance.value_objects).to contain_exactly(bucket1)
       end
     end
   end

--- a/modules/backlogs/spec/models/queries/work_packages/filter/sprint_filter_spec.rb
+++ b/modules/backlogs/spec/models/queries/work_packages/filter/sprint_filter_spec.rb
@@ -62,10 +62,11 @@ RSpec.describe Queries::WorkPackages::Filter::SprintFilter do
           .to receive(:for_project)
           .with(project)
           .and_return(scope)
-      end
 
-      allow(scope).to receive(:pluck).with(:id, :id).and_return([[sprint.id, sprint.id]])
-      allow(visible_scope).to receive(:pluck).with(:id, :id).and_return([[sprint.id, sprint.id]])
+        allow(scope).to receive(:pluck).with(:id).and_return([sprint.id])
+      else
+        allow(visible_scope).to receive(:pluck).with(:id).and_return([sprint.id])
+      end
 
       mock_permissions_for current_user do |mock|
         if project
@@ -73,6 +74,29 @@ RSpec.describe Queries::WorkPackages::Filter::SprintFilter do
         else
           # To mock having permissions for the `allowed_in_any_project?` check
           mock.allow_in_project(*project_permissions, project: build_stubbed(:project))
+        end
+      end
+    end
+
+    describe "#allowed_values" do
+      let(:sprint2) { build_stubbed(:sprint) }
+
+      before do
+        allow(scope).to receive(:pluck).with(:id).and_return([sprint.id, sprint2.id])
+      end
+
+      it "returns id pairs for sprints visible in the project" do
+        expect(instance.allowed_values).to contain_exactly(
+          [sprint.id.to_s, sprint.id.to_s],
+          [sprint2.id.to_s, sprint2.id.to_s]
+        )
+      end
+
+      context "when outside a project" do
+        let(:project) { nil }
+
+        it "returns id pairs for all visible sprints" do
+          expect(instance.allowed_values).to contain_exactly([sprint.id.to_s, sprint.id.to_s])
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-235 extracted from https://community.openproject.org/wp/AGILE-218

# What are you trying to accomplish?
Allow filtering work packages by backlog bucket

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
