### PR TITLE
[OP-19601] Convert cost business logic to services/contracts

### DIFF
--- a/modules/costs/app/contracts/cost_entries/base_contract.rb
+++ b/modules/costs/app/contracts/cost_entries/base_contract.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CostEntries
+  class BaseContract < ::ModelContract
+    delegate :entity,
+             :project,
+             :new_record?,
+             to: :model
+
+    def self.model
+      CostEntry
+    end
+
+    validate :validate_units_are_in_range
+    validate :validate_project_is_set
+    validate :validate_entity
+    validate :validate_user
+    validate :validate_cost_type
+
+    validates :spent_on,
+              date: { before_or_equal_to: Proc.new { Date.new(9999, 12, 31) },
+                      allow_blank: true },
+              unless: Proc.new { spent_on.blank? }
+
+    attribute :project_id
+    attribute :entity_id
+    attribute :entity_type
+    attribute :cost_type_id
+    attribute :user_id
+    attribute :units
+    attribute :overridden_costs
+    attribute :comments
+    attribute :spent_on
+    # Aggregation columns derived from spent_on by the model
+    attribute :tyear
+    attribute :tmonth
+    attribute :tweek
+
+    private
+
+    def validate_units_are_in_range
+      errors.add :units, :invalid if model.units&.negative?
+    end
+
+    def validate_project_is_set
+      errors.add :project_id, :invalid if model.project.nil?
+    end
+
+    def validate_entity
+      return if model.entity.nil?
+
+      errors.add :entity, :invalid if entity_invisible? || entity_not_in_project?
+    end
+
+    def validate_user # rubocop:disable Metrics/AbcSize
+      return unless model.user || model.user_id_changed?
+      return if model.user == model.logged_by
+
+      if model.user.nil?
+        errors.add :user_id, :blank
+      elsif !model.user.visible?(user)
+        errors.add :user_id, :invalid
+      end
+    end
+
+    def validate_cost_type
+      return if model.cost_type_id.blank?
+
+      errors.add :cost_type_id, :invalid if model.cost_type.nil? || model.cost_type.deleted_at.present?
+    end
+
+    def entity_invisible?
+      model.entity.nil? || !model.entity.visible?(user)
+    end
+
+    def entity_not_in_project?
+      model.entity && model.project != model.entity.project
+    end
+  end
+end

--- a/modules/costs/app/contracts/cost_entries/create_contract.rb
+++ b/modules/costs/app/contracts/cost_entries/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,27 +28,26 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :cost_entry do
-    project
-    user
-    logged_by { User.current }
-    entity factory: :work_package
-    cost_type
-    spent_on { Date.current }
-    units { 1 }
-    comments { "" }
+module CostEntries
+  class CreateContract < BaseContract
+    validate :user_allowed_to_add
 
-    before(:create) do |ce|
-      ce.project = ce.entity.project
+    private
 
-      unless ce.project.users.include?(ce.user)
-        Members::CreateService
-          .new(user: User.system, contract_class: EmptyContract)
-          .call(principal: ce.user,
-                project: ce.project,
-                roles: [create(:project_role)])
-      end
+    def user_allowed_to_add
+      return unless model.project
+      return if allowed_to_log_for_others?
+      return if allowed_to_log_to_himself?
+
+      errors.add :base, :error_unauthorized
+    end
+
+    def allowed_to_log_for_others?
+      user.allowed_in_project?(:log_costs, model.project)
+    end
+
+    def allowed_to_log_to_himself?
+      model.user == user && user.allowed_in_project?(:log_own_costs, model.project)
     end
   end
 end

--- a/modules/costs/app/contracts/cost_entries/delete_contract.rb
+++ b/modules/costs/app/contracts/cost_entries/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,27 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :cost_entry do
-    project
-    user
-    logged_by { User.current }
-    entity factory: :work_package
-    cost_type
-    spent_on { Date.current }
-    units { 1 }
-    comments { "" }
+module CostEntries
+  class DeleteContract < ::DeleteContract
+    delete_permission -> {
+      edit_all = user.allowed_in_project?(:edit_cost_entries, model.project)
 
-    before(:create) do |ce|
-      ce.project = ce.entity.project
-
-      unless ce.project.users.include?(ce.user)
-        Members::CreateService
-          .new(user: User.system, contract_class: EmptyContract)
-          .call(principal: ce.user,
-                project: ce.project,
-                roles: [create(:project_role)])
+      if model.user == user
+        edit_all || user.allowed_in_project?(:edit_own_cost_entries, model.project)
+      else
+        edit_all
       end
-    end
+    }
   end
 end

