### PR TITLE
[JIM-117] Jira Migration stops if multiple Jira accounts have the same email

### DIFF
--- a/app/models/import/jira_import.rb
+++ b/app/models/import/jira_import.rb
@@ -72,7 +72,6 @@ module Import
       (projects || []).pluck("id")
     end
 
-    # rubocop:disable Metrics/AbcSize
     def destroy_jira_objects
       Import::JiraField.where(jira_import_id: id).destroy_all
       Import::JiraIssue.where(jira_import_id: id).destroy_all
@@ -82,7 +81,6 @@ module Import
       Import::JiraStatus.where(jira_import_id: id).destroy_all
       Import::JiraUser.where(jira_import_id: id).destroy_all
     end
-    # rubocop:enable Metrics/AbcSize
 
     def import_users
       Import::JiraUser.where(jira_import_id: id).find_each do |jira_user|
@@ -92,11 +90,8 @@ module Import
 
     private
 
-    # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/AbcSize
     def import_user(jira_user)
       user_attrs = jira_user.to_op_attributes
-      user_attrs_without_password = user_attrs.except(:password)
       call = Users::CreateService
                .new(user: User.system, contract_class: EmptyContract)
                .call(user_attrs)
@@ -110,68 +105,163 @@ module Import
         )
       end
       call.on_failure do |_result|
-        if call.errors.find { |error| error.type == :taken }.present?
-          user = jira_user.try_to_find_existing_op_users.first
-          if user.present?
-            create_reference!(
-              op_leg: user,
-              jira_leg: jira_user,
-              jira_import: self,
-              uses_existing: true
-            )
-          else
-            raise "Existing User is expected to be found, because there was an email " \
-                  "or login collision. See attributes: #{user_attrs_without_password}"
-          end
-        else
-          raise "Error creating a user (#{user_attrs_without_password}): #{call.message}"
-        end
+        handle_create_user_failure(call, user_attrs, jira_user)
       end
 
-      jira_user_groups = jira_user.payload["groups"]["items"].pluck("name")
+      import_user_groups(jira_user)
+    end
 
-      jira_user_groups.each do |group_name|
-        call = Groups::CreateService
-                 .new(user: User.system, contract_class: EmptyContract)
-                 .call(name: group_name)
-        call.on_success do |result|
-          group = result.result
-          create_reference!(
-            op_leg: group,
-            jira_leg: nil,
-            jira_import: self,
-            uses_existing: false
-          )
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/PerceivedComplexity
+    def handle_create_user_failure(call, user_attrs, jira_user)
+      taken_error = call.errors.find { |error| error.type == :taken }
+      if taken_error.blank?
+        raise "Error creating a user (#{user_attrs.except(:password)}): #{call.message}"
+      end
+
+      if taken_error.attribute == :mail
+        user = User.find_by(["LOWER(mail) = ?", user_attrs[:mail]&.downcase])
+        if user.blank?
+          raise "Existing User is expected to be found, because there was an email " \
+                "collision. See attributes: #{user_attrs.except(:password)}"
         end
-        call.on_failure do |_result|
-          if call.errors.find { |error| error.type == :taken }.present?
-            group = Group.where(name: group_name).first
-            if group.present?
-              create_reference!(
-                op_leg: group,
-                jira_leg: nil,
-                jira_import: self,
-                uses_existing: true
-              )
-            else
-              raise "Existing Group is expected to be found. Group name: #{group_name}"
-            end
-          else
-            raise "Error creating a group #{group_name}: #{call.message}"
-          end
+
+        if jira_user_already_referenced?(user)
+          handle_referenced_user_mail_conflict(user_attrs, jira_user)
+        else
+          create_reference!(op_leg: user, jira_leg: jira_user, jira_import: self, uses_existing: true)
         end
