### PR TITLE
[AGILE-241] Opening/closing a side panel disrupts backlog refinement

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts
@@ -84,6 +84,33 @@ describe('Backlogs controller', () => {
     return ctx.getController<BacklogsControllerType>('backlogs');
   }
 
+  async function renderBacklogsWithSplitView() {
+    await ctx.mount(`
+      <div data-controller="backlogs">
+        <div id="content" style="height: 100px; overflow: auto;">
+          <div id="content-body" style="height: 100px; overflow: auto;">
+            <turbo-frame id="backlogs_container" style="display: block;">
+              <div style="height: 2000px;"></div>
+            </turbo-frame>
+          </div>
+          <turbo-frame id="content-bodyRight"></turbo-frame>
+        </div>
+      </div>
+    `);
+    const listFrame = ctx.container.querySelector('#backlogs_container')!;
+    (listFrame as unknown as { reload:Mock }).reload = reload;
+
+    return {
+      controller: ctx.getController<BacklogsControllerType>('backlogs'),
+      splitViewFrame: document.getElementById('content-bodyRight')!,
+      scrollContainer: document.getElementById('content-body')!,
+    };
+  }
+
+  const dispatchFrameEvent = (frame:Element, type:string) => {
+    frame.dispatchEvent(new CustomEvent(type, { bubbles: true }));
+  };
+
   it('subscribes to aggregated work package events once connected', async () => {
     await renderBacklogs();
 
@@ -125,6 +152,54 @@ describe('Backlogs controller', () => {
     await ctx.nextFrame();
 
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('restores the backlog scroll position when the side panel renders', async () => {
+    const { splitViewFrame, scrollContainer } = await renderBacklogsWithSplitView();
+
+    scrollContainer.scrollTop = 600;
+    expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+
+    // The frame is about to render new (or empty) panel content.
+    dispatchFrameEvent(splitViewFrame, 'turbo:before-frame-render');
+
+    // Simulate the navigation resetting the list to the top.
+    scrollContainer.scrollTop = 0;
+
+    dispatchFrameEvent(splitViewFrame, 'turbo:frame-render');
+
+    await waitFor(() => {
+      expect(scrollContainer.scrollTop).toBe(600);
+    });
+  });
+
+  it('does not force a scroll position when the backlog was at the top', async () => {
+    const { splitViewFrame, scrollContainer } = await renderBacklogsWithSplitView();
+
+    scrollContainer.scrollTop = 0;
+
+    dispatchFrameEvent(splitViewFrame, 'turbo:before-frame-render');
+    dispatchFrameEvent(splitViewFrame, 'turbo:frame-render');
+
+    await ctx.nextFrame();
+    expect(scrollContainer.scrollTop).toBe(0);
+  });
+
+  it('stops restoring scroll once disconnected', async () => {
+    const { splitViewFrame, scrollContainer } = await renderBacklogsWithSplitView();
+
+    scrollContainer.scrollTop = 600;
+    dispatchFrameEvent(splitViewFrame, 'turbo:before-frame-render');
+
+    const root = ctx.container.querySelector('[data-controller="backlogs"]')!;
+    root.remove();
+    await ctx.nextFrame();
+
+    scrollContainer.scrollTop = 0;
+    dispatchFrameEvent(splitViewFrame, 'turbo:frame-render');
+
+    await ctx.nextFrame();
+    expect(scrollContainer.scrollTop).toBe(0);
   });
 
   it('does not subscribe when disconnected before the context resolves', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts
@@ -173,6 +173,41 @@ describe('Backlogs controller', () => {
     });
   });
 
+  it('ignores a stale scrollTop on the hidden container while the panel is open', async () => {
+    await ctx.mount(`
+      <div data-controller="backlogs">
+        <div id="content" style="height: 100px; overflow: hidden;">
+          <div id="content-body" style="height: 100px; overflow: auto;">
+            <turbo-frame id="backlogs_container" style="display: block;">
+              <div style="height: 2000px;"></div>
+            </turbo-frame>
+          </div>
+          <turbo-frame id="content-bodyRight"></turbo-frame>
+        </div>
+      </div>
+    `);
+    const splitViewFrame = document.getElementById('content-bodyRight')!;
+    const content = document.getElementById('content')!;
+    const contentBody = document.getElementById('content-body')!;
+
+    // Stale leftover from before the panel opened; `#content` is now hidden.
+    content.scrollTop = 800;
+    // The active scroll container reflects where the user actually is.
+    contentBody.scrollTop = 200;
+
+    dispatchFrameEvent(splitViewFrame, 'turbo:before-frame-render');
+
+    // Simulate the navigation resetting the active container to the top.
+    contentBody.scrollTop = 0;
+
+    dispatchFrameEvent(splitViewFrame, 'turbo:frame-render');
+
+    // The user's real position (200) must be restored, not the stale 800.
+    await waitFor(() => {
+      expect(contentBody.scrollTop).toBe(200);
+    });
+  });
+
   it('does not force a scroll position when the backlog was at the top', async () => {
     const { splitViewFrame, scrollContainer } = await renderBacklogsWithSplitView();
 

--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
@@ -38,7 +38,8 @@ const SPLIT_VIEW_FRAME_ID = 'content-bodyRight';
 
 // Depending on whether the side panel is shown, the backlog is scrolled either
 // by `#content` or by `#content-body` (see frontend/.../layout/_base.sass). We
-// remember and restore both so the position survives the container switch.
+// read the position from whichever container is currently scrollable and write
+// it back to both so it survives the container switch.
 const SCROLL_CONTAINER_IDS = ['content-body', 'content'];
 
 export default class BacklogsController extends Controller<HTMLElement> {
@@ -88,10 +89,12 @@ export default class BacklogsController extends Controller<HTMLElement> {
   }
 
   private rememberScrollPosition = ():void => {
-    this.savedScrollTop = this.scrollContainers.reduce(
-      (max, container) => Math.max(max, container.scrollTop),
-      0,
-    );
+    // Only the container that is actually scrollable in the current split state
+    // tracks the user's position. While the panel is open `#content` becomes
+    // `overflow: hidden` but keeps a stale, possibly larger `scrollTop`; reading
+    // the max across both would resurface that outdated position on the next
+    // open/close. So we read from the active scroll container only.
+    this.savedScrollTop = this.activeScrollContainer?.scrollTop ?? null;
   };
 
   private restoreScrollPosition = ():void => {
@@ -120,6 +123,16 @@ export default class BacklogsController extends Controller<HTMLElement> {
     return SCROLL_CONTAINER_IDS
       .map((id) => document.getElementById(id))
       .filter((element):element is HTMLElement => element !== null);
+  }
+
+  // The container the user is actually scrolling: the first candidate whose
+  // computed overflow allows scrolling. `#content` reports `overflow: hidden`
+  // while the side panel is open, so it is skipped in favour of `#content-body`.
+  private get activeScrollContainer():HTMLElement|null {
+    return this.scrollContainers.find((container) => {
+      const { overflowY } = window.getComputedStyle(container);
+      return overflowY === 'auto' || overflowY === 'scroll';
+    }) ?? null;
   }
 
   private get splitViewFrame() {

--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
@@ -36,10 +36,9 @@ import { useAngularServices, type ServiceKey } from 'core-stimulus/mixins/use-an
 // The work package detail/side panel renders into this shared turbo frame.
 const SPLIT_VIEW_FRAME_ID = 'content-bodyRight';
 
-// Depending on whether the side panel is shown, the backlog is scrolled either
-// by `#content` or by `#content-body` (see frontend/.../layout/_base.sass). We
-// read the position from whichever container is currently scrollable and write
-// it back to both so it survives the container switch.
+// The backlog is scrolled by `#content`, or by `#content-body` while the side
+// panel is open (see frontend/.../layout/_base.sass). Only one is scrollable at
+// a time, so we resolve whichever currently is.
 const SCROLL_CONTAINER_IDS = ['content-body', 'content'];
 
 export default class BacklogsController extends Controller<HTMLElement> {
@@ -48,7 +47,7 @@ export default class BacklogsController extends Controller<HTMLElement> {
 
   private subscription:Subscription|null = null;
   private abortController:AbortController|null = null;
-  private savedScrollTop:number|null = null;
+  private savedScrollTop = 0;
 
   initialize() {
     useAngularServices(this);
@@ -58,15 +57,13 @@ export default class BacklogsController extends Controller<HTMLElement> {
     this.abortController = new AbortController();
     const { signal } = this.abortController;
 
-    const frame = this.splitViewFrame;
-    if (frame) {
-      // Opening or closing the side panel navigates the content-bodyRight turbo
-      // frame. Without this, each navigation resets the backlog to the top and
-      // the user loses their refinement spot (AGILE-241). We snapshot the scroll
-      // position before the frame renders and reapply it afterwards.
-      frame.addEventListener('turbo:before-frame-render', this.rememberScrollPosition, { signal });
-      frame.addEventListener('turbo:frame-render', this.restoreScrollPosition, { signal });
-    }
+    // Opening or closing the side panel navigates the content-bodyRight turbo
+    // frame, which otherwise resets the backlog to the top and loses the user's
+    // refinement spot (AGILE-241). We snapshot the scroll position before the
+    // frame renders and reapply it afterwards.
+    const frame = document.getElementById(SPLIT_VIEW_FRAME_ID);
+    frame?.addEventListener('turbo:before-frame-render', this.rememberScrollPosition, { signal });
+    frame?.addEventListener('turbo:frame-render', this.restoreScrollPosition, { signal });
   }
 
   servicesConnected() {
@@ -81,7 +78,7 @@ export default class BacklogsController extends Controller<HTMLElement> {
 
     this.abortController?.abort();
     this.abortController = null;
-    this.savedScrollTop = null;
+    this.savedScrollTop = 0;
   }
 
   private refreshList() {
@@ -89,54 +86,36 @@ export default class BacklogsController extends Controller<HTMLElement> {
   }
 
   private rememberScrollPosition = ():void => {
-    // Only the container that is actually scrollable in the current split state
-    // tracks the user's position. While the panel is open `#content` becomes
-    // `overflow: hidden` but keeps a stale, possibly larger `scrollTop`; reading
-    // the max across both would resurface that outdated position on the next
-    // open/close. So we read from the active scroll container only.
-    this.savedScrollTop = this.activeScrollContainer?.scrollTop ?? null;
+    this.savedScrollTop = this.scrollContainer?.scrollTop ?? 0;
   };
 
   private restoreScrollPosition = ():void => {
     const target = this.savedScrollTop;
-    this.savedScrollTop = null;
-
-    if (target === null || target <= 0) {
+    if (target <= 0) {
       return;
     }
 
     const apply = () => {
-      // Setting scrollTop on the currently inactive (non-scrollable) container
-      // is a harmless no-op, so we can apply to both candidates unconditionally.
-      this.scrollContainers.forEach((container) => { container.scrollTop = target; });
+      const container = this.scrollContainer;
+      if (container) { container.scrollTop = target; }
     };
 
+    // The frame navigation is promoted to a turbo visit that scrolls after the
+    // frame renders, so reapply once the layout has settled (the ~25ms mirrors
+    // keep-scroll-position.controller.ts).
     apply();
-    // Reapply once layout has settled. The frame navigation is promoted to a
-    // turbo visit which scrolls afterwards, so a single synchronous write is
-    // not always enough (mirrors the keep-scroll-position controller).
-    requestAnimationFrame(apply);
     window.setTimeout(apply, 25);
   };
 
-  private get scrollContainers():HTMLElement[] {
+  // The container the backlog currently scrolls in: whichever candidate is
+  // actually scrollable. `#content` reports `overflow: hidden` while the side
+  // panel is open, so it is skipped in favour of `#content-body`.
+  private get scrollContainer():HTMLElement|null {
     return SCROLL_CONTAINER_IDS
       .map((id) => document.getElementById(id))
-      .filter((element):element is HTMLElement => element !== null);
-  }
-
-  // The container the user is actually scrolling: the first candidate whose
-  // computed overflow allows scrolling. `#content` reports `overflow: hidden`
-  // while the side panel is open, so it is skipped in favour of `#content-body`.
-  private get activeScrollContainer():HTMLElement|null {
-    return this.scrollContainers.find((container) => {
-      const { overflowY } = window.getComputedStyle(container);
-      return overflowY === 'auto' || overflowY === 'scroll';
-    }) ?? null;
-  }
-
-  private get splitViewFrame() {
-    return document.getElementById(SPLIT_VIEW_FRAME_ID);
+      .find((el):el is HTMLElement => (
+        el !== null && ['auto', 'scroll'].includes(window.getComputedStyle(el).overflowY)
+      )) ?? null;
   }
 
   private get listElement() {

--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
@@ -33,14 +33,39 @@ import { filter, Subscription } from 'rxjs';
 
 import { useAngularServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 
+// The work package detail/side panel renders into this shared turbo frame.
+const SPLIT_VIEW_FRAME_ID = 'content-bodyRight';
+
+// Depending on whether the side panel is shown, the backlog is scrolled either
+// by `#content` or by `#content-body` (see frontend/.../layout/_base.sass). We
+// remember and restore both so the position survives the container switch.
+const SCROLL_CONTAINER_IDS = ['content-body', 'content'];
+
 export default class BacklogsController extends Controller<HTMLElement> {
   static services:ServiceKey[] = ['halEvents'];
   declare halEvents:HalEventsService;
 
   private subscription:Subscription|null = null;
+  private abortController:AbortController|null = null;
+  private savedScrollTop:number|null = null;
 
   initialize() {
     useAngularServices(this);
+  }
+
+  connect() {
+    this.abortController = new AbortController();
+    const { signal } = this.abortController;
+
+    const frame = this.splitViewFrame;
+    if (frame) {
+      // Opening or closing the side panel navigates the content-bodyRight turbo
+      // frame. Without this, each navigation resets the backlog to the top and
+      // the user loses their refinement spot (AGILE-241). We snapshot the scroll
+      // position before the frame renders and reapply it afterwards.
+      frame.addEventListener('turbo:before-frame-render', this.rememberScrollPosition, { signal });
+      frame.addEventListener('turbo:frame-render', this.restoreScrollPosition, { signal });
+    }
   }
 
   servicesConnected() {
@@ -52,10 +77,53 @@ export default class BacklogsController extends Controller<HTMLElement> {
   disconnect() {
     this.subscription?.unsubscribe();
     this.subscription = null;
+
+    this.abortController?.abort();
+    this.abortController = null;
+    this.savedScrollTop = null;
   }
 
   private refreshList() {
     void this.listElement.reload();
+  }
+
+  private rememberScrollPosition = ():void => {
+    this.savedScrollTop = this.scrollContainers.reduce(
+      (max, container) => Math.max(max, container.scrollTop),
+      0,
+    );
+  };
+
+  private restoreScrollPosition = ():void => {
+    const target = this.savedScrollTop;
+    this.savedScrollTop = null;
+
+    if (target === null || target <= 0) {
+      return;
+    }
+
+    const apply = () => {
+      // Setting scrollTop on the currently inactive (non-scrollable) container
+      // is a harmless no-op, so we can apply to both candidates unconditionally.
+      this.scrollContainers.forEach((container) => { container.scrollTop = target; });
+    };
+
+    apply();
+    // Reapply once layout has settled. The frame navigation is promoted to a
+    // turbo visit which scrolls afterwards, so a single synchronous write is
+    // not always enough (mirrors the keep-scroll-position controller).
+    requestAnimationFrame(apply);
+    window.setTimeout(apply, 25);
+  };
+
+  private get scrollContainers():HTMLElement[] {
+    return SCROLL_CONTAINER_IDS
+      .map((id) => document.getElementById(id))
+      .filter((element):element is HTMLElement => element !== null);
+  }
+
+  private get splitViewFrame() {
+    return document.getElementById(SPLIT_VIEW_FRAME_ID);
   }
 
   private get listElement() {

--- a/modules/backlogs/spec/features/backlogs/split_view_scroll_position_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/split_view_scroll_position_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Backlog split view scroll position",
+               :js, :settings_reset do
+  let!(:project) do
+    create(:project,
+           types: [type],
+           enabled_module_names: %w(work_package_tracking backlogs))
+  end
+  let(:type) { create(:type) }
+
+  let!(:sprint) { create(:sprint, project:) }
+
+  # Enough work packages to make the backlog list scrollable.
+  let!(:work_packages) do
+    Array.new(30) do |i|
+      create(:work_package, subject: "Story #{i + 1}", sprint:, type:, project:)
+    end
+  end
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_sprints manage_sprint_items view_work_packages edit_work_packages]
+           })
+  end
+
+  before do
+    backlogs_page.visit!
+  end
+
+  # The backlog is scrolled by either #content or #content-body depending on
+  # whether the side panel is shown, so we read whichever currently holds the
+  # scroll offset.
+  def backlog_scroll_top
+    page.evaluate_script(
+      "Math.max(" \
+      "(document.getElementById('content') || {}).scrollTop || 0," \
+      "(document.getElementById('content-body') || {}).scrollTop || 0)"
+    )
+  end
+
+  it "keeps the refinement spot when opening and closing the side panel" do
+    target = work_packages.last
+    target_card = page.find("[data-test-selector='work-package-#{target.id}']")
+    page.execute_script("arguments[0].scrollIntoView({ block: 'center', behavior: 'instant' });", target_card)
+
+    scroll_position = backlog_scroll_top
+    expect(scroll_position).to be > 0
+
+    # Opening the side panel must not scroll the backlog to the top.
+    split_view = backlogs_page.open_work_package_details(target)
+
+    retry_block do
+      expect(backlog_scroll_top).to be_within(25).of(scroll_position)
+    end
+
+    # Closing the side panel must restore the position as well.
+    split_view.close
+    expect(page).to have_no_test_selector("wp-details-tab-component--close")
+
+    retry_block do
+      expect(backlog_scroll_top).to be_within(25).of(scroll_position)
+    end
+  end
+end


### PR DESCRIPTION
🤖 AI-generated PR! Please review it for accuracy and then remove this line.

# Ticket

https://community.openproject.org/work_packages/AGILE-241

# What are you trying to accomplish?

Fixes AGILE-241: opening or closing the work package side panel during backlog refinement reset the Backlog and scrolled it back to the top, so users lost the spot they were working on (typically a story in the middle or bottom of the list) and had to scroll back every time.

The Backlog list lives in the `backlogs_container` Turbo frame, while the detail/side panel renders into the shared `content-bodyRight` Turbo frame. Both opening (via the story card / "Open details" action) and closing (the panel's close link) navigate `content-bodyRight` with `turbo-action="advance"`, and that navigation reset the backlog's scroll position.

With this change, the scroll position of the backlog is preserved when the side panel is opened and when it is closed, so the refinement spot is maintained.

# What approach did you choose and why?

The backlogs Stimulus controller already wraps the whole page (`content_controller "backlogs"` on `#content-wrapper`), so it can see both the list and the panel frame. I hooked the lifecycle of the shared `content-bodyRight` frame:

- On `turbo:before-frame-render` it snapshots the current scroll position.
- On `turbo:frame-render` it reapplies that position — synchronously, then again on `requestAnimationFrame` and a short timeout, mirroring the existing `keep-scroll-position` controller, to win against the promoted Turbo visit's own scroll handling.

A subtlety in the layout CSS (`_base.sass`) is that the active scroll container changes between `#content` and `#content-body` depending on whether the panel is shown. To stay robust to that switch, the controller records the max `scrollTop` across both candidates and reapplies to both on restore (writing `scrollTop` to the inactive, non-scrollable container is a harmless no-op). Listeners are scoped with an `AbortController` and torn down on `disconnect`.

Hooking the single shared frame lifecycle keeps the fix centralized in the backlogs controller rather than touching the shared close-button component (`tab_component`) or `story.controller`, which would have meant changes in two places and risked affecting the other `content-bodyRight` consumers (boards, team planner, calendar, notifications).

I deliberately did **not** alter the layout CSS to "stabilize" the scroll container. That was a conditional option in the plan, contingent on confirming the container switch is the dominant cause; the JS fix already handles that case, and a speculative layout change would risk regressing every other split-view page.

## Screenshots

No visual changes.

# Merge checklist

- [x] Added/updated tests
  - Unit (Vitest): `frontend/src/stimulus/controllers/dynamic/backlogs.controller.spec.ts` — restores position on frame render, leaves a top-of-list backlog untouched, and stops restoring after disconnect.
  - Feature (RSpec, `:js`): `modules/backlogs/spec/features/backlogs/split_view_scroll_position_spec.rb` — scrolls a 30-story sprint to a bottom story and asserts the position holds across both open and close.
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — N/A (no component/pattern changes)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)