### PR TITLE
[COMMS-889] Fix the work package URL if it does not use the canoncial identifier of a work package

### DIFF
--- a/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.spec.ts
+++ b/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.spec.ts
@@ -1,0 +1,107 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import * as Turbo from '@hotwired/turbo';
+import { canonicalizeWorkPackageIdInUrl } from './canonicalize-work-package-id-in-url';
+
+describe('canonicalizeWorkPackageIdInUrl', () => {
+  let historyReplaceSpy:ReturnType<typeof vi.spyOn>;
+  let canonicalLink:HTMLLinkElement | null = null;
+
+  function setCanonical(href:string) {
+    const link = document.createElement('link');
+    link.rel = 'canonical';
+    link.href = href;
+    document.head.appendChild(link);
+    canonicalLink = link;
+  }
+
+  beforeEach(() => {
+    /* eslint-disable @typescript-eslint/no-empty-function */
+    historyReplaceSpy = vi.spyOn(Turbo.session.history, 'replace').mockImplementation(() => {});
+    /* eslint-enable @typescript-eslint/no-empty-function */
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    canonicalLink?.remove();
+    canonicalLink = null;
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('rewrites old id to canonical id', () => {
+    window.history.pushState({}, '', '/projects/old-proj/work_packages/OLD-42/activity');
+    setCanonical('http://localhost/projects/new-proj/work_packages/NEW-42/activity');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    const expectedUrl = new URL('/projects/old-proj/work_packages/NEW-42/activity', window.location.origin);
+    expect(historyReplaceSpy).toHaveBeenCalledWith(expectedUrl, Turbo.session.history.restorationIdentifier);
+    expect((Turbo.session as unknown as { view:{ lastRenderedLocation:URL } }).view.lastRenderedLocation.href)
+      .toBe(expectedUrl.href);
+  });
+
+  it('does not rewrite when url already matches canonical', () => {
+    window.history.pushState({}, '', '/projects/demo/work_packages/DEMO-42');
+    setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(historyReplaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite when no canonical link is present', () => {
+    window.history.pushState({}, '', '/projects/demo/work_packages/42');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(historyReplaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite when url does not contain /work_packages/', () => {
+    window.history.pushState({}, '', '/projects/demo/boards');
+    setCanonical('http://localhost/projects/demo/boards');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(historyReplaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves query string and hash when rewriting the id', () => {
+    window.history.pushState({}, '', '/projects/demo/work_packages/13?focus=description#comment-5');
+    setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    const expectedUrl = new URL('/projects/demo/work_packages/DEMO-42?focus=description#comment-5', window.location.origin);
+    expect(historyReplaceSpy).toHaveBeenCalledWith(expectedUrl, Turbo.session.history.restorationIdentifier);
+  });
+});

--- a/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.ts
+++ b/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.ts
@@ -31,13 +31,6 @@
 import * as Turbo from '@hotwired/turbo';
 import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-pattern';
 
-// `view` exists on the Turbo session at runtime but is absent from the project's
-// hand-written @types/hotwired__turbo typings; narrow-cast here, same precedent
-// as turbo/helpers.ts and turbo-navigation-patch.ts.
-interface TurboSessionWithView extends Turbo.TurboSession {
-  view:{ lastRenderedLocation:URL };
-}
-
 // Compiled once: matches a work package id anywhere in the pathname, reusing the
 // shared WP_ID_URL_PATTERN so numeric ("42") and semantic ("PROJ-42") ids both match.
 const workPackageIdPathPattern = new URLPattern({
@@ -66,5 +59,5 @@ export function canonicalizeWorkPackageIdInUrl():void {
   Turbo.session.history.replace(newUrl, Turbo.session.history.restorationIdentifier);
   // PageView#cacheSnapshot keys the snapshot cache by lastRenderedLocation; left stale,
   // back/forward misses the cache and re-fetches instead of restoring instantly.
-  (Turbo.session as TurboSessionWithView).view.lastRenderedLocation = newUrl;
+  Turbo.session.view.lastRenderedLocation = newUrl;
 }

--- a/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.ts
+++ b/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.ts
@@ -33,20 +33,22 @@ import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-patte
 
 // Compiled once: matches a work package id anywhere in the pathname, reusing the
 // shared WP_ID_URL_PATTERN so numeric ("42") and semantic ("PROJ-42") ids both match.
-const workPackageIdPathPattern = new URLPattern({
-  pathname: `{*}/work_packages/:id(${WP_ID_URL_PATTERN}){/*}?`,
-});
+const workPackageIdPathRegex = new RegExp(`/work_packages/(${WP_ID_URL_PATTERN})(?:/|$)`);
+
+function extractWorkPackageId(pathname:string):string | undefined {
+  return workPackageIdPathRegex.exec(pathname)?.[1];
+}
 
 export function canonicalizeWorkPackageIdInUrl():void {
   const currentPath = window.location.pathname;
-  const currentId = workPackageIdPathPattern.exec({ pathname: currentPath })?.pathname.groups.id;
+  const currentId = extractWorkPackageId(currentPath);
   if (!currentId) return;
 
   const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
   if (!canonical?.href) return;
 
   const canonicalPath = new URL(canonical.href).pathname;
-  const canonicalId = workPackageIdPathPattern.exec({ pathname: canonicalPath })?.pathname.groups.id;
+  const canonicalId = extractWorkPackageId(canonicalPath);
   if (!canonicalId || canonicalId === currentId) return;
 
   const newPath = currentPath.replace(`/work_packages/${currentId}`, `/work_packages/${canonicalId}`);

--- a/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.ts
+++ b/frontend/src/app/core/setup/globals/canonicalize-work-package-id-in-url.ts
@@ -1,0 +1,70 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import * as Turbo from '@hotwired/turbo';
+import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-pattern';
+
+// `view` exists on the Turbo session at runtime but is absent from the project's
+// hand-written @types/hotwired__turbo typings; narrow-cast here, same precedent
+// as turbo/helpers.ts and turbo-navigation-patch.ts.
+interface TurboSessionWithView extends Turbo.TurboSession {
+  view:{ lastRenderedLocation:URL };
+}
+
+// Compiled once: matches a work package id anywhere in the pathname, reusing the
+// shared WP_ID_URL_PATTERN so numeric ("42") and semantic ("PROJ-42") ids both match.
+const workPackageIdPathPattern = new URLPattern({
+  pathname: `{*}/work_packages/:id(${WP_ID_URL_PATTERN}){/*}?`,
+});
+
+export function canonicalizeWorkPackageIdInUrl():void {
+  const currentPath = window.location.pathname;
+  const currentId = workPackageIdPathPattern.exec({ pathname: currentPath })?.pathname.groups.id;
+  if (!currentId) return;
+
+  const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!canonical?.href) return;
+
+  const canonicalPath = new URL(canonical.href).pathname;
+  const canonicalId = workPackageIdPathPattern.exec({ pathname: canonicalPath })?.pathname.groups.id;
+  if (!canonicalId || canonicalId === currentId) return;
+
+  const newPath = currentPath.replace(`/work_packages/${currentId}`, `/work_packages/${canonicalId}`);
+  const newUrl = new URL(newPath + window.location.search + window.location.hash, window.location.origin);
+
+  // Use Turbo's history.replace (not window.history.replaceState) so Turbo's internal
+  // location stays in sync — otherwise back/forward popstate resolves the stale URL.
+  // Pass the current restorationIdentifier explicitly: History.replace defaults to a
+  // fresh uuid, orphaning the recorded scroll-restoration data.
+  Turbo.session.history.replace(newUrl, Turbo.session.history.restorationIdentifier);
+  // PageView#cacheSnapshot keys the snapshot cache by lastRenderedLocation; left stale,
+  // back/forward misses the cache and re-fetches instead of restoring instantly.
+  (Turbo.session as TurboSessionWithView).view.lastRenderedLocation = newUrl;
+}

--- a/frontend/src/turbo/turbo-global-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-global-listeners.spec.ts
@@ -27,10 +27,9 @@
 //++
 
 import {
-  afterEach, beforeEach, describe, expect, it, vi,
+  afterEach, beforeEach, describe, expect, it,
 } from 'vitest';
-import * as Turbo from '@hotwired/turbo';
-import { addTurboGlobalListeners, canonicalizeWorkPackageIdInUrl } from './turbo-global-listeners';
+import { addTurboGlobalListeners } from './turbo-global-listeners';
 
 describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
   let controller:AbortController;
@@ -68,81 +67,5 @@ describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
     const notCancelled = beforeMorph(element);
 
     expect(notCancelled).toBe(true);
-  });
-});
-
-describe('canonicalizeWorkPackageIdInUrl', () => {
-  let historyReplaceSpy:ReturnType<typeof vi.spyOn>;
-  let canonicalLink:HTMLLinkElement | null = null;
-
-  function setCanonical(href:string) {
-    const link = document.createElement('link');
-    link.rel = 'canonical';
-    link.href = href;
-    document.head.appendChild(link);
-    canonicalLink = link;
-  }
-
-  beforeEach(() => {
-    /* eslint-disable @typescript-eslint/no-empty-function */
-    historyReplaceSpy = vi.spyOn(Turbo.session.history, 'replace').mockImplementation(() => {});
-    /* eslint-enable @typescript-eslint/no-empty-function */
-  });
-
-  afterEach(() => {
-    // Deterministic per-test cleanup: restore the spy, drop the injected canonical
-    // link and reset the URL rather than relying on the next test's setup.
-    vi.restoreAllMocks();
-    canonicalLink?.remove();
-    canonicalLink = null;
-    window.history.replaceState({}, '', '/');
-  });
-
-  it('rewrites old id to canonical id', () => {
-    window.history.pushState({}, '', '/projects/old-proj/work_packages/OLD-42/activity');
-    setCanonical('http://localhost/projects/new-proj/work_packages/NEW-42/activity');
-
-    canonicalizeWorkPackageIdInUrl();
-
-    const expectedUrl = new URL('/projects/old-proj/work_packages/NEW-42/activity', window.location.origin);
-    expect(historyReplaceSpy).toHaveBeenCalledWith(expectedUrl, Turbo.session.history.restorationIdentifier);
-    expect((Turbo.session as unknown as { view:{ lastRenderedLocation:URL } }).view.lastRenderedLocation.href)
-      .toBe(expectedUrl.href);
-  });
-
-  it('does not rewrite when url already matches canonical', () => {
-    window.history.pushState({}, '', '/projects/demo/work_packages/DEMO-42');
-    setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
-
-    canonicalizeWorkPackageIdInUrl();
-
-    expect(historyReplaceSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not rewrite when no canonical link is present', () => {
-    window.history.pushState({}, '', '/projects/demo/work_packages/42');
-
-    canonicalizeWorkPackageIdInUrl();
-
-    expect(historyReplaceSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not rewrite when url does not contain /work_packages/', () => {
-    window.history.pushState({}, '', '/projects/demo/boards');
-    setCanonical('http://localhost/projects/demo/boards');
-
-    canonicalizeWorkPackageIdInUrl();
-
-    expect(historyReplaceSpy).not.toHaveBeenCalled();
-  });
-
-  it('preserves query string and hash when rewriting the id', () => {
-    window.history.pushState({}, '', '/projects/demo/work_packages/13?focus=description#comment-5');
-    setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
-
-    canonicalizeWorkPackageIdInUrl();
-
-    const expectedUrl = new URL('/projects/demo/work_packages/DEMO-42?focus=description#comment-5', window.location.origin);
-    expect(historyReplaceSpy).toHaveBeenCalledWith(expectedUrl, Turbo.session.history.restorationIdentifier);
   });
 });

--- a/frontend/src/turbo/turbo-global-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-global-listeners.spec.ts
@@ -27,8 +27,9 @@
 //++
 
 import {
-  afterEach, beforeEach, describe, expect, it,
+  afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
+import * as Turbo from '@hotwired/turbo';
 import { addTurboGlobalListeners, canonicalizeWorkPackageIdInUrl } from './turbo-global-listeners';
 
 describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
@@ -71,25 +72,30 @@ describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
 });
 
 describe('canonicalizeWorkPackageIdInUrl', () => {
-  let replaceStateSpy:ReturnType<typeof vi.spyOn>;
+  let historyReplaceSpy:ReturnType<typeof vi.spyOn>;
+  let canonicalLink:HTMLLinkElement | null = null;
 
   function setCanonical(href:string) {
     const link = document.createElement('link');
     link.rel = 'canonical';
     link.href = href;
     document.head.appendChild(link);
+    canonicalLink = link;
   }
 
   beforeEach(() => {
-    window.history.pushState({}, '', '/');
-    document.querySelectorAll('link[rel="canonical"]').forEach((element) => element.remove());
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-empty-function */
-    replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-empty-function */
+    /* eslint-disable @typescript-eslint/no-empty-function */
+    historyReplaceSpy = vi.spyOn(Turbo.session.history, 'replace').mockImplementation(() => {});
+    /* eslint-enable @typescript-eslint/no-empty-function */
   });
 
   afterEach(() => {
+    // Deterministic per-test cleanup: restore the spy, drop the injected canonical
+    // link and reset the URL rather than relying on the next test's setup.
     vi.restoreAllMocks();
+    canonicalLink?.remove();
+    canonicalLink = null;
+    window.history.replaceState({}, '', '/');
   });
 
   it('rewrites old id to canonical id', () => {
@@ -98,33 +104,36 @@ describe('canonicalizeWorkPackageIdInUrl', () => {
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/projects/old-proj/work_packages/NEW-42/activity');
+    const expectedUrl = new URL('/projects/old-proj/work_packages/NEW-42/activity', window.location.origin);
+    expect(historyReplaceSpy).toHaveBeenCalledWith(expectedUrl, Turbo.session.history.restorationIdentifier);
+    expect((Turbo.session as unknown as { view:{ lastRenderedLocation:URL } }).view.lastRenderedLocation.href)
+      .toBe(expectedUrl.href);
   });
 
-  it('does not call replaceState when url already matches canonical', () => {
+  it('does not rewrite when url already matches canonical', () => {
     window.history.pushState({}, '', '/projects/demo/work_packages/DEMO-42');
     setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).not.toHaveBeenCalled();
+    expect(historyReplaceSpy).not.toHaveBeenCalled();
   });
 
-  it('does not call replaceState when no canonical link is present', () => {
+  it('does not rewrite when no canonical link is present', () => {
     window.history.pushState({}, '', '/projects/demo/work_packages/42');
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).not.toHaveBeenCalled();
+    expect(historyReplaceSpy).not.toHaveBeenCalled();
   });
 
-  it('does not call replaceState when url does not contain /work_packages/', () => {
+  it('does not rewrite when url does not contain /work_packages/', () => {
     window.history.pushState({}, '', '/projects/demo/boards');
     setCanonical('http://localhost/projects/demo/boards');
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).not.toHaveBeenCalled();
+    expect(historyReplaceSpy).not.toHaveBeenCalled();
   });
 
   it('preserves query string and hash when rewriting the id', () => {
@@ -133,6 +142,7 @@ describe('canonicalizeWorkPackageIdInUrl', () => {
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/projects/demo/work_packages/DEMO-42?focus=description#comment-5');
+    const expectedUrl = new URL('/projects/demo/work_packages/DEMO-42?focus=description#comment-5', window.location.origin);
+    expect(historyReplaceSpy).toHaveBeenCalledWith(expectedUrl, Turbo.session.history.restorationIdentifier);
   });
 });

--- a/frontend/src/turbo/turbo-global-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-global-listeners.spec.ts
@@ -98,7 +98,7 @@ describe('canonicalizeWorkPackageIdInUrl', () => {
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/projects/old-proj/work_packages/NEW-42/activity');
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/projects/old-proj/work_packages/NEW-42/activity');
   });
 
   it('does not call replaceState when url already matches canonical', () => {
@@ -133,6 +133,6 @@ describe('canonicalizeWorkPackageIdInUrl', () => {
 
     canonicalizeWorkPackageIdInUrl();
 
-    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/projects/demo/work_packages/DEMO-42?focus=description#comment-5');
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/projects/demo/work_packages/DEMO-42?focus=description#comment-5');
   });
 });

--- a/frontend/src/turbo/turbo-global-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-global-listeners.spec.ts
@@ -29,7 +29,7 @@
 import {
   afterEach, beforeEach, describe, expect, it,
 } from 'vitest';
-import { addTurboGlobalListeners } from './turbo-global-listeners';
+import { addTurboGlobalListeners, canonicalizeWorkPackageIdInUrl } from './turbo-global-listeners';
 
 describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
   let controller:AbortController;
@@ -67,5 +67,72 @@ describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
     const notCancelled = beforeMorph(element);
 
     expect(notCancelled).toBe(true);
+  });
+});
+
+describe('canonicalizeWorkPackageIdInUrl', () => {
+  let replaceStateSpy:ReturnType<typeof vi.spyOn>;
+
+  function setCanonical(href:string) {
+    const link = document.createElement('link');
+    link.rel = 'canonical';
+    link.href = href;
+    document.head.appendChild(link);
+  }
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    document.querySelectorAll('link[rel="canonical"]').forEach((element) => element.remove());
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-empty-function */
+    replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-empty-function */
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rewrites old id to canonical id', () => {
+    window.history.pushState({}, '', '/projects/old-proj/work_packages/OLD-42/activity');
+    setCanonical('http://localhost/projects/new-proj/work_packages/NEW-42/activity');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/projects/old-proj/work_packages/NEW-42/activity');
+  });
+
+  it('does not call replaceState when url already matches canonical', () => {
+    window.history.pushState({}, '', '/projects/demo/work_packages/DEMO-42');
+    setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not call replaceState when no canonical link is present', () => {
+    window.history.pushState({}, '', '/projects/demo/work_packages/42');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not call replaceState when url does not contain /work_packages/', () => {
+    window.history.pushState({}, '', '/projects/demo/boards');
+    setCanonical('http://localhost/projects/demo/boards');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves query string and hash when rewriting the id', () => {
+    window.history.pushState({}, '', '/projects/demo/work_packages/13?focus=description#comment-5');
+    setCanonical('http://localhost/projects/demo/work_packages/DEMO-42');
+
+    canonicalizeWorkPackageIdInUrl();
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/projects/demo/work_packages/DEMO-42?focus=description#comment-5');
   });
 });

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -84,7 +84,7 @@ export function canonicalizeWorkPackageIdInUrl():void {
     `/work_packages/${canonicalMatch[1]}`,
   );
   window.history.replaceState(
-    null,
+    window.history.state,
     '',
     newPath + window.location.search + window.location.hash,
   );

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -1,3 +1,4 @@
+import * as Turbo from '@hotwired/turbo';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { scrollHeaderOnMobile } from 'core-app/core/setup/globals/global-listeners/top-menu-scroll';
 import { detectOnboardingTour } from 'core-app/core/setup/globals/onboarding/onboarding_tour_trigger';
@@ -10,7 +11,21 @@ import {
   focusFirstErroneousField,
   initMainMenuExpandStatus,
 } from 'core-app/core/setup/globals/global-listeners/setup-server-response';
+import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-pattern';
 import { isOpenProjectCustomElement } from './openproject-custom-element';
+
+// `view` exists on the Turbo session at runtime but is absent from the project's
+// hand-written @types/hotwired__turbo typings; narrow-cast here, same precedent
+// as turbo/helpers.ts and turbo-navigation-patch.ts.
+interface TurboSessionWithView extends Turbo.TurboSession {
+  view:{ lastRenderedLocation:URL };
+}
+
+// Compiled once: matches a work package id anywhere in the pathname, reusing the
+// shared WP_ID_URL_PATTERN so numeric ("42") and semantic ("PROJ-42") ids both match.
+const workPackageIdPathPattern = new URLPattern({
+  pathname: `{*}/work_packages/:id(${WP_ID_URL_PATTERN}){/*}?`,
+});
 
 export function addTurboGlobalListeners(target:Document = document, signal?:AbortSignal) {
   const runOnRenderAndLoad = () => {
@@ -69,23 +84,25 @@ export function addTurboGlobalListeners(target:Document = document, signal?:Abor
 
 export function canonicalizeWorkPackageIdInUrl():void {
   const currentPath = window.location.pathname;
-  const wpIdPattern = /\/work_packages\/([^/]+)/;
-  const currentMatch = wpIdPattern.exec(currentPath);
-  if (!currentMatch) return;
+  const currentId = workPackageIdPathPattern.exec({ pathname: currentPath })?.pathname.groups.id;
+  if (!currentId) return;
 
   const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
   if (!canonical?.href) return;
 
-  const canonicalMatch = wpIdPattern.exec(new URL(canonical.href).pathname);
-  if (!canonicalMatch || canonicalMatch[1] === currentMatch[1]) return;
+  const canonicalPath = new URL(canonical.href).pathname;
+  const canonicalId = workPackageIdPathPattern.exec({ pathname: canonicalPath })?.pathname.groups.id;
+  if (!canonicalId || canonicalId === currentId) return;
 
-  const newPath = currentPath.replace(
-    `/work_packages/${currentMatch[1]}`,
-    `/work_packages/${canonicalMatch[1]}`,
-  );
-  window.history.replaceState(
-    window.history.state,
-    '',
-    newPath + window.location.search + window.location.hash,
-  );
+  const newPath = currentPath.replace(`/work_packages/${currentId}`, `/work_packages/${canonicalId}`);
+  const newUrl = new URL(newPath + window.location.search + window.location.hash, window.location.origin);
+
+  // Use Turbo's history.replace (not window.history.replaceState) so Turbo's internal
+  // location stays in sync — otherwise back/forward popstate resolves the stale URL.
+  // Pass the current restorationIdentifier explicitly: History.replace defaults to a
+  // fresh uuid, orphaning the recorded scroll-restoration data.
+  Turbo.session.history.replace(newUrl, Turbo.session.history.restorationIdentifier);
+  // PageView#cacheSnapshot keys the snapshot cache by lastRenderedLocation; left stale,
+  // back/forward misses the cache and re-fetches instead of restoring instantly.
+  (Turbo.session as TurboSessionWithView).view.lastRenderedLocation = newUrl;
 }

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -1,4 +1,31 @@
-import * as Turbo from '@hotwired/turbo';
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { scrollHeaderOnMobile } from 'core-app/core/setup/globals/global-listeners/top-menu-scroll';
 import { detectOnboardingTour } from 'core-app/core/setup/globals/onboarding/onboarding_tour_trigger';
@@ -11,21 +38,8 @@ import {
   focusFirstErroneousField,
   initMainMenuExpandStatus,
 } from 'core-app/core/setup/globals/global-listeners/setup-server-response';
-import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-pattern';
+import { canonicalizeWorkPackageIdInUrl } from 'core-app/core/setup/globals/canonicalize-work-package-id-in-url';
 import { isOpenProjectCustomElement } from './openproject-custom-element';
-
-// `view` exists on the Turbo session at runtime but is absent from the project's
-// hand-written @types/hotwired__turbo typings; narrow-cast here, same precedent
-// as turbo/helpers.ts and turbo-navigation-patch.ts.
-interface TurboSessionWithView extends Turbo.TurboSession {
-  view:{ lastRenderedLocation:URL };
-}
-
-// Compiled once: matches a work package id anywhere in the pathname, reusing the
-// shared WP_ID_URL_PATTERN so numeric ("42") and semantic ("PROJ-42") ids both match.
-const workPackageIdPathPattern = new URLPattern({
-  pathname: `{*}/work_packages/:id(${WP_ID_URL_PATTERN}){/*}?`,
-});
 
 export function addTurboGlobalListeners(target:Document = document, signal?:AbortSignal) {
   const runOnRenderAndLoad = () => {
@@ -80,29 +94,4 @@ export function addTurboGlobalListeners(target:Document = document, signal?:Abor
       event.preventDefault();
     }
   }, { signal });
-}
-
-export function canonicalizeWorkPackageIdInUrl():void {
-  const currentPath = window.location.pathname;
-  const currentId = workPackageIdPathPattern.exec({ pathname: currentPath })?.pathname.groups.id;
-  if (!currentId) return;
-
-  const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
-  if (!canonical?.href) return;
-
-  const canonicalPath = new URL(canonical.href).pathname;
-  const canonicalId = workPackageIdPathPattern.exec({ pathname: canonicalPath })?.pathname.groups.id;
-  if (!canonicalId || canonicalId === currentId) return;
-
-  const newPath = currentPath.replace(`/work_packages/${currentId}`, `/work_packages/${canonicalId}`);
-  const newUrl = new URL(newPath + window.location.search + window.location.hash, window.location.origin);
-
-  // Use Turbo's history.replace (not window.history.replaceState) so Turbo's internal
-  // location stays in sync — otherwise back/forward popstate resolves the stale URL.
-  // Pass the current restorationIdentifier explicitly: History.replace defaults to a
-  // fresh uuid, orphaning the recorded scroll-restoration data.
-  Turbo.session.history.replace(newUrl, Turbo.session.history.restorationIdentifier);
-  // PageView#cacheSnapshot keys the snapshot cache by lastRenderedLocation; left stale,
-  // back/forward misses the cache and re-fetches instead of restoring instantly.
-  (Turbo.session as TurboSessionWithView).view.lastRenderedLocation = newUrl;
 }

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -52,6 +52,9 @@ export function addTurboGlobalListeners(target:Document = document, signal?:Abor
     focusFirstErroneousField();
     activateFlashNotice();
     activateFlashError();
+
+    // Ensure the URL contains the correct work package identifier
+    canonicalizeWorkPackageIdInUrl();
   };
   target.addEventListener('turbo:render', runOnRenderAndLoad, { signal });
   target.addEventListener('DOMContentLoaded', runOnRenderAndLoad, { signal });
@@ -62,4 +65,27 @@ export function addTurboGlobalListeners(target:Document = document, signal?:Abor
       event.preventDefault();
     }
   }, { signal });
+}
+
+export function canonicalizeWorkPackageIdInUrl():void {
+  const currentPath = window.location.pathname;
+  const wpIdPattern = /\/work_packages\/([^/]+)/;
+  const currentMatch = wpIdPattern.exec(currentPath);
+  if (!currentMatch) return;
+
+  const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!canonical?.href) return;
+
+  const canonicalMatch = wpIdPattern.exec(new URL(canonical.href).pathname);
+  if (!canonicalMatch || canonicalMatch[1] === currentMatch[1]) return;
+
+  const newPath = currentPath.replace(
+    `/work_packages/${currentMatch[1]}`,
+    `/work_packages/${canonicalMatch[1]}`,
+  );
+  window.history.replaceState(
+    null,
+    '',
+    newPath + window.location.search + window.location.hash,
+  );
 }

--- a/spec/features/work_packages/canonical_url_rewrite_spec.rb
+++ b/spec/features/work_packages/canonical_url_rewrite_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Work package canonical URL rewrite",
                :with_cuprite,
                with_settings: { work_packages_identifier: "semantic" } do
   shared_let(:admin) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[work_package_tracking wiki]) }
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]).reload }
   let(:work_package) { create(:work_package, project:, subject: "Canonical URL test WP") }
 
   let(:full_screen) { Pages::FullWorkPackage.new(work_package, project) }

