### PR TITLE
Fix errors on journal update due to duplicate participant

### DIFF
--- a/modules/meeting/app/services/journals/create_service/participatable.rb
+++ b/modules/meeting/app/services/journals/create_service/participatable.rb
@@ -59,10 +59,9 @@ class Journals::CreateService
           COALESCE(participants.invited, false),
           COALESCE(participants.attended, false),
           participants.participation_status
-        FROM meeting_participants participants
+        FROM (#{current_participants_sql}) participants
         WHERE
           #{only_if_created_sql}
-          AND participants.meeting_id = :journable_id
         ON CONFLICT (journal_id, user_id) DO UPDATE SET
           invited = EXCLUDED.invited,
           attended = EXCLUDED.attended,
@@ -81,9 +80,7 @@ class Journals::CreateService
         ON
           meeting_participant_journals.journal_id = max_journals.id
         FULL JOIN
-          (SELECT *
-           FROM meeting_participants
-           WHERE meeting_participants.meeting_id = :journable_id) participants
+          (#{current_participants_sql}) participants
         ON
           participants.user_id = meeting_participant_journals.user_id
         WHERE
@@ -91,6 +88,26 @@ class Journals::CreateService
           OR (participants.invited IS DISTINCT FROM meeting_participant_journals.invited)
           OR (participants.attended IS DISTINCT FROM meeting_participant_journals.attended)
           OR (participants.participation_status IS DISTINCT FROM meeting_participant_journals.participation_status)
+      SQL
+    end
+
+    private
+
+    def current_participants_sql
+      <<~SQL.squish
+        SELECT DISTINCT ON (meeting_participants.user_id)
+          meeting_participants.user_id,
+          COALESCE(meeting_participants.invited, false) AS invited,
+          COALESCE(meeting_participants.attended, false) AS attended,
+          meeting_participants.participation_status
+        FROM meeting_participants
+        WHERE
+          meeting_participants.meeting_id = :journable_id
+          AND meeting_participants.user_id IS NOT NULL
+        ORDER BY
+          meeting_participants.user_id,
+          meeting_participants.updated_at DESC,
+          meeting_participants.id DESC
       SQL
     end
   end

--- a/modules/meeting/spec/models/meeting_acts_as_journalized_spec.rb
+++ b/modules/meeting/spec/models/meeting_acts_as_journalized_spec.rb
@@ -367,6 +367,39 @@ RSpec.describe Meeting do
         expect(meeting.journals.last.participant_journals.count).to eq(1)
       end
     end
+
+    context "when persisted participants contain duplicate users",
+            with_settings: { journal_aggregation_time_minutes: 0 } do
+      before do
+        MeetingParticipant.insert_all!(
+          [
+            {
+              meeting_id: meeting.id,
+              user_id: participant_user.id,
+              invited: false,
+              attended: true,
+              participation_status: "accepted",
+              created_at: Time.current,
+              updated_at: Time.current
+            }
+          ]
+        )
+      end
+
+      it "deduplicates the participant snapshot by user" do
+        meeting.update_column(:title, "Updated title")
+
+        expect { meeting.save_journals }.not_to raise_error
+
+        expect(meeting.journals.last.participant_journals.count).to eq(1)
+        expect(meeting.journals.last.participant_journals.last).to have_attributes(
+          user_id: participant_user.id,
+          invited: false,
+          attended: true,
+          participation_status: "accepted"
+        )
+      end
+    end
   end
 
   describe "participant change details" do


### PR DESCRIPTION
On the edge meeting https://qa.openproject-edge.com/projects/ACSMT/meetings/283, there is a duplicate particpant.
The duplicate is user_id 16 — two rows: id 560 (invited=true, attended=false, updated 2024-09-20) and id 552 (invited=true, attended=true, updated 2024-09-16). Same (meeting_id, user_id), non-null user_id.

This causes an error trying to insert participants for journals, as those have an on conflict condition.

We fix this in the selection of the items using DISTINCT ON (user_id).

A separate follow-up migration will ensure we add a database level constraint for dev/17.7 https://github.com/opf/openproject/pull/23919

https://community.openproject.org/projects/MEET/work_packages/MEET-563/