### PR TITLE
Defer loading of page link inline macro

### DIFF
--- a/modules/wikis/app/components/wikis/deferred_inline_page_link_macro_component.html.erb
+++ b/modules/wikis/app/components/wikis/deferred_inline_page_link_macro_component.html.erb
@@ -1,0 +1,37 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= content_tag("turbo-frame", id: frame_id, src: frame_src, data: { provider_id:, page_identifier: identifier, type: "wiki-page-link" }) do %>
+  <%= render(OpPrimer::InlineMacroComponent.new) do |component| %>
+    <% component.with_leading_visual_icon(icon: :"op-file-doc") %>
+
+    <%= render Primer::Beta::Spinner.new(size: :small, display: :flex, mr: 2) %>
+    <%= render(Primer::Beta::Text.new(color: :muted)) { t(".loading") } %>
+  <% end %>
+<% end %>

--- a/modules/wikis/app/components/wikis/deferred_inline_page_link_macro_component.rb
+++ b/modules/wikis/app/components/wikis/deferred_inline_page_link_macro_component.rb
@@ -29,43 +29,29 @@
 #++
 
 module Wikis
-  module TextFormatting
-    class WikiLinkMatcher < OpenProject::TextFormatting::Matchers::RegexMatcher
-      include Dry::Monads[:result]
+  class DeferredInlinePageLinkMacroComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpPrimer::ComponentHelpers
 
-      class << self
-        def applicable?(*)
-          super && OpenProject::FeatureDecisions.wiki_enhancements_active?
-        end
+    attr_reader :identifier, :provider_id
 
-        def regexp
-          /\[\[\[([0-9]+):([^\]\n]+)\]\]\]/
-        end
+    def initialize(identifier:, provider_id:, **)
+      super(nil, **)
 
-        def process_match(match, _matched_string, _context)
-          instance = new(
-            provider_id: match[1],
-            identifier: match[2]
-          )
+      @identifier = identifier
+      @provider_id = provider_id
+    end
 
-          instance.process
-        end
-      end
+    def frame_id
+      @frame_id ||= SecureRandom.uuid
+    end
 
-      attr_reader :provider_id, :identifier
-
-      def initialize(provider_id:, identifier:)
-        super()
-
-        @provider_id = provider_id
-        @identifier = identifier
-      end
-
-      def process
-        view_context = ApplicationController.new.view_context
-
-        DeferredInlinePageLinkMacroComponent.new(provider_id:, identifier:).render_in(view_context)
-      end
+    def frame_src
+      url_helpers.load_wiki_page_link_macro_path(
+        provider_id:,
+        page_identifier: identifier,
+        turbo_frame_id: frame_id
+      )
     end
   end
 end

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -131,6 +131,8 @@ en:
       wiki_page: Wiki page
     create_new_wiki_page_dialog:
       title: Create new wiki page
+    deferred_inline_page_link_macro_component:
+      loading: Loading…
     delete_relation_page_link_confirmation_dialog:
       heading: Delete related wiki page link?
       title: Delete related wiki page link


### PR DESCRIPTION
The main motivation for this is to not include user-specific information in the HTML-rendered formatted text of API responses, because we cache those responses across requests for different users.

This works around the caching issue by ensuring the relevant information is not part of the cache.

An alternative approach would be to ensure the caching is safe across different users.

# Ticket

https://community.openproject.org/wp/XWI-125