### PR TITLE
[SC-269] CSRF through /admin/import/jira/2/run/new via HTTP Method "import/jira/{id}/run/new"

### DIFF
--- a/app/controllers/admin/import/jira/import_runs_controller.rb
+++ b/app/controllers/admin/import/jira/import_runs_controller.rb
@@ -51,7 +51,7 @@ module Admin::Import::Jira
 
     def show; end
 
-    def new
+    def create
       jira = Import::Jira.find(params[:jira_id])
       jira_import = Import::JiraImport.create!(author_id: current_user.id, jira_id: jira.id)
       redirect_to(admin_import_jira_run_path(jira_id: jira.id, id: jira_import.id))

--- a/app/views/admin/import/jira/instances/show.html.erb
+++ b/app/views/admin/import/jira/instances/show.html.erb
@@ -60,7 +60,8 @@ See COPYRIGHT and LICENSE files for more details.
           scheme: :primary,
           tag: :a,
           size: :medium,
-          href: new_admin_import_jira_run_path(jira_id: @jira.id)
+          href: admin_import_jira_run_index_path(jira_id: @jira.id),
+          data: { turbo_method: :post }
         )
       ) do |button|
         button.with_leading_visual_icon(icon: :plus)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -849,7 +849,7 @@ Rails.application.routes.draw do
         member do
           delete :delete_token
         end
-        resources :run, controller: "/admin/import/jira/import_runs", module: :jiras do
+        resources :run, controller: "/admin/import/jira/import_runs", module: :jiras, except: [:new] do
           member do
             get :continue
             post :continue

--- a/spec/controllers/admin/import/jira/import_runs_controller_spec.rb
+++ b/spec/controllers/admin/import/jira/import_runs_controller_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Admin::Import::Jira::ImportRunsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns forbidden for GET #new" do
-      get :new, params: { jira_id: jira.id }
+    it "returns forbidden for POST #create" do
+      post :create, params: { jira_id: jira.id }
       expect(response).to have_http_status(:forbidden)
     end
 
@@ -132,10 +132,10 @@ RSpec.describe Admin::Import::Jira::ImportRunsController do
     end
   end
 
-  describe "GET #new" do
+  describe "POST #create" do
     it "creates a new jira import and redirects to show" do
       expect do
-        get :new, params: { jira_id: jira.id }
+        post :create, params: { jira_id: jira.id }
       end.to change(Import::JiraImport, :count).by(1)
 
       new_import = Import::JiraImport.last


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/SC-269

# What are you trying to achieve?

Creating new Jira import runs is a simple GET request, so an admin session can be used for creating them.

# What approach did you choose and why?

Remove the GET endpoint, instead use POST, so a CSRF token is required.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
