### PR TITLE
Make turbo wait helpers work under Selenium [Backlogs]

### DIFF
--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -812,80 +812,21 @@ module Pages
 
     # Waits for a backlogs move to settle.
     #
-    # A move responds with a turbo stream whose `turbo_frame_reload` action tells
-    # the `backlogs_container` frame to reload itself. That is two round-trips: the
-    # stream render (request 1, `op:turbo-stream-rendered`) and the frame reload it
-    # triggers (request 2, `turbo:frame-load`). The DOM is only swapped when request
-    # 2 completes, so callers that go on to interact with the refreshed frame must
-    # pass `frame_reload: true` to wait for the frame load rather than racing it.
+    # A successful move responds with a turbo stream whose `turbo_frame_reload`
+    # action reloads the `backlogs_container` frame — two round-trips: the stream
+    # render and the frame reload. Callers that go on to touch the refreshed frame
+    # pass `frame_reload: true` to await the frame load rather than racing it.
     #
-    # Moves that fail (e.g. dropping onto a completed sprint) only render an error
-    # flash and never reload the frame, so the default settles on the stream render.
+    # A failed move (e.g. dropping onto a completed sprint) only renders an error
+    # flash and never reloads the frame, so the default settles on the stream render.
     def wait_for_backlogs_turbo_stream(wait: 10, frame_reload: false, &)
       return yield unless wait
-      return wait_for_turbo_stream(wait:, &) if using_cuprite?
 
-      timeout = wait == true ? 10 : wait
-      timeout_ms = timeout * 1000
-      page.execute_script(<<~JS, timeout_ms)
-        window.__opBacklogsTurboStreamAbort?.abort();
-
-        const controller = new AbortController();
-        const state = {
-          rendered: false,
-          frameReloaded: false,
-          timeoutMs: arguments[0],
-          events: []
-        };
-
-        document.addEventListener('op:turbo-stream-rendered', (event) => {
-          state.rendered = true;
-          state.events.push({
-            type: event.type,
-            time: Math.round(performance.now())
-          });
-        }, { signal: controller.signal });
-
-        document.addEventListener('turbo:frame-load', (event) => {
-          if (event.target instanceof Element && event.target.id === 'backlogs_container') {
-            state.frameReloaded = true;
-            state.events.push({
-              type: event.type,
-              target: event.target.id,
-              time: Math.round(performance.now())
-            });
-          }
-        }, { signal: controller.signal });
-
-        window.__opBacklogsTurboStreamAbort = controller;
-        window.__opBacklogsTurboStreamState = state;
-      JS
-
-      yield
-
-      wait_for_backlogs_turbo_stream_event(timeout:, frame_reload:)
-    ensure
-      stop_backlogs_turbo_stream_probe unless using_cuprite?
-    end
-
-    def wait_for_backlogs_turbo_stream_event(timeout:, frame_reload: false)
-      flag = frame_reload ? "frameReloaded" : "rendered"
-      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-
-      loop do
-        return if page.evaluate_script("window.__opBacklogsTurboStreamState?.#{flag} === true")
-
-        if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-          missing = frame_reload ? "backlogs_container frame did not reload" : "no turbo stream rendered"
-          raise "wait_for_backlogs_turbo_stream: #{missing}\n#{backlogs_dnd_diagnostics}"
-        end
-
-        sleep 0.05
+      if frame_reload
+        wait_for_turbo_frame(frame: "backlogs_container", wait:, &)
+      else
+        wait_for_turbo_stream(wait:, &)
       end
-    end
-
-    def stop_backlogs_turbo_stream_probe
-      page.execute_script("window.__opBacklogsTurboStreamAbort?.abort();")
     end
 
     def install_backlogs_dnd_probe(source:, target:, edge:)
@@ -1122,39 +1063,6 @@ module Pages
           window.fetch = window.__opBacklogsOriginalFetch;
         }
       JS
