### PR TITLE
Fix flaky team planner and calendar sort specs

### DIFF
--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -185,10 +185,18 @@ module Pages
     end
 
     def expect_views_listed_in_order(*queries)
-      within ".generic-table tbody" do
-        listed_view_names = all("tr td.name").map(&:text)
+      expected_names = queries.map(&:name)
 
-        expect(listed_view_names).to eq(queries.map(&:name))
+      # Sorting reloads the whole page (the sort links navigate via a full
+      # browser visit, not a Turbo Stream), so the rows are replaced
+      # asynchronously. Asserting against a one-shot snapshot of the rows races
+      # the reload and intermittently reads the previous order. Use retrying
+      # matchers that re-query the document until the new order settles.
+      within ".generic-table tbody" do
+        expect(page).to have_css("tr td.name", count: expected_names.size)
+        expected_names.each_with_index do |name, index|
+          expect(page).to have_css("tr:nth-of-type(#{index + 1}) td.name", exact_text: name)
+        end
       end
     end
   end

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -180,10 +180,18 @@ module Pages
     end
 
     def expect_views_listed_in_order(*queries)
-      within ".generic-table tbody" do
-        listed_view_names = all("tr td.name").map(&:text)
+      expected_names = queries.map(&:name)
 
-        expect(listed_view_names).to eq(queries.map(&:name))
+      # Sorting reloads the whole page (the sort links navigate via a full
+      # browser visit, not a Turbo Stream), so the rows are replaced
+      # asynchronously. Asserting against a one-shot snapshot of the rows races
+      # the reload and intermittently reads the previous order. Use retrying
+      # matchers that re-query the document until the new order settles.
+      within ".generic-table tbody" do
+        expect(page).to have_css("tr td.name", count: expected_names.size)
+        expected_names.each_with_index do |name, index|
+          expect(page).to have_css("tr:nth-of-type(#{index + 1}) td.name", exact_text: name)
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Stabilizes the flaky CI failure in `team_planner_overview_spec.rb[1:4:4:1]` ("allows sorting by all columns"), and applies the same fix to the identical (and equally racy) helper in the calendar module.

# What approach did you choose and why?

The sortable column headers navigate via a full browser visit, not a Turbo Stream: `sort_header_tag` → `sort_link` → `link_to_content_update` renders the link with `target: "_top"`, and Turbo Drive does not intercept links carrying a `target`. So clicking a header triggers a full page reload that replaces the table asynchronously.

`Pages::TeamPlanner#expect_views_listed_in_order` snapshotted the rows once (`all("tr td.name").map(&:text)`) and compared them with a non-retrying `eq`. When the assertion ran before the post-sort document settled, it read the previous order and failed. Locally the lighter page settles before the snapshot, hiding the race; CI's compiled frontend and parallel load expose it.

The fix replaces the snapshot with retrying Capybara matchers that re-query the scoped table body until the expected order appears, so the assertion tolerates the reload instead of racing it. `exact_text:` preserves the exact-match semantics of the original `eq`. The change is scoped to the two spec page objects; no production code changes.

# Merge checklist

- [x] Added/updated tests
