### PR TITLE
[OP-19579] Harmonize behaviour between quick filters and "All filters"  

### DIFF
--- a/app/components/op_primer/quick_filter/select_panel_component.rb
+++ b/app/components/op_primer/quick_filter/select_panel_component.rb
@@ -106,7 +106,7 @@ module OpPrimer
         Rack::Utils.parse_nested_query(uri.query.to_s).tap do |params|
           # Pass other active filters (e.g. time=past) so the fragment endpoint builds
           # the same query scope as the current page, not its own default
-          params["filters"] = other_filters.to_json if other_filters.any?
+          params["filters"] = other_filters.to_json
           # Pass currently selected ids so the right items can be marked in the response
           params["selected"] = current_values.join(",") if current_values.any?
         end
@@ -122,7 +122,7 @@ module OpPrimer
 
       def base_url_params
         {}.tap do |params|
-          params[:filters] = other_filters.to_json if other_filters.any?
+          params[:filters] = other_filters.to_json
           params[:sortBy] = sort.to_json if sort.any?
         end
       end

--- a/app/models/queries/operators.rb
+++ b/app/models/queries/operators.rb
@@ -63,6 +63,8 @@ module Queries::Operators
     Queries::Operators::Required,
     Queries::Operators::Parent,
     Queries::Operators::Children,
-    Queries::Operators::Child
+    Queries::Operators::Child,
+    Queries::Operators::Upcoming,
+    Queries::Operators::Past
   ].index_by { |o| o.symbol.to_s }.freeze
 end

--- a/app/models/queries/operators/past.rb
+++ b/app/models/queries/operators/past.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,36 +26,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Meetings
-  module QueryLoading
-    private
+module Queries::Operators
+  class Past < Base
+    label "past"
+    set_symbol "past"
+    require_value false
 
-    def build_meeting_query
-      query = ParamsToQueryService.new(Meeting, current_user).call(params)
-      query.where("project_id", "=", @project.id) if @project
-      apply_default_filter_if_none_given(query)
-      apply_default_time_filter_and_sort(query)
-      query
-    end
+    extend DateRangeClauses
 
-    def apply_default_time_filter_and_sort(query)
-      time_filter = query.filters.find { |f| f.name == :time }
-
-      if time_filter.nil?
-        # Only default to upcoming on the initial, unfiltered view
-        query.where("time", Queries::Operators::Upcoming.symbol, []) unless params.key?(:filters)
-        query.order(start_time: :asc)
-      elsif time_filter.past? && query.orders.none?
-        query.order(start_time: :desc)
-      end
-    end
-
-    def apply_default_filter_if_none_given(query)
-      return if params.key?(:filters)
-
-      query.where("invited_user_id", "=", [User.current.id.to_s])
+    def self.sql_for_field(_values, db_table, db_field)
+      relative_date_range_clause(db_table, db_field, nil, -1)
     end
   end
 end

--- a/app/models/queries/operators/upcoming.rb
+++ b/app/models/queries/operators/upcoming.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,36 +26,19 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Meetings
-  module QueryLoading
-    private
+module Queries::Operators
+  # Value-less operator selecting today and onward, for date/datetime fields.
+  class Upcoming < Base
+    label "upcoming"
+    set_symbol "upcoming"
+    require_value false
 
-    def build_meeting_query
-      query = ParamsToQueryService.new(Meeting, current_user).call(params)
-      query.where("project_id", "=", @project.id) if @project
-      apply_default_filter_if_none_given(query)
-      apply_default_time_filter_and_sort(query)
-      query
-    end
+    extend DateRangeClauses
 
-    def apply_default_time_filter_and_sort(query)
-      time_filter = query.filters.find { |f| f.name == :time }
-
-      if time_filter.nil?
-        # Only default to upcoming on the initial, unfiltered view
-        query.where("time", Queries::Operators::Upcoming.symbol, []) unless params.key?(:filters)
-        query.order(start_time: :asc)
-      elsif time_filter.past? && query.orders.none?
-        query.order(start_time: :desc)
-      end
-    end
-
-    def apply_default_filter_if_none_given(query)
-      return if params.key?(:filters)
-
-      query.where("invited_user_id", "=", [User.current.id.to_s])
+    def self.sql_for_field(_values, db_table, db_field)
+      relative_date_range_clause(db_table, db_field, 0, nil)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4389,6 +4389,7 @@ en:
     Setting a parent group will make this group a subgroup of the selected parent group.
     This will also inherit all memberships, including permissions of the parent group.
   label_part_of: "part of"
