### PR TITLE
[MEET-560, 561, 562] Fix meetings API bugs

### DIFF
--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -61,7 +61,16 @@ module Meetings
     def meeting_is_editable
       return unless user.allowed_in_project?(:edit_meetings, model.project)
 
-      errors.add :base, I18n.t(:text_meeting_not_editable_anymore) unless model.editable?(user)
+      # A closed meeting may still be reopened or otherwise have its state changed
+      #  but no other attribute of it may be edited
+      return unless model.state_was == "closed"
+      return if only_state_changed?
+
+      errors.add :base, I18n.t(:text_meeting_not_editable_anymore)
+    end
+
+    def only_state_changed?
+      model.changed == %w[state]
     end
 
     def valid_rescheduling_date # rubocop:disable Metrics/AbcSize

--- a/modules/meeting/lib/api/v3/meeting_agenda_items/agenda_items_by_meeting_api.rb
+++ b/modules/meeting/lib/api/v3/meeting_agenda_items/agenda_items_by_meeting_api.rb
@@ -32,9 +32,27 @@ module API
   module V3
     module MeetingAgendaItems
       class AgendaItemsByMeetingAPI < ::API::OpenProjectAPI
+        helpers do
+          def agenda_item_includes(scope)
+            scope.includes(:author, :presenter, :work_package, :meeting_section)
+          end
+
+          def agenda_items(meeting)
+            # backlog: false is to not have duplicates for one-time meetings
+            items = agenda_item_includes(meeting.agenda_items.joins(:meeting_section)
+                                                .where(meeting_sections: { backlog: false })).to_a
+
+            if meeting.backlog.present?
+              items + agenda_item_includes(meeting.backlog.agenda_items).to_a
+            else
+              items
+            end
+          end
+        end
+
         resources :agenda_items do
           get do
-            items = @meeting.agenda_items.includes(:author, :presenter, :work_package, :meeting_section)
+            items = agenda_items(@meeting)
             MeetingAgendaItemCollectionRepresenter.new(items,
                                                        self_link: api_v3_paths.meeting_agenda_items(meeting_id: @meeting.id),
                                                        current_user:)
@@ -42,7 +60,10 @@ module API
 
           route_param :agenda_item_id, type: Integer, desc: "Agenda item ID" do
             after_validation do
-              @meeting_agenda_item = @meeting.agenda_items.find(declared_params[:agenda_item_id])
+              id = declared_params[:agenda_item_id]
+              @meeting_agenda_item = @meeting.agenda_items.find_by(id:) ||
+                                     @meeting.backlog&.agenda_items&.find_by(id:)
+              raise API::Errors::NotFound.new unless @meeting_agenda_item
             end
 
             get &::API::V3::Utilities::Endpoints::Show.new(model: MeetingAgendaItem).mount

--- a/modules/meeting/lib/api/v3/recurring_meetings/occurrence.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/occurrence.rb
@@ -32,23 +32,17 @@ module API
   module V3
     module RecurringMeetings
       class Occurrence
-        attr_accessor :start_time, :recurring_meeting_id, :meeting_id, :cancelled
+        attr_accessor :start_time, :recurring_meeting_id, :meeting_id, :meeting_state
 
-        def initialize(start_time:, recurring_meeting_id:, meeting_id: nil, cancelled: false)
+        def initialize(start_time:, recurring_meeting_id:, meeting_id: nil, meeting_state: nil)
           @start_time = start_time
           @recurring_meeting_id = recurring_meeting_id
           @meeting_id = meeting_id
-          @cancelled = cancelled
+          @meeting_state = meeting_state
         end
 
         def state
-          if cancelled
-            "cancelled"
-          elsif meeting_id
-            "open"
-          else
-            "scheduled"
-          end
+          meeting_state || "planned"
         end
       end
     end

