### PR TITLE
Fix/bump multi json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,6 @@ gem "sys-filesystem", "~> 1.5.0", require: false
 gem "bcrypt", "~> 3.1.22"
 
 gem "multi_json", "~> 1.21.0"
-gem "oj", "~> 3.17.3"
 
 gem "daemons"
 gem "good_job", "~> 4.19.0" # update should be done manually in sync with saas-openproject version.

--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem "sys-filesystem", "~> 1.5.0", require: false
 
 gem "bcrypt", "~> 3.1.22"
 
-gem "multi_json", "~> 1.20.0"
+gem "multi_json", "~> 1.21.0"
 gem "oj", "~> 3.17.3"
 
 gem "daemons"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -854,7 +854,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.3)
-    multi_json (1.20.1)
+    multi_json (1.21.1)
     mustermann (4.0.0)
     mustermann-grape (1.1.0)
       mustermann (>= 1.0.0)
@@ -1669,7 +1669,7 @@ DEPENDENCIES
   meta-tags (~> 2.23.0)
   mini_magick (~> 5.3.0)
   msgpack (~> 1.8.3)
-  multi_json (~> 1.20.0)
+  multi_json (~> 1.21.0)
   my_page!
   net-ldap (~> 0.20.0)
   nokogiri (~> 1.19.4)
@@ -2034,7 +2034,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
-  multi_json (1.20.1) sha256=2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   mustermann (4.0.0) sha256=91f67411bb208d1d93c41e6128cb3b0f8ddd9ec7c45966f1007e1c43c08040d7
   mustermann-grape (1.1.0) sha256=8d258a986004c8f01ce4c023c0b037c168a9ed889cf5778068ad54398fa458c5
   my_page (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -889,9 +889,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
-    oj (3.17.3)
-      bigdecimal (>= 3.0)
-      ostruct (>= 0.2)
     okcomputer (1.19.2)
       benchmark
     omniauth-saml (1.10.6)
@@ -1673,7 +1670,6 @@ DEPENDENCIES
   my_page!
   net-ldap (~> 0.20.0)
   nokogiri (~> 1.19.4)
-  oj (~> 3.17.3)
   okcomputer (~> 1.19.1)
   omniauth!
   omniauth-openid-connect!
@@ -2053,7 +2049,6 @@ CHECKSUMS
   nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
-  oj (3.17.3) sha256=ebe3967b0bb7ac4f206561d0d9ac8875b9973f778600d7b61b5c355662a707ed
   okcomputer (1.19.2) sha256=d069aedf1e31b8ebe7e1fdf9e327dee158ea49b9fbdebebc2f1bed4690cb7a6d
   omniauth (1.9.2)
   omniauth-openid-connect (0.5.0)

--- a/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
@@ -213,7 +213,7 @@ module Admin
         def parse_parent_input(new_parent_input)
           case new_parent_input
           in [new_parent]
-            input = MultiJson.load(new_parent, symbolize_keys: true)[:value]
+            input = MultiJSON.load(new_parent, symbolize_keys: true)[:value]
             new_parent = CustomField::Hierarchy::Item.including_children.find_by(id: input)
 
             if new_parent.present?

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -225,7 +225,7 @@ module Admin
     def parse_new_parent_id(input)
       return nil if input.blank?
 
-      value = MultiJson.load(Array(input).first, symbolize_keys: true)[:value]
+      value = MultiJSON.load(Array(input).first, symbolize_keys: true)[:value]
       value.presence
     end
 

--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -198,7 +198,7 @@ class OAuthClientsController < ApplicationController
 
       # FIXME: This is a hack, fetching additional information of the storage to identify the oauth client.
       # This must be fixed in #50872.
-      state_value = MultiJson.load(cookie, symbolize_keys: true)
+      state_value = MultiJSON.load(cookie, symbolize_keys: true)
       @oauth_client = OAuthClient.find_by(client_id: params[:oauth_client_id],
                                           integration_id: state_value[:integrationId])
     end

--- a/app/services/oauth_clients/redirect_uri_from_state_service.rb
+++ b/app/services/oauth_clients/redirect_uri_from_state_service.rb
@@ -56,7 +56,7 @@ module OAuthClients
       state_cookie = @cookies["oauth_state_#{@state}"]
       return nil if state_cookie.blank?
 
-      state_value = MultiJson.load(@cookies["oauth_state_#{@state}"], symbolize_keys: true)
+      state_value = MultiJSON.load(@cookies["oauth_state_#{@state}"], symbolize_keys: true)
       state_value[:href]
     end
   end

--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -38,7 +38,7 @@ module API
       }.freeze
 
       included do
