### PR TITLE
Bug/COMMS-837: Use semantic work package identifier in time tracking exports

### DIFF
--- a/modules/costs/lib/full_calendar/time_entry_event.rb
+++ b/modules/costs/lib/full_calendar/time_entry_event.rb
@@ -41,7 +41,7 @@ module FullCalendar
           starts_at: starts_at,
           ends_at: ends_at,
           all_day: !time_entry.ongoing? && time_entry.start_time.blank?,
-          title: "#{time_entry.project.name}: ##{time_entry.entity.id} #{time_entry.entity.subject}"
+          title: "#{time_entry.project.name}: #{time_entry.entity.formatted_id} #{time_entry.entity.subject}"
         )
         event.time_entry = time_entry
 
@@ -68,7 +68,7 @@ module FullCalendar
         durationEditable: time_entry.start_time.present?,
         hours: time_entry.hours_for_calculation,
         typeId: time_entry.entity.type_id,
-        workPackageId: time_entry.entity.id,
+        workPackageId: time_entry.entity.to_param,
         workPackageSubject: time_entry.entity.subject,
         projectId: time_entry.project.id,
         projectName: time_entry.project.name,

--- a/modules/costs/spec/lib/full_calendar/time_entry_event_spec.rb
+++ b/modules/costs/spec/lib/full_calendar/time_entry_event_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression guard for COMMS-837: the "My time tracking" workweek calendar must
+# link each time-entry event to its work package by the display identifier, so
+# semantic identifiers (e.g. "PROJ-42") route through /wp/<identifier> instead
+# of the bare numeric id.
+RSpec.describe FullCalendar::TimeEntryEvent do
+  shared_let(:project) { create(:project) }
+  shared_let(:type) { create(:type, name: "Task") }
+  shared_let(:work_package) do
+    create(:work_package, project:, type:, subject: "Fix the thing").tap do |wp|
+      wp.update_columns(identifier: "PROJ-42", sequence_number: 42)
+    end
+  end
+  shared_let(:time_entry) { create(:time_entry, entity: work_package) }
+
+  subject(:json) { described_class.from_time_entry(time_entry).as_json }
+
+  context "with semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+    it "links the work package by its semantic identifier" do
+      expect(json["workPackageId"]).to eq("PROJ-42")
+    end
+
+    it "shows the semantic identifier in the event title" do
+      expect(json["title"]).to eq("#{project.name}: PROJ-42 Fix the thing")
+    end
+  end
+
+  context "with classic mode", with_settings: { work_packages_identifier: "classic" } do
+    it "links the work package by its numeric id" do
+      expect(json["workPackageId"]).to eq(work_package.id.to_s)
+    end
+
+    it "shows the numeric id in the event title" do
+      expect(json["title"]).to eq("#{project.name}: ##{work_package.id} Fix the thing")
+    end
+  end
+end

--- a/modules/xls_export/lib/open_project/xls_export/xls_views.rb
+++ b/modules/xls_export/lib/open_project/xls_export/xls_views.rb
@@ -87,7 +87,7 @@ class OpenProject::XlsExport::XlsViews
 
   def work_package_representation(value)
     ar_presentation(WorkPackage, value) do |work_package|
-      "#{work_package.type} ##{work_package.id}: #{work_package.subject}"
+      "#{work_package.type} #{work_package.formatted_id}: #{work_package.subject}"
     end
   end
 

--- a/modules/xls_export/lib/open_project/xls_export/xls_views.rb
+++ b/modules/xls_export/lib/open_project/xls_export/xls_views.rb
@@ -95,7 +95,7 @@ class OpenProject::XlsExport::XlsViews
     # TODO: All possible time entry associations need to be checked here
     entity = GlobalID::Locator.locate(value, only: TimeEntry::ALLOWED_ENTITY_TYPES.map(&:safe_constantize))
     if entity.is_a?(WorkPackage)
