### PR TITLE
[DREAM-697] Migrate Border Box-based lists to `BorderBoxListComponent`

### DIFF
--- a/app/components/admin/departments/detail_component.html.erb
+++ b/app/components/admin/departments/detail_component.html.erb
@@ -29,66 +29,62 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper(tag: "turbo-frame", target: "_top") do
-    render(Primer::Beta::BorderBox.new) do |box|
-      box.with_header do
-        flex_layout(align_items: :center, justify_content: :space_between) do |header|
-          header.with_column do
+    render(OpenProject::Common::BorderBoxListComponent.new(container: "admin-departments-detail")) do |list|
+      list.with_header(title: header_title) do |header|
+        header.with_description(tag: :div, color: :default) do
+          concat(
             render(Primer::Beta::Breadcrumbs.new) do |loaf|
               breadcrumb_items.each do |item|
                 loaf.with_item(href: item[:href] || "#", target: nil) { item[:label] }
               end
             end
-          end
+          )
 
           if group&.ldap_managed?
-            header.with_column do
-              render(Primer::Beta::Label.new(scheme: :accent)) { I18n.t(:label_managed_by_ldap) }
-            end
-          elsif group
-            header.with_column do
-              render(
-                Primer::Beta::IconButton.new(
-                  tag: :a,
-                  href: edit_admin_department_path(group),
-                  icon: :pencil,
-                  scheme: :invisible,
-                  "aria-label": I18n.t(:button_edit)
-                )
-              )
-            end
+            concat(render(Primer::Beta::Label.new(scheme: :accent)) { I18n.t(:label_managed_by_ldap) })
           end
+        end
+
+        if group && !group.ldap_managed?
+          header.with_action_icon_button(
+            tag: :a,
+            href: edit_admin_department_path(group),
+            icon: :pencil,
+            scheme: :invisible,
+            "aria-label": I18n.t(:button_edit)
+          )
         end
       end
 
       if show_global_empty_state? && !add_subgroup?
-        box.with_row do
+        list.with_item do
           render(Admin::Departments::BlankslateComponent.new)
         end
       elsif show_department_empty_state? && !add_user? && !add_subgroup?
-        box.with_row do
+        list.with_item do
           render(Admin::Departments::DetailBlankslateComponent.new(group:))
         end
       else
         child_groups.each do |child|
-          box.with_row do
+          list.with_item do
             render(Admin::Departments::DepartmentRowComponent.new(department: child))
           end
         end
 
         if add_subgroup?
-          box.with_row do
+          list.with_item do
             render(Admin::Departments::AddDepartmentComponent.new(group:))
           end
         end
 
         users.each do |user|
-          box.with_row do
+          list.with_item do
             render(Admin::Departments::UserRowComponent.new(user:, group:))
           end
         end
 
         if add_user?
-          box.with_row do
+          list.with_item do
             render(Admin::Departments::AddUserComponent.new(group:))
           end
         end

--- a/app/components/admin/departments/detail_component.rb
+++ b/app/components/admin/departments/detail_component.rb
@@ -74,6 +74,10 @@ module Admin
         items
       end
 
+      def header_title
+        group&.name || organization_name
+      end
+
       def show_global_empty_state?
         group.blank? && child_groups.empty?
       end

--- a/app/components/my/notifications/show_page_component.html.erb
+++ b/app/components/my/notifications/show_page_component.html.erb
@@ -82,45 +82,44 @@ See COPYRIGHT and LICENSE files for more details.
         component.with_description { t("my_account.notifications.project_specific_settings.description") }
       end %>
 
-  <% if project_notification_settings.any? %>
-    <%= render(Primer::Beta::BorderBox.new(mb: 3)) do |box| %>
-      <% box.with_header { t("my_account.notifications.project_specific_settings.list_header") } %>
-      <% project_notification_settings.each do |setting| %>
-        <% box.with_row(test_selector: "project-specific-settings-list") do %>
-          <%= flex_layout(justify_content: :space_between, align_items: :center, width: :full) do |flex| %>
-            <%= flex.with_column do %>
-              <span><%= setting.project.name %></span>
-            <% end %>
-            <%= flex.with_column do %>
-              <%= render(Primer::Alpha::ActionMenu.new(test_selector: "project-specific-settings-list--action-menu")) do |menu|
-                    menu.with_show_button(
-                      scheme: :invisible,
-                      size: :small,
-                      icon: :"kebab-horizontal",
-                      "aria-label": t(:label_open_menu),
-                      tooltip_direction: :w
-                    )
-                    menu.with_item(
-                      label: t("button_edit"),
-                      href: edit_project_settings_url(setting.project_id),
-                      content_arguments: { data: { controller: "async-dialog" } }
-                    ) do |item|
-                      item.with_leading_visual_icon(icon: :pencil)
-                    end
-                    menu.with_item(
-                      label: t("button_delete"),
-                      scheme: :danger,
-                      href: project_setting_url(setting.project_id),
-                      content_arguments: { data: { turbo_method: :delete, turbo_confirm: t("text_are_you_sure") } }
-                    ) do |item|
-                      item.with_leading_visual_icon(icon: :trash)
-                    end
-                  end %>
-            <% end %>
+  <%= render(OpenProject::Common::BorderBoxListComponent.new(container: "project-specific-notification-settings", mb: 3)) do |list| %>
+    <% list.with_header(title: t("my_account.notifications.project_specific_settings.list_header")) %>
+    <% project_notification_settings.each do |setting| %>
+      <% list.with_item(test_selector: "project-specific-settings-list") do %>
+        <%= flex_layout(justify_content: :space_between, align_items: :center, width: :full) do |flex| %>
+          <%= flex.with_column do %>
+            <span><%= setting.project.name %></span>
+          <% end %>
+          <%= flex.with_column do %>
+            <%= render(Primer::Alpha::ActionMenu.new(test_selector: "project-specific-settings-list--action-menu")) do |menu|
+                  menu.with_show_button(
+                    scheme: :invisible,
+                    size: :small,
+                    icon: :"kebab-horizontal",
+                    "aria-label": t(:label_open_menu),
+                    tooltip_direction: :w
+                  )
+                  menu.with_item(
+                    label: t("button_edit"),
+                    href: edit_project_settings_url(setting.project_id),
+                    content_arguments: { data: { controller: "async-dialog" } }
+                  ) do |item|
+                    item.with_leading_visual_icon(icon: :pencil)
+                  end
+                  menu.with_item(
+                    label: t("button_delete"),
+                    scheme: :danger,
+                    href: project_setting_url(setting.project_id),
+                    content_arguments: { data: { turbo_method: :delete, turbo_confirm: t("text_are_you_sure") } }
+                  ) do |item|
+                    item.with_leading_visual_icon(icon: :trash)
+                  end
+                end %>
           <% end %>
         <% end %>
       <% end %>
     <% end %>
