### PR TITLE
Use Net::LDAP to parse dn

### DIFF
--- a/modules/ldap_departments/app/services/ldap_departments/dn.rb
+++ b/modules/ldap_departments/app/services/ldap_departments/dn.rb
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
 
 module LdapDepartments
-  # Small helpers for working with LDAP distinguished names. Splitting is escape-aware so that
-  # escaped commas (e.g. `cn=Doe\, John,ou=...`) do not break RDN boundaries.
+  # Helpers for working with LDAP distinguished names. Parsing is delegated to Net::LDAP::DN,
+  # which respects some of the weirder parsing and escaping rules.
   module Dn
     module_function
 
-    def split_rdns(value)
-      rdns = []
-      current = +""
-      escaped = false
-
-      value.to_s.each_char do |char|
-        if escaped
-          current << char
-          escaped = false
-        elsif char == "\\"
-          current << char
-          escaped = true
-        elsif char == ","
-          rdns << current
-          current = +""
-        else
-          current << char
-        end
-      end
-
-      rdns << current
-      rdns
+    # Number of key-value parts (RDN) in the DN. Used to find and process shallower OUs first.
+    def depth(value)
+      parse(value).size
     end
 
-    # The parent container DN (everything past the first RDN), or nil for a single-component DN.
+    # Normalized form for case- and escaping-insensitive comparison. Values are decoded by the parser
+    # and then re-escaped, in case there are differing encodings.
+    # The result is itself a valid DN, which ensures this method is idempotent.
+    def normalize(value)
+      canonical(parse(value))
+    end
+
+    # The parent DN (everything except the first RDN) in canonical form
+    # returns nil for a single-component DN.
     def parent(value)
-      rdns = split_rdns(value)
+      rdns = parse(value)
       return nil if rdns.size <= 1
 
-      rdns.drop(1).join(",").strip
+      canonical(rdns.drop(1))
     end
 
-    # Canonical form for case- and spacing-insensitive comparison.
-    def normalize(value)
-      split_rdns(value).map { |rdn| rdn.strip.downcase }.join(",")
+    # Parsed RDNs as [attribute, value] pairs with values already decoded. A malformed DN returns an
+    # empty array so a single bad entry is skipped rather than aborting the whole synchronization.
+    def parse(value)
+      return [] if value.blank?
+
+      Net::LDAP::DN.new(value.to_s).to_a.each_slice(2).to_a
+    rescue Net::LDAP::InvalidDNError
+      []
+    end
+
+    def canonical(rdns)
+      rdns
+        .map { |attribute, attribute_value| "#{attribute.downcase}=#{Net::LDAP::DN.escape(attribute_value.strip).downcase}" }
+        .join(",")
     end
   end
 end

--- a/modules/ldap_departments/app/services/ldap_departments/synchronize_tree_service.rb
+++ b/modules/ldap_departments/app/services/ldap_departments/synchronize_tree_service.rb
@@ -27,7 +27,7 @@ module LdapDepartments
     def synchronize!
       entries = fetch_ou_entries
       # Process shallow OUs first so a child can always resolve its already-persisted parent.
-      entries.sort_by! { |entry| Dn.split_rdns(entry[:dn]).size }
+      entries.sort_by! { |entry| Dn.depth(entry[:dn]) }
 
       seen = []
       entries.each do |entry|

--- a/modules/ldap_departments/spec/services/ldap_departments/dn_spec.rb
+++ b/modules/ldap_departments/spec/services/ldap_departments/dn_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe LdapDepartments::Dn do
+  describe ".normalize" do
+    it "lower-cases attributes and values" do
+      expect(described_class.normalize("OU=Frontend,DC=Example,DC=com"))
+        .to eq("ou=frontend,dc=example,dc=com")
+    end
+
+    it "ignores insignificant whitespace around RDNs" do
+      expect(described_class.normalize("OU = Frontend , OU=IT , DC=x"))
+        .to eq("ou=frontend,ou=it,dc=x")
+    end
+
+    it "is idempotent (its own output normalizes to itself)" do
+      normalized = described_class.normalize("CN=Doe\\, John,OU=Sales,DC=x")
+
+      expect(described_class.normalize(normalized)).to eq(normalized)
+    end
+
+    it "produces a key a child DN can match with end_with? for subtree scoping" do
+      base = described_class.normalize("DC=Example,DC=com")
+      child = described_class.normalize("ou=Frontend,ou=IT,dc=example,dc=com")
+
+      expect(child).to end_with(base)
+    end
+
+    # The hand-rolled splitter only treated a raw "," as an RDN boundary, so these three encodings of
+    # the same name (escaped comma, quoted value, hex escape) used to normalize differently.
+    context "with a value containing a comma" do
+      let(:backslash_escaped) { "CN=Doe\\, John,OU=Sales,DC=x" }
+      let(:quoted) { 'CN="Doe, John",OU=Sales,DC=x' }
+      let(:hex_escaped) { "CN=Doe\\2C John,OU=Sales,DC=x" }
+
+      it "treats the escaped comma as part of the value, not an RDN boundary" do
+        expect(described_class.normalize(backslash_escaped)).to eq("cn=doe\\, john,ou=sales,dc=x")
+      end
+
+      it "normalizes the backslash, quoted and hex encodings to the same value" do
+        expect([backslash_escaped, quoted, hex_escaped].map { |dn| described_class.normalize(dn) }.uniq)
+          .to contain_exactly("cn=doe\\, john,ou=sales,dc=x")
+      end
+    end
+
+    it "returns an empty string for a blank DN" do
+      expect(described_class.normalize("")).to eq("")
+      expect(described_class.normalize(nil)).to eq("")
+    end
+
+    it "returns an empty string for a malformed DN rather than raising" do
+      expect(described_class.normalize("=,,broken")).to eq("")
+    end
+  end
+
+  describe ".parent" do
+    it "returns the container DN in canonical form" do
+      expect(described_class.parent("CN=John Doe,OU=Frontend,OU=IT,DC=x"))
+        .to eq("ou=frontend,ou=it,dc=x")
+    end
+
+    it "returns nil for a single-component DN" do
+      expect(described_class.parent("dc=x")).to be_nil
+    end
+
+    it "returns nil for a blank DN" do
+      expect(described_class.parent("")).to be_nil
+    end
+
+    it "drops only the first RDN even when its value contains an escaped comma" do
+      expect(described_class.parent('CN="Doe, John",OU=Sales,DC=x'))
+        .to eq("ou=sales,dc=x")
+    end
+
+    it "treats a multi-valued RDN as a single component" do
+      expect(described_class.parent("CN=John+UID=jdoe,OU=Frontend,DC=x"))
+        .to eq("ou=frontend,dc=x")
+    end
+  end
+
+  describe ".depth" do
+    it "counts the number of RDNs" do
+      expect(described_class.depth("ou=Frontend,ou=IT,dc=example,dc=com")).to eq(4)
+    end
+
+    it "counts a multi-valued RDN as one" do
+      expect(described_class.depth("CN=John+UID=jdoe,OU=Frontend,DC=x")).to eq(3)
+    end
+
+    it "is not fooled by an escaped comma inside a value" do
+      expect(described_class.depth("CN=Doe\\, John,OU=Sales,DC=x")).to eq(3)
+    end
+
+    it "returns 0 for a blank DN" do
+      expect(described_class.depth("")).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Rather than trying to parse ourselves, which misses some edge cases:

- hex escapes like \2C,
- quoted RDN values (cn="Doe, John"),
- multi-valued RDNs joined with + (cn=John+uid=jdoe).