### PR TITLE
Department seeds

### DIFF
--- a/app/components/members/row_component.rb
+++ b/app/components/members/row_component.rb
@@ -139,9 +139,24 @@ module Members
     end
 
     def groups
-      if user?
-        (principal.groups & project.groups).map(&:name).join(", ")
-      end
+      return unless user?
+
+      member_groups = principal.groups & project.groups
+      safe_join(member_groups.map { |group| group_label(group) }, ", ")
+    end
+
+    # Departments (organizational units) are marked with a briefcase icon, the same icon used to
+    # represent them elsewhere, to set them apart from regular groups in the list.
+    def group_label(group)
+      return group.name unless group.organizational_unit?
+
+      safe_join(
+        [
+          render(Primer::Beta::Octicon.new(icon: :briefcase, mr: 1,
+                                           "aria-label": Group.human_attribute_name(:organizational_unit))),
+          group.name
+        ]
+      )
     end
 
     def status

--- a/app/seeders/demo_data/department_seeder.rb
+++ b/app/seeders/demo_data/department_seeder.rb
@@ -46,6 +46,7 @@ module DemoData
       seed_data.each("departments") do |department_data|
         department = create_department(department_data)
         seed_data.store_reference(department_data["reference"], department)
+        seed_members(department, department_data)
       end
     end
 
@@ -62,6 +63,41 @@ module DemoData
       return if reference.blank?
 
       seed_data.find_reference(reference).id
+    end
+
+    def seed_members(department, department_data)
+      users = Array(department_data["members"]).map do |member_data|
+        user = create_user(member_data)
+        seed_data.store_reference(member_data["reference"], user)
+        user
+      end
+
+      return if users.empty?
+
+      Groups::AddUsersService
+        .new(department, current_user: admin_user)
+        .call(ids: users.map(&:id), send_notifications: false)
+        .on_failure { |result| raise result.message }
+    end
+
+    def create_user(member_data)
+      firstname = member_data["firstname"]
+      lastname = member_data["lastname"]
+      login = "#{firstname}.#{lastname}".downcase
+
+      User.new(
+        login:,
+        firstname:,
+        lastname:,
+        mail: "#{login}@example.com",
+        status: User.statuses[:active],
+        language: I18n.locale.to_s,
+        password: login,
+        force_password_change: false
+      ).tap do |user|
+        user.notification_settings.build(assignee: true, responsible: true, mentioned: true, watched: true)
+        user.save!(validate: false)
+      end
     end
   end
 end

--- a/app/seeders/demo_data/department_seeder.rb
+++ b/app/seeders/demo_data/department_seeder.rb
@@ -26,19 +26,42 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-class DemoDataSeeder < CompositeSeeder
-  def data_seeder_classes
-    [
-      DemoData::GroupSeeder,
-      DemoData::UserCustomFieldsSeeder,
-      DemoData::DepartmentSeeder,
-      DemoData::GlobalQuerySeeder,
-      DemoData::ProjectsSeeder,
-      DemoData::OverviewSeeder
-    ]
-  end
+#++
 
-  def namespace
-    "DemoData"
+module DemoData
+  class DepartmentSeeder < Seeder
+    def seed_data!
+      print_status "    ↳ Creating departments" do
+        seed_departments
+      end
+    end
+
+    def applicable?
+      Group.organizational_units.none?
+    end
+
+    private
+
+    def seed_departments
+      seed_data.each("departments") do |department_data|
+        department = create_department(department_data)
+        seed_data.store_reference(department_data["reference"], department)
+      end
+    end
+
+    def create_department(department_data)
+      Group.create!(
+        lastname: department_data["name"],
+        organizational_unit: true,
+        parent_id: parent_id_for(department_data)
+      )
+    end
+
+    def parent_id_for(department_data)
+      reference = department_data["parent"]
+      return if reference.blank?
+
+      seed_data.find_reference(reference).id
+    end
   end
 end

--- a/app/seeders/demo_data/department_seeder.rb
+++ b/app/seeders/demo_data/department_seeder.rb
@@ -30,6 +30,15 @@
 
 module DemoData
   class DepartmentSeeder < Seeder
+    # Maps the member attributes in the seeding data to the user custom fields
+    # created by UserCustomFieldsSeeder, which runs earlier in the demo data.
+    CUSTOM_FIELD_BY_MEMBER_KEY = {
+      "job_title" => "Job title",
+      "spoken_languages" => "Spoken languages",
+      "key_skills" => "Key skills",
+      "job_start_date" => "Job start date"
+    }.freeze
+
     def seed_data!
       print_status "    ↳ Creating departments" do
         seed_departments
@@ -96,8 +105,36 @@ module DemoData
         force_password_change: false
       ).tap do |user|
         user.notification_settings.build(assignee: true, responsible: true, mentioned: true, watched: true)
+        user.custom_field_values = custom_field_values_for(member_data)
         user.save!(validate: false)
       end
+    end
+
+    def custom_field_values_for(member_data)
+      CUSTOM_FIELD_BY_MEMBER_KEY.each_with_object({}) do |(member_key, field_name), values|
+        next unless member_data.key?(member_key)
+
+        field = user_custom_field(field_name)
+        values[field.id] = custom_value_for(field, member_data[member_key])
+      end
+    end
+
+    def custom_value_for(field, raw_value)
+      return raw_value unless field.list?
+
+      Array(raw_value).map { |label| custom_option_id(field, label) }
+    end
+
+    def custom_option_id(field, label)
+      option = field.custom_options.find { |o| o.value == label }
+      raise "Unknown option #{label.inspect} for user custom field #{field.name.inspect}" if option.nil?
+
+      option.id
+    end
+
+    def user_custom_field(name)
+      @user_custom_fields ||= {}
+      @user_custom_fields[name] ||= UserCustomField.find_by!(name:)
     end
   end
 end

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -98,6 +98,29 @@ module DemoData
         principal: admin_user,
         roles: [role]
       )
+
+      seed_additional_members
+    end
+
+    # Adds the members configured via the project's `members` seed data. A principal can be a
+    # user (added directly) or a department (added as a group, with its users inheriting the role).
+    # References may be missing when the departments were not (re-)seeded, in which case we skip them.
+    def seed_additional_members
+      project_data.each("members") do |member_data|
+        principal = seed_data.find_reference(member_data["principal"], default: nil)
+        next if principal.nil?
+
+        role = seed_data.find_reference(member_data["role"])
+        Member.create!(project:, principal:, roles: [role])
+
+        inherit_group_roles(principal) if principal.is_a?(Group)
+      end
+    end
+
+    def inherit_group_roles(group)
+      Groups::CreateInheritedRolesService
+        .new(group, current_user: admin_user)
+        .call(user_ids: group.user_ids, project_ids: [project.id])
     end
 
     def set_types

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -61,7 +61,9 @@ module DemoData
         DemoData::WorkPackageBoardSeeder,
         ::Meetings::DemoData::MeetingSeriesSeeder,
         ::Meetings::DemoData::MeetingAgendaItemsSeeder,
-        ::Meetings::DemoData::MeetingSeriesFinalizerSeeder
+        ::Meetings::DemoData::MeetingParticipantsSeeder,
+        ::Meetings::DemoData::MeetingSeriesFinalizerSeeder,
+        ::Meetings::DemoData::MeetingOccurrencesSeeder
       ]
     end
 

