### PR TITLE
don't fail downstream-ci trigger, as we manually check the exic code

### DIFF
--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -72,7 +72,7 @@ jobs:
           echo "Triggering $WORKFLOW_ID workflow on $REPOSITORY branch '$REF', which will check out core branch '$CORE_REF'"
 
           status=$(
-            curl -i --fail-with-body --silent --output $OUTPUT_FILE --write-out "%{http_code}" \
+            curl -i --silent --output $OUTPUT_FILE --write-out "%{http_code}" \
               -H"authorization: Bearer $TOKEN" -H"Accept: application/vnd.github.v3+json" \
               -XPOST \
               -d "$PAYLOAD" \


### PR DESCRIPTION
`--fail-with-body` caused `curl` to exit with code `22` preventing script from reaching `if`

But is it expected that this doesn't work for external PRs?