### PR TITLE
Bump Node to 24.18.0, npm to ^11.0.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,7 +124,7 @@ jobs:
           bundler-cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22.22.3
+          node-version: 24.18.0
           package-manager-cache: false
           cache: npm
           cache-dependency-path: |

--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.22.3'
+          node-version: '24.18.0'
           package-manager-cache: false
           cache: npm
           cache-dependency-path: frontend/package-lock.json

--- a/.github/workflows/hocuspocus-test.yml
+++ b/.github/workflows/hocuspocus-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.22.3'
+          node-version: '24.18.0'
           package-manager-cache: false
           cache: npm
           cache-dependency-path: extensions/op-blocknote-hocuspocus/package-lock.json

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.22.3'
+          node-version: '24.18.0'
           package-manager-cache: false
 
       - name: Required git config

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -28,6 +28,6 @@ jobs:
         bundler-cache: false
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version: '20'
+        node-version: '24.18.0'
         package-manager-cache: false
     - run: ./script/api/validate_spec

--- a/.github/workflows/test-frontend-unit.yml
+++ b/.github/workflows/test-frontend-unit.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.22.3'
+          node-version: '24.18.0'
           package-manager-cache: false
 
       - name: Install Dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 - **Size**: Large monorepo (~840MB, ~1M+ lines of code)
 - **Backend**: Ruby 3.4.7, Rails ~8.0.3
-- **Frontend**: Node.js 22.22.3 or 24.15.0+, npm 10.9.8+, TypeScript
+- **Frontend**: Node.js 24.x (>= 24.15.0), npm 11.x, TypeScript
 - **Database**: PostgreSQL (required)
 - **Architecture**: Server-rendered HTML with Hotwire (Turbo + Stimulus). Legacy Angular components exist and are being migrated to custom elements. Uses GitHub's Primer Design System via ViewComponent.
 - **Editions**: Community, Enterprise (SSO, LDAP, SCIM), and BIM (construction industry, code in `modules/bim/`)
@@ -17,7 +17,7 @@
 
 **ALWAYS verify versions before building:**
 - Ruby: `3.4.7` (see `.ruby-version`)
-- Node: `^22.22.3 || ^24.15.0` (see `package.json` engines)
+- Node: `^24.15.0` (see `package.json` engines)
 - Bundler: Latest 2.x
 
 ### Local Development Setup

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,7 +2,7 @@
 ARG RUBY_VERSION
 FROM ruby:${RUBY_VERSION}-trixie
 
-ENV NODE_VERSION="22.22.3"
+ENV NODE_VERSION="24.18.0"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV BUNDLE_WITHOUT="development:production:docker"
 

--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.3
+FROM node:24.18.0
 LABEL org.opencontainers.image.authors="operations@openproject.com"
 
 ARG DEV_UID=1000

--- a/docker/dev/hocuspocus/docker-compose.override.example.yml
+++ b/docker/dev/hocuspocus/docker-compose.override.example.yml
@@ -5,7 +5,7 @@ services:
   hocuspocus:
     # In case of MacOS you need to specify the platform in your `docker/dev/hocuspocus/docker-compose.override.yml`:
     # platform: linux/amd64
-    image: node:22.22.3-alpine
+    image: node:24.18.0-alpine
     working_dir: /app
     command: sh -c "npm run dev"
     volumes:

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 FROM ruby:${RUBY_VERSION}-slim-trixie AS runtime-base
 LABEL maintainer="operations@openproject.com"
 
-ARG NODE_VERSION="22.22.3"
+ARG NODE_VERSION="24.18.0"
 ARG BIM_SUPPORT=true
 ENV USE_JEMALLOC=false
 ENV DEBIAN_FRONTEND=noninteractive
@@ -61,7 +61,7 @@ COPY ./docker/prod/setup/preinstall-common.sh ./docker/prod/setup/preinstall-com
 RUN ./docker/prod/setup/preinstall-common.sh
 
 FROM runtime-base AS build-base
-ARG NODE_VERSION="22.22.3"
+ARG NODE_VERSION="24.18.0"
 
 # build-only dependencies
 COPY ./docker/prod/setup/preinstall-build.sh ./docker/prod/setup/preinstall-build.sh

