### PR TITLE
[JIM-115] Blank user email on Jira side breaks Jira Import

### DIFF
--- a/app/models/import/jira_user.rb
+++ b/app/models/import/jira_user.rb
@@ -39,12 +39,16 @@ module Import
 
     def to_op_attributes
       firstname, lastname = split_display_name(payload["displayName"])
+      mail = payload["emailAddress"]
+      if mail.blank?
+        mail = "#{SecureRandom.hex(16)}@noemail.invalid"
+      end
       {
         login: payload["name"],
         password: OpenProject::Passwords::Generator.random_password,
         firstname: firstname.presence || I18n.t(FALLBACK_NAME_KEY),
         lastname: lastname.presence || I18n.t(FALLBACK_NAME_KEY),
-        mail: payload["emailAddress"],
+        mail:,
         status: :locked
       }
     end

--- a/spec/models/import/jira_import_spec.rb
+++ b/spec/models/import/jira_import_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe Import::JiraImport do
       end
     end
 
-    context "when importing a user without email(can happen in case of LDAP)" do
+    context "when importing a jira user without email(can happen in case of LDAP)" do
       let!(:jira_user) do
         create(:jira_user,
                jira:,
@@ -474,13 +474,11 @@ RSpec.describe Import::JiraImport do
                ))
       end
 
-      it "raises useful error message" do
-        expect do
-          jira_import.import_users
-        end.to raise_error(
-          'Error creating a user ({login: "jvd@example.com", firstname: "Jean Van Der", lastname: "Berg", ' \
-          "mail: nil, status: :locked}): Email can't be blank."
-        )
+      it "creates an OpenProject user with unresolvable email" do
+        jira_import.import_users
+
+        user = User.find_by(login: "jvd@example.com")
+        expect(user.mail).to match(/@noemail.invalid/)
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/JIM-115

- uses unresolvable random email for OpenProject user if jira user email is blank
