### PR TITLE
Move file links related code to storages module

### DIFF
--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -51,19 +51,12 @@ module WorkPackages
     default_attribute_permission :add_work_packages
 
     validate :user_allowed_to_add
-    validate :user_allowed_to_manage_file_links
 
     private
 
     def user_allowed_to_add
       if (model.project && !@user.allowed_in_project?(:add_work_packages, model.project)) ||
          !@user.allowed_in_any_project?(:add_work_packages)
-        errors.add(:base, :error_unauthorized)
-      end
-    end
-
-    def user_allowed_to_manage_file_links
-      if model.file_links.present? && model.project.present? && !user.allowed_in_project?(:manage_file_links, model.project)
         errors.add(:base, :error_unauthorized)
       end
     end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -66,6 +66,8 @@ class WorkPackage < ApplicationRecord
   has_many :file_links, dependent: :delete_all, class_name: "Storages::FileLink", as: :container
   has_many :storages, through: :project
 
+  attr_accessor :file_links_replacements
+
   has_and_belongs_to_many :changesets, -> { # rubocop:disable Rails/HasAndBelongsToMany
     order("#{Changeset.table_name}.committed_on ASC, #{Changeset.table_name}.id ASC")
   }

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -63,10 +63,6 @@ class WorkPackage < ApplicationRecord
   belongs_to :category, class_name: "Category", optional: true
 
   has_many :time_entries, dependent: :delete_all, inverse_of: :entity, as: :entity