+  label_past: "Past"
   label_password_lost: "Forgot your password?"
   label_password_rule_lowercase: "Lowercase"
   label_password_rule_numeric: "Numeric Characters"
@@ -4572,6 +4573,7 @@ en:
   label_type_new: "New type"
   label_type_plural: "Types"
   label_ui: "User Interface"
+  label_upcoming: "Upcoming"
   label_updated_time: "Updated %{value} ago"
   label_updated_time_at: "%{author} %{age}"
   label_updated_time_by: "Updated by %{author} %{age} ago"

--- a/lookbook/docs/components/quick-filters.md.erb
+++ b/lookbook/docs/components/quick-filters.md.erb
@@ -64,4 +64,30 @@ Quick filters and the advanced "All filters" panel edit the same query, so they 
 advanced filter form auto-submits, ideally re-render the entire subheader (or other component that encloses both) via
 morphing to keep things in sync. This will ensure that new quick filters do not have to be dealt with separately.
 
-An example can be seen in `MeetingsController#index`
+This has to be wired up manually in the controller action that the advanced filter form submits to. For example, in
+`MeetingsController#index`:
+
+```ruby
+def index
+  load_meetings
+
+  respond_to do |format|
+    format.html do
+      render "index", locals: { menu_name: project_or_global_menu }
+    end
+
+    format.turbo_stream do
+      # Re-render the whole subheader (which encloses both the quick filters and
+      # the "All filters" panel) via morphing
+      update_via_turbo_stream(
+        component: Meetings::IndexSubHeaderComponent.new(query: @query, project: @project, params:, lazy: false),
+        method: "morph"
+      )
+
+      # Re-render other components as well...
+
+      render turbo_stream: turbo_streams
+    end
+  end
+end
+```

--- a/lookbook/docs/components/quick-filters.md.erb
+++ b/lookbook/docs/components/quick-filters.md.erb
@@ -57,3 +57,11 @@ Note: Clicking on buttons in the above preview will break it and redirect to the
 
 Pass `src` to lazily load the panel items from an endpoint instead of providing them inline.
 The filter must implement `#value_objects`, and `src` cannot be combined with inline items or `select_variant: :single`.
+
+## Keeping in sync with "All filters"
+
+Quick filters and the advanced "All filters" panel edit the same query, so they must reflect each other. When the
+advanced filter form auto-submits, ideally re-render the entire subheader (or other component that encloses both) via
+morphing to keep things in sync. This will ensure that new quick filters do not have to be dealt with separately.
+
+An example can be seen in `MeetingsController#index`

--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -1,79 +1,81 @@
-<%=
-  render(
-    Primer::OpenProject::SubHeader.new(
-      data: {
-        controller: "filter--filters-form",
-        "filter--filters-form-output-format-value": "json",
-        "filter--filters-form-perform-turbo-requests-value": true,
-        "filter--filters-form-display-filters-value": filters_expanded?
-      }
-    )
-  ) do |subheader|
-    subheader.with_quick_filter do
-      render(Meetings::MeetingTimeFilterComponent.new(query: @query, project: @project))
-    end
-
-    if @project.nil?
+<%= component_wrapper do %>
+  <%=
+    render(
+      Primer::OpenProject::SubHeader.new(
+        data: {
+          controller: "filter--filters-form",
+          "filter--filters-form-output-format-value": "json",
+          "filter--filters-form-perform-turbo-requests-value": true,
+          "filter--filters-form-display-filters-value": filters_expanded?
+        }
+      )
+    ) do |subheader|
       subheader.with_quick_filter do
