### PR TITLE
Request root of REST API to determine user

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/user.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/user.rb
@@ -38,7 +38,7 @@ module Wikis
 
             def call(auth_strategy:)
               authenticated(auth_strategy) do |http|
-                handle_response(http.get(rest_url("wikis/xwiki/user")))
+                handle_response(http.get(rest_url("")))
               end
             end
 

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/user_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/user_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::User, :webmock do
   let(:user) { build_stubbed(:user) }
   let(:oauth_client) { build_stubbed(:oauth_client) }
   let(:wiki_provider) { build_stubbed(:xwiki_provider, url: "https://xwiki.local/") }
-  let(:user_url) { "https://xwiki.local/rest/wikis/xwiki/user" }
+  let(:root_url) { "https://xwiki.local/rest/" }
   let(:auth_strategy) { Wikis::Adapters::Input::AuthStrategy.build(key: :bearer_token, user:, provider: wiki_provider).value! }
 
   subject(:query) { described_class.new(model: wiki_provider) }
@@ -53,7 +53,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::User, :webmock do
   describe "#call" do
     context "when the request succeeds with an xwiki-user header" do
       before do
-        stub_request(:get, user_url)
+        stub_request(:get, root_url)
           .with(headers: { "Authorization" => "Bearer some-token" })
           .to_return(status: 200, body: "", headers: { "xwiki-user" => "XWiki.admin" })
       end
@@ -67,7 +67,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::User, :webmock do
 
     context "when the response is missing the xwiki-user header" do
       before do
-        stub_request(:get, user_url)
+        stub_request(:get, root_url)
           .to_return(status: 200, body: "")
       end
 
@@ -80,7 +80,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::User, :webmock do
 
     context "when XWiki returns a non-2xx status" do
       before do
-        stub_request(:get, user_url).to_return(status: 401, body: "Unauthorized")
+        stub_request(:get, root_url).to_return(status: 401, body: "Unauthorized")
       end
 
       it "returns Failure with :request_failed code" do
@@ -91,7 +91,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::User, :webmock do
     end
 
     context "when a network error occurs" do
-      before { stub_request(:get, user_url).to_timeout }
+      before { stub_request(:get, root_url).to_timeout }
 
       it "returns Failure with :connection_error code" do
         result = query.call(auth_strategy:)


### PR DESCRIPTION
We do not rely on any specifc endpoint's response, since every response from the XWiki API returns the current user in the headers.
On the other hand, the user endpoint has some downsides:

* it resides in the namespace of a wiki, so you have to guess the correct wiki that the user lives in
* it's only available starting with XWiki 18, not available in the current LTS release: 17