-    end
-
-    def backlogs_dnd_diagnostics
-      diagnostics = page.evaluate_script(<<~JS)
-        (() => {
-          const dnd = window.__opBacklogsDndProbeState ?? null;
-          const turbo = window.__opBacklogsTurboStreamState ?? null;
-
-          if (dnd) {
-            dnd.snapshots.push({
-              label: 'on-timeout',
-              draggingCount: document.querySelectorAll('[data-dragging]').length,
-              honeyPotCount: document.querySelectorAll('[data-pdnd-honey-pot]').length,
-              dropTargets: document.querySelectorAll('[data-drop-target-for-element]').length,
-              dropPositions: Array
-                .from(document.querySelectorAll('[data-drop-position]'))
-                .map((element) => ({
-                  itemId: element
-                    .closest('[data-sortable-lists--item-id-value]')
-                    ?.getAttribute('data-sortable-lists--item-id-value') ?? null,
-                  position: element.getAttribute('data-drop-position')
-                })),
-              source: dnd.source,
-              target: dnd.target,
-              time: Math.round(performance.now())
-            });
-          }
-
-          return { dnd, turbo };
-        })()
-      JS
-
-      JSON.pretty_generate(diagnostics)
     end
 
     def clear_pragmatic_dnd_honey_pot

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -200,11 +200,9 @@ RSpec.describe "Work Package boards spec",
 
     # Go to full view of WP
     split_view.switch_to_fullscreen
-    wait_for_turbo do
-      split_view.wait_for_activity_tab
-      find_by_id("action-show-more-dropdown-menu").click
-      click_link(I18n.t("js.button_delete"))
-    end
+    split_view.wait_for_activity_tab
+    find_by_id("action-show-more-dropdown-menu").click
+    click_link(I18n.t("js.button_delete"))
 
     # Delete the WP
     destroy_modal.expect_listed(wp)

--- a/spec/features/turbo_wait_helpers_spec.rb
+++ b/spec/features/turbo_wait_helpers_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# These helpers are driver shims. We assert the *wait mechanism*: the helper must
+# not return until its Turbo event has fired. We flip a JS flag on a timer inside
+# the block, dispatch the event, then read the flag SYNCHRONOUSLY (no Capybara
+# auto-retry) immediately after the helper returns. If the helper no-ops, the flag
+# is still false.
+RSpec.describe "Turbo wait helpers", :js do
+  shared_let(:admin) { create(:admin) }
+
+  before do
+    login_as(admin)
+    visit home_path
+  end
+
+  shared_examples "blocks until its event fires" do
+    it "wait_for_turbo_stream returns only after op:turbo-stream-rendered" do
+      page.execute_script("window.__turboWaitFlag = false;")
+      wait_for_turbo_stream do
+        page.execute_script(<<~JS)
+          setTimeout(() => {
+            window.__turboWaitFlag = true;
+            document.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
+          }, 300);
+        JS
+      end
+      expect(page.evaluate_script("window.__turboWaitFlag")).to be(true)
+    end
+
+    it "wait_for_turbo returns only after turbo:load" do
+      page.execute_script("window.__turboWaitFlag = false;")
+      wait_for_turbo do
+        page.execute_script(<<~JS)
+          setTimeout(() => {
+            window.__turboWaitFlag = true;
+            document.dispatchEvent(new CustomEvent('turbo:load'));
+          }, 300);
+        JS
+      end
+      expect(page.evaluate_script("window.__turboWaitFlag")).to be(true)
+    end
+
+    it "wait_for_turbo_frame returns only after turbo:frame-load" do
+      page.execute_script("window.__turboWaitFlag = false;")
+      wait_for_turbo_frame do
+        page.execute_script(<<~JS)
+          setTimeout(() => {
+            const el = document.createElement('turbo-frame');
+            el.id = 'any_frame';
+            document.body.appendChild(el);
+            window.__turboWaitFlag = true;
+            el.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }));
+          }, 300);
+        JS
+      end
+      expect(page.evaluate_script("window.__turboWaitFlag")).to be(true)
+    end
+
+    it "wait_for_turbo_frame(frame:) ignores other frames and waits for the named one" do
+      page.execute_script("window.__turboWaitFlag = false;")
+      wait_for_turbo_frame(frame: "wanted_frame") do
+        page.execute_script(<<~JS)
+          // An unrelated frame must NOT satisfy the wait.
+          setTimeout(() => {
+            const other = document.createElement('turbo-frame');
+            other.id = 'other_frame';
+            document.body.appendChild(other);
+            other.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }));
+          }, 150);
+          // The named frame is what we are waiting for.
+          setTimeout(() => {
+            const wanted = document.createElement('turbo-frame');
+            wanted.id = 'wanted_frame';
+            document.body.appendChild(wanted);
+            window.__turboWaitFlag = true;
+            wanted.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }));
+          }, 350);
+        JS
+      end
+      expect(page.evaluate_script("window.__turboWaitFlag")).to be(true)
+    end
+  end
+
+  context "when running under cuprite" do
+    it_behaves_like "blocks until its event fires"
+  end
+
+  context "when running under selenium", :selenium do
+    it_behaves_like "blocks until its event fires"
+  end
+end

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -96,8 +96,9 @@ def wait_for_turbo_stream(wait: 10, &block)
   timeout_ms = timeout * 1000
   page.execute_script(<<~JS, timeout_ms)
     window.__opTurboStreamRendered = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('wait_for_turbo_stream: no turbo stream rendered within #{timeout}s')), arguments[0]);