+        render(Meetings::MeetingTimeFilterComponent.new(query: @query, project: @project))
+      end
+
+      if @project.nil?
+        subheader.with_quick_filter do
+          render(
+            OpPrimer::QuickFilter::SelectPanelComponent.new(
+              name: I18n.t(:label_project),
+              query: @query,
+              filter_key: :project_id,
+              path_args: [@project, :meetings],
+              src: project_items_meetings_path
+            )
+          )
+        end
+      end
+
+      subheader.with_filter_component do
+        render(Meetings::MeetingFilterButtonComponent.new(query: @query, project: @project))
+      end
+
+      if render_create_button?
+        subheader.with_action_menu(
+          leading_icon: :plus,
+          trailing_icon: :"triangle-down",
+          label: label_text,
+          anchor_align: :end,
+          size: :small,
+          button_arguments: {
+            scheme: :primary,
+            id: id,
+            aria: { label: accessibility_label_text },
+            test_selector: "add-meeting-button"
+          }
+        ) do |menu|
+          menu.with_item(
+            label: I18n.t("meeting.types.one_time"),
+            tag: :a,
+            href: polymorphic_path([:new_dialog, @project, :meetings]),
+            content_arguments: { data: { controller: "async-dialog" } }
+          ) do |item|
+            item.with_description.with_content(t("meeting.types.structured_text"))
+          end
+
+          menu.with_item(
+            label: I18n.t("meeting.types.recurring"),
+            tag: :a,
+            href: polymorphic_path([:new_dialog, @project, :meetings], type: :recurring),
+            content_arguments: { data: { controller: "async-dialog" } }
+          ) do |item|
+            item.with_description.with_content(t("meeting.types.recurring_text"))
+          end
+        end
+      end
+
+      subheader.with_bottom_pane_component do
         render(
-          OpPrimer::QuickFilter::SelectPanelComponent.new(
-            name: I18n.t(:label_project),
+          Meetings::MeetingFiltersComponent.new(
             query: @query,
-            filter_key: :project_id,
-            path_args: [@project, :meetings],
-            src: project_items_meetings_path
+            project: @project,
+            lazy_loaded_path:,
+            initially_expanded: filters_expanded?
           )
         )
       end
     end
-
-    subheader.with_filter_component do
-      render(Meetings::MeetingFilterButtonComponent.new(query: @query, project: @project))
-    end
-
-    if render_create_button?
-      subheader.with_action_menu(
-        leading_icon: :plus,
-        trailing_icon: :"triangle-down",
-        label: label_text,
-        anchor_align: :end,
-        size: :small,
-        button_arguments: {
-          scheme: :primary,
-          id: id,
-          aria: { label: accessibility_label_text },
-          test_selector: "add-meeting-button"
-        }
-      ) do |menu|
-        menu.with_item(
-          label: I18n.t("meeting.types.one_time"),
-          tag: :a,
-          href: polymorphic_path([:new_dialog, @project, :meetings]),
-          content_arguments: { data: { controller: "async-dialog" } }
-        ) do |item|
-          item.with_description.with_content(t("meeting.types.structured_text"))
-        end
-
-        menu.with_item(
-          label: I18n.t("meeting.types.recurring"),
-          tag: :a,
-          href: polymorphic_path([:new_dialog, @project, :meetings], type: :recurring),
-          content_arguments: { data: { controller: "async-dialog" } }
-        ) do |item|
-          item.with_description.with_content(t("meeting.types.recurring_text"))
-        end
-      end
-    end
-
-    subheader.with_bottom_pane_component do
-      render(
-        Meetings::MeetingFiltersComponent.new(
-          query: @query,
-          project: @project,
-          lazy_loaded_path: :meetings_filters_path,
-          initially_expanded: filters_expanded?
-        )
-      )
-    end
-  end
-%>
+  %>
+<% end %>

--- a/modules/meeting/app/components/meetings/index_sub_header_component.rb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.rb
@@ -32,16 +32,23 @@ module Meetings
   # rubocop:disable OpenProject/AddPreviewForViewComponent
   class IndexSubHeaderComponent < ApplicationComponent
     # rubocop:enable OpenProject/AddPreviewForViewComponent
+    include OpTurbo::Streamable
     include ApplicationHelper
 
-    def initialize(query:, params:, project: nil)
+    def initialize(query:, params:, project: nil, lazy: true)
       super
       @query = query
       @project = project
       @params = params
+      @lazy = lazy
     end
 
     private
+
+    # Load inline for morph updates to prevent an additional flicker
+    def lazy_loaded_path
+      @lazy ? :meetings_filters_path : false
+    end
 
     def render_create_button?
       if @project

--- a/modules/meeting/app/components/meetings/meeting_time_filter_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_time_filter_component.rb
@@ -31,16 +31,36 @@
 module Meetings
   class MeetingTimeFilterComponent < OpPrimer::QuickFilter::SegmentedControlComponent
     def initialize(query:, project: nil)
+      upcoming = Queries::Operators::Upcoming.symbol
+      past = Queries::Operators::Past.symbol
+
       super(
         name: I18n.t(:label_meeting_date_time),
         query:,
         filter_key: :time,
-        orders: { "future" => { start_time: :asc }, "past" => { start_time: :desc } },
+        orders: { upcoming => { start_time: :asc }, past => { start_time: :desc } },
         path_args: [project, :meetings].compact
       )
 
-      with_item(label: I18n.t(:label_upcoming_meetings_short), value: "future")
-      with_item(label: I18n.t(:label_past_meetings_short), value: "past")
+      with_item(label: I18n.t(:label_upcoming_meetings_short), value: upcoming)
+      with_item(label: I18n.t(:label_past_meetings_short), value: past)
+    end
+
+    private
+
+    # Overrides to make the filter operator driven
+    def current_value
+      @query.find_active_filter(:time)&.operator&.to_s
+    end
+
+    def filters_params(operator)
+      filters = @query.filters
+        .reject { |f| f.name == :time }
+        .map { |f| { f.class.key.to_s => { "operator" => f.operator.to_s, "values" => f.values } } }
+
+      filters << { "time" => { "operator" => operator, "values" => [] } } if operator
+
+      filters
     end
   end
 end

--- a/modules/meeting/app/controllers/concerns/meetings/query_loading.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/query_loading.rb
@@ -44,7 +44,8 @@ module Meetings
       time_filter = query.filters.find { |f| f.name == :time }
 
       if time_filter.nil?
-        query.where("time", "=", Queries::Meetings::Filters::TimeFilter::FUTURE_VALUE)
+        # Only default to upcoming on the initial, unfiltered view
+        query.where("time", "=", Queries::Meetings::Filters::TimeFilter::FUTURE_VALUE) unless params.key?(:filters)
         query.order(start_time: :asc)
       elsif time_filter.past? && query.orders.none?
         query.order(start_time: :desc)

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -68,10 +68,8 @@ class MeetingsController < ApplicationController
 
       format.turbo_stream do
         update_via_turbo_stream(
-          component: Meetings::MeetingTimeFilterComponent.new(query: @query, project: @project)
-        )
-        update_via_turbo_stream(
-          component: Meetings::MeetingFilterButtonComponent.new(query: @query, project: @project, disable_buttons: false)
+          component: Meetings::IndexSubHeaderComponent.new(query: @query, project: @project, params:, lazy: false),
+          method: "morph"
         )
 
         current_url = url_for(params.permit(:controller, :action, :filters, :project_id, :sortBy, :upcoming))

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -382,9 +382,7 @@ class MeetingsController < ApplicationController
   end
 
   def project_items
-    @query = load_query
-    # Scope to projects that have meetings visible to the current user
-    projects = Project.where(id: @query.results.select(:project_id)).order(:name)
+    projects = Project.visible(User.current).active.order(:name)
     # The component appends ?selected=id1,id2 so we know which items to mark as selected.
     # Standard filters can't be passed to the query because then the projects from @query.results
     # would be *only* the already selected list

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -144,7 +144,7 @@ module Meetings
     def attendee_filter
       [
         { attended_user_id: { operator: "=", values: [User.current.id.to_s] } },
-        { time: { operator: "=", values: ["past"] } }
+        { time: { operator: Queries::Operators::Past.symbol, values: [] } }
       ].to_json
     end
 

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -77,8 +77,8 @@ module Meetings
       )
     end
 
