### PR TITLE
Only allow dispatching custom events with the `op-dispatched:` prefix 

### DIFF
--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -166,10 +166,21 @@ module OpTurbo
       turbo_streams << turbo_stream.turbo_frame_reload(target)
     end
 
+    # Prefix required for all events dispatched via the `dispatchEvent` turbo
+    # stream action. The client-side action refuses any event without it; see
+    # `frontend/src/turbo/dispatch-event-stream-action.ts` for the rationale.
+    DISPATCHED_EVENT_PREFIX = "op-dispatched:"
+
     # Dispatches a `CustomEvent` on `document` from a turbo stream, letting the
     # server signal a client-side change without knowing which listeners (if
     # any) react to it. `detail` is serialized and exposed as the event's detail.
+    # The event name must start with `op-dispatched:` to keep injected turbo
+    # streams from forging arbitrary `document` events.
     def dispatch_event_via_turbo_stream(name, detail: {})
+      unless name.to_s.start_with?(DISPATCHED_EVENT_PREFIX)
+        raise ArgumentError, "dispatched event name must start with #{DISPATCHED_EVENT_PREFIX.inspect}, got #{name.inspect}"
+      end
+
       turbo_streams << OpTurbo::StreamComponent
         .new(action: :dispatchEvent, target: nil, "event-name": name, detail: detail.to_json)
         .render_in(view_context)

