### PR TITLE
[AGILE-302] Do not carry the filter state in all the backlog urls

### DIFF
--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -162,6 +162,10 @@ module OpTurbo
       turbo_streams << OpTurbo::StreamComponent.new(action: :reloadPage, target: nil).render_in(view_context)
     end
 
+    def reload_frame_via_turbo_stream(target)
+      turbo_streams << turbo_stream.turbo_frame_reload(target)
+    end
+
     # Dispatches a `CustomEvent` on `document` from a turbo stream, letting the
     # server signal a client-side change without knowing which listeners (if
     # any) react to it. `detail` is serialized and exposed as the event's detail.

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/story.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/story.controller.ts
@@ -158,7 +158,7 @@ export default class StoryController extends Controller<HTMLElement> implements 
     }
   }
 
-  private openSplitPane():void {
+  openSplitPane():void {
     Turbo.visit(this.splitUrlValue, { frame: 'content-bodyRight', action: 'advance' });
   }
 

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -58,6 +58,7 @@ applyTurboNavigationPatch();
 // Register only the turbo-power stream actions we actually use
 TurboPower.register('push_state', TurboPower.Actions.push_state, StreamActions);
 TurboPower.register('turbo_frame_set_src', TurboPower.Actions.turbo_frame_set_src, StreamActions);
+TurboPower.register('turbo_frame_reload', TurboPower.Actions.turbo_frame_reload, StreamActions);
 TurboPower.register('redirect_to', TurboPower.Actions.redirect_to, StreamActions);
 TurboPower.register('set_dataset_attribute', TurboPower.Actions.set_dataset_attribute, StreamActions);
 TurboPower.register('set_title', TurboPower.Actions.set_title, StreamActions);

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
@@ -51,11 +51,11 @@ module Backlogs
     end
 
     def drop_url
-      url_helpers.move_project_backlogs_work_package_path(project, work_package, params)
+      url_helpers.move_project_backlogs_work_package_path(project, work_package)
     end
 
     def menu_src
-      url_helpers.menu_project_backlogs_work_package_path(project, work_package, params)
+      url_helpers.menu_project_backlogs_work_package_path(project, work_package)
     end
 
     # `story` data attrs match the live Stimulus controller and Dragula

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
@@ -31,10 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::Alpha::ActionMenu::List.new(menu_id:)) do |list|
     list.with_item(
       id: dom_target(work_package, :menu, :open_details),
-      tag: :a,
+      tag: :button,
       label: t(:"js.button_open_details"),
-      href: project_backlogs_backlog_details_path(project, work_package),
-      content_arguments: { data: { turbo_frame: "content-bodyRight", turbo_action: "advance" } }
+      content_arguments: { data: { action: "backlogs--story#openSplitPane" } }
     ) do |item|
       item.with_leading_visual_icon(icon: :"op-view-split")
     end

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
       id: dom_target(work_package, :menu, :open_details),
       tag: :a,
       label: t(:"js.button_open_details"),
-      href: project_backlogs_backlog_details_path(project, work_package, backlog_filter_params),
+      href: project_backlogs_backlog_details_path(project, work_package),
       content_arguments: { data: { turbo_frame: "content-bodyRight", turbo_action: "advance" } }
     ) do |item|
       item.with_leading_visual_icon(icon: :"op-view-split")
@@ -75,7 +75,7 @@ See COPYRIGHT and LICENSE files for more details.
           id: dom_target(work_package, :menu, :move_to_inbox),
           label: t(".action_menu.move_to_inbox"),
           tag: :button,
-          href: move_project_backlogs_work_package_path(project, work_package, backlog_filter_params),
+          href: move_project_backlogs_work_package_path(project, work_package),
           form_arguments: { method: :put, inputs: [{ name: "target_id", value: "inbox" }] }
         ) do |item|
           item.with_leading_visual_icon(icon: :inbox)
@@ -86,7 +86,7 @@ See COPYRIGHT and LICENSE files for more details.
         list.with_item(
           id: dom_target(work_package, :menu, :move_to_backlog_bucket),
           label: t(".action_menu.move_to_backlog_bucket"),
-          href: move_to_bucket_dialog_project_backlogs_work_package_path(project, work_package, backlog_filter_params),
+          href: move_to_bucket_dialog_project_backlogs_work_package_path(project, work_package),
           content_arguments: { data: { controller: "async-dialog" } }
         ) do |item|
           item.with_leading_visual_icon(icon: :package)
