### PR TITLE
[DREAM-726] Add blankslate for favorited projects when there are none

### DIFF
--- a/app/views/header/projects/index.html.erb
+++ b/app/views/header/projects/index.html.erb
@@ -34,13 +34,21 @@ See COPYRIGHT and LICENSE files for more details.
                 test_selector: "op-header-project-select--list" }
       )
     ) do |tree| %>
-  <% @tree.each do |node| %>
-    <%= render Header::Projects::NodeComponent.new(
-          component: tree,
-          node:,
-          current_project_id: @current_project_id,
-          favorited_ids: @favorited_ids,
-          jump: @jump
-        ) %>
+  <% if @tree.empty? && params[:filter_mode] == "favorited" && params[:query].blank? %>
+    <% tree.with_leaf(
+         label: t("header.project_select_component.no_favorite_projects"),
+         disabled: true,
+         data: { test_selector: "op-header-project-select--no-favourites" }
+       ) %>
+  <% else %>
+    <% @tree.each do |node| %>
+      <%= render Header::Projects::NodeComponent.new(
+            component: tree,
+            node:,
+            current_project_id: @current_project_id,
+            favorited_ids: @favorited_ids,
+            jump: @jump
+          ) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3608,6 +3608,7 @@ en:
       all_projects: "All projects"
       favorites: "Favorites"
       leave_project: "Leave project"
+      no_favorite_projects: "You have no favorite projects."
       title: "Projects"
 
   toggle_switch:

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Header::ProjectsController do
   end
 
   describe "#index" do
+    render_views
     shared_let(:parent_project) { create(:project, name: "Alpha Parent") }
     shared_let(:child_project)  { create(:project, name: "Beta Child", parent: parent_project) }
     shared_let(:other_project)  { create(:project, name: "Gamma Other") }
@@ -116,6 +117,20 @@ RSpec.describe Header::ProjectsController do
         it "returns an empty project list" do
           make_request
           expect(assigns(:projects)).to be_empty
+        end
+
+        it "renders the no-favourites placeholder" do
+          make_request
+          expect(response.body).to include("op-header-project-select--no-favourites")
+        end
+
+        context "when a query is present" do
+          subject(:make_request) { get :index, params: { filter_mode: "favorited", query: "Alpha" } }
+
+          it "does not render the no-favourites placeholder" do
+            make_request
+            expect(response.body).not_to include("op-header-project-select--no-favourites")
+          end
         end
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-726

# What are you trying to accomplish?
Show special node when there are no favourite projects yet

## Screenshots
<img width="518" height="200" alt="Bildschirmfoto 2026-06-17 um 10 49 42" src="https://github.com/user-attachments/assets/64ad5f02-8171-462d-a249-19883ac299e0" />

