### PR TITLE
[XWI-119] Add mentions API endpoint to the referencing page query

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
@@ -47,7 +47,7 @@ module Wikis
               authenticated(auth_strategy) do |http|
                 fetch_reference_ids(http, input_data).bind do |reference_ids|
                   fetch_mention_ids(http, input_data).bind do |mention_ids|
-                    ids = reference_ids + (mention_ids - reference_ids)
+                    ids = (reference_ids + mention_ids).uniq
                     success(ids.map { canonical_page_info(identifier: it, auth_strategy:) })
                   end
                 end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
@@ -57,16 +57,17 @@ module Wikis
             private
 
             def fetch_reference_ids(http, input_data)
-              handle_response(http.get(rest_url("openproject/links/workPackages/#{input_data.linkable.id}"),
-                                       params: { number: MAXIMUM_RESULTS })) do |data|
-                success(fetch_json(data, "searchResults").map { fetch_json(it, "id") }.uniq)
-              end
+              fetch_page_ids(http, rest_url("openproject/links/workPackages/#{input_data.linkable.id}"),
+                             params: { number: MAXIMUM_RESULTS })
             end
 
             def fetch_mention_ids(http, input_data)
-              handle_response(http.get(rest_url("openproject/mentions"),
-                                       params: { workPackage: input_data.linkable.id })) do |data|
-                success((data["searchResults"] || []).filter_map { it["id"] }.uniq)
+              fetch_page_ids(http, rest_url("openproject/mentions"), params: { workPackage: input_data.linkable.id })
+            end
+
+            def fetch_page_ids(http, url, params:)
+              handle_response(http.get(url, params:)) do |data|
+                success(fetch_json(data, "searchResults").map { fetch_json(it, "id") }.uniq)
               end
             end
           end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
@@ -33,6 +33,10 @@ module Wikis
     module Providers
       module XWiki
         module Queries
+          # Fetches all XWiki pages that reference a work package, combining two XWiki endpoints:
+          # - /openproject/links
+          # - /openproject/mentions
+          # Both sets are merged and deduplicated.
           class ReferencingPages < BaseQuery
             include Concerns::XWikiRequest
             include Concerns::XWikiPageQueries
@@ -41,15 +45,29 @@ module Wikis
 
             def call(input_data:, auth_strategy:)
               authenticated(auth_strategy) do |http|
-                url = rest_url("openproject/links/workPackages/#{input_data.linkable.id}")
-                handle_response(http.get(url, params: { number: MAXIMUM_RESULTS })) do |data|
-                  success(
-                    fetch_json(data, "searchResults")
-                      .uniq { |r| fetch_json(r, "id") }
-                      .map { canonical_page_info(identifier: fetch_json(it, "id"), auth_strategy:) }
-                  )
+                reference_ids = fetch_reference_ids(http, input_data)
+                mention_ids = fetch_mention_ids(http, input_data)
+
+                reference_ids.fmap do |ids|
+                  (ids + (mention_ids - ids)).map { canonical_page_info(identifier: it, auth_strategy:) }
                 end
               end
+            end
+
+            private
+
+            def fetch_reference_ids(http, input_data)
+              handle_response(http.get(rest_url("openproject/links/workPackages/#{input_data.linkable.id}"),
+                                       params: { number: MAXIMUM_RESULTS })) do |data|
+                success(fetch_json(data, "searchResults").map { fetch_json(it, "id") }.uniq)
+              end
+            end
+
+            def fetch_mention_ids(http, input_data)
+              handle_response(http.get(rest_url("openproject/mentions"),
+                                       params: { workPackage: input_data.linkable.id })) do |data|
+                success((data["searchResults"] || []).filter_map { it["id"] }.uniq)
+              end.value_or([])
             end
           end
         end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
@@ -34,7 +34,7 @@ module Wikis
       module XWiki
         module Queries
           # Fetches all XWiki pages that reference a work package, combining two XWiki endpoints:
