### PR TITLE
Allow semantic IDs to be parsed from version check script

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -31,7 +31,19 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: ./script/ci/version_check.sh "$PR_BODY" "$PR_TITLE"
+        run: ./script/ci/version_check.sh
+
+      - name: Add comment if no work package is linked
+        if: steps.version-check.outputs.no_ticket == 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: version-mismatch-comment
+          message: |
+            > [!WARNING]
+            > This pull request does not link an OpenProject work package.
+
+            Please add a link to the work package in the description, or reference it in the
+            title in square brackets, e.g. `[SLUG-123] My title here`.
 
       - name: Add comment if versions differ
         if: steps.version-check.outputs.version_mismatch == 'true'
@@ -52,7 +64,7 @@ jobs:
 
              - The work package version OR your pull request target branch is correct
       - name: Version check passed
-        if: steps.version-check.outputs.version_mismatch != 'true'
+        if: steps.version-check.outputs.version_mismatch != 'true' && steps.version-check.outputs.no_ticket != 'true'
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -30,7 +30,8 @@ jobs:
         id: version-check
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: ./script/ci/version_check.sh "$PR_BODY"
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: ./script/ci/version_check.sh "$PR_BODY" "$PR_TITLE"
 
       - name: Add comment if versions differ
         if: steps.version-check.outputs.version_mismatch == 'true'

--- a/script/ci/version_check.sh
+++ b/script/ci/version_check.sh
@@ -31,8 +31,10 @@ set -e
 
 # script/ci/version_check
 
-PR_BODY="$1"
-PR_TITLE="$2"
+# Read from the PR_BODY / PR_TITLE environment variables, falling back to
+# positional arguments so the script can still be run manually for testing.
+PR_BODY="${PR_BODY:-$1}"
+PR_TITLE="${PR_TITLE:-$2}"
 
 # Extract first work package URL from PR description.
 # IDs can be numeric (e.g. 12345) or semantic (e.g. SC-123: an uppercase prefix, a dash, then a number).
@@ -51,6 +53,7 @@ fi
 
 if [ -z "$WORK_PACKAGE_ID" ]; then
   echo "::warning::PR description does not contain a valid URL to an OpenProject ticket, nor a [ID] in the title."
+  echo "no_ticket=true" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 echo "Work Package ID: $WORK_PACKAGE_ID"

--- a/script/ci/version_check.sh
+++ b/script/ci/version_check.sh
@@ -31,18 +31,28 @@ set -e
 
 # script/ci/version_check
 
-PR_BODY="$@"
+PR_BODY="$1"
+PR_TITLE="$2"
 
-# Extract first work package URL from PR description
-WP_URL=$(echo "$PR_BODY" | grep -oE 'https://community.openproject.org/(wp|work_packages|projects/[^/]+/work_packages)/[0-9]+' | head -n 1 || true)
+# Extract first work package URL from PR description.
+# IDs can be numeric (e.g. 12345) or semantic (e.g. SC-123: an uppercase prefix, a dash, then a number).
+WP_URL=$(echo "$PR_BODY" | grep -oE 'https://community.openproject.org/(wp|work_packages|projects/[^/]+/work_packages)/([A-Z][A-Z0-9_]*-[0-9]+|[0-9]+)/?' | head -n 1 || true)
 
-if [ -z "$WP_URL" ]; then
-  echo "::warning::PR description does not contain a valid URL to an OpenProject ticket."
-  exit 0
+if [ -n "$WP_URL" ]; then
+  # Extract the work package ID (last path segment, numeric or semantic; ignore any trailing slash)
+  WORK_PACKAGE_ID=$(echo "${WP_URL%/}" | grep -oE '[^/]+$')
+else
+  # Fall back to an ID in square brackets in the PR title, e.g. [OP-19205] My title here
+  WORK_PACKAGE_ID=$(echo "$PR_TITLE" | grep -oE '\[([A-Z][A-Z0-9_]*-[0-9]+|[0-9]+)\]' | head -n 1 | tr -d '[]' || true)
+  if [ -n "$WORK_PACKAGE_ID" ]; then
+    WP_URL="https://community.openproject.org/wp/${WORK_PACKAGE_ID}"
+  fi
 fi
 
-# Extract the work package ID
-WORK_PACKAGE_ID=$(echo "$WP_URL" | grep -oE '[0-9]+$')
+if [ -z "$WORK_PACKAGE_ID" ]; then
+  echo "::warning::PR description does not contain a valid URL to an OpenProject ticket, nor a [ID] in the title."
+  exit 0
+fi
 echo "Work Package ID: $WORK_PACKAGE_ID"
 
 # Perform API request to fetch version


### PR DESCRIPTION
We use the script/ci/version_check.sh script to check for a work package ID in the PR description. Up until now, that expected a numeric version.

https://community.openproject.org/wp/DEVOPS-519