### PR TITLE
[DREAM-727] Long project names are not wrapping when they are not on the root level

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -72,7 +72,7 @@ $arrow-left-width: 36px
     padding: 0
 
     // -------------------- ALL menu items ---------------------------
-    li
+    li:not(.TreeViewItem)
       float: none
       list-style-type: none
       margin: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-727

# What are you trying to accomplish?
Exclude TreeView items form main menu list styles. Thus the wrapping is active again for child elements with long names. Long single words are explicitely out of scope for this PR.

## Screenshots
<img width="499" height="260" alt="Bildschirmfoto 2026-06-17 um 09 11 55" src="https://github.com/user-attachments/assets/fd14e0d4-443d-4ccf-bafc-8bbc5ea1f6fa" />