-        member_id = Import::JiraOpenProjectReference.where(
-          jira_import_id: id,
-          jira_entity_id: jira_user.id,
-          jira_entity_class: jira_user.class.to_s
-        ).pick(:op_entity_id)
-        group = Group.find_by!(name: group_name)
-        Groups::AddUsersService
-          .new(group, current_user: User.system)
-          .call(ids: [member_id], send_notifications: false)
+        return
+      end
+
+      user = jira_user.try_to_find_existing_op_users.first
+      if user.blank?
+        raise "Existing User is expected to be found, because there was a login " \
+              "collision. See attributes: #{user_attrs.except(:password)}"
+      end
+
+      if jira_user_already_referenced?(user)
+        raise "Login '#{user_attrs[:login]}' is already taken by an OP user that is referenced by another Jira user. " \
+              "See attributes: #{user_attrs.except(:password)}"
+      end
+
+      create_reference!(
+        op_leg: user,
+        jira_leg: jira_user,
+        jira_import: self,
+        uses_existing: true
+      )
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/PerceivedComplexity
+
+    def handle_referenced_user_mail_conflict(user_attrs, jira_user)
+      unique_mail, reusable_user = resolve_jira_email(user_attrs[:mail], jira_user.jira_user_key)
+      if reusable_user
+        create_reference!(
+          op_leg: reusable_user,
+          jira_leg: jira_user,
+          jira_import: self,
+          uses_existing: true
+        )
+      else
+        new_call = Users::CreateService
+                     .new(user: User.system, contract_class: EmptyContract)
+                     .call(user_attrs.merge(mail: unique_mail))
+        unless new_call.success?
+          raise "Error creating a user with modified email '#{unique_mail}' " \
+                "(#{user_attrs.except(:password)}): #{new_call.message}"
+        end
+
+        create_reference!(
+          op_leg: new_call.result,
+          jira_leg: jira_user,
+          jira_import: self,
+          uses_existing: false
+        )
       end
     end
-    # rubocop:enable Metrics/PerceivedComplexity
+
+    def import_user_groups(jira_user)
+      jira_user.payload["groups"]["items"].pluck("name").each do |group_name|
+        import_user_group(group_name, jira_user)
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def import_user_group(group_name, jira_user)
+      call = Groups::CreateService
+               .new(user: User.system, contract_class: EmptyContract)
+               .call(name: group_name)
+      call.on_success do |result|
+        create_reference!(
+          op_leg: result.result,
+          jira_leg: nil,
+          jira_import: self,
+          uses_existing: false
+        )
+      end
+      call.on_failure do |_result|
+        handle_create_group_failure(call, group_name)
+      end
+      member_id = Import::JiraOpenProjectReference.where(
+        jira_import_id: id,
+        jira_entity_id: jira_user.id,
+        jira_entity_class: jira_user.class.to_s
+      ).pick(:op_entity_id)
+      group = Group.find_by!(name: group_name)
+      Groups::AddUsersService
+        .new(group, current_user: User.system)
+        .call(ids: [member_id], send_notifications: false)
+    end
+
+    def handle_create_group_failure(call, group_name)
+      if call.errors.find { |error| error.type == :taken }.blank?
+        raise "Error creating a group #{group_name}: #{call.message}"
+      end
+
+      group = Group.where(name: group_name).first
+      if group.present?
+        create_reference!(
+          op_leg: group,
+          jira_leg: nil,
+          jira_import: self,
+          uses_existing: true
+        )
+      else
+        raise "Existing Group is expected to be found. Group name: #{group_name}"
+      end
+    end
+
+    def jira_user_already_referenced?(op_user)
+      Import::JiraOpenProjectReference.exists?(
+        jira_import_id: id,
+        jira_entity_class: Import::JiraUser.to_s,
+        op_entity_id: op_user.id,
+        op_entity_class: op_user.class.to_s
+      )
+    end
     # rubocop:enable Metrics/AbcSize
+
+    # Returns [email, existing_user_or_nil].
+    # existing_user_or_nil is set when a user already exists at that address and has no
+    # JiraUser reference yet - meaning it can be reused instead of creating a new account.
+    def resolve_jira_email(original_email, jira_user_key)
+      local, domain = original_email.split("@", 2)
+      safe_key = jira_user_key.gsub(/[^a-zA-Z0-9._-]/, "_")
+
+      candidate = "#{local}+#{safe_key}@#{domain}"
+      user = User.find_by(["LOWER(mail) = ?", candidate.downcase])
+      return [candidate, user] unless user && jira_user_already_referenced?(user)
+
+      counter = 1
+      loop do
+        candidate = "#{local}+#{safe_key}+#{counter}@#{domain}"
+        user = User.find_by(["LOWER(mail) = ?", candidate.downcase])
+        break [candidate, user] unless user && jira_user_already_referenced?(user)
+
+        counter += 1
+      end
+    end
   end
 end

--- a/spec/models/import/jira_import_spec.rb
+++ b/spec/models/import/jira_import_spec.rb
@@ -49,9 +49,7 @@ RSpec.describe Import::JiraImport do
     end
 
     it "memoizes the state machine instance" do
-      # rubocop:disable RSpec/IdenticalEqualityAssertion
       expect(jira_import.state_machine.object_id).to eq(jira_import.state_machine.object_id)
-      # rubocop:enable RSpec/IdenticalEqualityAssertion
     end
   end
 
@@ -479,6 +477,127 @@ RSpec.describe Import::JiraImport do
 
         user = User.find_by(login: "jvd@example.com")
         expect(user.mail).to match(/@noemail.invalid/)