--- a/modules/costs/app/contracts/cost_entries/update_contract.rb
+++ b/modules/costs/app/contracts/cost_entries/update_contract.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CostEntries
+  class UpdateContract < BaseContract
+    include UnchangedProject
+
+    validate :validate_user_allowed_to_update
+
+    def validate_user_allowed_to_update
+      errors.add :base, :error_unauthorized unless user_allowed_to_update?
+    end
+
+    ##
+    # Users may update cost entries IF they have the :edit_cost_entries
+    # permission, or it is their own entry and they have :edit_own_cost_entries.
+    # The permission is checked both in the original and the target project to
+    # prevent privilege escalation when moving an entry between projects.
+    def user_allowed_to_update?
+      with_unchanged_project_id do
+        user_allowed_to_update_in?(model)
+      end && user_allowed_to_update_in?(model)
+    end
+
+    private
+
+    def user_allowed_to_update_in?(cost_entry)
+      user.allowed_in_project?(:edit_cost_entries, cost_entry.project) ||
+        (own_entry? && user.allowed_in_project?(:edit_own_cost_entries, cost_entry.project))
+    end
+
+    # Whether the entry is the acting user's own entry. The previous owner is
+    # checked alongside the current one so that authorization cannot be gained by
+    # reassigning another user's entry to oneself within the same request.
+    def own_entry?
+      model.user_id_was == user.id && model.user == user
+    end
+  end
+end

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -31,7 +31,6 @@
 class CostlogController < ApplicationController
   menu_item :work_packages
   before_action :find_cost_entry_work_package_or_project, :authorize, only: %i[edit new create update destroy]
-  before_action :find_associated_objects, only: %i[create update]
 
   helper :work_packages
   include CostlogHelper
@@ -53,50 +52,52 @@ class CostlogController < ApplicationController
   end
 
   def create
-    new_default_cost_entry
-    update_cost_entry_from_params
+    service_call = CostEntries::CreateService
+                     .new(user: current_user, model: CostEntry.new(project: @project))
+                     .call(permitted_params.cost_entry)
 
-    if !@cost_entry.creatable_by?(User.current)
+    respond_with_service_call(service_call) do |call|
+      @cost_entry = call.result
 
-      render_403
-
-    elsif @cost_entry.save
-
-      flash[:notice] = t(:notice_cost_logged_successfully)
-      redirect_back_or_default polymorphic_path(@cost_entry.entity)
-    else
-      render action: :edit, status: :unprocessable_entity
+      if call.success?
+        flash[:notice] = t(:notice_cost_logged_successfully)
+        redirect_back_or_default polymorphic_path(@cost_entry.entity)
+      else
+        render action: :edit, status: :unprocessable_entity
+      end
     end
   end
 
   def update
-    update_cost_entry_from_params
+    service_call = CostEntries::UpdateService
+                     .new(user: current_user, model: @cost_entry)
+                     .call(permitted_params.cost_entry)
 
-    if !@cost_entry.editable_by?(User.current)
+    respond_with_service_call(service_call) do |call|
+      @cost_entry = call.result
 
-      render_403
-
-    elsif @cost_entry.save
-
-      flash[:notice] = t(:notice_successful_update)
-      redirect_back_or_to(polymorphic_path(@cost_entry.entity))
-
-    else
-      render action: "edit"
+      if call.success?
+        flash[:notice] = t(:notice_successful_update)
+        redirect_back_or_to(polymorphic_path(@cost_entry.entity))
+      else
+        render action: "edit"
+      end
     end
   end
 
   def destroy
     render_404 and return unless @cost_entry
-    render_403 and return unless @cost_entry.editable_by?(User.current)
 
-    @cost_entry.destroy
-    flash[:notice] = t(:notice_successful_delete)
+    service_call = CostEntries::DeleteService.new(user: current_user, model: @cost_entry).call
 
-    if request.referer.include?("cost_reports")
-      redirect_to controller: "/cost_reports", action: :index, status: :see_other
-    else
-      redirect_back_or_to(polymorphic_path(@cost_entry.entity), status: :see_other)
+    respond_with_service_call(service_call) do
+      flash[:notice] = t(:notice_successful_delete)
+
+      if request.referer.include?("cost_reports")
+        redirect_to controller: "/cost_reports", action: :index, status: :see_other
+      else
+        redirect_back_or_to(polymorphic_path(@cost_entry.entity), status: :see_other)
+      end
     end
   end
 