-          # - /openproject/links
+          # - /openproject/links/workPackages
           # - /openproject/mentions
           # Both sets are merged and deduplicated.
           class ReferencingPages < BaseQuery

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
@@ -36,7 +36,7 @@ module Wikis
           # Fetches all XWiki pages that reference a work package, combining two XWiki endpoints:
           # - /openproject/links/workPackages
           # - /openproject/mentions
-          # Both sets are merged and deduplicated.
+          # Results are merged and deduplicated. Either endpoint failing fails the whole query.
           class ReferencingPages < BaseQuery
             include Concerns::XWikiRequest
             include Concerns::XWikiPageQueries
@@ -45,11 +45,11 @@ module Wikis
 
             def call(input_data:, auth_strategy:)
               authenticated(auth_strategy) do |http|
-                reference_ids = fetch_reference_ids(http, input_data)
-                mention_ids = fetch_mention_ids(http, input_data)
-
-                reference_ids.fmap do |ids|
-                  (ids + (mention_ids - ids)).map { canonical_page_info(identifier: it, auth_strategy:) }
+                fetch_reference_ids(http, input_data).bind do |reference_ids|
+                  fetch_mention_ids(http, input_data).bind do |mention_ids|
+                    ids = reference_ids + (mention_ids - reference_ids)
+                    success(ids.map { canonical_page_info(identifier: it, auth_strategy:) })
+                  end
                 end
               end
             end
@@ -67,7 +67,7 @@ module Wikis
               handle_response(http.get(rest_url("openproject/mentions"),
                                        params: { workPackage: input_data.linkable.id })) do |data|
                 success((data["searchResults"] || []).filter_map { it["id"] }.uniq)
-              end.value_or([])
+              end
             end
           end
         end

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/referencing_pages_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/referencing_pages_spec.rb
@@ -133,16 +133,11 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
             .to_return(status: 500, body: "Internal Server Error")
         end
 
-        it "succeeds with only the linked pages" do
-          expect(result).to be_success
-          expect(resolved_identifiers).to contain_exactly("aaa111")
-        end
+        it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :request_failed)) }
       end
     end
 
     context "when the links request fails" do
-      before { stub_mentions([], provider: wiki_provider, linkable:) }
-
       context "with a server error" do
         before do
           stub_request(:get, search_endpoint(linkable, provider: wiki_provider))

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/referencing_pages_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/referencing_pages_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
     end
     let(:input_data) { Wikis::Adapters::Input::ReferencingPages.build(linkable:).value! }
     let(:query) { described_class.new(model: wiki_provider) }
+    let(:resolved_identifiers) { result.value!.map { it.value!.identifier } }
 
     subject(:result) { query.call(input_data:, auth_strategy:) }
 
@@ -72,6 +73,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
           provider: wiki_provider,
           linkable:
         )
