### PR TITLE
[op-12578] Tooltip on Team planner not entirely visible 

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -726,11 +726,12 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   }
 
   showDisabledText(workPackage:WorkPackageResource):{ text:string, orientation:'left'|'right' } {
-    const dueDate = new Date(workPackage.dueDate).setHours(0, 0, 0, 0);
+    const startDate = new Date(workPackage.startDate ?? workPackage.date).setHours(0, 0, 0, 0);
     const firstCalendarDay = this.ucCalendar.getApi().view.currentStart.setHours(0, 0, 0, 0);
+
     return {
       text: this.calendarDrag.workPackageDisabledExplanation(workPackage),
-      orientation: dueDate === firstCalendarDay ? 'right' : 'left',
+      orientation: startDate === firstCalendarDay ? 'right' : 'left',
     };
   }
 

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -726,7 +726,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   }
 
   showDisabledText(workPackage:WorkPackageResource):{ text:string, orientation:'left'|'right' } {
-    const dueDate = new Date(workPackage.dueDate ?? workPackage.date).setHours(0, 0, 0, 0);
+    const dueDate = new Date(workPackage.dueDate).setHours(0, 0, 0, 0);
     const firstCalendarDay = this.ucCalendar.getApi().view.currentStart.setHours(0, 0, 0, 0);
     const thirdCalendarDay = moment(firstCalendarDay).add(2, 'days').valueOf();
 

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -726,12 +726,13 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   }
 
   showDisabledText(workPackage:WorkPackageResource):{ text:string, orientation:'left'|'right' } {
-    const startDate = new Date(workPackage.startDate ?? workPackage.date).setHours(0, 0, 0, 0);
+    const dueDate = new Date(workPackage.dueDate ?? workPackage.date).setHours(0, 0, 0, 0);
     const firstCalendarDay = this.ucCalendar.getApi().view.currentStart.setHours(0, 0, 0, 0);
+    const thirdCalendarDay = moment(firstCalendarDay).add(2, 'days').valueOf();
 
     return {
       text: this.calendarDrag.workPackageDisabledExplanation(workPackage),
-      orientation: startDate === firstCalendarDay ? 'right' : 'left',
+      orientation: dueDate <= thirdCalendarDay ? 'right' : 'left',
     };
   }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-12578

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The tooltip direction was based on the work package due date. For work packages that start on the first visible calendar day but end later, this caused the tooltip to open left into the frozen assignee column.
This changes the direction check to use the work package start date instead, so tooltips open right when the card begins at the left edge of the timeline.

## Screenshots

<img width="1198" height="242" alt="Screenshot 2026-06-26 at 17 50 05" src="https://github.com/user-attachments/assets/22d3fd6c-dfa2-4845-a3a4-3d156d9d79ee" />
<img width="1213" height="220" alt="Screenshot 2026-06-26 at 17 49 40" src="https://github.com/user-attachments/assets/391f34f8-7d7f-4bb6-97bd-ee263d801183" />
<img width="1216" height="196" alt="Screenshot 2026-06-26 at 17 48 57" src="https://github.com/user-attachments/assets/e6556b22-85fb-4027-96aa-d14ced5d6b44" />