--- a/docs/development/development-environment/linux/README.md
+++ b/docs/development/development-environment/linux/README.md
@@ -161,11 +161,11 @@ git clone https://github.com/nodenv/node-build.git $(nodenv root)/plugins/node-b
 
 You can find the latest LTS version here: [nodejs.org/en/download/](https://nodejs.org/en/download/)
 
-At the time of writing this is v22.22.3 Install and activate it with:
+At the time of writing this is v24.18.0 Install and activate it with:
 
 ```shell
-nodenv install 22.22.3
-nodenv global 22.22.3
+nodenv install 24.18.0
+nodenv global 24.18.0
 nodenv rehash
 ```
 
@@ -187,10 +187,10 @@ bundler --version
 4.0.9
 
 node --version
-v22.22.3
+v24.18.0
 
 npm --version
-10.9.8
+11.16.0
 ```
 
 ## Install OpenProject Sources

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -115,11 +115,11 @@ nodenv init
 
 You can find the latest LTS version here: [nodejs.org/en/download](https://nodejs.org/en/download/)
 
-At the time of writing this is v22.22.3. Install and activate it with:
+At the time of writing this is v24.18.0. Install and activate it with:
 
 ```shell
-nodenv install 22.22.3
-nodenv global 22.22.3
+nodenv install 24.18.0
+nodenv global 24.18.0
 ```
 
 #### Update NPM to the latest version
@@ -140,10 +140,10 @@ $ bundler --version
 4.0.3
 
 node --version
-v22.22.3
+v24.18.0
 
 npm --version
-10.9.8
+11.16.0
 ```
 
 ## Install OpenProject

--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -145,7 +145,7 @@ time to finish.
 To check our Node installation we run `node --version`. It should output something very similar to:
 
 ```text
-v22.22.3
+v24.18.0
 ```
 
 ## Installation of OpenProject

--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -137,9 +137,9 @@ time to finish.
 [openproject@host] source ~/.profile
 [openproject@host] git clone https://github.com/OiNutter/node-build.git ~/.nodenv/plugins/node-build
 
-[openproject@host] nodenv install 14.16.0
+[openproject@host] nodenv install 24.18.0
 [openproject@host] nodenv rehash
-[openproject@host] nodenv global 14.16.0
+[openproject@host] nodenv global 24.18.0
 ```
 
 To check our Node installation we run `node --version`. It should output something very similar to:

--- a/extensions/op-blocknote-hocuspocus/Dockerfile
+++ b/extensions/op-blocknote-hocuspocus/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.3
+FROM node:24.18.0
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --omit=dev

--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -31,7 +31,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": "^22.22.3 || ^24.15.0"
+        "node": "^24.15.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/opf/openproject/tree/dev/extensions/op-blocknote-hocuspocus#readme",
   "engines": {
-    "node": "^22.22.3 || ^24.15.0"
+    "node": "^24.15.0"
   },
   "dependencies": {
     "@blocknote/server-util": "^0.51.3",

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Version Requirements
 
-- Node: `^22.22.3 || ^24.15.0` (see `package.json` engines)
+- Node: `^24.15.0` (see `package.json` engines)
 
 ## Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@redocly/cli": "^2.32.0"
       },
       "engines": {
-        "node": "^22.22.3 || ^24.15.0",
-        "npm": "^10.9.8 || ^11.0.0"
+        "node": "^24.15.0",
+        "npm": "^11.0.0"
       }
     },
     "node_modules/@redocly/cli": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "private": true,
   "engines": {
-    "node": "^22.22.3 || ^24.15.0",
-    "npm": "^10.9.8 || ^11.0.0"
+    "node": "^24.15.0",
+    "npm": "^11.0.0"
   },
   "devDependencies": {
     "@redocly/cli": "^2.32.0"


### PR DESCRIPTION

# Ticket

No ticket — follow-up to https://github.com/opf/openproject/pull/23588, which introduced the `^22.22.3 || ^24.15.0` compound engine range that the Heroku packaging buildpack cannot resolve.

# What are you trying to accomplish?

Bumps supported Node engines to `^24.15.0` (latest LTS, Krypton), dropping the `^22.22.3 || ^24.15.0` compound range.

The Heroku packaging buildpack cannot resolve `||` version ranges and failed with "No matching version found for Node", breaking the package build. Collapsing to a single range fixes it.

Updates to Node 24.18.0 for development, production, GitHub workflows and documentation; bumps the npm engine to `^11.0.0` (bundled 11.16.0).


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

