### PR TITLE
[OP-19609] Cost fields are still showing on WPs even if all cost types are disabled in the project

### DIFF
--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -301,31 +301,39 @@ module Costs
     end
 
     extend_api_response(:v3, :work_packages, :schema, :work_package_schema) do
+      costs_visible = ->(*) { represented.project&.costs_enabled? }
+
+      # Unit costs (and the overall total) require an available cost type.
+      # instance_exec keeps `represented` bound to the decorator.
+      unit_costs_visible = ->(*) {
+        instance_exec(&costs_visible) && represented.project.cost_types_available?
+      }
+
       # N.B. in the long term we should have a type like "Currency", but that requires a proper
       # format and not a string like "10 EUR"
       schema :overall_costs,
              type: "String",
              required: false,
              writable: false,
-             show_if: ->(*) { represented.project && represented.project.costs_enabled? }
+             show_if: unit_costs_visible
 
       schema :labor_costs,
              type: "String",
              required: false,
              writable: false,
-             show_if: ->(*) { represented.project && represented.project.costs_enabled? }
+             show_if: costs_visible
 
       schema :material_costs,
              type: "String",
              required: false,
              writable: false,
-             show_if: ->(*) { represented.project && represented.project.costs_enabled? }
+             show_if: unit_costs_visible
 
       schema :costs_by_type,
              type: "Collection",
              name_source: :spent_units,
              required: false,
-             show_if: ->(*) { represented.project && represented.project.costs_enabled? },
+             show_if: unit_costs_visible,
              writable: false
     end
 

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -342,12 +342,19 @@ module Costs
       ::Type.add_default_group(:costs, :label_cost_plural)
       ::Type.add_default_mapping(:costs, *cost_attributes)
 
