### PR TITLE
Add missing locales around MCP scope

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6420,6 +6420,8 @@ en:
     scopes:
       api_v3: "Full API v3 access"
       api_v3_text: "Application will receive full read & write access to the OpenProject API v3 to perform actions on your behalf."
+      mcp: "Access to MCP"
+      mcp_text: "Application will receive access to the OpenProject MCP endpoints. They are a limited subset of APIv3, that's tailored for usage with AI agents."
     grants:
       created_date: "Approved on"
       scopes: "Permissions"


### PR DESCRIPTION
These localizations will be shown when the user authorizes a client that requests access to the mcp scope.

<img width="797" height="570" alt="image" src="https://github.com/user-attachments/assets/6d7ba6a9-747c-4a58-9ec8-22e0a409d448" />
