### PR TITLE
Do not write to sessions table on every request unless necessary

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
   include Accounts::UserLogin
   include Accounts::Authorization
   include Accounts::EnterpriseGuard
-  include ::OpenProject::Authentication::SessionExpiration
+  include Accounts::SessionLifetime
   include AdditionalUrlHelpers
   include OpenProjectErrorHelper
   include Security::DefaultUrlOptions
@@ -391,16 +391,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :admin_first_level_menu_entry
 
-  def check_session_lifetime
-    if session_expired?
-      self.logged_user = nil
-
-      flash[:warning] = I18n.t("notice_forced_logout", ttl_time: Setting.session_ttl)
-      redirect_to(controller: "/account", action: "login", back_url: login_back_url)
-    end
-    session[:updated_at] = Time.now
-  end
-
   def feed_request?
     if params[:format].nil?
       %w(application/rss+xml application/atom+xml).include? request.format.to_s
@@ -416,10 +406,6 @@ class ApplicationController < ActionController::Base
   end
 
   private
-
-  def session_expired?
-    !api_request? && current_user.logged? && session_ttl_expired?
-  end
 
   def permitted_params
     @permitted_params ||= PermittedParams.new(params, current_user)

--- a/app/controllers/concerns/accounts/session_lifetime.rb
+++ b/app/controllers/concerns/accounts/session_lifetime.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+##
+# Enforces the inactivity session TTL and tracks session activity.
+#
+# Intended to be used by the ApplicationController via a +before_action :check_session_lifetime+.
+module Accounts::SessionLifetime
+  extend ActiveSupport::Concern
+
+  include ::OpenProject::Authentication::SessionExpiration
+
+  # Minimum age of session[:updated_at] before we refresh it.
+  # Previously, we would bump it on every request, which causes an unnecessary session write.
+  # The minimum TTL value is 5.minutes, so we set this to half of that.
+  SESSION_ACTIVITY_REFRESH_INTERVAL = 2.minutes
+
+  protected
+
+  def check_session_lifetime
+    if session_expired?
+      terminate_user_session
+    else
+      refresh_session_activity
+    end
+  end
+
+  private
+
+  def terminate_user_session
+    self.logged_user = nil
+
+    flash[:warning] = I18n.t("notice_forced_logout", ttl_time: Setting.session_ttl)
+    redirect_to(controller: "/account", action: "login", back_url: login_back_url)
+  end
+
+  def session_expired?
+    !api_request? && current_user.logged? && session_ttl_expired?
+  end
+
+  # Only write to the esssion if we really need to to prevent a session write
+  # that has no effect other than the updated_at.
+  def refresh_session_activity
+    last_seen = session[:updated_at]
+    return if last_seen.present? && last_seen > SESSION_ACTIVITY_REFRESH_INTERVAL.ago
+
+    session[:updated_at] = Time.zone.now
+  end
+end

--- a/app/controllers/concerns/accounts/session_lifetime.rb
+++ b/app/controllers/concerns/accounts/session_lifetime.rb
@@ -37,10 +37,17 @@ module Accounts::SessionLifetime
 
   include ::OpenProject::Authentication::SessionExpiration
 
-  # Minimum age of session[:updated_at] before we refresh it.
-  # Previously, we would bump it on every request, which causes an unnecessary session write.
-  # The minimum TTL value is 5.minutes, so we set this to half of that.
-  SESSION_ACTIVITY_REFRESH_INTERVAL = 2.minutes
+  # We refresh session[:updated_at] (causing a database write in our session store) at most
+  # once per the interval below, rather than on every request.
+  #
+  # Doing that MAY cause the session to expire within one interval earlier than its TTL,
+  # but it will never be expired later than that, ensuring that the setting is considered a maximum.
+  #
+  # The interval is a fraction of the configured TTL, with min and max values at 1 and 5 minutes respectively.
+  # This alllows us to save more writes on longer TTLs, while keeping the "expire ahead" minimal for smaller values.
+  SESSION_ACTIVITY_REFRESH_RATIO = 0.2
+  SESSION_ACTIVITY_REFRESH_MIN = 1.minute
+  SESSION_ACTIVITY_REFRESH_MAX = 5.minutes
 
   protected
 
@@ -65,12 +72,22 @@ module Accounts::SessionLifetime
     !api_request? && current_user.logged? && session_ttl_expired?
   end
 
-  # Only write to the esssion if we really need to to prevent a session write
-  # that has no effect other than the updated_at.
+  # Only write to the session if we really need to, to prevent a session write
+  # that has no effect other than bumping updated_at.
   def refresh_session_activity
     last_seen = session[:updated_at]
-    return if last_seen.present? && last_seen > SESSION_ACTIVITY_REFRESH_INTERVAL.ago
+    return if last_seen.present? && last_seen > session_activity_refresh_interval.ago
 
     session[:updated_at] = Time.zone.now
+  end
+
+  # See the SESSION_ACTIVITY_REFRESH_* constants. Without a TTL only the 30-day
+  # cleanup cares about updated_at, so the maximum interval is enough.
+  def session_activity_refresh_interval
+    return SESSION_ACTIVITY_REFRESH_MAX unless session_ttl_enabled?
+
+    scaled = (session_ttl_minutes.to_i * SESSION_ACTIVITY_REFRESH_RATIO).round
+    # Ensure our value it stays between the min and max interval
+    scaled.clamp(SESSION_ACTIVITY_REFRESH_MIN.to_i, SESSION_ACTIVITY_REFRESH_MAX.to_i).seconds
   end
 end

