### PR TITLE
Chore: strengthen the flaky-spec Copilot delegation prompt

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -109,7 +109,8 @@ jobs:
               printf '%s\n\n' "$specs"
               printf 'Treat this as a standalone task, unrelated to PR #%s. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #%s or reuse that branch.\n\n' "$PR_NUMBER" "$PR_NUMBER"
               printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the underlying race — do not skip, delete, or weaken the spec to make it pass; disabling is a last resort per the playbook, and only with a bug ticket. Verify the fix by running the spec(s) repeatedly (e.g. `script/bulk_run_rspec --run-count 10`).\n\n'
-              printf 'Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause, how the change resolves it, and the before/after results. Label the PR `flaky-spec`, assign @%s, and request a review from @%s.\n' "$PR_AUTHOR" "$PR_AUTHOR"
+              printf 'If you cannot reproduce the flake or are not confident in a fix after reasonable investigation, do not fabricate a change or skip the spec to force CI green. Instead, leave the pull request in draft and document what you tried, the suspected cause, and any leads in its description, then assign @%s to take over.\n\n' "$PR_AUTHOR"
+              printf 'Once the fix is verified, title the PR after the spec(s) it fixes, and use the PR description to explain the root cause, how the change resolves it, and the before/after results. Label the PR `flaky-spec`, assign @%s, and request a review from @%s.\n' "$PR_AUTHOR" "$PR_AUTHOR"
               printf 'On every commit, set @%s as the sole co-author with a `Co-authored-by:` trailer (use their GitHub no-reply email so it links to their account), so it is traceable who dispatched the fix.\n' "$PR_AUTHOR"
               printf '```\n\n'
               printf '</details>\n'

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -108,7 +108,7 @@ jobs:
               printf '@copilot The following spec(s) are flaky in CI (first seen on PR #%s, linked for reference only):\n\n' "$PR_NUMBER"
               printf '%s\n\n' "$specs"
               printf 'Treat this as a standalone task, unrelated to PR #%s. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #%s or reuse that branch.\n\n' "$PR_NUMBER" "$PR_NUMBER"
-              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the flakiness. Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause and how the change resolves it. Request a review from @%s.\n' "$PR_AUTHOR"
+              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the flakiness. Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause and how the change resolves it. Label the PR `flaky-spec`, assign @%s, and request a review from @%s.\n' "$PR_AUTHOR" "$PR_AUTHOR"
               printf '```\n\n'
               printf '</details>\n'
             } > tmp/flaky_comment.md

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -109,6 +109,7 @@ jobs:
               printf '%s\n\n' "$specs"
               printf 'Treat this as a standalone task, unrelated to PR #%s. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #%s or reuse that branch.\n\n' "$PR_NUMBER" "$PR_NUMBER"
               printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the flakiness. Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause and how the change resolves it. Label the PR `flaky-spec`, assign @%s, and request a review from @%s.\n' "$PR_AUTHOR" "$PR_AUTHOR"
+              printf 'On every commit, set @%s as the sole co-author with a `Co-authored-by:` trailer (use their GitHub no-reply email so it links to their account), so it is traceable who dispatched the fix.\n' "$PR_AUTHOR"
               printf '```\n\n'
               printf '</details>\n'
             } > tmp/flaky_comment.md

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -108,7 +108,8 @@ jobs:
               printf '@copilot The following spec(s) are flaky in CI (first seen on PR #%s, linked for reference only):\n\n' "$PR_NUMBER"
               printf '%s\n\n' "$specs"
               printf 'Treat this as a standalone task, unrelated to PR #%s. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #%s or reuse that branch.\n\n' "$PR_NUMBER" "$PR_NUMBER"
-              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the flakiness. Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause and how the change resolves it. Label the PR `flaky-spec`, assign @%s, and request a review from @%s.\n' "$PR_AUTHOR" "$PR_AUTHOR"
+              printf 'Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the underlying race — do not skip, delete, or weaken the spec to make it pass; disabling is a last resort per the playbook, and only with a bug ticket. Verify the fix by running the spec(s) repeatedly (e.g. `script/bulk_run_rspec --run-count 10`).\n\n'
+              printf 'Title the PR after the spec(s) it fixes, and use the PR description to explain the root cause, how the change resolves it, and the before/after results. Label the PR `flaky-spec`, assign @%s, and request a review from @%s.\n' "$PR_AUTHOR" "$PR_AUTHOR"
               printf 'On every commit, set @%s as the sole co-author with a `Co-authored-by:` trailer (use their GitHub no-reply email so it links to their account), so it is traceable who dispatched the fix.\n' "$PR_AUTHOR"
               printf '```\n\n'
               printf '</details>\n'


### PR DESCRIPTION
The CI flaky-spec reporter posts a comment with a ready-made `@copilot` prompt to delegate the investigation. This sharpens that prompt on two fronts. It keeps every dispatch traceable: the resulting PR carries the existing `flaky-spec` label, names the original author as both assignee and reviewer, and asks for that author as the sole `Co-authored-by:` trailer on every commit, so it is always clear who dispatched the fix. It also raises the bar on fix quality — the prompt now tells Copilot to fix the real race rather than skip, delete, or weaken the spec to go green, to verify by re-running the spec(s) repeatedly, and to report the before/after results in the PR description. The prompt also handles the case where Copilot cannot reproduce or confidently fix the flake: it keeps its draft PR, writes up the investigation there, and hands it back to the author rather than producing a speculative fix or skipping to green.

This is a standalone change off `dev`; there is no associated work package.

***

### Preview

> [!WARNING]
> The mentions below live inside a fenced code block so they stay inert and do not notify anyone.

<details>
<summary>🤖 Ask Copilot to investigate</summary>

```
@copilot The following spec(s) are flaky in CI (first seen on PR #23755, linked for reference only):

- `rspec ./spec/features/projects/create_spec.rb[1:12:3:2:1]`
- `rspec ./spec/features/work_packages/table/switch_types_spec.rb[1:1:2]`

Treat this as a standalone task, unrelated to PR #23755. Create a new branch from origin/dev and open a new pull request targeting dev — do not stack it on PR #23755 or reuse that branch.

Follow the playbook in docs/development/testing/handling-flaky-tests/README.md to find the root cause and fix the underlying race — do not skip, delete, or weaken the spec to make it pass; disabling is a last resort per the playbook, and only with a bug ticket. Verify the fix by running the spec(s) repeatedly (e.g. `script/bulk_run_rspec --run-count 10`).

If you cannot reproduce the flake or are not confident in a fix after reasonable investigation, do not fabricate a change or skip the spec to force CI green. Instead, leave the pull request in draft and document what you tried, the suspected cause, and any leads in its description, then assign @akabiru to take over.

Once the fix is verified, title the PR after the spec(s) it fixes, and use the PR description to explain the root cause, how the change resolves it, and the before/after results. Label the PR `flaky-spec`, assign @akabiru, and request a review from @akabiru.
On every commit, set @akabiru as the sole co-author with a `Co-authored-by:` trailer (use their GitHub no-reply email so it links to their account), so it is traceable who dispatched the fix.
```

</details>

***