--- a/app/seeders/demo_data/working_time_seeder.rb
+++ b/app/seeders/demo_data/working_time_seeder.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module DemoData
+  # Seeds working hours (weekly schedules) and vacations (non-working times) for the demo users,
+  # deliberately covering all cases: users without a schedule, users with a single schedule, and
+  # users whose schedule changes over time (e.g. reduced hours over the summer).
+  class WorkingTimeSeeder < Seeder
+    # Working hours are stored as minutes per weekday.
+    FULL_TIME        = { monday: 480, tuesday: 480, wednesday: 480, thursday: 480, friday: 480, saturday: 0, sunday: 0 }.freeze
+    SUMMER_HALF_DAYS = { monday: 240, tuesday: 240, wednesday: 240, thursday: 240, friday: 240, saturday: 0, sunday: 0 }.freeze
+    THREE_DAY_WEEK   = { monday: 480, tuesday: 480, wednesday: 480, thursday: 0,   friday: 0,   saturday: 0, sunday: 0 }.freeze
+    FOUR_DAY_WEEK    = { monday: 480, tuesday: 480, wednesday: 480, thursday: 480, friday: 0,   saturday: 0, sunday: 0 }.freeze
+
+    # Schedules per user reference. Each entry is [minutes, valid_from, availability_factor], where
+    # valid_from is [month, day] within the current year or nil for the start of the year. Multiple
+    # entries model a schedule that changes over time. Connie Comms, Carl Content, Polly PR and
+    # Adam Admin are intentionally absent to cover the "no schedule" case.
+    SCHEDULES = {
+      user__marko_marketing: [[FULL_TIME, nil, 100]],
+      user__wanda_web: [[FULL_TIME, nil, 100]],
+      user__evan_events: [[FULL_TIME, nil, 100]],
+      user__ivan_it: [[FULL_TIME, nil, 100]],
+      user__petra_press: [[THREE_DAY_WEEK, nil, 100]],     # part-time three-day week
+      user__fritz_finance: [[FULL_TIME, nil, 80]],         # full-time hours, 80% available
+      user__dora_design: [                                 # half days over the summer, full otherwise
+        [FULL_TIME, nil, 100],
+        [SUMMER_HALF_DAYS, [6, 1], 100],
+        [FULL_TIME, [9, 1], 100]
+      ],
+      user__olga_ops: [                                    # switched to a four-day week mid-year
+        [FULL_TIME, nil, 100],
+        [FOUR_DAY_WEEK, [7, 1], 100]
+      ]
+    }.freeze
+
+    # Vacations per user reference as [[start_month, start_day], [end_month, end_day]] within the
+    # current year. Polly PR has no schedule but still takes a vacation.
+    VACATIONS = {
+      user__marko_marketing: [[7, 14], [7, 25]],
+      user__wanda_web: [[12, 23], [12, 31]],
+      user__evan_events: [[4, 1], [4, 5]],
+      user__fritz_finance: [[8, 4], [8, 15]],
+      user__dora_design: [[12, 23], [12, 31]],
+      user__polly_pr: [[5, 19], [5, 23]]
+    }.freeze
+
+    def seed_data!
+      print_status "    ↳ Creating working hours and vacations" do
+        seed_schedules
+        seed_vacations
+      end
+    end
+
+    def applicable?
+      UserWorkingHours.none? && UserNonWorkingTime.none?
+    end
+
+    private
+
+    def seed_schedules
+      SCHEDULES.each do |reference, entries|
+        entries.each do |minutes, month_day, availability_factor|
+          valid_from = month_day ? Date.new(year, *month_day) : year_start
+          working_hours(reference, minutes, valid_from:, availability_factor:)
+        end
+      end
+    end
+
+    def seed_vacations
+      VACATIONS.each do |reference, ((start_month, start_day), (end_month, end_day))|
+        vacation(reference, Date.new(year, start_month, start_day), Date.new(year, end_month, end_day))
+      end
+    end
+
+    def working_hours(reference, minutes, valid_from:, availability_factor: 100)
+      user = find_user(reference)
+      return unless user
+
+      UserWorkingHours.create!(user:, valid_from:, availability_factor:, **minutes)
+    end
+
+    def vacation(reference, start_date, end_date)
+      user = find_user(reference)
+      return unless user
+
+      UserNonWorkingTime.create!(user:, start_date:, end_date:)
+    end
+
+    def find_user(reference)
+      seed_data.find_reference(reference, default: nil)
+    end
+
+    def year
+      @year ||= Date.current.year
+    end
+
+    def year_start
+      @year_start ||= Date.current.beginning_of_year
+    end
+  end
+end

--- a/app/seeders/demo_data/working_time_seeder.rb
+++ b/app/seeders/demo_data/working_time_seeder.rb
@@ -38,6 +38,7 @@ module DemoData
     SUMMER_HALF_DAYS = { monday: 240, tuesday: 240, wednesday: 240, thursday: 240, friday: 240, saturday: 0, sunday: 0 }.freeze
     THREE_DAY_WEEK   = { monday: 480, tuesday: 480, wednesday: 480, thursday: 0,   friday: 0,   saturday: 0, sunday: 0 }.freeze
     FOUR_DAY_WEEK    = { monday: 480, tuesday: 480, wednesday: 480, thursday: 480, friday: 0,   saturday: 0, sunday: 0 }.freeze
+    VERY_LOW_HOURS   = { monday: 120, tuesday: 0,   wednesday: 120, thursday: 0,   friday: 120, saturday: 0, sunday: 0 }.freeze
 
     # Schedules per user reference. Each entry is [minutes, valid_from, availability_factor], where
     # valid_from is [month, day] within the current year or nil for the start of the year. Multiple
@@ -47,9 +48,9 @@ module DemoData
       user__marko_marketing: [[FULL_TIME, nil, 100]],
       user__wanda_web: [[FULL_TIME, nil, 100]],
       user__evan_events: [[FULL_TIME, nil, 100]],
-      user__ivan_it: [[FULL_TIME, nil, 100]],
+      user__ivan_it: [[FULL_TIME, nil, 80]],               # full-time hours, 80% available
       user__petra_press: [[THREE_DAY_WEEK, nil, 100]],     # part-time three-day week
