### PR TITLE
[DREAM-693] Unify and document ExpandableTextComponent [FOLLOW UP - CSS vars]

### DIFF
--- a/app/components/op_primer/expandable_text_component.rb
+++ b/app/components/op_primer/expandable_text_component.rb
@@ -62,7 +62,7 @@ module OpPrimer
 
     # @param truncate [Symbol] truncation style. `:single_line` clips a
     #   single line; `:multi_line` clamps to `lines` rows.
-    # @param lines [Integer] number of visible rows in `:multi_line` mode, clamped to `2..8`.
+    # @param lines [Integer] number of visible rows in `:multi_line` mode (at least 2).
     # @param expansion [Symbol] `:inline` reveals the text in place; `:dialog`
     #   opens the component's `dialog` slot (the expander button is wired to it
     #   automatically) and the controller only manages the expander's visibility.

--- a/app/components/op_primer/vertical_truncate_component.rb
+++ b/app/components/op_primer/vertical_truncate_component.rb
@@ -36,11 +36,13 @@ module OpPrimer
   # line horizontally). Like `Truncate`, it wraps whatever block content it is
   # given; callers pass system arguments (e.g. `flex:`, `data:`) through.
   class VerticalTruncateComponent < Primer::Component # rubocop:disable OpenProject/AddPreviewForViewComponent
-    LINES_RANGE = (2..8)
+    LINES_MINIMUM = 2
     LINES_DEFAULT = 3
 
-    # @param lines [Integer] number of visible rows, clamped to `2..8` (a single
-    #   line is `Primer::Beta::Truncate`'s job).
+    # @param lines [Integer] number of visible rows (at least 2; a single line is
+    #   `Primer::Beta::Truncate`'s job). Applied via the
+    #   `--op-vertical-truncate-lines` custom property rather than a per-count
+    #   modifier class, so any count from 2 up is supported.
     # @param tag [Symbol] wrapping element; defaults to `:div` (safe for block
     #   content). Overridable, mirroring `Primer::Beta::Truncate`.
     # @param system_arguments [Hash] forwarded to the wrapping `Primer::BaseComponent`.
@@ -50,11 +52,14 @@ module OpPrimer
       @system_arguments = system_arguments
       @system_arguments[:tag] ||= :div
 
-      lines = lines.to_i.clamp(LINES_RANGE)
+      lines = [lines.to_i, LINES_MINIMUM].max
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
-        "op-vertical-truncate",
-        "op-vertical-truncate--lines-#{lines}"
+        "op-vertical-truncate"
+      )
+      @system_arguments[:style] = join_style_arguments(
+        @system_arguments[:style],
+        "--op-vertical-truncate-lines: #{lines};"
       )
     end
 

--- a/app/components/op_primer/vertical_truncate_component.sass
+++ b/app/components/op_primer/vertical_truncate_component.sass
@@ -1,14 +1,13 @@
 // Vertical (multi-line) truncation, the counterpart to Primer's `.Truncate`.
-// `OpPrimer::VerticalTruncateComponent` clamps content to `--lines-N` rows; the
-// `truncation` Stimulus controller toggles `--expanded` for inline expansion.
+// `OpPrimer::VerticalTruncateComponent` clamps content to the number of rows in
+// the `--op-vertical-truncate-lines` custom property (set inline by the
+// component); the `expandable-text` Stimulus controller toggles `--expanded`
+// for inline expansion.
 .op-vertical-truncate
   min-width: 0
+  @include line-clamp(var(--op-vertical-truncate-lines, 3))
 
-  @for $i from 2 through 8
-    &--lines-#{$i}
-      @include line-clamp($i)
-
-  // Defined after the line-clamp modifiers so it wins on equal specificity.
+  // Defined after the line-clamp declaration so it wins on equal specificity.
   &--expanded
     display: block
     overflow: visible

--- a/frontend/src/stimulus/controllers/expandable-text.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/expandable-text.controller.spec.ts
@@ -47,7 +47,7 @@ const singleLineTemplate = `
 
 const multiLineTemplate = `
   <div data-controller="expandable-text" data-expandable-text-expanded-value="false" data-expandable-text-mode-value="multi_line" data-expandable-text-inline-value="true">
