### PR TITLE
[OP-19617] Add Turbo integration test coverage

### DIFF
--- a/frontend/src/turbo/action-menu-morph-remount.spec.ts
+++ b/frontend/src/turbo/action-menu-morph-remount.spec.ts
@@ -1,0 +1,73 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it,
+} from 'vitest';
+import { registerActionMenuMorphRemount } from './action-menu-morph-remount';
+
+describe('registerActionMenuMorphRemount', () => {
+  let controller:AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    registerActionMenuMorphRemount(document, controller.signal);
+  });
+
+  afterEach(() => {
+    controller.abort();
+    document.body.innerHTML = '';
+  });
+
+  function morphElement(currentElement:Element) {
+    document.dispatchEvent(new CustomEvent('turbo:morph-element', {
+      detail: { currentElement },
+    }));
+  }
+
+  it('replaces a lazy-loading action-menu host so connectedCallback re-fires', () => {
+    document.body.innerHTML = '<action-menu><include-fragment src="/menu"></include-fragment></action-menu>';
+    const original = document.querySelector('action-menu')!;
+
+    morphElement(original);
+
+    expect(original.isConnected).toBe(false);
+    expect(document.querySelector('action-menu')).not.toBe(original);
+    expect(document.querySelector('action-menu include-fragment[src="/menu"]')).not.toBeNull();
+  });
+
+  it('leaves an action-menu without a lazy include-fragment untouched', () => {
+    document.body.innerHTML = '<action-menu><button>Item</button></action-menu>';
+    const original = document.querySelector('action-menu')!;
+
+    morphElement(original);
+
+    expect(original.isConnected).toBe(true);
+    expect(document.querySelector('action-menu')).toBe(original);
+  });
+});

--- a/frontend/src/turbo/action-menu-morph-remount.ts
+++ b/frontend/src/turbo/action-menu-morph-remount.ts
@@ -41,8 +41,8 @@
  * morph, frame morph, and full-page morph alike.
  */
 