-      constraint = ->(_type, project: nil) {
+      # Unit costs (and the overall total they feed into) are meaningless without a
+      # cost type, so they are hidden when none is available in the project.
+      unit_costs_constraint = ->(_type, project: nil) {
+        project.nil? || (project.costs_enabled? && project.cost_types_available?)
+      }
+      # Labor costs come from time entries and stay visible regardless.
+      costs_constraint = ->(_type, project: nil) {
         project.nil? || project.costs_enabled?
       }
 
-      cost_attributes.each do |attribute|
-        ::Type.add_constraint attribute, constraint
+      ::Type.add_constraint :labor_costs, costs_constraint
+      %i(costs_by_type material_costs overall_costs).each do |attribute|
+        ::Type.add_constraint attribute, unit_costs_constraint
       end
 
       ::Queries::Register.register(::Query) do

--- a/modules/costs/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -54,115 +54,87 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
   subject { representer.to_json }
 
-  describe "overallCosts" do
-    context "has the permissions" do
+  shared_examples_for "a cost schema property" do |json_path|
+    context "with costs enabled and a cost type available" do
       before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(true)
+        allow(project).to receive_messages(costs_enabled?: true, cost_types_available?: true)
       end
 
       it_behaves_like "has basic schema properties" do
-        let(:path) { "overallCosts" }
-        let(:type) { "String" }
-        let(:name) { I18n.t("activerecord.attributes.work_package.overall_costs") }
-        let(:required) { false }
-        let(:writable) { false }
+        let(:path) { json_path }
       end
     end
 
-    context "lacks the permissions" do
+    context "when costs are disabled" do
       before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(false)
+        allow(project).to receive_messages(costs_enabled?: false, cost_types_available?: true)
       end
 
-      it { is_expected.not_to have_json_path("overallCosts") }
+      it { is_expected.not_to have_json_path(json_path) }
     end
+  end
+
+  shared_examples_for "hidden without a cost type" do |json_path|
+    context "when no cost type is available" do
+      before do
+        allow(project).to receive_messages(costs_enabled?: true, cost_types_available?: false)
+      end
+
+      it { is_expected.not_to have_json_path(json_path) }
+    end
+  end
+
+  shared_examples_for "shown without a cost type" do |json_path|
+    context "when no cost type is available" do
+      before do
+        allow(project).to receive_messages(costs_enabled?: true, cost_types_available?: false)
+      end
+
+      it { is_expected.to have_json_path(json_path) }
+    end
+  end
+
+  describe "overallCosts" do
+    it_behaves_like "a cost schema property", "overallCosts" do
+      let(:type) { "String" }
+      let(:name) { I18n.t("activerecord.attributes.work_package.overall_costs") }
+      let(:required) { false }
+      let(:writable) { false }
+    end
+
+    it_behaves_like "hidden without a cost type", "overallCosts"
   end
 
   describe "laborCosts" do
-    context "has the permissions" do
-      before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(true)
-      end
-
-      it_behaves_like "has basic schema properties" do
-        let(:path) { "laborCosts" }
-        let(:type) { "String" }
-        let(:name) { I18n.t("activerecord.attributes.work_package.labor_costs") }
-        let(:required) { false }
-        let(:writable) { false }
-      end
+    it_behaves_like "a cost schema property", "laborCosts" do
+      let(:type) { "String" }
+      let(:name) { I18n.t("activerecord.attributes.work_package.labor_costs") }
+      let(:required) { false }
+      let(:writable) { false }
     end
 
-    context "lacks the permissions" do
-      before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(false)
-      end
-
-      it { is_expected.not_to have_json_path("laborCosts") }
-    end
+    it_behaves_like "shown without a cost type", "laborCosts"
   end
 
   describe "materialCosts" do
-    context "has the permissions" do
-      before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(true)
-      end
-
-      it_behaves_like "has basic schema properties" do
-        let(:path) { "materialCosts" }
-        let(:type) { "String" }
-        let(:name) { I18n.t("activerecord.attributes.work_package.material_costs") }
-        let(:required) { false }
-        let(:writable) { false }
-      end
+    it_behaves_like "a cost schema property", "materialCosts" do
+      let(:type) { "String" }
+      let(:name) { I18n.t("activerecord.attributes.work_package.material_costs") }
+      let(:required) { false }
+      let(:writable) { false }
     end
 
-    context "lacks the permissions" do
-      before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(false)
-      end
-
-      it { is_expected.not_to have_json_path("materialCosts") }
-    end
+    it_behaves_like "hidden without a cost type", "materialCosts"
   end
 
   describe "costsByType" do
-    context "has the permissions" do
-      before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(true)
-      end
-
-      it_behaves_like "has basic schema properties" do
-        let(:path) { "costsByType" }
-        let(:type) { "Collection" }
-        let(:name) { I18n.t("activerecord.attributes.work_package.spent_units") }
-        let(:required) { false }
-        let(:writable) { false }
-      end
+    it_behaves_like "a cost schema property", "costsByType" do
+      let(:type) { "Collection" }
+      let(:name) { I18n.t("activerecord.attributes.work_package.spent_units") }
+      let(:required) { false }
+      let(:writable) { false }
     end
 
-    context "lacks the permissions" do
-      before do
-        allow(project)
-          .to receive(:costs_enabled?)
-          .and_return(false)
-      end
-
-      it { is_expected.not_to have_json_path("costsByType") }
-    end
+    it_behaves_like "hidden without a cost type", "costsByType"
   end
 end

--- a/modules/costs/spec/lib/costs/work_package_cost_attributes_constraint_spec.rb
+++ b/modules/costs/spec/lib/costs/work_package_cost_attributes_constraint_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Costs attribute group cost type availability" do # rubocop:disable RSpec/DescribeClass
+  let(:type) { build(:type) }
+  let(:project) { build_stubbed(:project) }
+
+  # Unit-cost attributes (and the overall total they feed) are meaningless without
+  # a cost type, so they are hidden when none is available.
+  let(:cost_type_dependent_attributes) { %i[overall_costs material_costs costs_by_type] }
+  # Labor costs (time entries) and budgets do not depend on cost types and stay visible.
+  let(:cost_type_independent_attributes) { %i[labor_costs budget] }
+
+  before do
+    allow(project).to receive_messages(costs_enabled?: true, module_enabled?: true)
+  end
+
+  def passes_constraint?(attribute)
+    type.passes_attribute_constraint?(attribute, project:)
+  end
+
+  context "when at least one cost type is available in the project" do
+    before { allow(project).to receive(:cost_types_available?).and_return(true) }
+
+    it "keeps every cost attribute in the work package form configuration" do
+      (cost_type_dependent_attributes + cost_type_independent_attributes).each do |attribute|
+        expect(passes_constraint?(attribute)).to be(true), "expected #{attribute} to be shown"
+      end
+    end
+  end
+
+  context "when no cost type is available in the project" do
+    before { allow(project).to receive(:cost_types_available?).and_return(false) }
+
+    it "hides the cost-type-dependent attributes" do
+      cost_type_dependent_attributes.each do |attribute|
+        expect(passes_constraint?(attribute)).to be(false), "expected #{attribute} to be hidden"
+      end
+    end
+
+    it "still shows labor costs and the budget" do
+      cost_type_independent_attributes.each do |attribute|
+        expect(passes_constraint?(attribute)).to be(true), "expected #{attribute} to stay shown"
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -33,6 +33,8 @@ require "spec_helper"
 RSpec.describe "Shared Work Package Access",
                :js, with_ee: %i[work_package_sharing] do
   shared_let(:project) { create(:project_with_types) }
+  # A cost type must exist for the unit cost fields (e.g. overallCosts) to be shown.
+  shared_let(:cost_type) { create(:cost_type) }
   # This custom field is not explicitly displayed, but it's purpose is to ensure there are no errors
   # on the overview page while displaying project attributes.
   shared_let(:int_project_custom_field) { create(:integer_project_custom_field, projects: [project]) }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/OP-19609

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Hide the cost types related fields if no cost type is available to the project.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Nothing fancy, just using visibility constraints for work package fields.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