-        def to_json(*args)
+        def to_json(*)
           return super if no_caching?
 
           cached_json_rep = OpenProject::Cache.fetch(json_cache_key) do
@@ -51,17 +51,25 @@ module API
             super
           end
 
-          cached_hash_rep = ::JSON::parse(cached_json_rep)
+          cached_hash_rep = ::JSON.parse(cached_json_rep)
 
           apply_link_cache_ifs(cached_hash_rep)
           apply_property_cache_ifs(cached_hash_rep)
 
           add_uncacheable_links(cached_hash_rep)
 
-          uncached_hash_rep = ::JSON::parse(uncached_json_rep)
-          hash_rep = uncached_hash_rep.deep_merge(cached_hash_rep)
+          uncached_hash_rep = ::JSON.parse(uncached_json_rep)
 
-          ::JSON::dump(hash_rep)
+          ::JSON.dump(uncached_hash_rep.deep_merge(cached_hash_rep))
+        end
+
+        # When this representer is a nested value inside another
+        # representer, the JSON adapter (multi_json >= 1.21 json_gem) serializes it
+        # via #as_json instead of #to_json. Needs to be routed through the cache-aware #to_json
+        # so cache_if/uncacheable stripping is applied. Without it, ActiveSupport's
+        # Object#as_json falls back to #to_hash and leaks guarded fields.
+        def as_json(*)
+          ::JSON.parse(to_json)
         end
 
         def json_cache_key
@@ -99,7 +107,7 @@ module API
 
             name = config[:rel]
 
-            delete_from_hash(hash_rep, "_links", name)
+            delete_from_hash(hash_rep, "_links", name.to_s)
           end
         end
 
@@ -143,7 +151,7 @@ module API
 
         # Overriding Roar::Hypermedia#combile_links_for
         # to remove all uncacheable links if the caching_state is set to :cacheable
-        def compile_links_for(configs, *args)
+        def compile_links_for(configs, *)
           current_configs = case caching_state
                             when :cacheable
                               configs.reject { |c| c.first[:uncacheable] }
@@ -153,7 +161,7 @@ module API
                               configs
                             end
 
-          super(current_configs, *args)
+          super(current_configs, *)
         end
 
         def delete_from_hash(hash, path, key)

--- a/lib/api/formatter.rb
+++ b/lib/api/formatter.rb
@@ -34,7 +34,7 @@ module API
       elsif object.respond_to?(:to_json)
         object.to_json
       else
-        MultiJson.dump(object)
+        MultiJSON.dump(object)
       end
     end
   end

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -307,7 +307,7 @@ module API
     # TODO: Where do we expect this to be raised and **not** be a programming error?
     error_response NotImplementedError, ::API::Errors::NotImplemented, log: false
 
-    error_response MultiJson::ParseError, ::API::Errors::ParseError
+    error_response MultiJSON::ParseError, ::API::Errors::ParseError
 
     error_response ::API::Errors::Unauthenticated, headers: auth_headers, log: false
     error_response ::API::Errors::ErrorBase, rescue_subclasses: true, log: false

