### PR TITLE
Allow to seed scim clients from environment variables

### DIFF
--- a/app/contracts/scim_clients/base_contract.rb
+++ b/app/contracts/scim_clients/base_contract.rb
@@ -23,12 +23,31 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
 module ScimClients
-  class CreateContract < BaseContract
+  class BaseContract < ModelContract
+    attribute :name
+    validates :name, presence: true
+
+    attribute :auth_provider
+    validates :auth_provider, presence: true
+
+    attribute :authentication_method
+    validates :authentication_method, inclusion: { in: ScimClient.authentication_methods.keys }
+
+    attribute :jwt_sub
+    validates :jwt_sub, presence: true, if: -> { @model.authentication_method_sso? }
+
+    validate :not_configured_from_env
+
+    def not_configured_from_env
+      if model.configured_from_env?
+        errors.add :base, :configured_via_env
+      end
+    end
   end
 end

--- a/app/contracts/scim_clients/environment_create_contract.rb
+++ b/app/contracts/scim_clients/environment_create_contract.rb
@@ -23,12 +23,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
 module ScimClients
-  class CreateContract < BaseContract
+  class EnvironmentCreateContract < CreateContract
+    def not_configured_from_env = nil
   end
 end

--- a/app/contracts/scim_clients/environment_update_contract.rb
+++ b/app/contracts/scim_clients/environment_update_contract.rb
@@ -23,12 +23,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
 module ScimClients
-  class CreateContract < BaseContract
+  class EnvironmentUpdateContract < CreateContract
+    def not_configured_from_env = nil
   end
 end

--- a/app/contracts/scim_clients/update_contract.rb
+++ b/app/contracts/scim_clients/update_contract.rb
@@ -29,7 +29,7 @@
 #++
 
 module ScimClients
-  class UpdateContract < CreateContract
+  class UpdateContract < BaseContract
     attribute :authentication_method, writable: false
   end
 end

--- a/app/forms/scim_clients/form.rb
+++ b/app/forms/scim_clients/form.rb
@@ -38,7 +38,8 @@ module ScimClients
         label: ScimClient.human_attribute_name(:name),
         required: true,
         caption: I18n.t("admin.scim_clients.form.name_description"),
-        input_width: :large
+        input_width: :large,
+        disabled: model.configured_from_env?
       )
 
       client_form.select_list(
@@ -46,7 +47,8 @@ module ScimClients
         label: ScimClient.human_attribute_name(:auth_provider_id),
         caption: I18n.t("admin.scim_clients.form.auth_provider_description"),
         input_width: :large,
-        include_blank: false
+        include_blank: false,
+        disabled: model.configured_from_env?
       ) do |select|
         AuthProvider.find_each do |provider|
           select.option(
@@ -84,7 +86,8 @@ module ScimClients
           caption: link_translate("admin.scim_clients.form.jwt_sub_description",
                                   links: { docs_url: %i[sysadmin_docs scim_jwt_authetication_method] },
                                   external: true),
-          input_width: :large
+          input_width: :large,
+          disabled: model.configured_from_env?
         )
       end
 
@@ -98,7 +101,8 @@ module ScimClients
         name: :submit,
         label: model.persisted? ? I18n.t(:button_save) : I18n.t(:button_create),
         scheme: :primary,
-        data: { "scim-clients--form-inputs-target": "submitButton" }
+        data: { "scim-clients--form-inputs-target": "submitButton" },
+        disabled: model.configured_from_env?
       )
     end
 

--- a/app/models/scim_client.rb
+++ b/app/models/scim_client.rb
@@ -42,6 +42,10 @@ class ScimClient < ApplicationRecord
     oauth2_token: 2
   }, scopes: false, prefix: true
 
+  def configured_from_env?
+    Setting.scim_clients.any? { |c| c["name"] == name_was }
+  end
+
   def access_tokens
     return Doorkeeper::AccessToken.none unless authentication_method_oauth2_token?
 

--- a/app/seeders/composite_seeder.rb
+++ b/app/seeders/composite_seeder.rb
@@ -29,12 +29,11 @@
 class CompositeSeeder < Seeder
   def seed_data!
     ActiveRecord::Base.transaction do
-      seed_with(data_seeders)
+      print_status "Loading discovered seeders: #{discovered_seeders.map { seeder_name(it) }.join(', ')}"
+      seeders = data_seeders + discovered_seeders
+      seeders = sort_seeders_by_dependency(seeders)
 
-      if discovered_seeders.any?
-        print_status "Loading discovered seeders: #{discovered_seeders.map { seeder_name(it) }.join(', ')}"
-        seed_with(discovered_seeders)
-      end
+      seed_with(seeders)
     end
   end
 
@@ -86,5 +85,23 @@ class CompositeSeeder < Seeder
 
   def instantiate(seeder_classes)
     seeder_classes.map { |seeder_class| seeder_class.new(seed_data) }
+  end
+
+  # Making sure to run seeders last that depend on other seeders. A seeder can implement a #dependencies method
+  # that returns an array of seeder classes that it depends on.
+  def sort_seeders_by_dependency(seeders)
+    sorted_seeders = []
+    while seeders.any?
+      selected = seeders.select do |s|
+        (s.respond_to?(:dependencies) ? s.dependencies : []).all? { |dep| sorted_seeders.map(&:class).include?(dep) }
+      end
+
+      raise "Could not resolve all seeder dependencies. Remaining seeders: #{seeders.map(&:class)}" if selected.empty?
+
+      sorted_seeders += selected
+      seeders -= selected
+    end
+
+    sorted_seeders
   end
 end

--- a/app/seeders/env_data/scim_client_seeder.rb
+++ b/app/seeders/env_data/scim_client_seeder.rb
@@ -23,12 +23,32 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+module EnvData
+  class ScimClientSeeder < Seeder
+    def seed_data!
+      Rails.logger.debug "*** Seeding SCIM Clients from ENV"
 
