### PR TITLE
Fix invitation mails for series occurrence triggers

### DIFF
--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -31,7 +31,7 @@
 class MeetingMailer < UserMailer
   include CalendarAttachment
 
-  def invited(meeting, user, actor)
+  def invited(meeting, user, actor, standalone_occurrence: false)
     @actor = actor
     @meeting = meeting
     @user = user
@@ -39,7 +39,7 @@ class MeetingMailer < UserMailer
     open_project_headers "Project" => @meeting.project.identifier,
                          "Meeting-Id" => @meeting.id
 
-    with_attached_ics(meeting, user) do
+    with_attached_ics(meeting, user, standalone_occurrence:) do
       subject = "[#{@meeting.project.name}] #{@meeting.title}"
       mail(to: user, subject:)
     end
@@ -145,12 +145,12 @@ class MeetingMailer < UserMailer
     end
   end
 
-  def ics_service_call(meeting, user, **args)
+  def ics_service_call(meeting, user, standalone_occurrence: false, **args)
     if meeting.is_a?(RecurringMeeting)
       ::RecurringMeetings::ICalService
         .new(user:, series: meeting)
         .generate_series(**args)
-    elsif meeting.recurring?
+    elsif meeting.recurring? && !standalone_occurrence
       ::RecurringMeetings::ICalService
         .new(user:, series: meeting.recurring_meeting)
         .generate_single_occurrence(meeting: meeting, **args)

--- a/modules/meeting/app/services/meeting_notification_service.rb
+++ b/modules/meeting/app/services/meeting_notification_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class MeetingNotificationService
   attr_reader :meeting, :content_type
 
@@ -20,7 +21,7 @@ class MeetingNotificationService
   def send_notifications!(action, **)
     recipients_with_errors = []
     meeting.participants.includes(:user).find_each do |recipient|
-      MeetingMailer.send(action, meeting, recipient.user, User.current, **).deliver_later
+      send_notification(action, recipient, **)
     rescue StandardError => e
       Rails.logger.error do
         "Failed to deliver #{action} notification to #{recipient.mail}: #{e.message}"
@@ -29,5 +30,37 @@ class MeetingNotificationService
     end
 
     recipients_with_errors
+  end
+
+  def send_notification(action, recipient, **)
+    notification_mail(action, recipient, **).deliver_later
+  end
+
+  ##
+  # Sends the appropriate notification mail based on the action and recipient.
+  # In some cases, we need to send a different mail for series and standalone occurrences
+  # because the participant may be invited to the series or only the standalone occurrence.
+  def notification_mail(action, recipient, **)
+    if series_invite?(action)
+      send_series_invite(recipient)
+    else
+      MeetingMailer.public_send(action, meeting, recipient.user, User.current, **)
+    end
+  end
+
+  def send_series_invite(recipient)
+    if template_participant_user_ids.include?(recipient.user_id)
+      MeetingSeriesMailer.invited(meeting.recurring_meeting, recipient.user, User.current)
+    else
+      MeetingMailer.invited(meeting, recipient.user, User.current, standalone_occurrence: true)
+    end
+  end
+
+  def series_invite?(action)
+    action == :invited && meeting.recurring?
+  end
+
+  def template_participant_user_ids
+    MeetingParticipant.where(meeting_id: meeting.recurring_meeting.template.id).pluck(:user_id)
   end
 end

--- a/modules/meeting/app/services/meeting_notification_service.rb
+++ b/modules/meeting/app/services/meeting_notification_service.rb
@@ -61,6 +61,6 @@ class MeetingNotificationService
   end
 
   def template_participant_user_ids
-    MeetingParticipant.where(meeting_id: meeting.recurring_meeting.template.id).pluck(:user_id)
+    @template_participant_user_ids ||= MeetingParticipant.where(meeting_id: meeting.recurring_meeting.template.id).pluck(:user_id)
   end
 end

--- a/modules/meeting/app/services/recurring_meetings/ical_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/ical_service.rb
@@ -56,7 +56,7 @@ module RecurringMeetings
 
     def generate_single_occurrence(meeting:, cancelled: false) # rubocop:disable Metrics/AbcSize
       User.execute_as(user) do
-        calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default)
+        calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default, user:)
         calendar.add_single_recurring_occurrence(meeting:, cancelled:)
         calendar.update_calendar_status(cancelled:)
 

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -28,6 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+require "icalendar"
 require_relative "../spec_helper"
 
 RSpec.describe MeetingMailer do
