### PR TITLE
[DREAM-702] Status labels are cut off on desktop and mobile

### DIFF
--- a/app/components/work_packages/info_line_component.rb
+++ b/app/components/work_packages/info_line_component.rb
@@ -55,6 +55,7 @@ class WorkPackages::InfoLineComponent < ApplicationComponent
       "op-wp-info-line"
     )
     @system_arguments[:flex_wrap] = @wrap ? :wrap : :nowrap
+    @system_arguments[:align_items] ||= :center
     @system_arguments[:overflow] = :hidden unless @wrap
   end
 end

--- a/app/components/work_packages/info_line_component.sass
+++ b/app/components/work_packages/info_line_component.sass
@@ -4,9 +4,12 @@
     @include text-shortener
     min-width: 25px
     max-width: 66%
-    // The label has a height of 18.5px. Half pixels are resolved differently by each OS/browser combination,
-    // resulting in cases where the bottom of the label was cut off
-    min-height: 19px
+
+  &--status
+    display: inline-flex
+    align-items: center
+    .Label
+      line-height: 14px
 
   &--id
     white-space: nowrap


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/DREAM-702

# What are you trying to accomplish?
Set correct line height and flexbox to avoid that borders are being cut off

## Screenshots
Mac - Chrome
<img width="548" height="741" alt="Bildschirmfoto 2026-06-29 um 11 47 36" src="https://github.com/user-attachments/assets/5d1e3433-d907-4073-a858-78fab5f93260" />

Windows - FF
<img width="531" height="465" alt="Bildschirmfoto 2026-06-29 um 11 49 36" src="https://github.com/user-attachments/assets/0dbdce0e-2ab4-4a09-bac0-e350af359cf9" />

The vertical alignment issue in FF on Windows is on the component level and out of scope for this PR.