--- a/modules/meeting/lib/api/v3/recurring_meetings/occurrences_by_recurring_meeting_api.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/occurrences_by_recurring_meeting_api.rb
@@ -38,7 +38,7 @@ module API
               start_time:,
               recurring_meeting_id: @recurring_meeting.id,
               meeting_id: meeting&.id,
-              cancelled: meeting&.cancelled? || false
+              meeting_state: meeting&.state
             )
           end
 
@@ -53,7 +53,7 @@ module API
           def persisted_upcoming
             @recurring_meeting.meetings
               .recurring_occurrence
-              .where(recurrence_start_time: Time.current..)
+              .upcoming
               .index_by(&:recurrence_start_time)
           end
 
@@ -97,7 +97,7 @@ module API
           namespace :past do
             get do
               occurrence_collection(
-                occurrences_from_meetings(@recurring_meeting.meetings.recurring_occurrence.past.not_cancelled),
+                occurrences_from_meetings(@recurring_meeting.scheduled_instances(upcoming: false)),
                 self_link: api_v3_paths.recurring_meeting_occurrences_past(@recurring_meeting.id)
               )
             end

--- a/modules/meeting/spec/contracts/meetings/update_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meetings/update_contract_spec.rb
@@ -73,6 +73,27 @@ RSpec.describe Meetings::UpdateContract do
       end
 
       it_behaves_like "contract is invalid", base: I18n.t(:text_meeting_not_editable_anymore)
+
+      context "and only the state is being changed (reopening)" do
+        before { meeting.state = :open }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "and another attribute is changed alongside the state" do
+        before do
+          meeting.state = :open
+          meeting.title = "New title"
+        end
+
+        it_behaves_like "contract is invalid", base: I18n.t(:text_meeting_not_editable_anymore)
+      end
+    end
+
+    context "when closing an open meeting" do
+      before { meeting.state = :closed }
+
+      it_behaves_like "contract is valid"
     end
   end
 

--- a/modules/meeting/spec/requests/api/v3/meeting_agenda_items/agenda_items_by_meeting_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meeting_agenda_items/agenda_items_by_meeting_resource_spec.rb
@@ -141,6 +141,33 @@ RSpec.describe "API v3 Meeting Agenda Items sub-resource", content_type: :json d
       end
     end
 
+    context "with a recurring meeting occurrence whose backlog is owned by the series template" do
+      let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+      let(:template) { recurring_meeting.template }
+      let(:occurrence) do
+        create(:recurring_meeting_occurrence,
+               recurring_meeting:,
+               start_time: recurring_meeting.start_time + 1.week)
+      end
+      let!(:series_backlog_item) do
+        create(:meeting_agenda_item,
+               meeting: template,
+               meeting_section: template.backlog,
+               author: current_user,
+               title: "Series backlog item")
+      end
+      let(:path) { api_v3_paths.meeting_agenda_items(meeting_id: occurrence.id) }
+
+      before { get path }
+
+      it "includes the series backlog item in the occurrence's agenda items" do
+        elements = JSON.parse(last_response.body).dig("_embedded", "elements")
+        ids = elements.pluck("id")
+
+        expect(ids).to include(series_backlog_item.id)
+      end
+    end
+
     context "without view_meetings permission" do
       let(:permissions) { [] }
 
@@ -294,6 +321,32 @@ RSpec.describe "API v3 Meeting Agenda Items sub-resource", content_type: :json d
         expect(last_response.body)
           .to be_json_eql(api_v3_paths.meeting(meeting.id).to_json)
           .at_path("_embedded/section/_links/meeting/href")
