### PR TITLE
[DREAM-739] Password manager doesn't work on password overlay

### DIFF
--- a/app/components/my/password_confirmation_dialog.html.erb
+++ b/app/components/my/password_confirmation_dialog.html.erb
@@ -27,35 +27,41 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(Primer::Alpha::Dialog.new(
-      id: "password-confirmation-dialog",
-      title: t(".title"),
-      data: { controller: "password-confirmation-dialog" },
-      test_selector: "op-my--password-confirmation-dialog"
-    )) do |dialog|
+<%= render(
+      Primer::Alpha::Dialog.new(
+        id: "password-confirmation-dialog",
+        title: t(".title"),
+        data: { controller: "password-confirmation-dialog" },
+        test_selector: "op-my--password-confirmation-dialog"
+      )
+    ) do |dialog|
       dialog.with_body do
         content_tag(:form, id: "password-confirmation-form", data: { password_confirmation_dialog_target: "form" }) do
-          render(Primer::Alpha::TextField.new(
-            type: "password",
-            name: "password_confirmation",
-            label: User.human_attribute_name(:password),
-            caption: t(".confirmation_required"),
-            data: { password_confirmation_dialog_target: "passwordInput" }
-          ))
+          render(
+            Primer::Alpha::TextField.new(
+              type: "password",
+              name: "password_confirmation",
+              label: User.human_attribute_name(:password),
+              caption: t(".confirmation_required"),
+              autocomplete: "current-password",
+              data: { password_confirmation_dialog_target: "passwordInput" }
+            )
+          )
         end
       end
 
       dialog.with_footer do
         concat(render(Primer::Beta::Button.new(data: { "close-dialog-id": "password-confirmation-dialog" })) { t("button_cancel") })
         concat(
-          render(Primer::Beta::Button.new(
-            scheme: :primary,
-            type: :submit,
-            form: "password-confirmation-form",
-            test_selector: "op-my--password-confirmation-dialog--submit-button",
-            data: { password_confirmation_dialog_target: "submitButton" }
-          )) { t("button_confirm") }
+          render(
+            Primer::Beta::Button.new(
+              scheme: :primary,
+              type: :submit,
+              form: "password-confirmation-form",
+              test_selector: "op-my--password-confirmation-dialog--submit-button",
+              data: { password_confirmation_dialog_target: "submitButton" }
+            )
+          ) { t("button_confirm") }
         )
       end
-    end
-%>
+    end %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-739

# What are you trying to accomplish?
Set autocomplet option for current passwort to enable password managers to fill it.

