### PR TITLE
[MEET-565, 566] Fix meetings API bugs

### DIFF
--- a/modules/meeting/db/migrate/20260625073349_backfill_missing_recurrence_start_time.rb
+++ b/modules/meeting/db/migrate/20260625073349_backfill_missing_recurrence_start_time.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class BackfillMissingRecurrenceStartTime < ActiveRecord::Migration[8.1]
+  def up
+    # AddRecurrenceIdToMeetings backfilled recurrence_start_time from start_time,
+    # but in some cases because of missing scheduled_meetings in existing data,
+    # recurrence_start_time was still NULL, which this migration fixes.
+    execute <<~SQL.squish
+      UPDATE meetings
+      SET recurrence_start_time = meetings.start_time
+      WHERE meetings.recurring_meeting_id IS NOT NULL
+        AND meetings.template = false
+        AND meetings.recurrence_start_time IS NULL
+    SQL
+  end
+
+  def down
+    # No-op
+  end
+end

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -122,7 +122,8 @@ module API
 
         property :template
 
-        property :notify
+        property :notify,
+                 getter: ->(*) { notify? }
 
         associated_resource :author,
                             v3_path: :user,

--- a/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
@@ -97,4 +97,14 @@ RSpec.describe API::V3::Meetings::MeetingRepresenter do
       expect(subject).to be_json_eql(meeting.updated_at.utc.iso8601(3).to_json).at_path("updatedAt")
     end
   end
+
+  describe "notify" do
+    subject(:generated) { representer.to_json }
+
+    it "reflects the resolved notify status (notify?) rather than the raw column" do
+      allow(meeting).to receive_messages(notify?: true, notify: false)
+
+      expect(generated).to be_json_eql(true.to_json).at_path("notify")
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-565
https://community.openproject.org/wp/MEET-566

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- For 565, it seems like some old data caused the migration where we added `recurrence_start_time` to have nil values for a few records. I added a new migration to backfill those edge cases
- For 566, the API was using the `notify` value of the occurrence, which is unused/remains unchanged when updating the setting for a series. It now correctly uses the `notify` value of the series template instead

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
