### PR TITLE
[DREAM-688] Use BorderBoxList for enumerations

### DIFF
--- a/app/components/admin/enumerations/index_component.html.erb
+++ b/app/components/admin/enumerations/index_component.html.erb
@@ -17,18 +17,26 @@ component_wrapper do
     end
 
     flex.with_row do
-      render(border_box_container(data: drop_target_config)) do |component|
-        component.with_header(font_weight: :bold) { enumeration_class.model_name.human(count: :other) }
+      render(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "#{wrapper_key}-box",
+          position: :relative,
+          data: drop_target_config
+        )
+      ) do |list|
+        list.with_header(
+          title_tag: :h3,
+          title: enumeration_class.model_name.human(count: :other)
+        )
 
-        if enumerations.empty?
-          component.with_row do
-            render(Primer::Beta::Text.new(color: :subtle)) { t(:no_results_title_text) }
-          end
-        else
-          enumerations.each do |enumeration|
-            component.with_row(test_selector: "enumeration-row-#{enumeration.id}", data: draggable_item_config(enumeration)) do
-              render(item_component_class.new(enumeration: enumeration, max_position: max_position))
-            end
+        list.with_empty_state(
+          title: t(:no_results_title_text),
+          spacious: true
+        )
+
+        enumerations.each do |enumeration|
+          list.with_item(test_selector: "enumeration-row-#{enumeration.id}", data: draggable_item_config(enumeration)) do
+            render(item_component_class.new(enumeration: enumeration, max_position: max_position))
           end
         end
       end

--- a/app/components/admin/enumerations/index_component.html.erb
+++ b/app/components/admin/enumerations/index_component.html.erb
@@ -31,6 +31,7 @@ component_wrapper do
 
         list.with_empty_state(
           title: t(:no_results_title_text),
+          icon: :alert,
           spacious: true
         )
 

--- a/spec/components/admin/enumerations/index_component_spec.rb
+++ b/spec/components/admin/enumerations/index_component_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Admin::Enumerations::IndexComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/admin/settings/work_package_priorities") do
+      render_inline(described_class.new(enumerations:))
+    end
+  end
+
+  context "with enumerations" do
+    let!(:priority_a) { create(:priority, name: "Urgent") }
+    let!(:priority_b) { create(:priority, name: "Trivial") }
+    let(:enumerations) { IssuePriority.where(id: [priority_a.id, priority_b.id]).order(:position) }
+
+    it_behaves_like "rendering Box", row_count: 2
+    it_behaves_like "rendering Border Box List heading",
+                    text: IssuePriority.model_name.human(count: :other),
+                    level: 3
+
+    it "renders a row per enumeration", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-row", text: "Urgent")
+      expect(rendered_component).to have_css(".Box-row", text: "Trivial")
+    end
+
+    it_behaves_like "a reorderable Border Box List", drag_type: "enumeration" do
+      let(:draggable_records) { [priority_a, priority_b] }
+
+      def drop_url_for(record)
+        "/work_package_priorities/#{record.id}/move"
+      end
+    end
+  end
+
+  context "without enumerations" do
+    let(:enumerations) { IssuePriority.where(id: nil) }
+
+    it_behaves_like "rendering an empty Border Box List", heading: I18n.t(:no_results_title_text)
+  end
+end

--- a/spec/support/shared/components/border_box_list_component.rb
+++ b/spec/support/shared/components/border_box_list_component.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Shared expectations for lists rendered through
+# OpenProject::Common::BorderBoxListComponent.
+#
+# Asserts the heading is a real heading element rendered inside the
+# +.Box-header+, not merely text that happens to appear somewhere.
+RSpec.shared_examples_for "rendering Border Box List heading" do |text:, level: nil|
+  it "renders Border Box List heading '#{text}'" do
+    expect(rendered_component).to have_css(".Box-header") do |header|
+      expect(header).to have_heading(text, **{ level: }.compact)
+    end
+  end
+end
+
+# Shared expectations for an itemless Border Box List: the component renders
+# a single Blank Slate row in place of the list items.
+RSpec.shared_examples_for "rendering an empty Border Box List" do |heading:, icon: nil, row_count: 1, header: true|
+  it_behaves_like("rendering Box", row_count:, header:)
+  it_behaves_like("rendering Blank Slate", heading:, icon:)
+end
+
+# Shared expectations for lists rendered through
+# OpenProject::Common::BorderBoxListComponent with generic drag-and-drop
+# reordering.
+#
+# Including contexts must pass +drag_type:+ and define the following:
+#
+# - +draggable_records+: ordered records expected to render as rows.
+# - +drop_url_for(record)+: the value each row's +data-drop-url+ ends with.
+# - +draggable_id_for(record)+: optional value for +data-draggable-id+.
+#   Defaults to +record.id+.
+RSpec.shared_examples_for "a reorderable Border Box List" do |drag_type:|
+  it "renders a drag-and-drop enabled Border Box List container" do
+    expect(rendered_component)
+      .to have_css(".Box.op-border-box-list[data-generic-drag-and-drop-target='container']") do |box|
+        expect(box["data-target-container-accessor"]).to eq(":scope > ul")
+        expect(box["data-target-allowed-drag-type"]).to eq(drag_type)
+      end
+  end
+
+  it "renders the expected number of draggable rows" do
+    expect(rendered_component)
+      .to have_css(".Box-row[data-draggable-type='#{drag_type}']", count: draggable_records.size)
+  end
+
+  it "renders each record as a draggable row pointing at its drop URL", :aggregate_failures do
+    draggable_records.each do |record|
+      draggable_id = respond_to?(:draggable_id_for) ? draggable_id_for(record) : record.id
+      selector = ".Box-row[data-draggable-type='#{drag_type}'][data-draggable-id='#{draggable_id}']"
+
+      expect(rendered_component).to have_css(selector) do |row|
+        expect(row["data-drop-url"]).to end_with(drop_url_for(record))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-688

# What are you trying to accomplish?

Migrate the enumerations admin index list to the shared `OpenProject::Common::BorderBoxListComponent`, validating the primitive in a real drag-and-drop reordering context. Header, rows, empty state, and DnD wiring are preserved and covered by a component spec that shares the `"a reorderable Border Box List"` example.

> [!NOTE]
> Document Types are **not** migrated in this PR. Since the page actually uses a semantic table, it is intentionally left out of scope here.

## Screenshots

### Administration > Work packages > Priorities

<img width="1024" height="442" alt="Screenshot 2026-06-27 at 18 21 19" src="https://github.com/user-attachments/assets/b442b00c-bc19-46cb-a975-c6062ca7a082" />

### Administration > Time and costs > Time tracking activities

<img width="1021" height="616" alt="Screenshot 2026-06-27 at 18 23 06" src="https://github.com/user-attachments/assets/6b17ef63-c04b-46e2-b63b-73d61dba9213" />

# What approach did you choose and why?

Replaced the bespoke `border_box_container` header/row markup with the list component's slots (`with_header`, `with_item`, `with_empty_state`). The header now renders as an `h3` to match sibling admin lists, and the itemless list shows the default Blankslate empty state. Drag target and per-row draggable data attributes, the turbo wrapper, and locale keys are preserved.

The markup and specs are kept byte-identical to the equivalent commit in the wider DREAM-697 migration ([#23812](https://github.com/opf/openproject/pull/23812)) so the two branches reconcile without conflict.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
