### PR TITLE
Pass OpenProject installation uuid along to XWiki

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/referencing_pages.rb
@@ -58,17 +58,23 @@ module Wikis
 
             def fetch_reference_ids(http, input_data)
               fetch_page_ids(http, rest_url("openproject/links/workPackages/#{input_data.linkable.id}"),
-                             params: { number: MAXIMUM_RESULTS })
+                             params: { number: MAXIMUM_RESULTS, withInstance: instance_id })
             end
 
             def fetch_mention_ids(http, input_data)
-              fetch_page_ids(http, rest_url("openproject/mentions"), params: { workPackage: input_data.linkable.id })
+              fetch_page_ids(http, rest_url("openproject/mentions"), params: {
+                               workPackage: input_data.linkable.id, withInstance: instance_id
+                             })
             end
 
             def fetch_page_ids(http, url, params:)
               handle_response(http.get(url, params:)) do |data|
                 success(fetch_json(data, "searchResults").map { fetch_json(it, "id") }.uniq)
               end
+            end
+
+            def instance_id
+              Setting.installation_uuid
             end
           end
         end

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/referencing_pages_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/referencing_pages_spec.rb
@@ -166,7 +166,8 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :missing_token)) }
     end
 
-    context "with real XWiki responses", vcr: "xwiki/referencing_pages" do
+    # VCR setup: replace installation_uuid with one accepted by your XWiki instance (possible to search-and-replace it afterwards)
+    context "with real XWiki responses", vcr: "xwiki/referencing_pages", with_settings: { installation_uuid: "test_uuid" } do
       let(:wiki_provider) { create(:xwiki_provider, :for_local_connection, connected_user: user) }
       let(:linkable) { create(:work_package, id: 14) }
       let(:auth_strategy) { wiki_provider.auth_strategy_for(user).value! }
@@ -182,7 +183,8 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::ReferencingPages, :di
       end
     end
 
-    context "with no linked pages in XWiki (VCR)", vcr: "xwiki/referencing_pages_empty" do
+    context "with no linked pages in XWiki (VCR)", vcr: "xwiki/referencing_pages_empty",
+                                                   with_settings: { installation_uuid: "test_uuid" } do
       let(:wiki_provider) { create(:xwiki_provider, :for_local_connection, connected_user: user) }
       let(:linkable) { create(:work_package, id: 21) }
       let(:auth_strategy) { wiki_provider.auth_strategy_for(user).value! }

--- a/modules/wikis/spec/support/xwiki_stubs.rb
+++ b/modules/wikis/spec/support/xwiki_stubs.rb
@@ -30,11 +30,11 @@
 
 module XWikiStubs
   def search_endpoint(linkable, provider:, number: 25)
-    "#{provider.url}rest/openproject/links/workPackages/#{linkable.id}?number=#{number}"
+    "#{provider.url}rest/openproject/links/workPackages/#{linkable.id}?number=#{number}&withInstance=test_uuid"
   end
 
   def mentions_endpoint(linkable, provider:)
-    "#{provider.url}rest/openproject/mentions?workPackage=#{linkable.id}"
+    "#{provider.url}rest/openproject/mentions?workPackage=#{linkable.id}&withInstance=test_uuid"
   end
 
   def stub_canonical_page_info(identifier, uid:, title:, href:, provider:, token: "user-bearer-token")

--- a/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://xwiki.local/rest/openproject/links/workPackages/14?number=25
+    uri: https://xwiki.local/rest/openproject/links/workPackages/14?number=25&withInstance=test_uuid
     body:
       encoding: US-ASCII
       string: ''
@@ -49,7 +49,7 @@ http_interactions:
   recorded_at: Wed, 10 Jun 2026 13:09:46 GMT
 - request:
     method: get
-    uri: https://xwiki.local/rest/openproject/mentions?workPackage=14
+    uri: https://xwiki.local/rest/openproject/mentions?withInstance=test_uuid&workPackage=14
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages_empty.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/referencing_pages_empty.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://xwiki.local/rest/openproject/links/workPackages/21?number=25
+    uri: https://xwiki.local/rest/openproject/links/workPackages/21?number=25&withInstance=test_uuid
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Wed, 10 Jun 2026 13:35:49 GMT
 - request:
     method: get
-    uri: https://xwiki.local/rest/openproject/mentions?workPackage=21
+    uri: https://xwiki.local/rest/openproject/mentions?withInstance=test_uuid&workPackage=21
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This allows XWiki to properly filter out which mentions point to our instance of OpenProject and not antoher one. This is needed for cases where more than one OP instance is associated to an XWiki.