+        stub_mentions([], provider: wiki_provider, linkable:)
         stub_canonical_page_info(duplicate_id,
                                  uid: "aaa111",
                                  title: "Home",
@@ -87,17 +89,80 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
       it { is_expected.to be_success }
 
       it "deduplicates by page identifier, not by title" do
-        expect(result.value!.map { it.value!.identifier }).to contain_exactly("aaa111", "bbb222")
+        expect(resolved_identifiers).to contain_exactly("aaa111", "bbb222")
       end
     end
 
-    context "when the search request fails" do
+    context "with a single page" do
+      let(:page_id) { "xwiki:Main.WebHome" }
+
       before do
-        stub_request(:get, search_endpoint(linkable, provider: wiki_provider))
-          .to_return(status: 500, body: "Internal Server Error")
+        stub_canonical_page_info(page_id,
+                                 uid: "aaa111",
+                                 title: "Home",
+                                 href: "https://xwiki.example.com/bin/view/Main/",
+                                 provider: wiki_provider)
       end
 
-      it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :request_failed)) }
+      context "when a page appears in both links and mentions" do
+        before do
+          stub_search([{ "id" => page_id, "title" => "Home" }], provider: wiki_provider, linkable:)
+          stub_mentions([{ "id" => page_id }], provider: wiki_provider, linkable:)
+        end
+
+        it "returns the page only once" do
+          expect(resolved_identifiers).to contain_exactly("aaa111")
+        end
+      end
+
+      context "when pages appear only in mentions" do
+        before do
+          stub_search([], provider: wiki_provider, linkable:)
+          stub_mentions([{ "id" => page_id }], provider: wiki_provider, linkable:)
+        end
+
+        it "includes pages from the mentions endpoint" do
+          expect(resolved_identifiers).to contain_exactly("aaa111")
+        end
+      end
+
+      context "when the mentions request fails" do
+        before do
+          stub_search([{ "id" => page_id, "title" => "Home" }], provider: wiki_provider, linkable:)
+          stub_request(:get, mentions_endpoint(linkable, provider: wiki_provider))
+            .to_return(status: 500, body: "Internal Server Error")
+        end
+
+        it "succeeds with only the linked pages" do
+          expect(result).to be_success
+          expect(resolved_identifiers).to contain_exactly("aaa111")
+        end
+      end
+    end
+
+    context "when the links request fails" do
+      before { stub_mentions([], provider: wiki_provider, linkable:) }
+
+      context "with a server error" do
+        before do
+          stub_request(:get, search_endpoint(linkable, provider: wiki_provider))
+            .to_return(status: 500, body: "Internal Server Error")
+        end
+
+        it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :request_failed)) }
+      end
+
+      context "when unauthorized" do
+        before { stub_request(:get, search_endpoint(linkable, provider: wiki_provider)).to_return(status: 401, body: "") }
+
+        it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :unauthorized)) }
+      end
+
+      context "when timing out" do
+        before { stub_request(:get, search_endpoint(linkable, provider: wiki_provider)).to_timeout }
+
+        it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :connection_error)) }
+      end
     end
 
     context "when no OAuth token exists for the user" do
@@ -106,29 +171,18 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :missing_token)) }
     end
 
-    context "when the search request returns unauthorized" do
-      before { stub_request(:get, search_endpoint(linkable, provider: wiki_provider)).to_return(status: 401, body: "") }
-
-      it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :unauthorized)) }
-    end
-
-    context "when the search request times out" do
-      before { stub_request(:get, search_endpoint(linkable, provider: wiki_provider)).to_timeout }
-
-      it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :connection_error)) }
-    end
-
     context "with real XWiki responses", vcr: "xwiki/referencing_pages" do
       let(:wiki_provider) { create(:xwiki_provider, :for_local_connection, connected_user: user) }
       let(:linkable) { create(:work_package, id: 14) }
       let(:auth_strategy) { wiki_provider.auth_strategy_for(user).value! }
 
-      it "returns PageInfo for all linked pages" do
+      it "returns PageInfo for all linked and mentioned pages" do
         expect(result).to be_success
         expect(result.value!.map { it.value!.to_h.except(:provider) }).to contain_exactly(
           { identifier: "48944", title: "OpenProject integration", href: "https://xwiki.local/bin/view/test/" },
           { identifier: "42f2f", title: "Def New Page", href: "https://xwiki.local/bin/view/test/Def%20New%20Page/" },
-          { identifier: "a3739", title: "Just a normal page", href: "https://xwiki.local/bin/view/Just%20a%20normal%20page/" }
+          { identifier: "a3739", title: "Just a normal page", href: "https://xwiki.local/bin/view/Just%20a%20normal%20page/" },
+          { identifier: "f58c0", title: "Test reference", href: "https://xwiki.local/bin/view/Test%20reference/" }
         )
       end
     end

--- a/modules/wikis/spec/support/xwiki_stubs.rb
+++ b/modules/wikis/spec/support/xwiki_stubs.rb
@@ -33,20 +33,30 @@ module XWikiStubs
     "#{provider.url}rest/openproject/links/workPackages/#{linkable.id}?number=#{number}"
   end
 