-      user__fritz_finance: [[FULL_TIME, nil, 80]],         # full-time hours, 80% available
+      user__fritz_finance: [[VERY_LOW_HOURS, nil, 100]],   # part-time, very low hours (6h/week)
       user__dora_design: [                                 # half days over the summer, full otherwise
         [FULL_TIME, nil, 100],
         [SUMMER_HALF_DAYS, [6, 1], 100],

--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -32,6 +32,7 @@ class DemoDataSeeder < CompositeSeeder
       DemoData::GroupSeeder,
       DemoData::UserCustomFieldsSeeder,
       DemoData::DepartmentSeeder,
+      DemoData::WorkingTimeSeeder,
       DemoData::GlobalQuerySeeder,
       DemoData::ProjectsSeeder,
       DemoData::OverviewSeeder

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -65,18 +65,60 @@ priorities:
 departments:
   - reference: :department__marketing_communications
     t_name: Marketing & Communications
+    members:
+      - reference: :user__marko_marketing
+        firstname: Marko
+        lastname: Marketing
+      - reference: :user__connie_comms
+        firstname: Connie
+        lastname: Comms
   - reference: :department__public_relations
     t_name: Public Relations
     parent: :department__marketing_communications
+    members:
+      - reference: :user__petra_press
+        firstname: Petra
+        lastname: Press
+      - reference: :user__polly_pr
+        firstname: Polly
+        lastname: PR
   - reference: :department__design_content
     t_name: Design & Content
     parent: :department__marketing_communications
+    members:
+      - reference: :user__dora_design
+        firstname: Dora
+        lastname: Design
+      - reference: :user__carl_content
+        firstname: Carl
+        lastname: Content
   - reference: :department__events_operations
     t_name: Events & Operations
+    members:
+      - reference: :user__evan_events
+        firstname: Evan
+        lastname: Events
+      - reference: :user__olga_ops
+        firstname: Olga
+        lastname: Ops
   - reference: :department__web_it
     t_name: Web & IT
+    members:
+      - reference: :user__wanda_web
+        firstname: Wanda
+        lastname: Web
+      - reference: :user__ivan_it
+        firstname: Ivan
+        lastname: IT
   - reference: :department__finance_administration
     t_name: Finance & Administration
+    members:
+      - reference: :user__fritz_finance
+        firstname: Fritz
+        lastname: Finance
+      - reference: :user__adam_admin
+        firstname: Adam
+        lastname: Admin
 
 project_custom_field_sections:
   - reference: :default_project_attributes
@@ -90,6 +132,16 @@ projects:
     status_code: on_track
     t_status_explanation: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     t_description: This is a short summary of the goals of this demo project.
+    # Some people join the project directly, others through their whole department (group).
+    members:
+      - principal: :user__marko_marketing
+        role: :default_role_member
+      - principal: :user__wanda_web
+        role: :default_role_member
+      - principal: :department__events_operations
+        role: :default_role_member
+      - principal: :department__finance_administration
+        role: :default_role_member
     project_phases:
       - definition: :default_project_phase_initiating
         duration: 20

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -119,6 +119,12 @@ departments:
       - reference: :user__adam_admin
         firstname: Adam
         lastname: Admin
+  - reference: :department__quality_assurance
+    t_name: Quality Assurance
+    members:
+      - reference: :user__tessa_tester
+        firstname: Tessa
+        lastname: Tester
 
 project_custom_field_sections:
   - reference: :default_project_attributes
@@ -137,6 +143,8 @@ projects:
       - principal: :user__marko_marketing
         role: :default_role_member
       - principal: :user__wanda_web
+        role: :default_role_member
+      - principal: :user__tessa_tester
         role: :default_role_member
       - principal: :department__events_operations
         role: :default_role_member
@@ -394,6 +402,17 @@ projects:
             relations:
               - to: :set_date_and_location_of_conference
                 type: follows
+      - start: 15
+        t_subject: Test and quality-check the conference website
+        assigned_to: :user__tessa_tester
+        description: ''
+        status: :default_status_new
+        type: :default_type_task
+        duration: 3
+        schedule_manually: false
+        relations:
+          - to: :setup_conference_website
+            type: follows
       - start: 15
         t_subject: Conference
         description: ''

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -332,6 +332,7 @@ projects:
       - start: 0
         t_subject: Organize open source conference
         reference: :organize_open_source_conference
+        assigned_to: :department__events_operations
         description: ''
         status: :default_status_in_progress
         type: :default_type_summary_task
@@ -341,6 +342,7 @@ projects:
           - start: 0
             t_subject: Set date and location of conference
             reference: :set_date_and_location_of_conference
+            assigned_to: :user__olga_ops
             description: ''
             status: :default_status_in_progress
             type: :default_type_task
@@ -349,18 +351,21 @@ projects:
             children:
               - start: 0
                 t_subject: Send invitation to speakers
+                assigned_to: :user__marko_marketing
                 description: ''
                 status: :default_status_in_progress
                 type: :default_type_task
                 duration: 1
               - start: 0
                 t_subject: Contact sponsoring partners
+                assigned_to: :department__finance_administration
                 description: ''
                 status: :default_status_new
                 type: :default_type_task
                 duration: 2
               - start: 0
                 t_subject: Create sponsorship brochure and hand-outs
+                assigned_to: :user__marko_marketing
                 description: ''
                 status: :default_status_new
                 type: :default_type_task
@@ -368,6 +373,7 @@ projects:
           - start: 4
             t_subject: Invite attendees to conference
             reference: :invite_attendees_to_conference
+            assigned_to: :user__evan_events
             description: ''
             status: :default_status_new
             type: :default_type_task
@@ -379,6 +385,7 @@ projects:
           - start: 4
             t_subject: Setup conference website
             reference: :setup_conference_website
+            assigned_to: :user__wanda_web
             description: ''
             status: :default_status_new
             type: :default_type_task
@@ -400,6 +407,7 @@ projects:
       - start: 21
         t_subject: Follow-up tasks
         reference: :follow_up_tasks
+        assigned_to: :user__adam_admin
         description: ''
         status: :default_status_to_be_scheduled
         type: :default_type_summary_task
@@ -409,12 +417,14 @@ projects:
           - start: 21
             t_subject: Upload presentations to website
             reference: :upload_presentations_to_website
+            assigned_to: :user__wanda_web
             description: ''
             status: :default_status_new
             type: :default_type_task
             duration: 10
           - start: 31
             t_subject: Party for conference supporters :-)
+            assigned_to: :user__olga_ops
             t_description: |-
               *   [ ] Beer
               *   [ ] Snacks

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -69,9 +69,17 @@ departments:
       - reference: :user__marko_marketing
         firstname: Marko
         lastname: Marketing
+        job_title: Marketing Manager
+        spoken_languages: [English, German]
+        key_skills: [Marketing & Communications, Public Speaking]
+        job_start_date: "2021-03-01"
       - reference: :user__connie_comms
         firstname: Connie
         lastname: Comms
+        job_title: Technical Writer
+        spoken_languages: [English, French]
+        key_skills: [Copywriting, Marketing & Communications]
+        job_start_date: "2022-06-15"
   - reference: :department__public_relations
     t_name: Public Relations
     parent: :department__marketing_communications
@@ -79,9 +87,17 @@ departments:
       - reference: :user__petra_press
         firstname: Petra
         lastname: Press
+        job_title: Marketing Manager
+        spoken_languages: [English, German]
+        key_skills: [Public Speaking, Stakeholder Management]
+        job_start_date: "2020-09-01"
       - reference: :user__polly_pr
         firstname: Polly
         lastname: PR
+        job_title: Marketing Manager
+        spoken_languages: [English, Spanish]
+        key_skills: [Marketing & Communications, Stakeholder Management]
+        job_start_date: "2023-01-10"
   - reference: :department__design_content
     t_name: Design & Content
     parent: :department__marketing_communications
@@ -89,42 +105,78 @@ departments:
       - reference: :user__dora_design
         firstname: Dora
         lastname: Design
+        job_title: UX/UI Designer
+        spoken_languages: [English, Dutch]
+        key_skills: [UX/UI Design, Public Speaking]
+        job_start_date: "2021-11-02"
       - reference: :user__carl_content
         firstname: Carl
         lastname: Content
