### PR TITLE
[DREAM-740] Autocomplete options overlap the project list

### DIFF
--- a/app/components/header/projects/filterable_tree_view_component.html.erb
+++ b/app/components/header/projects/filterable_tree_view_component.html.erb
@@ -34,6 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
           include_sub_items_check_box_arguments: { hidden: true },
           filter_mode_control_arguments: logged? ? {} : { hidden: true },
           filter_input_arguments: { autofocus: true,
+                                    autocomplete: "off",
                                     data: { test_selector: "op-header-project-select--search" } },
           no_results_node_arguments: { data: { test_selector: "op-header-project-select--no-results" },
                                        label: I18n.t("filterable_tree_view.no_results_text") }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-740

# What are you trying to accomplish?
Turn autocomplete options off for the project selector

