### PR TITLE
Bug/COMMS-865: Keep polled-in activity comments in view while they settle

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -284,7 +284,7 @@ describe('Activities tab auto-scrolling controller', () => {
       return scrollIntoView;
     }
 
-    let followSpy:MockInstance<(onSettle:() => void) => void>;
+    let followSpy:MockInstance<(onSettle:() => void, options?:{ delay?:number }) => void>;
     let stopSpy:MockInstance<() => void>;
 
     beforeEach(() => {
@@ -337,27 +337,23 @@ describe('Activities tab auto-scrolling controller', () => {
     });
 
     // On mobile the comment input, not the container, is the scroll target, and the
-    // follow waits for the on-screen keyboard to settle before it opens.
+    // settle window waits for the on-screen keyboard to settle before it opens. The
+    // delay is handed to the window rather than timed here, so disconnecting while
+    // it is still pending tears it down with everything else.
     it('follows the input into view once the keyboard settles on mobile', async () => {
       const { index } = await renderActivities();
       index.sortingValue = 'asc';
       const scrollIntoView = stubMobileInput(index);
 
-      vi.useFakeTimers();
-      try {
-        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+      autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
 
-        expect(followSpy).not.toHaveBeenCalled();
-        vi.advanceTimersByTime(300);
-        expect(followSpy).toHaveBeenCalledTimes(1);
+      expect(followSpy).toHaveBeenCalledTimes(1);
+      expect(followSpy).toHaveBeenCalledWith(expect.any(Function), { delay: 300 });
 
-        // The callback scrolls the input, not the container, into view.
-        const [onSettle] = followSpy.mock.calls[0];
-        onSettle();
-        expect(scrollIntoView).toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+      // The callback scrolls the input, not the container, into view.
+      const [onSettle] = followSpy.mock.calls[0];
+      onSettle();
+      expect(scrollIntoView).toHaveBeenCalled();
     });
 
     // Submitting your own comment streams in an entry the same way, after the longer
@@ -367,21 +363,14 @@ describe('Activities tab auto-scrolling controller', () => {
       index.sortingValue = 'asc';
       const scrollIntoView = stubMobileInput(index);
 
-      vi.useFakeTimers();
-      try {
-        autoScrollingController().performAutoScrollingOnFormSubmit();
+      autoScrollingController().performAutoScrollingOnFormSubmit();
 
-        vi.advanceTimersByTime(300);
-        expect(followSpy).not.toHaveBeenCalled();
-        vi.advanceTimersByTime(500);
-        expect(followSpy).toHaveBeenCalledTimes(1);
+      expect(followSpy).toHaveBeenCalledTimes(1);
+      expect(followSpy).toHaveBeenCalledWith(expect.any(Function), { delay: 800 });
 
-        const [onSettle] = followSpy.mock.calls[0];
-        onSettle();
-        expect(scrollIntoView).toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+      const [onSettle] = followSpy.mock.calls[0];
+      onSettle();
+      expect(scrollIntoView).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -264,9 +264,9 @@ describe('Activities tab auto-scrolling controller', () => {
       return ctx.getController<AutoScrollingControllerType>('work-packages--activities-tab--auto-scrolling', el);
     }
 
-    // A streamed-in entry keeps growing as its avatar, reactions, and media render,
-    // so a single scroll can land just above it. The controller follows the bottom
-    // while the height settles.
+    // A streamed-in entry carries images that reserve no height until they load, so
+    // it keeps growing and a single scroll can land just above it. The controller
+    // follows the bottom while the height settles.
     it('re-asserts the bottom as the new entry grows after insertion', async () => {
       const original = globalThis.ResizeObserver;
       let resize:(() => void) | undefined;
@@ -291,6 +291,109 @@ describe('Activities tab auto-scrolling controller', () => {
         resize?.();
 
         expect(scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'smooth' });
+      } finally {
+        vi.stubGlobal('ResizeObserver', original);
+      }
+    });
+
+    // Each poll opens a settle window; without teardown the prior window keeps its
+    // observer alive and scrolling. A newer update, or a disconnect, must close it.
+    it('tears down the prior settle window when a newer update streams in', async () => {
+      const observers:{ disconnected:boolean }[] = [];
+      const original = globalThis.ResizeObserver;
+      /* eslint-disable @typescript-eslint/no-empty-function */
+      vi.stubGlobal('ResizeObserver', class {
+        state = { disconnected: false };
+
+        constructor() { observers.push(this.state); }
+
+        observe() {}
+
+        disconnect() { this.state.disconnected = true; }
+      });
+      /* eslint-enable @typescript-eslint/no-empty-function */
+
+      try {
+        const { index, scroller } = await renderActivities();
+        index.sortingAscending = true;
+        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+
+        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+
+        expect(observers).toHaveLength(2);
+        expect(observers[0].disconnected).toBe(true);
+        expect(observers[1].disconnected).toBe(false);
+      } finally {
+        vi.stubGlobal('ResizeObserver', original);
+      }
+    });
+
+    it('stops following when the controller disconnects', async () => {
+      const observers:{ disconnected:boolean }[] = [];
+      const original = globalThis.ResizeObserver;
+      /* eslint-disable @typescript-eslint/no-empty-function */
+      vi.stubGlobal('ResizeObserver', class {
+        state = { disconnected: false };
+
+        constructor() { observers.push(this.state); }
+
+        observe() {}
+
+        disconnect() { this.state.disconnected = true; }
+      });
+      /* eslint-enable @typescript-eslint/no-empty-function */
+
+      try {
+        const { index, scroller } = await renderActivities();
+        index.sortingAscending = true;
+        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+
+        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+        expect(observers[0].disconnected).toBe(false);
+
+        const root = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
+        root.remove();
+        await ctx.nextFrame();
+
+        expect(observers[0].disconnected).toBe(true);
+      } finally {
+        vi.stubGlobal('ResizeObserver', original);
+      }
+    });
+
+    // The follow only knows the user was at the bottom when the entry arrived. If
+    // they scroll up while it settles, late growth must not yank them back down.
+    it('stops following once the user scrolls during the settle window', async () => {
+      let disconnected = false;
+      let resize:(() => void) | undefined;
+      const original = globalThis.ResizeObserver;
+      /* eslint-disable @typescript-eslint/no-empty-function */
+      vi.stubGlobal('ResizeObserver', class {
+        constructor(cb:() => void) { resize = () => { if (!disconnected) { cb(); } }; }
+
+        observe() {}
+
+        disconnect() { disconnected = true; }
+      });
+      /* eslint-enable @typescript-eslint/no-empty-function */
+
+      try {
+        const { index, scroller } = await renderActivities();
+        index.sortingAscending = true;
+        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+
+        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+        expect(scrollTo).toHaveBeenCalledTimes(1);
+
+        // The user grabs the scroll before the entry finishes growing.
+        window.dispatchEvent(new WheelEvent('wheel'));
+
+        Object.defineProperty(scroller, 'scrollHeight', { value: 1400, configurable: true });
+        resize?.();
+
+        expect(scrollTo).toHaveBeenCalledTimes(1);
+        expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
       } finally {
         vi.stubGlobal('ResizeObserver', original);
       }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -348,6 +348,51 @@ describe('Activities tab auto-scrolling controller', () => {
         vi.useRealTimers();
       }
     });
+
+    // Submitting your own comment streams in an entry that grows the same way, so
+    // it follows the input too, after the longer wait for the keyboard to dismiss.
+    it('follows the input into view after submitting on mobile', async () => {
+      const { index } = await renderActivities();
+      index.sortingAscending = true;
+      index.sortingDescending = false;
+      index.viewPortService.isMobile = () => true;
+
+      const input = document.createElement('div');
+      input.className = 'work-packages-activities-tab-journals-new-component';
+      const scrollIntoView = vi.fn();
+      input.scrollIntoView = scrollIntoView;
+      ctx.container
+        .querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!
+        .appendChild(input);
+
+      vi.useFakeTimers();
+      const original = globalThis.ResizeObserver;
+      let resize:(() => void) | undefined;
+      /* eslint-disable @typescript-eslint/no-empty-function */
+      vi.stubGlobal('ResizeObserver', class {
+        constructor(cb:() => void) { resize = cb; }
+        observe() {}
+        disconnect() {}
+      });
+      /* eslint-enable @typescript-eslint/no-empty-function */
+
+      try {
+        autoScrollingController().performAutoScrollingOnFormSubmit();
+
+        // The first scroll waits the longer keyboard-dismiss window after a send.
+        vi.advanceTimersByTime(300);
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(500);
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        // The entry's late content settles and the list grows.
+        resize?.();
+        expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.stubGlobal('ResizeObserver', original);
+        vi.useRealTimers();
+      }
+    });
   });
 
   // The controller sets the hash only when it decides to handle a link, so the

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -39,9 +39,13 @@ const HIGHLIGHTED_CLASS = '--anchor-highlighted';
 // through the index controller's viewport service. A real index controller pulls
 // in the whole activities tab, so this stub exposes only what the scroll paths read.
 class StubIndexController extends Controller {
-  sortingAscending = false;
+  // Mirror the real controller: both flags derive from one sort value, so a test
+  // can never leave them in the impossible both-true / both-false state.
+  sortingValue = 'desc';
 
-  sortingDescending = true;
+  get sortingAscending():boolean { return this.sortingValue === 'asc'; }
+
+  get sortingDescending():boolean { return this.sortingValue === 'desc'; }
 
   viewPortService:ViewPortServiceInterface = {
     scrollableContainer: null,
@@ -280,7 +284,7 @@ describe('Activities tab auto-scrolling controller', () => {
 
       try {
         const { index, scroller } = await renderActivities();
-        index.sortingAscending = true;
+        index.sortingValue = 'asc';
         Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
 
         autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
@@ -315,7 +319,7 @@ describe('Activities tab auto-scrolling controller', () => {
 
       try {
         const { index, scroller } = await renderActivities();
-        index.sortingAscending = true;
+        index.sortingValue = 'asc';
         Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
 
         autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
@@ -346,7 +350,7 @@ describe('Activities tab auto-scrolling controller', () => {
 
       try {
         const { index, scroller } = await renderActivities();
-        index.sortingAscending = true;
+        index.sortingValue = 'asc';
         Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
 
         autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
@@ -380,7 +384,7 @@ describe('Activities tab auto-scrolling controller', () => {
 
       try {
         const { index, scroller } = await renderActivities();
-        index.sortingAscending = true;
+        index.sortingValue = 'asc';
         Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
 
         autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
@@ -401,7 +405,7 @@ describe('Activities tab auto-scrolling controller', () => {
 
     it('does not scroll when the list was not already at the bottom', async () => {
       const { index } = await renderActivities();
-      index.sortingAscending = true;
+      index.sortingValue = 'asc';
 
       autoScrollingController().performAutoScrollingOnStreamsUpdate(false);
 
@@ -412,8 +416,7 @@ describe('Activities tab auto-scrolling controller', () => {
     // waits for the keyboard, then follows the same way as the entry settles.
     it('follows the input into view as the new entry settles on mobile', async () => {
       const { index } = await renderActivities();
-      index.sortingAscending = true;
-      index.sortingDescending = false;
+      index.sortingValue = 'asc';
       index.viewPortService.isMobile = () => true;
 
       const input = document.createElement('div');
@@ -456,8 +459,7 @@ describe('Activities tab auto-scrolling controller', () => {
     // it follows the input too, after the longer wait for the keyboard to dismiss.
     it('follows the input into view after submitting on mobile', async () => {
       const { index } = await renderActivities();
-      index.sortingAscending = true;
-      index.sortingDescending = false;
+      index.sortingValue = 'asc';
       index.viewPortService.isMobile = () => true;
 
       const input = document.createElement('div');

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -41,6 +41,8 @@ const HIGHLIGHTED_CLASS = '--anchor-highlighted';
 class StubIndexController extends Controller {
   sortingAscending = false;
 
+  sortingDescending = true;
+
   viewPortService:ViewPortServiceInterface = {
     scrollableContainer: null,
     isMobile: () => false,
@@ -254,6 +256,98 @@ describe('Activities tab auto-scrolling controller', () => {
     // The listener was bound to the controller's AbortController, so it no longer
     // mutates the URL after disconnect.
     expect(window.location.hash).toBe('#comment-139');
+  });
+
+  describe('streamed updates in an ascending list', () => {
+    function autoScrollingController() {
+      const el = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
+      return ctx.getController<AutoScrollingControllerType>('work-packages--activities-tab--auto-scrolling', el);
+    }
+
+    // A streamed-in entry keeps growing as its avatar, reactions, and media render,
+    // so a single scroll can land just above it. The controller follows the bottom
+    // while the height settles.
+    it('re-asserts the bottom as the new entry grows after insertion', async () => {
+      const original = globalThis.ResizeObserver;
+      let resize:(() => void) | undefined;
+      /* eslint-disable @typescript-eslint/no-empty-function */
+      vi.stubGlobal('ResizeObserver', class {
+        constructor(cb:() => void) { resize = cb; }
+        observe() {}
+        disconnect() {}
+      });
+      /* eslint-enable @typescript-eslint/no-empty-function */
+
+      try {
+        const { index, scroller } = await renderActivities();
+        index.sortingAscending = true;
+        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+
+        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+        expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
+
+        // The entry's late content settles and the list grows taller.
+        Object.defineProperty(scroller, 'scrollHeight', { value: 1400, configurable: true });
+        resize?.();
+
+        expect(scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'smooth' });
+      } finally {
+        vi.stubGlobal('ResizeObserver', original);
+      }
+    });
+
+    it('does not scroll when the list was not already at the bottom', async () => {
+      const { index } = await renderActivities();
+      index.sortingAscending = true;
+
+      autoScrollingController().performAutoScrollingOnStreamsUpdate(false);
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    // On mobile the comment input, not the container, is the scroll target. It
+    // waits for the keyboard, then follows the same way as the entry settles.
+    it('follows the input into view as the new entry settles on mobile', async () => {
+      const { index } = await renderActivities();
+      index.sortingAscending = true;
+      index.sortingDescending = false;
+      index.viewPortService.isMobile = () => true;
+
+      const input = document.createElement('div');
+      input.className = 'work-packages-activities-tab-journals-new-component';
+      const scrollIntoView = vi.fn();
+      input.scrollIntoView = scrollIntoView;
+      ctx.container
+        .querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!
+        .appendChild(input);
+
+      vi.useFakeTimers();
+      const original = globalThis.ResizeObserver;
+      let resize:(() => void) | undefined;
+      /* eslint-disable @typescript-eslint/no-empty-function */
+      vi.stubGlobal('ResizeObserver', class {
+        constructor(cb:() => void) { resize = cb; }
+        observe() {}
+        disconnect() {}
+      });
+      /* eslint-enable @typescript-eslint/no-empty-function */
+
+      try {
+        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+
+        // The first scroll waits for the on-screen keyboard to settle.
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(300);
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        // The entry's late content settles and the list grows.
+        resize?.();
+        expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.stubGlobal('ResizeObserver', original);
+        vi.useRealTimers();
+      }
+    });
   });
 
   // The controller sets the hash only when it decides to handle a link, so the

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.spec.ts
@@ -26,12 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { vi, type Mock } from 'vitest';
+import { vi, type Mock, type MockInstance } from 'vitest';
 import { Controller } from '@hotwired/stimulus';
 
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type AutoScrollingControllerType from './auto-scrolling.controller';
 import { ViewPortServiceInterface } from './services/view-port-service';
+import SettleWindow from './services/settle-window';
 
 const HIGHLIGHTED_CLASS = '--anchor-highlighted';
 
@@ -268,233 +269,117 @@ describe('Activities tab auto-scrolling controller', () => {
       return ctx.getController<AutoScrollingControllerType>('work-packages--activities-tab--auto-scrolling', el);
     }
 
-    // A streamed-in entry carries images that reserve no height until they load, so
-    // it keeps growing and a single scroll can land just above it. The controller
-    // follows the bottom while the height settles.
-    it('re-asserts the bottom as the new entry grows after insertion', async () => {
-      const original = globalThis.ResizeObserver;
-      let resize:(() => void) | undefined;
-      /* eslint-disable @typescript-eslint/no-empty-function */
-      vi.stubGlobal('ResizeObserver', class {
-        constructor(cb:() => void) { resize = cb; }
-        observe() {}
-        disconnect() {}
-      });
-      /* eslint-enable @typescript-eslint/no-empty-function */
+    // Marks the input as the mobile scroll target and returns its scrollIntoView spy.
+    function stubMobileInput(index:StubIndexController) {
+      index.viewPortService.isMobile = () => true;
 
-      try {
-        const { index, scroller } = await renderActivities();
-        index.sortingValue = 'asc';
-        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+      const input = document.createElement('div');
+      input.className = 'work-packages-activities-tab-journals-new-component';
+      const scrollIntoView = vi.fn();
+      input.scrollIntoView = scrollIntoView;
+      ctx.container
+        .querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!
+        .appendChild(input);
 
-        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
-        expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
+      return scrollIntoView;
+    }
 
-        // The entry's late content settles and the list grows taller.
-        Object.defineProperty(scroller, 'scrollHeight', { value: 1400, configurable: true });
-        resize?.();
+    let followSpy:MockInstance<(onSettle:() => void) => void>;
+    let stopSpy:MockInstance<() => void>;
 
-        expect(scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'smooth' });
-      } finally {
-        vi.stubGlobal('ResizeObserver', original);
-      }
+    beforeEach(() => {
+      followSpy = vi.spyOn(SettleWindow.prototype, 'follow').mockImplementation(() => undefined);
+      stopSpy = vi.spyOn(SettleWindow.prototype, 'stop').mockImplementation(() => undefined);
     });
 
-    // Each poll opens a settle window; without teardown the prior window keeps its
-    // observer alive and scrolling. A newer update, or a disconnect, must close it.
-    it('tears down the prior settle window when a newer update streams in', async () => {
-      const observers:{ disconnected:boolean }[] = [];
-      const original = globalThis.ResizeObserver;
-      /* eslint-disable @typescript-eslint/no-empty-function */
-      vi.stubGlobal('ResizeObserver', class {
-        state = { disconnected: false };
+    it('follows the container to its bottom when a new entry lands at the bottom', async () => {
+      const { index, scroller } = await renderActivities();
+      index.sortingValue = 'asc';
+      Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
 
-        constructor() { observers.push(this.state); }
+      autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
 
-        observe() {}
+      expect(followSpy).toHaveBeenCalledTimes(1);
 
-        disconnect() { this.state.disconnected = true; }
-      });
-      /* eslint-enable @typescript-eslint/no-empty-function */
-
-      try {
-        const { index, scroller } = await renderActivities();
-        index.sortingValue = 'asc';
-        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
-
-        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
-        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
-
-        expect(observers).toHaveLength(2);
-        expect(observers[0].disconnected).toBe(true);
-        expect(observers[1].disconnected).toBe(false);
-      } finally {
-        vi.stubGlobal('ResizeObserver', original);
-      }
+      // The callback handed to the settle window scrolls the container to the bottom.
+      const [onSettle] = followSpy.mock.calls[0];
+      onSettle();
+      expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
     });
 
-    it('stops following when the controller disconnects', async () => {
-      const observers:{ disconnected:boolean }[] = [];
-      const original = globalThis.ResizeObserver;
-      /* eslint-disable @typescript-eslint/no-empty-function */
-      vi.stubGlobal('ResizeObserver', class {
-        state = { disconnected: false };
-
-        constructor() { observers.push(this.state); }
-
-        observe() {}
-
-        disconnect() { this.state.disconnected = true; }
-      });
-      /* eslint-enable @typescript-eslint/no-empty-function */
-
-      try {
-        const { index, scroller } = await renderActivities();
-        index.sortingValue = 'asc';
-        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
-
-        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
-        expect(observers[0].disconnected).toBe(false);
-
-        const root = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
-        root.remove();
-        await ctx.nextFrame();
-
-        expect(observers[0].disconnected).toBe(true);
-      } finally {
-        vi.stubGlobal('ResizeObserver', original);
-      }
-    });
-
-    // The follow only knows the user was at the bottom when the entry arrived. If
-    // they scroll up while it settles, late growth must not yank them back down.
-    it('stops following once the user scrolls during the settle window', async () => {
-      let disconnected = false;
-      let resize:(() => void) | undefined;
-      const original = globalThis.ResizeObserver;
-      /* eslint-disable @typescript-eslint/no-empty-function */
-      vi.stubGlobal('ResizeObserver', class {
-        constructor(cb:() => void) { resize = () => { if (!disconnected) { cb(); } }; }
-
-        observe() {}
-
-        disconnect() { disconnected = true; }
-      });
-      /* eslint-enable @typescript-eslint/no-empty-function */
-
-      try {
-        const { index, scroller } = await renderActivities();
-        index.sortingValue = 'asc';
-        Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
-
-        autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
-        expect(scrollTo).toHaveBeenCalledTimes(1);
-
-        // The user grabs the scroll before the entry finishes growing.
-        window.dispatchEvent(new WheelEvent('wheel'));
-
-        Object.defineProperty(scroller, 'scrollHeight', { value: 1400, configurable: true });
-        resize?.();
-
-        expect(scrollTo).toHaveBeenCalledTimes(1);
-        expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
-      } finally {
-        vi.stubGlobal('ResizeObserver', original);
-      }
-    });
-
-    it('does not scroll when the list was not already at the bottom', async () => {
+    it('does not follow when the list was not already at the bottom', async () => {
       const { index } = await renderActivities();
       index.sortingValue = 'asc';
 
       autoScrollingController().performAutoScrollingOnStreamsUpdate(false);
 
-      expect(scrollTo).not.toHaveBeenCalled();
+      expect(followSpy).not.toHaveBeenCalled();
     });
 
-    // On mobile the comment input, not the container, is the scroll target. It
-    // waits for the keyboard, then follows the same way as the entry settles.
-    it('follows the input into view as the new entry settles on mobile', async () => {
+    it('does not follow a descending list, where new entries land at the top', async () => {
+      await renderActivities();
+
+      autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
+
+      expect(followSpy).not.toHaveBeenCalled();
+    });
+
+    it('stops the settle window when the controller disconnects', async () => {
       const { index } = await renderActivities();
       index.sortingValue = 'asc';
-      index.viewPortService.isMobile = () => true;
+      autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
 
-      const input = document.createElement('div');
-      input.className = 'work-packages-activities-tab-journals-new-component';
-      const scrollIntoView = vi.fn();
-      input.scrollIntoView = scrollIntoView;
-      ctx.container
-        .querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!
-        .appendChild(input);
+      const root = ctx.container.querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!;
+      root.remove();
+      await ctx.nextFrame();
+
+      expect(stopSpy).toHaveBeenCalled();
+    });
+
+    // On mobile the comment input, not the container, is the scroll target, and the
+    // follow waits for the on-screen keyboard to settle before it opens.
+    it('follows the input into view once the keyboard settles on mobile', async () => {
+      const { index } = await renderActivities();
+      index.sortingValue = 'asc';
+      const scrollIntoView = stubMobileInput(index);
 
       vi.useFakeTimers();
-      const original = globalThis.ResizeObserver;
-      let resize:(() => void) | undefined;
-      /* eslint-disable @typescript-eslint/no-empty-function */
-      vi.stubGlobal('ResizeObserver', class {
-        constructor(cb:() => void) { resize = cb; }
-        observe() {}
-        disconnect() {}
-      });
-      /* eslint-enable @typescript-eslint/no-empty-function */
-
       try {
         autoScrollingController().performAutoScrollingOnStreamsUpdate(true);
 
-        // The first scroll waits for the on-screen keyboard to settle.
-        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(followSpy).not.toHaveBeenCalled();
         vi.advanceTimersByTime(300);
-        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(followSpy).toHaveBeenCalledTimes(1);
 
-        // The entry's late content settles and the list grows.
-        resize?.();
-        expect(scrollIntoView).toHaveBeenCalledTimes(2);
+        // The callback scrolls the input, not the container, into view.
+        const [onSettle] = followSpy.mock.calls[0];
+        onSettle();
+        expect(scrollIntoView).toHaveBeenCalled();
       } finally {
-        vi.stubGlobal('ResizeObserver', original);
         vi.useRealTimers();
       }
     });
 
-    // Submitting your own comment streams in an entry that grows the same way, so
-    // it follows the input too, after the longer wait for the keyboard to dismiss.
+    // Submitting your own comment streams in an entry the same way, after the longer
+    // wait for the keyboard to dismiss.
     it('follows the input into view after submitting on mobile', async () => {
       const { index } = await renderActivities();
       index.sortingValue = 'asc';
-      index.viewPortService.isMobile = () => true;
-
-      const input = document.createElement('div');
-      input.className = 'work-packages-activities-tab-journals-new-component';
-      const scrollIntoView = vi.fn();
-      input.scrollIntoView = scrollIntoView;
-      ctx.container
-        .querySelector('[data-controller~="work-packages--activities-tab--auto-scrolling"]')!
-        .appendChild(input);
+      const scrollIntoView = stubMobileInput(index);
 
       vi.useFakeTimers();
-      const original = globalThis.ResizeObserver;
-      let resize:(() => void) | undefined;
-      /* eslint-disable @typescript-eslint/no-empty-function */
-      vi.stubGlobal('ResizeObserver', class {
-        constructor(cb:() => void) { resize = cb; }
-        observe() {}
-        disconnect() {}
-      });
-      /* eslint-enable @typescript-eslint/no-empty-function */
-
       try {
         autoScrollingController().performAutoScrollingOnFormSubmit();
 
-        // The first scroll waits the longer keyboard-dismiss window after a send.
         vi.advanceTimersByTime(300);
-        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(followSpy).not.toHaveBeenCalled();
         vi.advanceTimersByTime(500);
-        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(followSpy).toHaveBeenCalledTimes(1);
 
-        // The entry's late content settles and the list grows.
-        resize?.();
-        expect(scrollIntoView).toHaveBeenCalledTimes(2);
+        const [onSettle] = followSpy.mock.calls[0];
+        onSettle();
+        expect(scrollIntoView).toHaveBeenCalled();
       } finally {
-        vi.stubGlobal('ResizeObserver', original);
         vi.useRealTimers();
       }
     });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -31,6 +31,10 @@
 import BaseController from './base.controller';
 import { UrlHelpers, ActivityAnchorType, ActivityAnchor } from './services/url-helpers';
 
+// How long to keep following the bottom after a streamed entry arrives, covering
+// late layout growth as its avatar, reactions, and media finish rendering.
+const STREAM_SETTLE_MS = 1000;
+
 interface CustomEventWithIdParam extends Event {
   params:{
     id:string;
@@ -72,14 +76,48 @@ export default class AutoScrollingController extends BaseController {
   }
 
   performAutoScrollingOnStreamsUpdate(journalsContainerAtBottom = false) {
-    if (this.indexOutlet.sortingAscending && journalsContainerAtBottom) {
-      // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before a new activity was added
-      if (this.isMobile()) {
-        this.scrollInputContainerIntoView(300);
-      } else {
-        this.scrollJournalContainer(true, true);
-      }
+    // Only follow a new activity into view when it lands at the foot of an
+    // ascending list the user was already reading the bottom of.
+    if (!this.indexOutlet.sortingAscending || !journalsContainerAtBottom) { return; }
+
+    if (this.isMobile()) {
+      this.keepInputInViewWhileSettling();
+    } else {
+      this.keepScrolledToBottomWhileSettling();
     }
+  }
+
+  // A streamed-in entry keeps growing for a moment after insertion as its avatar,
+  // reactions, and media render, leaving a one-shot scroll short of its final
+  // position. Re-assert the scroll while the height settles, then stop so we never
+  // fight a later deliberate scroll.
+  private followWhileSettling(scroll:() => void) {
+    scroll();
+
+    const observer = new ResizeObserver(scroll);
+    observer.observe(this.element);
+    setTimeout(() => observer.disconnect(), STREAM_SETTLE_MS);
+  }
+
+  private keepScrolledToBottomWhileSettling() {
+    const scrollableContainer = this.scrollableContainer;
+    if (!scrollableContainer) { return; }
+
+    this.followWhileSettling(() => scrollableContainer.scrollTo({
+      top: scrollableContainer.scrollHeight,
+      behavior: 'smooth',
+    }));
+  }
+
+  private keepInputInViewWhileSettling() {
+    const inputContainer = this.inputContainer;
+    if (!inputContainer) { return; }
+
+    // Wait for the on-screen keyboard to settle before the first scroll.
+    setTimeout(() => this.followWhileSettling(() => inputContainer.scrollIntoView({
+      behavior: 'smooth',
+      block: this.indexOutlet.sortingDescending ? 'nearest' : 'start',
+    })), 300);
   }
 
   performAutoScrollingOnFormSubmit() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -32,7 +32,7 @@ import BaseController from './base.controller';
 import { UrlHelpers, ActivityAnchorType, ActivityAnchor } from './services/url-helpers';
 
 // How long to keep following the bottom after a streamed entry arrives, covering
-// late layout growth as its avatar, reactions, and media finish rendering.
+// the late layout growth as its images reserve their height only once they load.
 const STREAM_SETTLE_MS = 1000;
 
 // Mobile on-screen keyboard timings, tuned on device. The keyboard slides while
@@ -57,6 +57,12 @@ export default class AutoScrollingController extends BaseController {
 
   private abortController!:AbortController;
 
+  // A single settle window at a time: a newer streamed entry, or a teardown,
+  // cancels the one in flight rather than leaving it scrolling in the background.
+  private settleObserver?:ResizeObserver;
+  private settleTimeout?:ReturnType<typeof setTimeout>;
+  private settleAbort?:AbortController;
+
   connect() {
     super.connect();
 
@@ -71,6 +77,7 @@ export default class AutoScrollingController extends BaseController {
 
   disconnect() {
     this.abortController.abort();
+    this.stopFollowing();
   }
 
   setAnchor(event:CustomEventWithIdParam) {
@@ -92,16 +99,38 @@ export default class AutoScrollingController extends BaseController {
     }
   }
 
-  // A streamed-in entry keeps growing for a moment after insertion as its avatar,
-  // reactions, and media render, leaving a one-shot scroll short of its final
-  // position. Re-assert the scroll while the height settles, then stop so we never
-  // fight a later deliberate scroll.
+  // A streamed-in entry carries images that reserve no height until they load, so
+  // it keeps growing for a moment after insertion and a one-shot scroll lands short
+  // of its final position. Re-assert the scroll while the height settles, yielding
+  // the moment the user scrolls so we never fight them, and stop once it closes.
   private followWhileSettling(scroll:() => void) {
+    this.stopFollowing();
     scroll();
 
-    const observer = new ResizeObserver(scroll);
-    observer.observe(this.element);
-    setTimeout(() => observer.disconnect(), STREAM_SETTLE_MS);
+    this.settleObserver = new ResizeObserver(scroll);
+    this.settleObserver.observe(this.element);
+
+    // A user scrolling mid-settle has taken over; wheel and touch gestures come
+    // only from them, never from our own scroll, so yield the moment one fires.
+    this.settleAbort = new AbortController();
+    const yieldToUser = () => this.stopFollowing();
+    window.addEventListener('wheel', yieldToUser, { signal: this.settleAbort.signal, passive: true });
+    window.addEventListener('touchmove', yieldToUser, { signal: this.settleAbort.signal, passive: true });
+
+    this.settleTimeout = setTimeout(() => this.stopFollowing(), STREAM_SETTLE_MS);
+  }
+
+  private stopFollowing() {
+    this.settleObserver?.disconnect();
+    this.settleObserver = undefined;
+
+    this.settleAbort?.abort();
+    this.settleAbort = undefined;
+
+    if (this.settleTimeout) {
+      clearTimeout(this.settleTimeout);
+      this.settleTimeout = undefined;
+    }
   }
 
   private keepScrolledToBottomWhileSettling() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -35,6 +35,11 @@ import { UrlHelpers, ActivityAnchorType, ActivityAnchor } from './services/url-h
 // late layout growth as its avatar, reactions, and media finish rendering.
 const STREAM_SETTLE_MS = 1000;
 
+// Mobile on-screen keyboard timings, tuned on device. The keyboard slides while
+// we scroll, so we wait it out before the first scroll settles the input.
+const KEYBOARD_SETTLE_MS = 300; // poll arrives with the keyboard already down
+const SUBMIT_KEYBOARD_DISMISS_MS = 800; // own comment sent, keyboard dismissing
+
 interface CustomEventWithIdParam extends Event {
   params:{
     id:string;
@@ -109,37 +114,32 @@ export default class AutoScrollingController extends BaseController {
     }));
   }
 
-  private keepInputInViewWhileSettling() {
-    const inputContainer = this.inputContainer;
-    if (!inputContainer) { return; }
+  private keepInputInViewWhileSettling(initialDelay = KEYBOARD_SETTLE_MS) {
+    if (!this.inputContainer) { return; }
 
     // Wait for the on-screen keyboard to settle before the first scroll.
-    setTimeout(() => this.followWhileSettling(() => inputContainer.scrollIntoView({
-      behavior: 'smooth',
-      block: this.indexOutlet.sortingDescending ? 'nearest' : 'start',
-    })), 300);
+    setTimeout(() => this.followWhileSettling(() => this.scrollInputIntoView()), initialDelay);
   }
 
   performAutoScrollingOnFormSubmit() {
     if (this.isMobile() && !this.isWithinNotificationCenter()) {
-      // wait for the keyboard to be fully down before scrolling further
-      // timeout amount tested on mobile devices for best possible user experience
-      this.scrollInputContainerIntoView(800);
+      // Your own comment streams in and keeps growing like a polled one, so follow
+      // it while it settles rather than scrolling once the keyboard is down.
+      this.keepInputInViewWhileSettling(SUBMIT_KEYBOARD_DISMISS_MS);
     } else {
       this.scrollJournalContainer(this.indexOutlet.sortingAscending, true);
     }
   }
 
-  scrollInputContainerIntoView(timeout = 0, behavior:ScrollBehavior = 'smooth') {
-    const inputContainer = this.inputContainer;
-    setTimeout(() => {
-      if (inputContainer) {
-        inputContainer.scrollIntoView({
-          behavior,
-          block: this.indexOutlet.sortingDescending ? 'nearest' : 'start',
-        });
-      }
-    }, timeout);
+  scrollInputContainerIntoView(timeout = 0) {
+    setTimeout(() => this.scrollInputIntoView(), timeout);
+  }
+
+  private scrollInputIntoView() {
+    this.inputContainer?.scrollIntoView({
+      behavior: 'smooth',
+      block: this.indexOutlet.sortingDescending ? 'nearest' : 'start',
+    });
   }
 
   scrollJournalContainer(toBottom:boolean, smooth = false) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -30,6 +30,7 @@
 
 import BaseController from './base.controller';
 import { UrlHelpers, ActivityAnchorType, ActivityAnchor } from './services/url-helpers';
+import SettleWindow from './services/settle-window';
 
 // How long to keep following the bottom after a streamed entry arrives, covering
 // the late layout growth as its images reserve their height only once they load.
@@ -57,11 +58,7 @@ export default class AutoScrollingController extends BaseController {
 
   private abortController!:AbortController;
 
-  // A single settle window at a time: a newer streamed entry, or a teardown,
-  // cancels the one in flight rather than leaving it scrolling in the background.
-  private settleObserver?:ResizeObserver;
-  private settleTimeout?:ReturnType<typeof setTimeout>;
-  private settleAbort?:AbortController;
+  private settleWindow!:SettleWindow;
 
   connect() {
     super.connect();
@@ -69,6 +66,7 @@ export default class AutoScrollingController extends BaseController {
     // Construct per connect so a disconnect→reconnect of the same instance gets a
     // fresh signal; an already-aborted one would silently drop these listeners.
     this.abortController = new AbortController();
+    this.settleWindow = new SettleWindow({ target: this.element, duration: STREAM_SETTLE_MS });
 
     window.addEventListener('hashchange', this.scrollToHashAnchor, { signal: this.abortController.signal });
     this.element.addEventListener('click', this.handleCommentReferenceClick, { signal: this.abortController.signal });
@@ -77,7 +75,7 @@ export default class AutoScrollingController extends BaseController {
 
   disconnect() {
     this.abortController.abort();
-    this.stopFollowing();
+    this.settleWindow.stop();
   }
 
   setAnchor(event:CustomEventWithIdParam) {
@@ -99,45 +97,11 @@ export default class AutoScrollingController extends BaseController {
     }
   }
 
-  // A streamed-in entry carries images that reserve no height until they load, so
-  // it keeps growing for a moment after insertion and a one-shot scroll lands short
-  // of its final position. Re-assert the scroll while the height settles, yielding
-  // the moment the user scrolls so we never fight them, and stop once it closes.
-  private followWhileSettling(scroll:() => void) {
-    this.stopFollowing();
-    scroll();
-
-    this.settleObserver = new ResizeObserver(scroll);
-    this.settleObserver.observe(this.element);
-
-    // A user scrolling mid-settle has taken over; wheel and touch gestures come
-    // only from them, never from our own scroll, so yield the moment one fires.
-    this.settleAbort = new AbortController();
-    const yieldToUser = () => this.stopFollowing();
-    window.addEventListener('wheel', yieldToUser, { signal: this.settleAbort.signal, passive: true });
-    window.addEventListener('touchmove', yieldToUser, { signal: this.settleAbort.signal, passive: true });
-
-    this.settleTimeout = setTimeout(() => this.stopFollowing(), STREAM_SETTLE_MS);
-  }
-
-  private stopFollowing() {
-    this.settleObserver?.disconnect();
-    this.settleObserver = undefined;
-
-    this.settleAbort?.abort();
-    this.settleAbort = undefined;
-
-    if (this.settleTimeout) {
-      clearTimeout(this.settleTimeout);
-      this.settleTimeout = undefined;
-    }
-  }
-
   private keepScrolledToBottomWhileSettling() {
     const scrollableContainer = this.scrollableContainer;
     if (!scrollableContainer) { return; }
 
-    this.followWhileSettling(() => scrollableContainer.scrollTo({
+    this.settleWindow.follow(() => scrollableContainer.scrollTo({
       top: scrollableContainer.scrollHeight,
       behavior: 'smooth',
     }));
@@ -147,7 +111,7 @@ export default class AutoScrollingController extends BaseController {
     if (!this.inputContainer) { return; }
 
     // Wait for the on-screen keyboard to settle before the first scroll.
-    setTimeout(() => this.followWhileSettling(() => this.scrollInputIntoView()), initialDelay);
+    setTimeout(() => this.settleWindow.follow(() => this.scrollInputIntoView()), initialDelay);
   }
 
   performAutoScrollingOnFormSubmit() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -111,7 +111,7 @@ export default class AutoScrollingController extends BaseController {
     if (!this.inputContainer) { return; }
 
     // Wait for the on-screen keyboard to settle before the first scroll.
-    setTimeout(() => this.settleWindow.follow(() => this.scrollInputIntoView()), initialDelay);
+    this.settleWindow.follow(() => this.scrollInputIntoView(), { delay: initialDelay });
   }
 
   performAutoScrollingOnFormSubmit() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/editor.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/editor.controller.ts
@@ -37,6 +37,11 @@ import BaseController from './base.controller';
 import type PollingController from './polling.controller';
 import type { TurboSubmitEndEvent, TurboSubmitStartEvent } from '@hotwired/turbo';
 
+// Mobile on-screen keyboard timings, tuned on device: wait for the keyboard
+// transition to finish before scrolling the input into view.
+const KEYBOARD_DISMISS_MS = 500; // editor hidden, keyboard sliding down
+const KEYBOARD_FOCUS_MS = 200; // editor focused, keyboard sliding up
+
 export default class EditorController extends BaseController {
   static outlets = [
     'work-packages--activities-tab--auto-scrolling',
@@ -124,9 +129,7 @@ export default class EditorController extends BaseController {
     this.indexOutlet.hideJournalsContainerInput();
 
     if (this.isMobile()) {
-      // wait for the keyboard to be fully down before scrolling further
-      // timeout amount tested on mobile devices for best possible user experience
-      this.autoScrollingOutlet.scrollInputContainerIntoView(500);
+      this.autoScrollingOutlet.scrollInputContainerIntoView(KEYBOARD_DISMISS_MS);
     }
   }
 
@@ -189,7 +192,7 @@ export default class EditorController extends BaseController {
       onBlurEditor: () => { void this.onBlurEditor(); },
       onFocusEditor: () => {
         void this.onFocusEditor();
-        if (this.isMobile()) { void this.autoScrollingOutlet.scrollInputContainerIntoView(200); }
+        if (this.isMobile()) { void this.autoScrollingOutlet.scrollInputContainerIntoView(KEYBOARD_FOCUS_MS); }
       },
     };
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.spec.ts
@@ -122,6 +122,48 @@ describe('SettleWindow', () => {
     expect(observers[1].disconnected).toBe(false);
   });
 
+  it('waits out the given delay before opening', () => {
+    vi.useFakeTimers();
+    const onSettle = vi.fn();
+
+    open().follow(onSettle, { delay: 300 });
+
+    expect(onSettle).not.toHaveBeenCalled();
+    expect(observers).toHaveLength(0);
+
+    vi.advanceTimersByTime(300);
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(observers[0].observed).toContain(target);
+  });
+
+  it('cancels a follow still waiting out its delay on stop()', () => {
+    vi.useFakeTimers();
+    const onSettle = vi.fn();
+    const settleWindow = open();
+
+    settleWindow.follow(onSettle, { delay: 300 });
+    settleWindow.stop();
+    vi.advanceTimersByTime(300);
+
+    expect(onSettle).not.toHaveBeenCalled();
+    expect(observers).toHaveLength(0);
+  });
+
+  it('supersedes a follow still waiting out its delay on a fresh follow', () => {
+    vi.useFakeTimers();
+    const delayed = vi.fn();
+    const fresh = vi.fn();
+    const settleWindow = open();
+
+    settleWindow.follow(delayed, { delay: 300 });
+    settleWindow.follow(fresh);
+    vi.advanceTimersByTime(300);
+
+    expect(delayed).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledTimes(1);
+  });
+
   it('stops observing and ignores later gestures after stop()', () => {
     const settleWindow = open();
     settleWindow.follow(vi.fn());

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SettleWindow from './settle-window';
+
+describe('SettleWindow', () => {
+  let target:HTMLElement;
+  let observers:FakeResizeObserver[];
+  let originalResizeObserver:typeof ResizeObserver;
+
+  // Captures each observer so a test can fire its callback and inspect teardown.
+  class FakeResizeObserver {
+    observed:Element[] = [];
+
+    disconnected = false;
+
+    constructor(public readonly callback:() => void) { observers.push(this); }
+
+    observe(element:Element) { this.observed.push(element); }
+
+    disconnect() { this.disconnected = true; }
+  }
+
+  function open(duration = 1000, yieldOn?:string[]) {
+    return new SettleWindow({ target, duration, yieldOn });
+  }
+
+  beforeEach(() => {
+    observers = [];
+    target = document.createElement('div');
+    originalResizeObserver = globalThis.ResizeObserver;
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.stubGlobal('ResizeObserver', originalResizeObserver);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('asserts the callback immediately and observes the target', () => {
+    const onSettle = vi.fn();
+
+    open().follow(onSettle);
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(observers[0].observed).toContain(target);
+  });
+
+  it('re-asserts the callback each time the target resizes', () => {
+    const onSettle = vi.fn();
+    open().follow(onSettle);
+
+    observers[0].callback();
+    observers[0].callback();
+
+    // one immediate assert plus one per resize
+    expect(onSettle).toHaveBeenCalledTimes(3);
+  });
+
+  it('closes on its own once the duration elapses', () => {
+    vi.useFakeTimers();
+    open(1000).follow(vi.fn());
+
+    vi.advanceTimersByTime(1000);
+
+    expect(observers[0].disconnected).toBe(true);
+  });
+
+  it('yields to the user on the first scroll gesture', () => {
+    open().follow(vi.fn());
+
+    window.dispatchEvent(new WheelEvent('wheel'));
+
+    expect(observers[0].disconnected).toBe(true);
+  });
+
+  it('yields to the user on a touch gesture', () => {
+    open().follow(vi.fn());
+
+    window.dispatchEvent(new Event('touchmove'));
+
+    expect(observers[0].disconnected).toBe(true);
+  });
+
+  it('runs only one window at a time, tearing down the prior on a fresh follow', () => {
+    const settleWindow = open();
+
+    settleWindow.follow(vi.fn());
+    settleWindow.follow(vi.fn());
+
+    expect(observers).toHaveLength(2);
+    expect(observers[0].disconnected).toBe(true);
+    expect(observers[1].disconnected).toBe(false);
+  });
+
+  it('stops observing and ignores later gestures after stop()', () => {
+    const settleWindow = open();
+    settleWindow.follow(vi.fn());
+
+    settleWindow.stop();
+    expect(observers[0].disconnected).toBe(true);
+
+    // stop() tears down the gesture listeners too, so a late scroll does nothing.
+    expect(() => window.dispatchEvent(new WheelEvent('wheel'))).not.toThrow();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.ts
@@ -35,19 +35,36 @@ interface SettleWindowOptions {
   yieldOn?:readonly string[];
 }
 
+interface FollowOptions {
+  // Defers the window's opening; the duration only starts counting once it opens.
+  delay?:number;
+}
+
 // Images reserve their height only once they load, so a single scroll to a freshly
 // inserted entry lands short of the settled layout. This re-runs the callback for a
 // bounded window as the element grows, and yields the moment the user scrolls.
 export default class SettleWindow {
   private observer?:ResizeObserver;
   private timeout?:ReturnType<typeof setTimeout>;
+  private delayTimeout?:ReturnType<typeof setTimeout>;
   private abort?:AbortController;
 
   constructor(private readonly options:SettleWindowOptions) {}
 
-  // Runs onSettle immediately, then on every resize until the window closes.
-  follow(onSettle:() => void) {
+  // Runs onSettle once the delay elapses, then on every resize until the window
+  // closes. stop() also cancels a follow still waiting out its delay, so the
+  // window's whole lifecycle, opened or pending, ends with it.
+  follow(onSettle:() => void, { delay = 0 }:FollowOptions = {}) {
     this.stop();
+
+    if (delay > 0) {
+      this.delayTimeout = setTimeout(() => this.open(onSettle), delay);
+    } else {
+      this.open(onSettle);
+    }
+  }
+
+  private open(onSettle:() => void) {
     onSettle();
 
     this.observer = new ResizeObserver(onSettle);
@@ -72,6 +89,11 @@ export default class SettleWindow {
     if (this.timeout) {
       clearTimeout(this.timeout);
       this.timeout = undefined;
+    }
+
+    if (this.delayTimeout) {
+      clearTimeout(this.delayTimeout);
+      this.delayTimeout = undefined;
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.ts
@@ -1,0 +1,77 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+interface SettleWindowOptions {
+  target:Element;
+  duration:number;
+  // Gestures that signal the user has taken over; defaults to wheel and touchmove.
+  yieldOn?:readonly string[];
+}
+
+// Images reserve their height only once they load, so a single scroll to a freshly
+// inserted entry lands short of the settled layout. This re-runs the callback for a
+// bounded window as the element grows, and yields the moment the user scrolls.
+export default class SettleWindow {
+  private observer?:ResizeObserver;
+  private timeout?:ReturnType<typeof setTimeout>;
+  private abort?:AbortController;
+
+  constructor(private readonly options:SettleWindowOptions) {}
+
+  // Runs onSettle immediately, then on every resize until the window closes.
+  follow(onSettle:() => void) {
+    this.stop();
+    onSettle();
+
+    this.observer = new ResizeObserver(onSettle);
+    this.observer.observe(this.options.target);
+
+    this.abort = new AbortController();
+    const yieldToUser = () => this.stop();
+    for (const gesture of this.options.yieldOn ?? ['wheel', 'touchmove']) {
+      window.addEventListener(gesture, yieldToUser, { signal: this.abort.signal, passive: true });
+    }
+
+    this.timeout = setTimeout(() => this.stop(), this.options.duration);
+  }
+
+  stop() {
+    this.observer?.disconnect();
+    this.observer = undefined;
+
+    this.abort?.abort();
+    this.abort = undefined;
+
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/settle-window.ts
@@ -86,14 +86,10 @@ export default class SettleWindow {
     this.abort?.abort();
     this.abort = undefined;
 
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-      this.timeout = undefined;
-    }
+    clearTimeout(this.timeout);
+    this.timeout = undefined;
 
-    if (this.delayTimeout) {
-      clearTimeout(this.delayTimeout);
-      this.delayTimeout = undefined;
-    }
+    clearTimeout(this.delayTimeout);
+    this.delayTimeout = undefined;
   }
 }

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -23,10 +23,14 @@ if (typeof CSS === 'undefined' || typeof CSS.escape !== 'function') {
   (globalThis as any).CSS.escape = (value:string) => String(value).replace(/[^a-zA-Z0-9_\-]/g, (ch) => `\\${ch}`);
 }
 
-// jsdom does not implement ResizeObserver.
+// jsdom does not implement ResizeObserver. The shim declares the native
+// constructor signature so static analysis resolving the global to this class
+// still accepts the callback every real call site passes.
 if (typeof (globalThis as any).ResizeObserver === 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).ResizeObserver = class {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor(_callback:ResizeObserverCallback) {}
     observe() {}
     unobserve() {}
     disconnect() {}


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/COMMS-865

## What issue are we solving?

When a new comment streams into the activity tab via polling while you are reading the bottom of an ascending list ("newest at the bottom"), the view is supposed to follow it into view. If the comment carries an image it can land short: the auto-scroll fires once, shortly after the entry renders, with a target computed from the scroll height at that instant. An image reserves no height until it finishes loading, so the entry keeps growing after the scroll has already run and the comment ends up below the fold, offset by exactly the image's rendered height.

The miss looks intermittent in the wild because Chrome's scroll anchoring sometimes rescues it: while the growing image box still intersects the viewport, the browser bumps the scroll position to compensate. Once the comment is long enough that the image sits fully below the fold when the scroll animation ends (a few paragraphs before a screenshot is all it takes), the miss is deterministic.

## How to reproduce it manually

1. Open a work package's activity tab sorted "newest at the bottom" and scroll to the bottom.
2. Throttle the network in that browser (DevTools > Network > Slow 4G). On a local stack attachments otherwise load faster than the race window.
3. From a second session, post a comment with several paragraphs, then an inline image, then one final line of text.
4. Wait for polling to bring it in (up to 10 seconds).

Without this change the view scrolls partway and stops; the image and the final line sit below the fold. With it, the view follows the comment as the image pops in and the final line ends up on screen.

## Fix

Instead of scrolling once toward a height that is still changing, the auto-scroll now follows the bottom for a bounded settle window (1s) after a streamed entry arrives: a `ResizeObserver` on the journals container re-asserts the scroll whenever the entry grows, and the follow yields on the first wheel or touch gesture so a deliberate scroll-away is never fought. Only one window runs at a time and it is torn down with the controller. The same mechanism keeps the comment input in view on mobile, where the on-screen keyboard adds its own settling delay.

A `ResizeObserver` is the right signal because it catches layout growth a `MutationObserver` misses: an image finishing loading changes the height without mutating the DOM.

**Before:**

https://github.com/user-attachments/assets/fdffe05e-4782-4a84-bfe7-bd535759b58c

**After:**

https://github.com/user-attachments/assets/28b1f822-4a3c-4905-a2a0-625a64aa902b

Reserving each image's box on the rendered comment so the entry never grows after insert is the proper fix for the underlying layout shift and remains separate follow-up work; images that finish loading after the settle window closes (roughly 1.8s after the entry is inserted) can still land short in the meantime.

## Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
