### PR TITLE
Bug/COMMS-464: Bring deep-linked comments fully into view

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -47,6 +47,7 @@ class StubIndexController extends Controller {
     isWithinNotificationCenter: () => false,
     isWithinSplitScreen: () => false,
     isJournalsContainerScrolledToBottom: () => false,
+    anchorScrollOffset: () => 0,
   };
 }
 
@@ -103,6 +104,7 @@ describe('Activities tab auto-scrolling controller', () => {
     index.viewPortService.scrollableContainer = scroller;
 
     return {
+      index,
       scroller,
       el131: ctx.container.querySelector<HTMLElement>('[data-anchor-comment-id="131"]')!,
       el139: ctx.container.querySelector<HTMLElement>('[data-anchor-comment-id="139"]')!,
@@ -148,20 +150,22 @@ describe('Activities tab auto-scrolling controller', () => {
     expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
   });
 
-  it('scrolls by the comment offset within the container, independent of offsetParent', async () => {
-    const { scroller, el139 } = await renderActivities();
+  it('scrolls by the comment offset within the container, less the anchor offset', async () => {
+    const { index, scroller, el139 } = await renderActivities();
 
     // The scroll container is offset from the viewport and already scrolled; the
     // comment's offsetParent is some other positioned ancestor, so the target must
-    // be derived from the rect delta, not offsetTop.
+    // be derived from the rect delta, not offsetTop. The viewport service supplies
+    // the offset that seats the comment below the pinned header.
     scroller.getBoundingClientRect = () => ({ top: 100 }) as DOMRect;
     el139.getBoundingClientRect = () => ({ top: 400 }) as DOMRect;
     Object.defineProperty(scroller, 'scrollTop', { value: 50, configurable: true });
+    index.viewPortService.anchorScrollOffset = () => 185;
 
     changeHash('#comment-139');
 
-    // 50 (current scroll) + (400 - 100) (comment offset within container) - 70 (header clearance)
-    expect(scrollTo).toHaveBeenCalledWith({ top: 280, behavior: 'smooth' });
+    // 50 (current scroll) + (400 - 100) (offset within container) - 185 (anchor offset)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 165, behavior: 'smooth' });
   });
 
   it('reacts to every hash change, moving the highlight rather than stacking it', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -38,10 +38,6 @@ interface CustomEventWithIdParam extends Event {
   };
 }
 
-// Clearance kept above a comment scrolled into view, so it settles below the
-// activities header rather than flush against the top of the scroll container.
-const ANCHOR_SCROLL_TOP_OFFSET = 70;
-
 export default class AutoScrollingController extends BaseController {
   static values = {
     resolvedCommentId: Number,
@@ -159,11 +155,12 @@ export default class AutoScrollingController extends BaseController {
     this.brieflyHighlightAndResetUrl(activityElement, window.location.hash);
 
     // offsetTop is relative to the element's offsetParent, which is not the
-    // scroll container, so measure the gap between the two directly.
+    // scroll container, so measure the gap between the two directly, then back
+    // the target off so the comment lands below the pinned header, not behind it.
     const relativeTop = activityElement.getBoundingClientRect().top
       - scrollableContainer.getBoundingClientRect().top;
     scrollableContainer.scrollTo({
-      top: scrollableContainer.scrollTop + relativeTop - ANCHOR_SCROLL_TOP_OFFSET,
+      top: scrollableContainer.scrollTop + relativeTop - this.anchorScrollOffset(),
       behavior: 'smooth',
     });
   };
@@ -226,7 +223,6 @@ export default class AutoScrollingController extends BaseController {
 
   private tryScroll(activityElement:HTMLElement|null, attempts:number, maxAttempts:number) {
     const scrollableContainer = this.scrollableContainer;
-    const topPadding = ANCHOR_SCROLL_TOP_OFFSET;
 
     if (activityElement && scrollableContainer) {
       scrollableContainer.scrollTop = 0;
@@ -236,7 +232,7 @@ export default class AutoScrollingController extends BaseController {
         const elementRect = activityElement.getBoundingClientRect();
         const relativeTop = elementRect.top - containerRect.top;
 
-        scrollableContainer.scrollTop = relativeTop - topPadding;
+        scrollableContainer.scrollTop = relativeTop - this.anchorScrollOffset();
       }, 50);
     } else if (attempts < maxAttempts) {
       setTimeout(() => {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/base.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/base.controller.ts
@@ -49,6 +49,7 @@ export default class BaseController extends Controller implements ViewPortServic
   isWithinNotificationCenter() { return this.indexOutlet.viewPortService.isWithinNotificationCenter(); }
   isWithinSplitScreen() { return this.indexOutlet.viewPortService.isWithinSplitScreen(); }
   isJournalsContainerScrolledToBottom() { return this.indexOutlet.viewPortService.isJournalsContainerScrolledToBottom(); }
+  anchorScrollOffset() { return this.indexOutlet.viewPortService.anchorScrollOffset(); }
 
   get scrollableContainer() { return this.indexOutlet.viewPortService.scrollableContainer; }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.spec.ts
@@ -1,0 +1,91 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi } from 'vitest';
+import { ViewPortService } from './view-port-service';
+
+// isMobile() compares against window.innerWidth, so pick a breakpoint either
+// side of the test window to force one layout or the other.
+function serviceForViewport(mobile:boolean):ViewPortService {
+  const breakpoint = mobile ? window.innerWidth + 1 : 0;
+  return new ViewPortService('notifications', 'work_packages/details', breakpoint);
+}
+
+describe('ViewPortService#anchorScrollOffset', () => {
+  let contentBody:HTMLElement;
+  let tabContent:HTMLElement;
+
+  beforeEach(() => {
+    contentBody = document.createElement('div'); // mobile scroll container
+    contentBody.id = 'content-body';
+    document.body.appendChild(contentBody);
+
+    tabContent = document.createElement('div'); // desktop scroll container
+    tabContent.className = 'tabcontent';
+    document.body.appendChild(tabContent);
+  });
+
+  afterEach(() => {
+    contentBody.remove();
+    tabContent.remove();
+    vi.restoreAllMocks();
+  });
+
+  // Pins a header to the top of the scroll container and makes it the only box
+  // the layout probe finds there. `reach` is how far it extends below the
+  // container top.
+  function pinHeader(container:HTMLElement, reach:number) {
+    container.getBoundingClientRect = () => ({ top: 0, left: 0 }) as DOMRect;
+    const header = document.createElement('div');
+    header.style.position = 'sticky';
+    container.appendChild(header);
+    header.getBoundingClientRect = () => ({ bottom: reach }) as DOMRect;
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([header]);
+  }
+
+  it('seats the comment below a header pinned over the scroll container, plus a gap', () => {
+    pinHeader(contentBody, 185);
+
+    // 185 (measured toolbar) + 16 (gap)
+    expect(serviceForViewport(true).anchorScrollOffset()).toBe(201);
+  });
+
+  it('uses just the gap when nothing is pinned over the container', () => {
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([]);
+
+    expect(serviceForViewport(true).anchorScrollOffset()).toBe(16);
+  });
+
+  it('seats the comment a small gap below the top on desktop, showing only the stem', () => {
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([]);
+
+    // .tabcontent has nothing pinned over it, so the offset is just the gap; a
+    // large offset here exposed the bottom of the preceding comment.
+    expect(serviceForViewport(false).anchorScrollOffset()).toBe(16);
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.spec.ts
@@ -81,11 +81,42 @@ describe('ViewPortService#anchorScrollOffset', () => {
     expect(serviceForViewport(true).anchorScrollOffset()).toBe(16);
   });
 
+  it('ignores an unpinned element sitting at the container top', () => {
+    // The layout reads as mobile well above the breakpoint where the toolbar
+    // turns sticky, so in that window the toolbar is still static and scrolls
+    // away. Reading the live position keeps it from reserving space it won't hold.
+    contentBody.getBoundingClientRect = () => ({ top: 0, left: 0 }) as DOMRect;
+    const staticHeader = document.createElement('div');
+    staticHeader.style.position = 'static';
+    staticHeader.getBoundingClientRect = () => ({ bottom: 185 }) as DOMRect;
+    contentBody.appendChild(staticHeader);
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([staticHeader]);
+
+    expect(serviceForViewport(true).anchorScrollOffset()).toBe(16);
+  });
+
   it('seats the comment a small gap below the top on desktop, showing only the stem', () => {
     vi.spyOn(document, 'elementsFromPoint').mockReturnValue([]);
 
     // .tabcontent has nothing pinned over it, so the offset is just the gap; a
     // large offset here exposed the bottom of the preceding comment.
     expect(serviceForViewport(false).anchorScrollOffset()).toBe(16);
+  });
+
+  it('ignores a pinned element that sits outside the scroll container', () => {
+    // The desktop toolbar is sticky but lives above .tabcontent, not within it,
+    // so it must not count toward the offset even while it overlaps the probe.
+    tabContent.getBoundingClientRect = () => ({ top: 0, left: 0 }) as DOMRect;
+    const outsideHeader = document.createElement('div');
+    outsideHeader.style.position = 'sticky';
+    outsideHeader.getBoundingClientRect = () => ({ bottom: 185 }) as DOMRect;
+    document.body.appendChild(outsideHeader);
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([outsideHeader]);
+
+    try {
+      expect(serviceForViewport(false).anchorScrollOffset()).toBe(16);
+    } finally {
+      outsideHeader.remove();
+    }
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.ts
@@ -34,9 +34,15 @@ export interface ViewPortServiceInterface {
   isWithinSplitScreen():boolean;
   isJournalsContainerScrolledToBottom():boolean;
   scrollableContainer:HTMLElement | null;
+  anchorScrollOffset():number;
 }
 
 export class ViewPortService implements ViewPortServiceInterface {
+  // Small gap kept above a comment reached by its anchor so it seats just below
+  // the connector stem (or, on mobile, just below the pinned toolbar) instead of
+  // exposing the bottom of the previous comment above it.
+  private static readonly ANCHOR_SCROLL_GAP = 16;
+
   private notificationCenterPathName:string;
   private splitScreenPathName:string;
 
@@ -93,5 +99,42 @@ export class ViewPortService implements ViewPortServiceInterface {
 
     // valid for desktop
     return document.querySelector('.tabcontent')!;
+  }
+
+  // How far down to seat a comment scrolled to via its anchor: just below any
+  // header pinned to the top of the scroll container (the work package toolbar on
+  // mobile), plus a small gap. Desktop pins nothing there, so the comment seats a
+  // gap below the top, showing only the connector stem above it rather than the
+  // previous comment.
+  anchorScrollOffset():number {
+    const container = this.scrollableContainer;
+    const pinnedHeader = container ? this.pinnedHeaderHeight(container) : 0;
+
+    return pinnedHeader + ViewPortService.ANCHOR_SCROLL_GAP;
+  }
+
+  // Height of any header pinned to the top of the container, read from the live
+  // paint stack because the toolbar's height is not fixed:
+  //
+  //   ┌─ pinned toolbar ─┐  ← container top
+  //   ├──────────────────┤  ← returned height; the comment seats below this line
+  //   │  journals …      │
+  //
+  private pinnedHeaderHeight(container:HTMLElement):number {
+    const containerRect = container.getBoundingClientRect();
+    const probeX = containerRect.left + (container.clientWidth / 2);
+    const stack = document.elementsFromPoint(probeX, containerRect.top + 1);
+
+    let height = 0;
+    for (const node of stack) {
+      if (node === container || !container.contains(node)) { continue; }
+
+      const { position } = window.getComputedStyle(node);
+      if (position === 'sticky' || position === 'fixed') {
+        height = Math.max(height, node.getBoundingClientRect().bottom - containerRect.top);
+      }
+    }
+
+    return height;
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.ts
@@ -129,8 +129,11 @@ export class ViewPortService implements ViewPortServiceInterface {
     for (const node of stack) {
       if (node === container || !container.contains(node)) { continue; }
 
+      // Only a sticky header is pinned relative to this container. A fixed
+      // element is positioned against the viewport, so its position over the
+      // container top is incidental and must not reserve space here.
       const { position } = window.getComputedStyle(node);
-      if (position === 'sticky' || position === 'fixed') {
+      if (position === 'sticky') {
         height = Math.max(height, node.getBoundingClientRect().bottom - containerRect.top);
       }
     }


### PR DESCRIPTION
[COMMS-464](https://community.openproject.org/wp/COMMS-464) _Follows #23894 (Bug/STC-469)_

Deep-linking to an activity comment relied on a fixed scroll offset, which on mobile left the comment hidden behind the pinned work package toolbar. The viewport service now derives the offset from whatever is actually pinned over the scroll container: the toolbar on mobile (measured, since its height is not fixed) and nothing on desktop, plus a small gap. A deep-linked comment now seats just below the toolbar on mobile, and just below the connector stem on desktop, rather than behind the toolbar or exposing the bottom of the previous comment.

Both the hash-change and initial-load scroll paths use the measured offset, and near-bottom comments still clamp to the bottom as before.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1440" height="2960" alt="openproject local_projects_JIRA101_work_packages_JIRA101-1_activity(Samsung Galaxy S8+) (2)" src="https://github.com/user-attachments/assets/5898b96e-b212-41c6-97b8-a19cfe203c67" /> | <img width="1440" height="2960" alt="openproject local_projects_JIRA101_work_packages_JIRA101-1_activity(Samsung Galaxy S8+)" src="https://github.com/user-attachments/assets/60241a73-ef0e-422b-a4b4-57848b4d5ffb" /> |