+    <% list.with_empty_state(title: t("my_account.notifications.project_specific_settings.empty_text")) %>
   <% end %>
 
   <%= render(

--- a/app/components/oauth/applications/index_component.html.erb
+++ b/app/components/oauth/applications/index_component.html.erb
@@ -4,58 +4,45 @@
       if OpenProject::FeatureDecisions.built_in_oauth_applications_active?
         index_container.with_row do
           render(
-            border_box_container(
-              mb: 4, data: {
-                "test-selector": "op-admin-oauth--built-in-applications"
-              }
+            OpenProject::Common::BorderBoxListComponent.new(
+              container: "op-admin-oauth--built-in-applications",
+              position: :relative,
+              mb: 4,
+              test_selector: "op-admin-oauth--built-in-applications"
             )
-          ) do |component|
-            component.with_header(font_weight: :bold) do
-              render(Primer::Beta::Text.new) do
-                t("oauth.header.builtin_applications")
-              end
-            end
-
-            if @built_in_applications.empty?
-              component.with_row do
-                render(
-                  Primer::Beta::Text.new(
-                    data: {
-                      "test-selector": "op-admin-oauth--built-in-applications-placeholder"
-                    }
-                  )
-                ) do
-                  t("oauth.empty_application_lists")
-                end
-              end
-            end
+          ) do |list|
+            list.with_header(title: t("oauth.header.builtin_applications"))
 
             @built_in_applications.each do |application|
-              component.with_row { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
+              list.with_item { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
             end
+
+            list.with_empty_state(
+              title: t("oauth.empty_application_lists"),
+              test_selector: "op-admin-oauth--built-in-applications-placeholder"
+            )
           end
         end
       end
 
       index_container.with_row do
-        render(border_box_container(mb: 4)) do |component|
-          component.with_header(font_weight: :bold) do
-            render(Primer::Beta::Text.new) do
-              t("oauth.header.other_applications")
-            end
-          end
-
-          if @other_applications.empty?
-            component.with_row do
-              render(Primer::Beta::Text.new(data: { "test-selector": "op-admin-oauth--applications-placeholder" })) do
-                t("oauth.empty_application_lists")
-              end
-            end
-          end
+        render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "op-admin-oauth--other-applications",
+            position: :relative,
+            mb: 4
+          )
+        ) do |list|
+          list.with_header(title: t("oauth.header.other_applications"))
 
           @other_applications.each do |application|
-            component.with_row { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
+            list.with_item { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
           end
+
+          list.with_empty_state(
+            title: t("oauth.empty_application_lists"),
+            test_selector: "op-admin-oauth--applications-placeholder"
+          )
         end
       end
     end

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -137,12 +137,10 @@ module OpenProject
       }
 
       # Optional empty-state content rendered when no items are present.
+      # When omitted, the component renders a generic default empty state.
       #
       # @!parse
-      #   # Adds empty-state content.
-      #   #
-      #   # Interactive lists announce this empty state only when the slot is
-      #   # configured explicitly.
+      #   # Adds custom empty-state content.
       #   #
       #   # @param title [String] empty-state title.
       #   # @param description [String, nil] optional supporting text.
@@ -195,8 +193,7 @@ module OpenProject
       #   the header's block padding.
       # @param interactive [Boolean] whether dynamic list updates should be
       #   announced politely to assistive technology. This affects the counter
-      #   and an explicitly configured empty state; it does not create default
-      #   empty-state content for manually composed lists.
+      #   and empty-state content.
       # @param collapsible [Boolean] whether the header renders a collapsible
       #   toggle. Defaults to `false`.
       # @param current_user [User] user context passed to work-package items.
@@ -243,6 +240,7 @@ module OpenProject
 
       def before_render
         content
+        configure_empty_state!
         configure_header!
       end
 
@@ -263,6 +261,15 @@ module OpenProject
         return unless collapsible? && footer?
 
         header.collapsible_id = [list_id, footer_id].compact.join(" ")
+      end
+
+      def configure_empty_state!
+        return if items.any? || empty_state?
+
+        with_empty_state(
+          title: I18n.t(:label_nothing_display),
+          description: I18n.t(:no_results_title_text)
+        )
       end
     end
   end

--- a/app/components/open_project/common/border_box_list_component/has_menu.rb
+++ b/app/components/open_project/common/border_box_list_component/has_menu.rb
@@ -40,39 +40,49 @@ module OpenProject
           # @!parse
           #   # Adds a trailing action menu.
           #   #
+          #   # By default the menu renders the standard invisible
+          #   # kebab-horizontal show button. Pass `button_arguments:` to
+          #   # customize that default trigger, or call `with_show_button` in
+          #   # the slot block to provide a custom trigger.
+          #   #
           #   # @param menu_id [String, nil] id prefix for the Primer action menu.
-          #   # @param button_aria_label [String, nil] accessible label for the
-          #   #   menu button.
+          #   # @param button_aria_label [String, nil] compatibility shortcut
+          #   #   for the default menu button accessible label. Prefer
+          #   #   `button_arguments: { aria: { label: ... } }`.
+          #   # @param button_arguments [Hash] forwarded to the default
+          #   #   `with_show_button` call.
           #   # @param system_arguments [Hash] forwarded to
           #   #   `Primer::Alpha::ActionMenu`.
           #   # @return [ViewComponent::Slot]
-          #   def with_menu(menu_id: nil, button_aria_label: nil, **system_arguments, &block)
+          #   def with_menu(menu_id: nil, button_aria_label: nil, button_arguments: {}, **system_arguments, &block)
           #   end
-          renders_one :menu, ->(menu_id: nil, button_aria_label: nil, **system_arguments) do
-            build_menu(menu_id:, button_aria_label:, **system_arguments)
+          renders_one :menu, ->(menu_id: nil, button_aria_label: nil, button_arguments: {}, **system_arguments) do
+            build_menu(menu_id:, button_aria_label:, button_arguments:, **system_arguments)
           end
         end
 
         private
 
-        def build_menu(menu_id: nil, button_aria_label: nil, **system_arguments)
+        def build_menu(menu_id: nil, button_aria_label: nil, button_arguments: {}, **system_arguments)
           system_arguments[:classes] = class_names(
             system_arguments[:classes],
             "hide-when-print"
           )
 
-          menu = Primer::Alpha::ActionMenu.new(
+          if button_aria_label.present?
+            button_arguments = button_arguments.deep_dup
+            button_arguments[:aria] = merge_aria(
+              { aria: { label: button_aria_label } },
+              button_arguments
+            )
+          end
+
+          Menu.new(
             menu_id: menu_id || default_menu_id,
+            button_arguments:,
             anchor_align: :end,
             **system_arguments
           )
-          menu.with_show_button(
-            scheme: :invisible,
-            icon: :"kebab-horizontal",
-            "aria-label": button_aria_label || I18n.t(:label_actions),
-            tooltip_direction: :se
-          )
-          menu
         end
 
         def default_menu_id

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -99,6 +99,10 @@ module OpenProject
         #
         #   # Adds a label to the header actions area.
         #   #
+        #   # @deprecated Slated for removal, pending an internal decision on
+        #   #   where a status label belongs in a list header. Do not add new
+        #   #   call sites: render the label from the `title` slot instead.
+        #   #
         #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Label`.
         #   # @return [ViewComponent::Slot]
         #   def with_action_label(**system_arguments, &block)
@@ -110,6 +114,7 @@ module OpenProject
           icon_button: ->(**system_arguments) do
             Primer::Beta::IconButton.new(**system_arguments)
           end,
+          # @deprecated See the `with_action_label` note above.
           label: ->(**system_arguments) do
             Primer::Beta::Label.new(**system_arguments)
           end

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -90,6 +90,13 @@ module OpenProject
         #   def with_action_button(**system_arguments, &block)
         #   end
         #
+        #   # Adds an icon button to the header actions area.
+        #   #
+        #   # @param system_arguments [Hash] forwarded to `Primer::Beta::IconButton`.
+        #   # @return [ViewComponent::Slot]
+        #   def with_action_icon_button(**system_arguments)
+        #   end
+        #
         #   # Adds a label to the header actions area.
         #   #
         #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Label`.
@@ -99,6 +106,9 @@ module OpenProject
         renders_many :actions, types: {
           button: ->(scheme: DEFAULT_ACTION_SCHEME, **system_arguments) do
             Primer::Beta::Button.new(scheme:, **system_arguments)
+          end,
+          icon_button: ->(**system_arguments) do
+            Primer::Beta::IconButton.new(**system_arguments)
           end,
           label: ->(**system_arguments) do
             Primer::Beta::Label.new(**system_arguments)
@@ -122,7 +132,8 @@ module OpenProject
 
         attr_writer :collapsible_id
 
-        # @param title [String] header title.
+        # @param title [String, nil] header title. Optional when the `title`
+        #   slot is filled.
         # @param count [Integer, Boolean, nil] count badge behavior. Pass
         #   `nil` or `false` to hide it, `true` to infer the rendered item
         #   count, or an integer to render an explicit value.

--- a/app/components/open_project/common/border_box_list_component/menu.rb
+++ b/app/components/open_project/common/border_box_list_component/menu.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Common
+    class BorderBoxListComponent
+      # Action menu wrapper for list headers and rows.
+      #
+      # The wrapper owns the default trigger decision while keeping the normal
+      # Primer ActionMenu slot API available to callers.
+      class Menu < ApplicationComponent
+        include Primer::AttributesHelper
+
+        DEFAULT_BUTTON_ARGUMENTS = {
+          scheme: :invisible,
+          icon: :"kebab-horizontal",
+          tooltip_direction: :se
+        }.freeze
+
+        delegate :items,
+                 :with_item,
+                 :with_avatar_item,
+                 :with_divider,
+                 :with_group,
+                 :with_sub_menu_item,
+                 to: :@menu
+
+        def initialize(button_arguments: {}, **system_arguments)
+          super()
+
+          @button_arguments = DEFAULT_BUTTON_ARGUMENTS.merge(button_arguments.deep_dup)
+          @button_arguments[:aria] = merge_aria(
+            { aria: { label: I18n.t(:label_actions) } },
+            @button_arguments
+          )
+          @show_button_configured = false
+          @menu = Primer::Alpha::ActionMenu.new(**system_arguments)
+        end
+
+        def with_show_button(**system_arguments, &)
+          @show_button_configured = true
+          @menu.with_show_button(**system_arguments, &)
+        end
+
+        def call
+          render(@menu)
+        end
+
+        private
+
+        def before_render
+          content
+          configure_default_show_button!
+        end
+
+        def configure_default_show_button!
+          return if @show_button_configured
+
+          @menu.with_show_button(**@button_arguments)
+        end
+      end
+    end
+  end
+end

--- a/app/components/portfolios/index_component.html.erb
+++ b/app/components/portfolios/index_component.html.erb
@@ -3,37 +3,26 @@
     flex_layout do |index_container|
       index_container.with_row do
         render(
-          border_box_container(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "op-portfolios--portfolios",
+            position: :relative,
             mb: 4,
-            data: {
-              "test-selector": "op-portfolios--portfolios"
-            }
+            test_selector: "op-portfolios--portfolios"
           )
-        ) do |component|
-          if portfolios.empty?
-            component.with_row do
-              render(
-                Primer::Beta::Text.new(
-                  data: {
-                    "test-selector": "op-portfolios--portfolios-placeholder"
-                  }
-                )
-              ) do
-                I18n.t(:no_results_title_text)
-              end
-            end
-          end
-
+        ) do |list|
           portfolios.each do |portfolio|
-            component.with_row(
+            list.with_item(
               classes: "portfolio",
-              data: {
-                test_selector: "op-portfolios--portfolio-#{portfolio.id}"
-              }
+              test_selector: "op-portfolios--portfolio-#{portfolio.id}"
             ) do
               render(Portfolios::DetailsComponent.new(portfolio:, current_user: @current_user))
             end
           end
+
+          list.with_empty_state(
+            title: I18n.t(:no_results_title_text),
+            test_selector: "op-portfolios--portfolios-placeholder"
+          )
         end
       end
     end

--- a/app/components/projects/settings/creation_wizard/project_custom_field_sections/show_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/project_custom_field_sections/show_component.html.erb
@@ -1,84 +1,67 @@
 <%=
   component_wrapper do
     render(
-      border_box_container(
-        mb: 3, classes: "op-project-custom-field-section", data: {
-          test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
-        }
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "project-custom-field-section-#{@project_custom_field_section.id}",
+        position: :relative,
+        mb: 3,
+        classes: "op-project-custom-field-section",
+        header_padding: :default,
+        test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
       )
-    ) do |component|
-      component.with_header(font_weight: :bold, py: 2) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(py: 2) do
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              @project_custom_field_section.name
-            end
-          end
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: enable_all_of_section_project_settings_creation_wizard_path(
-                    @project,
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_enable_all"),
-                  data: { "turbo-method": :put, test_selector: "enable-all-creation-wizard-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                t("projects.settings.actions.label_enable_all")
-              end
-            end
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: disable_all_of_section_project_settings_creation_wizard_path(
-                    @project,
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_disable_all"),
-                  data: { "turbo-method": :put, test_selector: "disable-all-creation-wizard-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                t("projects.settings.actions.label_disable_all")
-              end
-            end
-          end
+    ) do |list|
+      list.with_header(title: @project_custom_field_section.name) do |header|
+        header.with_action_button(
+          tag: :a,
+          href: enable_all_of_section_project_settings_creation_wizard_path(
+            @project,
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("projects.settings.actions.label_enable_all"),
+          test_selector: "enable-all-creation-wizard-#{@project_custom_field_section.id}",
+          data: { "turbo-method": :put }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+          t("projects.settings.actions.label_enable_all")
+        end
+        header.with_action_button(
+          tag: :a,
+          href: disable_all_of_section_project_settings_creation_wizard_path(
+            @project,
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("projects.settings.actions.label_disable_all"),
+          test_selector: "disable-all-creation-wizard-#{@project_custom_field_section.id}",
+          data: { "turbo-method": :put }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+          t("projects.settings.actions.label_disable_all")
         end
       end
-      if @project_custom_fields.empty?
-        component.with_row do
-          render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
-        end
-      else
-        @project_custom_fields.each do |project_custom_field|
-          component.with_row do
-            render(
-              Projects::Settings::CreationWizard::ProjectCustomFieldSections::CustomFieldRowComponent.new(
-                project: @project,
-                project_custom_field:
-              )
+      @project_custom_fields.each do |project_custom_field|
+        list.with_item do
+          render(
+            Projects::Settings::CreationWizard::ProjectCustomFieldSections::CustomFieldRowComponent.new(
+              project: @project,
+              project_custom_field:
             )
-          end
+          )
         end
       end
+
+      list.with_empty_state(title: t("settings.project_attributes.label_no_project_custom_fields"))
     end
   end
 %>
-

--- a/app/components/projects/settings/life_cycle/index_component.html.erb
+++ b/app/components/projects/settings/life_cycle/index_component.html.erb
@@ -22,66 +22,59 @@
     end
 
     flex.with_row do
-      render(border_box_container(mb: 3, data: { test_selector: "project-life-cycle-administration" })) do |component|
-        component.with_header(font_weight: :bold, py: 2) do
-          flex_layout(justify_content: :space_between, align_items: :center) do |header_container|
-            header_container.with_column(py: 2) do
-              # adding py: 2 here to match the padding of the actions_container
-              # otherwise the header height changes when the actions gets hidden when filtering
-              render(Primer::Beta::Text.new(font_weight: :bold)) do
-                I18n.t("projects.settings.life_cycle.section_header")
-              end
-            end
-            header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-              actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-                render(
-                  Primer::Beta::Button.new(
-                    tag: :a,
-                    href: enable_all_project_settings_life_cycle_steps_path(project_id: project),
-                    scheme: :invisible,
-                    font_weight: :bold,
-                    color: :subtle,
-                    "aria-label": t("projects.settings.actions.label_enable_all"),
-                    data: { "turbo-method": :post, test_selector: "enable-all-life-cycle-steps" }
-                  )
-                ) do |button|
-                  button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                  t("projects.settings.actions.label_enable_all")
-                end
-              end
-              actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-                render(
-                  Primer::Beta::Button.new(
-                    tag: :a,
-                    href: disable_all_project_settings_life_cycle_steps_path(project_id: project),
-                    scheme: :invisible,
-                    font_weight: :bold,
-                    color: :subtle,
-                    "aria-label": t("projects.settings.actions.label_disable_all"),
-                    data: { "turbo-method": :post, test_selector: "disable-all-life-cycle-steps" }
-                  )
-                ) do |button|
-                  button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                  t("projects.settings.actions.label_disable_all")
-                end
-              end
-            end
+      render(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "project-life-cycle-administration",
+          position: :relative,
+          mb: 3,
+          header_padding: :default,
+          test_selector: "project-life-cycle-administration"
+        )
+      ) do |list|
+        list.with_header(title: I18n.t("projects.settings.life_cycle.section_header")) do |header|
+          header.with_action_button(
+            tag: :a,
+            href: enable_all_project_settings_life_cycle_steps_path(project_id: project),
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            "aria-label": t("projects.settings.actions.label_enable_all"),
+            test_selector: "enable-all-life-cycle-steps",
+            data: {
+              "turbo-method": :post,
+              "projects--settings--border-box-filter-target": "hideWhenFiltering"
+            }
+          ) do |button|
+            button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+            t("projects.settings.actions.label_enable_all")
+          end
+          header.with_action_button(
+            tag: :a,
+            href: disable_all_project_settings_life_cycle_steps_path(project_id: project),
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            "aria-label": t("projects.settings.actions.label_disable_all"),
+            test_selector: "disable-all-life-cycle-steps",
+            data: {
+              "turbo-method": :post,
+              "projects--settings--border-box-filter-target": "hideWhenFiltering"
+            }
+          ) do |button|
+            button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+            t("projects.settings.actions.label_disable_all")
           end
         end
-        if life_cycle_definitions.empty?
-          component.with_row do
-            render(Primer::Beta::Text.new(color: :subtle)) { t("projects.settings.life_cycle.non_defined") }
-          end
-        else
-          life_cycle_definitions_and_step_active.each do |definition, active|
-            component.with_row(
-              data: { "projects--settings--border-box-filter-target": "searchItem" },
-              test_selector: "project-life-cycle-step-#{definition.id}"
-            ) do
-              render(Projects::Settings::LifeCycle::PhaseComponent.new(definition:, active?: active))
-            end
+        life_cycle_definitions_and_step_active.each do |definition, active|
+          list.with_item(
+            data: { "projects--settings--border-box-filter-target": "searchItem" },
+            test_selector: "project-life-cycle-step-#{definition.id}"
+          ) do
+            render(Projects::Settings::LifeCycle::PhaseComponent.new(definition:, active?: active))
           end
         end
+
+        list.with_empty_state(title: t("projects.settings.life_cycle.non_defined"))
       end
     end
     flex.with_row do

--- a/app/components/projects/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/projects/settings/project_custom_field_sections/show_component.html.erb
@@ -1,83 +1,73 @@
 <%=
   component_wrapper do
     render(
-      border_box_container(
-        mb: 3, classes: "op-project-custom-field-section", data: {
-          test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
-        }
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "project-custom-field-section-#{@project_custom_field_section.id}",
+        position: :relative,
+        mb: 3,
+        classes: "op-project-custom-field-section",
+        header_padding: :default,
+        test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
       )
-    ) do |component|
-      component.with_header(font_weight: :bold, py: 2) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(py: 2) do |_content_container|
-            # adding py: 2 here to match the padding of the actions_container
-            # otherwise the header height changes when the actions gets hidden when filtering
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              @project_custom_field_section.name
-            end
-          end
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: enable_all_of_section_project_settings_project_custom_fields_path(
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_enable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-project-custom-field-mappings-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                t("projects.settings.actions.label_enable_all")
-              end
-            end
-            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: disable_all_of_section_project_settings_project_custom_fields_path(
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_disable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-project-custom-field-mappings-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                t("projects.settings.actions.label_disable_all")
-              end
-            end
-          end
+    ) do |list|
+      list.with_header(title: @project_custom_field_section.name) do |header|
+        header.with_action_button(
+          tag: :a,
+          href: enable_all_of_section_project_settings_project_custom_fields_path(
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("projects.settings.actions.label_enable_all"),
+          test_selector: "enable-all-project-custom-field-mappings-#{@project_custom_field_section.id}",
+          data: {
+            "turbo-method": :put,
+            "turbo-stream": true,
+            "projects--settings--border-box-filter-target": "hideWhenFiltering"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+          t("projects.settings.actions.label_enable_all")
+        end
+        header.with_action_button(
+          tag: :a,
+          href: disable_all_of_section_project_settings_project_custom_fields_path(
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("projects.settings.actions.label_disable_all"),
+          test_selector: "disable-all-project-custom-field-mappings-#{@project_custom_field_section.id}",
+          data: {
+            "turbo-method": :put,
+            "turbo-stream": true,
+            "projects--settings--border-box-filter-target": "hideWhenFiltering"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+          t("projects.settings.actions.label_disable_all")
         end
       end
-      if @project_custom_fields.empty?
-        component.with_row do
-          render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
-        end
-      else
-        @project_custom_fields.each do |project_custom_field|
-          component.with_row(data: { "projects--settings--border-box-filter-target": "searchItem" }) do
-            render(
-              Projects::Settings::ProjectCustomFieldSections::CustomFieldRowComponent.new(
-                project: @project,
-                project_custom_field:
-              )
+      @project_custom_fields.each do |project_custom_field|
+        list.with_item(data: { "projects--settings--border-box-filter-target": "searchItem" }) do
+          render(
+            Projects::Settings::ProjectCustomFieldSections::CustomFieldRowComponent.new(
+              project: @project,
+              project_custom_field:
             )
-          end
+          )
         end
       end
+
+      list.with_empty_state(title: t("settings.project_attributes.label_no_project_custom_fields"))
     end
   end
 %>

--- a/app/components/settings/project_phase_definitions/index_component.html.erb
+++ b/app/components/settings/project_phase_definitions/index_component.html.erb
@@ -72,41 +72,35 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       flex.with_row do
-        render(border_box_container(mb: 3, data: drop_target_config)) do |component|
-          component.with_header(font_weight: :bold) do
-            flex_layout(justify_content: :space_between, align_items: :center) do |header_container|
-              header_container.with_column do
-                render(Primer::Beta::Text.new(font_weight: :bold)) do
-                  I18n.t("settings.project_phase_definitions.section_header")
-                end
-              end
-            end
-          end
-          if definitions.empty?
-            component.with_row do
-              render(Primer::Beta::Text.new(color: :subtle)) do
-                t("settings.project_phase_definitions.non_defined")
-              end
-            end
-          else
-            definitions.each do |definition|
-              component.with_row(
-                data: {
-                  "projects--settings--border-box-filter-target": "searchItem",
-                  test_selector: "project-phase-definition",
-                  **draggable_item_config(definition)
-                }
-              ) do
-                render(
-                  Settings::ProjectPhaseDefinitions::RowComponent.new(
-                    definition,
-                    first?: definition == definitions.first,
-                    last?: definition == definitions.last
-                  )
+        render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "project-phase-definitions",
+            position: :relative,
+            mb: 3,
+            data: drop_target_config
+          )
+        ) do |list|
+          list.with_header(title: I18n.t("settings.project_phase_definitions.section_header"))
+
+          definitions.each do |definition|
+            list.with_item(
+              test_selector: "project-phase-definition",
+              data: {
+                "projects--settings--border-box-filter-target": "searchItem",
+                **draggable_item_config(definition)
+              }
+            ) do
+              render(
+                Settings::ProjectPhaseDefinitions::RowComponent.new(
+                  definition,
+                  first?: definition == definitions.first,
+                  last?: definition == definitions.last
                 )
-              end
+              )
             end
           end
+
+          list.with_empty_state(title: t("settings.project_phase_definitions.non_defined"))
         end
       end
       flex.with_row(display: :none, data: { "projects--settings--border-box-filter-target": "noResultsText" }) do

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -118,45 +118,37 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   end
 
   def render_relation_group(title:, relation_group:, &)
-    render(border_box_container(
-             padding: :condensed,
-             data: { test_selector: "op-relation-group-#{relation_group.type}" }
-           )) do |border_box|
+    render(
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "op-relation-group-#{relation_group.type}",
+        padding: :condensed,
+        test_selector: "op-relation-group-#{relation_group.type}"
+      )
+    ) do |list|
       if relation_group.type.child? && should_render_add_child?
-        render_children_header(border_box, title, relation_group.count)
+        render_children_header(list, title, relation_group.count)
       else
-        render_header(border_box, title, relation_group.count)
+        render_header(list, title, relation_group.count)
       end
 
-      render_items(border_box, relation_group.all_relation_items, &)
+      render_items(list, relation_group.all_relation_items, &)
     end
   end
 
-  def render_header(border_box, title, count)
-    border_box.with_header(py: 3) do
-      concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
-      concat render(Primer::Beta::Counter.new(count:, round: true, scheme: :primary))
-    end
+  def render_header(list, title, count)
+    list.with_header(title:, count:, py: 3, title_arguments: { font_size: :normal })
   end
 
-  def render_children_header(border_box, title, count) # rubocop:disable Metrics/AbcSize
-    border_box.with_header(py: 3) do
-      flex_layout(justify_content: :space_between, align_items: :center) do |header|
-        header.with_column(mr: 2) do
-          concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
-          concat render(Primer::Beta::Counter.new(count:, round: true, scheme: :primary))
+  def render_children_header(list, title, count)
+    list.with_header(title:, count:, py: 3, title_arguments: { font_size: :normal }) do |header|
+      header.with_menu(menu_id: ADD_CHILD_ACTION_MENU) do |menu|
+        menu.with_show_button do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          button.with_trailing_action_icon(icon: :"triangle-down")
+          t("work_package_relations_tab.label_add_child_button")
         end
-        header.with_column do
-          render(Primer::Alpha::ActionMenu.new(menu_id: ADD_CHILD_ACTION_MENU)) do |menu|
-            menu.with_show_button do |button|
-              button.with_leading_visual_icon(icon: :plus)
-              button.with_trailing_action_icon(icon: :"triangle-down")
-              t("work_package_relations_tab.label_add_child_button")
-            end
 
-            render_add_relations_menu_items(menu, ADD_CHILD_MENU_TYPES)
-          end
-        end
+        render_add_relations_menu_items(menu, ADD_CHILD_MENU_TYPES)
       end
     end
   end
@@ -215,11 +207,11 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     I18n.t("#{I18N_NAMESPACE}.relations.#{relation_type}_description")
   end
 
-  def render_items(border_box, relation_items)
+  def render_items(list, relation_items)
     relation_items.each do |relation_item|
       relation = relation_item.relation || relation_item.related
       visibility = relation_item.visibility
-      border_box.with_row(
+      list.with_item(
         test_selector: row_test_selector(relation, visibility),
         data: data_attribute(relation)
       ) do

--- a/app/components/work_package_types/export_template_list_component.html.erb
+++ b/app/components/work_package_types/export_template_list_component.html.erb
@@ -29,54 +29,52 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper(data: wrapper_data_attributes) do
-    render(border_box_container(mb: 3, data: (readonly? ? {} : drag_and_drop_target_config))) do |component|
-      component.with_header(font_weight: :bold, py: 2) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(py: 2) do
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              I18n.t("types.edit.export_configuration.pdf_export_templates.label")
-            end
+    render(
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "pdf-export-templates",
+        position: :relative,
+        mb: 3,
+        header_padding: :default,
+        test_selector: "pdf-export-template-rows",
+        data: (readonly? ? {} : drag_and_drop_target_config)
+      )
+    ) do |list|
+      list.with_header(title: I18n.t("types.edit.export_configuration.pdf_export_templates.label")) do |header|
+        unless readonly?
+          header.with_action_button(
+            tag: :a,
+            href: enable_all_type_pdf_export_template_index_path(type_id: @type.id),
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            "aria-label": t("projects.settings.actions.label_enable_all"),
+            test_selector: "enable-all-pdf-export-templates",
+            data: { "turbo-method": :put, "turbo-stream": true }
+          ) do |button|
+            button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+            I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_enable_all")
           end
-          unless readonly?
-            section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-              actions_container.with_column do
-                render(
-                  Primer::Beta::Button.new(
-                    tag: :a,
-                    href: enable_all_type_pdf_export_template_index_path(type_id: @type.id),
-                    scheme: :invisible,
-                    font_weight: :bold,
-                    color: :subtle,
-                    "aria-label": t("projects.settings.actions.label_enable_all"),
-                    data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-pdf-export-templates" }
-                  )
-                ) do |button|
-                  button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                  I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_enable_all")
-                end
-              end
-              actions_container.with_column do
-                render(
-                  Primer::Beta::Button.new(
-                    tag: :a,
-                    href: disable_all_type_pdf_export_template_index_path(type_id: @type.id),
-                    scheme: :invisible,
-                    font_weight: :bold,
-                    color: :subtle,
-                    "aria-label": t("projects.settings.actions.label_disable_all"),
-                    data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-pdf-export-templates" }
-                  )
-                ) do |button|
-                  button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                  I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_disable_all")
-                end
-              end
-            end
+          header.with_action_button(
+            tag: :a,
+            href: disable_all_type_pdf_export_template_index_path(type_id: @type.id),
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            "aria-label": t("projects.settings.actions.label_disable_all"),
+            test_selector: "disable-all-pdf-export-templates",
+            data: { "turbo-method": :put, "turbo-stream": true }
+          ) do |button|
+            button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+            I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_disable_all")
           end
         end
       end
+
       @type.pdf_export_templates.list.each do |template|
-        component.with_row(data: (readonly? ? {} : draggable_item_config(template))) do
+        list.with_item(
+          test_selector: "pdf-export-template-row-#{template.id}",
+          data: (readonly? ? {} : draggable_item_config(template))
+        ) do
           render(
             WorkPackageTypes::ExportTemplateRowComponent.new(
               type: @type,

--- a/app/components/work_package_types/export_template_list_component.rb
+++ b/app/components/work_package_types/export_template_list_component.rb
@@ -55,8 +55,7 @@ module WorkPackageTypes
       {
         generic_drag_and_drop_target: "container",
         "target-container-accessor": ":scope > ul",
-        "target-allowed-drag-type": "template",
-        test_selector: "pdf-export-template-rows"
+        "target-allowed-drag-type": "template"
       }
     end
 
@@ -64,8 +63,7 @@ module WorkPackageTypes
       {
         "draggable-id": template.id,
         "draggable-type": "template",
-        "drop-url": drop_type_pdf_export_template_path(type_id: @type.id, id: template.id),
-        test_selector: "pdf-export-template-row-#{template.id}"
+        "drop-url": drop_type_pdf_export_template_path(type_id: @type.id, id: template.id)
       }
     end
   end

--- a/app/components/work_package_types/export_template_row_component.html.erb
+++ b/app/components/work_package_types/export_template_row_component.html.erb
@@ -52,6 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
           enabled: !readonly?,
           size: :small,
           status_label_position: :start,
+          aria: { label: toggle_label },
           test_selector: "toggle-pdf-export-template-row-#{@template.id}"
         }
         # A read-only toggle is disabled, so it never posts; omit the mutation wiring entirely.

--- a/app/components/work_package_types/export_template_row_component.rb
+++ b/app/components/work_package_types/export_template_row_component.rb
@@ -43,5 +43,18 @@ module WorkPackageTypes
     end
 
     def readonly? = @readonly
+
+    def wrapper_uniq_by
+      @template.id
+    end
+
+    private
+
+    def toggle_label
+      I18n.t(
+        "types.edit.export_configuration.pdf_export_templates.actions.label_toggle_template",
+        template: @template.label
+      )
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4244,6 +4244,7 @@ en:
         add_button: "Add project-specific notifications"
         description: "You can fine-tune your notification settings to only be notified of certain events in specific projects. Add a project below and choose which events should trigger a notification for you. These project-specific settings override default settings above."
         dialog_title: "Add project-specific notifications"
+        empty_text: "You have no project-specific notifications yet."
         list_header: "Projects with specific notifications"
         title: "Project-specific notifications"
     notifications_and_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6083,6 +6083,7 @@ en:
           actions:
             label_disable_all: "Disable all"
             label_enable_all: "Enable all"
+            label_toggle_template: "Toggle %{template}"
           label: "PDF Export templates"
         tab: "Generate PDF"
         templates:

--- a/lookbook/docs/components/border-box-list.md.erb
+++ b/lookbook/docs/components/border-box-list.md.erb
@@ -18,8 +18,10 @@ of the collapsible header and is hidden when the list is collapsed.
 **Items**
 The list rows. Items can render generic row content or a work package card.
 
-**Empty state** *(optional)*
-Shown when the list has no items.
+**Empty state**
+Shown when the list has no items. The component renders a generic empty state by
+default; use `with_empty_state` only when the list needs domain-specific copy,
+an icon, or custom system arguments.
 
 **Footer** *(optional)*
 Shown below the items. Use it for summary or follow-up content.
@@ -47,7 +49,7 @@ comparable lists should use headers.
 | `with_header` | Optional section header. See [Header parameters](#header-parameters) and [Header slots](#header-slots) below |
 | `with_item` | Generic list row that renders the provided block content |
 | `with_work_package_item` | Work package row that renders a work package card |
-| `with_empty_state` | Empty-state content rendered when no items are present |
+| `with_empty_state` | Custom empty-state content rendered when no items are present |
 | `with_footer` | Optional footer row below the list items |
 
 ## Header
@@ -70,7 +72,8 @@ comparable lists should use headers.
 | `with_title` | Block-based alternative to `title:`, for titles that need more than plain text. Takes precedence over `title:` |
 | `with_description` | Secondary content below the title, wrapped in `Primer::Beta::Text` with muted color by default. Accepts Primer system arguments |
 | `with_action_button` | Button rendered in the header actions area |
-| `with_menu` | Action menu rendered in the header actions area. Pass `button_aria_label:` for the trigger button |
+| `with_action_icon_button` | Icon button rendered in the header actions area |
+| `with_menu` | Action menu rendered in the header actions area. Pass `button_arguments:` for the default trigger button |
 
 ### Collapsible headers
 
@@ -111,11 +114,20 @@ for card-specific layout, parameters, and slots.
 
 <%= embed OpenProject::Common::BorderBoxListComponentPreview, :with_work_package_items, panels: %i[source] %>
 
+### Custom header content
+
+Use `with_title` when a header title needs composed inline content, such as a
+link. Use `menu.with_show_button` when the default action-menu trigger is not
+specific enough for the list action.
+
+<%= embed OpenProject::Common::BorderBoxListComponentPreview, :custom_header_content, panels: %i[source] %>
+
 ### Empty state
 
-Use `with_empty_state` when the list can be rendered without items. It renders a
-`Primer::Beta::Blankslate` under the hood, accepting `title:`, `description:`,
-and `icon:` keywords.
+When no items are present, the component renders a generic
+`Primer::Beta::Blankslate` with the global empty-state copy. Use
+`with_empty_state` for domain-specific copy, icons, or custom Blankslate system
+arguments.
 
 <%= embed OpenProject::Common::BorderBoxListComponentPreview, :empty_state, panels: %i[source] %>
 
@@ -171,7 +183,7 @@ render OpenProject::Common::BorderBoxListComponent.new(
     header.with_description(id: "project-attributes-description", font_size: :small) do
       "Visible in the project overview"
     end
-    header.with_menu(button_aria_label: "Project attribute actions") do |menu|
+    header.with_menu(button_arguments: { aria: { label: "Project attribute actions" } }) do |menu|
       menu.with_item(label: "Edit", href: edit_project_path(@project))
     end
   end

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -224,6 +224,21 @@ module OpenProject
         end
       end
 
+      # @label With header drag handle
+      # Reorderable list whose header and rows show a drag handle.
+      # @param padding [Symbol] select [default, condensed, spacious]
+      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
+      # @param collapsible toggle
+      def with_header_drag_handle(padding: :default, header_padding: :inherit, collapsible: false)
+        render_with_template(
+          locals: {
+            padding:,
+            header_padding:,
+            collapsible: boolean_preview_param(collapsible)
+          }
+        )
+      end
+
       # @label Empty state
       # List with a header and an empty state (Blankslate), no items.
       # @param padding [Symbol] select [default, condensed, spacious]
@@ -289,24 +304,6 @@ module OpenProject
           header_padding:,
           collapsible: true
         )
-      end
-
-      # @label With header drag handle
-      # @param padding [Symbol] select [default, condensed, spacious]
-      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
-      # @param collapsible toggle
-      def with_header_drag_handle(padding: :default, header_padding: :inherit, collapsible: false)
-        render OpenProject::Common::BorderBoxListComponent.new(
-          container: "border-box-list-header-drag-handle-preview",
-          padding:,
-          header_padding:,
-          collapsible: boolean_preview_param(collapsible)
-        ) do |list|
-          list.with_header(title: "Reorderable section", count: true, show_drag_handle: true)
-
-          list.with_item { "First item" }
-          list.with_item { "Second item" }
-        end
       end
 
       private

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -263,6 +263,8 @@ module OpenProject
 
       # @label With header action label
       # Header action area holding a status label, optionally next to an action button.
+      # Deprecated: `with_action_label` is slated for removal, do not add new call
+      # sites. Render the label from the `title` slot instead.
       # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
       # @param with_action_button toggle
       # @param padding [Symbol] select [default, condensed, spacious]
@@ -286,6 +288,8 @@ module OpenProject
       # @label With collapsible header action label
       # The collapsible header renders through its own heading markup, so the action
       # label alignment is worth checking separately.
+      # Deprecated: `with_action_label` is slated for removal, do not add new call
+      # sites. Render the label from the `title` slot instead.
       # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
       # @param with_action_button toggle
       # @param padding [Symbol] select [default, condensed, spacious]

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -64,7 +64,7 @@ module OpenProject
               button.with_leading_visual_icon(icon: :pencil)
               "Edit"
             end
-            header.with_menu(button_aria_label: "List actions") do |menu|
+            header.with_menu(button_arguments: { aria: { label: "List actions" } }) do |menu|
               menu.with_item(label: "Configure") do |menu_item|
                 menu_item.with_leading_visual_icon(icon: :gear)
               end
@@ -105,7 +105,7 @@ module OpenProject
               button.with_leading_visual_icon(icon: :rocket)
               "Start sprint"
             end
-            header.with_menu(button_aria_label: "Sprint actions") do |menu|
+            header.with_menu(button_arguments: { aria: { label: "Sprint actions" } }) do |menu|
               menu.with_item(label: "Edit sprint") do |menu_item|
                 menu_item.with_leading_visual_icon(icon: :pencil)
               end
@@ -141,6 +141,36 @@ module OpenProject
         ) do |list|
           list.with_header(title: "Work packages", count: true)
           render_work_package_items(list, work_packages)
+        end
+      end
+
+      # @label Custom header content
+      # List with a linked title slot and a custom action-menu trigger.
+      def custom_header_content
+        render OpenProject::Common::BorderBoxListComponent.new(
+          container: "border-box-list-custom-header-preview",
+          header_padding: :default
+        ) do |list|
+          list.with_header(count: true) do |header|
+            header.with_title do
+              '<a href="#" class="Link--primary no-underline">Linked delivery plan</a>'.html_safe
+            end
+            header.with_description do
+              "Milestones grouped by owner."
+            end
+            header.with_menu do |menu|
+              menu.with_show_button(scheme: :primary, "aria-label": "Add delivery item") do |button|
+                button.with_leading_visual_icon(icon: :plus)
+                "Add item"
+              end
+              menu.with_item(label: "Import milestones") do |menu_item|
+                menu_item.with_leading_visual_icon(icon: :upload)
+              end
+            end
+          end
+
+          list.with_item { "Alpha release checklist" }
+          list.with_item { "Customer review preparation" }
         end
       end
 

--- a/lookbook/previews/open_project/common/border_box_list_component_preview/with_header_drag_handle.html.erb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview/with_header_drag_handle.html.erb
@@ -1,0 +1,20 @@
+<%= render OpenProject::Common::BorderBoxListComponent.new(
+      container: "border-box-list-header-drag-handle-preview",
+      padding:,
+      header_padding:,
+      collapsible:
+    ) do |list| %>
+  <% list.with_header(title: "Reorderable section", count: true, show_drag_handle: true) %>
+  <% list.with_item do %>
+    <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center, ml: -2)) do |row| %>
+      <% row.with_column(style: "width: 1.5rem") { render(Primer::OpenProject::DragHandle.new) } %>
+      <% row.with_column(flex: 1) { "one" } %>
+    <% end %>
+  <% end %>
+  <% list.with_item do %>
+    <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center, ml: -2)) do |row| %>
+      <% row.with_column(style: "width: 1.5rem") { render(Primer::OpenProject::DragHandle.new) } %>
+      <% row.with_column(flex: 1) { "two" } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
       )
     ) do |list|
       list.with_header(title: backlog_bucket.name) do |header|
-        header.with_menu(button_aria_label: t(".label_actions")) do |menu|
+        header.with_menu(button_arguments: { aria: { label: t(".label_actions") } }) do |menu|
           with_item_group(menu) do
             if user_allowed?(:create_sprints)
               menu.with_item(

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -93,7 +93,7 @@ See COPYRIGHT and LICENSE files for more details.
           end
         end
 
-        header.with_menu(button_aria_label: t(".label_actions")) do |menu|
+        header.with_menu(button_arguments: { aria: { label: t(".label_actions") } }) do |menu|
           with_item_group(menu) do
             if can_open_edit_dialog?
               menu.with_item(

--- a/modules/costs/app/components/projects/settings/cost_types/index_component.html.erb
+++ b/modules/costs/app/components/projects/settings/cost_types/index_component.html.erb
@@ -26,73 +26,73 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
-<% if empty? %>
-  <%=
-    render Primer::Beta::Blankslate.new(border: true) do |c|
-      c.with_visual_icon(icon: :checklist)
-      c.with_heading(tag: :h2).with_content(I18n.t("cost_types.settings.cost_types.heading"))
-      c.with_description { I18n.t("cost_types.admin.cost_type_projects.no_projects.description") }
-    end
-  %>
-<% else %>
-  <%= render(Primer::Beta::BorderBox.new(test_selector: "op-project-settings-cost-types")) do |box| %>
-    <% box.with_header do %>
-      <%= render(Primer::Beta::Text.new(font_weight: :bold)) { CostType.model_name.human(count: 2) } %>
-    <% end %>
+<%= render(
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "project-settings-cost-types",
+        test_selector: "op-project-settings-cost-types"
+      )
+    ) do |list| %>
+  <% list.with_header(title: CostType.model_name.human(count: 2)) %>
 
-    <% cost_types.each do |cost_type| %>
-      <% box.with_row do %>
-        <%=
-          flex_layout(
-            align_items: :center, justify_content: :space_between,
-            classes: "op-project-cost-type",
-            data: { test_selector: "project-cost-type-#{cost_type.id}" }
-          ) do |row|
-            row.with_column(flex: 1) do
-              if User.current.admin?
-                render(Primer::Beta::Link.new(font_weight: :bold,
-                                              href: edit_admin_cost_type_path(cost_type))) { cost_type.name }
-              else
-                render(Primer::Beta::Text.new) { cost_type.name }
-              end
+  <% cost_types.each do |cost_type| %>
+    <% list.with_item do %>
+      <%=
+        flex_layout(
+          align_items: :center, justify_content: :space_between,
+          classes: "op-project-cost-type",
+          data: { test_selector: "project-cost-type-#{cost_type.id}" }
+        ) do |row|
+          row.with_column(flex: 1) do
+            if User.current.admin?
+              render(
+                Primer::Beta::Link.new(font_weight: :bold, href: edit_admin_cost_type_path(cost_type))
+              ) { cost_type.name }
+            else
+              render(Primer::Beta::Text.new) { cost_type.name }
             end
+          end
 
-            row.with_column(py: 1, mr: 2) do
-              concat(
-                render(
-                  Primer::Alpha::ToggleSwitch.new(
-                    src: toggle_path(cost_type),
-                    csrf_token: form_authenticity_token,
-                    data: toggle_data_attributes(cost_type),
-                    checked: toggle_checked?(cost_type),
-                    enabled: !toggle_disabled?(cost_type),
-                    size: :small,
-                    status_label_position: :start,
-                    classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"
-                  )
+          row.with_column(py: 1, mr: 2) do
+            concat(
+              render(
+                Primer::Alpha::ToggleSwitch.new(
+                  src: toggle_path(cost_type),
+                  csrf_token: form_authenticity_token,
+                  data: toggle_data_attributes(cost_type),
+                  checked: toggle_checked?(cost_type),
+                  enabled: !toggle_disabled?(cost_type),
+                  size: :small,
+                  status_label_position: :start,
+                  classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"
                 )
               )
+            )
 
-              if toggle_disabled?(cost_type)
-                concat(
-                  content_tag(:template, id: unique_hovercard_id(cost_type)) do
-                    flex_layout(
-                      classes: "op-project-cost-type--popover",
-                      data: { test_selector: "op-project-cost-type--hover-card-#{cost_type.id}" }
-                    ) do |hover_card|
-                      hover_card.with_column do
-                        render(Primer::Beta::Text.new) do
-                          disabled_hint(cost_type)
-                        end
+            if toggle_disabled?(cost_type)
+              concat(
+                content_tag(:template, id: unique_hovercard_id(cost_type)) do
+                  flex_layout(
+                    classes: "op-project-cost-type--popover",
+                    data: { test_selector: "op-project-cost-type--hover-card-#{cost_type.id}" }
+                  ) do |hover_card|
+                    hover_card.with_column do
+                      render(Primer::Beta::Text.new) do
+                        disabled_hint(cost_type)
                       end
                     end
                   end
-                )
-              end
+                end
+              )
             end
           end
-        %>
-      <% end %>
+        end
+      %>
     <% end %>
   <% end %>
+
+  <% list.with_empty_state(
+       title: I18n.t("cost_types.settings.cost_types.heading"),
+       description: I18n.t("cost_types.admin.cost_type_projects.no_projects.description"),
+       icon: :checklist
+     ) %>
 <% end %>

--- a/modules/costs/spec/components/projects/settings/cost_types/index_component_spec.rb
+++ b/modules/costs/spec/components/projects/settings/cost_types/index_component_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Projects::Settings::CostTypes::IndexComponent, type: :component do
+  shared_let(:admin) { create(:admin) }
+  let(:project) { create(:project) }
+
+  current_user { admin }
+
+  subject(:rendered_component) { render_inline(described_class.new(project:, cost_types:)) }
+
+  context "with cost types" do
+    let!(:cost_type) { create(:cost_type, name: "Consulting") }
+    let(:cost_types) { CostType.where(id: cost_type.id) }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders the cost types header" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(CostType.model_name.human(count: 2))
+      end
+    end
+
+    it "renders a row per cost type" do
+      expect(rendered_component).to have_css(".Box-row", text: "Consulting")
+    end
+  end
+
+  context "without cost types" do
+    let(:cost_types) { CostType.none }
+
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("cost_types.settings.cost_types.heading")
+  end
+end

--- a/modules/meeting/app/components/meetings/participants/list_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/list_component.html.erb
@@ -7,26 +7,26 @@
         end
       end
       container.with_row do
-        render(border_box_container) do |box|
-          box.with_header(color: :muted) do
-            render(Meetings::Participants::BoxHeaderComponent.new(meeting: @meeting))
+        render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "op-meeting-participants-#{@meeting.id}"
+          )
+        ) do |list|
+          list.with_header(color: :muted) do |header|
+            header.with_title do
+              render(Meetings::Participants::BoxHeaderComponent.new(meeting: @meeting))
+            end
           end
 
-          if @meeting_participants.none?
-            box.with_row do
-              render(Primer::Beta::Blankslate.new) do |blankslate|
-                blankslate.with_visual_icon(icon: :people, size: :medium)
-                blankslate.with_heading(tag: :h2).with_content(I18n.t("meeting.participants.blankslate.heading"))
-                blankslate.with_description_content(I18n.t("meeting.participants.blankslate.description"))
-              end
-            end
-          else
-            render(Primer::BaseComponent.new(tag: :div, classes: "participants-list")) do
-              @meeting_participants.each do |participant|
-                box.with_row do
-                  render(Meetings::Participants::BoxRowComponent.new(meeting: @meeting, participant:))
-                end
-              end
+          list.with_empty_state(
+            title: I18n.t("meeting.participants.blankslate.heading"),
+            description: I18n.t("meeting.participants.blankslate.description"),
+            icon: :people
+          )
+
+          @meeting_participants.each do |participant|
+            list.with_item do
+              render(Meetings::Participants::BoxRowComponent.new(meeting: @meeting, participant:))
             end
           end
         end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_component.html.erb
@@ -1,31 +1,28 @@
 <%=
   render(
-    border_box_container(
+    OpenProject::Common::BorderBoxListComponent.new(
+      container: "op-meeting-container-#{@meeting.id}",
       padding: :condensed,
       test_selector: "op-meeting-container-#{@meeting.id}"
     )
-  ) do |border_box|
-    border_box.with_header do
-      flex_layout do |flex|
-        flex.with_column(mr: 1) do
-          render(
-            Primer::Beta::Link.new(
-              href: meeting_path(@meeting), target: "_blank", font_size: :normal,
-              font_weight: :bold, scheme: :primary, underline: false
-            )
-          ) do
-            "#{@meeting.project.name}: #{@meeting.title}"
-          end
+  ) do |list|
+    list.with_header do |header|
+      header.with_title do
+        render(
+          Primer::Beta::Link.new(
+            href: meeting_path(@meeting), target: "_blank", font_size: :normal,
+            font_weight: :bold, scheme: :primary, underline: false
+          )
+        ) do
+          "#{@meeting.project.name}: #{@meeting.title}"
         end
-        flex.with_column do
-          render(Primer::Beta::Text.new(font_size: :normal, color: :muted)) do
-            format_time(@meeting.start_time)
-          end
-        end
+      end
+      header.with_description do
+        format_time(@meeting.start_time)
       end
     end
     @meeting_agenda_items.each do |meeting_agenda_item|
-      border_box.with_row do
+      list.with_item do
         render(WorkPackageMeetingsTab::MeetingAgendaItemComponent.new(work_package: @work_package, meeting_agenda_item:))
       end
     end

--- a/modules/meeting/spec/components/meetings/participants/list_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/participants/list_component_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Meetings::Participants::ListComponent, type: :component do
+  let(:meeting) { create(:meeting) }
+
+  subject(:rendered_component) do
+    meeting.reload
+    render_inline(described_class.new(meeting:))
+  end
+
+  context "with participants" do
+    let!(:participant) do
+      create(:meeting_participant, meeting:, user: create(:user, firstname: "Ada", lastname: "Lovelace"))
+    end
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders the participants header with its title and count", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_text(I18n.t("meeting.participants.label.participants"))
+        expect(header).to have_css(".Counter", text: "1")
+      end
+    end
+
+    it "renders a row per participant" do
+      expect(rendered_component).to have_css(".Box-row", text: "Ada Lovelace")
+    end
+  end
+
+  context "without participants" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("meeting.participants.blankslate.heading"), icon: :people
+  end
+end

--- a/modules/meeting/spec/components/work_package_meetings_tab/meeting_component_spec.rb
+++ b/modules/meeting/spec/components/work_package_meetings_tab/meeting_component_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe WorkPackageMeetingsTab::MeetingComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
+  let(:meeting) { create(:meeting, project:, title: "Sprint review") }
+  let(:agenda_item) { create(:meeting_agenda_item, meeting:, title: "Discuss scope") }
+
+  subject(:rendered_component) do
+    render_inline(
+      described_class.new(work_package:, meeting:, meeting_agenda_items: [agenda_item])
+    )
+  end
+
+  it_behaves_like "rendering Box", row_count: 1
+
+  it "renders a condensed box keyed to the meeting" do
+    expect(rendered_component).to have_css(".Box.Box--condensed#op-meeting-container-#{meeting.id}")
+  end
+
+  it "renders the meeting title as a heading linking to the meeting", :aggregate_failures do
+    expect(rendered_component).to have_css(".Box-header") do |header|
+      expect(header).to have_css(
+        "h4 a[href='#{meeting_path(meeting)}'][target='_blank']",
+        text: "#{project.name}: #{meeting.title}"
+      )
+      expect(header).to have_css(
+        ".op-border-box-list-header--description",
+        text: ApplicationController.helpers.format_time(meeting.start_time)
+      )
+    end
+  end
+end

--- a/modules/resource_management/app/components/resource_allocations/list_component.html.erb
+++ b/modules/resource_management/app/components/resource_allocations/list_component.html.erb
@@ -34,9 +34,13 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <% if allocations.any? %>
       <%= body.with_row do %>
-        <%= render(Primer::Beta::BorderBox.new) do |box| %>
+        <%= render(
+              OpenProject::Common::BorderBoxListComponent.new(
+                container: "resource-allocations-#{work_package.id}"
+              )
+            ) do |list| %>
           <% allocations.each do |allocation| %>
-            <% box.with_row do %>
+            <% list.with_item do %>
               <%= render ResourceAllocations::ListItemComponent.new(
                     allocation:,
                     project:,

--- a/modules/resource_management/spec/components/resource_allocations/list_component_spec.rb
+++ b/modules/resource_management/spec/components/resource_allocations/list_component_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe ResourceAllocations::ListComponent, type: :component do
+  shared_let(:work_package) { create(:work_package) }
+  shared_let(:member) { create(:user, firstname: "Sarah", lastname: "Smith") }
+
+  before { login_as(create(:admin)) }
+
+  subject(:rendered_component) do
+    render_inline(
+      described_class.new(
+        project: work_package.project,
+        work_package:,
+        allocations:,
+        visible_principal_ids: [member.id]
+      )
+    )
+  end
+
+  context "with allocations" do
+    let!(:allocation) { create(:resource_allocation, entity: work_package, principal: member) }
+    let(:allocations) { [allocation] }
+
+    it_behaves_like "rendering Box", row_count: 1, header: false
+
+    it "renders a row per allocation" do
+      expect(rendered_component).to have_css(".Box-row", text: "Sarah Smith")
+    end
+  end
+
+  context "without allocations" do
+    let(:allocations) { [] }
+
+    it "does not render the list box" do
+      expect(rendered_component).to have_no_css("#resource-allocations-#{work_package.id}")
+    end
+  end
+end

--- a/modules/wikis/app/components/wikis/collapsible_page_links_component.html.erb
+++ b/modules/wikis/app/components/wikis/collapsible_page_links_component.html.erb
@@ -28,16 +28,11 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Beta::BorderBox.new(padding: :condensed)) do |box|
-    box.with_header do
-      render(Primer::OpenProject::BorderBox::CollapsibleHeader.new(collapsed: true)) do |header|
-        header.with_title { heading }
-        header.with_count(count: page_links.count)
-      end
-    end
+  render(OpenProject::Common::BorderBoxListComponent.new(container:, collapsible: true, padding: :condensed)) do |list|
+    list.with_header(title: heading, count: page_links.count, collapsed: true)
 
     page_links.each do |view_model|
-      box.with_row do
+      list.with_item do
         render(
           Wikis::PageLinkComponent.new(
             view_model.page_info_result,

--- a/modules/wikis/app/components/wikis/collapsible_page_links_component.rb
+++ b/modules/wikis/app/components/wikis/collapsible_page_links_component.rb
@@ -33,12 +33,13 @@ module Wikis
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    attr_reader :heading
+    attr_reader :heading, :container
 
     alias_method :page_links, :model
 
-    def initialize(model = nil, heading:, linkable:, already_related_page_keys:, **)
+    def initialize(model = nil, heading:, container:, linkable:, already_related_page_keys:, **)
       @heading = heading
+      @container = container
       @linkable = linkable
       @already_related_page_keys = already_related_page_keys
 

--- a/modules/wikis/app/components/wikis/relation_page_links_component.html.erb
+++ b/modules/wikis/app/components/wikis/relation_page_links_component.html.erb
@@ -28,57 +28,44 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Beta::BorderBox.new(padding: :condensed)) do |box|
-    box.with_header do
-      flex_layout(align_items: :center, justify_content: :space_between) do |header|
-        header.with_column do
-          concat(render(Primer::Beta::Text.new(font_weight: :bold, mr: 2)) { provider.name })
-          concat(render(Primer::Beta::Counter.new(count: page_links.count, round: true, scheme: :primary)))
-        end
-        header.with_column do
-          render(Primer::Alpha::ActionMenu.new) do |menu|
-            menu.with_show_button(disabled: !can_manage_links?) do |button|
-              button.with_leading_visual_icon(icon: :plus)
-              button.with_trailing_action_icon(icon: :"triangle-down")
+  render(OpenProject::Common::BorderBoxListComponent.new(container: provider, padding: :condensed)) do |list|
+    list.with_header(
+      title: provider.name,
+      count: page_links.count,
+      count_arguments: { hide_if_zero: false }
+    ) do |header|
+      header.with_menu do |menu|
+        menu.with_show_button(disabled: !can_manage_links?) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          button.with_trailing_action_icon(icon: :"triangle-down")
 
-              t("wikis.buttons.wiki_page")
-            end
-
-            menu.with_item(
-              label: t(".link_existing"),
-              tag: :a,
-              href: link_existing_dialog_relation_wiki_page_links_path(work_package:, provider:),
-              content_arguments: { data: { controller: "async-dialog" } }
-            )
-            menu.with_item(
-              label: t(".link_new"),
-              tag: :a,
-              href: create_new_page_dialog_wiki_pages_path(create_new_page_parameters),
-              content_arguments: { data: { controller: "async-dialog" } }
-            )
-          end
+          t("wikis.buttons.wiki_page")
         end
+
+        menu.with_item(
+          label: t(".link_existing"),
+          tag: :a,
+          href: link_existing_dialog_relation_wiki_page_links_path(work_package:, provider:),
+          content_arguments: { data: { controller: "async-dialog" } }
+        )
+        menu.with_item(
+          label: t(".link_new"),
+          tag: :a,
+          href: create_new_page_dialog_wiki_pages_path(create_new_page_parameters),
+          content_arguments: { data: { controller: "async-dialog" } }
+        )
       end
     end
 
     if !user_connected?
-      box.with_row do
+      list.with_item do
         render(Wikis::OAuthLoginComponent.new(provider, return_url: work_package_url(work_package, tab: :wikis)))
       end
     elsif page_links.empty?
-      box.with_row do
-        if user_connected?
-          render(Primer::Beta::Blankslate.new(border: false)) do |blankslate|
-            blankslate.with_heading(tag: :h2).with_content(t(".empty_heading"))
-            blankslate.with_description { t(".empty_text") }
-          end
-        else
-          render(Wikis::OAuthLoginComponent.new(provider, return_url: work_package_url(work_package, tab: :wikis)))
-        end
-      end
+      list.with_empty_state(title: t(".empty_heading"), description: t(".empty_text"))
     else
       page_links.each do |page_link_aggregate|
-        box.with_row do
+        list.with_item do
           render(
             Wikis::PageLinkComponent.new(
               page_link_aggregate.page_info_result,

--- a/modules/wikis/app/components/wikis/work_package_wikis_tab_component.html.erb
+++ b/modules/wikis/app/components/wikis/work_package_wikis_tab_component.html.erb
@@ -43,6 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
               ::Wikis::CollapsiblePageLinksComponent.new(
                 inline_page_links,
                 heading: t(".inline_page_links"),
+                container: :inline_page_links,
                 linkable: work_package,
                 already_related_page_keys:
               )
@@ -56,6 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
               ::Wikis::CollapsiblePageLinksComponent.new(
                 referencing_wiki_pages,
                 heading: t(".referencing_pages"),
+                container: :referencing_wiki_pages,
                 linkable: work_package,
                 already_related_page_keys:
               )

--- a/modules/wikis/spec/components/wikis/collapsible_page_links_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/collapsible_page_links_component_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Wikis::CollapsiblePageLinksComponent, type: :component do
   let(:project) { create(:project) }
   let(:work_package) { create(:work_package, project:) }
   let(:provider) { create(:internal_wiki_provider) }
+  let(:heading) { "Referenced in" }
   let(:page_info) do
     Wikis::Adapters::Results::PageInfo.new(
       identifier: "MyPage",
@@ -47,23 +48,47 @@ RSpec.describe Wikis::CollapsiblePageLinksComponent, type: :component do
   let(:already_related_page_keys) { Set.new }
   let(:permissions) { [:manage_wiki_page_links] }
   let(:view_model) { Wikis::PageLinkViewModel.from_page_info_result(page_info_result) }
+  let(:page_links) { [view_model] }
 
   current_user { create(:user, member_with_permissions: { project => permissions }) }
 
-  subject(:render_component) do
+  subject(:rendered_component) do
     render_inline(
-      described_class.new([view_model],
-                          heading: "Referenced in",
+      described_class.new(page_links,
+                          heading:,
+                          container: :inline_page_links,
                           linkable: work_package,
                           already_related_page_keys:)
     )
   end
 
-  before { render_component }
+  before { rendered_component }
+
+  it_behaves_like "rendering Box", row_count: 1
 
   it "renders the heading and the page link" do
-    expect(page).to have_text("Referenced in")
+    expect(page).to have_text(heading)
     expect(page).to have_link(text: page_info.title, href: page_info.href)
+  end
+
+  it "renders a collapsible header with the heading and item count", :aggregate_failures do
+    expect(page).to have_css("collapsible-header")
+    expect(page).to have_css(".Box-header") do |header|
+      expect(header).to have_heading(heading)
+      expect(header).to have_css(".Counter", text: "1")
+    end
+  end
+
+  context "without page links" do
+    let(:page_links) { [] }
+
+    it "still renders the collapsible header with a hidden zero count", :aggregate_failures do
+      expect(page).to have_css("collapsible-header")
+      expect(page).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(heading)
+        expect(header).to have_css(".Counter[hidden]", text: "0", visible: :all)
+      end
+    end
   end
 
   context "when the user may manage wiki page links" do

--- a/modules/wikis/spec/components/wikis/relation_page_links_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/relation_page_links_component_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Wikis::RelationPageLinksComponent, type: :component do
 
     it { expect(page).to have_text(I18n.t("wikis.relation_page_links_component.empty_heading")) }
     it { expect(page).to have_no_text(I18n.t("wikis.oauth_login_component.heading", provider: provider.name)) }
+    it { expect(page).to have_button(I18n.t("wikis.buttons.wiki_page"), disabled: true) }
   end
 
   context "when the user has a token and there are page links" do
@@ -106,7 +107,7 @@ RSpec.describe Wikis::RelationPageLinksComponent, type: :component do
       render_component
     end
 
-    it { expect(page).to have_text("My Wiki Page") }
+    it { expect(page).to have_css(".Box-row", text: "My Wiki Page") }
     it { expect(page).to have_no_text(I18n.t("wikis.relation_page_links_component.empty_heading")) }
     it { expect(page).to have_no_text(I18n.t("wikis.oauth_login_component.heading", provider: provider.name)) }
   end

--- a/modules/wikis/spec/components/wikis/work_package_wikis_tab_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/work_package_wikis_tab_component_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::WorkPackageWikisTabComponent, type: :component do
+  let(:provider) { build_stubbed(:xwiki_provider) }
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:inline_page_links) { [] }
+  let(:referencing_wiki_pages) { [] }
+
+  let(:page_link_service) do
+    instance_double(
+      Wikis::PageLinkService,
+      inline_page_link_infos_for: inline_page_links,
+      referencing_wiki_page_references_for: referencing_wiki_pages,
+      relation_page_link_keys_for: Set.new
+    )
+  end
+
+  def page_info_result(title)
+    Dry::Monads::Success(
+      Wikis::Adapters::Results::PageInfo.new(
+        identifier: title,
+        title:,
+        href: "https://wiki.example.com/#{title}",
+        provider:
+      )
+    )
+  end
+
+  def page_reference_result(title, source: :mention)
+    page_info_result(title).fmap do |page_info|
+      Wikis::Adapters::Results::PageReference.new(page_info:, source:)
+    end
+  end
+
+  subject(:render_component) { render_inline(described_class.new(work_package)) }
+
+  before do
+    allow(Wikis::PageLinkService).to receive(:new).and_return(page_link_service)
+    render_component
+  end
+
+  context "without inline or referencing page links" do
+    it "renders the turbo-frame wrapper without any section", :aggregate_failures do
+      expect(page).to have_css("turbo-frame#work-package-wikis-tab-content")
+      expect(page).to have_no_text(I18n.t("wikis.work_package_wikis_tab_component.inline_page_links"))
+      expect(page).to have_no_text(I18n.t("wikis.work_package_wikis_tab_component.referencing_pages"))
+    end
+  end
+
+  context "with inline and referencing page links" do
+    let(:inline_page_links) { [page_info_result("Inline page")] }
+    let(:referencing_wiki_pages) { [page_reference_result("Referencing page")] }
+
+    it "renders a collapsible section for each link group" do
+      expect(page).to have_css("collapsible-header", count: 2)
+    end
+
+    it "renders the inline page links section", :aggregate_failures do
+      expect(page).to have_text(I18n.t("wikis.work_package_wikis_tab_component.inline_page_links"))
+      expect(page).to have_text("Inline page")
+    end
+
+    it "renders the referencing pages section", :aggregate_failures do
+      expect(page).to have_text(I18n.t("wikis.work_package_wikis_tab_component.referencing_pages"))
+      expect(page).to have_text("Referencing page")
+    end
+  end
+end

--- a/spec/components/admin/departments/detail_component_spec.rb
+++ b/spec/components/admin/departments/detail_component_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Admin::Departments::DetailComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  subject(:rendered_component) { render_inline(described_class.new(**args)) }
+
+  context "without a group (global empty state)" do
+    let(:args) { { group: nil, child_groups: [] } }
+
+    # The global blank slate carries its own call to action, so it renders as a
+    # regular row rather than through the list's empty state slot.
+    it_behaves_like "rendering Box", row_count: 1
+    it_behaves_like "rendering Blank Slate",
+                    heading: I18n.t("departments.blankslate.heading"), icon: :people
+  end
+
+  context "with an empty department" do
+    let(:group) { create(:department) }
+    let(:args) { { group:, child_groups: [] } }
+
+    it_behaves_like "rendering Box", row_count: 1
+    it_behaves_like "rendering Blank Slate",
+                    heading: I18n.t("departments.detail_blankslate.heading"), icon: :people
+
+    it "renders the department name in the breadcrumbs" do
+      expect(rendered_component).to have_css("li.breadcrumb-item", text: group.name)
+    end
+
+    it "renders the department title and edit action in the header", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(group.name, level: 4)
+        expect(header).to have_link(accessible_name: I18n.t(:button_edit), href: edit_admin_department_path(group))
+      end
+    end
+  end
+
+  context "with child departments" do
+    let(:group) { create(:department) }
+    let(:child) { create(:department, lastname: "Child dept") }
+    let(:args) { { group:, child_groups: [child] } }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders a row per child department" do
+      expect(rendered_component).to have_css(".Box-row", text: "Child dept")
+    end
+  end
+end

--- a/spec/components/my/notifications/show_page_component_spec.rb
+++ b/spec/components/my/notifications/show_page_component_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe My::Notifications::ShowPageComponent, type: :component do
+  let(:user) { create(:user) }
+  # create(:user) already seeds the global (project-less) notification setting.
+  let(:global_setting) { user.notification_settings.find_by!(project: nil) }
+
+  subject(:rendered_component) do
+    with_request_url("/my/notifications") do
+      render_inline(
+        described_class.new(
+          user:,
+          global_notification_setting: global_setting,
+          update_participating_url: { action: "update_participating" },
+          update_non_participating_url: { action: "update_non_participating" },
+          update_date_alerts_url: { action: "update_date_alerts" },
+          new_project_settings_url: "/my/project_notifications/new",
+          edit_project_settings_url: ->(project_id) { "/my/project_notifications/#{project_id}/edit" },
+          project_setting_url: ->(project_id) { "/my/project_notifications/#{project_id}" }
+        )
+      )
+    end
+  end
+
+  context "with project-specific settings" do
+    let(:project) { create(:project) }
+    let!(:project_setting) { create(:notification_setting, user:, project:) }
+
+    it "renders the list header and the add-project action", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(I18n.t("my_account.notifications.project_specific_settings.list_header"))
+      end
+      expect(rendered_component).to have_link(
+        I18n.t("my_account.notifications.project_specific_settings.add_button"),
+        href: "/my/project_notifications/new"
+      )
+    end
+
+    it "renders a row per project-specific setting with an edit/delete actions menu", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-row", text: project.name) do |row|
+        expect(row).to have_button(accessible_name: I18n.t(:label_open_menu))
+        expect(row).to have_link(I18n.t(:button_edit), href: "/my/project_notifications/#{project.id}/edit")
+        expect(row).to have_link(I18n.t(:button_delete), href: "/my/project_notifications/#{project.id}")
+      end
+    end
+  end
+
+  context "without project-specific settings" do
+    it_behaves_like "rendering Blank Slate",
+                    heading: I18n.t("my_account.notifications.project_specific_settings.empty_text")
+  end
+end

--- a/spec/components/oauth/applications/index_component_spec.rb
+++ b/spec/components/oauth/applications/index_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OAuth::Applications::IndexComponent, type: :component do
+  subject(:rendered_component) { render_inline(described_class.new(oauth_applications:)) }
+
+  context "with applications" do
+    let(:oauth_applications) { [create(:oauth_application, name: "My external app")] }
+
+    it "renders the other-applications list with a header and a row per application", :aggregate_failures do
+      expect(rendered_component).to have_css("#op-admin-oauth--other-applications.Box") do |box|
+        expect(box).to have_css(".Box-header") do |header|
+          expect(header).to have_heading(I18n.t("oauth.header.other_applications"))
+        end
+        expect(box).to have_css(".Box-row", text: "My external app")
+      end
+    end
+
+    it "keeps the other-applications empty state in the row hidden once rows exist" do
+      expect(rendered_component).to have_css("#op-admin-oauth--other-applications .Box-row[data-empty-list-item]") do |row|
+        expect(row).to have_css(".blankslate")
+      end
+    end
+  end
+
+  context "without applications" do
+    let(:oauth_applications) { [] }
+
+    it_behaves_like "rendering Blank Slate", heading: I18n.t("oauth.empty_application_lists")
+
+    it "renders the empty state inside the other-applications list" do
+      expect(rendered_component).to have_css("#op-admin-oauth--other-applications .blankslate")
+    end
+  end
+end

--- a/spec/components/open_project/common/border_box_list_component_preview_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_preview_spec.rb
@@ -123,4 +123,14 @@ RSpec.describe OpenProject::Common::BorderBoxListComponentPreview, type: :compon
     expect(page).to have_css(".op-border-box-list-header_collapsible")
     expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
   end
+
+  it "renders custom header content preview branches" do
+    render_preview(:custom_header_content, from: described_class)
+
+    expect(page).to have_heading("Linked delivery plan", level: 4)
+    expect(page).to have_link("Linked delivery plan")
+    expect(page).to have_button(accessible_name: "Add delivery item")
+    expect(page).to have_text("Add item")
+    expect(page).to have_no_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
+  end
 end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -198,6 +198,34 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_css(".op-border-box-list-header--description", text: "Some description")
     end
 
+    it "renders custom title slot content inside the title heading" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-title-content")
+      ) do |list|
+        list.with_header(title: "String title") do |header|
+          header.with_title { '<a href="/somewhere">Linked title</a>'.html_safe }
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_heading("Linked title", level: 4)
+      expect(rendered)
+        .to have_css(".op-border-box-list-header--heading-line h4.Box-title a[href='/somewhere']",
+                     text: "Linked title")
+      expect(rendered).to have_no_text("String title")
+    end
+
+    it "raises when the header has neither a title nor title slot" do
+      expect do
+        render_inline(
+          described_class.new(container: "hdr-without-title")
+        ) do |list|
+          list.with_header
+          list.with_item { "row" }
+        end
+      end.to raise_error(ArgumentError, /title/)
+    end
+
     it "forwards system arguments to the description text" do
       rendered = render_inline(
         described_class.new(container: "hdr-description-args")
@@ -230,6 +258,19 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_button("Edit")
     end
 
+    it "renders an action icon button" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-icon-action")
+      ) do |list|
+        list.with_header(title: "Actions") do |header|
+          header.with_action_icon_button(icon: :pencil, "aria-label": "Edit list")
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_button(accessible_name: "Edit list")
+    end
+
     it "renders a menu in the header" do
       rendered = render_inline(
         described_class.new(container: "hdr-menu")
@@ -245,6 +286,48 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_css(".Box-header")
       expect(rendered).to have_css("action-menu")
       expect(rendered).to have_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
+    end
+
+    it "forwards button arguments to the default menu show button" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-menu-button-arguments")
+      ) do |list|
+        list.with_header(title: "With configured menu") do |header|
+          header.with_menu(
+            button_arguments: {
+              aria: { label: "Configured actions" },
+              data: { test_selector: "configured-actions-button" }
+            }
+          ) do |menu|
+            menu.with_item(label: "Option A", value: "a")
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_button(
+        "hdr-menu-button-arguments_list_menu-button",
+        accessible_name: "Configured actions"
+      )
+      expect(rendered).to have_css("button[data-test-selector='configured-actions-button']")
+    end
+
+    it "renders a custom show button without adding the default show button" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-custom-menu")
+      ) do |list|
+        list.with_header(title: "With custom menu") do |header|
+          header.with_menu do |menu|
+            menu.with_show_button { "Add link" }
+            menu.with_item(label: "Option A", value: "a")
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css("action-menu")
+      expect(rendered).to have_button("Add link")
+      expect(rendered).to have_no_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
     end
 
     it "infers the count from rendered items" do
@@ -629,6 +712,28 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
   end
 
   describe "empty state" do
+    it "renders the default empty state when no items are present" do
+      rendered = render_inline(
+        described_class.new(container: "default-empty-list")
+      ) do |list|
+        list.with_header(title: "Empty list")
+      end
+
+      expect(rendered).to have_css(".blankslate")
+      expect(rendered).to have_heading(I18n.t(:label_nothing_display), level: 4)
+      expect(rendered).to have_text(I18n.t(:no_results_title_text))
+    end
+
+    it "renders the default empty state without requiring a header" do
+      rendered = render_inline(
+        described_class.new(container: "default-empty-list-without-header")
+      )
+
+      expect(rendered).to have_css(".Box#default-empty-list-without-header")
+      expect(rendered).to have_css(".blankslate")
+      expect(rendered).to have_heading(I18n.t(:label_nothing_display), level: 4)
+    end
+
     it "renders a Blankslate when no items are present" do
       rendered = render_inline(
         described_class.new(container: "empty-list")
@@ -670,6 +775,14 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       ) do |list|
         list.with_empty_state(title: "Empty")
       end
+
+      expect(rendered).to have_role(:status, aria: { live: "polite" })
+    end
+
+    it "sets aria role and live attributes on the default empty state when the list is interactive" do
+      rendered = render_inline(
+        described_class.new(container: "default-empty-interactive-aria", interactive: true)
+      )
 
       expect(rendered).to have_role(:status, aria: { live: "polite" })
     end

--- a/spec/components/portfolios/index_component_spec.rb
+++ b/spec/components/portfolios/index_component_spec.rb
@@ -52,13 +52,17 @@ RSpec.describe Portfolios::IndexComponent, type: :component do
 
   describe "Portfolios" do
     context "when the query returns a result" do
-      it "renders a list" do
-        expect(subject).to have_test_selector("op-portfolios--portfolio-#{portfolio_a.id}")
-        expect(subject).to have_test_selector("op-portfolios--portfolio-#{portfolio_b.id}")
+      it_behaves_like "rendering Box", row_count: 2, header: false
+
+      it "renders a row per portfolio", :aggregate_failures do
+        expect(rendered_component).to have_css(".Box-row.portfolio", text: portfolio_a.name)
+        expect(rendered_component).to have_css(".Box-row.portfolio", text: portfolio_b.name)
       end
 
-      it "does not render a placeholder" do
-        expect(subject).not_to have_test_selector("op-portfolios--portfolios-placeholder")
+      it "keeps the empty state in the row hidden once portfolios exist" do
+        expect(rendered_component).to have_css(".Box-row[data-empty-list-item]") do |row|
+          expect(row).to have_css(".blankslate")
+        end
       end
     end
 
@@ -67,13 +71,11 @@ RSpec.describe Portfolios::IndexComponent, type: :component do
       let!(:portfolio_a) { create(:project) }
       let!(:portfolio_b) { create(:project) }
 
-      it "does not render a list" do
-        expect(subject).not_to have_test_selector("op-portfolios--portfolio-#{portfolio_a.id}")
-        expect(subject).not_to have_test_selector("op-portfolios--portfolio-#{portfolio_b.id}")
-      end
+      it_behaves_like "rendering an empty Border Box List",
+                      heading: I18n.t(:no_results_title_text), header: false
 
-      it "renders a placeholder" do
-        expect(subject).to have_test_selector("op-portfolios--portfolios-placeholder")
+      it "does not render a portfolio row" do
+        expect(rendered_component).to have_no_css(".Box-row.portfolio")
       end
     end
   end

--- a/spec/components/projects/settings/creation_wizard/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/projects/settings/creation_wizard/project_custom_field_sections/show_component_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::CreationWizard::ProjectCustomFieldSections::ShowComponent, type: :component do
+  let(:project) { create(:project) }
+  let(:section) { create(:project_custom_field_section) }
+
+  subject(:rendered_component) do
+    with_request_url("/projects/#{project.id}/settings/creation_wizard") do
+      render_inline(described_class.new(project:, project_custom_field_section: section))
+    end
+  end
+
+  context "with enabled custom fields" do
+    let!(:custom_field) do
+      create(:project_custom_field, name: "My field", project_custom_field_section: section, projects: [project])
+    end
+
+    before { section.reload }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+
+    it "renders a row per custom field" do
+      expect(rendered_component).to have_css(".Box-row", text: "My field")
+    end
+  end
+
+  context "without custom fields" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("settings.project_attributes.label_no_project_custom_fields")
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+  end
+end

--- a/spec/components/projects/settings/life_cycle/index_component_spec.rb
+++ b/spec/components/projects/settings/life_cycle/index_component_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::LifeCycle::IndexComponent, type: :component do
+  let(:project) { create(:project) }
+
+  subject(:rendered_component) do
+    with_request_url("/projects/#{project.id}/settings/life_cycle") do
+      render_inline(
+        described_class.new(project:, life_cycle_definitions: Project::PhaseDefinition.order(position: :asc))
+      )
+    end
+  end
+
+  context "with definitions" do
+    let!(:definition) { create(:project_phase_definition) }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders a row per definition" do
+      expect(rendered_component).to have_css(".Box-row", text: definition.name)
+    end
+
+    it "renders the enable-all and disable-all header actions", :aggregate_failures do
+      expect(rendered_component).to have_link(accessible_name: I18n.t("projects.settings.actions.label_enable_all"))
+      expect(rendered_component).to have_link(accessible_name: I18n.t("projects.settings.actions.label_disable_all"))
+    end
+  end
+
+  context "without definitions" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("projects.settings.life_cycle.non_defined")
+  end
+end

--- a/spec/components/projects/settings/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/projects/settings/project_custom_field_sections/show_component_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::ProjectCustomFieldSections::ShowComponent, type: :component do
+  let(:project) { create(:project) }
+  let(:section) { create(:project_custom_field_section) }
+
+  subject(:rendered_component) do
+    with_request_url("/projects/#{project.id}/settings/project_custom_fields") do
+      render_inline(described_class.new(project:, project_custom_field_section: section))
+    end
+  end
+
+  context "with custom fields" do
+    let!(:custom_field) do
+      create(:project_custom_field, name: "My field", project_custom_field_section: section, projects: [project])
+    end
+
+    before { section.reload }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+
+    it "renders a row per custom field" do
+      expect(rendered_component).to have_css(".Box-row", text: "My field")
+    end
+  end
+
+  context "without custom fields" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("settings.project_attributes.label_no_project_custom_fields")
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+  end
+end

--- a/spec/components/settings/project_phase_definitions/index_component_spec.rb
+++ b/spec/components/settings/project_phase_definitions/index_component_spec.rb
@@ -28,38 +28,30 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Settings
-  module ProjectPhaseDefinitions
-    class IndexComponent < ApplicationComponent
-      include OpPrimer::ComponentHelpers
-      include OpTurbo::Streamable
-      include Projects::PhaseDefinitionHelper
+require "rails_helper"
 
-      options :definitions
+RSpec.describe Settings::ProjectPhaseDefinitions::IndexComponent, type: :component do
+  include Rails.application.routes.url_helpers
 
-      private
+  subject(:rendered_component) { render_inline(described_class.new(definitions:)) }
 
-      def wrapper_data_attributes
-        {
-          controller: "projects--settings--border-box-filter generic-drag-and-drop"
-        }
-      end
+  # The row component reads the +project_count+ column added by the
+  # +with_project_count+ scope, so definitions are loaded through it.
+  let(:definitions) { Project::PhaseDefinition.with_project_count }
 
-      def drop_target_config
-        {
-          generic_drag_and_drop_target: "container",
-          "target-container-accessor": ":scope > ul",
-          "target-allowed-drag-type": "life-cycle-step-definition"
-        }
-      end
+  def drop_url_for(definition)
+    drop_admin_settings_project_phase_definition_path(definition)
+  end
 
-      def draggable_item_config(definition)
-        {
-          "draggable-id": definition.id,
-          "draggable-type": "life-cycle-step-definition",
-          "drop-url": drop_admin_settings_project_phase_definition_path(definition)
-        }
-      end
-    end
+  context "with definitions" do
+    let!(:draggable_records) { create_list(:project_phase_definition, 2) }
+
+    it_behaves_like "rendering Box", row_count: 2
+    it_behaves_like "a reorderable Border Box List", drag_type: "life-cycle-step-definition"
+  end
+
+  context "without definitions" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("settings.project_phase_definitions.non_defined")
   end
 end

--- a/spec/components/work_package_relations_tab/index_component_spec.rb
+++ b/spec/components/work_package_relations_tab/index_component_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe WorkPackageRelationsTab::IndexComponent, type: :component do
     TABLE
 
     it "renders the relations group with the parent work package in it" do
-      expect(render_component).to have_test_selector("op-relation-group-parent")
       expect(render_component).to have_list "Parent"
 
       list = page.find(:list, "Parent")
@@ -75,7 +74,7 @@ RSpec.describe WorkPackageRelationsTab::IndexComponent, type: :component do
     TABLE
 
     it "renders the relations group" do
-      expect(render_component).to have_test_selector("op-relation-group-child")
+      expect(render_component).to have_list "Children"
     end
 
     it "renders the relations in child creation order" do
@@ -99,7 +98,7 @@ RSpec.describe WorkPackageRelationsTab::IndexComponent, type: :component do
     TABLE
 
     it "renders the relations group" do
-      expect(render_component).to have_test_selector("op-relation-group-follows")
+      expect(render_component).to have_list "Predecessors (before)"
     end
 
     it "renders the relations in relation creation order" do

--- a/spec/components/work_package_types/export_template_list_component_spec.rb
+++ b/spec/components/work_package_types/export_template_list_component_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2010-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,45 +26,39 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
 require "rails_helper"
 
-RSpec.describe WorkPackageTypes::ExportTemplateRowComponent, type: :component do
+RSpec.describe WorkPackageTypes::ExportTemplateListComponent, type: :component do
   include Rails.application.routes.url_helpers
 
   let(:type) { create(:type) }
-  let(:template) { Type::PdfExportTemplates::Template.new(id: 1, label: "Full", caption: "A4", enabled: true) }
+  let(:draggable_records) { type.pdf_export_templates.list }
 
-  context "when readonly" do
-    it "renders the toggle as a disabled, non-interactive switch", :aggregate_failures do
-      render_inline(described_class.new(type:, template:, readonly: true))
+  subject(:rendered_component) { render_inline(described_class.new(type:)) }
 
-      expect(page).to have_css("[data-test-selector='toggle-pdf-export-template-row-1']")
-      expect(page).to have_css(".ToggleSwitch--disabled")
-      expect(page).to have_no_css("[data-turbo-method]")
-    end
+  def drop_url_for(template)
+    drop_type_pdf_export_template_path(type_id: type.id, id: template.id)
   end
 
-  context "when editable (default)" do
-    subject(:rendered_component) { render_inline(described_class.new(type:, template:)) }
+  it_behaves_like "rendering Box", row_count: 3
+  it_behaves_like "a reorderable Border Box List", drag_type: "template"
 
-    it "renders an interactive toggle switch", :aggregate_failures do
-      expect(rendered_component).to have_css("[data-test-selector='toggle-pdf-export-template-row-1']")
-      expect(rendered_component).to have_no_css(".ToggleSwitch--disabled")
-    end
+  it "renders the enable-all and disable-all header actions", :aggregate_failures do
+    expect(rendered_component).to have_link(accessible_name: I18n.t("projects.settings.actions.label_enable_all"))
+    expect(rendered_component).to have_link(accessible_name: I18n.t("projects.settings.actions.label_disable_all"))
+  end
 
-    it "renders a unique wrapper derived from the template id" do
+  it "renders a unique wrapper for each template row" do
+    draggable_records.each do |template|
       expect(rendered_component)
         .to have_css("#work-package-types-export-template-row-component-#{template.id}", count: 1)
     end
+  end
 
-    it "renders the template label and caption" do
-      expect(rendered_component).to have_text(template.label)
-      expect(rendered_component).to have_text(template.caption)
-    end
-
-    it "labels the toggle button with its template and reflects the enabled state" do
+  it "labels each template toggle button with its template" do
+    draggable_records.each do |template|
       expect(rendered_component).to have_button(
         accessible_name: I18n.t(
           "types.edit.export_configuration.pdf_export_templates.actions.label_toggle_template",

--- a/spec/features/types/export_configuration_spec.rb
+++ b/spec/features/types/export_configuration_spec.rb
@@ -41,30 +41,41 @@ RSpec.describe "type export configuration tab", :js do
     visit edit_type_pdf_export_template_index_path(type)
   end
 
-  def within_pdf_export_template_container(template_id, &)
-    within("[data-test-selector='pdf-export-template-row-#{template_id}']", &)
+  def within_pdf_export_template_container(template, &)
+    within_test_selector("pdf-export-template-row-#{template.id}", &)
   end
 
-  def toggle_pdf_export_template(template_id)
-    page
-      .find("[data-test-selector='toggle-pdf-export-template-row-#{template_id}'] > button")
-      .click
+  def toggle_pdf_export_template(template)
+    find(:button, accessible_name: toggle_pdf_export_template_label(template)).click
   end
 
-  def expect_checked_state
-    expect(page).to have_css(".ToggleSwitch-statusOn")
+  def expect_checked_state(template)
+    expect(page).to have_button(
+      accessible_name: toggle_pdf_export_template_label(template),
+      aria: { pressed: true }
+    )
   end
 
-  def expect_unchecked_state
-    expect(page).to have_css(".ToggleSwitch-statusOff")
+  def expect_unchecked_state(template)
+    expect(page).to have_button(
+      accessible_name: toggle_pdf_export_template_label(template),
+      aria: { pressed: false }
+    )
+  end
+
+  def toggle_pdf_export_template_label(template)
+    I18n.t(
+      "types.edit.export_configuration.pdf_export_templates.actions.label_toggle_template",
+      template: template.label
+    )
   end
 
   it "disables/enables all" do
-    page.find("[data-test-selector='disable-all-pdf-export-templates']").click
+    click_link(I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_disable_all"))
     wait_for_reload
     type.reload
     expect(type.pdf_export_templates.list_enabled.length).to eq(0)
-    page.find("[data-test-selector='enable-all-pdf-export-templates']").click
+    click_link(I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_enable_all"))
     wait_for_reload
     type.reload
     expect(type.pdf_export_templates.list_enabled.length).to eq(type.pdf_export_templates.list.length)
@@ -72,15 +83,15 @@ RSpec.describe "type export configuration tab", :js do
 
   it "disables/enables one" do
     first = type.pdf_export_templates.list_enabled.first
-    within_pdf_export_template_container(first.id) do
-      expect_checked_state
-      toggle_pdf_export_template(first.id)
-      expect_unchecked_state
+    within_pdf_export_template_container(first) do
+      expect_checked_state(first)
+      toggle_pdf_export_template(first)
+      expect_unchecked_state(first)
       wait_for_reload
       type.reload
       expect(type.pdf_export_templates.list.first.enabled).to be(false)
-      toggle_pdf_export_template(first.id)
-      expect_checked_state
+      toggle_pdf_export_template(first)
+      expect_checked_state(first)
       wait_for_reload
       type.reload
       expect(type.pdf_export_templates.list.first.enabled).to be(true)
@@ -90,10 +101,13 @@ RSpec.describe "type export configuration tab", :js do
   it "reorders by drag and drop" do
     first_id = type.pdf_export_templates.list_enabled.first.id
     second_id = type.pdf_export_templates.list_enabled[1].id
-    source = page.find("[data-test-selector='pdf-export-template-row-#{first_id}'] .DragHandle")
-    target = page.find("[data-test-selector='pdf-export-template-row-#{second_id}'] .DragHandle")
-    source.native.drag_to(target.native, delay: 0.1)
-    sleep 1
+    Pages::Page.new.drag_and_drop_list(
+      from: 0,
+      to: 1,
+      elements: "[data-test-selector^='pdf-export-template-row-']",
+      handler: ".DragHandle"
+    )
+    wait_for_network_idle
 
     type.reload
     expect(type.pdf_export_templates.list[1].id).to eq(first_id)

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -117,12 +117,93 @@ module Pages
     end
 
     def drag_and_drop_list_cuprite(from:, to:, elements:, handler:)
-      list = page.all(elements, minimum: [from, to].max + 1)
-      source_handler = list[from].find(handler)
-      target_handler = list[to].find(handler)
+      return if from == to
 
-      # doesn't scroll
-      source_handler.native.drag_to(target_handler.native, delay: 0.1)
+      list = page.all(elements, minimum: [from, to].max + 1)
+
+      return if drag_and_drop_list_with_generic_controller_cuprite(
+        source: list[from],
+        target: list[to],
+        insert_after: from < to
+      )
+
+      list[from].find(handler).native.drag_to(list[to].find(handler).native, delay: 0.1)
+    end
+
+    def drag_and_drop_list_with_generic_controller_cuprite(source:, target:, insert_after:)
+      # Cuprite does not reliably trigger Dragula's mouse lifecycle for Primer lists,
+      # so exercise the generic controller's drop callback once it is connected.
+      result = page.evaluate_async_script(<<~JS, source.native, target.native, insert_after)
+        const source = arguments[0];
+        const target = arguments[1];
+        const insertAfter = arguments[2];
+        const done = arguments[arguments.length - 1];
+        const controllerRoot = source.closest('[data-controller~="generic-drag-and-drop"]');
+
+        if (!controllerRoot) {
+          done({ success: false, fallback: true });
+          return;
+        }
+
+        const getController = () => window.Stimulus?.getControllerForElementAndIdentifier(
+          controllerRoot,
+          'generic-drag-and-drop'
+        );
+
+        const drop = (controller) => {
+          try {
+            if (!source.getAttribute('data-drop-url')) {
+              done({ success: false, error: 'Draggable element has no drop URL' });
+              return;
+            }
+
+            const sourceContainer = source.parentElement;
+            const targetContainer = target.parentElement;
+
+            if (controller.accepts && !controller.accepts(source, targetContainer, sourceContainer, null)) {
+              done({ success: false, error: 'Target does not accept draggable element' });
+              return;
+            }
+
+            controller.dragOriginSource = sourceContainer;
+            controller.dragOriginNextSibling = source.nextElementSibling;
+
+            if (insertAfter) {
+              target.after(source);
+            } else {
+              target.before(source);
+            }
+
+            Promise.resolve(controller.drop(source, source.parentElement, sourceContainer, null))
+              .then(() => done({ success: true }))
+              .catch((error) => done({ success: false, error: String(error?.message || error) }));
+          } catch (error) {
+            done({ success: false, error: String(error?.message || error) });
+          }
+        };
+
+        const waitForController = (startedAt) => {
+          const controller = getController();
+
+          if (controller) {
+            drop(controller);
+            return;
+          }
+
+          if (performance.now() - startedAt > 5000) {
+            done({ success: false, error: 'Generic drag-and-drop controller did not connect' });
+            return;
+          }
+
+          setTimeout(() => waitForController(startedAt), 25);
+        };
+
+        waitForController(performance.now());
+      JS
+
+      raise result["error"] if result.is_a?(Hash) && result["error"]
+
+      result.is_a?(Hash) && result["success"]
     end
 
     def drag_and_drop_list_selenium(from:, to:, elements:, handler:)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-697

# What are you trying to accomplish?

Migrate list-shaped `Primer::Beta::BorderBox` / `border_box_container` usages onto `OpenProject::Common::BorderBoxListComponent`, so comparable lists share one tested composition for headers, items, empty states, counters, collapsibility, and drag-and-drop wiring.

The branch also extends the shared component API first, so the migrations use the final API shape instead of carrying local one-off header implementations.

# What changed?

## BorderBoxListComponent API

- Added custom header title content via `header.with_title`, rendered inside the configured heading element.
- Added header icon actions via `header.with_action_icon_button`.
- Reworked header/row menus through a small `BorderBoxListComponent::Menu` wrapper so the default kebab trigger is still automatic, but callers can pass `button_arguments:` or provide their own `menu.with_show_button`.
- Added default empty-state rendering when a list has no items and no custom `with_empty_state` slot.
- Updated Lookbook docs/previews and component specs for the new API branches.

## Migrated consumers

| Area | Component |
| --- | --- |
| BorderBoxList docs/previews | `OpenProject::Common::BorderBoxListComponent` |
| Backlogs buckets/sprints | existing menu calls updated to the new `button_arguments:` API |
| Work package wiki links | `Wikis::CollapsiblePageLinksComponent` |
| Work package wiki relation links | `Wikis::RelationPageLinksComponent` |
| Portfolios list | `Portfolios::IndexComponent` |
| Administration OAuth applications | `OAuth::Applications::IndexComponent` |
| Administration project phase definitions | `Settings::ProjectPhaseDefinitions::IndexComponent` |
| Project settings life cycle | `Projects::Settings::LifeCycle::IndexComponent` |
| Project settings project attributes | `Projects::Settings::ProjectCustomFieldSections::ShowComponent` |
| Project creation wizard custom fields | `Projects::Settings::CreationWizard::ProjectCustomFieldSections::ShowComponent` |
| Administration workflows type list | `Workflows::TypeListComponent`, renamed from `TableComponent` |
| Work package type PDF export templates | `WorkPackageTypes::ExportTemplateListComponent` |
| My account notification settings | `My::Notifications::ShowPageComponent` |
| Work package meetings tab | `WorkPackageMeetingsTab::MeetingComponent` |
| Administration departments detail | `Admin::Departments::DetailComponent` |
| Work package relation groups | `WorkPackageRelationsTab::IndexComponent` |
| Administration enumerations | `Admin::Enumerations::IndexComponent` |
| Meeting participants | `Meetings::Participants::ListComponent` |
| Project settings cost types | `Projects::Settings::CostTypes::IndexComponent` |
| Resource allocations | `ResourceAllocations::ListComponent` |

# What approach did you choose and why?

The PR keeps the shared API changes in the first commit, then migrates consumers in focused slices. That makes the new API reviewable on its own and keeps later commits atomic around the screens they convert.

Each migration maps existing markup onto the component slots while preserving test selectors, filter targets, accessible names, drag-and-drop data, and existing row behavior. The deliberate behavior change is that empty lists can now rely on the component's default Primer Blankslate unless a consumer needs domain-specific empty-state copy.

# Follow-up candidates (not in this PR)

Triaged by row shape. Rows with multiple data columns belong on a future BorderBoxTable / DataTable, not BorderBoxListComponent; rich headers (multiple menus plus a dialog) are deferred, with no header-API extension.

- **Still a BorderBoxList candidate:** `MeetingAgendaItems::ListComponent` (no header, lowest fit).
- **Reclassified to BorderBoxTable (multiple data columns):** `Documents::Admin::DocumentTypes::IndexComponent` (also in opf/openproject#23485), `Storages::Admin::StorageListComponent`, `Wikis::Admin::WikiProviderListComponent`, `Documents::ListComponent`.
- **Deferred, rich header / invasive:** `Settings::ProjectCustomFieldSections::ShowComponent` (admin header has a drag handle, position menu, kebab menu, and dialog — not a clone of the migrated `Projects::Settings::…` twin), `WorkPackageTypes::FormConfiguration::GroupComponent`, `MeetingSections::ShowComponent`.

# Verification

- Component specs for the shared component and migrated consumers pass; the four most recent migrations add 38 examples, 0 failures.
- Feature specs for workflow accessibility and export-template drag/toggle behavior: 4 examples, 0 failures.
- `bin/dirty-rubocop --against origin/dev`: no offenses.
- `erb_lint` on changed ERB files: no errors.
- `git diff --check origin/dev..HEAD`: clean.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
- [x] Update `BorderBoxListComponent` to render a default empty state when `with_empty_state` is not called