+        job_title: Technical Writer
+        spoken_languages: [English, German]
+        key_skills: [Copywriting, Marketing & Communications]
+        job_start_date: "2022-02-14"
   - reference: :department__events_operations
     t_name: Events & Operations
     members:
       - reference: :user__evan_events
         firstname: Evan
         lastname: Events
+        job_title: Event Coordinator
+        spoken_languages: [English, French]
+        key_skills: [Event Planning, Public Speaking]
+        job_start_date: "2019-05-20"
       - reference: :user__olga_ops
         firstname: Olga
         lastname: Ops
+        job_title: Event Coordinator
+        spoken_languages: [English, Polish]
+        key_skills: [Event Planning, Budgeting]
+        job_start_date: "2020-08-17"
   - reference: :department__web_it
     t_name: Web & IT
     members:
       - reference: :user__wanda_web
         firstname: Wanda
         lastname: Web
+        job_title: Software Developer
+        spoken_languages: [English, German]
+        key_skills: [Software Development, DevOps]
+        job_start_date: "2021-04-12"
       - reference: :user__ivan_it
         firstname: Ivan
         lastname: IT
+        job_title: Software Developer
+        spoken_languages: [English, Italian]
+        key_skills: [Software Development, DevOps]
+        job_start_date: "2018-10-01"
   - reference: :department__finance_administration
     t_name: Finance & Administration
     members:
       - reference: :user__fritz_finance
         firstname: Fritz
         lastname: Finance
+        job_title: Project Manager
+        spoken_languages: [English, German]
+        key_skills: [Budgeting, Stakeholder Management]
+        job_start_date: "2017-07-03"
       - reference: :user__adam_admin
         firstname: Adam
         lastname: Admin
+        job_title: Project Manager
+        spoken_languages: [English, German]
+        key_skills: [Project Management, Budgeting]
+        job_start_date: "2019-01-15"
   - reference: :department__quality_assurance
     t_name: Quality Assurance
     members:
       - reference: :user__tessa_tester
         firstname: Tessa
         lastname: Tester
+        job_title: QA Engineer
+        spoken_languages: [English, Portuguese]
+        key_skills: [Quality Assurance, Agile & Scrum]
+        job_start_date: "2022-09-05"
 
 project_custom_field_sections:
   - reference: :default_project_attributes

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -62,6 +62,22 @@ priorities:
     color_name: grape-5
     position: 4
 
+departments:
+  - reference: :department__marketing_communications
+    t_name: Marketing & Communications
+  - reference: :department__public_relations
+    t_name: Public Relations
+    parent: :department__marketing_communications
+  - reference: :department__design_content
+    t_name: Design & Content
+    parent: :department__marketing_communications
+  - reference: :department__events_operations
+    t_name: Events & Operations
+  - reference: :department__web_it
+    t_name: Web & IT
+  - reference: :department__finance_administration
+    t_name: Finance & Administration
+
 project_custom_field_sections:
   - reference: :default_project_attributes
     name: Project attributes

--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_occurrences_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_occurrences_seeder.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Meetings
+  module DemoData
+    # Instantiates the next few occurrences of the weekly meeting series (each inherits the
+    # template's participants) and adds a bit of realism to the responses: most attendees accept,
+    # but on some occurrences a few decline or are tentative and one-off guests are invited.
+    # Runs *after* the finalizer, which opens the template and creates the first occurrence.
+    class MeetingOccurrencesSeeder < ::Seeder
+      # How many occurrences of the series should exist after seeding.
+      OCCURRENCE_COUNT = 5
+
+      attr_reader :project
+
+      def initialize(project, seed_data)
+        super(seed_data)
+        @project = project
+      end
+
+      def applicable?
+        series&.template.present?
+      end
+
+      def not_applicable_message
+        "Skipping meeting occurrences as no meeting series exists for project #{project.identifier}"
+      end
+
+      def seed_data!
+        print_status "    ↳ Instantiating meeting occurrences" do
+          instantiate_occurrences
+          vary_responses(series.meetings.not_templated.order(:start_time).to_a)
+        end
+      end
+
+      private
+
+      def series
+        @series ||= project.recurring_meetings.first
+      end
+
+      # Instantiates the next scheduled occurrences that have not been materialized yet, using the
+      # same service the application uses. The occurrences already created by the finalizer (and
+      # its recurrence job) are skipped.
+      def instantiate_occurrences
+        series.scheduled_occurrences(limit: OCCURRENCE_COUNT).each do |start_time|
+          next if series.meetings.not_templated.exists?(recurrence_start_time: start_time)
+
+          ::RecurringMeetings::InitOccurrenceService
+            .new(user: admin_user, recurring_meeting: series)
+            .call(start_time:)
+            .on_failure { |result| raise "Failed to instantiate meeting occurrence: #{result.message}" }
+        end
+      end
+
+      def vary_responses(occurrences)
+        # The first occurrence keeps everybody accepted. On later occurrences some people can't
+        # make it, and a couple of one-off guests are invited.
+        if (second = occurrences[1])
+          set_response(second, :user__fritz_finance, :declined)
+          set_response(second, :user__evan_events, :tentative)
+          invite_individual(second, :user__olga_ops)
+          invite_individual(second, :user__tessa_tester)
+        end
+
+        if (third = occurrences[2])
+          set_response(third, :user__marko_marketing, :tentative)
+          invite_individual(third, :user__adam_admin)
+        end
+      end
+
+      def set_response(meeting, reference, status)
+        user = seed_data.find_reference(reference, default: nil)
+        return unless user
+
+        meeting.participants.find_by(user:)&.update!(participation_status: status)
+      end
+
+      def invite_individual(meeting, reference)
+        user = seed_data.find_reference(reference, default: nil)
+        return unless user
+
+        participant = meeting.participants.find_or_initialize_by(user:)
+        participant.update!(invited: true, participation_status: :accepted)
+      end
+    end
+  end
+end

--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_participants_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_participants_seeder.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Meetings
+  module DemoData
+    # Adds the regular attendees to the weekly meeting series template. This runs *before* the
+    # finalizer so every occurrence the finalizer (and the recurrence job) instantiates inherits
+    # the participants. Everybody accepts by default; individual exceptions are seeded per
+    # occurrence by the MeetingOccurrencesSeeder.
+    class MeetingParticipantsSeeder < ::Seeder
+      # The regular attendees of the weekly meeting (references to demo project members).
+      BASE_ATTENDEES = %i[
+        openproject_admin
+        user__marko_marketing
+        user__wanda_web
+        user__evan_events
+        user__fritz_finance
+      ].freeze
+
+      attr_reader :project
+
+      def initialize(project, seed_data)
+        super(seed_data)
+        @project = project
+      end
+
+      def applicable?
+        template.present?
+      end
+
+      def not_applicable_message
+        "Skipping meeting participants as no meeting series template exists for project #{project.identifier}"
+      end
+
+      def seed_data!
+        print_status "    ↳ Adding meeting participants" do
+          BASE_ATTENDEES.each do |reference|
+            user = seed_data.find_reference(reference, default: nil)
+            next unless user
+
+            # The meeting author is already a participant, so upsert rather than create.
+            participant = template.participants.find_or_initialize_by(user:)
+            participant.update!(invited: true, participation_status: :accepted)
+          end
+        end
+      end
+
+      private
+
+      def template
+        @template ||= project.recurring_meetings.first&.template
+      end
+    end
+  end
+end