+      end
+    end
+
+    context "when two Jira users share the same email address" do
+      let(:shared_email) { "shared@example.com" }
+      let!(:jira_user1) do
+        create(:jira_user,
+               jira:,
+               jira_import:,
+               payload: jira_user_payload(
+                 key: "JIRAUSER10110",
+                 name: "user.one",
+                 display_name: "User One",
+                 email: shared_email,
+                 groups: []
+               ))
+      end
+      let!(:jira_user2) do
+        create(:jira_user,
+               jira:,
+               jira_import:,
+               jira_user_key: "JIRAUSER10111",
+               payload: jira_user_payload(
+                 key: "JIRAUSER10111",
+                 name: "user.two",
+                 display_name: "User Two",
+                 email: shared_email,
+                 groups: []
+               ))
+      end
+
+      it "creates two separate OpenProject users" do
+        expect { jira_import.import_users }.to change(User, :count).by(2)
+      end
+
+      it "creates individual references for each Jira user" do
+        jira_import.import_users
+
+        ref1 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user1.id)
+        ref2 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user2.id)
+
+        expect(ref1).to be_present
+        expect(ref2).to be_present
+        expect(ref1.op_entity_id).not_to eq(ref2.op_entity_id)
+      end
+
+      it "keeps the original email for the first imported user" do
+        jira_import.import_users
+
+        ref1 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user1.id)
+        expect(User.find(ref1.op_entity_id).mail).to eq(shared_email)
+      end
+
+      it "assigns a plus-addressed email using the Jira key of the second imported user" do
+        jira_import.import_users
+
+        ref2 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user2.id)
+        expect(User.find(ref2.op_entity_id).mail).to eq("shared+JIRAUSER10111@example.com")
+      end
+
+      it "marks the second user as not using an existing OP user" do
+        jira_import.import_users
+
+        ref2 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user2.id)
+        expect(ref2.uses_existing).to be false
+      end
+
+      context "when a user already exists at the Jira-key address but has no JiraUser reference" do
+        let!(:unreferenced_user) do
+          create(:user,
+                 mail: "shared+JIRAUSER10111@example.com",
+                 login: "jira_key_existing",
+                 password: existing_user_password,
+                 password_confirmation: existing_user_password)
+        end
+
+        it "reuses that existing user instead of creating a new one" do
+          expect { jira_import.import_users }.to change(User, :count).by(1)
+
+          ref2 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user2.id)
+          expect(ref2.op_entity_id).to eq(unreferenced_user.id.to_s)
+        end
+
+        it "marks the reference as uses_existing" do
+          jira_import.import_users
+
+          ref2 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user2.id)
+          expect(ref2.uses_existing).to be true
+        end
+      end
+
+      context "when the Jira-key address is taken by an already-referenced user" do
+        let!(:referenced_user) do
+          create(:user,
+                 mail: "shared+JIRAUSER10111@example.com",
+                 login: "jira_key_referenced",
+                 password: existing_user_password,
+                 password_confirmation: existing_user_password)
+        end
+
+        before do
+          other_jira_user = create(:jira_user, jira:, jira_import:,
+                                               jira_user_key: "JIRAUSER99999",
+                                               payload: jira_user_payload(key: "JIRAUSER99999", name: "other",
+                                                                          display_name: "Other", email: "other@example.com",
+                                                                          groups: []))
+          create(:jira_open_project_reference,
+                 jira:,
+                 jira_import:,
+                 jira_entity_id: other_jira_user.id,
+                 jira_entity_class: Import::JiraUser.to_s,
+                 op_entity_id: referenced_user.id,
+                 op_entity_class: referenced_user.class.to_s)
+        end
+
+        it "falls back with a counter suffix" do
+          jira_import.import_users
+
+          ref2 = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user2.id)
+          expect(User.find(ref2.op_entity_id).mail).to eq("shared+JIRAUSER10111+1@example.com")
+        end
       end
     end
   end


### PR DESCRIPTION

# Ticket
https://community.openproject.org/wp/JIM-117

# What are you trying to achieve?
Jira data center allows multiple accounts with one shared email address. OP does not.
The import stops with a non-helping error message.

# What approach did you choose and why?
To satisfy OpenProject requirement of unique emails, the duplicated email is amended via the [sub addressing mechanism](https://en.wikipedia.org/wiki/Email_address#Sub-addressing) with the accounts’ Jira key
e.g. 
```
someone@example.com ⇒ someone+JIRA0001@example.com
someone+abc@example.com ⇒ someone+JIRA0001+abc@example.com
```
If even those are in use in the import run, an incremented counter will be appended `someone+JIRA0001+1@example.com`
   
# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
