### PR TITLE
Bug/COMMS-469: Highlight and scroll to activity comment on anchor change

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -1,0 +1,227 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi, type Mock } from 'vitest';
+import { Controller } from '@hotwired/stimulus';
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type AutoScrollingControllerType from './auto-scrolling.controller';
+
+const HIGHLIGHTED_CLASS = '--anchor-highlighted';
+
+// The auto-scrolling controller reaches its scroll target and viewport flags
+// through the index controller's viewport service. A real index controller pulls
+// in the whole activities tab, so this stub exposes only what the scroll paths read.
+class StubIndexController extends Controller {
+  sortingAscending = false;
+
+  viewPortService = {
+    scrollableContainer: undefined as HTMLElement | undefined,
+    isMobile: () => false,
+    isWithinNotificationCenter: () => false,
+    isWithinSplitScreen: () => false,
+    isJournalsContainerScrolledToBottom: () => false,
+  };
+}
+
+describe('Activities tab auto-scrolling controller', () => {
+  let ctx:StimulusTestContext;
+  let AutoScrollingController:typeof AutoScrollingControllerType;
+  let scrollTo:Mock;
+
+  beforeAll(async () => {
+    ({ default: AutoScrollingController } = await import('./auto-scrolling.controller'));
+  });
+
+  beforeEach(async () => {
+    window.location.hash = '';
+    scrollTo = vi.fn();
+
+    ctx = await setupStimulusTest({
+      controllers: {
+        'work-packages--activities-tab--index': StubIndexController,
+        'work-packages--activities-tab--auto-scrolling': AutoScrollingController,
+      },
+    });
+  });
+
+  afterEach(() => {
+    window.location.hash = '';
+    ctx.dispose();
+    vi.restoreAllMocks();
+  });
+
+  async function renderActivities(resolvedCommentId?:number) {
+    const resolvedAttr = resolvedCommentId === undefined
+      ? ''
+      : `data-work-packages--activities-tab--auto-scrolling-resolved-comment-id-value="${resolvedCommentId}"`;
+
+    await ctx.mount(`
+      <div id="work-packages--activities-tab--index"
+           data-controller="work-packages--activities-tab--index">
+        <div id="scroller">
+          <div data-controller="work-packages--activities-tab--auto-scrolling" ${resolvedAttr}>
+            <div data-anchor-comment-id="131">comment 131</div>
+            <div data-anchor-comment-id="139">comment 139</div>
+          </div>
+        </div>
+      </div>
+    `);
+
+    const scroller = ctx.container.querySelector<HTMLElement>('#scroller')!;
+    scroller.scrollTo = scrollTo;
+
+    const indexEl = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--index"]')!;
+    const index = ctx.getController<StubIndexController>('work-packages--activities-tab--index', indexEl);
+    index.viewPortService.scrollableContainer = scroller;
+
+    return {
+      scroller,
+      el131: ctx.container.querySelector<HTMLElement>('[data-anchor-comment-id="131"]')!,
+      el139: ctx.container.querySelector<HTMLElement>('[data-anchor-comment-id="139"]')!,
+    };
+  }
+
+  function changeHash(hash:string) {
+    window.location.hash = hash;
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  }
+
+  it('highlights and scrolls to the comment when the hash changes after load', async () => {
+    const { el139 } = await renderActivities();
+
+    changeHash('#comment-139');
+
+    expect(el139.classList.contains(HIGHLIGHTED_CLASS)).toBe(true);
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
+  });
+
+  it('scrolls by the comment offset within the container, independent of offsetParent', async () => {
+    const { scroller, el139 } = await renderActivities();
+
+    // The scroll container is offset from the viewport and already scrolled; the
+    // comment's offsetParent is some other positioned ancestor, so the target must
+    // be derived from the rect delta, not offsetTop.
+    scroller.getBoundingClientRect = () => ({ top: 100 } as DOMRect);
+    el139.getBoundingClientRect = () => ({ top: 400 } as DOMRect);
+    Object.defineProperty(scroller, 'scrollTop', { value: 50, configurable: true });
+
+    changeHash('#comment-139');
+
+    // 50 (current scroll) + (400 - 100) (comment offset within container) - 70 (header clearance)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 280, behavior: 'smooth' });
+  });
+
+  it('reacts to every hash change, moving the highlight rather than stacking it', async () => {
+    const { el131, el139 } = await renderActivities();
+
+    changeHash('#comment-139');
+    expect(el139.classList.contains(HIGHLIGHTED_CLASS)).toBe(true);
+
+    changeHash('#comment-131');
+    expect(el131.classList.contains(HIGHLIGHTED_CLASS)).toBe(true);
+    expect(el139.classList.contains(HIGHLIGHTED_CLASS)).toBe(false);
+    expect(scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes a timestamp-link click through the hash instead of scrolling directly', async () => {
+    await renderActivities();
+    const controller = ctx.getController<AutoScrollingControllerType>('work-packages--activities-tab--auto-scrolling');
+    const preventDefault = vi.fn();
+
+    controller.setAnchor({
+      preventDefault,
+      params: { id: '139', anchorName: 'comment' },
+    } as unknown as Parameters<AutoScrollingControllerType['setAnchor']>[0]);
+
+    // It suppresses the link's native jump and lets the hash drive the scroll.
+    expect(preventDefault).toHaveBeenCalled();
+    expect(window.location.hash).toBe('#comment-139');
+  });
+
+  it('ignores a legacy activity anchor, which only the server can resolve', async () => {
+    await renderActivities(139);
+
+    changeHash('#activity-5');
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe('#activity-5');
+  });
+
+  it('does nothing when no element matches the hash', async () => {
+    await renderActivities();
+
+    changeHash('#comment-999');
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('stops reacting to hash changes once disconnected', async () => {
+    const { el139 } = await renderActivities();
+    const root = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
+
+    root.remove();
+    await ctx.nextFrame();
+
+    changeHash('#comment-139');
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(el139.classList.contains(HIGHLIGHTED_CLASS)).toBe(false);
+  });
+
+  it('clears the highlight and strips the anchor on the next document click', async () => {
+    const { el139 } = await renderActivities();
+
+    changeHash('#comment-139');
+    expect(el139.classList.contains(HIGHLIGHTED_CLASS)).toBe(true);
+
+    // The reset listener is registered on a deferred tick.
+    await new Promise((resolve) => setTimeout(resolve));
+    document.body.click();
+
+    expect(el139.classList.contains(HIGHLIGHTED_CLASS)).toBe(false);
+    expect(window.location.hash).toBe('');
+  });
+
+  it('tears down the anchor-reset click listener on disconnect', async () => {
+    await renderActivities();
+
+    changeHash('#comment-139');
+    await new Promise((resolve) => setTimeout(resolve));
+
+    const root = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
+    root.remove();
+    await ctx.nextFrame();
+
+    document.body.click();
+
+    // The listener was bound to the controller's AbortController, so it no longer
+    // mutates the URL after disconnect.
+    expect(window.location.hash).toBe('#comment-139');
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -31,6 +31,7 @@ import { Controller } from '@hotwired/stimulus';
 
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type AutoScrollingControllerType from './auto-scrolling.controller';
+import { ViewPortServiceInterface } from './services/view-port-service';
 
 const HIGHLIGHTED_CLASS = '--anchor-highlighted';
 
@@ -40,8 +41,8 @@ const HIGHLIGHTED_CLASS = '--anchor-highlighted';
 class StubIndexController extends Controller {
   sortingAscending = false;
 
-  viewPortService = {
-    scrollableContainer: undefined as HTMLElement | undefined,
+  viewPortService:ViewPortServiceInterface = {
+    scrollableContainer: null,
     isMobile: () => false,
     isWithinNotificationCenter: () => false,
     isWithinSplitScreen: () => false,
@@ -77,9 +78,10 @@ describe('Activities tab auto-scrolling controller', () => {
   });
 
   async function renderActivities(resolvedCommentId?:number) {
-    const resolvedAttr = resolvedCommentId === undefined
-      ? ''
-      : `data-work-packages--activities-tab--auto-scrolling-resolved-comment-id-value="${resolvedCommentId}"`;
+    const resolvedAttr =
+      resolvedCommentId === undefined
+        ? ''
+        : `data-work-packages--activities-tab--auto-scrolling-resolved-comment-id-value="${resolvedCommentId}"`;
 
     await ctx.mount(`
       <div id="work-packages--activities-tab--index"
@@ -152,8 +154,8 @@ describe('Activities tab auto-scrolling controller', () => {
     // The scroll container is offset from the viewport and already scrolled; the
     // comment's offsetParent is some other positioned ancestor, so the target must
     // be derived from the rect delta, not offsetTop.
-    scroller.getBoundingClientRect = () => ({ top: 100 } as DOMRect);
-    el139.getBoundingClientRect = () => ({ top: 400 } as DOMRect);
+    scroller.getBoundingClientRect = () => ({ top: 100 }) as DOMRect;
+    el139.getBoundingClientRect = () => ({ top: 400 }) as DOMRect;
     Object.defineProperty(scroller, 'scrollTop', { value: 50, configurable: true });
 
     changeHash('#comment-139');

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -112,6 +112,31 @@ describe('Activities tab auto-scrolling controller', () => {
     window.dispatchEvent(new HashChangeEvent('hashchange'));
   }
 
+  // Appends a link inside the controller element, the way a comment body would
+  // render one, and returns it for dispatching clicks at.
+  function addCommentBodyLink(href:string) {
+    const root = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
+    const link = document.createElement('a');
+    link.href = href;
+    link.textContent = 'see that comment';
+    root.appendChild(link);
+    return link;
+  }
+
+  function clickLink(link:HTMLAnchorElement, init:MouseEventInit = {}) {
+    // A click the controller leaves alone would otherwise drive a real navigation
+    // and tear down the test page; cancel the native default after the controller
+    // (on this.element) has already had its turn in the bubble phase.
+    const blockNavigation = (event:Event) => event.preventDefault();
+    window.addEventListener('click', blockNavigation, { once: true });
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...init });
+    link.dispatchEvent(event);
+
+    window.removeEventListener('click', blockNavigation);
+    return event;
+  }
+
   it('highlights and scrolls to the comment when the hash changes after load', async () => {
     const { el139 } = await renderActivities();
 
@@ -223,5 +248,56 @@ describe('Activities tab auto-scrolling controller', () => {
     // The listener was bound to the controller's AbortController, so it no longer
     // mutates the URL after disconnect.
     expect(window.location.hash).toBe('#comment-139');
+  });
+
+  // The controller sets the hash only when it decides to handle a link, so the
+  // hash is the clean signal of whether a click was intercepted.
+  describe('in-content comment links', () => {
+    it('intercepts a same-page comment link and drives it through the hash', async () => {
+      await renderActivities();
+      const link = addCommentBodyLink(`${window.location.origin}${window.location.pathname}#comment-139`);
+
+      clickLink(link);
+
+      expect(window.location.hash).toBe('#comment-139');
+    });
+
+    it('leaves a link to a different page for normal navigation', async () => {
+      await renderActivities();
+      const link = addCommentBodyLink(`${window.location.origin}/another/page#comment-139`);
+
+      clickLink(link);
+
+      expect(window.location.hash).toBe('');
+    });
+
+    it('leaves an external link untouched', async () => {
+      await renderActivities();
+      const link = addCommentBodyLink('https://example.test/work_packages/1/activity#comment-139');
+
+      clickLink(link);
+
+      expect(window.location.hash).toBe('');
+    });
+
+    it('does not hijack a modifier click meant to open a new tab', async () => {
+      await renderActivities();
+      const link = addCommentBodyLink(`${window.location.origin}${window.location.pathname}#comment-139`);
+
+      clickLink(link, { metaKey: true });
+
+      expect(window.location.hash).toBe('');
+    });
+
+    it('defers to a handler that already acted on the click', async () => {
+      await renderActivities();
+      const link = addCommentBodyLink(`${window.location.origin}${window.location.pathname}#comment-139`);
+      // Mimics the timestamp link, whose own action preventDefaults first.
+      link.addEventListener('click', (event) => event.preventDefault());
+
+      clickLink(link);
+
+      expect(window.location.hash).toBe('');
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -50,10 +50,14 @@ export default class AutoScrollingController extends BaseController {
   declare readonly resolvedCommentIdValue:number;
   declare readonly hasResolvedCommentIdValue:boolean;
 
-  private abortController = new AbortController();
+  private abortController!:AbortController;
 
   connect() {
     super.connect();
+
+    // Construct per connect so a disconnect→reconnect of the same instance gets a
+    // fresh signal; an already-aborted one would silently drop these listeners.
+    this.abortController = new AbortController();
 
     window.addEventListener('hashchange', this.scrollToHashAnchor, { signal: this.abortController.signal });
     this.element.addEventListener('click', this.handleCommentReferenceClick, { signal: this.abortController.signal });
@@ -177,7 +181,10 @@ export default class AutoScrollingController extends BaseController {
     if (!link) { return; }
 
     const anchor = this.sameActivityPageCommentAnchor(link as HTMLAnchorElement);
-    if (!anchor) { return; }
+    // Only claim the click when the comment is rendered here; otherwise let it
+    // navigate, so a link to a comment on another page (or filtered view) is not
+    // swallowed into a hash change that resolves to nothing.
+    if (!anchor || !this.getActivityAnchorElement(anchor)) { return; }
 
     event.preventDefault();
     window.location.hash = `#${anchor.type}-${anchor.id}`;
@@ -293,7 +300,9 @@ export default class AutoScrollingController extends BaseController {
   }
 
   private getActivityAnchorElement(activityAnchor:ActivityAnchor):HTMLElement | null {
-    return document.querySelector(`[data-anchor-${activityAnchor.type}-id="${activityAnchor.id}"]`);
+    // Scope to this controller's own activities frame: the window-level hashchange
+    // listener fires on every controller, and each must only claim its own comments.
+    return this.element.querySelector(`[data-anchor-${activityAnchor.type}-id="${activityAnchor.id}"]`);
   }
 
   private get inputContainer():HTMLElement | null {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -38,6 +38,10 @@ interface CustomEventWithIdParam extends Event {
   };
 }
 
+// Clearance kept above a comment scrolled into view, so it settles below the
+// activities header rather than flush against the top of the scroll container.
+const ANCHOR_SCROLL_TOP_OFFSET = 70;
+
 export default class AutoScrollingController extends BaseController {
   static values = {
     resolvedCommentId: Number,
@@ -46,33 +50,24 @@ export default class AutoScrollingController extends BaseController {
   declare readonly resolvedCommentIdValue:number;
   declare readonly hasResolvedCommentIdValue:boolean;
 
+  private abortController = new AbortController();
+
   connect() {
     super.connect();
 
+    window.addEventListener('hashchange', this.scrollToHashAnchor, { signal: this.abortController.signal });
     this.handleInitialScroll();
   }
 
+  disconnect() {
+    this.abortController.abort();
+  }
+
   setAnchor(event:CustomEventWithIdParam) {
-    // native anchor scroll is causing positioning issues
+    // Suppress the link's native jump and let the resulting hash change drive the
+    // scroll and highlight, so a click here behaves like any other anchor change.
     event.preventDefault();
-
-    const activityId = event.params.id;
-    const anchorName = event.params.anchorName;
-
-    // not using the scrollToActivity method here as it is causing flickering issues
-    // in case of a setAnchor click, we can go for a direct scroll approach
-    const scrollableContainer = this.scrollableContainer;
-    const activityElement = this.getActivityAnchorElement({ type: anchorName, id: activityId });
-    const locationHash = `#${anchorName}-${activityId}`;
-
-    if (scrollableContainer && activityElement) {
-      this.brieflyHighlightAndResetUrl(activityElement, locationHash);
-      scrollableContainer.scrollTo({
-        top: activityElement.offsetTop - 90,
-        behavior: 'smooth',
-      });
-    }
-    window.location.hash = locationHash;
+    window.location.hash = `#${event.params.anchorName}-${event.params.id}`;
   }
 
   performAutoScrollingOnStreamsUpdate(journalsContainerAtBottom = false) {
@@ -139,6 +134,35 @@ export default class AutoScrollingController extends BaseController {
     }
   }
 
+  // Reacts to any hash change without a fresh render: a comment timestamp click,
+  // an in-page comment link, or editing the comment id in the URL. Initial-load
+  // scrolling stays in handleInitialScroll, which waits for not-yet-rendered content.
+  private scrollToHashAnchor = () => {
+    const anchorInfo = UrlHelpers.extractActivityAnchor(window.location.hash);
+    // Only a comment anchor maps to a rendered element. A legacy activity-N anchor
+    // is resolved to its comment by the server when the page loads with ?anchor;
+    // a hash change makes no such request, so there is nothing to scroll to.
+    if (anchorInfo?.type !== ActivityAnchorType.Comment) { return; }
+
+    const activityElement = this.getActivityAnchorElement(anchorInfo);
+    const scrollableContainer = this.scrollableContainer;
+    if (!activityElement || !scrollableContainer) { return; }
+
+    // Successive hash changes happen without a reload, so drop a previous
+    // highlight before applying the new one instead of stacking them.
+    this.clearAnchorHighlight();
+    this.brieflyHighlightAndResetUrl(activityElement, window.location.hash);
+
+    // offsetTop is relative to the element's offsetParent, which is not the
+    // scroll container, so measure the gap between the two directly.
+    const relativeTop = activityElement.getBoundingClientRect().top
+      - scrollableContainer.getBoundingClientRect().top;
+    scrollableContainer.scrollTo({
+      top: scrollableContainer.scrollTop + relativeTop - ANCHOR_SCROLL_TOP_OFFSET,
+      behavior: 'smooth',
+    });
+  };
+
   private canonicalizeActivityAnchor(anchorInfo:ActivityAnchor):ActivityAnchor {
     const resolvedCommentId = this.hasResolvedCommentIdValue ? this.resolvedCommentIdValue : null;
     const canonical = UrlHelpers.canonicalActivityAnchor(anchorInfo, resolvedCommentId);
@@ -165,7 +189,7 @@ export default class AutoScrollingController extends BaseController {
 
   private tryScroll(activityElement:HTMLElement|null, attempts:number, maxAttempts:number) {
     const scrollableContainer = this.scrollableContainer;
-    const topPadding = 70;
+    const topPadding = ANCHOR_SCROLL_TOP_OFFSET;
 
     if (activityElement && scrollableContainer) {
       scrollableContainer.scrollTop = 0;
@@ -219,6 +243,12 @@ export default class AutoScrollingController extends BaseController {
     });
   }
 
+  private clearAnchorHighlight() {
+    this.element
+      .querySelectorAll('.--anchor-highlighted')
+      .forEach((highlighted) => highlighted.classList.remove('--anchor-highlighted'));
+  }
+
   private brieflyHighlightAndResetUrl(activityElement:HTMLElement|null, locationHash:string) {
     if (activityElement) {
       activityElement.classList.add('--anchor-highlighted');
@@ -227,7 +257,7 @@ export default class AutoScrollingController extends BaseController {
           activityElement.classList.remove('--anchor-highlighted');
           const newLocation = window.location.href.replace(locationHash, '');
           window.history.replaceState(null, 'Remove anchor', newLocation);
-        }, {once: true});
+        }, { once: true, signal: this.abortController.signal });
       });
     }
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -56,6 +56,7 @@ export default class AutoScrollingController extends BaseController {
     super.connect();
 
     window.addEventListener('hashchange', this.scrollToHashAnchor, { signal: this.abortController.signal });
+    this.element.addEventListener('click', this.handleCommentReferenceClick, { signal: this.abortController.signal });
     this.handleInitialScroll();
   }
 
@@ -162,6 +163,35 @@ export default class AutoScrollingController extends BaseController {
       behavior: 'smooth',
     });
   };
+
+  // In-content comment references are plain links inside the activities frame, so
+  // Turbo would treat a click as a frame/page visit and drop the fragment. When a
+  // link points to a comment on this very page, drive it through the hash instead
+  // and let scrollToHashAnchor take over; anything else navigates as usual.
+  private handleCommentReferenceClick = (event:MouseEvent) => {
+    // Respect already-handled clicks (e.g. the timestamp link) and new-tab intents.
+    if (event.defaultPrevented || event.button !== 0
+      || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) { return; }
+
+    const link = (event.target as HTMLElement).closest('a[href]');
+    if (!link) { return; }
+
+    const anchor = this.sameActivityPageCommentAnchor(link as HTMLAnchorElement);
+    if (!anchor) { return; }
+
+    event.preventDefault();
+    window.location.hash = `#${anchor.type}-${anchor.id}`;
+  };
+
+  private sameActivityPageCommentAnchor(link:HTMLAnchorElement):ActivityAnchor | null {
+    const target = new URL(link.href, window.location.href);
+    if (target.origin !== window.location.origin || target.pathname !== window.location.pathname) {
+      return null;
+    }
+
+    const anchor = UrlHelpers.extractActivityAnchor(target.hash);
+    return anchor?.type === ActivityAnchorType.Comment ? anchor : null;
+  }
 
   private canonicalizeActivityAnchor(anchorInfo:ActivityAnchor):ActivityAnchor {
     const resolvedCommentId = this.hasResolvedCommentIdValue ? this.resolvedCommentIdValue : null;

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1172,7 +1172,6 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
       before do
         visit project_work_package_path(project, work_package.id, "activity", anchor: "comment-#{comment_1.id}")
         wp_page.wait_for_activity_tab
-        sleep 1 # let the initial auto-scroll settle
       end
 
       it "moves the highlight to the comment newly referenced in the URL hash" do
@@ -1193,7 +1192,6 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
       before do
         visit project_work_package_path(project, work_package.id, "activity", anchor: "comment-#{comment_1.id}")
         wp_page.wait_for_activity_tab
-        sleep 1 # let the initial auto-scroll settle
       end
 
       it "scrolls to and highlights the comment instead of letting Turbo drop the fragment" do

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1166,6 +1166,27 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
       def wait_for_auto_scrolling_to_finish = sleep(1)
     end
 
+    describe "when the comment anchor changes without reloading the page" do
+      let!(:admin_preferences) { create(:user_preference, user: admin, others: { comments_sorting: :asc }) }
+
+      before do
+        visit project_work_package_path(project, work_package.id, "activity", anchor: "comment-#{comment_1.id}")
+        wp_page.wait_for_activity_tab
+        sleep 1 # let the initial auto-scroll settle
+      end
+
+      it "moves the highlight to the comment newly referenced in the URL hash" do
+        expect(page).to have_css(".Box.--anchor-highlighted", text: "Comment 1")
+
+        # As clicking an in-page comment link or editing the comment id by hand would:
+        # the URL hash changes but the page is not reloaded.
+        page.execute_script("window.location.hash = '#comment-#{comment_2.id}'")
+
+        expect(page).to have_css(".Box.--anchor-highlighted", text: "Comment 2")
+        expect(page).to have_no_css(".Box.--anchor-highlighted", text: "Comment 1")
+      end
+    end
+
     context "when sorting set to asc" do
       let!(:admin_preferences) { create(:user_preference, user: admin, others: { comments_sorting: :asc }) }
 

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1187,6 +1187,39 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
       end
     end
 
+    describe "when clicking an in-content link to another comment on the same page" do
+      let!(:admin_preferences) { create(:user_preference, user: admin, others: { comments_sorting: :asc }) }
+
+      before do
+        visit project_work_package_path(project, work_package.id, "activity", anchor: "comment-#{comment_1.id}")
+        wp_page.wait_for_activity_tab
+        sleep 1 # let the initial auto-scroll settle
+      end
+
+      it "scrolls to and highlights the comment instead of letting Turbo drop the fragment" do
+        expect(page).to have_css(".Box.--anchor-highlighted", text: "Comment 1")
+
+        # Comment bodies render plain links. Inject one (so this stays independent of
+        # the rich-text formatter) pointing to another comment on this same activity
+        # page, as a pasted comment link would, then click it through a real browser
+        # click so Turbo's own handlers run. Turbo must not swallow it.
+        page.execute_script(<<~JS)
+          const root = document.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]');
+          const link = document.createElement('a');
+          link.href = window.location.pathname + '#comment-#{comment_2.id}';
+          link.textContent = 'jump to the other comment';
+          link.id = 'injected-comment-link';
+          root.prepend(link);
+        JS
+
+        find_by_id("injected-comment-link").click
+
+        expect(page).to have_css(".Box.--anchor-highlighted", text: "Comment 2")
+        expect(page).to have_no_css(".Box.--anchor-highlighted", text: "Comment 1")
+        expect(page.evaluate_script("window.location.hash")).to eq("#comment-#{comment_2.id}")
+      end
+    end
+
     context "when sorting set to asc" do
       let!(:admin_preferences) { create(:user_preference, user: admin, others: { comments_sorting: :asc }) }
 


### PR DESCRIPTION
[COMMS-469](https://community.openproject.org/wp/COMMS-469)

Updating the activity-tab anchor without a full page load didn't scroll to or highlight the referenced comment - whether clicking a comment-reference link inside another comment, or editing `#comment-<id>` in the address bar.

Two separate causes. The auto-scrolling controller only acted on initial render, so later hash changes were ignored; a `hashchange` listener now reacts to all of them. And a comment-reference link is a plain link inside the activities Turbo frame, so Turbo claimed the click as a navigation and dropped the fragment before anything could react; same-page comment links are now routed through the hash, while links to other pages and external links are left untouched.

> A previous attempt (#20609) was closed because its scroll-detection rework left a large empty gap at the bottom of the activity list [COMMS-469/activity#comment-1476892](https://community.openproject.org/projects/COMMS/work_packages/COMMS-469/activity#comment-1476892). This keeps the existing initial-load scrolling untouched and never resizes or pads the container, so it can't reintroduce that. The old `offsetTop`-based math measured against the wrong ancestor; the scroll target now comes from the comment's position within the actual scroll container, which is correct in the full view, split screen, notification center, and on mobile.

Legacy `#activity-<n>` anchors aren't handled on a hash change, since resolving a sequence version to a comment needs the server, which a same-page hash change never reaches.

https://github.com/user-attachments/assets/73965191-baaf-4a90-b441-2e757c10444b