@@ -97,7 +97,7 @@ See COPYRIGHT and LICENSE files for more details.
         list.with_item(
           id: dom_target(work_package, :menu, :move_to_sprint),
           label: t(".action_menu.move_to_sprint"),
-          href: move_to_sprint_dialog_project_backlogs_work_package_path(project, work_package, backlog_filter_params),
+          href: move_to_sprint_dialog_project_backlogs_work_package_path(project, work_package),
           content_arguments: { data: { controller: "async-dialog" } }
         ) do |item|
           item.with_leading_visual_icon(icon: :zap)

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
@@ -100,7 +100,7 @@ module Backlogs
         id: dom_target(work_package, :menu, label),
         label: I18n.t(label),
         tag: :button,
-        href: move_project_backlogs_work_package_path(project, work_package, backlog_filter_params),
+        href: move_project_backlogs_work_package_path(project, work_package),
         form_arguments: { method: :put, inputs: }
       ) do |item|
         item.with_leading_visual_icon(icon:)

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -31,7 +31,6 @@
 module Backlogs
   class WorkPackagesController < BaseController
     include OpTurbo::ComponentStream
-    include Backlogs::Concerns::ContainerLoading
 
     before_action :load_work_package
 
@@ -64,14 +63,11 @@ module Backlogs
     end
 
     def move # rubocop:disable Metrics/AbcSize
-      # Capture the source before the call; the service reloads @work_package internally via #move_after.
-      source_sprint = @work_package.sprint
-
       call = ::Backlogs::WorkPackages::UpdateService.new(user: current_user, story: @work_package)
                                    .call(**move_params.to_h.symbolize_keys)
 
       if call.success?
-        move_work_package_to_target_component_via_turbo_stream(source_sprint:, target_sprint: call.result.sprint)
+        reload_frame_via_turbo_stream("backlogs_container")
 
         if work_package_invisible_after_move?(call.result)
           backlog_name = call.result.backlog_bucket&.name || I18n.t(:label_inbox)
@@ -89,36 +85,6 @@ module Backlogs
     end
 
     private
-
-    def move_work_package_to_target_component_via_turbo_stream(source_sprint:, target_sprint:)
-      if source_sprint != target_sprint
-        replace_component_via_turbo_stream(sprint: source_sprint)
-      end
-
-      replace_component_via_turbo_stream(sprint: target_sprint)
-    end
-
-    def replace_component_via_turbo_stream(sprint:)
-      component = if sprint
-                    sprint_component(sprint:)
-                  else
-                    backlog_component
-                  end
-
-      replace_via_turbo_stream(component:, method: :morph)
-    end
-
-    def sprint_component(sprint:)
-      Backlogs::SprintComponent.new(sprint:, project: @project)
-    end
-
-    def backlog_component
-      load_backlog_data
-
-      Backlogs::BacklogComponent.new(buckets: @backlog_buckets,
-                                     work_packages_by_backlog_id: @work_packages_by_backlog_id,
-                                     project: @project)
-    end
 
     def load_work_package
       @work_packages = WorkPackage.visible.where(project: @project).order_by_position

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -175,19 +175,6 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
         expect(row["data-backlogs--story-split-url-value"]).to include("all=true")
       end
     end
-
-    it "includes all=true in the drop URL" do
-      expect(rendered_component).to have_css(".Box-row#work_package_#{work_package.id}") do |row|
-        expect(row["data-drop-url"]).to include("all=true")
-      end
-    end
-
-    it "includes all=true in the action-menu src" do
-      expect(rendered_component).to have_element(
-        "include-fragment",
-        src: menu_project_backlogs_work_package_path(project, work_package, all: "true")
-      )
-    end
   end
 
   context "when the user lacks the create_sprints permission" do

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -124,19 +124,6 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         end
       end
 
-      context "when params[:all] is true" do
-        before do
-          vc_test_controller.params[:all] = "1"
-        end
-
-        it "propagates ?all=true to the work package drop URL" do
-          expect(rendered_component).to have_css(".Box-row#work_package_#{work_package1.id}") do |row|
-            expect(row["data-drop-url"])
-              .to eq(move_project_backlogs_work_package_path(project, work_package1, all: true))
-          end
-        end
-      end
-
       it "renders the sprint kebab menu in the header" do
         expect(rendered_component).to have_element :"action-menu"
       end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
