### PR TITLE
[Dream-725] Missing space on the right side of the project selector

### DIFF
--- a/app/components/header/project_select_component.sass
+++ b/app/components/header/project_select_component.sass
@@ -34,6 +34,12 @@
     margin: var(--base-size-16)
     margin-right: 0
 
+    body.-browser-windows.-browser-firefox &
+      margin-right: var(--base-size-16)
+
+      .FilterableTreeViewLayout > .Stack
+        padding-right: 0
+
   &--frame
     max-height: 100%
     flex-basis: 100%

--- a/app/components/header/project_select_component.sass
+++ b/app/components/header/project_select_component.sass
@@ -34,9 +34,6 @@
     margin: var(--base-size-16)
     margin-right: 0
 
-    body.-browser-windows.-browser-firefox &
-      margin-right: var(--base-size-16)
-
   &--frame
     max-height: 100%
     flex-basis: 100%

--- a/app/components/header/project_select_component.sass
+++ b/app/components/header/project_select_component.sass
@@ -37,9 +37,6 @@
     body.-browser-windows.-browser-firefox &
       margin-right: var(--base-size-16)
 
-      .FilterableTreeViewLayout > .Stack
-        padding-right: 0
-
   &--frame
     max-height: 100%
     flex-basis: 100%

--- a/app/components/header/project_select_component.sass
+++ b/app/components/header/project_select_component.sass
@@ -47,6 +47,10 @@
   &--trigger-button
     min-width: unset
     display: block
+    color: var(--main-menu-font-color)
+
+    .Button-visual
+      color: inherit
 
     .Button-label
       @include text-shortener

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -226,17 +226,11 @@ ul.SegmentedControl,
   .FilterableTreeViewLayout
     > .Stack
       padding-right: var(--base-size-16)
-
-      // Firefox on Windows uses classic scrollbars. The project selector
-      // compensates for that with an outer right margin, so avoid adding
-      // toolbar padding on top of it.
-      body.-browser-windows.-browser-firefox &
-        padding-right: 0
-
     .FilterableTreeViewTreeContainer
       scrollbar-gutter: stable
 
-      // Keep the selected row action away from the classic scrollbar.
+      // Firefox on Windows can render the scrollbar over the tree content,
+      // so keep trailing actions out of that area.
       body.-browser-windows.-browser-firefox &
-        .TreeViewRootUlStyles
-          padding-right: var(--base-size-16)
+        .TreeViewItemContainer
+          width: calc(100% - var(--base-size-16))

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -231,6 +231,7 @@ ul.SegmentedControl,
 
       // Firefox on Windows can render the scrollbar over the tree content,
       // so keep trailing actions out of that area.
+      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1980289
       body.-browser-windows.-browser-firefox &
         .TreeViewItemContainer
           width: calc(100% - var(--base-size-16))

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -226,5 +226,17 @@ ul.SegmentedControl,
   .FilterableTreeViewLayout
     > .Stack
       padding-right: var(--base-size-16)
+
+      // Firefox on Windows uses classic scrollbars. The project selector
+      // compensates for that with an outer right margin, so avoid adding
+      // toolbar padding on top of it.
+      body.-browser-windows.-browser-firefox &
+        padding-right: 0
+
     .FilterableTreeViewTreeContainer
       scrollbar-gutter: stable
+
+      // Keep the selected row action away from the classic scrollbar.
+      body.-browser-windows.-browser-firefox &
+        .TreeViewRootUlStyles
+          padding-right: var(--base-size-16)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-725
https://community.openproject.org/wp/OP-19580

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Adds the missing right-side spacing in Firefox on Windows.
Uses the main-menu color for the selector button and chevron.

## Screenshots
<img width="411" height="182" alt="Screenshot 2026-06-22 at 14 26 05" src="https://github.com/user-attachments/assets/5038e576-3a36-465b-8c03-d4c1d6c93225" />