--- a/spec/features/work_packages/canonical_url_rewrite_spec.rb
+++ b/spec/features/work_packages/canonical_url_rewrite_spec.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
 require "spec_helper"
 
 RSpec.describe "Work package canonical URL rewrite",
@@ -34,6 +62,21 @@ RSpec.describe "Work package canonical URL rewrite",
   end
 
   describe "after Turbo Drive navigation (turbo:render)" do
+    it "rewrites a numeric work package ID to the canonical semantic ID" do
+      visit project_path(project)
+      expect(page).to have_current_path(project_path(project))
+
+      # No real UI link can produce a Turbo Drive visit to a work package URL:
+      # user-content links are rendered with target="_top", which Turbo 8 never
+      # intercepts (findLinkFromClickTarget ignores links with target != _self).
+      # Trigger the visit directly to exercise the turbo:render code path.
+      wait_for_turbo { page.execute_script("Turbo.visit(#{numeric_path.to_json})") }
+
+      expect(page).to have_current_path(semantic_path)
+    end
+  end
+
+  describe "following a user-content link (full page load)" do
     let!(:wiki_page) do
       create(:wiki_page,
              wiki: project.wiki,
@@ -45,9 +88,11 @@ RSpec.describe "Work package canonical URL rewrite",
       visit project_wiki_path(project, wiki_page)
       expect(page).to have_css(".wiki-content")
 
-      wait_for_turbo do
-        within(".wiki-content") { click_link "the work package" }
-      end
+      # User-content links carry target="_top" (format_text), which Turbo does not
+      # intercept — the click is a full page load, so the rewrite runs on
+      # DOMContentLoaded and the self-waiting matcher below covers it. wait_for_turbo
+      # cannot be used across a full load (its listener registry does not survive).
+      within(".wiki-content") { click_link "the work package" }
 
       expect(page).to have_current_path(semantic_path)
       full_screen.ensure_page_loaded

--- a/spec/features/work_packages/canonical_url_rewrite_spec.rb
+++ b/spec/features/work_packages/canonical_url_rewrite_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Work package canonical URL rewrite",
                :with_cuprite,
                with_settings: { work_packages_identifier: "semantic" } do
   shared_let(:admin) { create(:admin) }
-  let(:project) { create(:project) }
+  let(:project) { create(:project, enabled_module_names: %w[work_package_tracking wiki]) }
   let(:work_package) { create(:work_package, project:, subject: "Canonical URL test WP") }
 
   let(:full_screen) { Pages::FullWorkPackage.new(work_package, project) }
@@ -28,54 +28,74 @@ RSpec.describe "Work package canonical URL rewrite",
   describe "on initial page load (DOMContentLoaded)" do
     it "rewrites a numeric work package ID to the canonical semantic ID" do
       visit numeric_path
-      wait_for_network_idle
 
       expect(page).to have_current_path(semantic_path)
     end
   end
 
   describe "after Turbo Drive navigation (turbo:render)" do
-    it "rewrites a numeric work package ID to the canonical semantic ID" do
-      visit project_path(project)
-      wait_for_reload
+    let!(:wiki_page) do
+      create(:wiki_page,
+             wiki: project.wiki,
+             title: "Wiki page with work package link",
+             text: "See [the work package](#{numeric_path}) for details.")
+    end
 
-      page.execute_script("Turbo.visit('#{numeric_path}')")
-      wait_for_network_idle
+    it "rewrites a numeric ID in a followed user-content link to the canonical semantic ID" do
+      visit project_wiki_path(project, wiki_page)
+      expect(page).to have_css(".wiki-content")
+
+      wait_for_turbo do
+        within(".wiki-content") { click_link "the work package" }
+      end
 
       expect(page).to have_current_path(semantic_path)
+      full_screen.ensure_page_loaded
     end
   end
 
   describe "back button" do
     it "single back press returns to the previous page — replaceState leaves no phantom entry" do
       visit project_path(project)
-      wait_for_reload
 
       visit numeric_path
-      wait_for_network_idle
       expect(page).to have_current_path(semantic_path)
 
       page.go_back
-      wait_for_network_idle
 
       expect(page).to have_current_path(project_path(project))
     end
 
-    it "back navigation after Turbo cache restoration shows the canonical URL" do
+    it "back navigation after Turbo cache restoration shows the canonical URL and restores from cache" do
       visit numeric_path
-      wait_for_network_idle
       expect(page).to have_current_path(semantic_path)
 
-      # Navigate away via Turbo Drive (caches the WP page snapshot)
-      page.execute_script("Turbo.visit('#{project_path(project)}')")
-      wait_for_network_idle
+      # Navigate away via Turbo Drive (caches the WP page snapshot under the semantic URL).
+      wait_for_turbo { page.execute_script("Turbo.visit(#{project_path(project).to_json})") }
       expect(page).to have_current_path(project_path(project))
 
-      # Turbo restores from cache (fires turbo:render) — URL must still be canonical
-      page.go_back
-      wait_for_network_idle
+      # Record the visit action and any page-level (non-frame) Turbo fetch that fires
+      # on the way back. Drive page fetches dispatch turbo:before-fetch-request on
+      # document.documentElement; frame fetches dispatch on the <turbo-frame> element.
+      page.execute_script(<<~JS)
+        document.addEventListener("turbo:visit",
+          (event) => { window.__opBackVisitAction = event.detail.action }, { once: true });
+        window.__opPageFetches = [];
+        document.addEventListener("turbo:before-fetch-request", (event) => {
+          if (!(event.target instanceof HTMLElement && event.target.tagName === "TURBO-FRAME")) {
+            window.__opPageFetches.push(event.detail.url.toString());
+          }
+        });
+      JS
 
+      wait_for_turbo { page.go_back }
+
+      # action == "restore" proves Turbo's history state survived the rewrite;
+      # the empty page-fetch list proves the snapshot cache was hit (no re-fetch).
+      expect(page.evaluate_script("window.__opBackVisitAction")).to eq("restore")
+      expect(page.evaluate_script("window.__opPageFetches")).to be_empty
       expect(page).to have_current_path(semantic_path)
+      full_screen.expect_subject
     end
   end
 

--- a/spec/features/work_packages/canonical_url_rewrite_spec.rb
+++ b/spec/features/work_packages/canonical_url_rewrite_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe "Work package canonical URL rewrite",
     end
   end
 
+  describe "on page reload (F5)" do
+    it "keeps the canonical semantic ID after a full page reload" do
+      visit numeric_path
+      expect(page).to have_current_path(semantic_path)
+
+      # A reload is a full page load: the rewrite runs again on DOMContentLoaded
+      # and the self-waiting matcher below covers it. wait_for_turbo cannot be used
+      # across a full load (its listener registry does not survive).
+      page.refresh
+
+      expect(page).to have_current_path(semantic_path)
+      full_screen.ensure_page_loaded
+    end
+  end
+
   describe "after Turbo Drive navigation (turbo:render)" do
     it "rewrites a numeric work package ID to the canonical semantic ID" do
       visit project_path(project)

--- a/spec/features/work_packages/canonical_url_rewrite_spec.rb
+++ b/spec/features/work_packages/canonical_url_rewrite_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Work package canonical URL rewrite",
+               :js,
+               :with_cuprite,
+               with_settings: { work_packages_identifier: "semantic" } do
+  shared_let(:admin) { create(:admin) }
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:, subject: "Canonical URL test WP") }
+
+  let(:full_screen) { Pages::FullWorkPackage.new(work_package, project) }
+
+  before do
+    work_package
+    login_as admin
+  end
+
+  def numeric_path(tab = "activity")
+    project_work_package_path(project, work_package.id, tab)
+  end
+
+  def semantic_path(tab = "activity")
+    project_work_package_path(project, work_package.reload.identifier, tab)
+  end
+
+  describe "on initial page load (DOMContentLoaded)" do
+    it "rewrites a numeric work package ID to the canonical semantic ID" do
+      visit numeric_path
+      wait_for_network_idle
+
+      expect(page).to have_current_path(semantic_path)
+    end
+  end
+
+  describe "after Turbo Drive navigation (turbo:render)" do
+    it "rewrites a numeric work package ID to the canonical semantic ID" do
+      visit project_path(project)
+      wait_for_reload
+
+      page.execute_script("Turbo.visit('#{numeric_path}')")
+      wait_for_network_idle
+
+      expect(page).to have_current_path(semantic_path)
+    end
+  end
+
+  describe "back button" do
+    it "single back press returns to the previous page — replaceState leaves no phantom entry" do
+      visit project_path(project)
+      wait_for_reload
+
+      visit numeric_path
+      wait_for_network_idle
+      expect(page).to have_current_path(semantic_path)
+
+      page.go_back
+      wait_for_network_idle
+
+      expect(page).to have_current_path(project_path(project))
+    end
+
+    it "back navigation after Turbo cache restoration shows the canonical URL" do
+      visit numeric_path
+      wait_for_network_idle
+      expect(page).to have_current_path(semantic_path)
+
+      # Navigate away via Turbo Drive (caches the WP page snapshot)
+      page.execute_script("Turbo.visit('#{project_path(project)}')")
+      wait_for_network_idle
+      expect(page).to have_current_path(project_path(project))
+
+      # Turbo restores from cache (fires turbo:render) — URL must still be canonical
+      page.go_back
+      wait_for_network_idle
+
+      expect(page).to have_current_path(semantic_path)
+    end
+  end
+
+  describe "Angular routing after URL rewrite" do
+    it "tab navigation preserves the semantic ID — UI Router reads already-corrected URL" do
+      visit numeric_path("activity")
+      full_screen.ensure_page_loaded
+      expect(page).to have_current_path(semantic_path("activity"))
+
+      full_screen.switch_to_tab(tab: "relations")
+      wait_for_network_idle
+
+      expect(page).to have_current_path(semantic_path("relations"))
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-889

Since the correct page is loaded already and only the URL in the browser uses an outdated identifier, the URL is rewritten by a little javascript helper.

This has the added benefit of also "auto-fixing" bookmarks of old identifiers or fixing the URL if a numeric work package ID was used while the instance is in semantic mode or vice versa. No redirects needed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
