### PR TITLE
Prevent using final pages as parent of new page

### DIFF
--- a/modules/wikis/app/controllers/wikis/concerns/error_handling.rb
+++ b/modules/wikis/app/controllers/wikis/concerns/error_handling.rb
@@ -35,7 +35,11 @@ module Wikis
         in Dry::Validation::Result => failure
           failure.errors(full: true).to_h.values.flatten.join(" ")
         in Adapters::Results::Error => err
-          "An error occurred: #{err.code}, #{err.source}"
+          if I18n.exists?("wikis.errors.#{err.code}")
+            I18n.t("wikis.errors.#{err.code}")
+          else
+            "An unexpected error occurred: #{err.code}, #{err.source}"
+          end
         else
           error.to_s
         end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/commands/create_page.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/commands/create_page.rb
@@ -62,6 +62,8 @@ module Wikis
 
               authenticated(auth_strategy) do |http|
                 handle_response(http.get(rest_url(ref.rest_path))) do |data|
+                  return failure(code: :invalid_parent) if fetch_json(data, "name") != "WebHome"
+
                   success("#{fetch_json(data, 'wiki')}:#{fetch_json(data, 'space')}")
                 end
               end

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -134,6 +134,13 @@ en:
     delete_relation_page_link_confirmation_dialog:
       heading: Delete related wiki page link?
       title: Delete related wiki page link