--- a/modules/meeting/app/seeders/standard.yml
+++ b/modules/meeting/app/seeders/standard.yml
@@ -47,37 +47,37 @@ projects:
         notes: "News and focused topics for the upcoming week."
         meeting: :weekly_meeting_template
         author: :openproject_admin
-        presenter: :openproject_admin
+        presenter: :user__wanda_web
         duration: 5
       - t_title: Updates from product team
         notes: "News and focused topics for the upcoming week."
         meeting: :weekly_meeting_template
         author: :openproject_admin
-        presenter: :openproject_admin
+        presenter: :user__evan_events
         duration: 5
       - t_title: Updates from marketing team
         notes: "News and focused topics for the upcoming week."
         meeting: :weekly_meeting_template
         author: :openproject_admin
-        presenter: :openproject_admin
+        presenter: :user__marko_marketing
         duration: 5
       - work_package: :organize_open_source_conference
         notes: "**Today's topic**: Organizing the open-source conference."
         meeting: :weekly_meeting_template
         author: :openproject_admin
-        presenter: :openproject_admin
+        presenter: :user__evan_events
         duration: 5
       - t_title: Updates from sales team
         notes: "News and focused topics for the upcoming week."
         meeting: :weekly_meeting_template
         author: :openproject_admin
-        presenter: :openproject_admin
+        presenter: :user__fritz_finance
         duration: 5
       - t_title: Review of quarterly goals
         notes: "Assessing the status and progress of the defined quarterly goals."
         meeting: :weekly_meeting_template
         author: :openproject_admin
-        presenter: :openproject_admin
+        presenter: :user__fritz_finance
         duration: 5
       - t_title: Core values feedback
         notes: "Highlight employees who have lived the core values this week."

--- a/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
@@ -105,8 +105,9 @@ RSpec.describe DemoData::ProjectSeeder do
   it "instantiates the first occurrence with the template's agenda items" do
     series = RecurringMeeting.find_by(title: "Weekly")
     expect(series.template).not_to be_draft
-    expect(series.scheduled_instances.count).to eq(1)
-    instance = series.scheduled_instances.first
+    # The finalizer creates the first occurrence; the MeetingOccurrencesSeeder fills up the next few.
+    expect(series.scheduled_instances.count).to eq(5)
+    instance = series.scheduled_instances.order(:start_time).first
     expect(instance.duration).to eq 0.5
     expect(instance.agenda_items.count).to eq 2
 

--- a/spec/components/members/row_component_spec.rb
+++ b/spec/components/members/row_component_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Members::RowComponent, type: :component do
+  shared_let(:project) { create(:project) }
+  shared_let(:role) { create(:project_role) }
+
+  shared_let(:user) { create(:user) }
+  shared_let(:department) { create(:department, lastname: "Finance", members: [user]) }
+  shared_let(:regular_group) { create(:group, lastname: "A-Team", members: [user]) }
+
+  shared_let(:member) { create(:member, principal: user, project:, roles: [role]) }
+
+  before do
+    # Both groups need to be members of the project to show up in the user's "Groups" column.
+    create(:member, principal: department, project:, roles: [role])
+    create(:member, principal: regular_group, project:, roles: [role])
+  end
+
+  let(:table) do
+    instance_double(Members::TableComponent,
+                    columns: [:groups],
+                    project:,
+                    authorize_update: false,
+                    authorize_delete: false,
+                    authorize_work_package_shares_view: false,
+                    authorize_work_package_shares_delete: false,
+                    authorize_manage_user: false,
+                    hide_roles?: true)
+  end
+
+  subject(:rendered) { render_inline(described_class.new(row: member, table:)) }
+
+  it "marks departments with a briefcase icon but leaves regular groups unmarked" do
+    expect(rendered).to have_css("td.groups", text: "Finance")
+    expect(rendered).to have_css("td.groups", text: "A-Team")
+
+    # Exactly one briefcase: the department, not the regular group.
+    expect(rendered).to have_css("td.groups .octicon-briefcase", count: 1)
+    expect(rendered).to have_css("td.groups [aria-label='Organizational unit']", count: 1)
+  end
+end

--- a/spec/seeders/demo_data/department_seeder_spec.rb
+++ b/spec/seeders/demo_data/department_seeder_spec.rb
@@ -40,11 +40,22 @@ RSpec.describe DemoData::DepartmentSeeder do
       departments:
       - name: Marketing & Communications
         reference: :marketing
+        members:
+          - reference: :marko_marketing
+            firstname: Marko
+            lastname: Marketing
       - name: Public Relations
         reference: :public_relations
         parent: :marketing
+        members:
+          - reference: :petra_press
+            firstname: Petra
+            lastname: Press
     SEEDING_DATA_YAML
   end
+
+  # `Groups::AddUsersService` runs under an admin (`Seeder#admin_user`).
+  before { create(:admin) }
 
   it "creates a root department as an organizational unit with the given name" do
     seeder.seed!
@@ -63,6 +74,23 @@ RSpec.describe DemoData::DepartmentSeeder do
     expect(child).to have_attributes(lastname: "Public Relations", organizational_unit: true)
     expect(child.parent).to eq(root)
     expect(root.children).to include(child)
+  end
+
+  it "creates the member users with a derived login and mail and adds them to their department" do
+    seeder.seed!
+
+    marko = seed_data.find_reference(:marko_marketing)
+    expect(marko).to have_attributes(
+      firstname: "Marko",
+      lastname: "Marketing",
+      login: "marko.marketing",
+      mail: "marko.marketing@example.com",
+      status: "active"
+    )
+
+    expect(seed_data.find_reference(:marketing).users).to include(marko)
+    expect(seed_data.find_reference(:public_relations).users)
+      .to include(seed_data.find_reference(:petra_press))
   end
 
   it "is not applicable once an organizational unit already exists" do

--- a/spec/seeders/demo_data/department_seeder_spec.rb
+++ b/spec/seeders/demo_data/department_seeder_spec.rb
@@ -26,19 +26,48 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-class DemoDataSeeder < CompositeSeeder
-  def data_seeder_classes
-    [
-      DemoData::GroupSeeder,
-      DemoData::UserCustomFieldsSeeder,
-      DemoData::DepartmentSeeder,
-      DemoData::GlobalQuerySeeder,
-      DemoData::ProjectsSeeder,
-      DemoData::OverviewSeeder
-    ]
+#++
+
+require "spec_helper"
+
+RSpec.describe DemoData::DepartmentSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { Source::SeedData.new(data_hash) }
+
+  let(:data_hash) do
+    YAML.load <<~SEEDING_DATA_YAML
+      departments:
+      - name: Marketing & Communications
+        reference: :marketing
+      - name: Public Relations
+        reference: :public_relations
+        parent: :marketing
+    SEEDING_DATA_YAML
   end
 