-    def all_meetings_item
-      all_filter = [].to_json
+    def all_meetings_item # rubocop:disable Metrics/AbcSize
+      all_filter = [{ time: { operator: Queries::Operators::Upcoming.symbol, values: [] } }].to_json
       my_meetings_href = polymorphic_path([project, :meetings])
       query_params = { filters: all_filter }
 
@@ -114,7 +114,10 @@ module Meetings
     end
 
     def recurring_menu_item
-      recurring_filter = [{ type: { operator: "=", values: ["t"] } }].to_json
+      recurring_filter = [
+        { type: { operator: "=", values: ["t"] } },
+        { time: { operator: Queries::Operators::Upcoming.symbol, values: [] } }
+      ].to_json
 
       menu_item(title: I18n.t("label_recurring_meeting_plural"),
                 query_params: { filters: recurring_filter, sort: "start_time" })

--- a/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
@@ -28,20 +28,16 @@
 #++
 
 class Queries::Meetings::Filters::TimeFilter < Queries::Meetings::Filters::MeetingFilter
-  PAST_VALUE = "past".freeze
-  FUTURE_VALUE = "future".freeze
+  def available_operators
+    [Queries::Operators::Upcoming, Queries::Operators::Past]
+  end
 
-  validate :validate_only_single_value
-
-  def allowed_values
-    [
-      [I18n.t(:label_past_meetings_short), PAST_VALUE],
-      [I18n.t(:label_upcoming_meetings_short), FUTURE_VALUE]
-    ]
+  def default_operator
+    Queries::Operators::Upcoming
   end
 
   def past?
