### PR TITLE
Stop 2FA override leaking from definition spec

### DIFF
--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -359,9 +359,12 @@ RSpec.describe Settings::Definition, :settings_reset do
               "OPENPROJECT_2FA_ALLOW__REMEMBER__FOR__DAYS" => "15"
             }
           )
-          # override from env manually because these settings are added by plugin itself
-          described_class.send(:override_value, all[:plugin_openproject_two_factor_authentication])
-          expect(all[:plugin_openproject_two_factor_authentication].value).to eq(
+          # override from env manually because these settings are added by plugin itself.
+          # Operate on a dup so override_value does not mutate the shared definition
+          # instance, which the "with settings reset" snapshot only restores shallowly.
+          definition = all[:plugin_openproject_two_factor_authentication].dup
+          described_class.send(:override_value, definition)
+          expect(definition.value).to eq(
             "active_strategies" => %i[totp webauthn],
             "enforced" => true,
             "allow_remember_for_days" => 15
@@ -375,9 +378,12 @@ RSpec.describe Settings::Definition, :settings_reset do
               "OPENPROJECT_2FA" => '{"enforced": true, "allow_remember_for_days": 15}'
             }
           )
-          # override from env manually because these settings are added by plugin itself
-          described_class.send(:override_value, all[:plugin_openproject_two_factor_authentication])
-          expect(all[:plugin_openproject_two_factor_authentication].value)
+          # override from env manually because these settings are added by plugin itself.
+          # Operate on a dup so override_value does not mutate the shared definition
+          # instance, which the "with settings reset" snapshot only restores shallowly.
+          definition = all[:plugin_openproject_two_factor_authentication].dup
+          described_class.send(:override_value, definition)
+          expect(definition.value)
             .to eq({ "active_strategies" => %i[totp webauthn], "enforced" => true, "allow_remember_for_days" => 15 })
         end
       end


### PR DESCRIPTION
# What are you trying to accomplish?

A test-isolation leak in `spec/constants/settings/definition_spec.rb` intermittently fails unrelated request specs (e.g. `modules/backlogs/spec/requests/backlogs/sprints_spec.rb`) with `401`/`302`, depending on suite ordering. It surfaced on the CI for #23938 but is independent of that change.

The two "with definitions from plugins" examples call `override_value` directly on the shared `plugin_openproject_two_factor_authentication` definition instance. `override_value` mutates the object in place (`enforced: true`), and the `"with settings reset"` context only snapshots/restores `Settings::Definition.all` shallowly — so the mutation survives into later examples. Any spec that performs a real `post signin_path` login afterwards is then forced into 2FA, never completes login, and fails.

# What approach did you choose and why?

- Operate on a `dup` of the definition before calling `override_value`, so the shared instance retained by the snapshot is never mutated. `coerce`/`value=` already reassign (`deep_merge` returns a new hash), so the dup is fully independent.

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — N/A (test-only change)
