### PR TITLE
[AGILE-313] All sprints links directly to selected sprint

### DIFF
--- a/modules/backlogs/app/helpers/backlogs/sprints_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/sprints_helper.rb
@@ -35,7 +35,7 @@ module Backlogs
       if sprint.active? && (board = sprint.task_board_for(project))
         project_work_package_board_path(project, board)
       elsif sprint.in_planning?
-        project_backlogs_backlog_path(project)
+        project_backlogs_backlog_path(project, sprint_ids: [sprint.id])
       elsif sprint.completed?
         sprint_work_packages_path(sprint, project)
       end

--- a/modules/backlogs/spec/components/backlogs/sprints/row_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprints/row_component_spec.rb
@@ -63,8 +63,9 @@ RSpec.describe Backlogs::Sprints::RowComponent, type: :component do
     context "when sprint is in planning" do
       let(:sprint) { build_stubbed(:sprint, project:, status: :in_planning, name: "Planning sprint") }
 
-      it "links to the backlog" do
-        expect(rendered_component).to have_link("Planning sprint", href: project_backlogs_backlog_path(project))
+      it "links to the backlog filtered by sprint" do
+        expect(rendered_component).to have_link("Planning sprint",
+                                                href: project_backlogs_backlog_path(project, sprint_ids: [sprint.id]))
       end
     end
 
@@ -128,7 +129,7 @@ RSpec.describe Backlogs::Sprints::RowComponent, type: :component do
       it "shows dates, status and mapped work package count" do
         expect(rendered_component).to have_css(".start_date", text: "09/01/2025")
         expect(rendered_component).to have_css(".finish_date", text: "09/15/2025")
-        expect(rendered_component).to have_css(".status", text: I18n.t(:"activerecord.attributes.sprint.statuses.in_planning"))
+        expect(rendered_component).to have_css(".status", text: "In planning")
         expect(rendered_component).to have_css(".work_package_count", text: "7")
       end
     end

--- a/modules/backlogs/spec/features/backlogs/sprints/index_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/sprints/index_spec.rb
@@ -153,7 +153,8 @@ RSpec.describe "Sprint index", :js do
       sprints_page.visit!
 
       sprints_page.expect_sprint_present(shared_sprint)
-      sprints_page.expect_sprint_name_link(shared_sprint, href: project_backlogs_backlog_path(receiving_project))
+      sprints_page.expect_sprint_name_link(shared_sprint,
+                                           href: project_backlogs_backlog_path(receiving_project, sprint_ids: [shared_sprint.id]))
     end
   end
 
@@ -196,7 +197,8 @@ RSpec.describe "Sprint index", :js do
     it "links the sprint name according to status" do
       sprints_page.visit!
 
-      sprints_page.expect_sprint_name_link(planning_sprint, href: project_backlogs_backlog_path(project))
+      sprints_page.expect_sprint_name_link(planning_sprint,
+                                           href: project_backlogs_backlog_path(project, sprint_ids: [planning_sprint.id]))
       sprints_page.expect_sprint_name_link(active_sprint, href: project_work_package_board_path(project, active_board))
 
       default_columns = Setting.work_package_list_default_columns.map(&:to_s)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-313

# What are you trying to accomplish?
On the all sprints page, when selecting a sprint that is in planning, the link now filters for the correct sprint so that only the selected sprint is shown on the backlogs & sprints page.

## Screenshots

https://github.com/user-attachments/assets/9ff00ac0-32e8-4de5-b8c4-703dad53cc9e

# What approach did you choose and why?
I chose this over scrolling to the selected sprint as it's less error-prone (works with any display resolution and number of sprints) and less distracting (only shows the sprint you wanted to see).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
