### PR TITLE
Add a lookbook example for loading inline macros

### DIFF
--- a/lookbook/previews/op_primer/inline_macro_component_preview.rb
+++ b/lookbook/previews/op_primer/inline_macro_component_preview.rb
@@ -47,6 +47,10 @@ module OpPrimer
       end
     end
 
+    def loading_content
+      render_with_template
+    end
+
     def with_link
       render_with_template
     end

--- a/lookbook/previews/op_primer/inline_macro_component_preview/loading_content.html.erb
+++ b/lookbook/previews/op_primer/inline_macro_component_preview/loading_content.html.erb
@@ -1,0 +1,10 @@
+<p>
+  When the content is not fully loaded yet, best use a spinner and muted text to indicate it:
+
+  <%= render(OpPrimer::InlineMacroComponent.new) do |c| %>
+    <% c.with_leading_visual_icon(icon: :book) %>
+
+    <%= render(Primer::Beta::Spinner.new(size: :small, display: :flex, mr: 2, sr_text: "")) %>
+    <%= render(Primer::Beta::Text.new(color: :muted)) { "Loading…" } %>
+  <% end %>
+</p>


### PR DESCRIPTION
We discussed this during a UX meeting today and it can't hurt to document this as a specific case, because we might have multiple implementations that need to behave like that.

# Screenshot

<img width="131" height="38" alt="image" src="https://github.com/user-attachments/assets/ea42ead4-ac14-40a5-ad36-6f3acdf2bda3" />

