### PR TITLE
[DREAM-708] Bottom project line is shorter than the others

### DIFF
--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -207,6 +207,7 @@ $widget-box--enumeration-width: 20px
 
 .op-widget-box--rows
   margin: 0
+  overflow: auto
 
 .op-widget-box--row
   padding: var(--stack-padding-normal)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-708

# What are you trying to accomplish?
Make rows within widget scrollable so that nothing is cut while the footer remains visible permanently

