### PR TITLE
Whitelist npm install scripts for build tooling

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-allow-scripts=true

--- a/docs/development/development-environment/README.md
+++ b/docs/development/development-environment/README.md
@@ -28,6 +28,12 @@ The OpenProject logfile can be found in `log/development.log`.
 
 If an error occurs, it should be logged there (as well as in the output to STDOUT/STDERR of the rails server process).
 
+`npm ci` / `npm install` fails on a package with an unreviewed install script? `.npmrc` sets
+`strict-allow-scripts=true`, which blocks any script not listed in the nearest `package.json`'s
+`allowScripts` map. Review the script, then run
+[`npm approve-scripts`](https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts) (or edit
+`allowScripts` directly) to record a decision.
+
 ## Questions, Comments, and Feedback
 
 If you have any further questions, comments, feedback, or an idea to enhance this guide, please tell us at the

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -43,5 +43,10 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
     "vitest": "^4.1.9"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true,
+    "msw@2.14.6": true
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -202,6 +202,6 @@
     "msgpackr-extract@3.0.4": true,
     "core-js": false,
     "core-js-pure": false,
-    "es5-ext": false
+    "es5-ext@0.10.64": true
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -191,5 +191,17 @@
     "lint:fix": "ng lint --fix",
     "generate-typings": "tsc -d -p tsconfig.app.json",
     "postinstall": "patch-package"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "esbuild@0.27.7": true,
+    "@parcel/watcher@2.5.6": true,
+    "fsevents@2.3.3": true,
+    "fsevents@2.3.2": true,
+    "lmdb@3.5.4": true,
+    "msgpackr-extract@3.0.4": true,
+    "core-js": false,
+    "core-js-pure": false,
+    "es5-ext": false
   }
 }


### PR DESCRIPTION
npm 11 gates package install scripts behind an `allowScripts` allowlist in `package.json` and warns about any not yet reviewed. This reviews the 10 flagged scripts and records a decision for each.

I read every flagged install/postinstall script. None do anything malicious; none reach the network in normal flow (esbuild only does an integrity-checked fetch as a last-resort fallback when its platform optional-dep is missing). Every native dependency ships a prebuilt `darwin-arm64` / per-platform binary, so the `node-gyp` build scripts are effectively no-ops here.

> **⚠️ WARNING**
> This PR also adds `strict-allow-scripts=true` to `.npmrc`.
> `npm ci` / `npm install` will now **fail fast** on any install script not covered by the `allowScripts` allowlist, instead of only warning.
> Any future dependency bump that introduces a new unreviewed install script will break CI/local installs until it is triaged and added to the allowlist (approved or denied).

## Review

| Package | Script | What it does | Decision |
| --- | --- | --- | --- |
| `esbuild` (0.28.1, 0.27.7) | `node install.js` | Resolves the platform binary from its optional dep, SHA-256 integrity-checks it, and symlinks `bin/esbuild` → native bin for faster startup. Network fetch from npmjs **only** as a last-resort fallback if the optional dep is missing. | ✅ approve (pinned) |
| `@parcel/watcher` (2.5.6) | `node scripts/build-from-source.js` | No-op unless `npm_config_build_from_source=true`. Prebuilt `@parcel/watcher-darwin-arm64` present → never compiles. | ✅ approve (pinned) |
| `fsevents` (2.3.3, 2.3.2) | node-gyp build | macOS-only. Ships a committed prebuilt `fsevents.node` → no compile. | ✅ approve (pinned) |
| `lmdb` (3.5.4) | `node-gyp-build-optional-packages` | Resolves prebuilt `@lmdb/lmdb-darwin-arm64` (present) → no compile. Compiles only if no prebuild matches the platform. | ✅ approve (pinned) |
| `msgpackr-extract` (3.0.4) | `node-gyp-build-optional-packages` | Resolves prebuilt `@msgpackr-extract/...-darwin-arm64` (present) → no compile. | ✅ approve (pinned) |
| `core-js` (3.49.0) | `node -e "try{require('./postinstall')}catch(e){}"` | Prints an OpenCollective donation banner; writes a rate-limit marker to the OS tmpdir. Silent in CI. No functional value. | ❌ deny |
| `core-js-pure` (3.47.0) | same | Same donation banner. | ❌ deny |
| `es5-ext` (0.10.64) | `node -e "try{require('./_postinstall')}catch(e){}" \|\| exit 0` | Prints an anti-war message **only** if the timezone is Russian, else no-op. `process._rawDebug` only — no fs/net writes. Approved per team feedback to keep the message. | ✅ approve (pinned) |

Pinned entries force a re-review when those packages are bumped; the denied entries (`false`, version-agnostic) permanently block scripts for any future version.

## Other package.json roots

The repo has two more npm roots. The root `package.json` has no unreviewed install scripts, so it needs no change. `extensions/op-blocknote-hocuspocus` flagged three:

| Package | Script | What it does | Decision |
| --- | --- | --- | --- |
| `esbuild` (0.28.1) | `node install.js` | Same platform-binary resolver as in the frontend. | ✅ approve (pinned) |
| `fsevents` (2.3.3) | node-gyp build | Same committed prebuilt `fsevents.node`. | ✅ approve (pinned) |
| `msw` (2.14.6) | `node -e "import('./config/scripts/postinstall.js')..."` | Mock Service Worker dev dependency. Postinstall reads the parent `package.json` and **no-ops unless `msw.workerDirectory` is set** (it isn't here); when set it copies `mockServiceWorker.js` via `msw init`. Benign. | ✅ approve (pinned) |

After applying, `npm install` runs clean (no `allow-scripts` warning) in both `frontend/` and `extensions/op-blocknote-hocuspocus/`. Changes are limited to the two `package.json` files.

## Script extracts

<details>
<summary><code>core-js</code> / <code>core-js-pure</code> — <code>postinstall.js</code> (donation banner)</summary>

```js
var BANNER = '^[[96mThank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!^[[0m\n\n' +
             '^[[96mThe project needs your help! Please consider supporting core-js:^[[0m\n' +
             '^[[96m>^[[94m https://opencollective.com/core-js ^[[0m\n' +
             // ...patreon / boosty / bitcoin links...

function isBannerRequired() {
  if (ADBLOCK || CI || DISABLE_OPENCOLLECTIVE || SILENT || OPEN_SOURCE_CONTRIBUTOR) return false;
  var file = path.join(os.tmpdir(), 'core-js-banners');
  // ...rate-limit via mtime of the tmp marker file...
}

function showBanner() {
  console.log(COLOR ? BANNER : BANNER.replace(/^[\[\d+m/g, ''));
}

if (isBannerRequired()) showBanner();
```

</details>

<details>
<summary><code>es5-ext</code> — <code>_postinstall.js</code> (anti-war message, Russian timezones only)</summary>

```js
// Broadcasts "Call for peace" message when package is installed in Russia, otherwise no-op
"use strict";
try {
  if (
    [
      "Asia/Anadyr", "Asia/Barnaul", /* ...Russian TZs... */ "Europe/Moscow",
      "Europe/Volgograd", "W-SU"
    ].indexOf(new Intl.DateTimeFormat().resolvedOptions().timeZone) === -1
  ) {
    return;
  }
  // ...process._rawDebug(...) anti-war text in Russian...
} catch (error) {
  // ignore
}
```

</details>

<details>
<summary><code>@parcel/watcher</code> — <code>scripts/build-from-source.js</code> (opt-in compile)</summary>

```js
const {spawn} = require('child_process');

if (process.env.npm_config_build_from_source === 'true') {
  build();
}

function build() {
  spawn('node-gyp', ['rebuild'], { stdio: 'inherit', shell: true }).on('exit', function (code) {
    process.exit(code);
  });
}
```

</details>

<details>
<summary><code>lmdb</code> / <code>msgpackr-extract</code> — <code>node-gyp-build-optional-packages</code> (prebuild resolver)</summary>

```js
// Skips compilation when a prebuilt platform package resolves;
// only falls back to `node-gyp rebuild` if the native test binary fails.
if (!buildFromSource()) {
  proc.exec('node-gyp-build-optional-packages-test', function (err, stdout, stderr) {
    if (err) {
      console.error(stderr);
      console.error('...Will now attempt to build the package locally...');
      preinstall();
    }
  });
} else {
  preinstall();
}
```

</details>

<details>
<summary><code>esbuild</code> — <code>install.js</code> (platform-binary resolver, integrity-checked)</summary>

```js
// Resolves the per-platform optional dep, verifies its SHA-256, and
// optimises bin/esbuild into a direct symlink. Network fetch is a
// last-resort fallback only.

function binaryIntegrityCheck(pkg, subpath, bytes) {
  const hash = crypto.createHash("sha256").update(bytes).digest("hex");
  const expected = packageJSON["esbuild.binaryHashes"][`${pkg}/${subpath}`];
  if (!expected) throw new Error(`Missing hash for ...`);
  if (hash !== expected) throw new Error(`"..." doesn't match "..."`);
}

async function checkAndPreparePackage() {
  const { pkg, subpath, isWASM } = pkgAndSubpathForCurrentPlatform();
  let binPath;
  try {
    binPath = require.resolve(`${pkg}/${subpath}`);   // optional dep, already installed
  } catch (e) {
    // fallback: installUsingNPM(...) → downloadDirectlyFromNPM(...)
  }
  maybeOptimizePackage(binPath, isWASM);
}
```

</details>

<details>
<summary><code>msw</code> — <code>config/scripts/postinstall.js</code> (no-op unless <code>msw.workerDirectory</code> set)</summary>

```js
import fs from 'node:fs'
import path from 'node:path'
import { execFileSync } from 'node:child_process'

const parentPackageCwd = process.env.INIT_CWD

function postInstall() {
  const packageJson = JSON.parse(
    fs.readFileSync(path.resolve(parentPackageCwd, 'package.json'), 'utf8'),
  )

  // Early-return unless the consumer opted in via msw.workerDirectory
  if (!packageJson.msw || !packageJson.msw.workerDirectory) {
    return
  }

  const cliExecutable = path.resolve(process.cwd(), 'cli/index.js')
  try {
    // Copies mockServiceWorker.js to each saved msw.workerDirectory path
    execFileSync(process.execPath, [cliExecutable, 'init'], {
      cwd: parentPackageCwd,
    })
  } catch (error) {
    console.error(`[MSW] Failed to automatically update the worker script.\n\n${error}`)
  }
}

postInstall()
```

</details>
