### PR TITLE
Update node buildpack to v356

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git#v315
+https://github.com/heroku/heroku-buildpack-nodejs.git#v356
 https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1


### PR DESCRIPTION
# Ticket

no ticket

# What are you trying to accomplish?

Ensures support for latest node versions, including v24.15.0, which the project `package.json` was bumped to in 7504109c34b.

See also opf/openproject#23995.

# Merge checklist

- [ ] Added/updated tests
