### PR TITLE
[AGILE-299] Fix vertical alignment of Sprint and Backlog headers

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprints_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.html.erb
@@ -29,7 +29,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
-    head.with_heading(tag: :h3, size: :medium, font_weight: :bold) { Sprint.human_model_name.pluralize }
+    head.with_heading(
+      tag: :h3,
+      size: :medium,
+      font_weight: :bold,
+      display: :inline_flex,
+      align_items: :center
+    ) do
+      Sprint.human_model_name.pluralize
+    end
 
     if sprint_creation_allowed?
       head.with_actions do

--- a/modules/backlogs/app/components/backlogs/sprints_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
       display: :inline_flex,
       align_items: :center
     ) do
-      Sprint.human_model_name.pluralize
+      Sprint.human_plural_model_name
     end
 
     if sprint_creation_allowed?

--- a/modules/backlogs/app/services/backlogs/sprints/set_attributes_service.rb
+++ b/modules/backlogs/app/services/backlogs/sprints/set_attributes_service.rb
@@ -117,7 +117,7 @@ module Backlogs::Sprints
     end
 
     def default_sprint_name
-      [I18n.t("activerecord.models.sprint"), 1].join(" ")
+      [Sprint.human_model_name, 1].join(" ")
     end
   end
 end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -96,7 +96,9 @@ en:
               not_eligible_for_moving: "is not an active sprint in the project which holds the sprint the work package is moved out of."
 
     models:
-      sprint: "Sprint"
+      sprint:
+        one: "Sprint"
+        other: "Sprints"
 
   backlogs:
     administration_blankslate:

--- a/modules/backlogs/spec/services/backlogs/sprints/set_attributes_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/sprints/set_attributes_service_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Backlogs::Sprints::SetAttributesService, type: :model do
         it "assigns a default name for the first sprint" do
           service_call
 
-          expected_name = "#{I18n.t('activerecord.models.sprint')} 1"
+          expected_name = "#{Sprint.human_model_name} 1"
           expect(sprint.name).to eq(expected_name)
         end
       end
@@ -309,7 +309,7 @@ RSpec.describe Backlogs::Sprints::SetAttributesService, type: :model do
           create(:sprint, project: other_project, name: "Other Sprint 5")
 
           service_call
-          expect(sprint.name).to eq("#{I18n.t('activerecord.models.sprint')} 1")
+          expect(sprint.name).to eq("#{Sprint.human_model_name} 1")
         end
 
         it "only considers sprints from the same project" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-299

# What are you trying to accomplish?

The "Sprints" subheader on the backlogs page was vertically misaligned with its action button. This aligns the heading on its baseline by giving it `display: inline_flex` and `align_items: center`, matching the surrounding subhead row.

While here, the plural label no longer relies on `String#pluralize` (which only works for English) and instead uses `Sprint.human_plural_model_name`, so locales that inflect borrowed words (e.g. Polish) can translate it correctly.

## Screenshots

<img width="2045" height="119" alt="visual_diff_overlay" src="https://github.com/user-attachments/assets/345176ee-f9f4-4cd0-a714-b25b16159c85" />


| Before | After |
|--------|--------|
| <img width="2045" height="119" alt="before_aligned_crop" src="https://github.com/user-attachments/assets/a4388beb-6a8e-445b-914f-b319c9d3ffbb" /> | <img width="2045" height="119" alt="after_aligned_crop" src="https://github.com/user-attachments/assets/5f22c111-c09c-4a82-b212-c9df45ca61d5" /> | 

# What approach did you choose and why?

**Additional fix**: `pluralize` is an English-only inflector and happened to work for "Sprint" only because the word is unchanged in English plural. Passing a representative `count:` through `model_name.human` lets Crowdin supply the `one`/`few`/`many`/`other` variants per locale.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
