### PR TITLE
Vulnerability/sc 246 information disclosure on openproject through api v3 work packages 2 via http method patch api v3 work packages id workpackagerepresenter cache

### DIFF
--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -177,6 +177,7 @@ module API
                                 link_getter: :"#{name}_id",
                                 link_property_name: nil,
                                 uncacheable_link: false,
+                                link_cache_if: nil,
                                 getter: associated_resource_default_getter(name, representer, as || name),
                                 setter: associated_resource_default_setter(name, as, v3_path),
                                 link: associated_resource_default_link_lambda(link_property_name || name,
@@ -190,6 +191,7 @@ module API
                    setter:,
                    link:,
                    uncacheable_link:,
+                   link_cache_if:,
                    skip_render:)
         end
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -615,6 +615,7 @@ module API
                             v3_path: :budget,
                             link_title_attribute: :subject,
                             representer: ::API::V3::Budgets::BudgetRepresenter,
+                            link_cache_if: -> { view_budgets_allowed? },
                             skip_render: ->(*) { !view_budgets_allowed? }
 
         resources :customActions,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -616,7 +616,12 @@ module API
                             link_title_attribute: :subject,
                             representer: ::API::V3::Budgets::BudgetRepresenter,
                             link_cache_if: -> { view_budgets_allowed? },
-                            skip_render: ->(*) { !view_budgets_allowed? }
+                            skip_render: ->(*) { !view_budgets_allowed? },
+                            getter: ->(*) {
+                              if embed_link?(:budget) && represented.budget && view_budgets_allowed?
+                                ::API::V3::Budgets::BudgetRepresenter.create(represented.budget, current_user:)
+                              end
+                            }
 
         resources :customActions,
                   uncacheable_link: true,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -616,7 +616,6 @@ module API
                             link_title_attribute: :subject,
                             representer: ::API::V3::Budgets::BudgetRepresenter,
                             link_cache_if: -> { view_budgets_allowed? },
-                            skip_render: ->(*) { !view_budgets_allowed? },
                             getter: ->(*) {
                               if embed_link?(:budget) && represented.budget && view_budgets_allowed?
                                 ::API::V3::Budgets::BudgetRepresenter.create(represented.budget, current_user:)

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -823,6 +823,37 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
             .not_to have_json_path("_embedded/budget")
         end
       end
+
+      context "when a privileged user's response is cached before the current user reads it" do
+        let(:cached_json_with_budget) do
+          {
+            "_type" => "WorkPackage",
+            "_links" => {
+              "budget" => {
+                "href" => "/api/v3/budgets/#{budget.id}",
+                "title" => budget.subject
+              }
+            }
+          }.to_json
+        end
+
+        before do
+          # Simulate a poisoned cache: a previous privileged-user render cached the
+          # budget link, but the shared cache key does not include the user's permission set.
+          allow(OpenProject::Cache)
+            .to receive(:fetch)
+            .and_call_original
+
+          allow(OpenProject::Cache)
+            .to receive(:fetch)
+            .with(representer.json_cache_key)
+            .and_return(cached_json_with_budget)
+        end
+
+        it "does not leak the budget link to the user lacking view_budgets (regression AGILE-296)" do
+          expect(subject).not_to have_json_path("_links/budget")
+        end
+      end
     end
 
     describe "schema" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -822,6 +822,12 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           expect(subject)
             .not_to have_json_path("_embedded/budget")
         end
+
+        it "does not instantiate a budget representer" do
+          allow(API::V3::Budgets::BudgetRepresenter).to receive(:create)
+          subject
+          expect(API::V3::Budgets::BudgetRepresenter).not_to have_received(:create)
+        end
       end
 
       context "when a privileged user's response is cached before the current user reads it" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -831,29 +831,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
       end
 
       context "when a privileged user's response is cached before the current user reads it" do
-        let(:cached_json_with_budget) do
-          {
-            "_type" => "WorkPackage",
-            "_links" => {
-              "budget" => {
-                "href" => "/api/v3/budgets/#{budget.id}",
-                "title" => budget.subject
-              }
-            }
-          }.to_json
+        let(:privileged_user) { build_stubbed(:admin) }
+        let(:privileged_representer) do
+          described_class.create(work_package, current_user: privileged_user, embed_links:)
         end
 
         before do
-          # Simulate a poisoned cache: a previous privileged-user render cached the
-          # budget link, but the shared cache key does not include the user's permission set.
-          allow(OpenProject::Cache)
-            .to receive(:fetch)
-            .and_call_original
-
-          allow(OpenProject::Cache)
-            .to receive(:fetch)
-            .with(representer.json_cache_key)
-            .and_return(cached_json_with_budget)
+          # Privileged user renders first, warming the shared cache key
+          privileged_representer.to_json
         end
 
         it "does not leak the budget link to the user lacking view_budgets (regression AGILE-296)" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -810,6 +810,22 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
             .to be_json_eql(budget.subject.to_json)
                   .at_path("_embedded/budget/subject")
         end
+
+        context "when a non-privileged user's response is cached before the current user reads it" do
+          let(:non_privileged_user) { build_stubbed(:user) }
+          let(:non_privileged_representer) do
+            described_class.create(work_package, current_user: non_privileged_user, embed_links:)
+          end
+
+          before do
+            # Non-privileged user renders first, warming the shared cache key
+            non_privileged_representer.to_json
+          end
+
+          it "still renders the budget link for the user having view_budgets (regression AGILE-296)" do
+            expect(subject).to have_json_path("_links/budget")
+          end
+        end
       end
 
       context "with the user lacking the view_budgets permission" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SC-246

# What are you trying to accomplish?
Fixes the API cache for budgets so that users with lacking permissions don't receive a resource with information they are not allowed to see.

I also double checked that **project custom fields** are not affected by this vulnerability since they explicitly [include their permission check](https://github.com/opf/openproject/blob/3dba43ffbf3dfdbe294b5efe1ccbfc69ebe651fa/app/models/projects/custom_fields.rb#L70) into the [cache key.](https://github.com/opf/openproject/blob/3dba43ffbf3dfdbe294b5efe1ccbfc69ebe651fa/lib/api/caching/cached_representer.rb#L206)

# What approach did you choose and why?
Apply a `link_cache_if` condition similar to [sprints](https://github.com/opf/openproject/blob/dev/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb#L51-L70). Same for the getter. Added a spec to verify the regression.


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
