### PR TITLE
avoid deep hash manipulations to spill over spec boundaries

### DIFF
--- a/spec/support/shared/with_settings.rb
+++ b/spec/support/shared/with_settings.rb
@@ -41,7 +41,20 @@ def aggregate_mocked_settings(example, settings)
 end
 
 RSpec.shared_context "with settings reset" do
-  shared_let(:definitions_before) { Settings::Definition.all.dup }
+  # Snapshot per-Definition mutable state once, captured early enough that
+  # legitimate boot-time mutations (e.g. the 2FA plugin's TokenStrategyManager
+  # populating `active_strategies`) are part of the baseline. Definition
+  # objects are mutated in place by `override_value`, so a shallow `@all.dup`
+  # doesn't restore them — both copies point at the same mutated object.
+  shared_let(:definitions_snapshot) do
+    Settings::Definition.all.transform_values do |definition|
+      {
+        definition: definition,
+        value: definition.instance_variable_get(:@value).deep_dup,
+        writable: definition.instance_variable_get(:@writable)
+      }
+    end.freeze
+  end
 
   def reset(setting, **definitions)
     setting = setting.to_sym
@@ -71,7 +84,22 @@ RSpec.shared_context "with settings reset" do
   end
 
   after do
-    Settings::Definition.instance_variable_set(:@all, definitions_before.dup)
+    # Rewind in-place @value/@writable mutations on each original Definition.
+    definitions_snapshot.each_value do |snap|
+      snap[:definition].instance_variable_set(:@value, snap[:value].deep_dup)
+      snap[:definition].instance_variable_set(:@writable, snap[:writable])
+    end
+
+    # Rebuild @all from the snapshot, dropping Definitions added during the
+    # test (e.g. `described_class.add(:bogus)`).
+    Settings::Definition.instance_variable_set(
+      :@all,
+      definitions_snapshot.transform_values { |snap| snap[:definition] }
+    )
+
+    # Clear block-style overrides registered via add_value_override and the
+    # cached file config so the next test re-reads from disk.
+    Settings::Definition.clear_value_overrides
     Settings::Definition.instance_variable_set(:@file_config, nil)
   end
 end


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Avoid setting spillover e.g. when running

```
rspec './modules/backlogs/spec/requests/backlogs/sprints_spec.rb[1:1:1,1:2:1,1:2:2,1:2:3]' './spec/constants/settings/definition_spec.rb[1:2:6:26:2,1:2:7:5,1:2:7:11:2]' --seed 5065
```
