### PR TITLE
[AGILE-375] Rework backlog filter panels to Stimulus-driven navigation

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.spec.ts
@@ -1,0 +1,294 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Application } from '@hotwired/stimulus';
+import type { MockInstance } from 'vitest';
+
+import type BacklogFilterSelectPanelControllerType from './backlog-filter-select-panel.controller';
+
+interface Navigable {
+  visit(this:void, url:string):void;
+}
+
+interface PanelApi {
+  selectedItems:{ value:string|null }[];
+  items:HTMLElement[];
+  checkItem(item:HTMLElement):void;
+  uncheckItem(item:HTMLElement):void;
+  hide():void;
+}
+
+type PanelStub = HTMLElement & PanelApi;
+
+const IDENTIFIER = 'backlogs--backlog-filter-select-panel';
+
+describe('Backlogs filter select panel controller', () => {
+  let application:Application;
+  let fixture:HTMLElement;
+  let panel:PanelStub;
+  let panelHideCalls:number;
+  let Controller:typeof BacklogFilterSelectPanelControllerType;
+  let prototype:Navigable;
+
+  beforeAll(async () => {
+    ({ default: Controller } = await import('./backlog-filter-select-panel.controller'));
+  });
+
+  beforeEach(() => {
+    // Stub the navigation seam so submitting neither hits Turbo nor leaves the
+    // test page; the spy doubles as the submit assertion.
+    prototype = Controller.prototype as unknown as Navigable;
+    vi.spyOn(prototype, 'visit').mockReturnValue(undefined);
+
+    panelHideCalls = 0;
+
+    fixture = document.createElement('div');
+    document.body.appendChild(fixture);
+
+    application = Application.start();
+    application.register(IDENTIFIER, Controller);
+  });
+
+  afterEach(() => {
+    application?.stop();
+    fixture.remove();
+    vi.restoreAllMocks();
+  });
+
+  // Renders the panel + footer buttons and waits (on real timers) for Stimulus
+  // to connect the controller, which binds asynchronously via a MutationObserver.
+  async function mount({
+    url = '/projects/demo/backlogs',
+    items = [] as string[],
+    checked = [] as string[],
+  } = {}) {
+    window.history.replaceState({}, '', url);
+
+    fixture.innerHTML = `
+      <div
+        data-controller="${IDENTIFIER}"
+        data-${IDENTIFIER}-filter-key-value="bucket_ids"
+        data-action="itemActivated->${IDENTIFIER}#refreshButtons panelClosed->${IDENTIFIER}#revertOnClose"
+      >
+        <select-panel></select-panel>
+        <button type="button" data-${IDENTIFIER}-target="clearButton"
+                data-action="click->${IDENTIFIER}#clear" disabled>Clear</button>
+        <button type="button" data-${IDENTIFIER}-target="applyButton"
+                data-action="click->${IDENTIFIER}#apply" disabled>Apply</button>
+      </div>
+    `;
+
+    const root = fixture.querySelector<HTMLElement>(`[data-controller="${IDENTIFIER}"]`)!;
+    setupPanel(root, items, checked);
+
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    return root;
+  }
+
+  // Wires a minimal fake of Primer's SelectPanelElement onto <select-panel>:
+  // items carry their value on a `.ActionListContent[data-value]`, and
+  // check/uncheck mutate the selection and fire `itemActivated`, as Primer does.
+  function setupPanel(root:HTMLElement, items:string[], checked:string[]) {
+    const element = root.querySelector('select-panel') as unknown as PanelStub;
+    const selected = new Set(checked);
+
+    element.innerHTML = items.map((value) => `
+      <li><span class="ActionListContent" data-value="${value}"
+                aria-selected="${selected.has(value)}"></span></li>`).join('');
+
+    const setItem = (item:HTMLElement, on:boolean) => {
+      const content = item.querySelector('.ActionListContent')!;
+      const value = content.getAttribute('data-value')!;
+      if (on === selected.has(value)) return;
+
+      if (on) { selected.add(value); } else { selected.delete(value); }
+      content.setAttribute('aria-selected', String(on));
+      element.dispatchEvent(new CustomEvent('itemActivated', { bubbles: true }));
+    };
+
+    Object.defineProperty(element, 'items', {
+      configurable: true,
+      get: () => Array.from(element.querySelectorAll('li')),
+    });
+    Object.defineProperty(element, 'selectedItems', {
+      configurable: true,
+      get: () => [...selected].map((value) => ({ value })),
+    });
+    element.checkItem = (item:HTMLElement) => setItem(item, true);
+    element.uncheckItem = (item:HTMLElement) => setItem(item, false);
+    element.hide = () => { panelHideCalls += 1; };
+
+    panel = element;
+  }
+
+  // Simulates a user toggling an item in the open panel (fires itemActivated).
+  function toggle(value:string, on:boolean) {
+    const item = panel.items.find(
+      (li) => li.querySelector('.ActionListContent')?.getAttribute('data-value') === value,
+    )!;
+    if (on) { panel.checkItem(item); } else { panel.uncheckItem(item); }
+  }
+
+  function controllerFor(root:HTMLElement):BacklogFilterSelectPanelControllerType {
+    return application.getControllerForElementAndIdentifier(
+      root, IDENTIFIER,
+    ) as unknown as BacklogFilterSelectPanelControllerType;
+  }
+
+  const applyButton = () => fixture.querySelector<HTMLButtonElement>(`[data-${IDENTIFIER}-target="applyButton"]`)!;
+  const clearButton = () => fixture.querySelector<HTMLButtonElement>(`[data-${IDENTIFIER}-target="clearButton"]`)!;
+
+  function lastVisitedUrl():URL {
+    const calls = (prototype.visit as unknown as MockInstance<(url:string) => void>).mock.calls;
+    const [url] = calls.at(-1)!;
+    return new URL(url, window.location.origin);
+  }
+
+  function selectedValues():string[] {
+    return panel.selectedItems.map((item) => item.value).filter((v):v is string => v != null);
+  }
+
+  describe('button enablement', () => {
+    it('enables Apply when the selection differs from the applied filter and disables it when reverted', async () => {
+      await mount({ url: '/projects/demo/backlogs?bucket_ids=1', items: ['1', '2', '3'], checked: ['1'] });
+
+      expect(applyButton()).toBeDisabled();
+
+      toggle('2', true);
+      expect(applyButton()).toBeEnabled();
+
+      toggle('2', false);
+      expect(applyButton()).toBeDisabled();
+    });
+
+    it('treats whitespace around comma-delimited ids as already applied (Apply stays disabled)', async () => {
+      // The server tolerates padded, comma-delimited params (e.g. "1, 2 ,3"),
+      // so a URL carrying them must read back as the same applied selection.
+      await mount({ url: '/projects/demo/backlogs?bucket_ids=1,%202%20,3', items: ['1', '2', '3'], checked: ['1', '2', '3'] });
+
+      // Round-trip a toggle to re-run the change check without altering the
+      // selection: it must still equal the (padded) applied filter.
+      toggle('2', false);
+      toggle('2', true);
+
+      expect(applyButton()).toBeDisabled();
+    });
+
+    it('enables Clear only while something is selected', async () => {
+      await mount({ url: '/projects/demo/backlogs', items: ['1', '2'], checked: [] });
+
+      expect(clearButton()).toBeDisabled();
+
+      toggle('1', true);
+      expect(clearButton()).toBeEnabled();
+
+      toggle('1', false);
+      expect(clearButton()).toBeDisabled();
+    });
+  });
+
+  describe('apply', () => {
+    it('navigates the backlogs frame with the current selection, preserving other params', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1&sprint_ids=9',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+
+      controllerFor(root).apply();
+
+      expect(prototype.visit).toHaveBeenCalledTimes(1);
+      const params = lastVisitedUrl().searchParams;
+      expect(params.get('bucket_ids')).toBe('1,2');
+      expect(params.get('sprint_ids')).toBe('9');
+    });
+  });
+
+  describe('clear', () => {
+    it('navigates with an empty selection and removes the filter param', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+
+      controllerFor(root).clear();
+
+      expect(prototype.visit).toHaveBeenCalledTimes(1);
+      expect(lastVisitedUrl().searchParams.has('bucket_ids')).toBe(false);
+      expect(selectedValues()).toEqual([]);
+    });
+
+    it('deselects and closes without navigating when the filter is already empty', async () => {
+      const root = await mount({ url: '/projects/demo/backlogs', items: ['1', '2'], checked: [] });
+      toggle('1', true);
+      toggle('2', true);
+
+      controllerFor(root).clear();
+
+      expect(prototype.visit).not.toHaveBeenCalled();
+      expect(panelHideCalls).toBe(1);
+      expect(selectedValues()).toEqual([]);
+    });
+  });
+
+  describe('close (native dismiss)', () => {
+    it('reverts the selection to the applied filter without submitting', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+      toggle('1', false);
+      expect(selectedValues()).toEqual(['2']);
+
+      controllerFor(root).revertOnClose();
+
+      expect(prototype.visit).not.toHaveBeenCalled();
+      expect(selectedValues()).toEqual(['1']);
+    });
+
+    it('does not revert once a submit is in flight', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+      const controller = controllerFor(root);
+
+      controller.apply();
+      controller.revertOnClose();
+
+      expect(prototype.visit).toHaveBeenCalledTimes(1);
+      expect(selectedValues()).toEqual(['1', '2']);
+    });
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.spec.ts
@@ -1,0 +1,315 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Application } from '@hotwired/stimulus';
+import type { MockInstance } from 'vitest';
+
+import type BacklogFilterSelectPanelControllerType from './backlog-filter-select-panel.controller';
+
+interface Navigable {
+  visit(this:void, url:string):void;
+}
+
+interface PanelApi {
+  selectedItems:{ value:string|null }[];
+  items:HTMLElement[];
+  checkItem(item:HTMLElement):void;
+  uncheckItem(item:HTMLElement):void;
+  hide():void;
+}
+
+type PanelStub = HTMLElement & PanelApi;
+
+const IDENTIFIER = 'backlogs--backlog-filter-select-panel';
+
+describe('Backlogs filter select panel controller', () => {
+  let application:Application;
+  let fixture:HTMLElement;
+  let panel:PanelStub;
+  let panelHideCalls:number;
+  let Controller:typeof BacklogFilterSelectPanelControllerType;
+  let prototype:Navigable;
+
+  beforeAll(async () => {
+    ({ default: Controller } = await import('./backlog-filter-select-panel.controller'));
+  });
+
+  beforeEach(() => {
+    // Stub the navigation seam so submitting neither hits Turbo nor leaves the
+    // test page; the spy doubles as the submit assertion.
+    prototype = Controller.prototype as unknown as Navigable;
+    vi.spyOn(prototype, 'visit').mockReturnValue(undefined);
+
+    panelHideCalls = 0;
+
+    fixture = document.createElement('div');
+    document.body.appendChild(fixture);
+
+    application = Application.start();
+    application.register(IDENTIFIER, Controller);
+  });
+
+  afterEach(() => {
+    application?.stop();
+    fixture.remove();
+    vi.restoreAllMocks();
+  });
+
+  // Renders the panel + footer buttons and waits (on real timers) for Stimulus
+  // to connect the controller, which binds asynchronously via a MutationObserver.
+  async function mount({
+    url = '/projects/demo/backlogs',
+    baseUrl = '/projects/demo/backlogs',
+    items = [] as string[],
+    checked = [] as string[],
+  } = {}) {
+    window.history.replaceState({}, '', url);
+
+    fixture.innerHTML = `
+      <div
+        data-controller="${IDENTIFIER}"
+        data-${IDENTIFIER}-filter-key-value="bucket_ids"
+        data-${IDENTIFIER}-base-url-value="${baseUrl}"
+        data-action="itemActivated->${IDENTIFIER}#refreshButtons panelClosed->${IDENTIFIER}#revertOnClose"
+      >
+        <select-panel></select-panel>
+        <button type="button" data-${IDENTIFIER}-target="clearButton"
+                data-action="click->${IDENTIFIER}#clear" disabled>Clear</button>
+        <button type="button" data-${IDENTIFIER}-target="applyButton"
+                data-action="click->${IDENTIFIER}#apply" disabled>Apply</button>
+      </div>
+    `;
+
+    const root = fixture.querySelector<HTMLElement>(`[data-controller="${IDENTIFIER}"]`)!;
+    setupPanel(root, items, checked);
+
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    return root;
+  }
+
+  // Wires a minimal fake of Primer's SelectPanelElement onto <select-panel>:
+  // items carry their value on a `.ActionListContent[data-value]`, and
+  // check/uncheck mutate the selection and fire `itemActivated`, as Primer does.
+  function setupPanel(root:HTMLElement, items:string[], checked:string[]) {
+    const element = root.querySelector('select-panel') as unknown as PanelStub;
+    const selected = new Set(checked);
+
+    element.innerHTML = items.map((value) => `
+      <li><span class="ActionListContent" data-value="${value}"
+                aria-selected="${selected.has(value)}"></span></li>`).join('');
+
+    const setItem = (item:HTMLElement, on:boolean) => {
+      const content = item.querySelector('.ActionListContent')!;
+      const value = content.getAttribute('data-value')!;
+      if (on === selected.has(value)) return;
+
+      if (on) { selected.add(value); } else { selected.delete(value); }
+      content.setAttribute('aria-selected', String(on));
+      element.dispatchEvent(new CustomEvent('itemActivated', { bubbles: true }));
+    };
+
+    Object.defineProperty(element, 'items', {
+      configurable: true,
+      get: () => Array.from(element.querySelectorAll('li')),
+    });
+    Object.defineProperty(element, 'selectedItems', {
+      configurable: true,
+      get: () => [...selected].map((value) => ({ value })),
+    });
+    element.checkItem = (item:HTMLElement) => setItem(item, true);
+    element.uncheckItem = (item:HTMLElement) => setItem(item, false);
+    element.hide = () => { panelHideCalls += 1; };
+
+    panel = element;
+  }
+
+  // Simulates a user toggling an item in the open panel (fires itemActivated).
+  function toggle(value:string, on:boolean) {
+    const item = panel.items.find(
+      (li) => li.querySelector('.ActionListContent')?.getAttribute('data-value') === value,
+    )!;
+    if (on) { panel.checkItem(item); } else { panel.uncheckItem(item); }
+  }
+
+  function controllerFor(root:HTMLElement):BacklogFilterSelectPanelControllerType {
+    return application.getControllerForElementAndIdentifier(
+      root, IDENTIFIER,
+    ) as unknown as BacklogFilterSelectPanelControllerType;
+  }
+
+  const applyButton = () => fixture.querySelector<HTMLButtonElement>(`[data-${IDENTIFIER}-target="applyButton"]`)!;
+  const clearButton = () => fixture.querySelector<HTMLButtonElement>(`[data-${IDENTIFIER}-target="clearButton"]`)!;
+
+  function lastVisitedUrl():URL {
+    const calls = (prototype.visit as unknown as MockInstance<(url:string) => void>).mock.calls;
+    const [url] = calls.at(-1)!;
+    return new URL(url, window.location.origin);
+  }
+
+  function selectedValues():string[] {
+    return panel.selectedItems.map((item) => item.value).filter((v):v is string => v != null);
+  }
+
+  describe('button enablement', () => {
+    it('enables Apply when the selection differs from the applied filter and disables it when reverted', async () => {
+      await mount({ url: '/projects/demo/backlogs?bucket_ids=1', items: ['1', '2', '3'], checked: ['1'] });
+
+      expect(applyButton()).toBeDisabled();
+
+      toggle('2', true);
+      expect(applyButton()).toBeEnabled();
+
+      toggle('2', false);
+      expect(applyButton()).toBeDisabled();
+    });
+
+    it('treats whitespace around comma-delimited ids as already applied (Apply stays disabled)', async () => {
+      // The server tolerates padded, comma-delimited params (e.g. "1, 2 ,3"),
+      // so a URL carrying them must read back as the same applied selection.
+      await mount({ url: '/projects/demo/backlogs?bucket_ids=1,%202%20,3', items: ['1', '2', '3'], checked: ['1', '2', '3'] });
+
+      // Round-trip a toggle to re-run the change check without altering the
+      // selection: it must still equal the (padded) applied filter.
+      toggle('2', false);
+      toggle('2', true);
+
+      expect(applyButton()).toBeDisabled();
+    });
+
+    it('enables Clear only while something is selected', async () => {
+      await mount({ url: '/projects/demo/backlogs', items: ['1', '2'], checked: [] });
+
+      expect(clearButton()).toBeDisabled();
+
+      toggle('1', true);
+      expect(clearButton()).toBeEnabled();
+
+      toggle('1', false);
+      expect(clearButton()).toBeDisabled();
+    });
+  });
+
+  describe('apply', () => {
+    it('navigates the backlogs frame with the current selection, preserving other params', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1&sprint_ids=9',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+
+      controllerFor(root).apply();
+
+      expect(prototype.visit).toHaveBeenCalledTimes(1);
+      const params = lastVisitedUrl().searchParams;
+      expect(params.get('bucket_ids')).toBe('1,2');
+      expect(params.get('sprint_ids')).toBe('9');
+    });
+
+    it('navigates the backlog list endpoint, not the split-view details route', async () => {
+      // On a split-view details page the browser URL is the details route, but
+      // the frame must reload the backlog list. Navigation derives its path from
+      // the configured base URL, not window.location.
+      const root = await mount({
+        url: '/projects/demo/backlogs/backlog/details/42?bucket_ids=1',
+        baseUrl: '/projects/demo/backlogs',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+
+      controllerFor(root).apply();
+
+      const visited = lastVisitedUrl();
+      expect(visited.pathname).toBe('/projects/demo/backlogs');
+      expect(visited.searchParams.get('bucket_ids')).toBe('1,2');
+    });
+  });
+
+  describe('clear', () => {
+    it('navigates with an empty selection and removes the filter param', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+
+      controllerFor(root).clear();
+
+      expect(prototype.visit).toHaveBeenCalledTimes(1);
+      expect(lastVisitedUrl().searchParams.has('bucket_ids')).toBe(false);
+      expect(selectedValues()).toEqual([]);
+    });
+
+    it('deselects and closes without navigating when the filter is already empty', async () => {
+      const root = await mount({ url: '/projects/demo/backlogs', items: ['1', '2'], checked: [] });
+      toggle('1', true);
+      toggle('2', true);
+
+      controllerFor(root).clear();
+
+      expect(prototype.visit).not.toHaveBeenCalled();
+      expect(panelHideCalls).toBe(1);
+      expect(selectedValues()).toEqual([]);
+    });
+  });
+
+  describe('close (native dismiss)', () => {
+    it('reverts the selection to the applied filter without submitting', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+      toggle('1', false);
+      expect(selectedValues()).toEqual(['2']);
+
+      controllerFor(root).revertOnClose();
+
+      expect(prototype.visit).not.toHaveBeenCalled();
+      expect(selectedValues()).toEqual(['1']);
+    });
+
+    it('does not revert once a submit is in flight', async () => {
+      const root = await mount({
+        url: '/projects/demo/backlogs?bucket_ids=1',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+      const controller = controllerFor(root);
+
+      controller.apply();
+      controller.revertOnClose();
+
+      expect(prototype.visit).toHaveBeenCalledTimes(1);
+      expect(selectedValues()).toEqual(['1', '2']);
+    });
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.spec.ts
@@ -84,6 +84,7 @@ describe('Backlogs filter select panel controller', () => {
   // to connect the controller, which binds asynchronously via a MutationObserver.
   async function mount({
     url = '/projects/demo/backlogs',
+    baseUrl = '/projects/demo/backlogs',
     items = [] as string[],
     checked = [] as string[],
   } = {}) {
@@ -93,6 +94,7 @@ describe('Backlogs filter select panel controller', () => {
       <div
         data-controller="${IDENTIFIER}"
         data-${IDENTIFIER}-filter-key-value="bucket_ids"
+        data-${IDENTIFIER}-base-url-value="${baseUrl}"
         data-action="itemActivated->${IDENTIFIER}#refreshButtons panelClosed->${IDENTIFIER}#revertOnClose"
       >
         <select-panel></select-panel>
@@ -227,6 +229,25 @@ describe('Backlogs filter select panel controller', () => {
       const params = lastVisitedUrl().searchParams;
       expect(params.get('bucket_ids')).toBe('1,2');
       expect(params.get('sprint_ids')).toBe('9');
+    });
+
+    it('navigates the backlog list endpoint, not the split-view details route', async () => {
+      // On a split-view details page the browser URL is the details route, but
+      // the frame must reload the backlog list. Navigation derives its path from
+      // the configured base URL, not window.location.
+      const root = await mount({
+        url: '/projects/demo/backlogs/backlog/details/42?bucket_ids=1',
+        baseUrl: '/projects/demo/backlogs',
+        items: ['1', '2'],
+        checked: ['1'],
+      });
+      toggle('2', true);
+
+      controllerFor(root).apply();
+
+      const visited = lastVisitedUrl();
+      expect(visited.pathname).toBe('/projects/demo/backlogs');
+      expect(visited.searchParams.get('bucket_ids')).toBe('1,2');
     });
   });
 

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.ts
@@ -1,0 +1,179 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Controller } from '@hotwired/stimulus';
+import * as Turbo from '@hotwired/turbo';
+import type {
+  SelectPanelElement,
+  SelectPanelItem,
+} from '@primer/view-components/app/components/primer/alpha/select_panel_element';
+
+const FRAME_ID = 'backlogs_container';
+
+// Drives a backlog filter select panel. Submission is explicit:
+//
+//   * Apply  - navigates the backlogs frame with the current selection.
+//   * Clear  - deselects everything and navigates with an empty selection.
+//   * Close  - the native dialog dismiss (X / Escape / click-away). It does
+//              NOT submit; instead the selection is reverted to the applied
+//              filter, so the panel always mirrors what is actually applied.
+//
+// The applied filter is read from the URL, which is the single source of truth
+// for both the "has it changed?" check (Apply/Clear enablement) and the revert
+// target. The selection is serialized into the compact comma form
+// (?bucket_ids=1,2,inbox); Backlogs::BacklogFilters parses both that and the
+// legacy array form on the server.
+export default class BacklogFilterSelectPanelController extends Controller<HTMLElement> {
+  static values = {
+    filterKey: String,
+  };
+
+  static targets = ['applyButton', 'clearButton'];
+
+  declare filterKeyValue:string;
+  declare readonly applyButtonTarget:HTMLButtonElement;
+  declare readonly clearButtonTarget:HTMLButtonElement;
+  declare readonly hasApplyButtonTarget:boolean;
+  declare readonly hasClearButtonTarget:boolean;
+
+  // Suppresses re-entrancy: Primer's checkItem/uncheckItem fire itemActivated,
+  // which would otherwise recurse through refreshButtons while we are setting
+  // the selection programmatically.
+  private reverting = false;
+
+  // Each controller submits at most once; the frame reload that follows
+  // replaces it. Also tells the close handler that a submit is in flight, so it
+  // does not revert a selection that is about to be re-rendered.
+  private submitted = false;
+
+  refreshButtons():void {
+    if (this.reverting) return;
+
+    const current = this.selectedValues();
+    if (this.hasApplyButtonTarget) {
+      this.applyButtonTarget.disabled = sameMembers(current, this.appliedValues());
+    }
+    if (this.hasClearButtonTarget) {
+      this.clearButtonTarget.disabled = current.length === 0;
+    }
+  }
+
+  revertOnClose():void {
+    if (this.submitted) return; // a submit is navigating; the reload will re-render
+
+    this.setSelection([...this.appliedValues()]);
+    this.refreshButtons();
+  }
+
+  apply():void {
+    this.navigateWith(this.selectedValues());
+  }
+
+  clear():void {
+    this.setSelection([]);
+    this.refreshButtons();
+
+    // Navigating reloads the frame, which closes the panel. When the filter is
+    // already empty there is nothing to submit, so close the panel directly.
+    if (!this.navigateWith([])) {
+      this.panel?.hide();
+    }
+  }
+
+  // Navigation seam: overridable so specs can assert the target URL without
+  // stubbing the Turbo module.
+  protected visit(url:string):void {
+    Turbo.visit(url, { frame: FRAME_ID, action: 'advance' });
+  }
+
+  // Returns false (no navigation) when the selection already matches the
+  // applied filter.
+  private navigateWith(values:string[]):boolean {
+    if (this.submitted || sameMembers(values, this.appliedValues())) return false;
+
+    const url = new URL(window.location.href);
+    if (values.length > 0) {
+      url.searchParams.set(this.filterKeyValue, values.join(','));
+    } else {
+      url.searchParams.delete(this.filterKeyValue);
+    }
+
+    this.submitted = true;
+    this.visit(url.toString());
+    return true;
+  }
+
+  private setSelection(values:string[]):void {
+    const panel = this.panel;
+    if (!panel) return;
+
+    const wanted = new Set(values);
+    this.reverting = true;
+    panel.items.forEach((item) => {
+      const value = this.itemValue(item);
+      if (value === null) return;
+
+      if (wanted.has(value)) {
+        panel.checkItem(item);
+      } else {
+        panel.uncheckItem(item);
+      }
+    });
+    this.reverting = false;
+  }
+
+  private selectedValues():string[] {
+    return (this.panel?.selectedItems ?? [])
+      .map((item) => item.value)
+      .filter((value):value is string => value != null && value.length > 0);
+  }
+
+  private appliedValues():Set<string> {
+    const raw = new URL(window.location.href).searchParams.get(this.filterKeyValue);
+    return new Set(raw ? raw.split(',').map((value) => value.trim()).filter(Boolean) : []);
+  }
+
+  // Swappable once Primer exposes a public value accessor on panel items.
+  private itemValue(item:SelectPanelItem):string|null {
+    return item.querySelector('.ActionListContent')?.getAttribute('data-value') ?? null;
+  }
+
+  private get panel():SelectPanelElement|null {
+    return this.element.querySelector<SelectPanelElement>('select-panel');
+  }
+}
+
+// Order-insensitive comparison of two value collections.
+function sameMembers(a:Iterable<string>, b:Iterable<string>):boolean {
+  return key(a) === key(b);
+}
+
+function key(values:Iterable<string>):string {
+  return [...values].filter(Boolean).sort()
+    .join(',');
+}

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.ts
@@ -1,0 +1,198 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Controller } from '@hotwired/stimulus';
+import * as Turbo from '@hotwired/turbo';
+import type {
+  SelectPanelElement,
+  SelectPanelItem,
+} from '@primer/view-components/app/components/primer/alpha/select_panel_element';
+
+const FRAME_ID = 'backlogs_container';
+
+// Drives a backlog filter select panel. Submission is explicit:
+//
+//   * Apply  - navigates the backlogs frame with the current selection.
+//   * Clear  - deselects everything and navigates with an empty selection.
+//   * Close  - the native dialog dismiss (X / Escape / click-away). It does
+//              NOT submit; instead the selection is reverted to the applied
+//              filter, so the panel always mirrors what is actually applied.
+//
+// The applied filter is read from the backlog show URL, which is the single
+// source of truth for both the "has it changed?" check (Apply/Clear enablement)
+// and the revert target. That base URL is provided as a value so navigation
+// always targets the backlog list endpoint, even when the page URL is a
+// split-view details route (/backlogs/backlog/details/:id) whose frame would
+// otherwise render the split view instead of the list. The selection is
+// serialized into the compact comma form (?bucket_ids=1,2,inbox);
+// Backlogs::BacklogFilters parses both that and the legacy array form on the
+// server.
+export default class BacklogFilterSelectPanelController extends Controller<HTMLElement> {
+  static values = {
+    filterKey: String,
+    baseUrl: String,
+  };
+
+  static targets = ['applyButton', 'clearButton'];
+
+  declare filterKeyValue:string;
+  declare baseUrlValue:string;
+  declare readonly hasBaseUrlValue:boolean;
+  declare readonly applyButtonTarget:HTMLButtonElement;
+  declare readonly clearButtonTarget:HTMLButtonElement;
+  declare readonly hasApplyButtonTarget:boolean;
+  declare readonly hasClearButtonTarget:boolean;
+
+  // Suppresses re-entrancy: Primer's checkItem/uncheckItem fire itemActivated,
+  // which would otherwise recurse through refreshButtons while we are setting
+  // the selection programmatically.
+  private reverting = false;
+
+  // Each controller submits at most once; the frame reload that follows
+  // replaces it. Also tells the close handler that a submit is in flight, so it
+  // does not revert a selection that is about to be re-rendered.
+  private submitted = false;
+
+  refreshButtons():void {
+    if (this.reverting) return;
+
+    const current = this.selectedValues();
+    if (this.hasApplyButtonTarget) {
+      this.applyButtonTarget.disabled = sameMembers(current, this.appliedValues());
+    }
+    if (this.hasClearButtonTarget) {
+      this.clearButtonTarget.disabled = current.length === 0;
+    }
+  }
+
+  revertOnClose():void {
+    if (this.submitted) return; // a submit is navigating; the reload will re-render
+
+    this.setSelection([...this.appliedValues()]);
+    this.refreshButtons();
+  }
+
+  apply():void {
+    this.navigateWith(this.selectedValues());
+  }
+
+  clear():void {
+    this.setSelection([]);
+    this.refreshButtons();
+
+    // Navigating reloads the frame, which closes the panel. When the filter is
+    // already empty there is nothing to submit, so close the panel directly.
+    if (!this.navigateWith([])) {
+      this.panel?.hide();
+    }
+  }
+
+  // Navigation seam: overridable so specs can assert the target URL without
+  // stubbing the Turbo module.
+  protected visit(url:string):void {
+    Turbo.visit(url, { frame: FRAME_ID, action: 'advance' });
+  }
+
+  // Returns false (no navigation) when the selection already matches the
+  // applied filter.
+  private navigateWith(values:string[]):boolean {
+    if (this.submitted || sameMembers(values, this.appliedValues())) return false;
+
+    const url = this.baseUrl();
+    if (values.length > 0) {
+      url.searchParams.set(this.filterKeyValue, values.join(','));
+    } else {
+      url.searchParams.delete(this.filterKeyValue);
+    }
+
+    this.submitted = true;
+    this.visit(url.toString());
+    return true;
+  }
+
+  private setSelection(values:string[]):void {
+    const panel = this.panel;
+    if (!panel) return;
+
+    const wanted = new Set(values);
+    this.reverting = true;
+    panel.items.forEach((item) => {
+      const value = this.itemValue(item);
+      if (value === null) return;
+
+      if (wanted.has(value)) {
+        panel.checkItem(item);
+      } else {
+        panel.uncheckItem(item);
+      }
+    });
+    this.reverting = false;
+  }
+
+  private selectedValues():string[] {
+    return (this.panel?.selectedItems ?? [])
+      .map((item) => item.value)
+      .filter((value):value is string => value != null && value.length > 0);
+  }
+
+  private appliedValues():Set<string> {
+    const raw = this.baseUrl().searchParams.get(this.filterKeyValue);
+    return new Set(raw ? raw.split(',').map((value) => value.trim()).filter(Boolean) : []);
+  }
+
+  // The navigation/applied-state base: the configured backlog show URL with the
+  // live query string layered on, so other panels' filter params survive and
+  // navigation never targets the split-view details route. Falls back to the
+  // page URL when no base is configured.
+  private baseUrl():URL {
+    const base = this.hasBaseUrlValue
+      ? new URL(this.baseUrlValue, window.location.origin)
+      : new URL(window.location.href);
+    base.search = window.location.search;
+    return base;
+  }
+
+  // Swappable once Primer exposes a public value accessor on panel items.
+  private itemValue(item:SelectPanelItem):string|null {
+    return item.querySelector('.ActionListContent')?.getAttribute('data-value') ?? null;
+  }
+
+  private get panel():SelectPanelElement|null {
+    return this.element.querySelector<SelectPanelElement>('select-panel');
+  }
+}
+
+// Order-insensitive comparison of two value collections.
+function sameMembers(a:Iterable<string>, b:Iterable<string>):boolean {
+  return key(a) === key(b);
+}
+
+function key(values:Iterable<string>):string {
+  return [...values].filter(Boolean).sort()
+    .join(',');
+}

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog-filter-select-panel.controller.ts
@@ -43,19 +43,26 @@ const FRAME_ID = 'backlogs_container';
 //              NOT submit; instead the selection is reverted to the applied
 //              filter, so the panel always mirrors what is actually applied.
 //
-// The applied filter is read from the URL, which is the single source of truth
-// for both the "has it changed?" check (Apply/Clear enablement) and the revert
-// target. The selection is serialized into the compact comma form
-// (?bucket_ids=1,2,inbox); Backlogs::BacklogFilters parses both that and the
-// legacy array form on the server.
+// The applied filter is read from the backlog show URL, which is the single
+// source of truth for both the "has it changed?" check (Apply/Clear enablement)
+// and the revert target. That base URL is provided as a value so navigation
+// always targets the backlog list endpoint, even when the page URL is a
+// split-view details route (/backlogs/backlog/details/:id) whose frame would
+// otherwise render the split view instead of the list. The selection is
+// serialized into the compact comma form (?bucket_ids=1,2,inbox);
+// Backlogs::BacklogFilters parses both that and the legacy array form on the
+// server.
 export default class BacklogFilterSelectPanelController extends Controller<HTMLElement> {
   static values = {
     filterKey: String,
+    baseUrl: String,
   };
 
   static targets = ['applyButton', 'clearButton'];
 
   declare filterKeyValue:string;
+  declare baseUrlValue:string;
+  declare readonly hasBaseUrlValue:boolean;
   declare readonly applyButtonTarget:HTMLButtonElement;
   declare readonly clearButtonTarget:HTMLButtonElement;
   declare readonly hasApplyButtonTarget:boolean;
@@ -116,7 +123,7 @@ export default class BacklogFilterSelectPanelController extends Controller<HTMLE
   private navigateWith(values:string[]):boolean {
     if (this.submitted || sameMembers(values, this.appliedValues())) return false;
 
-    const url = new URL(window.location.href);
+    const url = this.baseUrl();
     if (values.length > 0) {
       url.searchParams.set(this.filterKeyValue, values.join(','));
     } else {
@@ -154,8 +161,20 @@ export default class BacklogFilterSelectPanelController extends Controller<HTMLE
   }
 
   private appliedValues():Set<string> {
-    const raw = new URL(window.location.href).searchParams.get(this.filterKeyValue);
+    const raw = this.baseUrl().searchParams.get(this.filterKeyValue);
     return new Set(raw ? raw.split(',').map((value) => value.trim()).filter(Boolean) : []);
+  }
+
+  // The navigation/applied-state base: the configured backlog show URL with the
+  // live query string layered on, so other panels' filter params survive and
+  // navigation never targets the split-view details route. Falls back to the
+  // page URL when no base is configured.
+  private baseUrl():URL {
+    const base = this.hasBaseUrlValue
+      ? new URL(this.baseUrlValue, window.location.origin)
+      : new URL(window.location.href);
+    base.search = window.location.search;
+    return base;
   }
 
   // Swappable once Primer exposes a public value accessor on panel items.

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
@@ -12,9 +12,9 @@
         )
       ) do |panel| %>
     <% panel.with_show_button(**show_button_arguments) do |button| %>
-      <% button.with_trailing_visual_icon(icon: :"triangle-down", color: :default) %>
+      <% button.with_trailing_visual_counter(**counter_arguments) %>
+      <% button.with_trailing_action_icon(icon: :"triangle-down") %>
       <%= t(".label_#{filter_field_name}_filter", count:) %>
-      <%= render Primer::Beta::Counter.new(**counter_arguments) %>
     <% end %>
 
     <% items.each do |item| %>

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
@@ -1,56 +1,51 @@
-<%= form_with(
-      url: project_backlogs_backlog_path(project),
-      method: :get,
-      id: clear_form_id,
-      data: { turbo_frame: "backlogs_container", turbo_action: "advance" }
-    ) do %>
-  <% filter_fields_for.each do |input| %>
-    <%= hidden_field_tag *input %>
-  <% end %>
-<% end %>
-
-<%= primer_form_with(
-      url: project_backlogs_backlog_path(project), method: :get,
-      data: { turbo_frame: "backlogs_container", turbo_action: "advance" }
-    ) do |f| %>
-  <% filter_fields_for.each do |input| %>
-    <%= hidden_field_tag *input %>
-  <% end %>
+<div
+  data-controller="backlogs--backlog-filter-select-panel"
+  data-backlogs--backlog-filter-select-panel-filter-key-value="<%= filter_field %>"
+  data-action="itemActivated->backlogs--backlog-filter-select-panel#refreshButtons
+               panelClosed->backlogs--backlog-filter-select-panel#revertOnClose">
   <%= render(
         Primer::Alpha::SelectPanel.new(
           select_variant: :multiple,
           fetch_strategy: :local,
-          form_arguments: { builder: f, name: filter_field },
           title: t(".select_panel_title")
         )
       ) do |panel| %>
-        <% panel.with_show_button(**show_button_arguments) do |button| %>
-          <% button.with_trailing_visual_icon(icon: :"triangle-down", color: :default) %>
-          <%= t(".label_#{filter_field_name}_filter", count:) %>
-          <%= render Primer::Beta::Counter.new(**counter_arguments) %>
-        <% end %>
+    <% panel.with_show_button(**show_button_arguments) do |button| %>
+      <% button.with_trailing_visual_icon(icon: :"triangle-down", color: :default) %>
+      <%= t(".label_#{filter_field_name}_filter", count:) %>
+      <%= render Primer::Beta::Counter.new(**counter_arguments) %>
+    <% end %>
 
-        <% items.each do |item|
-             panel.with_item(
-               label: item.name,
-               active: selected_ids&.include?(item.id) || false,
-               content_arguments: { data: { value: item.id } }
-             )
-           end %>
+    <% items.each do |item| %>
+      <% panel.with_item(
+           label: item.name,
+           active: selected_ids&.include?(item.id) || false,
+           content_arguments: { data: { value: item.id } }
+         ) %>
+    <% end %>
 
-        <% panel.with_footer(show_divider: true) do %>
-          <%= render(
-                Primer::Beta::Button.new(
-                  scheme: :secondary,
-                  type: :submit,
-                  form: clear_form_id,
-                  data: { turbo_submits_with: t(:button_clear) }
-                )
-              ) { t(:button_clear) } %>
+    <% panel.with_footer(show_divider: true) do %>
+      <%= render(
+            Primer::Beta::Button.new(
+              scheme: :secondary,
+              disabled: selected_ids.blank?,
+              data: {
+                action: "click->backlogs--backlog-filter-select-panel#clear",
+                backlogs__backlog_filter_select_panel_target: "clearButton"
+              }
+            )
+          ) { t(:button_clear) } %>
 
-          <%= render(
-                Primer::Beta::Button.new(scheme: :primary, type: :submit)
-              ) { t(:button_apply) } %>
-        <% end %>
-      <% end %>
-<% end %>
+      <%= render(
+            Primer::Beta::Button.new(
+              scheme: :primary,
+              disabled: true,
+              data: {
+                action: "click->backlogs--backlog-filter-select-panel#apply",
+                backlogs__backlog_filter_select_panel_target: "applyButton"
+              }
+            )
+          ) { t(:button_apply) } %>
+    <% end %>
+  <% end %>
+</div>

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
@@ -5,6 +5,7 @@
                panelClosed->backlogs--backlog-filter-select-panel#revertOnClose">
   <%= render(
         Primer::Alpha::SelectPanel.new(
+          id: panel_id,
           select_variant: :multiple,
           fetch_strategy: :local,
           title: t(".select_panel_title")
@@ -18,6 +19,7 @@
 
     <% items.each do |item| %>
       <% panel.with_item(
+           id: item_id(item),
            label: item.name,
            active: selected_ids&.include?(item.id) || false,
            content_arguments: { data: { value: item.id } }

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
@@ -1,56 +1,54 @@
-<%= form_with(
-      url: project_backlogs_backlog_path(project),
-      method: :get,
-      id: clear_form_id,
-      data: { turbo_frame: "backlogs_container", turbo_action: "advance" }
-    ) do %>
-  <% filter_fields_for.each do |input| %>
-    <%= hidden_field_tag *input %>
-  <% end %>
-<% end %>
-
-<%= primer_form_with(
-      url: project_backlogs_backlog_path(project), method: :get,
-      data: { turbo_frame: "backlogs_container", turbo_action: "advance" }
-    ) do |f| %>
-  <% filter_fields_for.each do |input| %>
-    <%= hidden_field_tag *input %>
-  <% end %>
+<div
+  data-controller="backlogs--backlog-filter-select-panel"
+  data-backlogs--backlog-filter-select-panel-filter-key-value="<%= filter_field %>"
+  data-backlogs--backlog-filter-select-panel-base-url-value="<%= backlog_show_path %>"
+  data-action="itemActivated->backlogs--backlog-filter-select-panel#refreshButtons
+               panelClosed->backlogs--backlog-filter-select-panel#revertOnClose">
   <%= render(
         Primer::Alpha::SelectPanel.new(
+          id: panel_id,
           select_variant: :multiple,
           fetch_strategy: :local,
-          form_arguments: { builder: f, name: filter_field },
           title: t(".select_panel_title")
         )
       ) do |panel| %>
-        <% panel.with_show_button(**show_button_arguments) do |button| %>
-          <% button.with_trailing_visual_counter(**counter_arguments) %>
-          <% button.with_trailing_action_icon(icon: :"triangle-down", color: :default) %>
-          <%= t(".label_#{filter_field_name}_filter", count:) %>
-        <% end %>
+    <% panel.with_show_button(**show_button_arguments) do |button| %>
+      <% button.with_trailing_visual_counter(**counter_arguments) %>
+      <% button.with_trailing_action_icon(icon: :"triangle-down") %>
+      <%= t(".label_#{filter_field_name}_filter", count:) %>
+    <% end %>
 
-        <% items.each do |item|
-             panel.with_item(
-               label: item.name,
-               active: selected_ids&.include?(item.id) || false,
-               content_arguments: { data: { value: item.id } }
-             )
-           end %>
+    <% items.each do |item| %>
+      <% panel.with_item(
+           id: item_id(item),
+           label: item.name,
+           active: selected_ids&.include?(item.id) || false,
+           content_arguments: { data: { value: item.id } }
+         ) %>
+    <% end %>
 
-        <% panel.with_footer(show_divider: true) do %>
-          <%= render(
-                Primer::Beta::Button.new(
-                  scheme: :secondary,
-                  type: :submit,
-                  form: clear_form_id,
-                  data: { turbo_submits_with: t(:button_clear) }
-                )
-              ) { t(:button_clear) } %>
+    <% panel.with_footer(show_divider: true) do %>
+      <%= render(
+            Primer::Beta::Button.new(
+              scheme: :secondary,
+              disabled: selected_ids.blank?,
+              data: {
+                action: "click->backlogs--backlog-filter-select-panel#clear",
+                backlogs__backlog_filter_select_panel_target: "clearButton"
+              }
+            )
+          ) { t(:button_clear) } %>
 
-          <%= render(
-                Primer::Beta::Button.new(scheme: :primary, type: :submit)
-              ) { t(:button_apply) } %>
-        <% end %>
-      <% end %>
-<% end %>
+      <%= render(
+            Primer::Beta::Button.new(
+              scheme: :primary,
+              disabled: true,
+              data: {
+                action: "click->backlogs--backlog-filter-select-panel#apply",
+                backlogs__backlog_filter_select_panel_target: "applyButton"
+              }
+            )
+          ) { t(:button_apply) } %>
+    <% end %>
+  <% end %>
+</div>

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.html.erb
@@ -1,6 +1,7 @@
 <div
   data-controller="backlogs--backlog-filter-select-panel"
   data-backlogs--backlog-filter-select-panel-filter-key-value="<%= filter_field %>"
+  data-backlogs--backlog-filter-select-panel-base-url-value="<%= backlog_show_path %>"
   data-action="itemActivated->backlogs--backlog-filter-select-panel#refreshButtons
                panelClosed->backlogs--backlog-filter-select-panel#revertOnClose">
   <%= render(

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
@@ -47,10 +47,7 @@ module Backlogs
     def filter_fields_for
       backlog_filter_params
         .except(filter_field)
-        .flat_map do |name, value|
-          field_name = value.is_a?(Array) ? "#{name}[]" : name
-          Array(value).map { |v| [field_name, v, { id: nil }] }
-        end
+        .map { |name, value| [name, value, { id: nil }] }
     end
 
     def items

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
@@ -44,6 +44,14 @@ module Backlogs
 
     private
 
+    def panel_id
+      dom_target(filter_field_name, :filter_select_panel)
+    end
+
+    def item_id(item)
+      dom_target(panel_id, :item, item.id.to_s)
+    end
+
     def items
       if filter_field == :sprint_ids
         all_sprints_for(project)

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
@@ -71,7 +71,7 @@ module Backlogs
     def counter_arguments
       aria = { label: I18n.t(:label_x_items, count:), live: "polite" }
 
-      { count:, hide_if_zero: true, ml: 2, aria: }
+      { count:, hide_if_zero: true, aria: }
     end
 
     def show_button_arguments

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
@@ -44,12 +44,6 @@ module Backlogs
 
     private
 
-    def filter_fields_for
-      backlog_filter_params
-        .except(filter_field)
-        .map { |name, value| [name, value, { id: nil }] }
-    end
-
     def items
       if filter_field == :sprint_ids
         all_sprints_for(project)
@@ -86,10 +80,6 @@ module Backlogs
 
     def filter_field_name
       filter_field == :sprint_ids ? "sprint" : "backlog_bucket"
-    end
-
-    def clear_form_id
-      "#{filter_field_name}-clear-form"
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
@@ -44,13 +44,16 @@ module Backlogs
 
     private
 
-    def filter_fields_for
-      backlog_filter_params
-        .except(filter_field)
-        .flat_map do |name, value|
-          field_name = value.is_a?(Array) ? "#{name}[]" : name
-          Array(value).map { |v| [field_name, v, { id: nil }] }
-        end
+    def panel_id
+      dom_target(filter_field_name, :filter_select_panel)
+    end
+
+    def backlog_show_path
+      project_backlogs_backlog_path(project)
+    end
+
+    def item_id(item)
+      dom_target(panel_id, :item, item.id.to_s)
     end
 
     def items
@@ -89,10 +92,6 @@ module Backlogs
 
     def filter_field_name
       filter_field == :sprint_ids ? "sprint" : "backlog_bucket"
-    end
-
-    def clear_form_id
-      "#{filter_field_name}-clear-form"
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_select_panel_component.rb
@@ -48,6 +48,10 @@ module Backlogs
       dom_target(filter_field_name, :filter_select_panel)
     end
 
+    def backlog_show_path
+      project_backlogs_backlog_path(project)
+    end
+
     def item_id(item)
       dom_target(panel_id, :item, item.id.to_s)
     end

--- a/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
@@ -32,22 +32,41 @@ module Backlogs
   BacklogFilters = Data.define(:bucket_ids, :sprint_ids, :show_all) do
     def self.from_params(params)
       new(
-        bucket_ids: Array(params[:bucket_ids]).filter_map do |id|
-                      id == "inbox" ? "inbox" : id.to_i.nonzero?
-                    end.presence,
-        sprint_ids: Array(params[:sprint_ids]).filter_map { |id| id.to_i.nonzero? }.presence,
+        bucket_ids: parse_ids(params[:bucket_ids]) { |id| id == "inbox" ? "inbox" : id.to_i.nonzero? },
+        sprint_ids: parse_ids(params[:sprint_ids]) { |id| id.to_i.nonzero? },
         show_all: ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
       )
     end
+
+    # Coerces a raw filter param into a deduplicated list of ids, or nil when
+    # empty. Accepts both the compact comma-delimited form ("1,2,inbox") and a
+    # plain array (["1", "2"]). Tampered or nested structures (e.g. the URL
+    # +?bucket_ids[0]=5+, which arrives as a Hash/ActionController::Parameters)
+    # are ignored rather than raising.
+    def self.parse_ids(raw, &)
+      tokenize(raw).filter_map(&).uniq.presence
+    end
+
+    def self.tokenize(raw)
+      case raw
+      when String then raw.split(",")
+      when Array then raw
+      else []
+      end.filter_map { |value| value.to_s.strip.presence }
+    end
+    private_class_method :tokenize
 
     def show_inbox?
       bucket_ids.nil? || bucket_ids.include?("inbox")
     end
 
+    # Serializes back to query params, joining id lists into the compact
+    # comma-delimited form so generated URLs stay bookmarkable
+    # (+?bucket_ids=1,2+ rather than +?bucket_ids[]=1&bucket_ids[]=2+).
     def to_h
       result = show_all? ? { all: true } : {}
-      result[:bucket_ids] = bucket_ids if bucket_ids
-      result[:sprint_ids] = sprint_ids if sprint_ids
+      result[:bucket_ids] = bucket_ids.join(",") if bucket_ids
+      result[:sprint_ids] = sprint_ids.join(",") if sprint_ids
       result
     end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
@@ -44,7 +44,7 @@ module OpenProject::Backlogs::Patches::PermittedParamsPatch
     end
 
     def backlog_filters
-      params.permit(:all, bucket_ids: [], sprint_ids: [])
+      params.permit(:all, :bucket_ids, :sprint_ids, bucket_ids: [], sprint_ids: [])
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
@@ -88,26 +88,23 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
   describe "hidden filter fields" do
     it "passes through sprint_ids when rendering the bucket panel" do
       render_component(field_name: :bucket_ids, sprint_ids: ["1"])
-      expect(page).to have_field("sprint_ids[]", type: :hidden, with: "1", visible: :all)
+      expect(page).to have_field("sprint_ids", type: :hidden, with: "1", visible: :all)
     end
 
     it "passes through bucket_ids when rendering the sprint panel" do
       render_component(field_name: :sprint_ids, bucket_ids: ["2"])
-      expect(page).to have_field("bucket_ids[]", type: :hidden, with: "2", visible: :all)
+      expect(page).to have_field("bucket_ids", type: :hidden, with: "2", visible: :all)
     end
 
-    it "expands array values into multiple hidden inputs" do
+    it "joins array values into a single comma-delimited hidden input" do
       render_component(field_name: :sprint_ids, bucket_ids: [1, 2])
-      expect(page).to have_field("bucket_ids[]", type: :hidden, with: "1", visible: :all)
-      expect(page).to have_field("bucket_ids[]", type: :hidden, with: "2", visible: :all)
+      expect(page).to have_field("bucket_ids", type: :hidden, with: "1,2", visible: :all)
     end
 
-    it "passes through scalar params as a single hidden input without brackets" do
+    it "renders each passthrough param once per form (clear + filter)" do
       render_component(field_name: :sprint_ids, all: true)
-      # The clear form has 1 `all`, the filter form has 1 `all` and 1 `sprint_ids[]` parameter
-      expect(page).to have_field(type: :hidden, count: 3, visible: :all)
+      # The clear form carries 1 `all`, the filter form carries another.
       expect(page).to have_field("all", type: :hidden, with: "true", count: 2, visible: :all)
-      expect(page).to have_field("sprint_ids[]", type: :hidden, count: 1, visible: :all)
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
@@ -85,26 +85,49 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
     end
   end
 
-  describe "hidden filter fields" do
-    it "passes through sprint_ids when rendering the bucket panel" do
-      render_component(field_name: :bucket_ids, sprint_ids: ["1"])
-      expect(page).to have_field("sprint_ids", type: :hidden, with: "1", visible: :all)
+  describe "submission wiring" do
+    it "wires the panel root to refresh buttons on change and revert on close" do
+      render_component(field_name: :bucket_ids)
+
+      expect(page).to have_css(
+        "[data-controller='backlogs--backlog-filter-select-panel']" \
+        "[data-backlogs--backlog-filter-select-panel-filter-key-value='bucket_ids']" \
+        "[data-action*='itemActivated->backlogs--backlog-filter-select-panel#refreshButtons']" \
+        "[data-action*='panelClosed->backlogs--backlog-filter-select-panel#revertOnClose']"
+      )
     end
 
-    it "passes through bucket_ids when rendering the sprint panel" do
-      render_component(field_name: :sprint_ids, bucket_ids: ["2"])
-      expect(page).to have_field("bucket_ids", type: :hidden, with: "2", visible: :all)
+    it "renders the Apply button disabled and wired to the apply action" do
+      render_component(field_name: :sprint_ids)
+
+      apply = page.find(
+        "button[data-action='click->backlogs--backlog-filter-select-panel#apply']",
+        visible: :all
+      )
+      expect(apply).to be_disabled
+      expect(apply).to have_text(I18n.t(:button_apply))
+      expect(apply["data-backlogs--backlog-filter-select-panel-target"]).to eq("applyButton")
     end
 
-    it "joins array values into a single comma-delimited hidden input" do
-      render_component(field_name: :sprint_ids, bucket_ids: [1, 2])
-      expect(page).to have_field("bucket_ids", type: :hidden, with: "1,2", visible: :all)
+    it "disables the Clear button when no filter is selected" do
+      render_component(field_name: :bucket_ids)
+
+      clear = page.find(
+        "button[data-action='click->backlogs--backlog-filter-select-panel#clear']",
+        visible: :all
+      )
+      expect(clear).to be_disabled
+      expect(clear["data-backlogs--backlog-filter-select-panel-target"]).to eq("clearButton")
     end
 
-    it "renders each passthrough param once per form (clear + filter)" do
-      render_component(field_name: :sprint_ids, all: true)
-      # The clear form carries 1 `all`, the filter form carries another.
-      expect(page).to have_field("all", type: :hidden, with: "true", count: 2, visible: :all)
+    it "enables the Clear button when a filter is already selected" do
+      render_component(field_name: :bucket_ids, bucket_ids: ["1"])
+
+      clear = page.find(
+        "button[data-action='click->backlogs--backlog-filter-select-panel#clear']",
+        visible: :all
+      )
+      expect(clear).not_to be_disabled
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
       expect(page).to have_css("[aria-selected='true']", text: "Alpha Sprint")
       expect(page).to have_css("[aria-selected='false']", text: "Beta Sprint")
     end
+
+    it "scopes each item id under the panel id" do
+      render_component(field_name: :sprint_ids)
+      expect(page).to have_css("#sprint_filter_select_panel_item_#{sprint1.id}", visible: :all, text: "Alpha Sprint")
+      expect(page).to have_css("#sprint_filter_select_panel_item_#{sprint2.id}", visible: :all, text: "Beta Sprint")
+    end
   end
 
   describe "bucket panel" do
@@ -82,6 +88,29 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
       render_component(field_name: :bucket_ids, bucket_ids: [bucket2.id])
       expect(page).to have_element(aria: { selected: false }, text: "Ideas")
       expect(page).to have_element(aria: { selected: true }, text: "Backlog")
+    end
+
+    it "scopes each item id under the panel id, including the inbox sentinel" do
+      render_component(field_name: :bucket_ids)
+      expect(page).to have_css("#backlog_bucket_filter_select_panel_item_#{bucket1.id}", visible: :all, text: "Ideas")
+      expect(page).to have_css("#backlog_bucket_filter_select_panel_item_#{bucket2.id}", visible: :all, text: "Backlog")
+      expect(page).to have_css("#backlog_bucket_filter_select_panel_item_inbox", visible: :all, text: I18n.t(:label_inbox))
+    end
+  end
+
+  describe "stable DOM ids" do
+    it "derives the sprint panel and its trigger button ids from the field name" do
+      render_component(field_name: :sprint_ids)
+
+      expect(page).to have_css("#sprint_filter_select_panel", visible: :all)
+      expect(page).to have_css("#sprint_filter_select_panel-button", visible: :all)
+    end
+
+    it "derives the bucket panel and its trigger button ids from the field name" do
+      render_component(field_name: :bucket_ids)
+
+      expect(page).to have_css("#backlog_bucket_filter_select_panel", visible: :all)
+      expect(page).to have_css("#backlog_bucket_filter_select_panel-button", visible: :all)
     end
   end
 

--- a/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
@@ -31,6 +31,8 @@
 require "rails_helper"
 
 RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
 
@@ -61,6 +63,12 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
       expect(page).to have_css("[aria-selected='true']", text: "Alpha Sprint")
       expect(page).to have_css("[aria-selected='false']", text: "Beta Sprint")
     end
+
+    it "scopes each item id under the panel id" do
+      render_component(field_name: :sprint_ids)
+      expect(page).to have_css("#sprint_filter_select_panel_item_#{sprint1.id}", visible: :all, text: "Alpha Sprint")
+      expect(page).to have_css("#sprint_filter_select_panel_item_#{sprint2.id}", visible: :all, text: "Beta Sprint")
+    end
   end
 
   describe "bucket panel" do
@@ -83,31 +91,84 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
       expect(page).to have_element(aria: { selected: false }, text: "Ideas")
       expect(page).to have_element(aria: { selected: true }, text: "Backlog")
     end
+
+    it "scopes each item id under the panel id, including the inbox sentinel" do
+      render_component(field_name: :bucket_ids)
+      expect(page).to have_css("#backlog_bucket_filter_select_panel_item_#{bucket1.id}", visible: :all, text: "Ideas")
+      expect(page).to have_css("#backlog_bucket_filter_select_panel_item_#{bucket2.id}", visible: :all, text: "Backlog")
+      expect(page).to have_css("#backlog_bucket_filter_select_panel_item_inbox", visible: :all, text: I18n.t(:label_inbox))
+    end
   end
 
-  describe "hidden filter fields" do
-    it "passes through sprint_ids when rendering the bucket panel" do
-      render_component(field_name: :bucket_ids, sprint_ids: ["1"])
-      expect(page).to have_field("sprint_ids[]", type: :hidden, with: "1", visible: :all)
+  describe "stable DOM ids" do
+    it "derives the sprint panel and its trigger button ids from the field name" do
+      render_component(field_name: :sprint_ids)
+
+      expect(page).to have_css("#sprint_filter_select_panel", visible: :all)
+      expect(page).to have_css("#sprint_filter_select_panel-button", visible: :all)
     end
 
-    it "passes through bucket_ids when rendering the sprint panel" do
-      render_component(field_name: :sprint_ids, bucket_ids: ["2"])
-      expect(page).to have_field("bucket_ids[]", type: :hidden, with: "2", visible: :all)
+    it "derives the bucket panel and its trigger button ids from the field name" do
+      render_component(field_name: :bucket_ids)
+
+      expect(page).to have_css("#backlog_bucket_filter_select_panel", visible: :all)
+      expect(page).to have_css("#backlog_bucket_filter_select_panel-button", visible: :all)
+    end
+  end
+
+  describe "submission wiring" do
+    it "wires the panel root to refresh buttons on change and revert on close" do
+      render_component(field_name: :bucket_ids)
+
+      expect(page).to have_css(
+        "[data-controller='backlogs--backlog-filter-select-panel']" \
+        "[data-backlogs--backlog-filter-select-panel-filter-key-value='bucket_ids']" \
+        "[data-action*='itemActivated->backlogs--backlog-filter-select-panel#refreshButtons']" \
+        "[data-action*='panelClosed->backlogs--backlog-filter-select-panel#revertOnClose']"
+      )
     end
 
-    it "expands array values into multiple hidden inputs" do
-      render_component(field_name: :sprint_ids, bucket_ids: [1, 2])
-      expect(page).to have_field("bucket_ids[]", type: :hidden, with: "1", visible: :all)
-      expect(page).to have_field("bucket_ids[]", type: :hidden, with: "2", visible: :all)
+    it "exposes the backlog show path as the navigation base url" do
+      render_component(field_name: :bucket_ids)
+
+      expect(page).to have_css(
+        "[data-controller='backlogs--backlog-filter-select-panel']" \
+        "[data-backlogs--backlog-filter-select-panel-base-url-value=" \
+        "'#{project_backlogs_backlog_path(project)}']"
+      )
     end
 
-    it "passes through scalar params as a single hidden input without brackets" do
-      render_component(field_name: :sprint_ids, all: true)
-      # The clear form has 1 `all`, the filter form has 1 `all` and 1 `sprint_ids[]` parameter
-      expect(page).to have_field(type: :hidden, count: 3, visible: :all)
-      expect(page).to have_field("all", type: :hidden, with: "true", count: 2, visible: :all)
-      expect(page).to have_field("sprint_ids[]", type: :hidden, count: 1, visible: :all)
+    it "renders the Apply button disabled and wired to the apply action" do
+      render_component(field_name: :sprint_ids)
+
+      apply = page.find(
+        "button[data-action='click->backlogs--backlog-filter-select-panel#apply']",
+        visible: :all
+      )
+      expect(apply).to be_disabled
+      expect(apply).to have_text(I18n.t(:button_apply))
+      expect(apply["data-backlogs--backlog-filter-select-panel-target"]).to eq("applyButton")
+    end
+
+    it "disables the Clear button when no filter is selected" do
+      render_component(field_name: :bucket_ids)
+
+      clear = page.find(
+        "button[data-action='click->backlogs--backlog-filter-select-panel#clear']",
+        visible: :all
+      )
+      expect(clear).to be_disabled
+      expect(clear["data-backlogs--backlog-filter-select-panel-target"]).to eq("clearButton")
+    end
+
+    it "enables the Clear button when a filter is already selected" do
+      render_component(field_name: :bucket_ids, bucket_ids: ["1"])
+
+      clear = page.find(
+        "button[data-action='click->backlogs--backlog-filter-select-panel#clear']",
+        visible: :all
+      )
+      expect(clear).not_to be_disabled
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filter_select_panel_component_spec.rb
@@ -31,6 +31,8 @@
 require "rails_helper"
 
 RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
 
@@ -123,6 +125,16 @@ RSpec.describe Backlogs::BacklogFilterSelectPanelComponent, type: :component do
         "[data-backlogs--backlog-filter-select-panel-filter-key-value='bucket_ids']" \
         "[data-action*='itemActivated->backlogs--backlog-filter-select-panel#refreshButtons']" \
         "[data-action*='panelClosed->backlogs--backlog-filter-select-panel#revertOnClose']"
+      )
+    end
+
+    it "exposes the backlog show path as the navigation base url" do
+      render_component(field_name: :bucket_ids)
+
+      expect(page).to have_css(
+        "[data-controller='backlogs--backlog-filter-select-panel']" \
+        "[data-backlogs--backlog-filter-select-panel-base-url-value=" \
+        "'#{project_backlogs_backlog_path(project)}']"
       )
     end
 

--- a/modules/backlogs/spec/controllers/backlogs/backlog_filters_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/backlog_filters_spec.rb
@@ -55,6 +55,38 @@ RSpec.describe Backlogs::BacklogFilters, type: :model do
         expect(filters.bucket_ids).to eq([1, 2])
       end
     end
+
+    context "when bucket_ids are a comma-delimited string" do
+      let(:params) { { bucket_ids: "1, 2 ,inbox" } }
+
+      it "splits, trims and preserves the inbox sentinel" do
+        expect(filters.bucket_ids).to eq([1, 2, "inbox"])
+      end
+    end
+
+    context "when bucket_ids repeat" do
+      let(:params) { { bucket_ids: "1,1,2" } }
+
+      it "deduplicates" do
+        expect(filters.bucket_ids).to eq([1, 2])
+      end
+    end
+
+    context "when bucket_ids are a tampered nested structure (?bucket_ids[0]=5)" do
+      let(:params) { ActionController::Parameters.new(bucket_ids: { "0" => "5" }) }
+
+      it "ignores them without raising" do
+        expect(filters.bucket_ids).to be_nil
+      end
+    end
+
+    context "when bucket_ids are a tampered array of structures (?bucket_ids[][x]=5)" do
+      let(:params) { ActionController::Parameters.new(bucket_ids: [{ "x" => "5" }]) }
+
+      it "ignores them without raising" do
+        expect(filters.bucket_ids).to be_nil
+      end
+    end
   end
 
   describe "#sprint_ids" do
@@ -119,8 +151,8 @@ RSpec.describe Backlogs::BacklogFilters, type: :model do
     context "with bucket_ids and sprint_ids" do
       let(:params) { { bucket_ids: %w[1 2], sprint_ids: %w[3] } }
 
-      it "includes both" do
-        expect(filters.to_h).to eq({ bucket_ids: [1, 2], sprint_ids: [3] })
+      it "joins both into compact comma-delimited strings" do
+        expect(filters.to_h).to eq({ bucket_ids: "1,2", sprint_ids: "3" })
       end
     end
 
@@ -128,7 +160,15 @@ RSpec.describe Backlogs::BacklogFilters, type: :model do
       let(:params) { { all: "1", bucket_ids: %w[1], sprint_ids: %w[2] } }
 
       it "includes everything" do
-        expect(filters.to_h).to eq({ all: true, bucket_ids: [1], sprint_ids: [2] })
+        expect(filters.to_h).to eq({ all: true, bucket_ids: "1", sprint_ids: "2" })
+      end
+    end
+
+    context "with the inbox sentinel among bucket_ids" do
+      let(:params) { { bucket_ids: ["5", "inbox"] } }
+
+      it "keeps the sentinel in the serialized string" do
+        expect(filters.to_h).to eq({ bucket_ids: "5,inbox" })
       end
     end
   end

--- a/modules/backlogs/spec/features/backlogs/filter_panel_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filter_panel_spec.rb
@@ -157,6 +157,27 @@ RSpec.describe "Backlog filter panel", :js do
     end
   end
 
+  describe "with the work package details pane open" do
+    # Exercises filtering from the split-view route (/backlog/details/:id),
+    # where the page URL is no longer the backlog list. This is coverage for the
+    # scenario, not a tight regression guard: the backlogs_container frame is a
+    # lazy frame whose src always points at the list endpoint, so the list
+    # recovers even if navigation aims elsewhere. The controller-level guard for
+    # the navigation target lives in the Stimulus controller spec.
+    it "applies a filter while the details pane is open" do
+      backlogs_page.open_work_package_details(sprint_a_wp)
+
+      backlogs_page.apply_bucket_filter(bucket_a)
+
+      expect(page).to have_css("#owner_backlogs_container")
+      expect(page).to have_css("#sprint_backlogs_container")
+      backlogs_page.expect_backlog_bucket(bucket_a)
+      backlogs_page.expect_no_backlog_bucket(bucket_b)
+      backlogs_page.expect_sprint(sprint_a)
+      backlogs_page.expect_sprint(sprint_b)
+    end
+  end
+
   describe "filter counter" do
     it "shows no counter when no filter is active and the count when items are selected" do
       backlogs_page.expect_no_filter_count(:sprint)

--- a/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
+++ b/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Backlogs::CommonHelper do
       let(:params) { { bucket_ids: %w[1 2], sprint_ids: %w[3] } }
 
       it "includes both in to_h" do
-        expect(helper.backlog_filters.to_h).to eq({ bucket_ids: [1, 2], sprint_ids: [3] })
+        expect(helper.backlog_filters.to_h).to eq({ bucket_ids: "1,2", sprint_ids: "3" })
       end
     end
   end

--- a/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
+++ b/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Backlogs::CommonHelper do
       let(:params) { { bucket_ids: %w[1 2], sprint_ids: %w[3] } }
 
       it "includes both in to_h" do
-        expect(helper.backlog_filters.to_h).to eq({ bucket_ids: [1, 2], sprint_ids: [3] })
+        expect(helper.backlog_filters.to_h).to eq({ bucket_ids: "1,2", sprint_ids: "3" })
       end
     end
 

--- a/modules/backlogs/spec/lib/open_project/backlogs/patches/permitted_params_patch_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/patches/permitted_params_patch_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe PermittedParams do
       end
     end
 
+    context "with bucket_ids and sprint_ids as compact comma-delimited strings" do
+      let(:params) { ActionController::Parameters.new(bucket_ids: "1,2", sprint_ids: "3") }
+
+      it "permits both strings" do
+        expect(permitted).to eq("bucket_ids" => "1,2", "sprint_ids" => "3")
+      end
+    end
+
     context "with the all flag" do
       let(:params) { ActionController::Parameters.new(all: "1") }
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -434,9 +434,8 @@ module Pages
       end
       within_dialog "Select items" do
         sprints.each { |sprint| click_on sprint.name, role: "option" }
-        click_on "Apply"
       end
-      wait_for_network_idle
+      close_filter_panel
     end
 
     def apply_bucket_filter(*buckets, include_inbox: false)
@@ -446,8 +445,16 @@ module Pages
       within_dialog "Select items" do
         buckets.each { |bucket| click_on bucket.name, role: "option" }
         click_on(I18n.t(:label_inbox), role: "option") if include_inbox
-        click_on "Apply"
       end
+      close_filter_panel
+    end
+
+    # Applying closes the select panel, which submits the selection.
+    def close_filter_panel
+      within_dialog "Select items" do
+        click_on I18n.t(:button_apply)
+      end
+      expect(page).to have_no_dialog("Select items")
       wait_for_network_idle
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -676,9 +676,8 @@ module Pages
       end
       within_dialog "Select items" do
         sprints.each { |sprint| click_on sprint.name, role: "option" }
-        click_on "Apply"
       end
-      wait_for_network_idle
+      close_filter_panel
     end
 
     def apply_bucket_filter(*buckets, include_inbox: false)
@@ -688,8 +687,16 @@ module Pages
       within_dialog "Select items" do
         buckets.each { |bucket| click_on bucket.name, role: "option" }
         click_on(I18n.t(:label_inbox), role: "option") if include_inbox
-        click_on "Apply"
       end
+      close_filter_panel
+    end
+
+    # Applying closes the select panel, which submits the selection.
+    def close_filter_panel
+      within_dialog "Select items" do
+        click_on I18n.t(:button_apply)
+      end
+      expect(page).to have_no_dialog("Select items")
       wait_for_network_idle
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-375

# What are you trying to accomplish?

This revives the stale multi-select filter panel work from PR `#23820` (originally AGILE-176) and brings it current with `dev`. It replaces the backlog board's sprint/bucket filter form with a Stimulus-driven panel: a Primer `SelectPanel` with trailing count and clear/apply actions, addressable via stable ids and updating the board without a full page navigation. The branch was merged with `origin/dev` (through `df1aecd1af1`), and a semantic regression introduced by that merge — dev's independent strong-params hardening silently dropping this branch's compact comma-delimited `bucket_ids`/`sprint_ids` filter params — has been diagnosed and fixed with test coverage for both param shapes.

## Screenshots

N/A for this update — no visual changes beyond what `#23820` already documented.

# What approach did you choose and why?

The merge kept the branch's Stimulus-driven panel template over dev's independent slot-swap commit (`7844891efe7`) as the superset resolution — it already includes dev's trailing-counter/action-slot change plus the panel's own `data-controller` wiring, apply/clear actions, and stable ids, so no functionality from either side was dropped.

The one substantive issue found during revival was a merge collision rather than a spec bug: dev's `permitted_params_patch.rb` (`b1ead62f386`, landed 2026-06-22) tightened `bucket_ids`/`sprint_ids` to array-only permitted params, which silently discards the compact comma-delimited string form this branch's controller sends (`?sprint_ids=8` rather than `?sprint_ids[]=8`). That made every server-side filter Apply through the new panel a no-op, and was the root cause of 10 `filter_panel_spec` failures. The fix permits both shapes side by side (`params.permit(:all, :bucket_ids, :sprint_ids, bucket_ids: [], sprint_ids: [])`) rather than reverting either side's independent hardening, and adds a spec case for the compact-string form so the gap can't recur silently. Considered switching to `Backlogs::BacklogFilters.tokenize` doing all the shape handling and permitting the raw keys unconstrained, but keeping explicit permit entries for both shapes stays closer to the strong-params intent dev's commit was going for.

Test results: Vitest controller spec 9/9 (chromium); RSpec controller/component/helper specs 45/45; permitted-params unit spec 8/8 (including the new compact-string case); feature spec `filter_panel_spec.rb` 13/13, re-verified independently twice after the fix. Rubocop and erb_lint are clean on every file this branch touches.

Known accepted limitation: if a filter navigation's frame visit fails outright (network error, aborted request), the panel's Apply/Clear buttons stay disabled until the next page load — the controller's one-shot submit guard relies on the frame reload replacing it, which is the intended lifecycle for controls living inside the `backlogs_container` frame.

One pre-existing issue was found and deliberately **not** fixed here: `start_finish_spec.rb`'s "move unfinished work packages to top/bottom of the backlog" examples are intermittently flaky (~40-60% of runs) on `dev` itself, independent of this branch — confirmed on a clean `origin/dev` baseline with the identical failure signature, and ruled out as the known Selenium `rack_session` login-race flake via screenshot inspection (the page is fully authenticated and correctly rendered on failure). It looks like a Turbo Stream/JS timing race in the complete-sprint / move-unfinished-work-packages flow. This needs its own ticket and branch rather than being folded into this PR.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