-  def namespace
-    "DemoData"
+  it "creates a root department as an organizational unit with the given name" do
+    seeder.seed!
+
+    root = seed_data.find_reference(:marketing)
+    expect(root).to have_attributes(lastname: "Marketing & Communications", organizational_unit: true)
+    expect(root.parent).to be_nil
+  end
+
+  it "creates a child department nested under its parent" do
+    seeder.seed!
+
+    root = seed_data.find_reference(:marketing)
+    child = seed_data.find_reference(:public_relations)
+
+    expect(child).to have_attributes(lastname: "Public Relations", organizational_unit: true)
+    expect(child.parent).to eq(root)
+    expect(root.children).to include(child)
+  end
+
+  it "is not applicable once an organizational unit already exists" do
+    create(:department)
+
+    expect(seeder).not_to be_applicable
   end
 end

--- a/spec/seeders/demo_data/department_seeder_spec.rb
+++ b/spec/seeders/demo_data/department_seeder_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe DemoData::DepartmentSeeder do
           - reference: :marko_marketing
             firstname: Marko
             lastname: Marketing
+            job_title: Marketing Manager
+            spoken_languages: [English, German]
+            key_skills: [Public Speaking]
+            job_start_date: "2021-03-01"
       - name: Public Relations
         reference: :public_relations
         parent: :marketing
@@ -53,6 +57,18 @@ RSpec.describe DemoData::DepartmentSeeder do
             lastname: Press
     SEEDING_DATA_YAML
   end
+
+  # UserCustomFieldsSeeder runs earlier in the demo data and creates these.
+  shared_let(:job_title_field) do
+    create(:user_custom_field, :list, name: "Job title", possible_values: ["Marketing Manager", "Software Developer"])
+  end
+  shared_let(:languages_field) do
+    create(:user_custom_field, :multi_list, name: "Spoken languages", possible_values: %w[English German French])
+  end
+  shared_let(:skills_field) do
+    create(:user_custom_field, :multi_list, name: "Key skills", possible_values: ["Public Speaking", "DevOps"])
+  end
+  shared_let(:start_date_field) { create(:user_custom_field, :date, name: "Job start date") }
 
   # `Groups::AddUsersService` runs under an admin (`Seeder#admin_user`).
   before { create(:admin) }
@@ -91,6 +107,25 @@ RSpec.describe DemoData::DepartmentSeeder do
     expect(seed_data.find_reference(:marketing).users).to include(marko)
     expect(seed_data.find_reference(:public_relations).users)
       .to include(seed_data.find_reference(:petra_press))
+  end
+
+  it "assigns the curated user custom field values to the member" do
+    seeder.seed!
+
+    marko = seed_data.find_reference(:marko_marketing).reload
+
+    expect(marko.typed_custom_value_for(job_title_field)).to eq("Marketing Manager")
+    expect(marko.typed_custom_value_for(languages_field)).to contain_exactly("English", "German")
+    expect(marko.typed_custom_value_for(skills_field)).to contain_exactly("Public Speaking")
+    expect(marko.typed_custom_value_for(start_date_field)).to eq(Date.new(2021, 3, 1))
+  end
+
+  it "persists no custom values for members without curated values" do
+    seeder.seed!
+
+    petra = seed_data.find_reference(:petra_press).reload
+
+    expect(petra.custom_values).to be_empty
   end
 
   it "is not applicable once an organizational unit already exists" do

--- a/spec/seeders/demo_data/working_time_seeder_spec.rb
+++ b/spec/seeders/demo_data/working_time_seeder_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe DemoData::WorkingTimeSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { Source::SeedData.new({}) }
+
+  let(:marko) { create(:user) }  # single full-time schedule + vacation
+  let(:dora) { create(:user) }   # schedule change over the summer
+  let(:olga) { create(:user) }   # schedule change (four-day week)
+  let(:connie) { create(:user) } # no schedule
+  let(:polly) { create(:user) }  # no schedule, but a vacation
+
+  before do
+    seed_data.store_reference(:user__marko_marketing, marko)
+    seed_data.store_reference(:user__dora_design, dora)
+    seed_data.store_reference(:user__olga_ops, olga)
+    seed_data.store_reference(:user__connie_comms, connie)
+    seed_data.store_reference(:user__polly_pr, polly)
+
+    seeder.seed!
+  end
+
+  it "creates a single full-time schedule for a user with one schedule" do
+    expect(marko.working_hours.count).to eq 1
+    expect(marko.working_hours.sole.weekly_working_hours).to eq 40
+  end
+
+  it "creates multiple dated schedules for a user whose schedule changes" do
+    schedules = dora.working_hours.order(:valid_from).to_a
+    expect(schedules.count).to eq 3
+
+    # full-time, then half days over the summer, then full-time again
+    expect(schedules.map(&:weekly_working_hours)).to eq [40, 20, 40]
+    expect(schedules.map(&:valid_from).uniq.count).to eq 3
+
+    expect(olga.working_hours.count).to eq 2
+  end
+
+  it "leaves users without a schedule untouched" do
+    expect(connie.working_hours).to be_empty
+    expect(polly.working_hours).to be_empty
+  end
+
+  it "creates vacations, including for a user without a schedule" do
+    expect(marko.non_working_times.count).to eq 1
+    expect(polly.non_working_times.count).to eq 1
+  end
+
+  it "is not applicable once working times exist" do
+    expect(seeder).not_to be_applicable
+  end
+end

--- a/spec/seeders/demo_data/working_time_seeder_spec.rb
+++ b/spec/seeders/demo_data/working_time_seeder_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe DemoData::WorkingTimeSeeder do
   let(:marko) { create(:user) }  # single full-time schedule + vacation
   let(:dora) { create(:user) }   # schedule change over the summer
   let(:olga) { create(:user) }   # schedule change (four-day week)
+  let(:fritz) { create(:user) }  # part-time, very low hours
   let(:connie) { create(:user) } # no schedule
   let(:polly) { create(:user) }  # no schedule, but a vacation
 
@@ -45,6 +46,7 @@ RSpec.describe DemoData::WorkingTimeSeeder do
     seed_data.store_reference(:user__marko_marketing, marko)
     seed_data.store_reference(:user__dora_design, dora)
     seed_data.store_reference(:user__olga_ops, olga)
+    seed_data.store_reference(:user__fritz_finance, fritz)
     seed_data.store_reference(:user__connie_comms, connie)
     seed_data.store_reference(:user__polly_pr, polly)
 
@@ -65,6 +67,11 @@ RSpec.describe DemoData::WorkingTimeSeeder do
     expect(schedules.map(&:valid_from).uniq.count).to eq 3
 
     expect(olga.working_hours.count).to eq 2
+  end
+
+  it "gives Fritz Finance a part-time schedule with very low hours" do
+    schedule = fritz.working_hours.sole
+    expect(schedule.weekly_working_hours).to eq 6
   end
 
   it "leaves users without a schedule untouched" do

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RootSeeder,
     it "creates the demo data" do # rubocop:disable RSpec/MultipleExpectations
       expect(Project.count).to eq 2
       expect(EnabledModule.count).to eq 19
-      expect(WorkPackage.count).to eq 36
+      expect(WorkPackage.count).to eq 37
       expect(Wiki.count).to eq 2
       expect(Query.having_views.count).to eq 8
       expect(View.where(type: "work_packages_table").count).to eq 5
