### PR TITLE
[STC-806] Documents: impossible to delete characters with backspace after adding a wp link  

### DIFF
--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -42,8 +42,8 @@ import {
   openProjectWorkPackageInlineSpec,
   workPackageSlashMenu,
   useOpBlockNoteExtensions,
-  PasteDeduplicateInstanceIdsExtension,
   useHashWpMenu,
+  OpBlockNoteExtensions,
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo } from 'react';
 import * as Y from 'yjs';
@@ -119,7 +119,7 @@ export function OpBlockNoteEditor({
       dictionary: localeDictionary,
       ...(attachmentsEnabled && { uploadFile }),
       extensions: [
-        PasteDeduplicateInstanceIdsExtension,
+        OpBlockNoteExtensions,
         ExternalLinkA11yExtension,
         ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
       ],


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/STC-806

# What are you trying to accomplish?
Consume the fix for STC-806 from op-blocknote-extensions.
Replaces the deprecated `PasteDeduplicateInstanceIdsExtension` with the new
`OpBlockNoteExtensions`, which bundles both fixes:
- `BackspaceCharDeleteExtension` - fixes Backspace broken after inserting a WP link
- `PasteDeduplicateExtension` - fixes pasted WP chips sharing the same instanceId

# What approach did you choose and why?
Two-line import swap. All implementation details and root cause analysis are in
the op-blocknote-extensions PR: https://github.com/opf/op-blocknote-extensions/pull/165

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
