### PR TITLE
[OP-19592] Security page not showing 2FA settings when reached via "Change password" link from *Account settings* widget

### DIFF
--- a/app/components/homescreen/blocks/my_account.html.erb
+++ b/app/components/homescreen/blocks/my_account.html.erb
@@ -8,7 +8,7 @@
                   title: t(:"my_page.label") %>
     </li>
     <li>
-      <%= link_to t(:button_change_password), my_password_path, title: t(:button_change_password) %>
+      <%= link_to t(:button_change_password), my_security_path, title: t(:button_change_password) %>
     </li>
   </ul>
 <% end %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19592

# What are you trying to accomplish?
Update "change password" link to new security page


