### PR TITLE
Properly check permission to save cost report as public

### DIFF
--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -144,6 +144,8 @@ class CostReportsController < ApplicationController
   ##
   # Create a new saved query. Returns the redirect url to an XHR or redirects directly
   def create
+    return deny_access if make_query_public? && !allowed_in_report?(:save_as_public, @query)
+
     @query.name = params[:query_name].presence || ::I18n.t(:label_default)
     @query.public! if make_query_public?
     @query.send(:"#{user_key}=", current_user.id)

--- a/modules/reporting/spec/controllers/cost_reports_controller_spec.rb
+++ b/modules/reporting/spec/controllers/cost_reports_controller_spec.rb
@@ -141,6 +141,42 @@ RSpec.describe CostReportsController do
     end
   end
 
+  describe "POST save_as" do
+    let(:user) { create(:user) }
+
+    context "when only save_private_cost_reports is granted" do
+      before do
+        is_member project, user, %i[view_cost_entries save_private_cost_reports]
+      end
+
+      it "does not create a public report when query_is_public is requested" do
+        expect do
+          post :create, params: { query_name: "Shared report", query_is_public: "1" }
+        end.not_to change { CostQuery.where(is_public: true).count }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "still allows creating a private report" do
+        expect do
+          post :create, params: { query_name: "My report" }
+        end.to change { CostQuery.where(is_public: false, user_id: user.id).count }.by(1)
+      end
+    end
+
+    context "when save_cost_reports is granted" do
+      before do
+        is_member project, user, %i[view_cost_entries save_cost_reports]
+      end
+
+      it "creates a public report when query_is_public is requested" do
+        expect do
+          post :create, params: { query_name: "Shared report", query_is_public: "1" }
+        end.to change { CostQuery.where(is_public: true).count }.by(1)
+      end
+    end
+  end
+
   describe "POST update" do
     let(:user) { create(:user) }
     let(:owner) { create(:user) }


### PR DESCRIPTION
The separate permission to save a public cost report was not properly checked against.

https://community.openproject.org/wp/COSTS-158