@@ -131,15 +131,6 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
           .to end_with(move_project_backlogs_work_package_path(project, work_package))
       end
     end
-
-    context "with params" do
-      let(:params) { { all: true } }
-
-      it "passes params into row URLs" do
-        expect(item.row_args.dig(:data, :backlogs__story_split_url_value)).to match(/all=true/)
-        expect(item.row_args.dig(:data, :drop_url)).to match(/all=true/)
-      end
-    end
   end
 
   describe "#card" do
@@ -184,17 +175,6 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
         expect(rendered_card).to have_element(
           "include-fragment",
           src: menu_project_backlogs_work_package_path(project, work_package)
-        )
-      end
-    end
-
-    context "with params" do
-      let(:params) { { all: 1 } }
-
-      it "passes params into the menu source" do
-        expect(rendered_card).to have_element(
-          "include-fragment",
-          src: menu_project_backlogs_work_package_path(project, work_package, all: 1)
         )
       end
     end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -80,19 +80,19 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       render_component
 
       expect(page).to have_element(:ul, id: /\Awork_package_#{work_package.id}_menu-list\z/)
-      expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_details\z/)
+      expect(page).to have_element(:button, id: /\Awork_package_#{work_package.id}_menu_open_details\z/)
       expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_fullscreen\z/)
       expect(page).to have_element(:"clipboard-copy", id: /\Awork_package_#{work_package.id}_menu_copy_url_to_clipboard\z/)
       expect(page).to have_element(:"clipboard-copy", id: /\Awork_package_#{work_package.id}_menu_copy_work_package_id\z/)
     end
 
-    it "shows Open details link (split view)" do
+    it "shows Open details action (split view)" do
       render_component
 
       expect(page).to have_text(I18n.t(:"js.button_open_details"))
       expect(page).to have_octicon(:"op-view-split")
       expect(page).to have_css(
-        "a[data-turbo-frame='content-bodyRight'][data-turbo-action='advance']",
+        "button[data-action='backlogs--story#openSplitPane']",
         text: I18n.t(:"js.button_open_details")
       )
     end
@@ -136,15 +136,11 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
             with_settings: { work_packages_identifier: "semantic" } do
       let(:project) { create(:project, types: [type_feature, type_task], identifier: "STORY") }
 
-      it "uses the semantic displayId in the open details, fullscreen, and clipboard URLs" do
+      it "uses the semantic displayId in the fullscreen and clipboard URLs" do
         render_component
 
         semantic_id = work_package.reload.identifier
         expect(semantic_id).to start_with("STORY-")
-
-        details = page.find_by_id("work_package_#{work_package.id}_menu_open_details")
-        expect(details[:href]).to include("/details/#{semantic_id}")
-        expect(details[:href]).not_to include("/details/#{work_package.id}")
 
         fullscreen = page.find_by_id("work_package_#{work_package.id}_menu_open_fullscreen")
         expect(fullscreen[:href]).to end_with("/work_packages/#{semantic_id}")

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -97,16 +97,6 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       )
     end
 
-    context "when params[:all] is true" do
-      before { vc_test_controller.params[:all] = "1" }
-
-      it "adds the all param to the open details href" do
-        render_component
-
-        expect(page).to have_css(%(#work_package_#{work_package.id}_menu_open_details[href*="all=true"]))
-      end
-    end
-
     it "shows Open fullscreen link (full page)" do
       render_component
 
@@ -346,16 +336,6 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
 
       expect(page).to have_no_element(:a, id: /\Awork_package_#{work_package.id}_menu_move_to_sprint\z/)
     end
-
-    context "when params[:all] is true" do
-      before { vc_test_controller.params[:all] = "1" }
-
-      it "adds the all param to the move to sprint href" do
-        render_component(open_sprints_exist: true)
-
-        expect(page).to have_css(%(#work_package_#{work_package.id}_menu_move_to_sprint[href*="all=true"]))
-      end
-    end
   end
 
   describe "Move to backlog inbox item" do
@@ -387,16 +367,6 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
         render_component
 
         expect(page).to have_no_element(:button, id: /\Awork_package_#{work_package.id}_menu_move_to_inbox\z/)
-      end
-    end
-
-    context "when params[:all] is true" do
-      before { vc_test_controller.params[:all] = "1" }
-
-      it "adds the all param to the form action for the inbox move" do
-        render_component
-
-        expect(page).to have_css(%(form[action*="all=true"]))
       end
     end
   end
@@ -437,16 +407,6 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       render_component(other_buckets_exist: false)
 
       expect(page).to have_no_element(:a, id: /\Awork_package_#{work_package.id}_menu_move_to_backlog_bucket\z/)
-    end
-
-    context "when params[:all] is true" do
-      before { vc_test_controller.params[:all] = "1" }
-
-      it "adds the all param to the dialog href" do
-        render_component(other_buckets_exist: true)
-
-        expect(page).to have_css(%(#work_package_#{work_package.id}_menu_move_to_backlog_bucket[href*="all=true"]))
-      end
     end
   end
 end

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -49,38 +49,6 @@ RSpec.describe Backlogs::WorkPackagesController do
   let(:sprint) { create(:sprint, name: "Agile Sprint 1", project:) }
   let(:work_package) { create(:work_package, status:, sprint:, project:, type: type_feature) }
 
-  shared_examples "respecting the all param for inbox pagination" do
-    context "with an inbox over the pagination threshold" do
-      shared_let(:wps) { create_list(:work_package, 5, project:, status:) }
-
-      before do
-        stub_const("Backlogs::InboxComponent::TRUNCATE_MIDDLE", 2)
-      end
-
-      context "when all param is not present" do
-        let(:all) { nil }
-
-        it "replaces the inbox with a show-more row in the stream" do
-          subject
-
-          expect(response).to be_successful
-          expect(response.body).to include("inbox_project_#{project.id}_show_more")
-        end
-      end
-
-      context "when all=true" do
-        let(:all) { "true" }
-
-        it "replaces the inbox without a show-more row in the stream" do
-          subject
-
-          expect(response).to be_successful
-          expect(response.body).not_to include("inbox_project_#{project.id}_show_more")
-        end
-      end
-    end
-  end
-
   describe "load_work_package" do
     let(:params) { { project_id: project.id, id: work_package.id } }
 
@@ -135,9 +103,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{sprint.id}",
-                                                method: "morph"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
         end
 
         it "does not change the work_package's sprint and position" do
@@ -157,10 +124,8 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(response).to be_successful
           expect(response).to have_http_status :ok
-          expect(response)
-            .to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}", method: "morph"
-          expect(response)
-            .to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{other_sprint.id}", method: "morph"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(assigns(:project)).to eq(project)
           expect(assigns(:work_package)).to eq(work_package_in_sprint)
         end
@@ -182,10 +147,8 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(response).to be_successful
           expect(response).to have_http_status :ok
-          expect(response)
-            .to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}", method: "morph"
-          expect(response)
-            .to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{project.id}", method: "morph"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(assigns(:project)).to eq(project)
           expect(assigns(:work_package)).to eq(work_package_in_sprint)
         end
@@ -211,8 +174,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(work_package_in_sprint.reload).to have_attributes(sprint_id: nil, backlog_bucket_id: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with a Backlog bucket as target" do
@@ -225,11 +186,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{sprint.id}",
-                                                method: "morph"
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
         end
 
         context "when the project is configured to exclude the work packages status from backlogs" do
@@ -253,8 +211,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(work_package_in_sprint.reload).to have_attributes(backlog_bucket: bucket, sprint_id: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with direction param" do
@@ -265,8 +221,8 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(response).to be_successful
           expect(response).to have_http_status :ok
-          expect(response)
-            .to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}", method: "morph"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(assigns(:work_package)).to eq(work_package_in_sprint)
         end
 
@@ -288,7 +244,8 @@ RSpec.describe Backlogs::WorkPackagesController do
 
             expect(response).to have_http_status :unprocessable_entity
             expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
-            expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}"
+            expect(response).not_to have_turbo_stream action: "turbo_frame_reload",
+                                                      target: "backlogs_container"
           end
         end
       end
@@ -306,10 +263,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{target_sprint.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
 
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
@@ -319,8 +274,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(inbox_work_package.reload).to have_attributes(sprint: target_sprint, backlog_bucket_id: nil, position: 1)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with the same Inbox as target" do
@@ -332,8 +285,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 
@@ -341,8 +294,6 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
           expect(inbox_work_package.reload).to have_attributes(sprint: nil, backlog_bucket: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with a Backlog bucket as target" do
@@ -355,8 +306,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 
@@ -364,8 +315,6 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
           expect(inbox_work_package.reload).to have_attributes(backlog_bucket: bucket, sprint_id: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with direction param" do
@@ -376,7 +325,9 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
+
           expect(assigns(:work_package)).to eq(inbox_work_package)
         end
 
@@ -385,8 +336,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(inbox_work_package.reload).to have_attributes(backlog_bucket_id: nil, sprint_id: nil, position: 1)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
     end
 
@@ -404,10 +353,9 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{target_sprint.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
+
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 
@@ -416,8 +364,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(bucket_work_package.reload).to have_attributes(sprint: target_sprint, backlog_bucket: nil, position: 1)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with the Inbox as target" do
@@ -429,8 +375,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 
@@ -439,8 +385,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(bucket_work_package.reload).to have_attributes(backlog_bucket_id: nil, sprint_id: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with the same Backlog bucket as target" do
@@ -451,8 +395,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 
@@ -461,8 +405,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(bucket_work_package.reload).to have_attributes(backlog_bucket: bucket, sprint_id: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with another Backlog bucket as target" do
@@ -475,8 +417,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 
@@ -485,8 +427,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(bucket_work_package.reload).to have_attributes(backlog_bucket: other_bucket, sprint_id: nil, position: 2)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
 
       context "with direction param" do
@@ -496,7 +436,8 @@ RSpec.describe Backlogs::WorkPackagesController do
           subject
 
           expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{project.id}"
+          expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                                target: "backlogs_container"
           expect(assigns(:work_package)).to eq(bucket_work_package)
         end
 
@@ -505,8 +446,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
           expect(bucket_work_package.reload).to have_attributes(backlog_bucket_id: bucket.id, sprint_id: nil, position: 1)
         end
-
-        include_examples "respecting the all param for inbox pagination"
       end
     end
 
@@ -556,16 +495,6 @@ RSpec.describe Backlogs::WorkPackagesController do
 
       expect(response).to have_http_status :ok
       expect(response.body).to include(I18n.t(:"js.button_open_details"))
-    end
-
-    context "when all=true is in params" do
-      let(:params) { { project_id: project.id, id: work_package_id, all: "true" } }
-
-      it "embeds the all query in deferred action URLs" do
-        subject
-
-        expect(response.body).to match(/all=true/)
-      end
     end
 
     context "when another open sprint exists" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-302

# What are you trying to accomplish?
1. Allow the `WorkPackageCardItemComponent`'s to be cached more efficiently by removing the filter parameters from their urls.
2. Find a better way of maintaining the filter state of the Backlogs page without passing all the filter parameters to every action on the page.

# What approach did you choose and why?

Shift the responsibility of updating the Backlogs page from the controller action response to the frame on the frontend, resulting in a simpler state management. The shift is done with the help of the TurboPower gem provided [turbo frame action](https://github.com/marcoroth/turbo_power#turbo-frame-actions): `turbo_stream.turbo_frame_reload(frame_id)`.

Instead of rendering components from the controller action, it just calls the `turbo_frame_reload` StreamAction. This will tell to the target frame to reload itself.

The only downside of this approach is an extra query resulting from the frame reload, but that is rather negligible.

- [X] Change the `WorkPackagesController#move` action to respond with a `reload_frame_via_turbo_stream("backlogs_container")` StreamAction.
- [X] Remove the state parameters from the work package card lazy menu source.
- [X] Maintain the filter params when opening the details view. This requires a special handling, because the details view close button will have to know the url to navigate to. The solution is to trigger the same action from the inline menu as clicking the work package card itself. This is a known shortcomming and ~will be addressed in a follow up PR~ Edit: It is addressed in this PR 9c7d4f4c52f9173ba47875e96711926c5053d960 .
<details><summary>Demo for the details view issue.</summary>
<p>

<img width="1226" height="704" alt="Jun-23-2026 12-08-28" src="https://github.com/user-attachments/assets/1ee2c82f-d82a-437b-b605-19e149dd7c24" />


</p>
</details> 

In order to keep this PR small, only the work package move actions are updated, DnD, Move to (Inbox|Sprint|Bucket), Move (up|down). A follow up PR will be made for the rest of page.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