-    <div data-expandable-text-target="truncate" class="op-vertical-truncate op-vertical-truncate--lines-3" style="overflow: hidden;">
+    <div data-expandable-text-target="truncate" class="op-vertical-truncate" style="--op-vertical-truncate-lines: 3; overflow: hidden;">
       <p>Line one of a multi-line block of text.</p>
       <p>Line two with more content.</p>
       <p>Line three extends beyond the clamp limit.</p>
@@ -61,7 +61,7 @@ const multiLineTemplate = `
 
 const dialogTemplate = `
   <div data-controller="expandable-text" data-expandable-text-expanded-value="false" data-expandable-text-mode-value="multi_line" data-expandable-text-inline-value="false">
-    <div data-expandable-text-target="truncate" class="op-vertical-truncate op-vertical-truncate--lines-3" style="overflow: hidden;">
+    <div data-expandable-text-target="truncate" class="op-vertical-truncate" style="--op-vertical-truncate-lines: 3; overflow: hidden;">
       <p>Content that opens in a dialog.</p>
     </div>
     <div data-expandable-text-target="expander">
@@ -425,7 +425,7 @@ describe('ExpandableTextController', () => {
       // should not advertise a disclosure state, so the controller strips it.
       const dialogWithAriaTemplate = `
         <div data-controller="expandable-text" data-expandable-text-expanded-value="false" data-expandable-text-mode-value="multi_line" data-expandable-text-inline-value="false">
-          <div data-expandable-text-target="truncate" class="op-vertical-truncate op-vertical-truncate--lines-3" style="overflow: hidden;">
+          <div data-expandable-text-target="truncate" class="op-vertical-truncate" style="--op-vertical-truncate-lines: 3; overflow: hidden;">
             <p>Content that opens in a dialog.</p>
           </div>
           <div data-expandable-text-target="expander">
@@ -472,7 +472,7 @@ describe('ExpandableTextController', () => {
     it('preserves server-rendered expander when content fits but has omitted paragraphs', async () => {
       const serverVisibleTemplate = `
         <div data-controller="expandable-text" data-expandable-text-expanded-value="false" data-expandable-text-mode-value="multi_line" data-expandable-text-inline-value="false">
-          <div data-expandable-text-target="truncate" class="op-vertical-truncate op-vertical-truncate--lines-3" style="overflow: hidden;">
+          <div data-expandable-text-target="truncate" class="op-vertical-truncate" style="--op-vertical-truncate-lines: 3; overflow: hidden;">
             <span>Short first paragraph that fits.</span>
           </div>
           <div data-expandable-text-target="expander">
@@ -500,7 +500,7 @@ describe('ExpandableTextController', () => {
     it('toggles a server-hidden expander based on truncation', async () => {
       const serverHiddenTemplate = `
         <div data-controller="expandable-text" data-expandable-text-expanded-value="false" data-expandable-text-mode-value="multi_line" data-expandable-text-inline-value="false">
-          <div data-expandable-text-target="truncate" class="op-vertical-truncate op-vertical-truncate--lines-3" style="overflow: hidden;">
+          <div data-expandable-text-target="truncate" class="op-vertical-truncate" style="--op-vertical-truncate-lines: 3; overflow: hidden;">
             <span>Single paragraph.</span>
           </div>
           <div data-expandable-text-target="expander" hidden>

--- a/lookbook/docs/components/expandable-text.md.erb
+++ b/lookbook/docs/components/expandable-text.md.erb
@@ -18,7 +18,7 @@ versus `multi_line` only decides how much shows while collapsed.
 | `single_line` (default) | A single line, cut off with an ellipsis (`…`) | Short labels in table cells or list rows — permission names, statuses |
 | `multi_line` | The first `lines:` rows, then clamped | Multi-line descriptions or rich-text previews |
 
-`multi_line` takes a `lines:` count (2–8, default 3):
+`multi_line` takes a `lines:` count (2 or more, default 3):
 
 <%= embed OpPrimer::ExpandableTextComponentPreview, :multi_line %>
 
@@ -82,7 +82,7 @@ case: **single_line + inline** (table and list labels) and **multi_line + dialog
 
 The component is a flex container with two children:
 
-- **Truncation wrapper** — `Primer::Beta::Truncate` for `single_line` (`text-overflow: ellipsis`) or `OpPrimer::VerticalTruncateComponent` for `multi_line` (`-webkit-line-clamp` via `.op-vertical-truncate--lines-N`)
+- **Truncation wrapper** — `Primer::Beta::Truncate` for `single_line` (`text-overflow: ellipsis`) or `OpPrimer::VerticalTruncateComponent` for `multi_line` (`-webkit-line-clamp` driven by the inline `--op-vertical-truncate-lines` custom property)
 - **Expander button** — a `Primer::Alpha::HiddenTextExpander`, initially hidden, shown by the private `expandable-text` Stimulus controller when overflow is detected
 
 The private `expandable-text` Stimulus controller (for `ExpandableTextComponent` only):

--- a/lookbook/previews/op_primer/expandable_text_component_preview.rb
+++ b/lookbook/previews/op_primer/expandable_text_component_preview.rb
@@ -37,7 +37,7 @@ module OpPrimer
     # @param text "The text content to display" text
     # @param width "Container width in pixels" range { min: 100, max: 600, step: 10 }
     # @param truncate "Truncation style" select { choices: [single_line, multi_line] }
-    # @param lines "Lines (multi_line mode only)" range { min: 2, max: 8, step: 1 }
+    # @param lines "Lines (multi_line mode only)" range { min: 2, max: 12, step: 1 }
     # @param expansion "Reveal text in place or in a dialog" select { choices: [inline, dialog] }
     def playground(text: "OpenProject is an open source project management software that supports " \
                          "classic, agile, and hybrid approaches.",
@@ -63,7 +63,7 @@ module OpPrimer
     end
 
     # Multi-line truncation with inline expansion using line-clamp
-    # @param lines "Number of visible lines" range { min: 2, max: 8, step: 1 }
+    # @param lines "Number of visible lines" range { min: 2, max: 12, step: 1 }
     # @display min_height 300px
     def multi_line(lines: 3)
       render_with_template(locals: { lines: })

--- a/spec/components/op_primer/expandable_text_component_preview_spec.rb
+++ b/spec/components/op_primer/expandable_text_component_preview_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe OpPrimer::ExpandableTextComponentPreview, type: :component do
     render_preview(:multi_line, from: described_class, params: { lines: 4 })
 
     expect(page).to have_css("[data-expandable-text-mode-value='multi_line']")
-    expect(page).to have_css(".op-vertical-truncate--lines-4[data-expandable-text-target='truncate']")
+    expect(page).to have_css(
+      ".op-vertical-truncate[style*='--op-vertical-truncate-lines: 4'][data-expandable-text-target='truncate']"
+    )
   end
 
   it "renders the dialog preview (inline: false)" do
@@ -88,6 +90,8 @@ RSpec.describe OpPrimer::ExpandableTextComponentPreview, type: :component do
     render_preview(:playground, from: described_class, params: { truncate: "multi_line", lines: 2 })
 
     expect(page).to have_css("[data-controller='expandable-text'][data-expandable-text-mode-value='multi_line']")
-    expect(page).to have_css(".op-vertical-truncate--lines-2[data-expandable-text-target='truncate']")
+    expect(page).to have_css(
+      ".op-vertical-truncate[style*='--op-vertical-truncate-lines: 2'][data-expandable-text-target='truncate']"
+    )
   end
 end

--- a/spec/components/op_primer/expandable_text_component_spec.rb
+++ b/spec/components/op_primer/expandable_text_component_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe OpPrimer::ExpandableTextComponent, type: :component do
         "div.d-flex[data-expandable-text-mode-value='multi_line']"
       )
       expect(page).to have_css(
-        "div.op-vertical-truncate.op-vertical-truncate--lines-3[data-expandable-text-target='truncate']",
+        "div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 3']" \
+        "[data-expandable-text-target='truncate']",
         text: "Multi-line content"
       )
       expect(page).to have_no_css(".Truncate")
@@ -89,15 +90,21 @@ RSpec.describe OpPrimer::ExpandableTextComponent, type: :component do
     it "supports configurable line count" do
       render_component(truncate: :multi_line, lines: 5) { "Content" }
 
-      expect(page).to have_css("div.op-vertical-truncate--lines-5[data-expandable-text-target='truncate']")
+      expect(page).to have_css(
+        "div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 5'][data-expandable-text-target='truncate']"
+      )
     end
 
-    it "clamps the line count to the supported range" do
+    it "applies the line count via a custom property, clamping to a minimum of 2" do
       render_component(truncate: :multi_line, lines: 99) { "Content" }
-      expect(page).to have_css("div.op-vertical-truncate--lines-8[data-expandable-text-target='truncate']")
+      expect(page).to have_css(
+        "div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 99'][data-expandable-text-target='truncate']"
+      )
 
       render_component(truncate: :multi_line, lines: 1) { "Content" }
-      expect(page).to have_css("div.op-vertical-truncate--lines-2[data-expandable-text-target='truncate']")
+      expect(page).to have_css(
+        "div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 2'][data-expandable-text-target='truncate']"
+      )
     end
   end
 

--- a/spec/components/op_primer/vertical_truncate_component_spec.rb
+++ b/spec/components/op_primer/vertical_truncate_component_spec.rb
@@ -38,15 +38,18 @@ RSpec.describe OpPrimer::VerticalTruncateComponent, type: :component do
   it "wraps content in a line-clamped div" do
     render_component(lines: 3) { "Multi-line content" }
 
-    expect(page).to have_css("div.op-vertical-truncate.op-vertical-truncate--lines-3", text: "Multi-line content")
+    expect(page).to have_css(
+      "div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 3']",
+      text: "Multi-line content"
+    )
   end
 
-  it "clamps the line count to the supported range" do
+  it "applies the line count via a custom property, clamping to a minimum of 2" do
     render_component(lines: 99) { "Content" }
-    expect(page).to have_css("div.op-vertical-truncate--lines-8")
+    expect(page).to have_css("div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 99']")
 
     render_component(lines: 1) { "Content" }
-    expect(page).to have_css("div.op-vertical-truncate--lines-2")
+    expect(page).to have_css("div.op-vertical-truncate[style*='--op-vertical-truncate-lines: 2']")
   end
 
   it "forwards system arguments to the wrapper" do

--- a/spec/components/open_project/common/attribute_component_spec.rb
+++ b/spec/components/open_project/common/attribute_component_spec.rb
@@ -47,7 +47,10 @@ RSpec.describe OpenProject::Common::AttributeComponent, type: :component do
       render_component(lines: 3)
 
       expect(page).to have_css("[data-expandable-text-mode-value='multi_line']")
-      expect(page).to have_css(".op-vertical-truncate--lines-3[data-expandable-text-target='truncate']", text: "Some long text")
+      expect(page).to have_css(
+        ".op-vertical-truncate[style*='--op-vertical-truncate-lines: 3'][data-expandable-text-target='truncate']",
+        text: "Some long text"
+      )
     end
   end
 


### PR DESCRIPTION
> [!NOTE]
> This PR is based off #23328. Please merge first. 

# Ticket

https://community.openproject.org/wp/DREAM-693 (follow up)

# What are you trying to accomplish?

Drive ExpandableText line clamp via CSS variable

Replaces the per-count `op-vertical-truncate--lines-N` modifier classes with an inline `--op-vertical-truncate-lines` custom property, set through Primer's `join_style_arguments` like `Primer::Beta::Truncate` does for `max-width`. This drops the generated-class explosion and the hard upper bound, so any count from 2 up works. The floor is 2 because a single clamped line is `single_line`'s job, not `multi_line`'s.

## Screenshots

no visual changes

# What approach did you choose and why?

see https://github.com/opf/openproject/pull/23328#discussion_r3430118436

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
