### PR TITLE
Output occurrences that fall in previous schedule using RDATE

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -120,6 +120,11 @@ module Meetings
 
         # Add exceptions for all cancelled recurrences
         set_excluded_recurrence_dates(event: e, recurring_meeting: recurring_meeting)
+
+        # Previous-schedule overrides are outside the current RRULE expansion.
+        # Add them as RDATEs so strict clients can attach their RECURRENCE-ID
+        # overrides to the master event.
+        set_included_recurrence_dates(event: e, recurring_meeting: recurring_meeting)
       end
 
       # Add single events for all occurrences
@@ -306,16 +311,31 @@ module Meetings
 
     # Methods for recurring meetings
     def add_instantiated_occurrences(recurring_meeting:)
-      previous, upcoming = instantiated_schedules(recurring_meeting)
-                             .partition { |meeting| in_previous_schedule?(meeting, recurring_meeting) }
-
-      recent_previous = previous
-                          .sort_by(&:recurrence_start_time)
-                          .last(PAST_OCCURRENCES_LIMIT)
-
-      (recent_previous + upcoming).each do |meeting|
+      instantiated_occurrences_for_export(recurring_meeting).each do |meeting|
         add_single_recurring_occurrence(meeting:)
       end
+    end
+
+    def instantiated_occurrences_for_export(recurring_meeting)
+      previous_schedule_occurrences(recurring_meeting) + upcoming_schedule_occurrences(recurring_meeting)
+    end
+
+    def previous_schedule_occurrences(recurring_meeting)
+      instantiated_schedules_partitioned(recurring_meeting)
+        .first
+        .sort_by(&:recurrence_start_time)
+        .last(PAST_OCCURRENCES_LIMIT)
+    end
+
+    def upcoming_schedule_occurrences(recurring_meeting)
+      instantiated_schedules_partitioned(recurring_meeting).second
+    end
+
+    def instantiated_schedules_partitioned(recurring_meeting)
+      @instantiated_schedules_partition_cache ||= {}
+      @instantiated_schedules_partition_cache[recurring_meeting.id] ||=
+        instantiated_schedules(recurring_meeting)
+          .partition { |meeting| in_previous_schedule?(meeting, recurring_meeting) }
     end
 
     def in_previous_schedule?(meeting, recurring_meeting)
@@ -365,6 +385,11 @@ module Meetings
     def set_excluded_recurrence_dates(event:, recurring_meeting:)
       event.exdate = cancelled_recurrence_dates(recurring_meeting)
                        .map { ical_datetime(it, timezone: recurring_meeting.time_zone) }
+    end
+
+    def set_included_recurrence_dates(event:, recurring_meeting:)
+      event.rdate = previous_schedule_occurrences(recurring_meeting)
+                    .map { ical_datetime(it.recurrence_start_time, timezone: recurring_meeting.time_zone) }
     end
 
     def cancelled_recurrence_dates(recurring_meeting)

--- a/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
@@ -241,11 +241,12 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       recurring_meeting.update!(current_schedule_start: new_schedule_start)
     end
 
-    it "emits only the 10 most recent previous-schedule occurrences as overrides without polluting EXDATE" do
+    it "emits only the 10 most recent previous-schedule occurrences as RDATE-backed overrides" do
       builder.add_series_event(recurring_meeting: recurring_meeting)
 
       master_event = parsed_calendar.events.find { |event| event.recurrence_id.nil? }
       override_events = parsed_calendar.events.select { |event| event.recurrence_id.present? }
+      previous_schedule_start_times = past_occurrence_start_times.last(10).map(&:to_time)
 
       expect(master_event.dtstart).to eq(new_schedule_start)
       expect(master_event.dtend).to eq(new_schedule_start + recurring_meeting.template.duration.hours)
@@ -253,10 +254,12 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       # EXDATE is reserved for cancelled meetings still in the RRULE expansion.
       # Previous-schedule occurrences are already outside it, so EXDATE'ing them would be a no-op.
       expect(Array(master_event.exdate)).to be_empty
+      expect(Array(master_event.rdate).map { |date| date.value.to_time })
+        .to match_array(previous_schedule_start_times)
 
       expect(override_events.count).to eq(10)
       expect(override_events.map { |evt| evt.recurrence_id.to_time })
-        .to match_array(past_occurrence_start_times.last(10).map(&:to_time))
+        .to match_array(previous_schedule_start_times)
     end
   end
 end


### PR DESCRIPTION
A recurring meeting series is exported as one master event using DTSTART and RRULE. Individual meetings that differ from the schedule are exported as separate override events, each tagged with a RECURRENCE-ID pointing at the original slot it replaces.

The problem: when someone changes the series schedule, we insert a new current_schedule_start date as DTSTART. But the older meetings that already happened before that new start are still exported as overrides, with a RECURRENCE-ID sitting before DTSTART.

Strict clients like OX complain about this and fail the input

This fix adds those older dates back as RDATE entries on the master event. RDATE means "this date is also part of the recurrence set, even though the RRULE wouldn't generate it." Now the override has a real instance to atccept it.

What does not get an RDATE:
- Occurrences at or after the new DTSTART: the RRULE already covers them, so they're valid instances on their own.
- Cancelled occurrences: those use EXDATE (removal), the opposite

https://community.openproject.org/projects/MEET/work_packages/MEET-574/activity