### PR TITLE
Fix 404 on sprints index/new for private projects

### DIFF
--- a/modules/backlogs/app/controllers/backlogs/base_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/base_controller.rb
@@ -33,19 +33,14 @@ module Backlogs
   class BaseController < ::ApplicationController
     helper "backlogs/common"
 
-    before_action :load_sprint_and_project,
+    before_action :load_project,
+                  :load_sprint,
                   :authorize
 
     private
 
     # Loads the project to be used by the authorize filter to determine if
     # User.current has permission to invoke the method in question.
-    def load_sprint_and_project
-      load_project
-
-      load_sprint
-    end
-
     def load_project
       @project = Project.visible.find(params.expect(:project_id))
     end

--- a/modules/backlogs/app/controllers/backlogs/sprints_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/sprints_controller.rb
@@ -36,10 +36,9 @@ module Backlogs
     SHARED_SPRINT_EDIT_ACTIONS = %i[edit_dialog update refresh_form].freeze
     SPRINTLESS_ACTIONS = %i[index new_dialog create].freeze
 
-    skip_before_action :load_sprint_and_project, only: SPRINTLESS_ACTIONS
+    skip_before_action :load_sprint, only: SPRINTLESS_ACTIONS
     skip_before_action :authorize, only: SPRINT_STATE_ACTIONS + SHARED_SPRINT_EDIT_ACTIONS
 
-    prepend_before_action :load_project, only: SPRINTLESS_ACTIONS
     before_action :load_sprint_from_form_id, only: :refresh_form
     before_action :authorize_sprint_edit!, only: SHARED_SPRINT_EDIT_ACTIONS
     before_action :authorize_start!, only: :start

--- a/modules/backlogs/spec/requests/backlogs/sprints_spec.rb
+++ b/modules/backlogs/spec/requests/backlogs/sprints_spec.rb
@@ -30,17 +30,30 @@
 
 require "spec_helper"
 
+# A real session login (rather than the current_user stub) is required so the
+# request runs through user_setup. Otherwise User.current is stubbed from the
+# start and the project is never loaded as an anonymous user, which is exactly
+# the regression these specs guard against on a private project.
 RSpec.describe "Backlogs::Sprints", :skip_csrf, type: :rails_request do
-  shared_let(:type_feature) { create(:type_feature) }
-  shared_let(:type_task) { create(:type_task) }
-  shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project) }
-  shared_let(:status) { create(:status, name: "status 1", is_default: true) }
-  shared_let(:sprint) { create(:sprint, name: "Original sprint name", project:) }
+  let(:password) { "adminADMIN!" }
+  let(:user) do
+    create(:user,
+           password:,
+           password_confirmation: password,
+           member_with_permissions: { project => %i[view_sprints create_sprints view_work_packages show_board_views] })
+  end
 
-  current_user { user }
+  before do
+    post signin_path, params: { username: user.login, password: }
+    follow_redirect! while response.redirect?
+  end
 
   describe "PUT #update" do
+    let(:project) do
+      create(:project, public: true, enabled_module_names: %w[work_package_tracking backlogs])
+    end
+    let!(:sprint) { create(:sprint, name: "Original sprint name", project:) }
+
     it "loads the sprint from sprint_id and updates it", :aggregate_failures do
       put "/projects/#{project.identifier}/backlogs/sprints/#{sprint.id}",
           headers: { "ACCEPT" => "text/vnd.turbo-stream.html" },
@@ -48,6 +61,33 @@ RSpec.describe "Backlogs::Sprints", :skip_csrf, type: :rails_request do
 
       expect(response).to be_successful
       expect(sprint.reload.name).to eq("Changed sprint name")
+    end
+  end
+
+  describe "private project access" do
+    let(:project) do
+      create(:project, public: false, enabled_module_names: %w[work_package_tracking backlogs])
+    end
+
+    it "GET #index is reachable" do
+      get project_backlogs_sprints_path(project)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "GET #new_dialog is reachable" do
+      get new_dialog_project_backlogs_sprints_path(project), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "POST #create is reachable", :aggregate_failures do
+      post project_backlogs_sprints_path(project),
+           headers: { "Accept" => "text/vnd.turbo-stream.html" },
+           params: { sprint: { name: "New sprint", start_date: Time.zone.today, finish_date: Time.zone.today + 14.days } }
+
+      expect(response).to be_successful
+      expect(Sprint.for_project(project).where(name: "New sprint")).to exist
     end
   end
 end


### PR DESCRIPTION
# Ticket

Regression from the sprint goals work: https://community.openproject.org/wp/71059

# What are you trying to accomplish?

The sprint pages (`backlogs/sprints` and the `+ Sprint` dialog) returned a 404 on private projects. The regression was introduced by #23271, which prepended `load_project` to the controller's callback chain — ahead of `ApplicationController#user_setup`. The project was therefore loaded before `User.current` was populated from the session, so `Project.visible` scoped to the anonymous user and raised `RecordNotFound`. Public projects were unaffected, which is why it surfaced inconsistently.

# What approach did you choose and why?

Split the base controller's combined loader into separate `load_project` and `load_sprint` callbacks so the controller can skip only the sprint load while project loading stays in its normal slot — after authentication, before `authorize`. This mirrors how `BucketsController` (sharing the same `create_sprints` actions) already loads the project.

The regression test uses a real session login rather than the usual `current_user` stub: the stub sets `User.current` from the start and so cannot exercise an auth-ordering bug like this one.

# Merge checklist

- [x] Added/updated tests