-    values.first == PAST_VALUE
+    operator.to_s == Queries::Operators::Past.symbol
   end
 
   def where
@@ -57,20 +53,10 @@ class Queries::Meetings::Filters::TimeFilter < Queries::Meetings::Filters::Meeti
   end
 
   def type
-    :list
+    :date
   end
 
   def self.key
     :time
-  end
-
-  def available_operators
-    [::Queries::Operators::Equals]
-  end
-
-  private
-
-  def validate_only_single_value
-    errors.add(:values, :invalid) if values.length != 1
   end
 end

--- a/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
@@ -37,7 +37,7 @@ class Queries::Meetings::Filters::TimeFilter < Queries::Meetings::Filters::Meeti
   end
 
   def past?
-    operator.to_s == Queries::Operators::Past.symbol
+    operator.to_sym == Queries::Operators::Past.to_sym
   end
 
   def where

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "Meetings", "Index", :js do
           wait_for_network_idle
 
           sort = [["start_time", "desc"]].to_json
-          time_filters = [{ "time" => { "operator" => "=", "values" => ["past"] } }].to_json
+          time_filters = [{ "time" => { "operator" => "past", "values" => [] } }].to_json
           if context == :global
             expect(page).to have_current_path(meetings_path(filters: time_filters, sortBy: sort))
           else
@@ -236,7 +236,7 @@ RSpec.describe "Meetings", "Index", :js do
           # On mobile the segmented quick filter is hidden, so users apply the past
           # filter via the all filters form. That form does not add sortBy to the URL.
           # The backend must apply start_time: :desc as a default in this case
-          time_filters = [{ "time" => { "operator" => "=", "values" => ["past"] } }].to_json
+          time_filters = [{ "time" => { "operator" => "past", "values" => [] } }].to_json
 
           if context == :global
             visit meetings_path(filters: time_filters)

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -257,6 +257,23 @@ RSpec.describe "Meetings", "Index", :js do
         end
       end
 
+      context "when the time filter is removed via the all filters form" do
+        before do
+          meetings_page.set_quick_filter upcoming: true
+        end
+
+        it "lets the quick filter enter an unselected state" do
+          meetings_page.expect_quick_filter_selected "Upcoming"
+
+          meetings_page.open_filters
+          meetings_page.remove_filter "time"
+
+          wait_for_network_idle
+
+          meetings_page.expect_quick_filter_unselected
+        end
+      end
+
       context 'with the "Attendee" filter' do
         before do
           meetings_page.set_sidebar_filter "Attended"

--- a/modules/meeting/spec/models/queries/meeting_query_spec.rb
+++ b/modules/meeting/spec/models/queries/meeting_query_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Queries::Meetings::MeetingQuery do
   context "when filtering by time" do
     context "for future meetings" do
       before do
-        subject.where("time", "=", ["future"])
+        subject.where("time", "upcoming", [])
       end
 
       it "returns meetings starting in the future and meetings currently ongoing" do
