### PR TITLE
[DREAM-732] Cannot open project selector on mobile

### DIFF
--- a/app/components/header/project_select_component.html.erb
+++ b/app/components/header/project_select_component.html.erb
@@ -34,7 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
         anchor_side: :outside_bottom,
         anchor_align: :start,
         size: :medium_portrait,
-        padding: :none
+        padding: :none,
+        role: :dialog
       )
     ) do |overlay| %>
   <% overlay.with_show_button(

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -63,6 +63,8 @@ export class MainMenuToggleService {
 
   private wasCollapsedByUser = false;
 
+  private lastInnerWidth = window.innerWidth;
+
   constructor() {
     this.initializeMenu();
     // Add resize event listener
@@ -93,6 +95,12 @@ export class MainMenuToggleService {
   }
 
   private onWindowResize():void {
+    // Skip if only the visual viewport changed (e.g. virtual keyboard opening) —
+    // adjustMenuVisibility() only cares about innerWidth, and the keyboard does not change it.
+    const currentWidth = window.innerWidth;
+    if (currentWidth === this.lastInnerWidth) return;
+    this.lastInnerWidth = currentWidth;
+
     this.adjustMenuVisibility();
   }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-732

# What are you trying to accomplish?
On Chrome (mobile) the project selector directly closed after being opened. 

Root cause: Opening the virtual keyboard on Chrome fires a `window.resize` event. The `MainMenuToggleService` reacted to this by collapsing the main navigation menu. This caused a layout shift, which triggered `AnchoredPositionElement.update()` to recalculate the overlay position incorrectly, moving it off-screen.

Fix: `MainMenuToggleService.onWindowResize()` now skips `adjustMenuVisibility()` when the innerWidth hasn't changed. Since the virtual keyboard only affects viewport height, not width, this filters out keyboard-triggered resize events.