+  def mentions_endpoint(linkable, provider:)
+    "#{provider.url}rest/openproject/mentions?workPackage=#{linkable.id}"
+  end
+
   def stub_canonical_page_info(identifier, uid:, title:, href:, provider:, token: "user-bearer-token")
-    stub_request(:get, "#{provider.url}rest/openproject/documents")
-      .with(query: { "docRef" => identifier },
-            headers: { "Authorization" => "Bearer #{token}" })
-      .to_return(status: 200,
-                 body: { "id" => uid, "title" => title, "xwikiAbsoluteUrl" => href }.to_json,
-                 headers: { "Content-Type" => "application/json" })
+    stub_xwiki_get("#{provider.url}rest/openproject/documents",
+                   { "id" => uid, "title" => title, "xwikiAbsoluteUrl" => href },
+                   token:,
+                   query: { "docRef" => identifier })
   end
 
   def stub_search(search_results, provider:, linkable:, number: 25, token: "user-bearer-token")
-    stub_request(:get, search_endpoint(linkable, provider:, number:))
-      .with(headers: { "Authorization" => "Bearer #{token}" })
-      .to_return(status: 200,
-                 body: { "searchResults" => search_results }.to_json,
-                 headers: { "Content-Type" => "application/json" })
+    stub_xwiki_get(search_endpoint(linkable, provider:, number:), { "searchResults" => search_results }, token:)
+  end
+
+  def stub_mentions(search_results, provider:, linkable:, token: "user-bearer-token")
+    stub_xwiki_get(mentions_endpoint(linkable, provider:), { "searchResults" => search_results }, token:)
+  end
+
+  private
+
+  def stub_xwiki_get(url, body, token: "user-bearer-token", **with_opts)
+    stub_request(:get, url)
+      .with(headers: { "Authorization" => "Bearer #{token}" }, **with_opts)
+      .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages.yml
@@ -49,6 +49,50 @@ http_interactions:
   recorded_at: Wed, 10 Jun 2026 13:09:46 GMT
 - request:
     method: get
+    uri: https://xwiki.local/rest/openproject/mentions?workPackage=14
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenProject 17.6.0 HTTPX Client
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <SECRET>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Language:
+      - en
+      Content-Script-Type:
+      - text/javascript
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Jun 2026 16:34:00 GMT
+      Set-Cookie:
+      - JSESSIONID=A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6; Path=/; HttpOnly
+      Xwiki-Form-Token:
+      - QVVZtN1gchKDZcFGGdo7Rg
+      Xwiki-User:
+      - xwiki:XWiki.admin
+      Xwiki-Version:
+      - 18.3.0
+      Content-Length:
+      - '855'
+    body:
+      encoding: UTF-8
+      string: '{"links":[],"searchResults":[{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20reference/pages/WebHome","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null}],"type":"page","id":"xwiki:Test
+        reference.WebHome","pageFullName":"Test reference.WebHome","title":"Test reference","wiki":"xwiki","space":"Test
+        reference","pageName":"WebHome","modified":1781187743000,"author":"xwiki:XWiki.admin","authorName":null,"version":"4.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":0.54726034,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
+  recorded_at: Wed, 10 Jun 2026 16:34:00 GMT
+- request:
+    method: get
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:test.WebHome
     body:
       encoding: US-ASCII