@@ -116,28 +117,19 @@ class CostlogController < ApplicationController
     end
   end
 
-  def find_associated_objects # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
-    user_id = cost_entry_params.delete(:user_id)
-    @user = if @cost_entry.present? && @cost_entry.user_id == user_id
-              @cost_entry.user
-            else
-              User.visible.find_by(id: user_id)
-            end
+  # Renders 403 when the service call failed because of missing permissions and
+  # yields the call otherwise, so each action handles its own success and
+  # validation outcomes consistently.
+  def respond_with_service_call(service_call)
+    if service_unauthorized?(service_call)
+      render_403
+    else
+      yield service_call
+    end
+  end
 
-    entity_id = cost_entry_params.delete(:entity_id)
-    entity_type = cost_entry_params.delete(:entity_type)
-    @work_package = if @cost_entry.present? && @cost_entry.entity_type == "WorkPackage" && @cost_entry.entity_id == entity_id
-                      @cost_entry.entity
-                    elsif entity_type == "WorkPackage"
-                      WorkPackage.visible.find_by(id: entity_id)
-                    end
-
-    cost_type_id = cost_entry_params.delete(:cost_type_id)
-    @cost_type = if @cost_entry.present? && @cost_entry.cost_type_id == cost_type_id
-                   @cost_entry.cost_type
-                 else
-                   CostType.find_by(id: cost_type_id)
-                 end
+  def service_unauthorized?(service_call)
+    service_call.errors.added?(:base, :error_unauthorized)
   end
 
   def new_default_cost_entry
@@ -148,24 +140,5 @@ class CostlogController < ApplicationController
       ce.spent_on = Time.zone.today
       ce.cost_type = CostType.default_for_project(@project) if @project
     end
-  end
-
-  def update_cost_entry_from_params
-    @cost_entry.user = @user
-    @cost_entry.entity = @work_package
-    @cost_entry.cost_type = @cost_type
-
-    attributes = permitted_params.cost_entry
-    attributes[:units] = Rate.parse_number_string_to_number(attributes[:units])
-
-    if attributes[:overridden_costs].present?
-      attributes[:overridden_costs] = Rate.parse_number_string_to_number(attributes[:overridden_costs])
-    end
-
-    @cost_entry.attributes = attributes
-  end
-
-  def cost_entry_params
-    params.expect(cost_entry: %i[user_id entity_id entity_type spent_on cost_type_id units comments])
   end
 end

--- a/modules/costs/app/models/cost_entry.rb
+++ b/modules/costs/app/models/cost_entry.rb
@@ -43,7 +43,6 @@ class CostEntry < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 
-  after_initialize :after_initialize
   before_validation :before_validation
   before_save :before_save
   validate :validate
@@ -65,17 +64,6 @@ class CostEntry < ApplicationRecord
   include Entry::Costs
   include Entry::SplashedDates
   include Entry::DeprecatedAssociation
-
-  def after_initialize
-    return unless new_record?
-
-    # This belongs in a SetAttributesService, but cost_entries are not yet created as such
-    self.logged_by = User.current
-
-    if cost_type.nil? && default_cost_type = CostType.default
-      self.cost_type_id = default_cost_type.id
-    end
-  end
 
   def before_validation
     self.project = entity.project if entity && project.nil?

--- a/modules/costs/app/services/cost_entries/create_service.rb
+++ b/modules/costs/app/services/cost_entries/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,27 +28,4 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :cost_entry do
-    project
-    user
-    logged_by { User.current }
-    entity factory: :work_package
-    cost_type
-    spent_on { Date.current }
-    units { 1 }
-    comments { "" }
-
-    before(:create) do |ce|
-      ce.project = ce.entity.project
-
-      unless ce.project.users.include?(ce.user)
-        Members::CreateService
-          .new(user: User.system, contract_class: EmptyContract)
-          .call(principal: ce.user,
-                project: ce.project,
-                roles: [create(:project_role)])
-      end
-    end
-  end
-end
+class CostEntries::CreateService < BaseServices::Create; end