@@ -74,8 +74,8 @@ RSpec.describe RootSeeder,
 
     it "creates the company departments with their member users" do
       departments = Group.organizational_units
-      expect(departments.count).to eq 6
-      expect(departments.where_detail(parent_id: nil).count).to eq 4
+      expect(departments.count).to eq 7
+      expect(departments.where_detail(parent_id: nil).count).to eq 5
 
       # Compare records, not names: the names are translatable (t_name) and get prefixed in the
       # translated language test contexts.
@@ -119,6 +119,34 @@ RSpec.describe RootSeeder,
       # Assigned to a whole department (group member of the project).
       expect(data.find_reference(:organize_open_source_conference).assigned_to)
         .to eq(data.find_reference(:department__events_operations))
+    end
+
+    it "seeds working hours and vacations for demo users" do
+      data = root_seeder.seed_data
+
+      # Schedule change: three dated schedules for the same user.
+      expect(data.find_reference(:user__dora_design).working_hours.count).to eq 3
+      # Single schedule.
+      expect(data.find_reference(:user__marko_marketing).working_hours.count).to eq 1
+      # No schedule.
+      expect(data.find_reference(:user__connie_comms).working_hours).to be_empty
+      # Vacation seeded.
+      expect(data.find_reference(:user__wanda_web).non_working_times.count).to eq 1
+    end
+
+    it "includes a QA department with a QA user and a QA work package" do
+      data = root_seeder.seed_data
+
+      qa_department = data.find_reference(:department__quality_assurance)
+      tessa = data.find_reference(:user__tessa_tester)
+      expect(qa_department).to be_organizational_unit
+      expect(qa_department.users).to include(tessa)
+
+      qa_work_package = WorkPackage.find_by(assigned_to: tessa)
+      expect(qa_work_package).to be_present
+      # The QA task follows the website setup task.
+      website = data.find_reference(:setup_conference_website)
+      expect(Relation.follows.exists?(from_id: qa_work_package.id, to_id: website.id)).to be true
     end
 
     it "links work packages to their version" do
@@ -234,7 +262,7 @@ RSpec.describe RootSeeder,
 
       it "does not create additional data and does not raise any errors" do # rubocop:disable RSpec/MultipleExpectations
         expect(Project.count).to eq 2
-        expect(WorkPackage.count).to eq 36
+        expect(WorkPackage.count).to eq 37
         expect(Wiki.count).to eq 2
         expect(Query.having_views.count).to eq 8
         expect(View.where(type: "work_packages_table").count).to eq 5
@@ -263,7 +291,7 @@ RSpec.describe RootSeeder,
 
       it "does not create additional data and does not raise any errors" do
         expect(Project.count).to eq 2
-        expect(WorkPackage.count).to eq 36
+        expect(WorkPackage.count).to eq 37
         expect(Wiki.count).to eq 2
       end
     end
@@ -374,7 +402,7 @@ RSpec.describe RootSeeder,
     end
 
     it "creates 4 additional work packages for development" do
-      expect(WorkPackage.count).to eq 40
+      expect(WorkPackage.count).to eq 41
     end
 
     it "creates 1 project with custom fields" do
@@ -403,7 +431,7 @@ RSpec.describe RootSeeder,
 
     it "seeds without any errors, but locks the admin user", :aggregate_failures do
       expect(Project.count).to eq 2
-      expect(WorkPackage.count).to eq 36
+      expect(WorkPackage.count).to eq 37
       expect(root_seeder.admin_user).to be_locked
     end
   end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -72,6 +72,43 @@ RSpec.describe RootSeeder,
       expect(DocumentType.count).to be >= 3 # at least the 3 default types
     end
 
+    it "creates the company departments with their member users" do
+      departments = Group.organizational_units
+      expect(departments.count).to eq 6
+      expect(departments.where_detail(parent_id: nil).count).to eq 4
+
+      # Compare records, not names: the names are translatable (t_name) and get prefixed in the
+      # translated language test contexts.
+      marketing = root_seeder.seed_data.find_reference(:department__marketing_communications)
+      expect(marketing.children).to contain_exactly(
+        root_seeder.seed_data.find_reference(:department__public_relations),
+        root_seeder.seed_data.find_reference(:department__design_content)
+      )
+
+      fritz = root_seeder.seed_data.find_reference(:user__fritz_finance)
+      expect(fritz).to have_attributes(login: "fritz.finance", mail: "fritz.finance@example.com", status: "active")
+      expect(root_seeder.seed_data.find_reference(:department__finance_administration).users)
+        .to include(fritz)
+    end
+
+    it "adds members to the demo project directly and through their department" do
+      demo_project = Project.find_by(identifier: "demo-project")
+
+      marko = root_seeder.seed_data.find_reference(:user__marko_marketing) # direct member
+      finance = root_seeder.seed_data.find_reference(:department__finance_administration) # group member
+      fritz = root_seeder.seed_data.find_reference(:user__fritz_finance) # member via Finance department
+
+      # Direct member: roles assigned directly, not inherited from a group.
+      marko_member = demo_project.members.find_by(user_id: marko.id)
+      expect(marko_member.member_roles.map(&:inherited_from)).to all(be_nil)
+
+      # The department group itself is a member (groups are excluded from #members, hence #memberships),
+      # and its users inherit the role from it.
+      expect(demo_project.memberships.exists?(user_id: finance.id)).to be true
+      fritz_member = demo_project.members.find_by(user_id: fritz.id)
+      expect(fritz_member.member_roles.map(&:inherited_from)).to all(be_present)
+    end
+
     it "links work packages to their version" do
       count_by_version = WorkPackage.joins(:version).group("versions.name").count
       # testing with strings would fail for the German language test

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -178,6 +178,11 @@ RSpec.describe RootSeeder,
       expect(template.agenda_items.count).to eq 9
       expect(template.agenda_items.sum(:duration_in_minutes)).to eq 60
 
+      # Agenda items are presented by several different participants, not just the admin,
+      # while the meeting organizer (admin) remains the author of every item.
+      expect(template.agenda_items.pluck(:presenter_id).uniq.count).to be > 1
+      expect(template.agenda_items.pluck(:author_id).uniq).to eq([root_seeder.admin_user.id])
+
       # The first two instances come from the finalizer seeder (and its chained job), the rest
       # are instantiated by the MeetingOccurrencesSeeder.
       expect(Meeting.where(template: false).count).to eq 5

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe RootSeeder,
       expect(default_modules).to include("reporting_module")
     end
 
-    it "creates a weekly recurring meeting with the first two instances" do
+    it "creates a weekly recurring meeting with several instances" do
       expect(RecurringMeeting.count).to eq 1
 
       # The template is created and is no longer in draft state.
@@ -178,14 +178,34 @@ RSpec.describe RootSeeder,
       expect(template.agenda_items.count).to eq 9
       expect(template.agenda_items.sum(:duration_in_minutes)).to eq 60
 
-      # The first instance is created synchronously by the finalizer seeder,
-      # the second by the chained InitNextOccurrenceJob.
-      expect(Meeting.where(template: false).count).to eq 2
+      # The first two instances come from the finalizer seeder (and its chained job), the rest
+      # are instantiated by the MeetingOccurrencesSeeder.
+      expect(Meeting.where(template: false).count).to eq 5
       Meeting.not_templated.find_each do |instance|
         expect(instance.duration).to eq 1.0
         expect(instance.agenda_items.count).to eq 9
         expect(instance.agenda_items.sum(:duration_in_minutes)).to eq 60
       end
