### PR TITLE
Correctly block disabled cost type in a project

### DIFF
--- a/modules/budgets/app/views/budgets/items/_material_budget_item.html.erb
+++ b/modules/budgets/app/views/budgets/items/_material_budget_item.html.erb
@@ -72,7 +72,7 @@ See COPYRIGHT and LICENSE files for more details.
     <td class="cost_type">
       <label class="sr-only" for="<%= id_prefix %>_cost_type_id"><%= MaterialBudgetItem.human_attribute_name(:cost_type) %></label>
       <%= cost_form.select :cost_type_id,
-                           cost_types_collection_for_select_options(material_budget_item.cost_type),
+                           cost_types_collection_for_select_options(material_budget_item.cost_type, project: @project),
                            {},
                            {
                              index: id_or_index,

--- a/modules/budgets/spec/features/budgets/add_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/add_budget_spec.rb
@@ -78,6 +78,29 @@ RSpec.describe "adding a new budget", :js do
       expect(page).to have_css(".material_budget_items td.units", text: "15.00")
       expect(page).to have_css(".material_budget_items td", text: "Foobar")
     end
+
+    context "and a project-scoped cost type not mapped to this project" do
+      let!(:scoped_mapped) do
+        create(:cost_type, name: "Mapped", unit: "x", unit_plural: "xs", for_all_projects: false).tap do |ct|
+          CostTypesProject.create!(cost_type: ct, project: project)
+        end
+      end
+      let!(:scoped_unmapped) do
+        create(:cost_type, name: "Hidden", unit: "y", unit_plural: "ys", for_all_projects: false)
+      end
+
+      it "omits the unmapped cost type from the dropdown" do
+        visit new_projects_budget_path(project)
+
+        select_id = "budget_new_material_budget_item_attributes_0_cost_type_id"
+        within("##{select_id}") do
+          expect(page).to have_css("option", text: "Post-war")
+          expect(page).to have_css("option", text: "Foobar")
+          expect(page).to have_css("option", text: "Mapped")
+          expect(page).to have_no_css("option", text: "Hidden")
+        end
+      end
+    end
   end
 
   it "create the budget" do

--- a/modules/costs/app/helpers/costlog_helper.rb
+++ b/modules/costs/app/helpers/costlog_helper.rb
@@ -27,8 +27,9 @@
 #++
 
 module CostlogHelper
-  def cost_types_collection_for_select_options(selected_type = nil)
-    cost_types = CostType.active.sort
+  def cost_types_collection_for_select_options(selected_type = nil, project: nil)
+    scope = project ? CostType.available_for_project(project).active : CostType.active
+    cost_types = scope.sort
 
     if selected_type && !cost_types.include?(selected_type)
       cost_types << selected_type

--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -92,7 +92,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="form--field -required">
     <%# see above %>
     <%= f.select :cost_type_id,
-                 cost_types_collection_for_select_options,
+                 cost_types_collection_for_select_options(project: @project),
                  { prompt: true,
                    container_class: "-middle" },
                  {

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -274,7 +274,7 @@ en:
       rates:
         title: "Rate history"
     settings:
-      time_and_costs: "Time & Costs"
+      time_and_costs: "Time and costs"
       cost_types:
         heading: "Cost types"
         none_active: "No cost types are currently active in this project."

--- a/modules/costs/spec/features/time_entry/activity_spec.rb
+++ b/modules/costs/spec/features/time_entry/activity_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Time entry activity", :js do
 
     visit project_settings_general_path(project)
 
-    click_on "Time & Costs"
+    click_on "Time and costs"
 
     expect(page).to have_field("Development", checked: true)
 

--- a/modules/reporting/spec/features/menu_spec.rb
+++ b/modules/reporting/spec/features/menu_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "project menu" do
         end
 
         it "leads to cost reports" do
-          find("#main-menu #{test_selector('op-menu--item-action')}", text: "Time and costs").click
+          find("#main-menu .costs-menu-item", text: "Time and costs").click
 
           expect(page).to have_current_path("/projects/ponyo/cost_reports")
         end


### PR DESCRIPTION
Cost type selection for a new cost entry was still drawing from all global cost types, not correctly filtering them. I added a separate create example to ensure we have that tested.

https://community.openproject.org/projects/OP/work_packages/OP-19599/activity