-      "#{entity.type} ##{entity.id}: #{entity.subject}"
+      "#{entity.type} #{entity.formatted_id}: #{entity.subject}"
     elsif entity.is_a?(Meeting)
       "#{Meeting.model_name.human} ##{entity.id}: #{entity.title}"
     end

--- a/modules/xls_export/spec/lib/open_project/xls_export/xls_views_spec.rb
+++ b/modules/xls_export/spec/lib/open_project/xls_export/xls_views_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression guard for COMMS-837: the XLS cost-report export must render the
+# work package's display identifier in the "Logged for" column, so semantic
+# identifiers (e.g. "PROJ-42") appear instead of the numeric id.
+RSpec.describe OpenProject::XlsExport::XlsViews do
+  subject(:view) { described_class.new }
+
+  shared_let(:project) { create(:project) }
+  shared_let(:type) { create(:type, name: "Task") }
+  shared_let(:work_package) do
+    create(:work_package, project:, type:, subject: "Fix the thing").tap do |wp|
+      wp.update_columns(identifier: "PROJ-42", sequence_number: 42)
+    end
+  end
+
+  # The "Logged for" cell is the entity_gid attribute; the renderer locates the
+  # work package from its GlobalID and formats "<type> <id>: <subject>".
+  describe "#entity_global_id_representation" do
+    let(:entity_gid) { work_package.to_global_id.to_s }
+
+    context "with semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      it "renders the semantic identifier, not the numeric id" do
+        expect(view.entity_global_id_representation(entity_gid))
+          .to eq("Task PROJ-42: Fix the thing")
+      end
+    end
+
+    context "with classic mode", with_settings: { work_packages_identifier: "classic" } do
+      it "renders the numeric id with a # prefix (no regression)" do
+        expect(view.entity_global_id_representation(entity_gid))
+          .to eq("Task ##{work_package.id}: Fix the thing")
+      end
+    end
+  end
+end

--- a/modules/xls_export/spec/lib/open_project/xls_export/xls_views_spec.rb
+++ b/modules/xls_export/spec/lib/open_project/xls_export/xls_views_spec.rb
@@ -35,4 +35,22 @@ RSpec.describe OpenProject::XlsExport::XlsViews do
       end
     end
   end
+
+  # The :work_package_id column renderer is fed the numeric id directly and
+  # formats "<type> <id>: <subject>"; it must honour the same display identifier.
+  describe "#work_package_representation" do
+    context "with semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      it "renders the semantic identifier, not the numeric id" do
+        expect(view.work_package_representation(work_package.id))
+          .to eq("Task PROJ-42: Fix the thing")
+      end
+    end
+
+    context "with classic mode", with_settings: { work_packages_identifier: "classic" } do
+      it "renders the numeric id with a # prefix (no regression)" do
+        expect(view.work_package_representation(work_package.id))
+          .to eq("Task ##{work_package.id}: Fix the thing")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

[COMMS-837](https://community.openproject.org/wp/COMMS-837): Semantic identifier is missing in XLS timesheets

# What are you trying to accomplish?

On instances using semantic work package identifiers, two time-tracking surfaces still fell back to the numeric id:

- [x] The "Logged for" column of the Time and costs XLS export now shows the work package's display identifier (e.g. `Task JIRA101-1: Subject`) instead of `Task #41: Subject`.
- [x] The My time tracking workweek calendar now links each entry to the work package by its display identifier (e.g. `/wp/JIRA101-1`) instead of `/wp/41`.

## Screenshots

| XLS Export | Calendar WP Links |
|--------|--------|
| <img width="236" height="92" alt="Screenshot 2026-06-30 at 4 13 00 PM" src="https://github.com/user-attachments/assets/c2514684-ee13-4237-b858-f0e05cec9931" /> | <img width="1078" height="716" alt="Screenshot 2026-06-30 at 4 14 41 PM" src="https://github.com/user-attachments/assets/7d5e391f-3042-4e1d-a410-6fdebe8a2493" /> |


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
