### PR TITLE
[op-19486] Previous work package opens in detail view from the wp list

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
@@ -26,9 +26,7 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
   constructor(public readonly injector:Injector) {
   }
 
-  public get EVENT():EventType {
-    return 'click';
-  }
+  public readonly EVENT:EventType = 'click';
 
   public get SELECTOR() {
     return `.${uiStateLinkClass}`;
@@ -76,7 +74,7 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
 
     // Keep the focused work package in sync when opening the details view
     // from a row other than the currently selected one.
-    this.wpTableFocus.updateFocus(workPackageId);
+    this.wpTableFocus.updateFocus(workPackageId, false, false);
 
     // Update single selection if no modifier present
     this.wpTableSelection.setSelection(workPackageId, index);

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
@@ -74,6 +74,10 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
     const classIdentifier = row.dataset.classIdentifier!;
     const [index] = view.workPackageTable.findRenderedRow(classIdentifier);
 
+    // Keep the focused work package in sync when opening the details view
+    // from a row other than the currently selected one.
+    this.wpTableFocus.updateFocus(workPackageId);
+
     // Update single selection if no modifier present
     this.wpTableSelection.setSelection(workPackageId, index);
 

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -80,7 +80,7 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
 
   hasState = !!this.$state.current;
   /** Reference to the base route e.g., work-packages.partitioned.list or bim.partitioned.split */
-  private baseRoute:string = this.$state.current?.data?.baseRoute as string;
+  private baseRoute = (this.$state.current?.data as { baseRoute?:string } | undefined)?.baseRoute ?? '';
 
   @Input() showTabs = true;
 
@@ -97,7 +97,7 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
   ngOnInit():void {
     this.observeWorkPackage();
 
-    this.wpTableFocus.whenChanged()
+    this.wpTableFocus.whenNavigationRequested()
       .pipe(
         this.untilDestroyed(),
       )

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service.ts
@@ -44,7 +44,7 @@ export class WorkPackageViewFocusService extends WorkPackageViewBaseService<WPFo
   wpTableSelection = inject(WorkPackageViewSelectionService);
 
   public isFocused(workPackageId:string) {
-    return this.focusedWorkPackage === workPackageId;
+    return this.current?.workPackageId === workPackageId;
   }
 
   public ifShouldFocus(callback:(workPackageId:string) => void) {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service.ts
@@ -28,7 +28,7 @@
 
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { distinctUntilChanged, map } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import { WorkPackageViewBaseService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-base.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
@@ -37,6 +37,7 @@ import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/w
 export interface WPFocusState {
   workPackageId:string;
   focusAfterRender:boolean;
+  navigate:boolean;
 }
 
 @Injectable()
@@ -81,15 +82,24 @@ export class WorkPackageViewFocusService extends WorkPackageViewBaseService<WPFo
       );
   }
 
-  public updateFocus(workPackageId:string, setFocusAfterRender = false) {
+  public whenNavigationRequested():Observable<string> {
+    return this.live$()
+      .pipe(
+        filter((val:WPFocusState) => val.navigate),
+        map((val:WPFocusState) => val.workPackageId),
+        distinctUntilChanged(),
+      );
+  }
+
+  public updateFocus(workPackageId:string, setFocusAfterRender = false, navigate = true) {
     // Set the selection to this row, if nothing else is selected.
     if (this.wpTableSelection.isEmpty) {
       this.wpTableSelection.setRowState(workPackageId, true);
     }
-    this.update({ workPackageId, focusAfterRender: setFocusAfterRender });
+    this.update({ workPackageId, focusAfterRender: setFocusAfterRender, navigate });
   }
 
-  valueFromQuery(query:QueryResource, results:WorkPackageCollectionResource):WPFocusState|undefined {
+  valueFromQuery(_query:QueryResource, _results:WorkPackageCollectionResource):WPFocusState|undefined {
     return undefined;
   }
 }

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -100,6 +100,7 @@ table.generic-table
       text-align: left
       line-height: 34px
       padding: 0
+      border-bottom: 1px solid var(--borderColor-default)
       // This is needed for a bug in FF as described here
       // https://www.456bereastreet.com/archive/201305/firefox_and_the_magical_text-overflowellipsis_z-index/
       z-index: 1
@@ -283,7 +284,6 @@ thead.-sticky th
   line-height:  var(--generic-table--header-height)
   height:  var(--generic-table--header-height)
   z-index:      1
-  border-bottom: 1px solid var(--borderColor-default)
 
   &:hover,
   &.hover
@@ -306,7 +306,6 @@ thead.-sticky th
 .generic-table--empty-header
   height:        var(--generic-table--header-height)
   line-height:   var(--generic-table--header-height)
-  border-bottom: 1px solid var(--borderColor-default)
   z-index:       1
 
   // In case the table header contains invisible content for screen readers

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -107,9 +107,6 @@ tr.context-menu-selection,
 tr.-checked
   background-color: var(--box-list-item-selected-bg-color) !important
   border-bottom: 1px solid var(--box-list-item-selected-border-color) !important
-  &:first-child
-    td
-      border-top: 1px solid var(--box-list-item-selected-border-color) !important
   &[class*=__hl_background]
     outline: var(--bgColor-accent-emphasis) solid 2px
 
@@ -123,15 +120,18 @@ tr.-checked
 
 tr.-pressed
   border-bottom: 1px solid var(--box-list-item-pressed-border-color) !important
-  &:first-child
-    td
-      border-top: 1px solid var(--box-list-item-pressed-border-color) !important
 
 tr:not(.-pressed):has(+ tr.-checked)
   border-bottom: 1px solid var(--box-list-item-selected-border-color) !important
 
 tr:not(.-pressed):has(+ tr.-pressed)
   border-bottom: 1px solid var(--box-list-item-pressed-border-color) !important
+
+thead:has(+ tbody > tr:first-child.-checked) th
+  border-bottom-color: var(--box-list-item-selected-border-color) !important
+
+thead:has(+ tbody > tr:first-child.-pressed) th
+  border-bottom-color: var(--box-list-item-pressed-border-color) !important
 
 #custom-options-table
   .custom-option-value

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -107,6 +107,9 @@ tr.context-menu-selection,
 tr.-checked
   background-color: var(--box-list-item-selected-bg-color) !important
   border-bottom: 1px solid var(--box-list-item-selected-border-color) !important
+  &:first-child
+    td
+      border-top: 1px solid var(--box-list-item-selected-border-color) !important
   &[class*=__hl_background]
     outline: var(--bgColor-accent-emphasis) solid 2px
 
@@ -120,6 +123,9 @@ tr.-checked
 
 tr.-pressed
   border-bottom: 1px solid var(--box-list-item-pressed-border-color) !important
+  &:first-child
+    td
+      border-top: 1px solid var(--box-list-item-pressed-border-color) !important
 
 tr:not(.-pressed):has(+ tr.-checked)
   border-bottom: 1px solid var(--box-list-item-selected-border-color) !important

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
       expect(details_anchor[:href]).not_to end_with("/null")
       expect(details_anchor[:href]).not_to include("/details/#{work_package.id}")
     end
+
+    it "switches an already open split view to the clicked work package" do
+      wp_table.open_split_view(work_package)
+
+      split_page = wp_table.open_split_view(other_wp)
+
+      split_page.expect_attributes Subject: other_wp.subject
+    end
   end
 
   describe "right-click context menu 'Open fullscreen' item" do

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
       expect(details_anchor[:href]).not_to include("/details/#{work_package.id}")
     end
 
-    it "switches an already open split view to the clicked work package" do
+    it "switches an already open split view to the clicked work package (OP-19486)" do
       wp_table.open_split_view(work_package)
 
       split_page = wp_table.open_split_view(other_wp)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-718
https://community.openproject.org/wp/OP-19486

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Avoid highlighting the first row when no work package is explicitly focused.
Keep row focus synchronized when opening another work package via its info button.