--- a/lib/api/utilities/json_gem_parser.rb
+++ b/lib/api/utilities/json_gem_parser.rb
@@ -1,5 +1,5 @@
 # Forces using the classic json gem when parsing.
-# This might be beneficial in cases where other parsers, orchestrated by MultiJson misbehave.
+# This might be beneficial in cases where other parsers, orchestrated by MultiJSON misbehave.
 # This is e.g. the case with oj which sometimes turns numbers into BigDecimal values.
 module API::Utilities::JsonGemParser
   def self.call(object, _)

--- a/lib/api/v3/parser.rb
+++ b/lib/api/v3/parser.rb
@@ -29,8 +29,8 @@
 module API::V3
   class Parser
     def call(object, _env)
-      MultiJson.load(object)
-    rescue MultiJson::ParseError => e
+      MultiJSON.load(object)
+    rescue MultiJSON::ParseError => e
       error = ::API::Errors::ParseError.new(details: e.message)
       representer = ::API::V3::Errors::ErrorRepresenter.new(error)
 

--- a/modules/storages/app/common/storages/adapters/providers/one_drive/validators/storage_configuration_validator.rb
+++ b/modules/storages/app/common/storages/adapters/providers/one_drive/validators/storage_configuration_validator.rb
@@ -141,7 +141,7 @@ module Storages
             def auth_strategy = Registry["one_drive.authentication.userless"].call
 
             def error_payload
-              @error_payload ||= query_result.either(->(_) { {} }, -> { MultiJson.load(it.payload, symbolize_keys: true) })
+              @error_payload ||= query_result.either(->(_) { {} }, -> { MultiJSON.load(it.payload, symbolize_keys: true) })
             end
           end
         end

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/validators/storage_configuration_validator.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/validators/storage_configuration_validator.rb
@@ -129,7 +129,7 @@ module Storages
             def auth_strategy = Registry["sharepoint.authentication.userless"].call
 
             def error_payload
-              @error_payload ||= query_result.either(->(_) { {} }, -> { MultiJson.load(it.payload, symbolize_keys: true) })
+              @error_payload ||= query_result.either(->(_) { {} }, -> { MultiJSON.load(it.payload, symbolize_keys: true) })
             end
           end
         end

--- a/modules/storages/app/validator/nextcloud_compatible_host_validator.rb
+++ b/modules/storages/app/validator/nextcloud_compatible_host_validator.rb
@@ -147,13 +147,13 @@ class NextcloudCompatibleHostValidator < ActiveModel::EachValidator
 
   def read_version(response)
     response.json.dig("ocs", "data", "version", "major")
-  rescue HTTPX::Error, MultiJson::ParseError
+  rescue HTTPX::Error, MultiJSON::ParseError
     false
   end
 
   def read_authorization_header(response)
     response.json["authorization_header"]
-  rescue HTTPX::Error, MultiJson::ParseError
+  rescue HTTPX::Error, MultiJSON::ParseError
     nil
   end
 end

--- a/modules/storages/spec/requests/api/v3/storages/storage_files_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storage_files_api_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe "API v3 storage files", :disable_ssrf_filter, :storage_server_hel
         expect(subject).to be_json_eql("post".to_json).at_path("_links/destination/method")
         expect(subject).to be_json_eql("Upload File".to_json).at_path("_links/destination/title")
 
-        href = MultiJson.load(subject).dig("_links", "destination", "href")
+        href = MultiJSON.load(subject).dig("_links", "destination", "href")
         expect(href).to match(destination)
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe "API v3 storage files", :disable_ssrf_filter, :storage_server_hel
         it "fails with an internal error" do
           expect(last_response).to have_http_status(:internal_server_error)
 
-          body = MultiJson.load(last_response.body, symbolize_keys: true)
+          body = MultiJSON.load(last_response.body, symbolize_keys: true)
           expect(body[:message]).to eq(I18n.t("services.errors.messages.error"))
           expect(body[:errorIdentifier]).to eq("urn:openproject-org:api:v3:errors:InternalServerError")
         end