+    end
+
+    it "gives the meeting participants and varies their responses across occurrences" do
+      series = RecurringMeeting.first
+
+      # The template carries the regular attendees, all accepting by default.
+      expect(series.template.participants.count).to eq 5
+      expect(series.template.participants).to all(be_participation_accepted)
+
+      occurrences = series.meetings.not_templated.order(:start_time).to_a
+
+      # The first occurrence inherited the template participants, everybody accepted.
+      expect(occurrences.first.participants.count).to eq 5
+      expect(occurrences.first.participants).to all(be_participation_accepted)
+
+      # A later occurrence has declined/tentative responses and extra one-off guests.
+      second = occurrences.second
+      expect(second.participants.count).to eq 7 # 5 regulars + 2 one-off guests
+      statuses = second.participants.pluck(:participation_status)
+      expect(statuses).to include("declined", "tentative")
     end
 
     it "creates different types of queries" do

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe RootSeeder,
         .to include(fritz)
     end
 
+    it "assigns job title, languages, skills and a job start date to the member users" do
+      fritz = root_seeder.seed_data.find_reference(:user__fritz_finance)
+      job_title = UserCustomField.find_by!(name: "Job title")
+      languages = UserCustomField.find_by!(name: "Spoken languages")
+      skills = UserCustomField.find_by!(name: "Key skills")
+      job_start_date = UserCustomField.find_by!(name: "Job start date")
+
+      expect(fritz.typed_custom_value_for(job_title)).to eq("Project Manager")
+      expect(fritz.typed_custom_value_for(languages)).to contain_exactly("English", "German")
+      expect(fritz.typed_custom_value_for(skills)).to contain_exactly("Budgeting", "Stakeholder Management")
+      expect(fritz.typed_custom_value_for(job_start_date)).to eq(Date.new(2017, 7, 3))
+    end
+
     it "adds members to the demo project directly and through their department" do
       demo_project = Project.find_by(identifier: "demo-project")
 
@@ -285,7 +298,7 @@ RSpec.describe RootSeeder,
         end
       end
 
-      it "does not create additional data and does not raise any errors" do # rubocop:disable RSpec/MultipleExpectations
+      it "does not create additional data and does not raise any errors" do
         expect(Project.count).to eq 2
         expect(WorkPackage.count).to eq 37
         expect(Wiki.count).to eq 2

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe RootSeeder,
       expect(fritz_member.member_roles.map(&:inherited_from)).to all(be_present)
     end
 
+    it "assigns demo work packages to individual users and to whole departments" do
+      data = root_seeder.seed_data
+
+      # Assigned to an individual user (direct project member).
+      expect(data.find_reference(:setup_conference_website).assigned_to)
+        .to eq(data.find_reference(:user__wanda_web))
+
+      # Assigned to a whole department (group member of the project).
+      expect(data.find_reference(:organize_open_source_conference).assigned_to)
+        .to eq(data.find_reference(:department__events_operations))
+    end
+
     it "links work packages to their version" do
       count_by_version = WorkPackage.joins(:version).group("versions.name").count
       # testing with strings would fail for the German language test


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-19607/activity

# What are you trying to accomplish?

Enrich the **standard demo data** so that a freshly seeded instance shows a small, believable company structure around the existing "organize an open source conference" demo project. Previously the standard edition seeded no groups and only the admin user, so the departments admin page and the members/working-times/meeting features were empty in demos.

## What's added

### Departments (organizational units)
A small company structure seeded into the standard demo (`app/seeders/demo_data/department_seeder.rb`, data in `standard.yml`):

```
Marketing & Communications        (root)
├── Public Relations
└── Design & Content
Events & Operations               (root)
Web & IT                          (root)
Finance & Administration          (root)
Quality Assurance                 (root)
```

### Demo users
Two users per department (plus one for QA), with alliterative, role-depicting names — Marko Marketing, Connie Comms, Petra Press, Polly PR, Dora Design, Carl Content, Evan Events, Olga Ops, Wanda Web, Ivan IT, Fritz Finance, Adam Admin and Tessa Tester. Each is a member of their department.

### Project membership
Some users join the demo project **directly** (Marko Marketing, Wanda Web, Tessa Tester), others join **through their whole department** added as a group member (Events & Operations, Finance & Administration), with their users inheriting the role.

### Work package assignment
The demo project's tasks are assigned to a mix of **individual users** and **whole departments** (e.g. *Setup conference website* → Wanda Web, *Organize open source conference* → Events & Operations).

### Working hours & vacations
`app/seeders/demo_data/working_time_seeder.rb` seeds `UserWorkingHours` and `UserNonWorkingTime` for most demo users, deliberately covering every case:
- **no schedule** (Connie Comms, Carl Content, Polly PR, Adam Admin)
- **a single schedule** (full-time; a part-time three-day week; full-time hours at reduced availability; a very-low-hours part-timer — Fritz Finance at 6h/week)
- **a schedule that changes over time** (half-days over the summer; switching to a four-day week mid-year)
- **vacations** (non-working time ranges), including for a user without a schedule

### QA
A dedicated **Quality Assurance** department, a QA user (**Tessa Tester**), and a QA work package — *"Test and quality-check the conference website"* — that **follows** the website setup task.

### Weekly meeting: participants, occurrences and responses
The demo project's weekly meeting series is fleshed out (`modules/meeting/app/seeders/meetings/demo_data/`):
- **Participants** are added to the series template (admin + several project members), so every occurrence inherits them.
- The **next few occurrences** are instantiated (5 in total).
- **Responses** are varied for realism: most attendees accept, but on some occurrences a few **decline** or are **tentative**, and one-off guests are invited to a single instance.
- **Agenda presenters** are distributed across the participants (each topic is presented by the relevant person) while the admin organizer remains the **author** of every agenda item.

### Members table: briefcase icon
In the project members table, the **Groups** column now marks departments (organizational units) with a briefcase icon to set them apart from regular groups (`app/components/members/row_component.rb`).

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

- Department/user/membership/assignment data lives in `standard.yml` and is consumed **only** by the demo-data seeders, so it is never created by the basic-data or other seeders.
- Group → project membership uses `Member.create!` plus `Groups::CreateInheritedRolesService` to propagate the role to the group's users, mirroring how the app does it.
- Working-hours/vacation data is a small Ruby-driven seeder rather than YAML, because the `valid_from`/vacation dates need to be **relative to the current date** (so they don't go stale).
- The QA work package is a top-level task that `follows` the website setup task at the right offset so the **automatic-scheduling lag stays 0** and the existing Conference-milestone chain and parent date spans are not disturbed.
- Meeting participants are seeded onto the template **before** the finalizer runs, so every instantiated occurrence syncs them automatically (no backfill); occurrences are instantiated via the app's own `InitOccurrenceService`, guarding against already-materialized times for a deterministic count.
- User first/last names are intentionally **not** translatable (alliteration only works in English and would otherwise bloat all Crowdin files); department names remain translatable as before.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
