### PR TITLE
Bug/STC-642: Fix spurious connection error on repeat document navigation

### DIFF
--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -33,6 +33,12 @@
 
 <% if @document.collaborative? %>
   <% if Setting.real_time_text_collaboration_enabled? %>
+    <% content_for :header_tags do %>
+      <%# Keep this page out of Turbo's snapshot cache: a restored snapshot rebuilds
+          the editor against a stale collaboration token and reconnects the WebSocket,
+          which the editor briefly surfaces as a spurious offline banner (STC-642). %>
+      <meta name="turbo-cache-control" content="no-cache">
+    <% end %>
     <%=
       render(
         Documents::ShowEditView::BlockNoteEditorComponent.new(

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -164,6 +164,10 @@ RSpec.describe DocumentsController do
       expect(response).to be_successful
       expect(response).to render_template("show")
     end
+
+    it "does not opt out of Turbo snapshot caching" do
+      expect(response.body).not_to include('name="turbo-cache-control"')
+    end
   end
 
   describe "destroy" do
@@ -201,6 +205,11 @@ RSpec.describe DocumentsController do
       it "generates a token payload for show action" do
         get :show, params: { id: document.id }
         expect(assigns(:token_payload)).to be_present
+      end
+
+      it "opts the collaborative editor page out of Turbo snapshot caching" do
+        get :show, params: { id: document.id }
+        expect(response.body).to include('<meta name="turbo-cache-control" content="no-cache">')
       end
     end
 


### PR DESCRIPTION
[STC-642/activity#comment-1630437](https://community.openproject.org/projects/STC/work_packages/STC-642/activity#comment-1630437)

Opening a collaborative document, going back to the index, and reopening it a few times - particularly via the browser back button - surfaces a "real-time text collaboration server is unreachable" banner on a fully loaded page, even though the server is reachable. It clears itself after a few seconds when the provider reconnects.

Turbo keeps the document page in its snapshot cache. Reopening it restores that snapshot (on a back-button restoration visit) or shows it as a preview (on a repeat click), rebuilding the editor against a stale collaboration token and reconnecting the WebSocket. The editor reads that brief reconnection as a dropped connection and flips into offline mode. The first visit is clean because nothing is cached yet, which is why it only shows up on subsequent visits.

See: https://turbo.hotwired.dev/handbook/building#opting-out-of-caching

Opting the collaborative editor page out of Turbo's snapshot cache makes every visit load fresh, so the editor only ever sees a single, stable connection. This covers both the back-button restoration path and the repeat-click preview path.

https://github.com/user-attachments/assets/4e619e98-c208-4d85-b4a6-e3ac23f8302d