--- a/modules/costs/app/services/cost_entries/delete_service.rb
+++ b/modules/costs/app/services/cost_entries/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,27 +28,4 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :cost_entry do
-    project
-    user
-    logged_by { User.current }
-    entity factory: :work_package
-    cost_type
-    spent_on { Date.current }
-    units { 1 }
-    comments { "" }
-
-    before(:create) do |ce|
-      ce.project = ce.entity.project
-
-      unless ce.project.users.include?(ce.user)
-        Members::CreateService
-          .new(user: User.system, contract_class: EmptyContract)
-          .call(principal: ce.user,
-                project: ce.project,
-                roles: [create(:project_role)])
-      end
-    end
-  end
-end
+class CostEntries::DeleteService < BaseServices::Delete; end

--- a/modules/costs/app/services/cost_entries/set_attributes_service.rb
+++ b/modules/costs/app/services/cost_entries/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,27 +28,44 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :cost_entry do
-    project
-    user
-    logged_by { User.current }
-    entity factory: :work_package
-    cost_type
-    spent_on { Date.current }
-    units { 1 }
-    comments { "" }
+module CostEntries
+  class SetAttributesService < ::BaseServices::SetAttributes
+    private
 
-    before(:create) do |ce|
-      ce.project = ce.entity.project
+    def set_attributes(_attributes)
+      parse_overridden_costs
 
-      unless ce.project.users.include?(ce.user)
-        Members::CreateService
-          .new(user: User.system, contract_class: EmptyContract)
-          .call(principal: ce.user,
-                project: ce.project,
-                roles: [create(:project_role)])
+      super
+    end
+
+    # Called by parent SetAttributes#set_attributes
+    def set_default_attributes(*)
+      model.spent_on ||= Time.zone.today
+    end
+
+    # Called by parent SetAttributes#set_attributes for new records
+    def ensure_default_attributes(*)
+      set_project
+      set_logged_by
+    end
+
+    def set_project
+      model.project ||= model.entity&.project
+    end
+
+    # Always record the acting user as the one who logged the entry.
+    def set_logged_by
+      model.change_by_system do
+        model.logged_by = user
       end
+    end
+
+    # The locale-aware units setter on the model already parses unit strings.
+    # The overridden_costs column has no such setter, so we parse it here.
+    def parse_overridden_costs
+      return if params[:overridden_costs].blank?
+
+      params[:overridden_costs] = CostRate.parse_number_string_to_number(params[:overridden_costs])
     end
   end
 end

--- a/modules/costs/app/services/cost_entries/update_service.rb
+++ b/modules/costs/app/services/cost_entries/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,27 +28,4 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :cost_entry do
-    project
-    user
-    logged_by { User.current }
-    entity factory: :work_package
-    cost_type
-    spent_on { Date.current }
-    units { 1 }
-    comments { "" }
-
-    before(:create) do |ce|
-      ce.project = ce.entity.project
-
-      unless ce.project.users.include?(ce.user)
-        Members::CreateService
-          .new(user: User.system, contract_class: EmptyContract)
-          .call(principal: ce.user,
-                project: ce.project,
-                roles: [create(:project_role)])
-      end
-    end
-  end
-end
+class CostEntries::UpdateService < BaseServices::Update; end

--- a/modules/costs/lib/costs/patches/permitted_params_patch.rb
+++ b/modules/costs/lib/costs/patches/permitted_params_patch.rb
@@ -38,7 +38,11 @@ module Costs::Patches::PermittedParamsPatch
       params.require(:cost_entry).permit(:comments,
                                          :units,
                                          :overridden_costs,
-                                         :spent_on)
+                                         :spent_on,
+                                         :user_id,
+                                         :entity_id,
+                                         :entity_type,
+                                         :cost_type_id)
     end
 
     def budget

--- a/modules/costs/spec/controllers/costlog_controller_spec.rb
+++ b/modules/costs/spec/controllers/costlog_controller_spec.rb
@@ -524,7 +524,7 @@ RSpec.describe CostlogController do
         params["cost_entry"]["user_id"] = user.id.to_s
       end
 
-      let(:expected_user) { nil } # user isn't member so won't be found
+      let(:expected_user) { user } # assigned but rejected because the user is not a project member
 
       it_behaves_like "invalid create"
     end
@@ -537,7 +537,7 @@ RSpec.describe CostlogController do
                               type: project2.types.first,
                               author: user)
       end