-module ScimClients
-  class CreateContract < BaseContract
+      Setting.scim_clients.each do |config|
+        result = ScimClients::EnvSyncService.new(config).call
+
+        if result.success?
+          print_status "   - #{result.result.name}: OK"
+        else
+          raise result.message
+        end
+      end
+    end
+
+    def applicable?
+      Setting.scim_clients.present?
+    end
+
+    def dependencies
+      [EnvData::OpenIDConnect::ProviderSeeder]
+    end
   end
 end

--- a/app/seeders/env_data_seeder.rb
+++ b/app/seeders/env_data_seeder.rb
@@ -31,6 +31,7 @@ class EnvDataSeeder < CompositeSeeder
     [
       EnvData::CustomDesignSeeder,
       EnvData::LdapSeeder,
+      EnvData::ScimClientSeeder,
       EnvData::TokenSeeder
     ]
   end

--- a/app/services/scim_clients/env_sync_service.rb
+++ b/app/services/scim_clients/env_sync_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ScimClients
+  class EnvSyncService
+    attr_reader :config
+
+    def initialize(env_config)
+      @config = env_config.deep_symbolize_keys
+    end
+
+    def call
+      existing_client = find_existing_client
+      ActiveRecord::Base.transaction do
+        if existing_client
+          update!(existing_client)
+        else
+          create!
+        end
+      end
+    end
+
+    def create!
+      CreateService.new(user:, contract_class: EnvironmentCreateContract).call(**attributes)
+    end
+
+    def update!(client)
+      UpdateService.new(user:, model: client, contract_class: EnvironmentUpdateContract).call(**attributes)
+    end
+
+    private
+
+    def find_existing_client
+      ScimClient.find_by(name: config.fetch(:name))
+    end
+
+    def user = User.system
+
+    def attributes
+      {
+        name: config.fetch(:name),
+        jwt_sub: config.fetch(:jwt_sub),
+        auth_provider_id: AuthProvider.find_by!(slug: config.fetch(:auth_provider_slug)).id,
+        authentication_method: :sso
+      }
+    end
+
+    def result!(service_result)
+      raise service_result.message if service_result.failure?
+
+      service_result.result
+    end
+  end
+end

--- a/app/views/admin/scim_clients/edit.html.erb
+++ b/app/views/admin/scim_clients/edit.html.erb
@@ -57,6 +57,10 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% if @scim_client.configured_from_env? %>
+  <%= render(Primer::Alpha::Banner.new(mb: 3, icon: :info)) { t("admin.banners.environment_configured_readonly") } %>
+<% end %>
+
 <%= render(Admin::ScimClients::FormComponent.new(@scim_client)) %>
 
 <%= render(Admin::ScimClients::TokenListComponent.new(@scim_client)) if @scim_client.authentication_method_oauth2_token? %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1015,6 +1015,12 @@ module Settings
       repository_truncate_at: {
         default: 500
       },
+      scim_clients: {
+        description: "Configure SCIM clients through environment variables",
+        writable: false,
+        default: [],
+        format: :array
+      },
       scm: {
         format: :hash,
         default: {},

--- a/spec/seeders/env_data/scim_client_seeder_spec.rb
+++ b/spec/seeders/env_data/scim_client_seeder_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe EnvData::ScimClientSeeder do
+  subject { described_class.new(seed_data).seed! }
+
+  let(:seed_data) { Source::SeedData.new({}) }
+  let(:auth_provider) { create(:oidc_provider, slug: "my-provider-slug") }
+
+  before do
+    auth_provider
+  end
+
+  it "does not seed any clients" do
+    expect { subject }.not_to change(ScimClient, :count)
+  end
+
+  context "when configuring a client", with_settings: {
+    scim_clients: [
+      { name: "My SCIM client", auth_provider_slug: "my-provider-slug", jwt_sub: "Princess Donut" }
+    ]
+  } do
+    it "seeds the client with expected data" do
+      expect { subject }.to change(ScimClient, :count).from(0).to(1)
+
+      expect(ScimClient.first.name).to eq("My SCIM client")
+      expect(ScimClient.first.auth_provider_link.auth_provider_id).to eq(auth_provider.id)
+      expect(ScimClient.first.auth_provider_link.external_id).to eq("Princess Donut")
+    end
+
+    context "and when a provider with the same name exists" do
+      let(:existing_client) { create(:scim_client, name: "My SCIM client") }
+
+      before do
+        existing_client
+      end
+
+      it "does not seed the client twice" do
+        expect { subject }.not_to change(ScimClient, :count)
+      end
+
+      it "updates configuration in-place" do
+        subject
+
+        expect(ScimClient.first.name).to eq("My SCIM client")
+        expect(ScimClient.first.auth_provider_link.auth_provider_id).to eq(auth_provider.id)
+        expect(ScimClient.first.auth_provider_link.external_id).to eq("Princess Donut")
+      end
+    end
+
+    context "and when a provider with a different name exists" do
+      let(:existing_client) { create(:scim_client) }
+
+      before do
+        existing_client
+      end
+
+      it "creates a second client" do
+        expect { subject }.to change(ScimClient, :count).from(1).to(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
So far this only supports creation of SCIM clients with SSO as authentication method. Though those seem to be the most relevant for automated setups. Static tokens seems very implausible to implement, because the static access token would need to be seeded as well. For OAuth client credentials it would theoretically work, but would require additional rework of the ScimClients::UpdateService.

# Ticket
https://community.openproject.org/wp/SI-233

# TODO

* [x] Update UI to prevent changes
* [x] Merge after https://github.com/opf/openproject/pull/23886 for properly translated messages