### PR TITLE
Fix flaky project list filter specs

### DIFF
--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -45,12 +45,12 @@ module Components
         if filter_name == "name_and_identifier"
           expect(page.find_by_id(filter_name).value).not_to be_empty
         elsif value
-          within(".advanced-filters--filter[data-filter-name='#{filter_name}']") do
+          within(filter_selector(filter_name)) do
             expect(page).to have_css(".advanced-filters--filter-value", text: value, visible: :all)
           end
         else
           expect(page)
-            .to have_css(".advanced-filters--filter[data-filter-name='#{filter_name}']")
+            .to have_css(filter_selector(filter_name))
         end
       end
 
@@ -73,23 +73,33 @@ module Components
       end
 
       def set_advanced_filter(name, human_name, human_operator = nil, values = [], send_keys: false)
-        selected_filter = select_filter(name, human_name)
+        select_filter(name, human_name)
+
+        # Classify the row before apply_operator re-renders it; the type and
+        # autocomplete markers are fixed per filter, so selecting the operator
+        # does not change them. Skipped when there is nothing to set.
+        kind = filter_kind(name) if values.any?
+
         apply_operator(name, human_operator)
 
-        within(selected_filter) do
-          return unless values.any?
+        return unless values.any?
 
-          if boolean_filter?(name)
-            set_toggle_filter(values)
-          elsif autocomplete_filter?(selected_filter)
-            select(human_operator, from: "operator_#{name}")
-            set_autocomplete_filter(values)
-          elsif name == "created_at"
-            select(human_operator, from: "operator_#{name}")
-            set_datetime_filter(name, human_operator, values, send_keys:)
-          elsif date_filter?(selected_filter) && human_operator == "on"
-            set_date_filter(values, send_keys)
-          end
+        # Re-find after apply_operator: selecting the operator re-renders the
+        # filter row, leaving an earlier reference stale (ObsoleteNode).
+        within(filter_selector(name)) do
+          set_advanced_filter_value(name, kind, human_operator, values, send_keys:)
+        end
+      end
+
+      def set_advanced_filter_value(name, kind, human_operator, values, send_keys:)
+        if boolean_filter?(name)
+          set_toggle_filter(values)
+        elsif kind == :autocomplete
+          set_autocomplete_filter(values)
+        elsif name == "created_at"
+          set_datetime_filter(name, human_operator, values, send_keys:)
+        elsif kind == :date && human_operator == "on"
+          set_date_filter(values, send_keys)
         end
       end
 
@@ -121,14 +131,14 @@ module Components
 
       def select_filter(name, human_name)
         select human_name, from: "add_filter_select"
-        page.find(".advanced-filters--filter[data-filter-name='#{name}']")
+        page.find(filter_selector(name))
       end
 
       def remove_filter(name)
         if name == "name_and_identifier"
           page.find_by_id("name_and_identifier").find(:xpath, "following-sibling::button").click
         else
-          page.find(".advanced-filters--filter[data-filter-name='#{name}'] .advanced-filters--remove-filter").click
+          page.find("#{filter_selector(name)} .advanced-filters--remove-filter").click
         end
       end
 
@@ -223,16 +233,27 @@ module Components
         page.has_css?(".op-filters-form.-expanded", wait: 0)
       end
 
-      def autocomplete_filter?(filter)
-        filter.has_css?('[data-filter-autocomplete="true"]', wait: 0)
+      def filter_selector(name)
+        ".advanced-filters--filter[data-filter-name='#{name}']"
       end
 
-      def date_filter?(filter)
-        filter[:"data-filter-type"] == "date"
-      end
+      # Classifies the filter row by re-finding it once. Returns :autocomplete
+      # when the value container carries the autocomplete marker, otherwise the
+      # row's data-filter-type as a symbol (:date, :datetime_past, ...).
+      #
+      # Re-finding is required because adding/operating on a filter re-renders
+      # the row, leaving a captured reference stale (ObsoleteNode). The raising
+      # find waits for the row; the marker check is then instant, mirroring the
+      # synchronous data-filter-type read. The marker check stays wait: 0 on
+      # purpose: rows are pre-rendered, so the marker is present whenever the row
+      # is, and a default wait would only stall the non-autocomplete branches for
+      # the full Capybara timeout before falling through.
+      def filter_kind(name)
+        row = page.find(filter_selector(name))
 
-      def date_time_filter?(filter)
-        filter[:"data-filter-type"] == "datetime_past"
+        return :autocomplete if row.has_css?('[data-filter-autocomplete="true"]', wait: 0)
+
+        row[:"data-filter-type"]&.to_sym
       end
 
       def boolean_filter?(_filter)

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -239,28 +239,23 @@ module Pages
       def set_advanced_filter(name, human_name, human_operator = nil, values = [], send_keys: false)
         select_filter(name, human_name)
 
-        # Re-find after select_filter, as adding the filter triggers DOM updates
-        # that make the returned reference immediately stale (ObsoleteNode)
-        selected_filter = page.find(".advanced-filters--filter[data-filter-name='#{name}']")
+        # Classify the row before apply_operator re-renders it. Skipped when
+        # there is nothing to set.
+        kind = filter_kind(name) if values.any?
 
-        is_autocomplete = autocomplete_filter?(selected_filter)
-        is_date_or_datetime = date_filter?(selected_filter) || date_time_filter?(selected_filter)
-
-        within(selected_filter) do
+        within(filter_selector(name)) do
           apply_operator(name, human_operator)
         end
 
         return unless values.any?
 
         # Re-find again as apply_operator may have triggered further DOM updates
-        selected_filter = page.find(".advanced-filters--filter[data-filter-name='#{name}']")
-
-        within(selected_filter) do
+        within(filter_selector(name)) do
           if boolean_filter?(name)
             set_toggle_filter(values)
-          elsif is_autocomplete
+          elsif kind == :autocomplete
             set_autocomplete_filter(values)
-          elsif is_date_or_datetime
+          elsif %i[date datetime_past].include?(kind)
             wait_for_network_idle
             set_datetime_filter(name, human_operator, values, send_keys:)
           end


### PR DESCRIPTION
# Ticket

None (flaky spec fixes only)

# What are you trying to accomplish?

Fix the intermittent `Capybara::Cuprite::ObsoleteNode` / `Ferrum::NodeNotFoundError` failures in `spec/features/projects/lists/filters_spec.rb` (the 'created on' filter, among others).

Adding a filter and selecting its operator re-render the filter row, so a node reference captured beforehand goes stale. The next access then raises instead of retrying.

# What approach did you choose and why?

Re-resolve the filter row from the document by its unique `data-filter-name` on each access instead of reusing a captured node, via a single `filter_selector(name)` helper.

A single `filter_kind(name)` classifier replaces the old `autocomplete_filter?` / `date_filter?` / `date_time_filter?` predicates. It finds the row once and returns `:autocomplete` (from the value container's marker, matching how the Stimulus controller classifies) or the row's `data-filter-type` as a symbol. The raising `find` waits for the row through any re-render; the autocomplete-marker check stays `wait: 0` because rows are pre-rendered, so a default wait would only stall the non-autocomplete branches for the full Capybara timeout.

The kind is computed before `apply_operator` (the DOM-mutating step) and outside the `within` scope — page-level finders are scoped to the current `within` element, so a row-rooted selector cannot resolve from inside it. The `within` blocks re-find the row fresh after each mutation, and the redundant operator re-select inside the block is dropped since `apply_operator` already selected it.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