-  has_many :file_links, dependent: :delete_all, class_name: "Storages::FileLink", as: :container
-  has_many :storages, through: :project
-
-  attr_accessor :file_links_replacements
 
   has_and_belongs_to_many :changesets, -> { # rubocop:disable Rails/HasAndBelongsToMany
     order("#{Changeset.table_name}.committed_on ASC, #{Changeset.table_name}.id ASC")

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -35,8 +35,6 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
   def set_attributes(attributes)
     validate_custom_fields = attributes.delete(:validate_custom_fields)
-    file_links_ids = attributes.delete(:file_links_ids)
-    model.file_links = Storages::FileLink.where(id: file_links_ids) if file_links_ids
 
     set_attachments_attributes(attributes)
     set_static_attributes(attributes)

--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -40,25 +40,6 @@ module API
           WorkPackageMetaRepresenter
         end
 
-        property :file_links,
-                 exec_context: :decorator,
-                 getter: ->(*) {},
-                 setter: ->(fragment:, **) do
-                   next unless fragment.is_a?(Array)
-
-                   ids = fragment.map do |link|
-                     ::API::Utilities::ResourceLinkParser.parse_id link["href"],
-                                                                   property: :file_link,
-                                                                   expected_version: "3",
-                                                                   expected_namespace: :file_links
-                   end
-
-                   represented.file_links_ids = ids
-                 end,
-                 skip_render: ->(*) { true },
-                 linked_resource: true,
-                 uncacheable: true
-
         def writable_attributes
           super + %w[date]
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -36,7 +36,6 @@ module API
         include API::Decorators::FormattableProperty
         include API::Caching::CachedRepresenter
         include ::API::V3::Attachments::AttachableRepresenterMixin
-        include ::API::V3::FileLinks::FileLinkRelationRepresenter
         extend ::API::V3::Utilities::CustomFieldInjector::RepresenterClass
         include TimestampedRepresenter
 

--- a/modules/storages/app/contracts/storages/file_links/create_contract.rb
+++ b/modules/storages/app/contracts/storages/file_links/create_contract.rb
@@ -60,10 +60,9 @@ class Storages::FileLinks::CreateContract < ModelContract
   end
 
   def validate_user_allowed_to_manage
-    container = model.container
-    if container.present? && !user.allowed_in_project?(:manage_file_links, container.project)
-      errors.add(:base, :error_unauthorized)
-    end
+    return if model.user_allowed_to_manage?(user)
+
+    errors.add(:base, :error_unauthorized)
   end
 
   def validate_storage_presence

--- a/modules/storages/app/contracts/storages/file_links/validate_replacements.rb
+++ b/modules/storages/app/contracts/storages/file_links/validate_replacements.rb
@@ -23,35 +23,48 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# A FileLink represents a relation to a single file stored in some cloud file storage.
-# Additional attributes and constraints are defined in db/migrate/20220113144759_create_file_links.rb
-# FileLinks are attached to a "container", which currently has to be a WorkPackage.
-class Storages::FileLink < ApplicationRecord
-  belongs_to :storage
-  belongs_to :creator, class_name: "User"
-  belongs_to :container, polymorphic: true
+module Storages
+  module FileLinks
+    module ValidateReplacements
+      extend ActiveSupport::Concern
 
-  validates :container_type, inclusion: { in: ["WorkPackage", nil] }
-  validates :origin_id, presence: true
+      included do
+        validate :user_allowed_to_manage_file_links
+        validate :validate_file_links_replacements
+      end
 
-  attribute :origin_status
+      private
 
-  delegate :project, to: :container
+      def user_allowed_to_manage_file_links
+        return if model.file_links_replacements.nil?
+        return if user.allowed_in_project?(:manage_file_links, model.project)
 
-  def name
-    origin_name
-  end
+        errors.add(:base, :error_unauthorized)
+      end
 
-  def user_allowed_to_manage?(user)
-    if container.present?
-      user.allowed_in_project?(:manage_file_links, container.project)
-    else
-      user == creator
+      def validate_file_links_replacements
+        model.file_links_replacements&.each do |file_link|
+          error_if_wrong_storage(file_link)
+          error_if_not_allowed_to_manage(file_link)
+        end
+      end
+
+      def error_if_wrong_storage(file_link)
+        return if model.project.storages.include?(file_link.storage)
+
+        errors.add :file_links, :invalid
+      end
+
+      def error_if_not_allowed_to_manage(file_link)
+        return if file_link.user_allowed_to_manage?(user)
+
+        errors.add(:base, :error_unauthorized)
+      end
     end
   end
 end

--- a/modules/storages/app/services/storages/file_links/replace_file_links.rb
+++ b/modules/storages/app/services/storages/file_links/replace_file_links.rb
@@ -23,35 +23,29 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# A FileLink represents a relation to a single file stored in some cloud file storage.
-# Additional attributes and constraints are defined in db/migrate/20220113144759_create_file_links.rb
-# FileLinks are attached to a "container", which currently has to be a WorkPackage.
-class Storages::FileLink < ApplicationRecord
-  belongs_to :storage
-  belongs_to :creator, class_name: "User"
-  belongs_to :container, polymorphic: true
+module Storages
+  module FileLinks
+    module ReplaceFileLinks
+      def self.included(base)
+        base.prepend Prepends
+      end
 
-  validates :container_type, inclusion: { in: ["WorkPackage", nil] }
-  validates :origin_id, presence: true
+      module Prepends
+        private
 
-  attribute :origin_status
-
-  delegate :project, to: :container
-
-  def name
-    origin_name
-  end
-
-  def user_allowed_to_manage?(user)
-    if container.present?
-      user.allowed_in_project?(:manage_file_links, container.project)
-    else
-      user == creator
+        def set_attributes(attributes, *)
+          super.tap do |call|
+            if call.success? && call.result.file_links_replacements
+              call.result.file_links = call.result.file_links_replacements
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/modules/storages/app/services/storages/file_links/set_replacements.rb
+++ b/modules/storages/app/services/storages/file_links/set_replacements.rb
@@ -23,35 +23,34 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# A FileLink represents a relation to a single file stored in some cloud file storage.
-# Additional attributes and constraints are defined in db/migrate/20220113144759_create_file_links.rb
-# FileLinks are attached to a "container", which currently has to be a WorkPackage.
-class Storages::FileLink < ApplicationRecord
-  belongs_to :storage
-  belongs_to :creator, class_name: "User"
-  belongs_to :container, polymorphic: true
+module Storages
+  module FileLinks
+    module SetReplacements
+      def self.included(base)
+        base.prepend Prepends
+      end
 
-  validates :container_type, inclusion: { in: ["WorkPackage", nil] }
-  validates :origin_id, presence: true
+      module Prepends
+        private
 
-  attribute :origin_status
+        def set_attributes(attributes)
+          set_file_links_attributes(attributes)
 
-  delegate :project, to: :container
+          super
+        end
 
-  def name
-    origin_name
-  end
+        def set_file_links_attributes(attributes)
+          file_links_ids = attributes.delete(:file_links_ids)
+          return unless file_links_ids
 
-  def user_allowed_to_manage?(user)
-    if container.present?
-      user.allowed_in_project?(:manage_file_links, container.project)
-    else
-      user == creator
+          model.file_links_replacements = FileLink.where(id: file_links_ids)
+        end
+      end
     end
   end
 end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
         storage: Storage
         storage_url: Storage URL
         tenant: Directory (tenant) ID
+      work_package:
+        file_links: File links
     errors:
       messages:
         invalid_host_url: is not a valid URL.

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -297,6 +297,14 @@ module OpenProject::Storages
         end
       end
 
+      WorkPackages::SetAttributesService.include Storages::FileLinks::SetReplacements
+
+      WorkPackages::CreateService.include Storages::FileLinks::ReplaceFileLinks
+      WorkPackages::UpdateService.include Storages::FileLinks::ReplaceFileLinks
+
+      WorkPackages::CreateContract.include Storages::FileLinks::ValidateReplacements
+      WorkPackages::UpdateContract.include Storages::FileLinks::ValidateReplacements
+
       API::V3::WorkPackages::WorkPackageRepresenter.include ::API::V3::FileLinks::FileLinkRelationRepresenter
 
       API::V3::WorkPackages::WorkPackagePayloadRepresenter

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -49,6 +49,9 @@ module OpenProject::Storages
     # please see comments inside ActsAsOpEngine class
     include OpenProject::Plugins::ActsAsOpEngine
 
+    patches %i[WorkPackage]
+    patch_with_namespace :API, :V3, :WorkPackages, :WorkPackagePayloadRepresenter
+
     initializer "openproject_storages.feature_decisions" do
       OpenProject::FeatureDecisions.add :storage_file_picking_select_all
     end
@@ -306,26 +309,6 @@ module OpenProject::Storages
       WorkPackages::UpdateContract.include Storages::FileLinks::ValidateReplacements
 
       API::V3::WorkPackages::WorkPackageRepresenter.include ::API::V3::FileLinks::FileLinkRelationRepresenter
-
-      API::V3::WorkPackages::WorkPackagePayloadRepresenter
-        .property :file_links,
-                  exec_context: :decorator,
-                  getter: ->(*) {},
-                  setter: ->(fragment:, **) do
-                    next unless fragment.is_a?(Array)
-
-                    ids = fragment.map do |link|
-                      ::API::Utilities::ResourceLinkParser.parse_id link["href"],
-                                                                    property: :file_link,
-                                                                    expected_version: "3",
-                                                                    expected_namespace: :file_links
-                    end
-
-                    represented.file_links_ids = ids
-                  end,
-                  skip_render: ->(*) { true },
-                  linked_resource: true,
-                  uncacheable: true
     end
 
     # This helper methods adds a method on the `api_v3_paths` helper. It is created with one parameter (storage_id)

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -296,6 +296,28 @@ module OpenProject::Storages
           filter ::Queries::Storages::ProjectStorages::Filter::ProjectIdFilter
         end
       end
+
+      API::V3::WorkPackages::WorkPackageRepresenter.include ::API::V3::FileLinks::FileLinkRelationRepresenter
+
+      API::V3::WorkPackages::WorkPackagePayloadRepresenter
+        .property :file_links,
+                  exec_context: :decorator,
+                  getter: ->(*) {},
+                  setter: ->(fragment:, **) do
+                    next unless fragment.is_a?(Array)
+
+                    ids = fragment.map do |link|
+                      ::API::Utilities::ResourceLinkParser.parse_id link["href"],
+                                                                    property: :file_link,
+                                                                    expected_version: "3",
+                                                                    expected_namespace: :file_links
+                    end
+
+                    represented.file_links_ids = ids
+                  end,
+                  skip_render: ->(*) { true },
+                  linked_resource: true,
+                  uncacheable: true
     end
 
     # This helper methods adds a method on the `api_v3_paths` helper. It is created with one parameter (storage_id)

--- a/modules/storages/lib/open_project/storages/patches/api/v3/work_packages/work_package_payload_representer_patch.rb
+++ b/modules/storages/lib/open_project/storages/patches/api/v3/work_packages/work_package_payload_representer_patch.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Storages::Patches::API::V3::WorkPackages::WorkPackagePayloadRepresenterPatch
+  def self.included(base) # :nodoc:
+    base.extend(ClassMethods)
+    base.include(InstanceMethods)
+
+    base.class_eval do
+      property :file_links,
+               exec_context: :decorator,
+               getter: ->(*) {},
+               setter: ->(fragment:, **) do
+                 next unless fragment.is_a?(Array)
+
+                 ids = fragment.map do |link|
+                   ::API::Utilities::ResourceLinkParser.parse_id link["href"],
+                                                                 property: :file_link,
+                                                                 expected_version: "3",
+                                                                 expected_namespace: :file_links
+                 end
+
+                 represented.file_links_ids = ids
+               end,
+               skip_render: ->(*) { true },
+               linked_resource: true,
+               uncacheable: true
+    end
+  end
+
+  module ClassMethods
+  end
+
+  module InstanceMethods
+  end
+end

--- a/modules/storages/lib/open_project/storages/patches/work_package_patch.rb
+++ b/modules/storages/lib/open_project/storages/patches/work_package_patch.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Storages::Patches::WorkPackagePatch
+  def self.included(base) # :nodoc:
+    base.extend(ClassMethods)
+    base.include(InstanceMethods)
+
+    base.class_eval do
+      has_many :file_links, dependent: :delete_all, class_name: "Storages::FileLink", as: :container
+      has_many :storages, through: :project
+
+      attr_accessor :file_links_replacements
+    end
+  end
+
+  module ClassMethods
+  end
+
+  module InstanceMethods
+  end
+end

--- a/spec/requests/api/v3/work_packages/create_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_resource_spec.rb
@@ -66,11 +66,13 @@ RSpec.describe "API v3 Work package resource",
         }
       }
     end