@@ -84,6 +85,33 @@ RSpec.describe MeetingMailer do
     it "renders the html body" do
       User.execute_as(watcher1) do
         check_meeting_mail_content mail.html_part.body
+      end
+    end
+
+    context "when a recurring occurrence is sent as a standalone occurrence" do
+      let(:recurring_meeting) do
+        create(:recurring_meeting,
+               title: "Weekly Sync",
+               project:,
+               author:)
+      end
+      let(:meeting) do
+        create(:recurring_meeting_occurrence,
+               recurring_meeting:,
+               start_time: recurring_meeting.start_time,
+               recurrence_start_time: recurring_meeting.start_time)
+      end
+      let(:mail) { described_class.invited(meeting, watcher1, author, standalone_occurrence: true) }
+      let(:calendar) { Icalendar::Calendar.parse(mail.attachments["meeting.ics"].body.decoded).first }
+      let(:entry) { calendar.events.first }
+
+      it "renders one standalone event for the occurrence" do
+        expect(calendar.events.length).to eq(1)
+
+        expect(entry.uid).to eq(meeting.uid)
+        expect(entry.recurrence_id).to be_nil
+        expect(entry.rrule).to be_empty
+        expect(entry.description).to eq("Link to meeting: http://#{Setting.host_name}/meetings/#{meeting.id}")
       end
     end
 

--- a/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
@@ -141,6 +141,33 @@ RSpec.describe MeetingSeriesMailer do
       expect(entry.description).to eq "Link to meeting series: http://#{Setting.host_name}/recurring_meetings/#{series.id}"
       expect(entry.location).to eq(series.template&.location.presence)
     end
+
+    context "with an instantiated occurrence" do
+      let!(:template_participant) do
+        create(:meeting_participant, :invitee, meeting: series.template, user: recipient)
+      end
+      let!(:occurrence) do
+        create(:recurring_meeting_occurrence,
+               recurring_meeting: series,
+               start_time: series.start_time,
+               recurrence_start_time: series.start_time)
+      end
+      let(:calendar) { Icalendar::Calendar.parse(mail.attachments["meeting.ics"].body.decoded).first }
+      let(:master_event) { calendar.events.find { |event| event.recurrence_id.blank? } }
+      let(:occurrence_event) { calendar.events.find { |event| event.recurrence_id.present? } }
+
+      it "renders the series master and occurrence override" do
+        expect(calendar.events.length).to eq(2)
+
+        expect(master_event.uid).to eq(series.uid)
+        expect(master_event.rrule).not_to be_empty
+
+        expect(occurrence_event.uid).to eq(series.uid)
+        expect(occurrence_event.recurrence_id).to eq(occurrence.recurrence_start_time)
+        expect(occurrence_event.description.to_s)
+          .to include("Link to meeting occurrence: http://#{Setting.host_name}/meetings/#{occurrence.id}")
+      end
+    end
   end
 
   context "with a recipient with another time zone" do

--- a/modules/meeting/spec/services/meeting_notification_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_notification_service_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "icalendar"
+require "spec_helper"
+
+RSpec.describe MeetingNotificationService do
+  shared_let(:project) { create(:project) }
+  shared_let(:actor) { create(:user) }
+  shared_let(:series_participant) { create(:user) }
+  shared_let(:occurrence_participant) { create(:user) }
+
+  before do
+    User.current = actor
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "#call" do
+    subject(:service_call) { described_class.new(meeting).call(:invited) }
+
+    context "for a recurring meeting occurrence" do
+      let(:recurring_meeting) do
+        create(:recurring_meeting,
+               project:,
+               author: actor,
+               start_time: Time.zone.tomorrow + 10.hours)
+      end
+
+      let(:meeting) do
+        create(:recurring_meeting_occurrence,
+               recurring_meeting:,
+               start_time: recurring_meeting.start_time,
+               recurrence_start_time: recurring_meeting.start_time)
+      end
+
+      before do
+        recurring_meeting.template.update!(notify: true)
+
+        create(:meeting_participant, :invitee, meeting: recurring_meeting.template, user: series_participant)
+        create(:meeting_participant, :invitee, meeting:, user: series_participant)
+        create(:meeting_participant, :invitee, meeting:, user: occurrence_participant)
+      end
+
+      it "sends a series ICS to template participants and a standalone ICS to occurrence-only participants" do
+        perform_enqueued_jobs do
+          expect(service_call).to be_success
+        end
+
+        expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+        series_mail = delivered_mail_for(series_participant)
+        occurrence_mail = delivered_mail_for(occurrence_participant)
+
+        series_calendar = parse_ics_attachment(series_mail)
+        series_master_event = series_calendar.events.find { |event| event.recurrence_id.blank? }
+
+        expect(series_master_event).to be_present
+        expect(series_master_event.uid).to eq(recurring_meeting.uid)
+        expect(series_master_event.rrule).not_to be_empty
+
+        occurrence_calendar = parse_ics_attachment(occurrence_mail)
+
+        expect(occurrence_calendar.events.length).to eq(1)
+        expect(occurrence_calendar.events.first.uid).to eq(meeting.uid)
+        expect(occurrence_calendar.events.first.recurrence_id).to be_nil
+        expect(occurrence_calendar.events.first.rrule).to be_empty
+      end
+    end
+  end
+
+  def delivered_mail_for(user)
+    ActionMailer::Base.deliveries.find { |mail| mail.to == [user.mail] }
+  end
+
+  def parse_ics_attachment(mail)
+    Icalendar::Calendar.parse(mail.attachments["meeting.ics"].body.decoded).first
+  end
+end