@@ -190,4 +234,54 @@ http_interactions:
         URL Shortener.","content":"{{openproject instance=\"OpenProject\"/}}","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Just
         a normal page","name":"Just a normal page","type":"space","url":"https://xwiki.local/bin/view/Just%20a%20normal%20page/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Just%20a%20normal%20page/"}]},"rights":[],"renderedContent":null}'
   recorded_at: Wed, 10 Jun 2026 13:09:46 GMT
+- request:
+    method: get
+    uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:Test%20reference.WebHome
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenProject 17.6.0 HTTPX Client
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <SECRET>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Language:
+      - en
+      Content-Script-Type:
+      - text/javascript
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Jun 2026 16:34:00 GMT
+      Set-Cookie:
+      - JSESSIONID=B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7; Path=/; HttpOnly
+      Xwiki-Form-Token:
+      - QVVZtN1gchKDZcFGGdo7Rg
+      Xwiki-User:
+      - xwiki:XWiki.admin
+      Xwiki-Version:
+      - 18.3.0
+      Content-Length:
+      - '2156'
+    body:
+      encoding: UTF-8
+      string: '{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20reference","rel":"http://www.xwiki.org/rel/space","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20reference/pages/WebHome","rel":"http://www.xwiki.org/rel/parent","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20reference/pages/WebHome/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20reference/pages/WebHome/children","rel":"http://www.xwiki.org/rel/children","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20reference/pages/WebHome/objects","rel":"http://www.xwiki.org/rel/objects","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/syntaxes","rel":"http://www.xwiki.org/rel/syntaxes","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/openproject/documents","rel":"self","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/classes/Test%20reference.WebHome","rel":"http://www.xwiki.org/rel/class","type":null,"hrefLang":null}],"id":"f58c0","fullName":"Test
+        reference.WebHome","wiki":"xwiki","space":"Test reference","name":"WebHome","title":"Test
+        reference","rawTitle":"Test reference","parent":"Main.WebHome","parentId":"xwiki:Main.WebHome","version":"4.1","author":"XWiki.admin","authorName":null,"xwikiRelativeUrl":"https://xwiki.local/bin/view/Test%20reference/","xwikiAbsoluteUrl":"https://xwiki.local/bin/view/Test%20reference/","translations":{"links":[],"translations":[],"default":"en"},"syntax":"xwiki/2.1","language":"","majorVersion":4,"minorVersion":1,"hidden":false,"enforceRequiredRights":false,"created":1780651564000,"creator":"XWiki.admin","creatorName":null,"modified":1781187743000,"modifier":"XWiki.admin","modifierName":null,"originalMetadataAuthor":"xwiki:XWiki.admin","originalMetadataAuthorName":null,"comment":"","content":"Hello
+        new page!\n\n[[openproject wp 14>>https://openproject.local/projects/demo-project/work_packages/14/activity]]\n\n\n{{openproject
+        description=\"test\" identifier=\"14\" instance=\"OpenProject\" limit=\"10\"
+        workItemsDisplayer=\"workItemsSingle\"/}}","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
+        reference","name":"Test reference","type":"space","url":"https://xwiki.local/bin/view/Test%20reference/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20reference/"}]},"rights":[],"renderedContent":null}'
+  recorded_at: Wed, 10 Jun 2026 16:34:00 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages_empty.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages_empty.yml
@@ -42,4 +42,36 @@ http_interactions:
       encoding: UTF-8
       string: '{"links":[],"searchResults":[],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
   recorded_at: Wed, 10 Jun 2026 13:35:49 GMT
+- request:
+    method: get
+    uri: https://xwiki.local/rest/openproject/mentions?workPackage=21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenProject 17.6.0 HTTPX Client
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <SECRET>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Jun 2026 13:35:49 GMT
+      Content-Length:
+      - '20'
+    body:
+      encoding: UTF-8
+      string: '{"searchResults":[]}'
+  recorded_at: Wed, 10 Jun 2026 13:35:49 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
# Ticket
[XWI-119](https://community.openproject.org/projects/XWI/work_packages/XWI-119/activity)

# What are you trying to accomplish?
Return the results from the `mentions` API endpoint in the same query as referencing pages. 

## Screenshots
<img width="540" height="184" alt="Screenshot 2026-06-17 at 14 18 44" src="https://github.com/user-attachments/assets/d9fb9f5e-e6d2-4eda-856f-e7f32149869c" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
