### PR TITLE
[NEX-630] Remove breaking unescape

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/commands/set_permissions_command.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/commands/set_permissions_command.rb
@@ -56,7 +56,7 @@ module Storages
                                               UrlBuilder.url(@storage.uri,
                                                              "remote.php/dav/files",
                                                              username,
-                                                             CGI.unescape(folder_info.location)),
+                                                             folder_info.location),
                                               xml: body)
 
                       handle_response(response)


### PR DESCRIPTION
# Ticket
[NEX-630](https://community.openproject.org/wp/NEX-630)

# What are you trying to accomplish?
- set permission service must work again

# What approach did you choose and why?
- building proppatch must not unescape the location value, as it is already unescaped
- characters like '+' break the proppatch request