--- a/modules/meeting/spec/services/meeting_notification_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_notification_service_spec.rb
@@ -28,7 +28,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "icalendar"
 require "spec_helper"
 
 RSpec.describe MeetingNotificationService do
@@ -39,7 +38,6 @@ RSpec.describe MeetingNotificationService do
 
   before do
     User.current = actor
-    ActionMailer::Base.deliveries.clear
   end
 
   describe "#call" do
@@ -68,38 +66,17 @@ RSpec.describe MeetingNotificationService do
         create(:meeting_participant, :invitee, meeting:, user: occurrence_participant)
       end
 
-      it "sends a series ICS to template participants and a standalone ICS to occurrence-only participants" do
-        perform_enqueued_jobs do
-          expect(service_call).to be_success
-        end
+      it "routes template participants to the series mailer and occurrence-only participants to a standalone occurrence" do
+        allow(MeetingSeriesMailer).to receive(:invited).and_call_original
+        allow(MeetingMailer).to receive(:invited).and_call_original
 
-        expect(ActionMailer::Base.deliveries.count).to eq(2)
+        expect(service_call).to be_success
 
-        series_mail = delivered_mail_for(series_participant)
-        occurrence_mail = delivered_mail_for(occurrence_participant)
-
-        series_calendar = parse_ics_attachment(series_mail)
-        series_master_event = series_calendar.events.find { |event| event.recurrence_id.blank? }
-
-        expect(series_master_event).to be_present
-        expect(series_master_event.uid).to eq(recurring_meeting.uid)
-        expect(series_master_event.rrule).not_to be_empty
-
-        occurrence_calendar = parse_ics_attachment(occurrence_mail)
-
-        expect(occurrence_calendar.events.length).to eq(1)
-        expect(occurrence_calendar.events.first.uid).to eq(meeting.uid)
-        expect(occurrence_calendar.events.first.recurrence_id).to be_nil
-        expect(occurrence_calendar.events.first.rrule).to be_empty
+        expect(MeetingSeriesMailer).to have_received(:invited)
+          .with(recurring_meeting, series_participant, actor)
+        expect(MeetingMailer).to have_received(:invited)
+          .with(meeting, occurrence_participant, actor, standalone_occurrence: true)
       end
     end
-  end
-
-  def delivered_mail_for(user)
-    ActionMailer::Base.deliveries.find { |mail| mail.to == [user.mail] }
-  end
-
-  def parse_ics_attachment(mail)
-    Icalendar::Calendar.parse(mail.attachments["meeting.ics"].body.decoded).first
   end
 end


### PR DESCRIPTION
When triggering an invitation email of a series occurrence, only the individual event was sent out.

This is only correct for participants that only join the one meeting, not the series. For them, the invite should be a plain one-time event.

Manual invites from a recurring occurrence now send full series ICS data to series participants, while occurrence-only participants receive a standalone one-time event. This avoids sending isolated recurrence ICS files that cannot be parsed.

# Ticket
https://community.openproject.org/projects/MEET/work_packages/MEET-573/activity