+      end
+    end
+
+    context "when the agenda item is in the backlog of a recurring series, fetched via an occurrence" do
+      let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+      let(:template) { recurring_meeting.template }
+      let(:occurrence) do
+        create(:recurring_meeting_occurrence,
+               recurring_meeting:,
+               start_time: recurring_meeting.start_time + 1.week)
+      end
+      let!(:series_backlog_item) do
+        create(:meeting_agenda_item,
+               meeting: template,
+               meeting_section: template.backlog,
+               author: current_user,
+               title: "Series backlog item")
+      end
+      let(:path) { api_v3_paths.meeting_agenda_item(series_backlog_item.id, meeting_id: occurrence.id) }
+
+      it "returns 200 and the backlog agenda item" do
+        expect(last_response).to have_http_status(:ok)
+
+        expect(last_response.body)
+          .to be_json_eql(series_backlog_item.id.to_json)
+          .at_path("id")
       end
     end
 

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/occurrences_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/occurrences_resource_spec.rb
@@ -170,6 +170,63 @@ RSpec.describe "API v3 Recurring Meeting Occurrences", content_type: :json do
     end
   end
 
+  describe "an in progress occurrence" do
+    # Matching the web, an ongoing occurrence appears in both upcoming and past
+    let(:ongoing_start) { 30.minutes.ago }
+    let!(:ongoing_occurrence) do
+      create(:recurring_meeting_occurrence,
+             recurring_meeting:,
+             start_time: ongoing_start,
+             recurrence_start_time: ongoing_start,
+             duration: 1.0,
+             state: :open)
+    end
+
+    it "is returned as open by the upcoming endpoint" do
+      get api_v3_paths.recurring_meeting_occurrences_upcoming(recurring_meeting.id)
+
+      occurrence = JSON.parse(last_response.body)
+        .dig("_embedded", "elements")
+        .find { |e| e["startTime"] == ongoing_start.utc.iso8601 }
+
+      expect(occurrence).to be_present
+      expect(occurrence["state"]).to eq("open")
+    end
+
+    it "is returned as open by the past endpoint" do
+      get api_v3_paths.recurring_meeting_occurrences_past(recurring_meeting.id)
+
+      occurrence = JSON.parse(last_response.body)
+        .dig("_embedded", "elements")
+        .find { |e| e["startTime"] == ongoing_start.utc.iso8601 }
+
+      expect(occurrence).to be_present
+      expect(occurrence["state"]).to eq("open")
+    end
+  end
+
+  describe "occurrence state reflects the meeting's real state" do
+    let(:closed_start) { 2.days.ago }
+    let!(:closed_occurrence) do
+      create(:recurring_meeting_occurrence,
+             recurring_meeting:,
+             start_time: closed_start,
+             recurrence_start_time: closed_start,
+             state: :closed)
+    end
+
+    it "returns the actual state (closed) when closed, instead of 'open'" do
+      get api_v3_paths.recurring_meeting_occurrences_past(recurring_meeting.id)
+
+      occurrence = JSON.parse(last_response.body)
+        .dig("_embedded", "elements")
+        .find { |e| e["startTime"] == closed_start.utc.iso8601 }
+
+      expect(occurrence).to be_present
+      expect(occurrence["state"]).to eq("closed")
+    end
+  end
+
   describe "DELETE .../occurrences/:start_time" do
     let(:start_time) { recurring_meeting.first_occurrence }
     let(:path) { api_v3_paths.recurring_meeting_occurrence(recurring_meeting.id, start_time.utc.iso8601) }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-560
https://community.openproject.org/wp/MEET-561
https://community.openproject.org/wp/MEET-562

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Fix API bugs

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- For 560, I updated the state and upcoming/past determination via the API to always match the web versions. I'm not sure why they were not based off of the same thing in the first place
- For 561, I updated the contract to allow switching state when closed as well. This issue was never run into via the web version because [we update state directly without going through the contract](https://github.com/opf/openproject/blob/dev/modules/meeting/app/controllers/meetings_controller.rb#L305-L313). Not sure if that needs to be handled separately, but it is out of scope for now imo
- For 562, I changed the agenda_items response to also include backlog agenda items. These were previously excluded since for the web version we handle those lists of items separately, but such a distinction doesn't really make much sense for the API response

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
