### PR TITLE
Implementation/agile 309 improve the dragging experience with the frame reloading

### DIFF
--- a/app/components/open_project/common/border_box_list_component.html.erb
+++ b/app/components/open_project/common/border_box_list_component.html.erb
@@ -34,13 +34,13 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   <% end %>
 
-  <% if items.any? %>
-    <% items.each do |item| %>
-      <% border_box.with_row(**item.row_args) do %>
-        <%= item %>
-      <% end %>
+  <% items.each do |item| %>
+    <% border_box.with_row(**item.row_args) do %>
+      <%= item %>
     <% end %>
-  <% elsif empty_state? %>
+  <% end %>
+
+  <% if empty_state? %>
     <% border_box.with_row(data: { empty_list_item: true }) do %>
       <%= empty_state %>
     <% end %>

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -17,8 +17,9 @@
 
   & + .Box-row
     border-top-color: $color
-
-  &:last-child
+  // Display the selected state margin for the last child, or the penultimate child,
+  // if the last one is the hidden blankslate.
+  &:is(:last-child, :has(+ [data-empty-list-item]))
     margin-bottom: calc(var(--borderWidth-thin) * -1)
     border-bottom: var(--borderWidth-thin) solid $color
 
@@ -97,8 +98,15 @@
   // The empty-state row only makes sense while it is alone in the list. Hiding
   // it as soon as a sibling row appears (e.g. dropped by drag and drop) avoids
   // a flicker between the drop and the server render removing it.
-  > .Box-list > .Box-row[data-empty-list-item]:not(:only-child)
-    display: none
+  > .Box-list
+    > .Box-row
+      &[data-empty-list-item]:not(:only-child)
+        display: none
+      // Display rounded corners for the penultimate child, if the last child is the
+      // hidden blankslate.
+      &:has(+ [data-empty-list-item])
+        border-bottom-right-radius: var(--borderRadius-medium)
+        border-bottom-left-radius: var(--borderRadius-medium)
 
 .op-border-box-list-header
   display: grid

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
@@ -31,9 +31,10 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::Alpha::ActionMenu::List.new(menu_id:)) do |list|
     list.with_item(
       id: dom_target(work_package, :menu, :open_details),
-      tag: :button,
+      tag: :a,
       label: t(:"js.button_open_details"),
-      content_arguments: { data: { action: "backlogs--work-package#openSplitPane" } }
+      href: project_backlogs_backlog_details_path(project, work_package),
+      content_arguments: { data: { action: "backlogs--work-package#openSplitPane:prevent" } }
     ) do |item|
       item.with_leading_visual_icon(icon: :"op-view-split")
     end

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -121,7 +121,6 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
       end
 
       it "renders one shared-card row per work package" do
-        expect(rendered_component).to have_css(".Box-row", count: 1)
         expect(rendered_component).to have_text("Bucket Work Package")
         expect(rendered_component).to have_text("##{work_package.id}")
       end
@@ -170,7 +169,7 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
     end
 
     context "without work packages" do
-      it_behaves_like "rendering Box", row_count: 1, header: true, footer: false
+      it_behaves_like "rendering Box", row_count: 0, header: true, footer: false
       it_behaves_like "rendering Blank Slate", heading: "Backlog bucket is empty"
 
       it "renders the bucket empty-state blankslate" do

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -57,17 +57,20 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     render_inline component
   end
 
-  before { render_component }
+  subject(:rendered_component) do
+    render_component
+  end
+
 
   describe "container" do
     it "renders a Primer::Beta::BorderBox with the inbox DOM id" do
-      expect(page).to have_css(".Box#inbox_project_#{project.id}")
+      expect(rendered_component).to have_css(".Box#inbox_project_#{project.id}")
     end
 
     it "wires the list controller for the inbox" do
       list_type = Backlogs::Target::InboxId.list_type
 
-      expect(page).to have_css(".Box#inbox_project_#{project.id}") do |box|
+      expect(rendered_component).to have_css(".Box#inbox_project_#{project.id}") do |box|
         expect(box["data-controller"]).to include("sortable-lists--list")
         expect(box["data-sortable-lists--list-type-value"]).to eq(list_type)
         expect(box["data-sortable-lists--list-id-value"]).to be_nil
@@ -77,7 +80,7 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     end
 
     it "announces dynamic empty-state updates" do
-      expect(page).to have_role(:status, aria: { live: "polite" })
+      expect(rendered_component).to have_role(:status, aria: { live: "polite" })
     end
   end
 