-      let(:expected_entity) { nil } # user has no access to the WP so it won't be found
+      let(:expected_entity) { work_package2 } # assigned but rejected because it is not in the project
 
       before do
         grant_current_user_permissions user, %i[view_project view_work_packages log_costs]
@@ -719,7 +719,7 @@ RSpec.describe CostlogController do
              "WHEN updating the user " \
              "WHEN the new user isn't a member of the project" do
       let(:user2) { create(:user) }
-      let(:expected_user) { nil } # user is not allowed to see the user so we cannot expect it to be assigned
+      let(:expected_user) { user2 } # assigned but rejected because the user is not a project member
 
       before do
         grant_current_user_permissions user, %i[view_project view_work_packages view_cost_entries edit_cost_entries]
@@ -738,7 +738,7 @@ RSpec.describe CostlogController do
         create(:work_package, project: project2,
                               type: project2.types.first)
       end
-      let(:expected_entity) { nil } # user has no access to the WP so it won't be found
+      let(:expected_entity) { work_package2 } # assigned but rejected because it is not in the project
 
       before do
         grant_current_user_permissions user, %i[view_project view_work_packages view_cost_entries edit_cost_entries]

--- a/modules/costs/spec/models/cost_entry_spec.rb
+++ b/modules/costs/spec/models/cost_entry_spec.rb
@@ -383,11 +383,6 @@ RSpec.describe CostEntry do
         expect(cost_entry).not_to be_valid
         expect(cost_entry.errors[:logged_by_id]).to be_present
       end
-
-      it "sets logged_by from current user" do
-        entry = User.execute_as(user2) { described_class.new logged_by: user }
-        expect(entry.logged_by).to eq(user2)
-      end
     end
 
     describe "#editable_by?" do

--- a/modules/costs/spec/services/cost_entries/create_service_integration_spec.rb
+++ b/modules/costs/spec/services/cost_entries/create_service_integration_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CostEntries::CreateService, "integration", type: :model do
+  let(:project) { create(:project_with_types) }
+  let(:work_package) { create(:work_package, project:, type: project.types.first) }
+  let(:cost_type) { create(:cost_type) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:permissions) { %i[view_work_packages log_costs] }
+
+  let(:params) do
+    {
+      entity_type: "WorkPackage",
+      entity_id: work_package.id,
+      user_id: user.id,
+      cost_type_id: cost_type.id,
+      units: "5",
+      overridden_costs: "500",
+      comments: ""
+    }
+  end
+
+  subject(:service_call) { described_class.new(user:).call(params) }
+
+  it "creates the cost entry, derives the project and records the logging user" do
+    expect(service_call).to be_success
+
+    cost_entry = service_call.result
+    expect(cost_entry).to be_persisted
+    expect(cost_entry.project).to eq(project)
+    expect(cost_entry.entity).to eq(work_package)
+    expect(cost_entry.user).to eq(user)
+    expect(cost_entry.logged_by).to eq(user)
+    expect(cost_entry.units).to eq(5)
+    expect(cost_entry.overridden_costs).to eq(500)
+  end
+
+  context "when no date is given" do
+    before { params.delete(:spent_on) }
+
+    it "defaults spent_on to today" do
+      expect(service_call).to be_success
+      expect(service_call.result.spent_on).to eq(Time.zone.today)
+    end
+  end
+
+  context "when the cost type does not exist" do
+    before { params[:cost_type_id] = 0 }
+
+    it "fails validation" do
+      expect(service_call).not_to be_success
+      expect(service_call.result.cost_type).to be_nil
+      expect(service_call.errors.symbols_for(:cost_type_id)).to include(:invalid)
+    end
+  end
+
+  context "when the work package is not visible to the user" do
+    let(:other_work_package) { create(:work_package) }
+
+    before { params[:entity_id] = other_work_package.id }
+
+    it "assigns the entity but fails the visibility validation in the contract" do
+      expect(service_call).not_to be_success
+      expect(service_call.result.entity).to eq(other_work_package)
+      expect(service_call.errors.symbols_for(:entity)).to include(:invalid)
+    end
+  end
+
+  context "when the user may only log own costs and logs for somebody else" do
+    let(:permissions) { %i[view_work_packages log_own_costs] }
+    let(:other_user) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+
+    before { params[:user_id] = other_user.id }
+
+    it "is unauthorized" do
+      expect(service_call).not_to be_success
+      expect(service_call.errors.symbols_for(:base)).to include(:error_unauthorized)
+    end
+  end
+
+  context "when the user may only log own costs and logs for themselves" do
+    let(:permissions) { %i[view_work_packages log_own_costs] }
+
+    it "succeeds" do
+      expect(service_call).to be_success
+    end
+  end
+end