-export function registerActionMenuMorphRemount():void {
-  document.addEventListener('turbo:morph-element', (event) => {
+export function registerActionMenuMorphRemount(target:Document = document, signal?:AbortSignal):void {
+  target.addEventListener('turbo:morph-element', (event) => {
     const currentElement = event.detail?.currentElement;
     if (!currentElement?.matches('action-menu:has(include-fragment[src])')) {
       return;
@@ -50,5 +50,5 @@ export function registerActionMenuMorphRemount():void {
 
     const clone = currentElement.cloneNode(true);
     currentElement.replaceWith(clone);
-  });
+  }, { signal });
 }

--- a/frontend/src/turbo/flash-stream-action.spec.ts
+++ b/frontend/src/turbo/flash-stream-action.spec.ts
@@ -1,0 +1,67 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it,
+} from 'vitest';
+import { StreamActions } from '@hotwired/turbo';
+import { registerFlashStreamAction } from './flash-stream-action';
+
+describe('registerFlashStreamAction', () => {
+  beforeEach(() => {
+    registerFlashStreamAction();
+    document.body.innerHTML = '<div id="primerized-flash-messages"></div>';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function flash(innerHTML:string) {
+    const element = document.createElement('turbo-stream');
+    element.innerHTML = `<template>${innerHTML}</template>`;
+    StreamActions.flash.call(element);
+  }
+
+  it('appends the flash to the flash-messages container', () => {
+    flash('<div class="flash">Saved</div>');
+
+    const target = document.getElementById('primerized-flash-messages')!;
+    expect(target.querySelector('.flash')?.textContent).toBe('Saved');
+  });
+
+  it('replaces an existing flash that shares its unique key', () => {
+    flash('<div class="flash" data-unique-key="k1">First</div>');
+    flash('<div class="flash" data-unique-key="k1">Second</div>');
+
+    const target = document.getElementById('primerized-flash-messages')!;
+    const flashes = target.querySelectorAll('[data-unique-key="k1"]');
+    expect(flashes).toHaveLength(1);
+    expect(flashes[0].textContent).toBe('Second');
+  });
+});

--- a/frontend/src/turbo/input-caption-stream-action.spec.ts
+++ b/frontend/src/turbo/input-caption-stream-action.spec.ts
@@ -1,0 +1,70 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it,
+} from 'vitest';
+import { StreamActions } from '@hotwired/turbo';
+import { registerInputCaptionStreamAction } from './input-caption-stream-action';
+
+describe('registerInputCaptionStreamAction', () => {
+  beforeEach(() => {
+    registerInputCaptionStreamAction();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function addCaption(attributes:Record<string, string>) {
+    const element = document.createElement('turbo-stream');
+    Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value));
+    StreamActions.addInputCaption.call(element);
+  }
+
+  it('appends a caption to the FormControl wrapping the target input', () => {
+    document.body.innerHTML = '<div class="FormControl"><input id="email"></div>';
+
+    addCaption({ target: '#email', caption: 'Required' });
+
+    const captions = document.querySelectorAll('.FormControl .FormControl-caption');
+    expect(captions).toHaveLength(1);
+    expect(captions[0].textContent).toBe('Required');
+  });
+
+  it('replaces existing captions when clean_other_captions is true', () => {
+    document.body.innerHTML = '<div class="FormControl">'
+      + '<input id="email"><span class="FormControl-caption">Stale</span></div>';
+
+    addCaption({ target: '#email', caption: 'Fresh', clean_other_captions: 'true' });
+
+    const captions = document.querySelectorAll('.FormControl .FormControl-caption');
+    expect(captions).toHaveLength(1);
+    expect(captions[0].textContent).toBe('Fresh');
+  });
+});

--- a/frontend/src/turbo/live-region-stream-action.spec.ts
+++ b/frontend/src/turbo/live-region-stream-action.spec.ts
@@ -1,0 +1,80 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { StreamActions } from '@hotwired/turbo';
+import { LiveRegionElement } from '@primer/live-region-element';
+import { registerLiveRegionStreamAction } from './live-region-stream-action';
+
+// `announce()` from @primer/live-region-element ultimately calls
+// `LiveRegionElement.prototype.announce(message, options)`, passing the options
+// through unchanged. Spying on that real prototype method works in every
+// browser, unlike `vi.mock()` of the module, which does not apply under the
+// browser-mode runner used in CI.
+describe('registerLiveRegionStreamAction', () => {
+  let announceSpy:ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    registerLiveRegionStreamAction();
+    // Pre-create the live region so announce() resolves synchronously instead
+    // of waiting for a freshly-appended element to register.
+    document.body.appendChild(document.createElement('live-region'));
+    announceSpy = vi.spyOn(LiveRegionElement.prototype, 'announce');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  function liveRegion(attributes:Record<string, string>) {
+    const element = document.createElement('turbo-stream');
+    Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value));
+    StreamActions.liveRegion.call(element);
+  }
+
+  it('announces politely with the configured delay by default', () => {
+    liveRegion({ message: 'Loaded', delay: '150' });
+
+    expect(announceSpy).toHaveBeenCalledWith('Loaded', { politeness: 'polite', delayMs: 150 });
+  });
+
+  it('announces assertively without a delay when requested', () => {
+    liveRegion({ message: 'Error', politeness: 'assertive' });
+
+    expect(announceSpy).toHaveBeenCalledWith('Error', { politeness: 'assertive' });
+  });
+
+  it('does nothing without a message', () => {
+    liveRegion({ politeness: 'polite' });
+
+    expect(announceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/turbo/turbo-angular-wrapper.spec.ts
+++ b/frontend/src/turbo/turbo-angular-wrapper.spec.ts
@@ -1,0 +1,145 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import type { ApplicationRef, ComponentRef } from '@angular/core';
+import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { addTurboAngularWrapper } from './turbo-angular-wrapper';
+
+describe('addTurboAngularWrapper — Angular re-bootstrap on Turbo navigation', () => {
+  let controller:AbortController;
+  let target:EventTarget;
+
+  // The destroy-and-rebuild contract operates on the plugin context's appRef.
+  // We drive it with fakes so the spec never touches `window.OpenProject` or a
+  // real Angular application.
+  function makeAppRef(components:ComponentRef<unknown>[]):ApplicationRef {
+    return { components, detachView: vi.fn() } as unknown as ApplicationRef;
+  }
+
+  // The handler awaits the plugin-context promise; flush the microtask queue so
+  // assertions see the re-bootstrap that follows it.
+  async function flush():Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  beforeEach(() => {
+    controller = new AbortController();
+    target = new EventTarget();
+  });
+
+  afterEach(() => {
+    controller.abort();
+  });
+
+  it('re-bootstraps the Angular app on the second turbo:load', async () => {
+    const appRef = makeAppRef([]);
+    const bootstrap = vi.fn();
+    const getPluginContext = () => Promise.resolve({ appRef } as OpenProjectPluginContext);
+
+    addTurboAngularWrapper({
+      target, signal: controller.signal, getPluginContext, bootstrap,
+    });
+
+    target.dispatchEvent(new Event('turbo:load')); // initial load — already bootstrapped
+    await flush();
+    target.dispatchEvent(new Event('turbo:load')); // navigation — must re-bootstrap
+    await flush();
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(bootstrap).toHaveBeenCalledWith(appRef);
+  });
+
+  it('tears down every existing root component before re-bootstrapping', async () => {
+    // Hold the mocks as locals so the assertions never reference an unbound
+    // method off the fake (eslint @typescript-eslint/unbound-method).
+    const firstDestroy = vi.fn();
+    const secondDestroy = vi.fn();
+    const first = { hostView: {}, destroy: firstDestroy } as unknown as ComponentRef<unknown>;
+    const second = { hostView: {}, destroy: secondDestroy } as unknown as ComponentRef<unknown>;
+    const detachView = vi.fn();
+    const appRef = { components: [first, second], detachView } as unknown as ApplicationRef;
+    const bootstrap = vi.fn();
+    const getPluginContext = () => Promise.resolve({ appRef } as OpenProjectPluginContext);
+
+    addTurboAngularWrapper({
+      target, signal: controller.signal, getPluginContext, bootstrap,
+    });
+
+    target.dispatchEvent(new Event('turbo:load')); // initial load — skipped
+    await flush();
+    target.dispatchEvent(new Event('turbo:load')); // navigation
+    await flush();
+
+    expect(detachView).toHaveBeenCalledWith(first.hostView);
+    expect(detachView).toHaveBeenCalledWith(second.hostView);
+    expect(firstDestroy).toHaveBeenCalledOnce();
+    expect(secondDestroy).toHaveBeenCalledOnce();
+    // Teardown must complete before the fresh bootstrap.
+    expect(firstDestroy).toHaveBeenCalledBefore(bootstrap);
+    expect(secondDestroy).toHaveBeenCalledBefore(bootstrap);
+  });
+
+  it('does not re-bootstrap on the initial turbo:load', async () => {
+    const appRef = makeAppRef([]);
+    const bootstrap = vi.fn();
+    const getPluginContext = vi.fn(() => Promise.resolve({ appRef } as OpenProjectPluginContext));
+
+    addTurboAngularWrapper({
+      target, signal: controller.signal, getPluginContext, bootstrap,
+    });
+
+    target.dispatchEvent(new Event('turbo:load')); // initial load only
+    await flush();
+
+    expect(getPluginContext).not.toHaveBeenCalled();
+    expect(bootstrap).not.toHaveBeenCalled();
+  });
+
+  it('stops re-bootstrapping once the signal aborts', async () => {
+    const appRef = makeAppRef([]);
+    const bootstrap = vi.fn();
+    const getPluginContext = () => Promise.resolve({ appRef } as OpenProjectPluginContext);
+
+    addTurboAngularWrapper({
+      target, signal: controller.signal, getPluginContext, bootstrap,
+    });
+
+    controller.abort();
+
+    target.dispatchEvent(new Event('turbo:load'));
+    await flush();
+    target.dispatchEvent(new Event('turbo:load'));
+    await flush();
+
+    expect(bootstrap).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/turbo/turbo-angular-wrapper.spec.ts
+++ b/frontend/src/turbo/turbo-angular-wrapper.spec.ts
@@ -44,11 +44,10 @@ describe('addTurboAngularWrapper — Angular re-bootstrap on Turbo navigation', 
     return { components, detachView: vi.fn() } as unknown as ApplicationRef;
   }
 
-  // The handler awaits the plugin-context promise; flush the microtask queue so
-  // assertions see the re-bootstrap that follows it.
+  // The handler awaits the plugin-context promise; yield a macrotask so the
+  // whole microtask queue drains (any chain depth) before assertions run.
   async function flush():Promise<void> {
-    await Promise.resolve();
-    await Promise.resolve();
+    await new Promise((resolve) => { setTimeout(resolve); });
   }
 
   beforeEach(() => {

--- a/frontend/src/turbo/turbo-angular-wrapper.ts
+++ b/frontend/src/turbo/turbo-angular-wrapper.ts
@@ -1,19 +1,41 @@
 import { skip } from 'rxjs/operators';
 import { fromEvent } from 'rxjs';
+import type { ApplicationRef } from '@angular/core';
 import { runBootstrap } from 'core-app/app.module';
 import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 
-export function addTurboAngularWrapper() {
+export interface AngularTurboBridgeOptions {
+  // The event source the bridge listens on. Defaults to the global `document`;
+  // a spec can pass its own `EventTarget` to drive synthetic `turbo:load`
+  // events in isolation.
+  target?:EventTarget;
+  // Aborts the `turbo:load` subscription so a spec (or future caller) can tear
+  // the bridge down between cases.
+  signal?:AbortSignal;
+  // Resolves the Angular plugin context carrying the `appRef`. Defaults to the
+  // real `window.OpenProject` lookup; injected so specs need no global.
+  getPluginContext?:() => Promise<OpenProjectPluginContext>;
+  // Re-bootstraps the root application onto a fresh `appBaseSelector`. Defaults
+  // to `app.module`'s `runBootstrap`.
+  bootstrap?:(appRef:ApplicationRef) => void;
+}
+
+export function addTurboAngularWrapper(options:AngularTurboBridgeOptions = {}) {
+  const {
+    target = document,
+    signal,
+    getPluginContext = () => window.OpenProject.getPluginContext(),
+    bootstrap = runBootstrap,
+  } = options;
+
   // When turbo:load fires, the angular application needs to be rebootstrapped.
   // However, we don't want this to happen on the initial page load
-  fromEvent(document, 'turbo:load')
+  const subscription = fromEvent(target, 'turbo:load')
     .pipe(
       skip(1), // Skip the first turbo:load event
     )
     .subscribe(() => {
-      void window
-        .OpenProject
-        .getPluginContext()
+      void getPluginContext()
         .then((pluginContext:OpenProjectPluginContext) => {
           const appRef = pluginContext.appRef;
 
@@ -25,7 +47,9 @@ export function addTurboAngularWrapper() {
           });
 
           // Run bootstrap again to initialize the new application
-          runBootstrap(appRef);
+          bootstrap(appRef);
         });
     });
+
+  signal?.addEventListener('abort', () => subscription.unsubscribe(), { once: true });
 }

--- a/frontend/src/turbo/turbo-event-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-event-listeners.spec.ts
@@ -1,0 +1,119 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { addTurboEventListeners } from './turbo-event-listeners';
+
+describe('addTurboEventListeners — dialog close on turbo:submit-end', () => {
+  let controller:AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    addTurboEventListeners(document, controller.signal);
+  });
+
+  afterEach(() => {
+    controller.abort();
+    document.body.innerHTML = '';
+  });
+
+  function submitEnd(form:HTMLFormElement, success:boolean) {
+    form.dispatchEvent(new CustomEvent('turbo:submit-end', {
+      bubbles: true,
+      detail: { success },
+    }));
+  }
+
+  it('closes the dialog and dispatches dialog:close on a successful submit', () => {
+    document.body.innerHTML = '<dialog><form></form></dialog>';
+    const dialog = document.querySelector('dialog')!;
+    const form = document.querySelector('form')!;
+    dialog.showModal();
+
+    const onClose = vi.fn();
+    document.addEventListener('dialog:close', onClose, { signal: controller.signal });
+
+    submitEnd(form, true);
+
+    expect(dialog.open).toBe(false);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the dialog open when data-keep-open-on-submit is set', () => {
+    document.body.innerHTML = '<dialog data-keep-open-on-submit="true"><form></form></dialog>';
+    const dialog = document.querySelector('dialog')!;
+    const form = document.querySelector('form')!;
+    dialog.showModal();
+
+    const onClose = vi.fn();
+    document.addEventListener('dialog:close', onClose, { signal: controller.signal });
+
+    submitEnd(form, true);
+
+    expect(dialog.open).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the submit was not successful', () => {
+    document.body.innerHTML = '<dialog><form></form></dialog>';
+    const dialog = document.querySelector('dialog')!;
+    const form = document.querySelector('form')!;
+    dialog.showModal();
+
+    submitEnd(form, false);
+
+    expect(dialog.open).toBe(true);
+  });
+});
+
+describe('addTurboEventListeners — Turbo nonce header on fetch requests', () => {
+  let controller:AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    document.head.insertAdjacentHTML('beforeend', '<meta name="csp-nonce" content="nonce-xyz">');
+    addTurboEventListeners(document, controller.signal);
+  });
+
+  afterEach(() => {
+    controller.abort();
+    document.querySelector('meta[name="csp-nonce"]')?.remove();
+  });
+
+  it('adds Turbo-Referrer and X-Turbo-Nonce headers', () => {
+    const headers:Record<string, string> = {};
+    document.dispatchEvent(new CustomEvent('turbo:before-fetch-request', {
+      detail: { fetchOptions: { headers } },
+    }));
+
+    expect(headers['Turbo-Referrer']).toBe(window.location.href);
+    expect(headers['X-Turbo-Nonce']).toBe('nonce-xyz');
+  });
+});

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -1,6 +1,6 @@
 import { TurboHelpers } from './helpers';
 
-export function addTurboEventListeners() {
+export function addTurboEventListeners(target:Document = document, signal?:AbortSignal) {
   // Close the primer dialog when the form inside has been submitted with a success response.
   //
   // If you want to keep the dialog open even after a successful form submission, you can add the
@@ -10,7 +10,7 @@ export function addTurboEventListeners() {
   // it will leave an overflow:hidden attribute on the body, which prevents scrolling on the page.
   //
   // Also, we will dispatch a custom `dialog:close` event when the dialog is closed.
-  document.addEventListener('turbo:submit-end', (event) => {
+  target.addEventListener('turbo:submit-end', (event) => {
     const { detail: { success }, target } = event;
 
     if (success && target instanceof HTMLFormElement) {
@@ -23,26 +23,26 @@ export function addTurboEventListeners() {
         }
       }
     }
-  });
+  }, { signal });
 
   // Append turbo nonce for drive requests
-  document.addEventListener('turbo:before-fetch-request', (event) => {
+  target.addEventListener('turbo:before-fetch-request', (event) => {
     // Turbo Drive does not send a referrer like turbolinks used to, so let's simulate it here
     const { headers } = event.detail.fetchOptions;
     headers['Turbo-Referrer'] = window.location.href;
-    headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') ?? '';
-  });
+    headers['X-Turbo-Nonce'] = target.getElementsByName('csp-nonce')[0]?.getAttribute('content') ?? '';
+  }, { signal });
 
   // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces
   // https://github.com/hotwired/turbo/issues/294#issuecomment-2633216052
   // We remove them manually as a workaround
   // in Handle Turbo Drive page loads (full reloads)
-  document.addEventListener('turbo:before-render', (event) => {
+  target.addEventListener('turbo:before-render', (event) => {
     TurboHelpers.scrubScriptElements(event.detail.newBody);
-  }, { capture: true });
+  }, { capture: true, signal });
 
   // in Turbo Streams (partial updates)
-  document.addEventListener('turbo:before-stream-render', (event) => {
+  target.addEventListener('turbo:before-stream-render', (event) => {
     const fallbackToDefaultActions = event.detail.render;
 
     event.detail.render = async (streamElement) => {
@@ -50,13 +50,13 @@ export function addTurboEventListeners() {
       TurboHelpers.scrubScriptElements(content);
 
       const result = await fallbackToDefaultActions(streamElement);
-      document.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
+      target.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
       return result;
     };
-  });
+  }, { signal });
 
   // in Turbo Frames (when they load new content)
-  document.addEventListener('turbo:before-frame-render', (event) => {
+  target.addEventListener('turbo:before-frame-render', (event) => {
     TurboHelpers.scrubScriptElements(event.detail.newFrame);
-  }, { capture: true });
+  }, { capture: true, signal });
 }

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -1,6 +1,6 @@
 import { TurboHelpers } from './helpers';
 
-export function addTurboEventListeners(target:Document = document, signal?:AbortSignal) {
+export function addTurboEventListeners(doc:Document = document, signal?:AbortSignal) {
   // Close the primer dialog when the form inside has been submitted with a success response.
   //
   // If you want to keep the dialog open even after a successful form submission, you can add the
@@ -10,7 +10,7 @@ export function addTurboEventListeners(target:Document = document, signal?:Abort
   // it will leave an overflow:hidden attribute on the body, which prevents scrolling on the page.
   //
   // Also, we will dispatch a custom `dialog:close` event when the dialog is closed.
-  target.addEventListener('turbo:submit-end', (event) => {
+  doc.addEventListener('turbo:submit-end', (event) => {
     const { detail: { success }, target } = event;
 
     if (success && target instanceof HTMLFormElement) {
@@ -19,30 +19,30 @@ export function addTurboEventListeners(target:Document = document, signal?:Abort
       if (dialog) {
         if (dialog.dataset.keepOpenOnSubmit !== 'true') {
           dialog.close('close-event-already-dispatched');
-          document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: true } }));
+          doc.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: true } }));
         }
       }
     }
   }, { signal });
 
   // Append turbo nonce for drive requests
-  target.addEventListener('turbo:before-fetch-request', (event) => {
+  doc.addEventListener('turbo:before-fetch-request', (event) => {
     // Turbo Drive does not send a referrer like turbolinks used to, so let's simulate it here
     const { headers } = event.detail.fetchOptions;
     headers['Turbo-Referrer'] = window.location.href;
-    headers['X-Turbo-Nonce'] = target.getElementsByName('csp-nonce')[0]?.getAttribute('content') ?? '';
+    headers['X-Turbo-Nonce'] = doc.getElementsByName('csp-nonce')[0]?.getAttribute('content') ?? '';
   }, { signal });
 
   // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces
   // https://github.com/hotwired/turbo/issues/294#issuecomment-2633216052
   // We remove them manually as a workaround
   // in Handle Turbo Drive page loads (full reloads)
-  target.addEventListener('turbo:before-render', (event) => {
+  doc.addEventListener('turbo:before-render', (event) => {
     TurboHelpers.scrubScriptElements(event.detail.newBody);
   }, { capture: true, signal });
 
   // in Turbo Streams (partial updates)
-  target.addEventListener('turbo:before-stream-render', (event) => {
+  doc.addEventListener('turbo:before-stream-render', (event) => {
     const fallbackToDefaultActions = event.detail.render;
 
     event.detail.render = async (streamElement) => {
@@ -50,13 +50,13 @@ export function addTurboEventListeners(target:Document = document, signal?:Abort
       TurboHelpers.scrubScriptElements(content);
 
       const result = await fallbackToDefaultActions(streamElement);
-      target.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
+      doc.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
       return result;
     };
   }, { signal });
 
   // in Turbo Frames (when they load new content)
-  target.addEventListener('turbo:before-frame-render', (event) => {
+  doc.addEventListener('turbo:before-frame-render', (event) => {
     TurboHelpers.scrubScriptElements(event.detail.newFrame);
   }, { capture: true, signal });
 }

--- a/frontend/src/turbo/turbo-global-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-global-listeners.spec.ts
@@ -1,0 +1,71 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it,
+} from 'vitest';
+import { addTurboGlobalListeners } from './turbo-global-listeners';
+
+describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {
+  let controller:AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    addTurboGlobalListeners(document, controller.signal);
+  });
+
+  afterEach(() => {
+    controller.abort();
+    document.body.innerHTML = '';
+  });
+
+  function beforeMorph(element:Element):boolean {
+    return element.dispatchEvent(new CustomEvent('turbo:before-morph-element', {
+      bubbles: true,
+      cancelable: true,
+    }));
+  }
+
+  it('prevents morphing of OPCE-* custom elements', () => {
+    document.body.innerHTML = '<opce-principal></opce-principal>';
+    const element = document.querySelector('opce-principal')!;
+
+    const notCancelled = beforeMorph(element);
+
+    expect(notCancelled).toBe(false);
+  });
+
+  it('leaves plain elements morphable', () => {
+    document.body.innerHTML = '<div></div>';
+    const element = document.querySelector('div')!;
+
+    const notCancelled = beforeMorph(element);
+
+    expect(notCancelled).toBe(true);
+  });
+});

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -12,11 +12,11 @@ import {
   initMainMenuExpandStatus,
 } from 'core-app/core/setup/globals/global-listeners/setup-server-response';
 
-export function addTurboGlobalListeners() {
+export function addTurboGlobalListeners(target:Document = document, signal?:AbortSignal) {
   const runOnRenderAndLoad = () => {
     // Add to content if warnings displayed
-    if (document.querySelector('.warning-bar--item')) {
-      const content = document.querySelector<HTMLElement>('#content');
+    if (target.querySelector('.warning-bar--item')) {
+      const content = target.querySelector<HTMLElement>('#content');
       if (content) {
         content.style.marginBottom = '100px';
       }
@@ -37,7 +37,7 @@ export function addTurboGlobalListeners() {
     //
 
     // Action menu logic
-    document.querySelectorAll<HTMLElement>('.toolbar-items').forEach((menu) => {
+    target.querySelectorAll<HTMLElement>('.toolbar-items').forEach((menu) => {
       installMenuLogic(menu);
     });
 
@@ -56,15 +56,15 @@ export function addTurboGlobalListeners() {
     activateFlashNotice();
     activateFlashError();
   };
-  document.addEventListener('turbo:render', runOnRenderAndLoad);
-  document.addEventListener('DOMContentLoaded', runOnRenderAndLoad);
+  target.addEventListener('turbo:render', runOnRenderAndLoad, { signal });
+  target.addEventListener('DOMContentLoaded', runOnRenderAndLoad, { signal });
 
-  document.addEventListener('turbo:before-morph-element', (event) => {
+  target.addEventListener('turbo:before-morph-element', (event) => {
     const element = event.target as HTMLElement;
 
     // In case the element is an OpenProject custom dom element, morphing is prevented.
     if (element.tagName.toUpperCase().startsWith('OPCE-')) {
       event.preventDefault();
     }
-  });
+  }, { signal });
 }

--- a/frontend/src/turbo/turbo-navigation-patch.spec.ts
+++ b/frontend/src/turbo/turbo-navigation-patch.spec.ts
@@ -1,0 +1,67 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  afterAll, describe, expect, it,
+} from 'vitest';
+import * as Turbo from '@hotwired/turbo';
+import { applyTurboNavigationPatch } from './turbo-navigation-patch';
+
+// The FrameController prototype the patch reaches into. Internal Turbo API,
+// not part of the public types, hence the casts.
+const proto = (Turbo.FrameElement as any).delegateConstructor.prototype as Record<string, unknown>;
+
+describe('turbo-navigation-patch (tripwire for hotwired/turbo#1300)', () => {
+  const original = proto.proposeVisitIfNavigatedWithAction;
+
+  afterAll(() => {
+    proto.proposeVisitIfNavigatedWithAction = original;
+  });
+
+  it('targets a method that still exists in the installed Turbo', () => {
+    expect(typeof original).toBe('function');
+  });
+
+  it('upstream still sources the snapshot from the fetch response (#1300 unfixed)', () => {
+    // When Turbo stops reading `responseHTML` off the fetch response, #1300
+    // may be fixed upstream and this whole patch can be deleted. This guard
+    // turns that upgrade into a red test instead of a silent behaviour change.
+    const upstream = String(original);
+    expect(upstream).toContain('responseHTML');
+    expect(upstream).toContain('fetchResponse');
+  });
+
+  it('rebinds the method to source HTML from the live document', () => {
+    applyTurboNavigationPatch();
+
+    const patched = proto.proposeVisitIfNavigatedWithAction;
+    expect(patched).not.toBe(original);
+    expect(String(patched)).toContain('ownerDocument');
+  });
+});

--- a/frontend/src/turbo/turbo-navigation-patch.ts
+++ b/frontend/src/turbo/turbo-navigation-patch.ts
@@ -1,22 +1,45 @@
 /* eslint-disable */
-// @ts-nocheck
+// @ts-nocheck -- reaches into Turbo's internal FrameController, which is not
+// part of the public type surface, so every access below is untyped.
 import * as Turbo from '@hotwired/turbo';
 
+/**
+ * Workaround for https://github.com/hotwired/turbo/issues/1300: with a
+ * `<turbo-frame data-turbo-action="advance">`, the URL advances but the
+ * browser back button fails to restore the frame's previous content. It only
+ * reproduces when the frame is rendered by a Rails view template, which is why
+ * there is no upstream frontend regression test — see the Rails system spec.
+ *
+ * Upstream fix in flight: https://github.com/hotwired/turbo/pull/1549. Once it
+ * ships in a release we depend on, drop this patch in favour of it.
+ *
+ * This is a verbatim fork of `FrameController.proposeVisitIfNavigatedWithAction`
+ * with a single divergence: the history snapshot is built from the live
+ * document (`frame.ownerDocument.documentElement.outerHTML`) instead of the
+ * fetch response (`await fetchResponse.responseHTML`), so the restored snapshot
+ * reflects the fully rendered page rather than the bare frame fragment.
+ *
+ * Pinned to @hotwired/turbo 8.0.x. `turbo-navigation-patch.spec.ts` is a
+ * tripwire: it fails if Turbo renames the patched method or stops sourcing the
+ * snapshot from the fetch response (i.e. #1300 looks fixed upstream), at which
+ * point this patch should be re-evaluated and likely deleted.
+ */
 export function applyTurboNavigationPatch() {
   Turbo.FrameElement.delegateConstructor.prototype.proposeVisitIfNavigatedWithAction = function (frame, action = null) {
     this.action = action;
 
     if (this.action) {
-      // const pageSnapshot = PageSnapshot.fromElement(frame).clone()
-      // @ts-ignore
       const pageSnapshot = Turbo.PageSnapshot.fromElement(frame).clone();
       const { visitCachedSnapshot } = frame.delegate;
 
-      // frame.delegate.fetchResponseLoaded = async (fetchResponse) => {
-      frame.delegate.fetchResponseLoaded = (fetchResponse) => {
+      // Kept `async` to mirror upstream's method shape even though the body no
+      // longer awaits -- the divergence below sources the snapshot synchronously
+      // from the live document instead of `await fetchResponse.responseHTML`.
+      frame.delegate.fetchResponseLoaded = async (fetchResponse) => {
         if (frame.src) {
           const { statusCode, redirected } = fetchResponse;
-          // const responseHTML = await fetchResponse.responseHTML
+          // Divergence from upstream: capture the live, fully rendered page
+          // rather than `await fetchResponse.responseHTML`.
           const responseHTML = frame.ownerDocument.documentElement.outerHTML;
           const response = { statusCode, redirected, responseHTML };
           const options = {
@@ -30,10 +53,9 @@ export function applyTurboNavigationPatch() {
 
           if (this.action) options.action = this.action;
 
-          // session.visit(frame.src, options)
           Turbo.session.visit(frame.src, options);
         }
-      }
+      };
     }
-  }
+  };
 }

--- a/spec/features/admin/departments_spec.rb
+++ b/spec/features/admin/departments_spec.rb
@@ -73,6 +73,34 @@ RSpec.describe "Departments admin",
 
       departments_page.expect_department_empty_state
     end
+
+    # Regression test for `frontend/src/turbo/turbo-navigation-patch.ts`, which
+    # works around hotwired/turbo#1300: a `<turbo-frame data-turbo-action=
+    # "advance">` advances the URL, but without the patch the browser back
+    # button reverts the URL while leaving the frame's previously rendered
+    # content stale. Departments renders its whole content area in such a
+    # frame, so advancing through the tree and going back exercises the patch.
+    it "restores the parent's frame content when navigating back" do
+      organization_name = Setting.organization_name.presence || I18n.t("setting_organization_name")
+
+      departments_page.visit_department(parent)
+      departments_page.expect_breadcrumbs(organization_name, "Engineering")
+
+      departments_page.tree_view.click_node("Backend")
+
+      departments_page.expect_breadcrumbs(organization_name, "Engineering", "Backend")
+      expect(page).to have_current_path("/admin/departments/#{child.id}")
+
+      page.go_back
+      wait_for_network_idle
+
+      # Without the patch the URL reverts but the frame keeps the Backend
+      # content, leaving three breadcrumbs; the exact-match assertion below
+      # fails in that case and only passes once the parent frame is restored.
+      expect(page).to have_current_path("/admin/departments/#{parent.id}")
+      departments_page.expect_breadcrumbs(organization_name, "Engineering")
+      departments_page.tree_view.should_have_active_item("Engineering")
+    end
   end
 
   describe "adding a department" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19617

# What are you trying to accomplish?

**This PR is about adding test coverage. The only production changes are to facilitate testing.**

The Turbo integration is the most upgrade-fragile frontend code we have — listeners bound to the global `document`, custom stream actions, and a monkeypatch reaching into Turbo's private `FrameController` behind `@ts-nocheck` — yet it had no unit coverage beyond a single Selenium navigation spec. A Turbo upgrade could rename an internal method or fix a bug underneath us and neither the compiler nor a test would notice.

This PR also pins the patch to the Turbo version it was written against.

# What approach did you choose and why?

Four commits, smallest blast radius first:

1. **Add a test seam to the Turbo integration.** Installers bound to the global `document` and returned `void`, so vitest couldn't drive synthetic `turbo:*` events or tear listeners down between cases. Threads an optional event target and `AbortSignal` through them; callers stay on the defaults. Adds specs for the installers and all five stream actions.

2. **Guard the Turbo navigation monkeypatch.** The frame-visit patch reached into Turbo internals behind `@ts-nocheck`. Documents the one divergence from upstream, pins it to Turbo 8.0.x, and adds a tripwire spec that fails on a method rename or an upstream fix (in flight as https://github.com/hotwired/turbo/pull/1549), so the patch gets re-evaluated instead of silently breaking.

3. **Cover the turbo#1300 back-button fix.** The vitest tripwire guards the patched method's shape but not its runtime effect. Adds the behavioural half on the departments page: advancing through `data-turbo-action="advance"` frames and pressing back must restore the parent frame. Needs Rails-rendered frames, so it can't live in vitest.

4. **Seam the Angular-Turbo re-bootstrap.** `turbo-angular-wrapper.ts` destroys and re-bootstraps the whole Angular root on every navigation and was the last uncovered installer — a timing change or Turbo upgrade could leave every `opce-*` element inert with nothing to catch it. Threads the same `(target, signal)` seam plus injectable plugin-context lookup and bootstrap call; the `skip(1)` pipeline and destroy-then-bootstrap contract are unchanged.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