+    errors:
+      connection_error: Could not connect to the wiki provider.
+      invalid_parent: The selected page is not a valid parent page.
+      invalid_response: The wiki provider responded unexpectedly.
+      missing_token: The user account is not yet connected to the wiki provider.
+      request_failed: The wiki provider experienced an unexpected error.
+      unauthorized: An authorization error occured.
     health_checks:
       authentication:
         existing_token: User token

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/commands/create_page_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/commands/create_page_spec.rb
@@ -84,6 +84,23 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Commands::CreatePage, :disable
         expect(WebMock).not_to have_requested(:put, %r{https://xwiki.local/rest/openproject/documents})
       end
     end
+
+    context "when the parent is a final page", vcr: "xwiki/create_page_invalid_parent" do
+      # For VCR recording set this to the identifier of a final page, i.e. one where the ID does not end in ".WebHome"
+      # For example you can use "Sandbox Test Page 1"
+      let(:parent_identifier) { "76e14" }
+
+      it "returns a :parent_invalid error" do
+        expect(result).to be_failure
+        expect(result.failure.code).to eq(:invalid_parent)
+      end
+
+      it "does not create a page" do
+        result
+
+        expect(WebMock).not_to have_requested(:put, %r{https://xwiki.local/rest/openproject/documents})
+      end
+    end
   end
 
   describe ".derive_page_id" do

--- a/spec/support/fixtures/vcr_cassettes/xwiki/create_page_and_confirm.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/create_page_and_confirm.yml
@@ -27,11 +27,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 12 Jun 2026 07:01:29 GMT
+      - Mon, 22 Jun 2026 07:11:10 GMT
       Set-Cookie:
-      - JSESSIONID=6533D0723B8276B5E0C9F0DF53503F6D; Path=/; HttpOnly
+      - JSESSIONID=9D29DF572D1B1245C0DC709197019EC7; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - Lgex3rjqeBxHH0hyu8cGBQ
+      - Q2mTvZxYrU5KAp9nzlv5lg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -45,7 +45,7 @@ http_interactions:
         Page for RSpec","rawTitle":"Test Page for RSpec","parent":"Main.WebHome","parentId":"xwiki:Main.WebHome","version":"1.1","author":"XWiki.admin","authorName":null,"xwikiRelativeUrl":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/","xwikiAbsoluteUrl":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/","translations":{"links":[],"translations":[],"default":"en"},"syntax":"xwiki/2.1","language":"","majorVersion":1,"minorVersion":1,"hidden":false,"enforceRequiredRights":false,"created":1781247375000,"creator":"XWiki.admin","creatorName":null,"modified":1781247375000,"modifier":"XWiki.admin","modifierName":null,"originalMetadataAuthor":"xwiki:XWiki.admin","originalMetadataAuthorName":null,"comment":"Created
         URL Shortener.","content":"I recreated this page, but it is for RSpec still.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
         Page for RSpec","name":"Test Page for RSpec","type":"space","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 12 Jun 2026 07:01:29 GMT
+  recorded_at: Mon, 22 Jun 2026 07:11:10 GMT
 - request:
     method: put
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:Test%20Page%20for%20RSpec.A%20page%20automatically%20created%20during%20a%20create_page%20test.WebHome
@@ -67,8 +67,8 @@ http_interactions:
       - Bearer <SECRET>
   response:
     status:
-      code: 201
-      message: Created
+      code: 202
+      message: Accepted
     headers:
       Content-Language:
       - en
@@ -77,20 +77,20 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 12 Jun 2026 07:01:29 GMT
+      - Mon, 22 Jun 2026 07:11:10 GMT
       Set-Cookie:
-      - JSESSIONID=ADC41F7E6B022B280D38635BE03C2FF1; Path=/; HttpOnly
+      - JSESSIONID=C9FC39EF8472F667AD66A9ECB63CC8AD; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - Lgex3rjqeBxHH0hyu8cGBQ
+      - Q2mTvZxYrU5KAp9nzlv5lg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
       - 18.3.0
       Content-Length:
-      - '2974'
+      - '3231'
     body:
       encoding: UTF-8
-      string: '{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test","rel":"http://www.xwiki.org/rel/space","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test/pages/WebHome/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/syntaxes","rel":"http://www.xwiki.org/rel/syntaxes","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/openproject/documents","rel":"self","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/classes/Test%20Page%20for%20RSpec.A%20page%20automatically%20created%20during%20a%20create_page%20test.WebHome","rel":"http://www.xwiki.org/rel/class","type":null,"hrefLang":null}],"id":"91d8c","fullName":"Test
+      string: '{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test","rel":"http://www.xwiki.org/rel/space","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test/pages/WebHome/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test/pages/WebHome/objects","rel":"http://www.xwiki.org/rel/objects","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/syntaxes","rel":"http://www.xwiki.org/rel/syntaxes","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/openproject/documents","rel":"self","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/classes/Test%20Page%20for%20RSpec.A%20page%20automatically%20created%20during%20a%20create_page%20test.WebHome","rel":"http://www.xwiki.org/rel/class","type":null,"hrefLang":null}],"id":"91d8c","fullName":"Test
         Page for RSpec.A page automatically created during a create_page test.WebHome","wiki":"xwiki","space":"Test
         Page for RSpec.A page automatically created during a create_page test","name":"WebHome","title":"A
         page automatically created during a create_page test","rawTitle":"A page automatically
@@ -98,7 +98,7 @@ http_interactions:
         Page for RSpec","name":"Test Page for RSpec","type":"space","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/"},{"label":"A
         page automatically created during a create_page test","name":"A page automatically
         created during a create_page test","type":"space","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 12 Jun 2026 07:01:29 GMT
+  recorded_at: Mon, 22 Jun 2026 07:11:10 GMT
 - request:
     method: get
     uri: https://xwiki.local/rest/openproject/documents/91d8c
@@ -126,27 +126,26 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 12 Jun 2026 07:01:29 GMT
+      - Mon, 22 Jun 2026 07:11:10 GMT
       Set-Cookie:
-      - JSESSIONID=D0A3382830FA89629B3D86592A6FF515; Path=/; HttpOnly
+      - JSESSIONID=BB6E6FF41DAE21FD493B5A4377417832; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - Lgex3rjqeBxHH0hyu8cGBQ
+      - Q2mTvZxYrU5KAp9nzlv5lg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
       - 18.3.0
       Content-Length:
-      - '3259'
+      - '3237'
     body:
       encoding: UTF-8
       string: '{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test","rel":"http://www.xwiki.org/rel/space","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test/pages/WebHome/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page%20for%20RSpec/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test/pages/WebHome/objects","rel":"http://www.xwiki.org/rel/objects","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/syntaxes","rel":"http://www.xwiki.org/rel/syntaxes","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/openproject/documents/91d8c","rel":"self","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/classes/Test%20Page%20for%20RSpec.A%20page%20automatically%20created%20during%20a%20create_page%20test.WebHome","rel":"http://www.xwiki.org/rel/class","type":null,"hrefLang":null}],"id":"91d8c","fullName":"Test
         Page for RSpec.A page automatically created during a create_page test.WebHome","wiki":"xwiki","space":"Test
         Page for RSpec.A page automatically created during a create_page test","name":"WebHome","title":"A
         page automatically created during a create_page test","rawTitle":"A page automatically
-        created during a create_page test","parent":"","parentId":"","version":"1.1","author":"XWiki.admin","authorName":null,"xwikiRelativeUrl":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/","xwikiAbsoluteUrl":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/","translations":{"links":[],"translations":[],"default":""},"syntax":"xwiki/2.1","language":"","majorVersion":1,"minorVersion":1,"hidden":false,"enforceRequiredRights":false,"created":1781247689000,"creator":"XWiki.admin","creatorName":null,"modified":1781247689000,"modifier":"XWiki.admin","modifierName":null,"originalMetadataAuthor":"xwiki:XWiki.admin","originalMetadataAuthorName":null,"comment":"Created
-        URL Shortener.","content":"","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
+        created during a create_page test","parent":"","parentId":"","version":"1.1","author":"XWiki.admin","authorName":null,"xwikiRelativeUrl":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/","xwikiAbsoluteUrl":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/","translations":{"links":[],"translations":[],"default":""},"syntax":"xwiki/2.1","language":"","majorVersion":1,"minorVersion":1,"hidden":false,"enforceRequiredRights":false,"created":1781247689000,"creator":"XWiki.admin","creatorName":null,"modified":1781247689000,"modifier":"XWiki.admin","modifierName":null,"originalMetadataAuthor":"xwiki:XWiki.admin","originalMetadataAuthorName":null,"comment":"","content":"","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
         Page for RSpec","name":"Test Page for RSpec","type":"space","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/"},{"label":"A
         page automatically created during a create_page test","name":"A page automatically
         created during a create_page test","type":"space","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20Page%20for%20RSpec/A%20page%20automatically%20created%20during%20a%20create_page%20test/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 12 Jun 2026 07:01:29 GMT
+  recorded_at: Mon, 22 Jun 2026 07:11:10 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/create_page_invalid_parent.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/create_page_invalid_parent.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://xwiki.local/rest/openproject/documents/76e14
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenProject 17.6.0 HTTPX Client
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <SECRET>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Language:
+      - en
+      Content-Script-Type:
+      - text/javascript
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 22 Jun 2026 07:11:10 GMT
+      Set-Cookie:
+      - JSESSIONID=BBAF653F5895BAF72E35CB8678CC4508; Path=/; HttpOnly
+      Xwiki-Form-Token:
+      - Q2mTvZxYrU5KAp9nzlv5lg
+      Xwiki-User:
+      - xwiki:XWiki.admin
+      Xwiki-Version:
+      - 18.3.0
+      Content-Length:
+      - '8157'
+    body:
+      encoding: UTF-8
+      string: '{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox","rel":"http://www.xwiki.org/rel/space","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/WebHome","rel":"http://www.xwiki.org/rel/parent","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/objects","rel":"http://www.xwiki.org/rel/objects","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/syntaxes","rel":"http://www.xwiki.org/rel/syntaxes","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/openproject/documents/76e14","rel":"self","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/classes/Sandbox.TestPage1","rel":"http://www.xwiki.org/rel/class","type":null,"hrefLang":null}],"id":"76e14","fullName":"Sandbox.TestPage1","wiki":"secondwiki","space":"Sandbox","name":"TestPage1","title":"Sandbox
+        Test Page 1","rawTitle":"Sandbox Test Page 1","parent":"Sandbox.WebHome","parentId":"secondwiki:Sandbox.WebHome","version":"1.1","author":"xwiki:XWiki.superadmin","authorName":null,"xwikiRelativeUrl":"https://xwiki.local/wiki/secondwiki/view/Sandbox/TestPage1","xwikiAbsoluteUrl":"https://xwiki.local/wiki/secondwiki/view/Sandbox/TestPage1","translations":{"links":[],"translations":[{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"en"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/de","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/de/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"de"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/ja","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/ja/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"ja"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/lv","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/lv/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"lv"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/hr","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/hr/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"hr"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/uk","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/uk/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"uk"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/mr","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/mr/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"mr"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/ru","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/ru/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"ru"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/en_GB","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/en_GB/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"en_GB"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/fr","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/fr/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"fr"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/ko","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/ko/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"ko"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/pt_BR","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/pt_BR/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"pt_BR"},{"links":[{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/es","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/secondwiki/spaces/Sandbox/pages/TestPage1/translations/es/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null}],"language":"es"}],"default":"en"},"syntax":"xwiki/2.1","language":"","majorVersion":1,"minorVersion":1,"hidden":false,"enforceRequiredRights":false,"created":1780916403000,"creator":"xwiki:XWiki.superadmin","creatorName":null,"modified":1780916403000,"modifier":"xwiki:XWiki.superadmin","modifierName":null,"originalMetadataAuthor":"XWiki.superadmin","originalMetadataAuthorName":null,"comment":"Created
+        URL Shortener.","content":"Click on **\"Edit\"** and modify the contents of
+        this page, then click on **\"Save & View\"** to see how they look like on
+        your page!\n\n= Here''s some dummy text to show you what the page looks like
+        =\n\nLorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+        eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+        sunt in culpa qui officia deserunt mollit anim id est laborum.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"secondwiki","name":"secondwiki","type":"wiki","url":"https://xwiki.local/wiki/secondwiki/view/Main/"},{"label":"Sandbox","name":"Sandbox","type":"space","url":"https://xwiki.local/wiki/secondwiki/view/Sandbox/"},{"label":"TestPage1","name":"TestPage1","type":"document","url":"https://xwiki.local/wiki/secondwiki/view/Sandbox/TestPage1"}]},"rights":[],"renderedContent":null}'
+  recorded_at: Mon, 22 Jun 2026 07:11:10 GMT
+recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/create_page_not_found.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/create_page_not_found.yml
@@ -27,11 +27,11 @@ http_interactions:
       Content-Type:
       - text/html;charset=utf-8
       Date:
-      - Thu, 11 Jun 2026 14:40:01 GMT
+      - Mon, 22 Jun 2026 07:11:10 GMT
       Set-Cookie:
-      - JSESSIONID=D9B95B99F5C18BBBF0957992EE0CBD09; Path=/; HttpOnly
+      - JSESSIONID=F821CE788BE7A7BC6ED84560B7C7F0D4; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - 1FHSxxmCi5SpcFuCzBbysA
+      - Q2mTvZxYrU5KAp9nzlv5lg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -48,5 +48,5 @@ http_interactions:
         Not Found</p><p><b>Description</b> The origin server did not find a current
         representation for the target resource or is not willing to disclose that
         one exists.</p><hr class="line" /><h3>Apache Tomcat/10.1.55</h3></body></html>
-  recorded_at: Thu, 11 Jun 2026 14:40:01 GMT
+  recorded_at: Mon, 22 Jun 2026 07:11:10 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
Final pages are not allowed to be used as a parent of any other page. If we let
those be selected, we'd effectively make the page a sibling of the requested page.

By ensuring that we try to attach to a "WebHome" page, we know that we attach to a space,
not a final page.

# Ticket
https://community.openproject.org/wp/XWI-129