+    let(:project_storage) { nil }
 
     before do
       status.save!
       priority.save!
       other_user
+      project_storage
 
       perform_enqueued_jobs do
         post path, parameters.to_json
@@ -407,7 +409,7 @@ RSpec.describe "API v3 Work package resource",
               href: api_v3_paths.project(project.id)
             },
             attachments: [
-              href: api_v3_paths.attachment(attachment.id)
+              { href: api_v3_paths.attachment(attachment.id) }
             ]
           }
         }
@@ -425,6 +427,7 @@ RSpec.describe "API v3 Work package resource",
 
     context "when file links are being claimed" do
       let(:storage) { create(:nextcloud_storage) }
+      let(:project_storage) { create(:project_storage, project:, storage:) }
       let(:file_link) do
         create(:file_link,
                container_id: nil,
@@ -443,29 +446,37 @@ RSpec.describe "API v3 Work package resource",
               href: api_v3_paths.project(project.id)
             },
             fileLinks: [
-              href: api_v3_paths.file_link(file_link.id)
+              { href: api_v3_paths.file_link(file_link.id) }
             ]
           }
         }
       end
-      let(:extra_permissions) do
-        %i[view_file_links]
+      let(:extra_permissions) { %i[view_file_links manage_file_links] }
+
+      context "when user is not allowed to manage file links" do
+        let(:extra_permissions) { %i[view_file_links] }
+
+        it "does not create a work package and responds with an error" do
+          expect(WorkPackage.count).to eq(0)
+          expect(last_response.body).to be_json_eql(
+            "urn:openproject-org:api:v3:errors:MissingPermission".to_json
+          ).at_path("errorIdentifier")
+        end
       end
 