@@ -90,12 +93,12 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     end
 
     it "renders the inbox title" do
-      expect(page).to have_heading "Inbox", level: 4
-      expect(page).to have_css("h4.f4", text: "Inbox")
+      expect(rendered_component).to have_heading "Inbox", level: 4
+      expect(rendered_component).to have_css("h4.f4", text: "Inbox")
     end
 
     it "renders the work-package count" do
-      expect(page).to have_css(
+      expect(rendered_component).to have_css(
         ".Counter",
         text: "2",
         aria: { label: I18n.t(:label_x_items, count: 2) }
@@ -103,10 +106,10 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     end
 
     it "renders the add work package menu actions" do
-      expect(page).to have_selector(:menuitem, "Add new work package") do |link|
+      expect(rendered_component).to have_selector(:menuitem, "Add new work package") do |link|
         expect(link[:href]).to eq new_project_work_packages_dialog_path(project)
       end
-      expect(page).to have_selector(:menuitem, "Add existing work package") do |link|
+      expect(rendered_component).to have_selector(:menuitem, "Add existing work package") do |link|
         expect(link[:href]).to eq add_existing_dialog_project_backlogs_work_packages_path(project, list_type: "inbox")
       end
     end
@@ -120,8 +123,8 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       end
 
       it "does not render the add work package menu actions" do
-        expect(page).to have_no_selector(:menuitem, "Add new work package")
-        expect(page).to have_no_selector(:menuitem, "Add existing work package")
+        expect(rendered_component).to have_no_selector(:menuitem, "Add new work package")
+        expect(rendered_component).to have_no_selector(:menuitem, "Add existing work package")
       end
     end
   end
@@ -130,8 +133,9 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     let(:work_packages) { [] }
 
     it "shows the blankslate heading and description" do
-      expect(page).to have_css("h4", text: "Backlog inbox is empty")
-      expect(page).to have_text("Open work packages that are not in a sprint or backlog bucket automatically appear here")
+      expect(rendered_component).to have_css("h4", text: "Backlog inbox is empty")
+      expect(rendered_component)
+        .to have_text("Open work packages that are not in a sprint or backlog bucket automatically appear here")
     end
   end
 
@@ -143,22 +147,21 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       ]
     end
 
+    it_behaves_like "rendering Box", row_count: 2, header: true, footer: false
+    # does render the blankslate but it is being hidden by CSS
+    it_behaves_like "rendering Blank Slate", heading: "Backlog inbox is empty"
+
     it "renders a row for each work package", :aggregate_failures do
-      expect(page).to have_css(".Box-row", count: 2)
-
       # renders the subject of each work package
-      expect(page).to have_text("First item")
-      expect(page).to have_text("Second item")
-
-      # does not show the blankslate
-      expect(page).to have_no_css("h4", text: "Backlog inbox is empty")
+      expect(rendered_component).to have_text("First item")
+      expect(rendered_component).to have_text("Second item")
     end
 
     it "renders story points on each work package card" do
-      expect(page).to have_css("span", text: "2", aria: { hidden: true })
-      expect(page).to have_css(".sr-only", text: "2 story points")
-      expect(page).to have_css("span", text: "4", aria: { hidden: true })
-      expect(page).to have_css(".sr-only", text: "4 story points")
+      expect(rendered_component).to have_css("span", text: "2", aria: { hidden: true })
+      expect(rendered_component).to have_css(".sr-only", text: "2 story points")
+      expect(rendered_component).to have_css("span", text: "4", aria: { hidden: true })
+      expect(rendered_component).to have_css(".sr-only", text: "4 story points")
     end
   end
 
@@ -174,8 +177,8 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       let(:work_packages) { create_list(:work_package, threshold, project:) }
 
       it "renders all items without pagination" do
-        expect(page).to have_css(".Box-row", count: threshold)
-        expect(page).to have_no_css("##{show_more_id}")
+        expect(rendered_component).to have_css(".Box-row:not([data-empty-list-item])", count: threshold)
+        expect(rendered_component).to have_no_css("##{show_more_id}")
       end
     end
 
@@ -184,14 +187,17 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       let(:middle_count) { total - truncate_middle - tail_size }
       let(:work_packages) { create_list(:work_package, total, project:) }
 
-      it "renders only the first page and last page items (not all)" do
-        expect(page).to have_css(".Box-row", count: truncate_middle + tail_size + 1) # +1 for "show more" row
-        expect(page).to have_css("##{show_more_id}")
-        expect(page).to have_text("Show #{middle_count} more items")
+      it "renders only the first rendered_component and last rendered_component items (not all)" do
+        expect(rendered_component).to have_css(
+          ".Box-row:not([data-empty-list-item])",
+          count: truncate_middle + tail_size + 1 # +1 is for "show more" row
+        )
+        expect(rendered_component).to have_css("##{show_more_id}")
+        expect(rendered_component).to have_text("Show #{middle_count} more items")
       end
 
       it "renders the full work-package count in the header" do
-        expect(page).to have_css(
+        expect(rendered_component).to have_css(
           ".Counter",
           text: total.to_s,
           aria: { label: I18n.t(:label_x_items, count: total) }
@@ -199,9 +205,10 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       end
 
       it "renders show-more targeting the full backlog turbo frame with all=true" do
-        show_link = page.find("##{show_more_id}")
-        expect(show_link[:href]).to include("all=true")
-        expect(show_link["data-turbo-frame"]).to eq("backlogs_container")
+        expect(rendered_component).to have_css("##{show_more_id}") do |show_link|
+          expect(show_link[:href]).to include("all=true")
+          expect(show_link["data-turbo-frame"]).to eq("backlogs_container")
+        end
       end
 
       context "when filter params are active" do
@@ -209,16 +216,17 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
         let(:filter_params) { { sprint_ids: [sprint.id.to_s] } }
 
         it "carries filter params in the show-more href alongside all=true" do
-          show_link = page.find("##{show_more_id}")
-          expect(show_link[:href]).to include("all=")
-          expect(show_link[:href]).to include("sprint_ids")
+          expect(rendered_component).to have_css("##{show_more_id}") do |show_link|
+            expect(show_link[:href]).to include("all=")
+            expect(show_link[:href]).to include("sprint_ids")
+          end
         end
       end
 
       it "renders the show-more row with the last omitted work package id" do
         last_omitted = work_packages.sort_by(&:position)[-(tail_size + 1)]
 
-        expect(page).to have_css("[data-sortable-lists-prev-item-id='#{last_omitted.id}']")
+        expect(rendered_component).to have_css("[data-sortable-lists-prev-item-id='#{last_omitted.id}']")
       end
     end
 
@@ -228,8 +236,8 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       let(:work_packages) { create_list(:work_package, total, project:) }
 
       it "renders all items without pagination" do
-        expect(page).to have_css(".Box-row", count: total)
-        expect(page).to have_no_css("##{show_more_id}")
+        expect(rendered_component).to have_css(".Box-row:not([data-empty-list-item])", count: total)
+        expect(rendered_component).to have_no_css("##{show_more_id}")
       end
     end
   end

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       end
 
       it "renders one Box-row per work package" do
-        expect(rendered_component).to have_css(".Box-row", count: 2)
         expect(rendered_component).to have_text(work_package1.subject)
         expect(rendered_component).to have_text(work_package2.subject)
       end
@@ -173,7 +172,7 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
     end
 
     context "without work packages" do
-      it_behaves_like "rendering Box", row_count: 1, header: true, footer: false
+      it_behaves_like "rendering Box", row_count: 0, header: true, footer: false
       it_behaves_like "rendering Blank Slate", heading: "Sprint 1 is empty"
 
       it "renders the empty-state blankslate" do

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
@@ -260,8 +260,8 @@ RSpec.describe Backlogs::WorkPackageCardListComponent, type: :component do
         ]
       end
 
-      it "does not render the blankslate" do
-        expect(rendered_component).to have_no_css(".blankslate")
+      it "renders the blankslate in the DOM (hidden by CSS when items are present)" do
+        expect(rendered_component).to have_css(".blankslate")
       end
     end
   end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       render_component
 
       expect(page).to have_element(:ul, id: /\Awork_package_#{work_package.id}_menu-list\z/)
-      expect(page).to have_element(:button, id: /\Awork_package_#{work_package.id}_menu_open_details\z/)
+      expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_details\z/)
       expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_fullscreen\z/)
       expect(page).to have_element(:"clipboard-copy", id: /\Awork_package_#{work_package.id}_menu_copy_url_to_clipboard\z/)
       expect(page).to have_element(:"clipboard-copy", id: /\Awork_package_#{work_package.id}_menu_copy_work_package_id\z/)
@@ -87,7 +87,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       expect(page).to have_text(I18n.t(:"js.button_open_details"))
       expect(page).to have_octicon(:"op-view-split")
       expect(page).to have_css(
-        "button[data-action='backlogs--work-package#openSplitPane']",
+        "a[href$='/backlogs/backlog/details/#{work_package.id}'][data-action='backlogs--work-package#openSplitPane:prevent']",
         text: I18n.t(:"js.button_open_details")
       )
     end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -641,7 +641,7 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_text("Add some items")
     end
 
-    it "does not render the empty state when items are present" do
+    it "renders the empty state in the DOM even when items are present (hidden by CSS for drag support)" do
       rendered = render_inline(
         described_class.new(container: "non-empty-list")
       ) do |list|
@@ -649,7 +649,7 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
         list.with_item { "Has content" }
       end
 
-      expect(rendered).to have_no_css(".blankslate")
+      expect(rendered).to have_css(".blankslate")
       expect(rendered).to have_text("Has content")
     end
 

--- a/spec/support/shared/components/border_box_list_component.rb
+++ b/spec/support/shared/components/border_box_list_component.rb
@@ -43,8 +43,8 @@ end
 
 # Shared expectations for an itemless Border Box List: the component renders
 # a single Blank Slate row in place of the list items.
-RSpec.shared_examples_for "rendering an empty Border Box List" do |heading:, icon: nil, row_count: 1, header: true|
-  it_behaves_like("rendering Box", row_count:, header:)
+RSpec.shared_examples_for "rendering an empty Border Box List" do |heading:, icon: nil, header: true|
+  it_behaves_like("rendering Box", row_count: 0, header:)
   it_behaves_like("rendering Blank Slate", heading:, icon:)
 end
 

--- a/spec/support/shared/components/box.rb
+++ b/spec/support/shared/components/box.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples_for "rendering Box" do |row_count:, header: true, footer: 
   end
 
   it "renders #{row_count} Box rows" do
-    expect(rendered_component).to have_css ".Box-row", count: row_count
+    expect(rendered_component).to have_css ".Box-row:not([data-empty-list-item])", count: row_count
   end
 
   if footer


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-309

# What are you trying to accomplish?
In #23885 , the reloading of the backlogs has been changed. Now a separate request is fired after each action to reload the page. This can result in a sluggish experience when drag and dropping work packages. See https://github.com/opf/openproject/pull/23885#pullrequestreview-4563754344 . This PR is intended to improve the drag and drop loading mechanism.

## Screenshots

<details><summary><del>Demo of data-turbo-permanent with a slow request. (It updates the displays the counter, but does not touch the list)</del></summary>
<p>

<img width="1228" height="700" alt="slow request" src="https://github.com/user-attachments/assets/98a306ff-dde4-4e94-b24c-b0c3f7c6b7cf" />


</p>
</details> 

<details><summary><del>Demo of fast sequence drag and drop. (No flickering)</del></summary>
<p>

<img width="944" height="588" alt="fast drag" src="https://github.com/user-attachments/assets/3df8852e-fcb8-4fb6-b856-7b687ceb3841" />


</p>
</details> 

<details><summary>Demo for instantly appearing blankslate</summary>
<p>

<img width="1228" height="700" alt="Jul-22-2026 00-25-50" src="https://github.com/user-attachments/assets/874f0a88-9c2d-4f01-8b27-77d52a48a3b3" />


</p>
</details> 

# What approach did you choose and why?
- [X] ~~In order to prevent flickering, prevent draggable lists from morphing when an item is actively dragged. Adding the data-turbo-permanent eliminates the race condition between the backlog frame loading and ongoing drag actions. This will prevent flickering of the lists when multiple cards are dragged in a short time. Note: The other elements are still updated by the reload, for example the work package counters.~~
- [X] Show and hide the blankslates by css in order to prevent further unexpected movements due to the delayed loading.
- [X] Restore using a link for the split work package view.

**Note:** There is a possibility for another race condition that causes flickering, however that happens only in single threaded dev mode. When dragging multiple items fast and the reload is slow, the second move request is not initiated until the first reload request is done. Since dragula already moves the items to their right place, the delayed reload will put the item temporarily back to its original position, until all the sequential move and reload requests catch up. This is not an issue in production because the move requests will fire simultaneously and each of them will fire a separate reload request. Fortunately turbo is smart enough to abort the pending reload requests and execute just the last one. In this case, the counter updates might be updated with a small delay, but the UI will not flicker due having only a single reload request.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
