### PR TITLE
[STC-836] Fixes for the Copy numeric ID feature

### DIFF
--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -158,10 +158,10 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
 
     // Copying the numeric ID is only useful in semantic mode, where the
     // displayed identifier (e.g. "PROJ-42") is not the numeric ID itself.
-    const copyIdAction = actions.find((action) => action.key === 'copy_numeric_id_to_clipboard');
-    if (copyIdAction) {
-      copyIdAction.hidden = !isSemanticWorkPackageId(this.workPackage.displayId);
-    }
+    actions = actions.filter((action) => (
+      action.key !== 'copy_numeric_id_to_clipboard'
+      || isSemanticWorkPackageId(this.workPackage.displayId)
+    ));
 
     // Splice plugin actions onto the core actions
     _.each(this.getPermittedPluginActions(authorization), (action:WorkPackageAction) => {

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
@@ -33,7 +33,7 @@ export const PERMITTED_CONTEXT_MENU_ACTIONS:WorkPackageAction[] = [
   },
   {
     key: 'copy_numeric_id_to_clipboard',
-    icon: 'icon-clipboard',
+    icon: 'icon-code-tag',
     link: 'id',
   },
   {

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
@@ -28,6 +28,7 @@ import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { isSemanticWorkPackageId } from 'core-app/shared/helpers/work-package-id-pattern';
 
 import { Placement } from '@floating-ui/dom';
 
@@ -123,6 +124,10 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
         this.copyToClipboardService.copy(url.toString());
         break;
       }
+      case 'copy_numeric_id_to_clipboard':
+        this.copyToClipboardService.copy(`${id}`);
+        break;
+
       case 'copy_to_other_project':
         window.location.href = `${this.pathHelper.staticBase}/work_packages/move/new?copy=true&ids[]=${id}`;
         break;
@@ -212,7 +217,15 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
 
   protected buildItems():OpContextMenuItem[] {
     const selected = this.getSelectedWorkPackages();
-    const items = this.permittedActions.map((action:WorkPackageAction) => ({
+
+    // Copying the numeric ID is only useful in semantic mode, where the
+    // displayed identifier (e.g. "PROJ-42") is not the numeric ID itself.
+    const visibleActions = this.permittedActions.filter((action) => (
+      action.key !== 'copy_numeric_id_to_clipboard'
+      || isSemanticWorkPackageId(this.workPackage.displayId)
+    ));
+
+    const items = visibleActions.map((action:WorkPackageAction) => ({
       class: undefined as string | undefined,
       disabled: false,
       linkText: action.text,

--- a/spec/features/work_packages/details/context_menu_spec.rb
+++ b/spec/features/work_packages/details/context_menu_spec.rb
@@ -30,4 +30,24 @@ RSpec.describe "Work package single context menu", :js, :selenium do
     # It can either succeed (showing success message) or fail (showing the URL to copy manually).
     expect(page).to have_message_copied_to_clipboard("/wp/#{work_package.id}")
   end
+
+  describe "'Copy numeric ID to clipboard' item" do
+    context "in classic (numeric) mode", with_settings: { work_packages_identifier: "classic" } do
+      it "is not offered (the displayed id is already the numeric id)" do
+        find("button[wpsinglecontextmenu]").click
+        within(".op-context-menu--overlay") do
+          expect(page).to have_no_css(".menu-item", text: "Copy numeric ID to clipboard")
+        end
+      end
+    end
+
+    context "in semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      it "is offered" do
+        find("button[wpsinglecontextmenu]").click
+        within(".op-context-menu--overlay") do
+          expect(page).to have_css(".menu-item", text: "Copy numeric ID to clipboard")
+        end
+      end
+    end
+  end
 end

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -92,6 +92,52 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
     end
   end
 
+  describe "right-click context menu 'Copy numeric ID to clipboard' item" do
+    it "copies the numeric id and does not navigate away (regression: used to 404)" do
+      numeric_id = work_package.id.to_s
+      semantic_id = work_package.reload.identifier
+
+      # Spy directly on navigator.clipboard.writeText (see the sibling
+      # 'Copy link to clipboard' example for why the flash matcher won't do).
+      page.execute_script(<<~JS)
+        window.__lastCopiedText = null;
+        navigator.clipboard.writeText = function(text) {
+          window.__lastCopiedText = text;
+          return Promise.resolve();
+        };
+      JS
+
+      context_menu.open_for(work_package)
+      context_menu.choose("Copy numeric ID to clipboard")
+
+      copied = nil
+      retry_block do
+        copied = page.evaluate_script("window.__lastCopiedText")
+        raise "clipboard write not yet observed" if copied.nil?
+      end
+
+      expect(copied).to eq(numeric_id)
+      expect(copied).not_to eq(semantic_id)
+
+      # The action used to fall through to `window.location.href = undefined`,
+      # navigating to a non-existent URL. It must stay on the table instead.
+      wp_table.expect_work_package_listed(work_package, other_wp)
+    end
+  end
+
+  context "in classic (numeric) mode", with_settings: { work_packages_identifier: "classic" } do
+    # Classic mode validates project identifiers against the lowercase classic
+    # format, so the uppercase semantic identifier used above is invalid here.
+    let(:project) { create(:project, identifier: "navfollow") }
+
+    describe "right-click context menu 'Copy numeric ID to clipboard' item" do
+      it "is not offered (the displayed id is already the numeric id)" do
+        context_menu.open_for(work_package)
+        context_menu.expect_no_options("Copy numeric ID to clipboard")
+      end
+    end
+  end
+
   describe "toolbar info icon" do
     it "opens the split view at the semantic identifier URL" do
       semantic_id = work_package.reload.identifier


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-836/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Address following bugs:

* In semantic mode, newly created wps trigger 404 when we click on that menu item.
* In numeric mode, on the WP listing page, this menu item is visible (triggering the same error) but shouldn't be visible at all.
* We want a different icon for the numeric ID menu item


## Screenshots
<img width="235" height="356" alt="Screenshot 2026-06-22 at 10 28 19" src="https://github.com/user-attachments/assets/d6d699f2-b860-40e7-b3ea-01b6c394e6ba" />


# What approach did you choose and why?
* Add a copy handler to fix the 404
* Add a missing actions filtering mechanism to `WpContextMenuActions`
  * Also, make the pre-existing `WpSingleContextMenu` mechanism switch to this one, as it's cleaner than setting `hidden`
* Change the icon to the recommended one

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
