### PR TITLE
Avoid capturing external links in wikis tab

### DIFF
--- a/modules/wikis/app/components/wikis/page_link_component.html.erb
+++ b/modules/wikis/app/components/wikis/page_link_component.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
       if error?
         render(Primer::Beta::Text.new(color: :muted)) { page_title }
       else
-        render(Primer::Beta::Link.new(href: page_href, scheme: :primary)) { page_title }
+        render(Primer::Beta::Link.new(href: page_href, scheme: :primary, data: { allow_external_link: true })) { page_title }
       end
     end
   %>


### PR DESCRIPTION
Apparently we have a stimulus controller that replaces every external link in the app with a capturing redirect, see `frontend/src/stimulus/controllers/external-links.controller.ts`.

It can be disabled on a per-link basis, which is what this PR does. This came at a slight surprise to me, because according to our caption of the external link capture setting, we only _intend_ to capture external links in formatted text and there is a `TextFormatting` filter just for that.

Looking at https://github.com/opf/openproject/pull/21844, probably the idea was to _also_ capture documents (BlockNote), which wasn't covered by the TextFormatting filters before?

Only @oliverguenther will be able to give that context.

# Ticket
https://community.openproject.org/wp/XWI-118