-      document.addEventListener('op:turbo-stream-rendered', () => { clearTimeout(timer); resolve(true); }, { once: true });
+      const handler = () => { clearTimeout(timer); document.removeEventListener('op:turbo-stream-rendered', handler); resolve(true); };
+      const timer = setTimeout(() => { document.removeEventListener('op:turbo-stream-rendered', handler); reject(new Error('wait_for_turbo_stream: no turbo stream rendered within #{timeout}s')); }, arguments[0]);
+      document.addEventListener('op:turbo-stream-rendered', handler);
     });
   JS
 
@@ -135,8 +136,9 @@ def wait_for_turbo(wait: 10, &block)
   timeout_ms = timeout * 1000
   page.execute_script(<<~JS, timeout_ms)
     window.__opTurboLoaded = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('wait_for_turbo: no turbo:load event within #{timeout}s')), arguments[0]);
-      document.addEventListener('turbo:load', () => { clearTimeout(timer); resolve(true); }, { once: true });
+      const handler = () => { clearTimeout(timer); document.removeEventListener('turbo:load', handler); resolve(true); };
+      const timer = setTimeout(() => { document.removeEventListener('turbo:load', handler); reject(new Error('wait_for_turbo: no turbo:load event within #{timeout}s')); }, arguments[0]);
+      document.addEventListener('turbo:load', handler);
     });
   JS
 
@@ -181,13 +183,13 @@ def wait_for_turbo_frame(frame: nil, wait: 10, &block)
     const timeoutMs = arguments[0];
     const frameId = arguments[1];
     window.__opTurboFrameLoaded = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('wait_for_turbo_frame: no turbo:frame-load event within #{timeout}s')), timeoutMs);
       const handler = (event) => {
         if (frameId && !(event.target instanceof Element && event.target.id === frameId)) { return; }
         clearTimeout(timer);
         document.removeEventListener('turbo:frame-load', handler);
         resolve(true);
       };
+      const timer = setTimeout(() => { document.removeEventListener('turbo:frame-load', handler); reject(new Error('wait_for_turbo_frame: no turbo:frame-load event within #{timeout}s')); }, timeoutMs);
       document.addEventListener('turbo:frame-load', handler);
     });
   JS

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -87,11 +87,6 @@ end
 #   expect(page).to have_text("Saved")
 #
 def wait_for_turbo_stream(wait: 10, &block)
-  unless using_cuprite?
-    yield if block
-    return
-  end
-
   unless wait
     yield if block
     return
@@ -131,11 +126,6 @@ end
 #   expect(page).to have_text("Saved")
 #
 def wait_for_turbo(wait: 10, &block)
-  unless using_cuprite?
-    yield if block
-    return
-  end
-
   unless wait
     yield if block
     return
@@ -170,16 +160,15 @@ end
 # Sets up a listener for turbo:frame-load BEFORE yielding, avoiding the race
 # condition where the frame loads before the listener is registered.
 #
