### PR TITLE
Prevent duplication of meeting occurrence

### DIFF
--- a/modules/meeting/app/components/recurring_meetings/row_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/row_component.rb
@@ -112,16 +112,21 @@ module RecurringMeetings
     def create
       return unless creatable?
 
-      render(
-        Primer::Beta::Button.new(
-          scheme: :default,
-          size: :medium,
-          tag: :a,
-          data: { "turbo-method": "post" },
-          href: init_project_recurring_meeting_path(project, recurring_meeting.id, start_time: occurrence_time.iso8601)
-        )
-      ) do |_c|
-        I18n.t(:label_recurring_meeting_create)
+      # Submit via a real form so Turbo disables the button while the request is in
+      # flight. turbo_submits_with only works on form submit buttons, not on an
+      # <a data-turbo-method="post">, which is why repeated clicks duplicated occurrences.
+      helpers.primer_form_with(
+        url: init_project_recurring_meeting_path(project, recurring_meeting.id, start_time: occurrence_time.iso8601),
+        method: :post
+      ) do
+        render(
+          Primer::Beta::Button.new(
+            scheme: :default,
+            size: :medium,
+            type: :submit,
+            data: { turbo_submits_with: I18n.t(:label_loading) }
+          )
+        ) { I18n.t(:label_recurring_meeting_create) }
       end
     end
 
@@ -153,14 +158,18 @@ module RecurringMeetings
 
       menu.with_item(
         label: I18n.t(:label_recurring_meeting_create),
-        tag: :a,
         href: init_project_recurring_meeting_path(
           project,
           recurring_meeting.id,
           start_time: occurrence_time.iso8601
         ),
+        # Submit via a real form (like restore_action) so Turbo disables the item
+        # while in flight, preventing the double submit that duplicated occurrences.
+        form_arguments: {
+          method: :post
+        },
         content_arguments: {
-          data: { turbo_method: :post }
+          data: { turbo_submits_with: I18n.t(:label_loading) }
         }
       ) do |item|
         item.with_leading_visual_icon(icon: :"issue-opened")
@@ -246,6 +255,5 @@ module RecurringMeetings
     def start_time_changed?
       instantiated? && meeting.start_time != occurrence_time
     end
-
   end
 end

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -55,12 +55,17 @@ module RecurringMeetings
     end
 
     def instantiate(start_time)
-      # If a cancelled occurrence exists for this recurrence_start_time, restore it
       existing = recurring_meeting.meetings.not_templated.find_by(recurrence_start_time: start_time)
-      if existing&.cancelled?
+
+      if existing.nil?
+        copy_from_template(start_time)
+      elsif existing.cancelled?
+        # Restore a cancelled occurrence for this recurrence_start_time.
         restore_cancelled(existing)
       else
-        copy_from_template(start_time)
+        # An occurrence already exists for this slot (e.g. a double submit): return
+        # it instead of creating a duplicate the unique index would reject anyway.
+        ServiceResult.success(result: existing)
       end
     end
 

--- a/modules/meeting/db/migrate/20260625120000_add_recurrence_start_time_constraints_to_meetings.rb
+++ b/modules/meeting/db/migrate/20260625120000_add_recurrence_start_time_constraints_to_meetings.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddRecurrenceStartTimeConstraintsToMeetings < ActiveRecord::Migration[8.1]
+  PRESENCE_CONSTRAINT = "recurrence_start_time_present_for_occurrences"
+  ABSENCE_CONSTRAINT = "recurrence_start_time_absent_for_templates"
+
+  # Mirror Meeting's model validations at the database level:
+  #   presence: true, if: -> { recurring? && !template? }
+  #   absence:  true, if: :template?
+  def up
+    # A non-template occurrence belonging to a series must have a recurrence_start_time.
+    add_check_constraint :meetings,
+                         "template OR recurring_meeting_id IS NULL OR recurrence_start_time IS NOT NULL",
+                         name: PRESENCE_CONSTRAINT
+
+    # A template must not have a recurrence_start_time.
+    add_check_constraint :meetings,
+                         "template = false OR recurrence_start_time IS NULL",
+                         name: ABSENCE_CONSTRAINT
+  end
+
+  def down
+    remove_check_constraint :meetings, name: PRESENCE_CONSTRAINT
+    remove_check_constraint :meetings, name: ABSENCE_CONSTRAINT
+  end
+end

--- a/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_spec.rb
@@ -53,6 +53,56 @@ RSpec.describe RecurringMeetings::InitOccurrenceService, type: :model do
   let(:service_result) { instance.call(**params) }
   let(:created_meeting) { service_result.result }
 
+  describe "instantiating an occurrence for a slot" do
+    let(:start_time) { series.start_time + 3.days }
+
+    context "when no occurrence exists yet for the slot" do
+      it "creates a new occurrence for the series" do
+        expect(service_result).to be_success
+        expect(created_meeting).to be_persisted
+        expect(created_meeting).not_to be_template
+        expect(created_meeting.recurring_meeting).to eq(series)
+        expect(created_meeting.recurrence_start_time).to eq(start_time)
+      end
+
+      it "adds exactly one occurrence" do
+        expect { instance.call(**params) }
+          .to change { series.meetings.not_templated.count }.by(1)
+      end
+    end
+
+    context "when a non-cancelled occurrence already exists for the slot" do
+      let!(:existing) do
+        create(:recurring_meeting_occurrence, recurring_meeting: series, start_time:)
+      end
+
+      it "returns the existing occurrence instead of creating a duplicate" do
+        expect(service_result).to be_success
+        expect(created_meeting).to eq(existing)
+      end
+
+      it "does not create another meeting" do
+        expect { instance.call(**params) }.not_to change(Meeting, :count)
+      end
+    end
+
+    context "when a cancelled occurrence exists for the slot" do
+      let!(:existing) do
+        create(:recurring_meeting_occurrence, :cancelled, recurring_meeting: series, start_time:)
+      end
+
+      it "restores the cancelled occurrence rather than creating a new one" do
+        expect(service_result).to be_success
+        expect(created_meeting).to eq(existing)
+        expect(created_meeting.reload).to be_open
+      end
+
+      it "does not create another meeting" do
+        expect { instance.call(**params) }.not_to change(Meeting, :count)
+      end
+    end
+  end
+
   describe "handling the interim responses" do
     let(:start_time) { series.start_time + 10.days }
 


### PR DESCRIPTION
https://community.openproject.org/projects/MEET/work_packages/MEET-571/activity


- [x] Add a check constraint to prevent NULL recurrence_start_time for non-templates, and ensure it for templates
- [x] Turn the "open" button on meeting series show page to a form, so we can prevent double submits
- [x] Look for an existing open instance when trying to instantiate it