--- a/modules/wikis/app/controllers/wikis/page_selection_form_input.rb
+++ b/modules/wikis/app/controllers/wikis/page_selection_form_input.rb
@@ -33,7 +33,7 @@ module Wikis
     def parse_identifier(wiki_page_selection)
       case wiki_page_selection
       in [selected_page]
-        MultiJson.load(selected_page, symbolize_keys: true)[:value]
+        MultiJSON.load(selected_page, symbolize_keys: true)[:value]
       else
         nil
       end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/concerns/xwiki_request.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/concerns/xwiki_request.rb
@@ -78,7 +78,7 @@ module Wikis
               in { status: 200..299 }
                 begin
                   json = response.json
-                rescue MultiJson::ParseError
+                rescue MultiJSON::ParseError
                   return failure(code: :invalid_response)
                 end
 

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
       end
 
       it "only returns the filtered type" do
-        json = MultiJson.load(last_response.body, symbolize_keys: true)
+        json = MultiJSON.load(last_response.body, symbolize_keys: true)
 
         expect(json.dig(:_embedded, :elements))
           .to all(include(wikiPageLinkType: API::V3::PageLinks::URN_PAGE_LINK_TYPE["Wikis::RelationPageLink"]))
@@ -283,7 +283,7 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
       end
 
       it "contains the error" do
-        json = MultiJson.load(response_body)
+        json = MultiJSON.load(response_body)
 
         expect(json["message"]).to match("Wiki Provider does not exist")
       end

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe "API v3 Work package form resource" do
               end
 
               it_behaves_like "parse error",
-                              "unexpected comma (after ) at line 1, column 3"
+                              "expected object key, got ',' at line 1 column 3"
             end
 
             describe "lock version" do

--- a/spec/support/multi_json_issue_workaround.rb
+++ b/spec/support/multi_json_issue_workaround.rb
@@ -7,7 +7,7 @@
 # test executed.
 #
 # Calling this will prevent the error from happening
-MultiJson::OptionsCache.reset
+MultiJSON::OptionsCache.reset
 
 # This file can be removed once the issue has been fixed and released in a new
 # version of multi_json gem (issue exists in 1.15.0)

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -74,7 +74,7 @@ VCR.configure do |config|
     content_type = interaction.response.headers["Content-Type"]&.first
 
     if content_type&.include?("application/json")
-      MultiJson.load(interaction.response.body)["access_token"]
+      MultiJSON.load(interaction.response.body)["access_token"]
     end
   end
 
@@ -82,7 +82,7 @@ VCR.configure do |config|
     content_type = interaction.response.headers["Content-Type"]&.first
 
     if content_type&.include?("application/json")
-      MultiJson.load(interaction.response.body)["refresh_token"]
+      MultiJSON.load(interaction.response.body)["refresh_token"]
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19611

# What are you trying to accomplish?

Starts by bumping multi_json. However, this is not a simple gem bump. In `1.21.0` `multi_json` [switches from `oj` to the std-lib `json` as the preferred parsing and rendering lib.](https://github.com/sferik/multi_json/blob/main/CHANGELOG.md#changed). 

That adapter requires to have `as_json` overwritten by rendering the cached representers to json right away. [Otherwise, the caching specific properties, i.e. cache_if would not be executed](https://github.com/sferik/multi_json/blob/9ae5a429e519fb70440833d8b8968a2123da9098/lib/multi_json/adapters/json_gem.rb#L60-L61). This leads to the unfortunate behaviour that after this change, there is one more round trip where the already serialized json is parsed only to be serialized again next. This is non sensical but locally performed tests indicate that the real world impact of this is marginal. But it is something to look out for.

An alternative would have been to force `multi_json` to continue using `oj`. Both the tests of `multi_json` as well as those done for this PR on my local machine indicate however, that `oj` is now the slower of the two libraries.    

