### PR TITLE
[JIM-113] Migrator: Attachment import with exception

### DIFF
--- a/app/services/import/jira_client.rb
+++ b/app/services/import/jira_client.rb
@@ -260,7 +260,8 @@ module Import
           end
           yield tempfile
         else
-          raise ApiError.new(I18n.t("admin.jira.client.api_error"), status: response.code.to_i, response_body: response.body)
+          status = response.code.to_i
+          raise ApiError.new(I18n.t("admin.jira.client.api_error", status:), status:, response_body: response.body)
         end
       end
       nil

--- a/app/workers/import/jira_import_projects_job.rb
+++ b/app/workers/import/jira_import_projects_job.rb
@@ -358,9 +358,13 @@ module Import
                  .call(container: work_package, filename:, file: tempfile)
 
         call.on_failure do
-          raise call.message
+          OpenProject.logger.error("#{work_package}: Attachment creation failed for #{filename}: #{call.message}")
         end
       end
+    rescue JiraClient::SsrfError,
+           JiraClient::ConnectionError,
+           JiraClient::ApiError => e
+      OpenProject.logger.error("#{work_package}: Download attachment failed for #{filename}: #{e.message}")
     end
 
     def import_member(project, member)

--- a/spec/workers/import/jira_import_projects_job_spec.rb
+++ b/spec/workers/import/jira_import_projects_job_spec.rb
@@ -133,11 +133,12 @@ RSpec.describe Import::JiraImportProjectsJob, :webmock do
         end
 
         let(:attachment_content) { Rails.root.join("spec/fixtures/files/airplane-wing-over-cloudy-sky.jpg").binread }
+        let(:download_attachment_url) { "https://jira-dc.openproject.org/secure/attachment/10100/airplane-wing-over-cloudy-sky.jpg" }
 
         include_context "with ssrf stubs"
 
         before do
-          stub_request(:get, "https://jira-dc.openproject.org/secure/attachment/10100/airplane-wing-over-cloudy-sky.jpg")
+          stub_request(:get, download_attachment_url)
             .to_return(status: 200, body: attachment_content, headers: { "Content-Type" => "image/jpg" })
         end
 
@@ -227,6 +228,22 @@ RSpec.describe Import::JiraImportProjectsJob, :webmock do
         it "creates references for imported entities" do
           expect { described_class.new.perform(jira_import.id) }
             .to change(Import::JiraOpenProjectReference, :count).by_at_least(4)
+        end
+
+        context "when attachment download fails" do
+          before do
+            stub_request(:get, download_attachment_url).to_return(status: 404, body: "Not Found")
+          end
+
+          it "does not fail, but logs the error" do
+            # rubocop:disable RSpec/MessageSpies
+            expect(OpenProject.logger).to receive(:error).with(
+              "Bug DPPP-6: Demo bug: Download attachment failed for airplane-wing-over-cloudy-sky.jpg: " \
+              "Jira API returned error status 404"
+            )
+            # rubocop:enable RSpec/MessageSpies
+            described_class.new.perform(jira_import.id)
+          end
         end
 
         context "when there is issue from a different import run with the same jira_project_id" do


### PR DESCRIPTION
https://community.openproject.org/wp/JIM-113

- Does not fail jira import if jira issue attachemnt is not available. Logs an error instead.
- Fix "Jira API hat den Fehlerstatus %{status} zurückgegeben" issue(no interpolation of status)

