### PR TITLE
Remove TravisCI references in docs/development/README

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -58,9 +58,9 @@ Please see this separate guide for the [process of building packages of OpenProj
 
 Please add tests to your code to verify functionality, especially if it is a new feature.
 
-Pull requests will be verified by TravisCI as well, but please run them locally as well and make sure they are green before creating your pull request. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
+Pull requests will be verified by the Continuous Integration system (CI) as well, but please run them locally as well and make sure they are green before creating your pull request. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
 
-If you push to your branch in quick succession, please consider stopping the associated Travis builds, as Travis will run for each commit. This is especially true if you force push to the branch.
+If you push to your branch in quick succession, please consider stopping the associated CI builds, as they will run for each commit. This is especially true if you force push to the branch.
 
 Please also use `[ci skip]` in your commit message to suppress builds which are not necessary (e.g. after fixing a typo in the `README`).
 


### PR DESCRIPTION
# What are you trying to accomplish?

Extend on #9360 and remove (last) TravisCI references from the docs.

# Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
