### PR TITLE
[DREAM-735] User administration quick filter search field is not collapsed by default

### DIFF
--- a/app/components/users/index_sub_header_component.html.erb
+++ b/app/components/users/index_sub_header_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  render(Primer::OpenProject::SubHeader.new(data: sub_header_data_attributes)) do |subheader|
+  render(Primer::OpenProject::SubHeader.new(collapsed_search: true, data: sub_header_data_attributes)) do |subheader|
     subheader.with_action_button(
       scheme: :primary,
       leading_icon: :plus,

--- a/spec/features/users/unaccent_user_filter_spec.rb
+++ b/spec/features/users/unaccent_user_filter_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "Finding users with accents", :js do
   it "finds a user with accents in the name in the global administration" do
     visit users_path
 
+    click_button accessible_name: "Search"
     fill_in "Search", with: "Cecile"
     wait_for_network_idle
     expect(page).to have_css("td.firstname", text: "Cécile")

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -86,6 +86,9 @@ module Pages
         end
 
         def filter_by_name(value)
+          within("#content") do
+            click_button accessible_name: "Search"
+          end
           fill_in "Search", with: value
 
           wait_for_network_idle


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-735

# What are you trying to accomplish?
Use collapsed search for filter input

## Screenshots

<img width="889" height="378" alt="Bildschirmfoto 2026-06-23 um 08 25 29" src="https://github.com/user-attachments/assets/2b1ac644-9c8f-41c8-8124-96984346cc94" />