--- a/spec/controllers/concerns/accounts/session_lifetime_spec.rb
+++ b/spec/controllers/concerns/accounts/session_lifetime_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe ApplicationController, "session lifetime handling" do # rubocop:disable RSpec/SpecFilePathFormat
+  shared_let(:user) { create(:user) }
+
+  controller do
+    authorization_checked! :index
+
+    def index
+      render plain: "OK"
+    end
+  end
+
+  before do
+    @routes.draw { get "/anonymous/index" } # rubocop:disable RSpec/InstanceVariable
+    session[:user_id] = user.id
+  end
+
+  after { User.current = nil }
+
+  context "when the session TTL is enabled", with_settings: { session_ttl_enabled?: true, session_ttl: "120" } do
+    context "and the last activity is within the refresh interval" do
+      it "does not rewrite the session timestamp, avoiding a redundant session write" do
+        last_seen = 1.minute.ago
+        session[:updated_at] = last_seen
+
+        get :index
+
+        expect(response).to have_http_status(:ok)
+        expect(session[:updated_at]).to eq(last_seen)
+      end
+    end
+
+    context "and the last activity is older than the refresh interval but within the TTL" do
+      it "refreshes the session timestamp" do
+        session[:updated_at] = 5.minutes.ago
+
+        get :index
+
+        expect(response).to have_http_status(:ok)
+        expect(session[:updated_at]).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    context "and the last activity exceeds the TTL" do
+      it "logs the user out and does not refresh the now-invalidated session" do
+        # The anonymous controller has no generatable route for the back_url
+        allow(controller).to receive(:login_back_url).and_return("/")
+        allow(controller).to receive(:refresh_session_activity)
+        session[:updated_at] = 3.hours.ago
+
+        get :index
+
+        expect(controller).not_to have_received(:refresh_session_activity)
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:warning]).to eq(I18n.t(:notice_forced_logout, ttl_time: Setting.session_ttl))
+      end
+    end
+  end
+
+  context "when the session TTL is disabled", with_settings: { session_ttl_enabled?: false } do
+    it "still refreshes a stale timestamp for the 30-day cleanup window" do
+      session[:updated_at] = 5.minutes.ago
+
+      get :index
+
+      expect(session[:updated_at]).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "does not rewrite a fresh timestamp" do
+      last_seen = 30.seconds.ago
+      session[:updated_at] = last_seen
+
+      get :index
+
+      expect(session[:updated_at]).to eq(last_seen)
+    end
+  end
+end

--- a/spec/controllers/concerns/accounts/session_lifetime_spec.rb
+++ b/spec/controllers/concerns/accounts/session_lifetime_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ApplicationController, "session lifetime handling" do # rubocop:d
 
     context "and the last activity is older than the refresh interval but within the TTL" do
       it "refreshes the session timestamp" do
-        session[:updated_at] = 5.minutes.ago
+        session[:updated_at] = 10.minutes.ago
 
         get :index
 
@@ -88,9 +88,31 @@ RSpec.describe ApplicationController, "session lifetime handling" do # rubocop:d
     end
   end
 
+  context "with a short TTL", with_settings: { session_ttl_enabled?: true, session_ttl: "5" } do
+    it "refreshes more promptly, scaling the interval down with the TTL" do
+      # 90s is past the ~1 minute interval a 5 minute TTL yields, but would have
+      # been skipped by a fixed multi-minute window.
+      session[:updated_at] = 90.seconds.ago
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(session[:updated_at]).to be_within(5.seconds).of(Time.current)
+    end
+  end
+
   context "when the session TTL is disabled", with_settings: { session_ttl_enabled?: false } do
+    it "does not terminate even a very old session" do
+      session[:updated_at] = 1.year.ago
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(session[:user_id]).to eq(user.id)
+    end
+
     it "still refreshes a stale timestamp for the 30-day cleanup window" do
-      session[:updated_at] = 5.minutes.ago
+      session[:updated_at] = 10.minutes.ago
 
       get :index
 

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -177,7 +177,8 @@ RSpec.describe MyController, :skip_2fa_stage do
 
   context "when the logged-in user differs in case" do
     let(:header_login_value) { "h.WURST" }
-    let(:session_update_time) { 1.minute.ago }
+    # Must exceed SESSION_ACTIVITY_REFRESH_INTERVAL so the request refreshes it
+    let(:session_update_time) { 5.minutes.ago }
     let(:last_login) { 1.minute.ago }
 
     before do

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe MyController, :skip_2fa_stage do
 
   context "when the logged-in user differs in case" do
     let(:header_login_value) { "h.WURST" }
-    # Must exceed SESSION_ACTIVITY_REFRESH_INTERVAL so the request refreshes it
-    let(:session_update_time) { 5.minutes.ago }
+    # Must exceed the session activity refresh interval so the request refreshes it
+    let(:session_update_time) { 10.minutes.ago }
     let(:last_login) { 1.minute.ago }
 
     before do


### PR DESCRIPTION
Writing the session updated_at on every request has the highest resolution, but we only compare in 5 minute increments anyway.

https://community.openproject.org/projects/OP/work_packages/OP-19590/activity