### PR TITLE
[STC-816] Reintroduce spec that was flaky and removed to fix a build

### DIFF
--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe "External links in BlockNote editor",
       )
 
       editor.wait_for_shadow_content("hello world")
+      expect(editor.shadow_root).to have_css("a[target='_blank'] span.sr-only", visible: :all, count: 1)
       hints = editor.shadow_root.all("span.sr-only", visible: :all)
       expect(hints.size).to eq(1)
       expect(hints.first.text(:all)).to include(I18n.t(:open_link_in_a_new_tab))

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -188,8 +188,8 @@ RSpec.describe "External links in BlockNote editor",
         plain: "hello world"
       )
 
-      link = editor.shadow_root.find("a[target='_blank']", text: /hello\s*world/, wait: 5)
-      hints = link.all("span.sr-only", visible: :all)
+      editor.wait_for_shadow_content("hello world")
+      hints = editor.shadow_root.all("span.sr-only", visible: :all)
       expect(hints.size).to eq(1)
       expect(hints.first.text(:all)).to include(I18n.t(:open_link_in_a_new_tab))
     end

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -177,6 +177,23 @@ RSpec.describe "External links in BlockNote editor",
       end
     end
 
+    it "emits exactly one hint when a link spans multiple inline nodes" do
+      # Paste HTML with a nested mark so the resulting <a> contains two adjacent
+      # text nodes ("hello " with only the link mark, "world" with link+bold).
+      # This exercises the sameLinkContinues coalescing path — without it we'd
+      # get a spurious hint after "hello " mid-link.
+      paste_clipboard_into(
+        editor.element,
+        html: '<a href="https://example.com/split">hello <strong>world</strong></a>',
+        plain: "hello world"
+      )
+
+      link = editor.shadow_root.find("a[target='_blank']", text: /hello\s*world/, wait: 5)
+      hints = link.all("span.sr-only", visible: :all)
+      expect(hints.size).to eq(1)
+      expect(hints.first.text(:all)).to include(I18n.t(:open_link_in_a_new_tab))
+    end
+
     it_behaves_like "does not freeze when pasting multiple external links"
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/STC-816

# What are you trying to accomplish?
Reintroduce a spec and make it more robust by checking a little bit different (but keep the essence of the test)

# What approach did you choose and why?
1. Use existing editor helper for waiting until the element is in the DOM - I deem this reliable with the shadow DOM because I used it a lot with other specs in the past
2. Check for the hint, which is allowed to appear only once, in the whole editor content

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