--- a/modules/costs/spec/services/cost_entries/delete_service_integration_spec.rb
+++ b/modules/costs/spec/services/cost_entries/delete_service_integration_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CostEntries::DeleteService, "integration", type: :model do
+  let(:project) { create(:project_with_types) }
+  let(:work_package) { create(:work_package, project:, type: project.types.first) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:owner) { user }
+  let(:cost_entry) do
+    create(:cost_entry, project:, entity: work_package, user: owner, units: 1)
+  end
+
+  subject(:service_call) { described_class.new(user:, model: cost_entry).call }
+
+  context "when deleting own entry with edit_own_cost_entries" do
+    let(:permissions) { %i[view_work_packages view_cost_entries edit_own_cost_entries] }
+
+    it "deletes the entry" do
+      cost_entry
+      expect { service_call }.to change(CostEntry, :count).by(-1)
+      expect(service_call).to be_success
+    end
+  end
+
+  context "when deleting a foreign entry with only edit_own_cost_entries" do
+    let(:permissions) { %i[view_work_packages view_cost_entries edit_own_cost_entries] }
+    let(:owner) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+
+    it "is unauthorized and keeps the entry" do
+      cost_entry
+      expect { service_call }.not_to change(CostEntry, :count)
+      expect(service_call).not_to be_success
+      expect(service_call.errors.symbols_for(:base)).to include(:error_unauthorized)
+    end
+  end
+end

--- a/modules/costs/spec/services/cost_entries/update_service_integration_spec.rb
+++ b/modules/costs/spec/services/cost_entries/update_service_integration_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CostEntries::UpdateService, "integration", type: :model do
+  let(:project) { create(:project_with_types) }
+  let(:work_package) { create(:work_package, project:, type: project.types.first) }
+  let(:cost_type) { create(:cost_type) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:permissions) { %i[view_work_packages view_cost_entries edit_own_cost_entries] }
+  let(:owner) { user }
+  let(:cost_entry) do
+    create(:cost_entry, project:, entity: work_package, cost_type:, user: owner, units: 1)
+  end
+
+  subject(:service_call) { described_class.new(user:, model: cost_entry).call(params) }
+
+  context "when updating own entry's units" do
+    let(:params) { { units: "9" } }
+
+    it "succeeds" do
+      expect(service_call).to be_success
+      expect(cost_entry.reload.units).to eq(9)
+    end
+  end
+
+  context "when reassigning own entry to another user with only edit_own permission" do
+    let(:other_user) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+    let(:params) { { user_id: other_user.id } }
+
+    it "is unauthorized" do
+      expect(service_call).not_to be_success
+      expect(service_call.errors.symbols_for(:base)).to include(:error_unauthorized)
+    end
+  end
+
+  context "when editing a foreign entry with only edit_own permission" do
+    let(:owner) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+    let(:params) { { units: "9" } }
+
+    it "is unauthorized" do
+      expect(service_call).not_to be_success
+      expect(service_call.errors.symbols_for(:base)).to include(:error_unauthorized)
+    end
+  end
+
+  context "when moving the entry to a work package in another project" do
+    let(:permissions) { %i[view_work_packages view_cost_entries edit_cost_entries] }
+    let(:target_project) { create(:project_with_types) }
+    let(:target_work_package) { create(:work_package, project: target_project, type: target_project.types.first) }
+    let(:params) { { entity_type: "WorkPackage", entity_id: target_work_package.id } }
+
+    before do
+      # The user can even see work packages in the target project
+      create(:member,
+             principal: user,
+             project: target_project,
+             roles: [create(:project_role, permissions: %i[view_work_packages])])
+    end
+
+    it "is rejected because the entry keeps its project and the entity no longer matches it" do
+      expect(service_call).not_to be_success
+      expect(cost_entry.project).to eq(project)
+      expect(service_call.errors.symbols_for(:entity)).to include(:invalid)
+    end
+  end
+end


### PR DESCRIPTION
Cost entries did not use service/contract architecture, making it harder to reason about permission checking. This PR introduces both and moves all checks from the CostlogController

https://community.openproject.org/projects/OP/work_packages/OP-19601/activity
