### PR TITLE
Deal with duplicated meetings in the backfilling of recurrence meetings

### DIFF
--- a/modules/meeting/db/migrate/20260625073349_backfill_missing_recurrence_start_time.rb
+++ b/modules/meeting/db/migrate/20260625073349_backfill_missing_recurrence_start_time.rb
@@ -31,8 +31,53 @@
 class BackfillMissingRecurrenceStartTime < ActiveRecord::Migration[8.1]
   def up
     # AddRecurrenceIdToMeetings backfilled recurrence_start_time from start_time,
-    # but in some cases because of missing scheduled_meetings in existing data,
-    # recurrence_start_time was still NULL, which this migration fixes.
+    # but occurrences whose scheduled_meetings link was already missing ended up
+    # NULL. Setting those to start_time can collide with the unique index
+    # (recurring_meeting_id, recurrence_start_time) when another occurrence in the
+    # same series already owns that slot: such rows are duplicate occurrences.
+    #
+    # We do not delete them. Instead we detach the duplicate from its series
+    # (recurring_meeting_id => NULL), turning it into a standalone meeting so no
+    # data is lost. The occurrence that keeps the slot is backfilled below.
+
+    # Duplicate of an occurrence that already owns the slot (recurrence_start_time set).
+    execute <<~SQL.squish
+      UPDATE meetings dup
+      SET recurring_meeting_id = NULL,
+          recurrence_start_time = NULL,
+          updated_at = NOW()
+      WHERE dup.recurring_meeting_id IS NOT NULL
+        AND dup.template = false
+        AND dup.recurrence_start_time IS NULL
+        AND EXISTS (
+          SELECT 1 FROM meetings holder
+          WHERE holder.recurring_meeting_id = dup.recurring_meeting_id
+            AND holder.template = false
+            AND holder.id <> dup.id
+            AND holder.recurrence_start_time = dup.start_time
+        )
+    SQL
+
+    # Two or more NULL occurrences share the same slot: keep the newest, detach the rest.
+    execute <<~SQL.squish
+      UPDATE meetings dup
+      SET recurring_meeting_id = NULL,
+          recurrence_start_time = NULL,
+          updated_at = NOW()
+      WHERE dup.recurring_meeting_id IS NOT NULL
+        AND dup.template = false
+        AND dup.recurrence_start_time IS NULL
+        AND EXISTS (
+          SELECT 1 FROM meetings other
+          WHERE other.recurring_meeting_id = dup.recurring_meeting_id
+            AND other.template = false
+            AND other.recurrence_start_time IS NULL
+            AND other.start_time = dup.start_time
+            AND other.id > dup.id
+        )
+    SQL
+
+    # Backfill the occurrences that simply lost their scheduled_meetings link.
     execute <<~SQL.squish
       UPDATE meetings
       SET recurrence_start_time = meetings.start_time


### PR DESCRIPTION
The reason we had duplicates meetings for the same slot was causing the backfilling of recurrence_start_time not workign correctly. The would have no ScheduledMeeting (as that had a unique constraint), so there was some historic code path that caused meetings to be created like that. 

This causes the recently introduced migration that tried to ensure recurrence_start_time to be present to fail, as either 

- Two meetings with the same start time would collide into the same recurrence_start_time (qa-edge)
- One meeting was already correct, but a duplicate had recurrence_start_time=NULL (qa-stage)