### PR TITLE
[Dream-731] Meeting update banner reload action is difficult to reach by keyboard/screen reader

### DIFF
--- a/frontend/src/stimulus/controllers/flash.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.spec.ts
@@ -29,7 +29,7 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import FlashController, { ACTION_FOCUS_DELAY, LIVE_REGION_ANNOUNCEMENT_DELAY, SUCCESS_AUTOHIDE_TIMEOUT } from './flash.controller';
+import FlashController, { LIVE_REGION_ANNOUNCEMENT_DELAY, SUCCESS_AUTOHIDE_TIMEOUT } from './flash.controller';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 
 interface LiveRegionTestElement extends HTMLElement {
@@ -141,8 +141,6 @@ describe('FlashController', () => {
 
   describe('action focus', () => {
     it('focuses the flash with the requested action', async () => {
-      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-
       ctx.appendHTML(`
         <div data-controller="flash">
           <div data-flash-target="item" data-announcement="Meeting updated" data-testid="flash-item">
@@ -154,15 +152,13 @@ describe('FlashController', () => {
       await ctx.nextFrame();
 
       const flashItem = ctx.screen.getByTestId('flash-item');
-      vi.advanceTimersByTime(ACTION_FOCUS_DELAY);
+      await ctx.nextFrame();
 
       expect(flashItem).toHaveFocus();
       expect(flashItem).toHaveAttribute('aria-label', 'Meeting updated');
     });
 
     it('does not move focus for regular flash actions', async () => {
-      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-
       ctx.appendHTML(`
         <button>Current action</button>
         <div data-controller="flash">
@@ -175,15 +171,12 @@ describe('FlashController', () => {
       const currentAction = ctx.screen.getByRole('button', { name: 'Current action' });
       currentAction.focus();
       await ctx.nextFrame();
-
-      vi.advanceTimersByTime(ACTION_FOCUS_DELAY);
+      await ctx.nextFrame();
 
       expect(currentAction).toHaveFocus();
     });
 
     it('does not also announce focused flashes via the live region', async () => {
-      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-
       ctx.appendHTML(`
         <div data-controller="flash">
           <live-region data-testid="live-region"></live-region>
@@ -196,8 +189,7 @@ describe('FlashController', () => {
       const announceSpy:LiveRegionTestElement['announce'] = vi.fn((_message:string, _options:unknown) => undefined);
       stubLiveRegionAnnouncement(announceSpy);
       await ctx.nextFrame();
-
-      vi.advanceTimersByTime(ACTION_FOCUS_DELAY);
+      await ctx.nextFrame();
 
       expect(ctx.screen.getByTestId('flash-item')).toHaveFocus();
       expect(announceSpy).not.toHaveBeenCalled();

--- a/frontend/src/stimulus/controllers/flash.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.spec.ts
@@ -29,7 +29,7 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import FlashController, { LIVE_REGION_ANNOUNCEMENT_DELAY, SUCCESS_AUTOHIDE_TIMEOUT } from './flash.controller';
+import FlashController, { ACTION_FOCUS_DELAY, LIVE_REGION_ANNOUNCEMENT_DELAY, SUCCESS_AUTOHIDE_TIMEOUT } from './flash.controller';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 
 interface LiveRegionTestElement extends HTMLElement {
@@ -136,6 +136,71 @@ describe('FlashController', () => {
       `);
 
       expect(ctx.screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  describe('action focus', () => {
+    it('focuses the flash with the requested action', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+      ctx.appendHTML(`
+        <div data-controller="flash">
+          <div data-flash-target="item" data-announcement="Meeting updated" data-testid="flash-item">
+            Meeting updated
+            <a href="/meeting" data-flash-focus-action="true">Reload</a>
+          </div>
+        </div>
+      `);
+      await ctx.nextFrame();
+
+      const flashItem = ctx.screen.getByTestId('flash-item');
+      vi.advanceTimersByTime(ACTION_FOCUS_DELAY);
+
+      expect(flashItem).toHaveFocus();
+      expect(flashItem).toHaveAttribute('aria-label', 'Meeting updated');
+    });
+
+    it('does not move focus for regular flash actions', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+      ctx.appendHTML(`
+        <button>Current action</button>
+        <div data-controller="flash">
+          <div data-flash-target="item" data-announcement="Saved">
+            Saved
+            <a href="/details">Details</a>
+          </div>
+        </div>
+      `);
+      const currentAction = ctx.screen.getByRole('button', { name: 'Current action' });
+      currentAction.focus();
+      await ctx.nextFrame();
+
+      vi.advanceTimersByTime(ACTION_FOCUS_DELAY);
+
+      expect(currentAction).toHaveFocus();
+    });
+
+    it('does not also announce focused flashes via the live region', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+      ctx.appendHTML(`
+        <div data-controller="flash">
+          <live-region data-testid="live-region"></live-region>
+          <div data-flash-target="item" data-announcement="Meeting updated" data-testid="flash-item">
+            Meeting updated
+            <a href="/meeting" data-flash-focus-action="true">Reload</a>
+          </div>
+        </div>
+      `);
+      const announceSpy:LiveRegionTestElement['announce'] = vi.fn((_message:string, _options:unknown) => undefined);
+      stubLiveRegionAnnouncement(announceSpy);
+      await ctx.nextFrame();
+
+      vi.advanceTimersByTime(ACTION_FOCUS_DELAY);
+
+      expect(ctx.screen.getByTestId('flash-item')).toHaveFocus();
+      expect(announceSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/stimulus/controllers/flash.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.spec.ts
@@ -123,6 +123,32 @@ describe('FlashController', () => {
 
       expect(announceSpy).not.toHaveBeenCalled();
     });
+
+    it('announces actionable flashes without moving focus', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      ctx.appendHTML(`
+        <button>Current action</button>
+        <div data-controller="flash">
+          <live-region data-testid="live-region"></live-region>
+          <div data-flash-target="item" data-announcement="Meeting updated. Reload to view changes.">
+            Meeting updated.
+            <a href="/meeting">Reload</a>
+          </div>
+        </div>
+      `);
+      const currentAction = ctx.screen.getByRole('button', { name: 'Current action' });
+      const announceSpy:LiveRegionTestElement['announce'] = vi.fn((_message:string, _options:unknown) => undefined);
+      stubLiveRegionAnnouncement(announceSpy);
+      currentAction.focus();
+      await ctx.nextFrame();
+      vi.advanceTimersByTime(LIVE_REGION_ANNOUNCEMENT_DELAY);
+
+      expect(currentAction).toHaveFocus();
+      expect(announceSpy).toHaveBeenCalledWith(
+        'Meeting updated. Reload to view changes.',
+        expect.objectContaining({ politeness: 'polite' }),
+      );
+    });
   });
 
   describe('without autohide', () => {
@@ -136,63 +162,6 @@ describe('FlashController', () => {
       `);
 
       expect(ctx.screen.getByRole('alert')).toBeInTheDocument();
-    });
-  });
-
-  describe('action focus', () => {
-    it('focuses the flash with the requested action', async () => {
-      ctx.appendHTML(`
-        <div data-controller="flash">
-          <div data-flash-target="item" data-announcement="Meeting updated" data-testid="flash-item">
-            Meeting updated
-            <a href="/meeting" data-flash-focus-action="true">Reload</a>
-          </div>
-        </div>
-      `);
-      await ctx.nextFrame();
-
-      const flashItem = ctx.screen.getByTestId('flash-item');
-      await ctx.nextFrame();
-
-      expect(flashItem).toHaveFocus();
-      expect(flashItem).toHaveAttribute('aria-label', 'Meeting updated');
-    });
-
-    it('does not move focus for regular flash actions', async () => {
-      ctx.appendHTML(`
-        <button>Current action</button>
-        <div data-controller="flash">
-          <div data-flash-target="item" data-announcement="Saved">
-            Saved
-            <a href="/details">Details</a>
-          </div>
-        </div>
-      `);
-      const currentAction = ctx.screen.getByRole('button', { name: 'Current action' });
-      currentAction.focus();
-      await ctx.nextFrame();
-      await ctx.nextFrame();
-
-      expect(currentAction).toHaveFocus();
-    });
-
-    it('does not also announce focused flashes via the live region', async () => {
-      ctx.appendHTML(`
-        <div data-controller="flash">
-          <live-region data-testid="live-region"></live-region>
-          <div data-flash-target="item" data-announcement="Meeting updated" data-testid="flash-item">
-            Meeting updated
-            <a href="/meeting" data-flash-focus-action="true">Reload</a>
-          </div>
-        </div>
-      `);
-      const announceSpy:LiveRegionTestElement['announce'] = vi.fn((_message:string, _options:unknown) => undefined);
-      stubLiveRegionAnnouncement(announceSpy);
-      await ctx.nextFrame();
-      await ctx.nextFrame();
-
-      expect(ctx.screen.getByTestId('flash-item')).toHaveFocus();
-      expect(announceSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/stimulus/controllers/flash.controller.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.ts
@@ -5,9 +5,6 @@ export const SUCCESS_AUTOHIDE_TIMEOUT = 5000;
 // Match Primer's live-region registration delay. Manual screen reader
 // testing showed the first announcement can be missed without this pause.
 export const LIVE_REGION_ANNOUNCEMENT_DELAY = 150;
-// Let the live-region timing window pass before focusing a flash that has an
-// important action. The extra 50ms is only a small scheduler buffer.
-export const ACTION_FOCUS_DELAY = LIVE_REGION_ANNOUNCEMENT_DELAY + 50;
 
 export default class FlashController extends ApplicationController {
   static values = {
@@ -101,13 +98,13 @@ export default class FlashController extends ApplicationController {
       element.setAttribute('aria-label', element.dataset.announcement);
     }
 
-    window.setTimeout(() => {
+    window.requestAnimationFrame(() => {
       if (!element.isConnected || !action.isConnected) {
         return;
       }
 
       element.focus();
-    }, ACTION_FOCUS_DELAY);
+    });
 
     return true;
   }

--- a/frontend/src/stimulus/controllers/flash.controller.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.ts
@@ -5,6 +5,9 @@ export const SUCCESS_AUTOHIDE_TIMEOUT = 5000;
 // Match Primer's live-region registration delay. Manual screen reader
 // testing showed the first announcement can be missed without this pause.
 export const LIVE_REGION_ANNOUNCEMENT_DELAY = 150;
+// Let the live-region timing window pass before focusing a flash that has an
+// important action. The extra 50ms is only a small scheduler buffer.
+export const ACTION_FOCUS_DELAY = LIVE_REGION_ANNOUNCEMENT_DELAY + 50;
 
 export default class FlashController extends ApplicationController {
   static values = {
@@ -26,8 +29,12 @@ export default class FlashController extends ApplicationController {
   }
 
   itemTargetConnected(element:HTMLElement) {
-    // Announce the flash message to screen readers via global live region
-    this.announceFlash(element);
+    const focusesFlash = this.focusRequestedFlash(element);
+
+    // Focused flashes announce themselves, and Tab then reaches the action.
+    if (!focusesFlash) {
+      this.announceFlash(element);
+    }
 
     // Schedule auto-hide timer if enabled for both controller and individual element
     const autohide = element.dataset.autohide === 'true';
@@ -81,6 +88,28 @@ export default class FlashController extends ApplicationController {
 
       void announce(message, { politeness, from: element });
     }, LIVE_REGION_ANNOUNCEMENT_DELAY);
+  }
+
+  private focusRequestedFlash(element:HTMLElement) {
+    const action = element.querySelector<HTMLElement>('[data-flash-focus-action="true"]');
+    if (!action) {
+      return false;
+    }
+
+    element.setAttribute('tabindex', '-1');
+    if (element.dataset.announcement) {
+      element.setAttribute('aria-label', element.dataset.announcement);
+    }
+
+    window.setTimeout(() => {
+      if (!element.isConnected || !action.isConnected) {
+        return;
+      }
+
+      element.focus();
+    }, ACTION_FOCUS_DELAY);
+
+    return true;
   }
 
   /**

--- a/frontend/src/stimulus/controllers/flash.controller.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.ts
@@ -26,12 +26,8 @@ export default class FlashController extends ApplicationController {
   }
 
   itemTargetConnected(element:HTMLElement) {
-    const focusesFlash = this.focusRequestedFlash(element);
-
-    // Focused flashes announce themselves, and Tab then reaches the action.
-    if (!focusesFlash) {
-      this.announceFlash(element);
-    }
+    // Announce the flash message to screen readers via global live region
+    this.announceFlash(element);
 
     // Schedule auto-hide timer if enabled for both controller and individual element
     const autohide = element.dataset.autohide === 'true';
@@ -85,28 +81,6 @@ export default class FlashController extends ApplicationController {
 
       void announce(message, { politeness, from: element });
     }, LIVE_REGION_ANNOUNCEMENT_DELAY);
-  }
-
-  private focusRequestedFlash(element:HTMLElement) {
-    const action = element.querySelector<HTMLElement>('[data-flash-focus-action="true"]');
-    if (!action) {
-      return false;
-    }
-
-    element.setAttribute('tabindex', '-1');
-    if (element.dataset.announcement) {
-      element.setAttribute('aria-label', element.dataset.announcement);
-    }
-
-    window.requestAnimationFrame(() => {
-      if (!element.isConnected || !action.isConnected) {
-        return;
-      }
-
-      element.focus();
-    });
-
-    return true;
   }
 
   /**

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -47,7 +48,7 @@ module Meetings
           href: helpers.project_meeting_path(project, meeting),
           size: :medium,
           data: {
-
+            "flash-focus-action": true,
             keep_scroll_position_target: "triggerButton"
           }
         ) { I18n.t("label_meeting_reload") }

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -48,7 +48,6 @@ module Meetings
           href: helpers.project_meeting_path(project, meeting),
           size: :medium,
           data: {
-            "flash-focus-action": true,
             keep_scroll_position_target: "triggerButton"
           }
         ) { I18n.t("label_meeting_reload") }

--- a/modules/meeting/spec/components/meetings/update_flash_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/update_flash_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Meetings::UpdateFlashComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  let(:meeting) { create(:meeting, project:) }
+
+  it "marks the reload action as the flash focus target" do
+    render_inline(described_class.new(meeting))
+
+    expect(page).to have_link(I18n.t("label_meeting_reload"), href: project_meeting_path(project, meeting))
+    expect(page).to have_css("a[data-flash-focus-action='true']", text: I18n.t("label_meeting_reload"))
+  end
+end

--- a/modules/meeting/spec/components/meetings/update_flash_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/update_flash_component_spec.rb
@@ -36,10 +36,17 @@ RSpec.describe Meetings::UpdateFlashComponent, type: :component do
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   let(:meeting) { create(:meeting, project:) }
 
-  it "marks the reload action as the flash focus target" do
+  it "renders a persistent reload action with a polite announcement" do
     render_inline(described_class.new(meeting))
 
     expect(page).to have_link(I18n.t("label_meeting_reload"), href: project_meeting_path(project, meeting))
-    expect(page).to have_css("a[data-flash-focus-action='true']", text: I18n.t("label_meeting_reload"))
+    expect(page).to have_css(
+      ".Banner-message + .Banner-actions a:not([tabindex])",
+      text: I18n.t("label_meeting_reload")
+    )
+    expect(page).to have_css(
+      ".op-primer-flash--item[data-politeness='polite'][data-announcement='#{I18n.t('notice_meeting_updated')}']"
+    )
+    expect(page).to have_no_button(I18n.t(:button_close))
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-731

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When a meeting is updated in another session, the update flash now focuses the flash item itself and makes the reload action the next logical keyboard stop. 

# What approach did you choose and why?
- Marks the meeting update reload action as an important flash action.
- Focuses the flash item instead of the reload link directly.
- Adds an accessible announcement label to the focused flash item.
- Skips the separate live-region announcement for this focused-flash case to avoid duplicate output.