### PR TITLE
Update op-blocknote-extensions to latest version

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.2.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -4289,9 +4289,9 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
-      "integrity": "sha512-pt27sZ6apZe3bcVh3Zzowt/XBZIcW4YNOC+A/73L5YRgCK3VDmXoKrvoeVCvQYebvrudol5Y42xbdNtGJud20g==",
+      "version": "0.1.5",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
+      "integrity": "sha512-cc3j0BP2R1VmxSjo7st9GRSpysFxF6qsVE09jwI78WxJ2pcOxqewoWIBPPa3l6c5sZDYd3oRVxR03h29shGL0w==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.2.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
     "tsx": "^4.21.0"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.3.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
         "openapi-explorer": "^2.4.799",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -13751,9 +13751,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
-      "integrity": "sha512-pt27sZ6apZe3bcVh3Zzowt/XBZIcW4YNOC+A/73L5YRgCK3VDmXoKrvoeVCvQYebvrudol5Y42xbdNtGJud20g==",
+      "version": "0.1.5",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
+      "integrity": "sha512-cc3j0BP2R1VmxSjo7st9GRSpysFxF6qsVE09jwI78WxJ2pcOxqewoWIBPPa3l6c5sZDYd3oRVxR03h29shGL0w==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -152,7 +152,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.3.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.4/op-blocknote-extensions-0.1.4.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
     "openapi-explorer": "^2.4.799",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         expect(editor.element).to have_no_text("##tiger") # wait for work package to load
 
         expect(editor.element).to have_no_text("…")
-        expect(editor.element.text).to match(/##{work_package.display_id}\sLIFE GOALS\spet a tiger/)
+        expect(editor.element.text).to match(/##{work_package.display_id}LIFE GOALSpet a tiger/)
         # Capybara's have_link seems not to work in a shadow dom, so it's tested via the property
         expect(editor.element.find_link(text: "pet a tiger").native.property("href"))
           .to end_with("/wp/#{work_package.id}")
@@ -173,7 +173,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         expect(editor.element).to have_no_text("###tiger") # wait for work package to load
 
         expect(editor.element).to have_no_text("…")
-        expect(editor.element.text).to match(/##{work_package.display_id}\sLIFE GOALS\sOpen\spet a tiger/)
+        expect(editor.element.text).to match(/##{work_package.display_id}LIFE GOALSOpenpet a tiger/)
         # Capybara's have_link seems not to work in a shadow dom, so it's tested via the property
         expect(editor.element.find_link(text: "pet a tiger").native.property("href"))
           .to end_with("/wp/#{work_package.id}")


### PR DESCRIPTION
This includes:
- [BNE-92] Add eslint to op-blocknote-extensions https://community.openproject.org/wp/BNE-92
- [BNE-95] Blue border sometimes missing for Block Work Package Card in BlockNote https://community.openproject.org/wp/BNE-95
- [BNE-83] Copy/paste of a single work package link does not work https://community.openproject.org/wp/BNE-83
- [BNE-114] Slash-command for linking work package should highlight first search result https://community.openproject.org/wp/BNE-114
- [COMMS-866] Safari: Incorrect selection UI when clicking on inline wp link https://community.openproject.org/wp/COMMS-866
- [BNE-110] Work package titles should not be cut off for inline work package links in documents https://community.openproject.org/wp/BNE-110

# Ticket
See above

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