+# Pass `frame:` to wait for a specific frame by id; only a turbo:frame-load
+# whose target element has that id satisfies the wait. With no `frame:` the
+# first frame load of any frame satisfies it.
+#
 # @example
 #   wait_for_turbo_frame { click_link "Remove column" }
-#   expect(page).to have_text("Updated")
+#   wait_for_turbo_frame(frame: "backlogs_container") { drop_card }
 #
-def wait_for_turbo_frame(wait: 10, &block)
-  unless using_cuprite?
-    yield if block
-    return
-  end
-
+def wait_for_turbo_frame(frame: nil, wait: 10, &block)
   unless wait
     yield if block
     return
@@ -187,10 +176,19 @@ def wait_for_turbo_frame(wait: 10, &block)
 
   timeout = wait == true ? 10 : wait
   timeout_ms = timeout * 1000
-  page.execute_script(<<~JS, timeout_ms)
+  frame_id = frame&.to_s
+  page.execute_script(<<~JS, timeout_ms, frame_id)
+    const timeoutMs = arguments[0];
+    const frameId = arguments[1];
     window.__opTurboFrameLoaded = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('wait_for_turbo_frame: no turbo:frame-load event within #{timeout}s')), arguments[0]);
-      document.addEventListener('turbo:frame-load', () => { clearTimeout(timer); resolve(true); }, { once: true });
+      const timer = setTimeout(() => reject(new Error('wait_for_turbo_frame: no turbo:frame-load event within #{timeout}s')), timeoutMs);
+      const handler = (event) => {
+        if (frameId && !(event.target instanceof Element && event.target.id === frameId)) { return; }
+        clearTimeout(timer);
+        document.removeEventListener('turbo:frame-load', handler);
+        resolve(true);
+      };
+      document.addEventListener('turbo:frame-load', handler);
     });
   JS
 


### PR DESCRIPTION
🤖 _Opened by an agent on behalf of @alexbcoles._

## What

Makes the shared Capybara wait helpers (`wait_for_turbo_stream`, `wait_for_turbo`, `wait_for_turbo_frame` in `spec/support/shared/cuprite_helpers.rb`) work under **Selenium**, not just Cuprite. They previously no-opped under any non-Cuprite driver, silently leaving `:selenium`-tagged specs to race on Capybara auto-wait.

The `execute_script` + `evaluate_async_script` mechanism is already driver-agnostic — an over-conservative `unless using_cuprite?` early-return was the only thing forcing the no-op. Removing it is provably inert for the Cuprite path (that path never reached the early-return). `wait_for_turbo_frame` also gains an optional `frame:` id filter so a caller can await a specific frame's reload rather than the first frame load of any frame.

The backlogs DnD support then delegates to these shared helpers instead of hand-rolling its own Selenium turbo-stream / frame-load probe.

## Commits

`f4b8e90` — adds a behavioral spec proving each helper blocks until its Turbo event fires (synchronous flag read, so a no-op is caught); runs under both Cuprite and Selenium.
`edcdb58` — **global**: drops the `using_cuprite?` guard on the three helpers; adds the `frame:` filter to `wait_for_turbo_frame`.
`57e2464` — `wait_for_backlogs_turbo_stream` delegates to the shared helpers; removes the duplicated inline JS probe and the now-dead `backlogs_dnd_diagnostics`.
`dc5e258` — drops a misused `wait_for_turbo` wrapper in `board_navigation_spec` that the now-real Selenium wait exposed (it wrapped a dropdown + delete-modal click that never navigate).

## Notes

This PR is **stacked on** #23218 (base = `implementation/74970-backlogs-pragmatic-dnd`); rebase/retarget to `dev` once that merges.
Out of scope (deliberately): Selenium implementations of `wait_for_network_idle` / `wait_for_reload`, and the `backlogs_container` morph-settle "Node ... does not belong to the document" residual flake.
The global helper change (`f4b8e90`, `edcdb58`, `dc5e258`) can be extracted into its own PR independent of the backlogs delegation (`57e2464`) if preferred.

## Verification

`turbo_wait_helpers_spec` 8/8 under both drivers. backlogs DnD, boards, and activity + meeting indirect `:selenium` callers run clean (the only residual failures are the known out-of-scope morph-settle flake, which passes standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