-      it "does not create a work packages and responds with an error " \
-         "when user is not allowed to manage file links", :aggregate_failtures do
-        expect(WorkPackage.count).to eq(0)
-        expect(last_response.body).to be_json_eql(
-          "urn:openproject-org:api:v3:errors:MissingPermission".to_json
-        ).at_path("errorIdentifier")
+      context "when there is no project storage for the file link's storage" do
+        let(:project_storage) { create(:project_storage, project:) }
+
+        it "does not create a work package and responds with an error" do
+          expect(WorkPackage.count).to eq(0)
+          expect(last_response.body).to be_json_eql(
+            "urn:openproject-org:api:v3:errors:PropertyConstraintViolation".to_json
+          ).at_path("errorIdentifier")
+        end
       end
 
       context "when user is allowed to manage file links" do
-        let(:extra_permissions) do
-          %i[view_file_links manage_file_links]
-        end
-
-        it "creates a work package and assigns the file links", :aggregate_failtures do
+        it "creates a work package and assigns the file links" do
           expect(WorkPackage.count).to eq(1)
           work_package = WorkPackage.first
           expect(work_package.file_links).to eq([file_link])


### PR DESCRIPTION
Lots of the file links code was initially put into the core instead of the storages module (where file links themselves are defined). The corresponding code has now been moved to storages and the same pattern as we use it for attachments has been applied to their update code.

This allows to perform validations more consistently before the corresponding change is applied, because a direct assignment to `#file_links=` would immediately be persisted to the database.

# Ticket
https://community.openproject.org/wp/SC-241