@@ -88,7 +88,7 @@ RSpec.describe Queries::Meetings::MeetingQuery do
 
     context "for past meetings" do
       before do
-        subject.where("time", "=", ["past"])
+        subject.where("time", "past", [])
       end
 
       it "returns meetings starting in the past and meetings currently ongoing" do

--- a/modules/meeting/spec/requests/meetings_index_spec.rb
+++ b/modules/meeting/spec/requests/meetings_index_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe "Meeting index",
 
   context "when showing past meetings" do
     let(:request) do
-      filters = [{ "time" => { "operator" => "=", "values" => ["past"] } }].to_json
+      filters = [{ "time" => { "operator" => "past", "values" => [] } }].to_json
       sort = [["start_time", "desc"]].to_json
       get "/projects/#{project.id}/meetings", params: { filters:, sortBy: sort }
     end

--- a/modules/meeting/spec/requests/meetings_spec.rb
+++ b/modules/meeting/spec/requests/meetings_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Meeting requests",
   describe "Meetings index" do
     context "when sorting by meeting type" do
       it "does not raise an error (Regression #55839)" do
-        get meetings_path(sort: "type", filters: '[{"time":{"operator":"=","values":["future"]}}]')
+        get meetings_path(sort: "type", filters: '[{"time":{"operator":"upcoming","values":[]}}]')
         expect(response).to have_http_status(:ok)
         expect(response.body).to have_text(meeting.title)
       end

--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -149,6 +149,19 @@ module Pages::Meetings
       wait_for_network_idle
     end
 
+    def expect_quick_filter_selected(label)
+      within "#content-body" do
+        expect(page).to have_css("segmented-control .SegmentedControl-item--selected", text: label)
+      end
+    end
+
+    def expect_quick_filter_unselected
+      within "#content-body" do
+        expect(page).to have_css("segmented-control")
+        expect(page).to have_no_css("segmented-control .SegmentedControl-item--selected")
+      end
+    end
+
     def set_project_filter(*projects)
       find_test_selector("quick-filter-select-panel-button").click
 

--- a/spec/components/op_primer/quick_filter/select_panel_component_spec.rb
+++ b/spec/components/op_primer/quick_filter/select_panel_component_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe OpPrimer::QuickFilter::SelectPanelComponent, type: :component do
   end
 
   context "when other filters are active" do
-    let(:query) { build_meeting_query.where("time", "=", ["future"]) }
+    let(:query) { build_meeting_query.where("time", "past", []) }
 
     before { render_with_items }
 

--- a/spec/components/op_primer/quick_filter/select_panel_component_spec.rb
+++ b/spec/components/op_primer/quick_filter/select_panel_component_spec.rb
@@ -205,4 +205,16 @@ RSpec.describe OpPrimer::QuickFilter::SelectPanelComponent, type: :component do
       expect(time_filter["time"]["values"]).to eq(original.values)
     end
   end
+
+  context "when no other filters are active" do
+    before { render_with_items }
+
+    it "still carries an explicit (empty) filter scope so the endpoint keeps the current scope" do
+      base_url = page.find("[data-controller='quick-filter--select-panel']")[
+        "data-quick-filter--select-panel-base-url-value"
+      ]
+
+      expect(filters_from_base_url(base_url)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-19579

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Fix problems caused by quick filters and all filters having different behaviours
- Ensure quick filters and all filters are always in sync when updating filters

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Allow the time quick filter to enter an unselected state when the filter is not exactly set to upcoming or past, by removing a default
- Update the underlying meeting time filter to use generic operators
   - As a side effect, the upcoming/past operators are now available wherever else the date/time filters are used, but I haven't added them anywhere else as part of this PR
   - I also haven't added the other filters (in between, on, etc.) to meetings as part of this PR as that requires a rethink of the index pages. Currently we differentiate between past and upcoming, and the other states don't play so nice with this set up
- Remove special filtering of projects for the projects quick filter. It now shows all visible projects and matches the options shown in the all filters project autocompleter
- Use morphing on the entire subheader to keep quick filters and all filters in sync. The previous turbo-stream approach had already been missed for the project quick filter, leading to different states in both components. Using morphing on the whole subheader should more easily ensure that newly added quickfilters will not miss sync updates

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