--- a/frontend/src/stimulus/controllers/reload-frame-on-event.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/reload-frame-on-event.controller.spec.ts
@@ -46,7 +46,7 @@ describe('ReloadFrameOnEventController', () => {
     await ctx.mount(`
       <turbo-frame id="frame"
                    data-controller="reload-frame-on-event"
-                   data-reload-frame-on-event-event-name-value="resource-allocations:changed"
+                   data-reload-frame-on-event-event-name-value="op-dispatched:resource-allocations:changed"
                    data-reload-frame-on-event-url-value="/planner/view">
         content
       </turbo-frame>
@@ -69,11 +69,11 @@ describe('ReloadFrameOnEventController', () => {
   it('points the frame at its url on the first event, then reloads on later events', async () => {
     const { frame, calls } = await mountFrame();
 
-    document.dispatchEvent(new CustomEvent('resource-allocations:changed'));
+    document.dispatchEvent(new CustomEvent('op-dispatched:resource-allocations:changed'));
     expect(frame.src).toContain('/planner/view');
     expect(calls.count).toBe(0);
 
-    document.dispatchEvent(new CustomEvent('resource-allocations:changed'));
+    document.dispatchEvent(new CustomEvent('op-dispatched:resource-allocations:changed'));
     expect(calls.count).toBe(1);
   });
 
@@ -90,7 +90,7 @@ describe('ReloadFrameOnEventController', () => {
     const { frame, calls } = await mountFrame();
     ctx.getController<ReloadFrameOnEventController>('reload-frame-on-event', frame).disconnect();
 
-    document.dispatchEvent(new CustomEvent('resource-allocations:changed'));
+    document.dispatchEvent(new CustomEvent('op-dispatched:resource-allocations:changed'));
 
     expect(calls.count).toBe(0);
   });

--- a/frontend/src/turbo/dispatch-event-stream-action.spec.ts
+++ b/frontend/src/turbo/dispatch-event-stream-action.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { vi } from 'vitest';
+import { StreamActions } from '@hotwired/turbo';
+import { registerDispatchEventStreamAction } from './dispatch-event-stream-action';
+
+describe('dispatchEvent turbo stream action', () => {
+  // Invoke the action the way Turbo does: `this` bound to the <turbo-stream>
+  // element carrying the attributes.
+  const runAction = (attributes:Record<string, string>):void => {
+    const element = document.createElement('turbo-stream');
+    Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, value));
+    StreamActions.dispatchEvent.call(element);
+  };
+
+  // Capture every event the action dispatches on `document`, regardless of
+  // name, so we can assert both what fires and what does not.
+  let dispatched:CustomEvent[];
+
+  beforeEach(() => {
+    registerDispatchEventStreamAction();
+    dispatched = [];
+    // jsdom does not let us add a listener for an arbitrary name retroactively,
+    // so we spy on dispatchEvent itself to record everything.
+    vi.spyOn(document, 'dispatchEvent').mockImplementation((event:Event) => {
+      dispatched.push(event as CustomEvent);
+      return true;
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches an op-dispatched: prefixed event on document with parsed detail', () => {
+    runAction({ 'event-name': 'op-dispatched:resource-allocations:changed', detail: '{"workPackageId":42}' });
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe('op-dispatched:resource-allocations:changed');
+    expect(dispatched[0].detail).toEqual({ workPackageId: 42 });
+  });
+
+  it('defaults detail to an empty object when no detail attribute is present', () => {
+    runAction({ 'event-name': 'op-dispatched:no-detail' });
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].detail).toEqual({});
+  });
+
+  it('refuses to dispatch a native event name like submit', () => {
+    runAction({ 'event-name': 'submit' });
+
+    expect(dispatched).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('submit'));
+  });
+
+  it('refuses an event in the general op: namespace', () => {
+    runAction({ 'event-name': 'op:theme-changed' });
+
+    expect(dispatched).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('op:theme-changed'));
+  });
+
+  it('refuses an unprefixed event even if it matches a real listener', () => {
+    runAction({ 'event-name': 'resource-allocations:changed' });
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it('does nothing when no event-name is given', () => {
+    runAction({ detail: '{"workPackageId":42}' });
+
+    expect(dispatched).toHaveLength(0);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/turbo/dispatch-event-stream-action.ts
+++ b/frontend/src/turbo/dispatch-event-stream-action.ts
@@ -1,9 +1,24 @@
 import { StreamActions, StreamElement } from '@hotwired/turbo';
 
+// Dedicated namespace for events dispatched via the `dispatchEvent` turbo stream
+// action. This is a security boundary: turbo streams can be injected into the
+// DOM (e.g. via stored content), so an attacker could otherwise forge arbitrary
+// `document` events. Restricting to this prefix keeps the forgeable surface
+// disjoint from the general `op:` event namespace (e.g. `op:theme-changed`),
+// whose listeners must never be reachable from an injected stream. Every
+// server-side `dispatch_event_via_turbo_stream` caller must name its event
+// `op-dispatched:<name>`.
+const DISPATCHED_EVENT_PREFIX = 'op-dispatched:';
+
 export function registerDispatchEventStreamAction() {
   StreamActions.dispatchEvent = function dispatchEventStreamAction(this:StreamElement) {
     const name = this.getAttribute('event-name');
     if (!name) { return; }
+
+    if (!name.startsWith(DISPATCHED_EVENT_PREFIX)) {
+      console.error(`[dispatchEvent] Refusing to dispatch event "${name}": name must start with "${DISPATCHED_EVENT_PREFIX}".`);
+      return;
+    }
 
     const detail = JSON.parse(this.getAttribute('detail') ?? '{}') as unknown;
     document.dispatchEvent(new CustomEvent(name, { detail }));

--- a/modules/resource_management/app/controllers/resource_management/resource_allocations_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/resource_allocations_controller.rb
@@ -350,7 +350,7 @@ module ::ResourceManagement
     def notify_allocation_change(entity)
       return unless entity.is_a?(WorkPackage)
 
-      dispatch_event_via_turbo_stream("resource-allocations:changed", detail: { work_package_id: entity.id })
+      dispatch_event_via_turbo_stream("op-dispatched:resource-allocations:changed", detail: { work_package_id: entity.id })
     end
 
     def allocation_kind

--- a/modules/resource_management/app/views/resource_management/resource_planner_views/show.html.erb
+++ b/modules/resource_management/app/views/resource_management/resource_planner_views/show.html.erb
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
   frame_data = if @view
                  {
                    controller: "reload-frame-on-event",
-                   "reload-frame-on-event-event-name-value": "resource-allocations:changed",
+                   "reload-frame-on-event-event-name-value": "op-dispatched:resource-allocations:changed",
                    "reload-frame-on-event-url-value": project_resource_planner_view_path(@project, @resource_planner, @view)
                  }
                else

--- a/modules/resource_management/spec/requests/resource_allocations_spec.rb
+++ b/modules/resource_management/spec/requests/resource_allocations_spec.rb
@@ -721,7 +721,7 @@ RSpec.describe "ResourceAllocations requests",
     event = Nokogiri::HTML5.fragment(response.body).at_css('turbo-stream[action="dispatchEvent"]')
 
     expect(event).to be_present
-    expect(event["event-name"]).to eq("resource-allocations:changed")
+    expect(event["event-name"]).to eq("op-dispatched:resource-allocations:changed")
     expect(JSON.parse(event["detail"])).to eq("work_package_id" => work_package.id)
   end
 end

--- a/spec/controllers/concerns/op_turbo/component_stream_spec.rb
+++ b/spec/controllers/concerns/op_turbo/component_stream_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe OpTurbo::ComponentStream do
       it "renders a dispatchEvent turbo stream carrying the detail" do
         get :update, params: { event_name: "op-dispatched:resource-allocations:changed" }, as: :turbo_stream
 
-        expect(response.body).to include '<turbo-stream action="dispatchEvent"'
+        expect(response.body).to have_turbo_stream(action: "dispatchEvent")
         expect(response.body).to include 'event-name="op-dispatched:resource-allocations:changed"'
 
         stream = Nokogiri::HTML5.fragment(response.body).at_css('turbo-stream[action="dispatchEvent"]')

--- a/spec/controllers/concerns/op_turbo/component_stream_spec.rb
+++ b/spec/controllers/concerns/op_turbo/component_stream_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OpTurbo::ComponentStream do
+  described_module = described_class
+
+  controller(ApplicationController) do
+    include described_module
+
+    no_authorization_required! :update
+
+    def update
+      dispatch_event_via_turbo_stream(params[:event_name], detail: { work_package_id: 42 })
+      respond_to_with_turbo_streams
+    end
+  end
+
+  current_user { build_stubbed(:user) }
+
+  before do
+    routes.draw { get "update" => "anonymous#update" }
+  end
+
+  describe "#dispatch_event_via_turbo_stream" do
+    context "when the event name is prefixed with op-dispatched:" do
+      it "renders a dispatchEvent turbo stream carrying the detail" do
+        get :update, params: { event_name: "op-dispatched:resource-allocations:changed" }, as: :turbo_stream
+
+        expect(response.body).to include '<turbo-stream action="dispatchEvent"'
+        expect(response.body).to include 'event-name="op-dispatched:resource-allocations:changed"'
+
+        stream = Nokogiri::HTML5.fragment(response.body).at_css('turbo-stream[action="dispatchEvent"]')
+        expect(JSON.parse(stream["detail"])).to eq("work_package_id" => 42)
+      end
+    end
+
+    context "when the event name lacks the op-dispatched: prefix" do
+      it "raises an ArgumentError" do
+        expect { get :update, params: { event_name: "submit" }, as: :turbo_stream }
+          .to raise_error(ArgumentError, /op-dispatched:/)
+      end
+    end
+
+    context "when the event name uses the general op: namespace" do
+      it "raises an ArgumentError" do
+        expect { get :update, params: { event_name: "op:theme-changed" }, as: :turbo_stream }
+          .to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our custom implementation exposed a similar surface to the one that we fixed in [#23484](https://github.com/opf/openproject/pull/23484). This PR changes the code so that only events with a given prefix can be dispatched using the turbo stream.