### PR TITLE
[OP-19600] Lazy-load xeokit viewer chunk

### DIFF
--- a/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
@@ -122,7 +122,10 @@ export class IFCViewerComponent implements OnInit, OnDestroy, AfterViewInit {
             enableMeasurements: false,
           },
           this.ifcData.projects,
-        );
+        ).catch((error:unknown) => {
+          // The viewer chunk is loaded on demand; surface a download/init failure.
+          console.error('Failed to initialize the IFC viewer:', error);
+        });
       });
 
     this.insertXeokitToolbarIcons();

--- a/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -27,7 +27,6 @@
 //++
 
 import { Injectable } from '@angular/core';
-import { XeokitServer } from 'core-app/features/bim/ifc_models/xeokit/xeokit-server';
 import { ViewerBridgeService } from 'core-app/features/bim/bcf/bcf-viewer-bridge/viewer-bridge.service';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
@@ -41,7 +40,6 @@ import {
   IfcModelsDataService,
   IfcProjectDefinition,
 } from 'core-app/features/bim/ifc_models/pages/viewer/ifc-models-data.service';
-import { BIMViewer } from '@xeokit/xeokit-bim-viewer/dist/xeokit-bim-viewer.es';
 import { BcfViewpointData, CreateBcfViewpointData } from 'core-app/features/bim/bcf/api/bcf-api.model';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
@@ -101,6 +99,12 @@ type XeokitBimViewer = Controller&{
   destroy:() => void
 };
 
+/**
+ * Minimal constructor type for the untyped `@xeokit/xeokit-bim-viewer` default export,
+ * so the dynamic import stays type-checked without an `any` escape hatch.
+ */
+type BimViewerConstructor = new (server:unknown, elements:XeokitElements) => XeokitBimViewer;
+
 @Injectable()
 export class IFCViewerService extends ViewerBridgeService {
   public shouldShowViewer = true;
@@ -123,10 +127,17 @@ export class IFCViewerService extends ViewerBridgeService {
 
   @LazyInject() httpClient:HttpClient;
 
-  public newViewer(elements:XeokitElements, projects:IfcProjectDefinition[]):void {
+  public async newViewer(elements:XeokitElements, projects:IfcProjectDefinition[]):Promise<void> {
+    // Load the heavy xeokit SDK and BIM viewer on demand so they are split into
+    // their own chunk instead of bloating the eager bundle (see OP-19600).
+    const [{ XeokitServer }, { BIMViewer }] = await Promise.all([
+      import('core-app/features/bim/ifc_models/xeokit/xeokit-server'),
+      // @xeokit/xeokit-bim-viewer ships no type declarations; cast its untyped export.
+      import('@xeokit/xeokit-bim-viewer/dist/xeokit-bim-viewer.es') as Promise<{ BIMViewer:BimViewerConstructor }>,
+    ]);
+
     const server = new XeokitServer(this.pathHelper, this.ifcModelsDataService);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const viewerUI = new BIMViewer(server, elements) as XeokitBimViewer;
+    const viewerUI = new BIMViewer(server, elements);
 
     viewerUI.on('modelLoaded', () => this.viewerVisible$.next(true));
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19600

# What are you trying to accomplish?

Keep the heavy `@xeokit/*` packages (~6.9 MB) out of the eager JS bundle so they no longer download on every page load.

xeokit is only needed by the IFC/BIM viewer, but it was reachable from the **eager** module graph (`WorkPackages module → BCF module → IFCViewerService → xeokit`). The Angular esbuild builder therefore hoisted it into a shared chunk that `main` statically imports, so every page paid for it.

This defers the `xeokit-sdk` and `xeokit-bim-viewer` imports in `IFCViewerService#newViewer` to a dynamic `import()`. esbuild then splits them into on-demand chunks fetched only when a BIM viewer actually opens.

Impact (esbuild metafile, before → after):

| metric | before | after |
| --- | --- | --- |
| xeokit in eager set | yes (`main → chunk`) | **none** |
| static edges into xeokit | `main` + lazy ifc module | **none** |
| edge into xeokit | static | `dynamic-import` only |
| **eager JS total** | **22.93 MB** | **16.38 MB** |

≈ **−6.55 MB raw** off the initial bundle (~1.5–2 MB gzipped).

## Bundle Size Analysis

| Before | After |
|--------|--------|
| <img width="1066" height="726" alt="Screenshot 2026-06-24 at 21 17 24" src="https://github.com/user-attachments/assets/5b01541c-93db-4e66-8618-38312e88c0cb" /> | <img width="934" height="732" alt="Screenshot 2026-06-24 at 21 16 34" src="https://github.com/user-attachments/assets/ef4ee37f-84ad-401b-9ecd-59e81c7f6cd5" /> |

`npm run analyze` and open `public/assets/frontend/stats.json` in the [esbuild Bundle Size Analyzer](https://esbuild.github.io/analyze/)

# What approach did you choose and why?

Angular's application (esbuild) builder has no `manualChunks` config — the only code-split lever is a dynamic `import()` boundary in source. The single instantiation site (`IFCViewerService#newViewer`) is the natural seam:

- `newViewer` becomes `async` and `await`s `import()` of `XeokitServer` (which carries `xeokit-sdk`) and `BIMViewer` (`xeokit-bim-viewer`).
- Its sole caller (`ifc-viewer.component.ts`) already ignores the return value inside a `subscribe` callback, so it is simply marked `void` — no behavioural change beyond a one-time async chunk fetch before the (already heavy, interactive) 3D viewer mounts.

Alternative considered: lazy-loading the BCF module to break the eager chain. Rejected — far more invasive, and BCF is legitimately used outside the viewer; the `import()` seam is minimal and localized.

Verification:

- `npm run generate-typings` — clean
- `npm run build` — exit 0
- `npm run test` — 2466 specs / 351 files passed
- `npx eslint src/` — no new errors
- esbuild metafile diff confirms the `main → xeokit` static edge is gone and xeokit is reached only via `dynamic-import`

# Merge checklist

- [ ] Added/updated tests >
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)