### PR TITLE
Add on-demand flaky spec report script

### DIFF
--- a/.github/flaky-spec-copilot-comment.md
+++ b/.github/flaky-spec-copilot-comment.md
@@ -1,6 +1,12 @@
 > [!WARNING]
 > Flaky specs
 
+<!-- openproject-flaky-specs:
+commit=${GITHUB_SHA}
+run_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+run_id=${GITHUB_RUN_ID}
+-->
+
 ${SPECS}
 
 <details>

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -100,7 +100,7 @@ jobs:
           cat tmp/retried_specs.txt >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$PR_NUMBER" ]; then
             SPECS="$(cat tmp/retried_specs.txt)" \
-              envsubst '$SPECS $PR_NUMBER $PR_AUTHOR' \
+              envsubst '$SPECS $PR_NUMBER $PR_AUTHOR $GITHUB_SHA $GITHUB_SERVER_URL $GITHUB_REPOSITORY $GITHUB_RUN_ID' \
               < .github/flaky-spec-copilot-comment.md > tmp/flaky_comment.md
             if [ "$PR_HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
               echo "::warning::Flaky specs detected in this PR - see job summary for details"

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -15,7 +15,7 @@ ENV CHROME_SOURCE_URL="https://dl.google.com/dl/linux/direct/google-chrome-stabl
 RUN --mount=type=cache,target=/var/cache/apt export f="/tmp/chrome.deb" && \
   wget --no-verbose -O $f $CHROME_SOURCE_URL && \
   apt-get update -qq && \
-  apt-get install -y "$f" postgresql-$PGVERSION postgresql-client-$PGVERSION time imagemagick default-jre-headless firefox-esr && \
+  apt-get install -y "$f" postgresql-$PGVERSION postgresql-client-$PGVERSION time imagemagick default-jre-headless firefox-esr jq && \
   rm -f "$f" && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/postgresql && \

--- a/script/flaky_specs_report
+++ b/script/flaky_specs_report
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# Aggregate flaky specs reported on PRs over a recent time window.
+#
+# The CI "Report flaky specs" step posts a PR comment (an issue comment) for
+# every run that had to retry failed feature specs. Those comments are the only
+# durable record of flakiness, so this script reads them back: it lists every
+# issue comment in the repo since a cutoff, keeps the flaky-spec ones, extracts
+# the rspec identifiers, and ranks them by how often they recurred.
+#
+# By default this makes a single (paginated) API call and prints raw recurrence
+# counts, which is cheap. Pass --freshness for an optional, heavier pass that
+# classifies each occurrence against dev (one PR/compare lookup per occurrence)
+# so you can tell flakes on current branches from ones on stale ones.
+#
+# Usage:
+#   script/flaky_specs_report [options] [HOURS] [REPO]
+#
+#   HOURS  Look-back window in hours (default: 24; e.g. 24, 48, 72)
+#   REPO   owner/name (default: opf/openproject)
+#
+# Requires: gh (authenticated), jq, and a date(1) that supports the flags below.
+#
+set -euo pipefail
+
+HOURS="24"
+REPO="opf/openproject"
+FRESHNESS_COMMITS="50"
+FRESHNESS="false"
+INCLUDE_STALE="false"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  script/flaky_specs_report [options] [HOURS] [REPO]
+
+By default, prints raw recurrence counts from a single API call (cheap).
+
+Options:
+  --freshness            Classify occurrences against dev (extra PR/compare
+                         lookups per occurrence; slower, more API calls)
+  --freshness-commits N  Treat runs within N commits of dev as fresh
+                         (default: 50; implies --freshness)
+  --include-stale        Rank by total count while still showing the freshness
+                         split (implies --freshness)
+  -h, --help             Print this help
+USAGE
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --freshness)
+      FRESHNESS="true"
+      shift
+      ;;
+    --freshness-commits)
+      FRESHNESS_COMMITS="${2:?Missing value for --freshness-commits}"
+      FRESHNESS="true"
+      shift 2
+      ;;
+    --include-stale)
+      INCLUDE_STALE="true"
+      FRESHNESS="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -gt 0 ]]; then
+  HOURS="${POSITIONAL[0]}"
+fi
+if [[ ${#POSITIONAL[@]} -gt 1 ]]; then
+  REPO="${POSITIONAL[1]}"
+fi
+if [[ ${#POSITIONAL[@]} -gt 2 ]]; then
+  echo "Too many positional arguments" >&2
+  usage >&2
+  exit 1
+fi
+
+# Compute the ISO-8601 cutoff. BSD date (macOS) uses -v; GNU date uses -d.
+if date -u -v-1H >/dev/null 2>&1; then
+  SINCE="$(date -u -v-"${HOURS}"H +%Y-%m-%dT%H:%M:%SZ)"   # BSD/macOS
+else
+  SINCE="$(date -u -d "${HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)"  # GNU/Linux
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+fetch_comments() {
+  gh api -X GET "repos/${REPO}/issues/comments" \
+    -f since="${SINCE}" -f per_page=100 --paginate
+}
+
+extract_occurrences() {
+  jq -r '
+    def pr_number:
+      .issue_url | split("/") | last;
+
+    def visible_flaky_block:
+      .body | split("<details>")[0];
+
+    def metadata_commit:
+      (
+        .body
+        | capture("<!-- openproject-flaky-specs:\\r?\\ncommit=(?<commit>[A-Fa-f0-9]{7,40})\\r?\\nrun_url=(?<run_url>[^\\r\\n]+)\\r?\\nrun_id=(?<run_id>[0-9]+)\\r?\\n-->"; "m")?
+      ).commit // "-";
+
+    .[]
+    | select(.body | test("(?m)^> Flaky specs$"))
+    | . as $comment
+    | (visible_flaky_block | match("`rspec (?<spec>(?:\\./|modules)[^`]+)`"; "g").captures[0].string) as $spec
+    | [($comment | pr_number), ($comment | metadata_commit), $spec]
+    | @tsv
+  '
+}
+
+print_raw_report() {
+  local occurrences_file="$1"
+
+  if [[ ! -s "${occurrences_file}" ]]; then
+    echo "No flaky specs found"
+    return
+  fi
+
+  cut -f3 "${occurrences_file}" \
+    | sort \
+    | uniq -c \
+    | sort -rn \
+    | awk '{ printf "%4d  %s\n", $1, $2 }'
+}
+
+lookup_tsv() {
+  local file="$1"
+  local key="$2"
+
+  awk -F '\t' -v key="${key}" '$1 == key { print $2; found = 1; exit } END { exit found ? 0 : 1 }' "${file}"
+}
+
+fetch_dev_sha() {
+  gh api "repos/${REPO}/branches/dev" | jq -r '.commit.sha'
+}
+
+fetch_pr_head() {
+  local pr="$1"
+
+  gh api "repos/${REPO}/pulls/${pr}" | jq -r '.head.sha'
+}
+
+fetch_behind_by() {
+  local dev_sha="$1"
+  local occurrence_sha="$2"
+
+  gh api "repos/${REPO}/compare/${dev_sha}...${occurrence_sha}" | jq -r '.behind_by'
+}
+
+resolve_occurrence_shas() {
+  local occurrences_file="$1"
+  local pr_heads_file="$2"
+  local resolved_file="$3"
+  local pr
+  local sha
+  local metadata_sha
+  local spec
+
+  awk -F '\t' '$2 == "-" { print $1 }' "${occurrences_file}" | sort -u | while read -r pr; do
+    [[ -z "${pr}" ]] && continue
+
+    if sha="$(fetch_pr_head "${pr}" 2>/dev/null)" && [[ -n "${sha}" && "${sha}" != "null" ]]; then
+      printf "%s\t%s\n" "${pr}" "${sha}" >> "${pr_heads_file}"
+    fi
+  done
+
+  while IFS=$'\t' read -r pr metadata_sha spec; do
+    if [[ "${metadata_sha}" != "-" ]]; then
+      printf "%s\t%s\texact\t%s\n" "${pr}" "${metadata_sha}" "${spec}" >> "${resolved_file}"
+    elif sha="$(lookup_tsv "${pr_heads_file}" "${pr}" 2>/dev/null)"; then
+      printf "%s\t%s\tapprox\t%s\n" "${pr}" "${sha}" "${spec}" >> "${resolved_file}"
+    else
+      printf "%s\t-\tunknown\t%s\n" "${pr}" "${spec}" >> "${resolved_file}"
+    fi
+  done < "${occurrences_file}"
+}
+
+classify_shas() {
+  local resolved_file="$1"
+  local comparisons_file="$2"
+  local dev_sha
+  local sha
+  local behind_by
+
+  if ! dev_sha="$(fetch_dev_sha 2>/dev/null)" || [[ -z "${dev_sha}" || "${dev_sha}" == "null" ]]; then
+    return 1
+  fi
+
+  awk -F '\t' '$2 != "" && $2 != "-" { print $2 }' "${resolved_file}" | sort -u | while read -r sha; do
+    if behind_by="$(fetch_behind_by "${dev_sha}" "${sha}" 2>/dev/null)" && [[ "${behind_by}" =~ ^[0-9]+$ ]]; then
+      if [[ "${behind_by}" -le "${FRESHNESS_COMMITS}" ]]; then
+        printf "%s\tfresh\t%s\n" "${sha}" "${behind_by}" >> "${comparisons_file}"
+      else
+        printf "%s\tstale\t%s\n" "${sha}" "${behind_by}" >> "${comparisons_file}"
+      fi
+    fi
+  done
+
+  echo "${dev_sha}"
+}
+
+print_freshness_report() {
+  local classified_file="$1"
+
+  if [[ ! -s "${classified_file}" ]]; then
+    echo "No flaky specs found"
+    return
+  fi
+
+  printf "%4s  %5s  %5s  %5s  %7s  %6s  %s\n" "count" "total" "fresh" "stale" "unknown" "approx" "spec"
+
+  awk -F '\t' -v include_stale="${INCLUDE_STALE}" '
+    {
+      spec = $4
+      status = $5
+      source = $3
+
+      total[spec]++
+      if (status == "fresh") fresh[spec]++
+      else if (status == "stale") stale[spec]++
+      else unknown[spec]++
+
+      if (source == "approx") approx[spec]++
+    }
+    END {
+      for (spec in total) {
+        primary = include_stale == "true" ? total[spec] : fresh[spec]
+        printf "%08d\t%08d\t%08d\t%08d\t%08d\t%08d\t%s\n",
+          primary, total[spec], fresh[spec], stale[spec], unknown[spec], approx[spec], spec
+      }
+    }
+  ' "${classified_file}" \
+    | sort -t $'\t' -k1,1rn -k2,2rn -k7,7 \
+    | awk -F '\t' '{ printf "%4d  %5d  %5d  %5d  %7d  %6d  %s\n", $1 + 0, $2 + 0, $3 + 0, $4 + 0, $5 + 0, $6 + 0, $7 }'
+}
+
+require_command gh
+require_command jq
+
+COMMENTS_FILE="$(mktemp)"
+OCCURRENCES_FILE="$(mktemp)"
+trap 'rm -f "${COMMENTS_FILE}" "${OCCURRENCES_FILE}"' EXIT
+
+fetch_comments > "${COMMENTS_FILE}"
+extract_occurrences < "${COMMENTS_FILE}" > "${OCCURRENCES_FILE}"
+
+echo "Flaky specs on ${REPO} since ${SINCE} (last ${HOURS}h)" >&2
+echo >&2
+
+if [[ "${FRESHNESS}" != "true" ]]; then
+  print_raw_report "${OCCURRENCES_FILE}"
+  exit 0
+fi
+
+if [[ ! -s "${OCCURRENCES_FILE}" ]]; then
+  echo "No flaky specs found"
+  exit 0
+fi
+
+PR_HEADS_FILE="$(mktemp)"
+RESOLVED_FILE="$(mktemp)"
+COMPARISONS_FILE="$(mktemp)"
+CLASSIFIED_FILE="$(mktemp)"
+trap 'rm -f "${COMMENTS_FILE}" "${OCCURRENCES_FILE}" "${PR_HEADS_FILE}" "${RESOLVED_FILE}" "${COMPARISONS_FILE}" "${CLASSIFIED_FILE}"' EXIT
+
+resolve_occurrence_shas "${OCCURRENCES_FILE}" "${PR_HEADS_FILE}" "${RESOLVED_FILE}"
+
+if dev_sha="$(classify_shas "${RESOLVED_FILE}" "${COMPARISONS_FILE}")"; then
+  echo "Freshness: dev=${dev_sha:0:12}, threshold=${FRESHNESS_COMMITS} commits" >&2
+else
+  echo "Freshness: dev lookup failed; treating all occurrences as unknown" >&2
+fi
+echo >&2
+
+while IFS=$'\t' read -r pr sha source spec; do
+  if [[ -n "${sha}" && "${sha}" != "-" ]] && status="$(lookup_tsv "${COMPARISONS_FILE}" "${sha}" 2>/dev/null)"; then
+    printf "%s\t%s\t%s\t%s\t%s\n" "${pr}" "${sha}" "${source}" "${spec}" "${status}" >> "${CLASSIFIED_FILE}"
+  else
+    printf "%s\t%s\t%s\t%s\tunknown\n" "${pr}" "${sha}" "${source}" "${spec}" >> "${CLASSIFIED_FILE}"
+  fi
+done < "${RESOLVED_FILE}"
+
+print_freshness_report "${CLASSIFIED_FILE}"

--- a/spec/scripts/flaky_specs_report_spec.rb
+++ b/spec/scripts/flaky_specs_report_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require "rspec_helper"
+require "fileutils"
+require "json"
+require "open3"
+require "tmpdir"
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "script/flaky_specs_report" do
+  let(:root) { Pathname(__dir__).join("../..").expand_path }
+  let(:script) { root.join("script/flaky_specs_report") }
+  let(:stub_dir) { Pathname(Dir.mktmpdir("flaky_specs_report")) }
+  let(:bin_dir) { stub_dir.join("bin") }
+  let(:gh_log_path) { stub_dir.join("gh.log") }
+
+  before do
+    bin_dir.mkpath
+    gh_log_path.write("")
+    write_gh_stub
+  end
+
+  after do
+    FileUtils.remove_entry(stub_dir) if stub_dir.exist?
+  end
+
+  it "counts each visible flaky spec once in raw mode" do
+    write_comments(
+      flaky_comment(
+        pull_request_number: 24011,
+        specs: [
+          "./spec/features/projects/lists/filters_spec.rb[1:6:1]",
+          "./modules/gantt/spec/features/timeline/timeline_dates_spec.rb[1:2:1]"
+        ]
+      )
+    )
+
+    result = run_report("24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(result.stdout).to include("   1  ./spec/features/projects/lists/filters_spec.rb[1:6:1]")
+    expect(result.stdout).to include("   1  ./modules/gantt/spec/features/timeline/timeline_dates_spec.rb[1:2:1]")
+    expect(result.stdout.scan("filters_spec.rb[1:6:1]").size).to eq(1)
+    expect(gh_log).not_to include("branches/dev")
+    expect(gh_log).not_to include("compare/")
+  end
+
+  it "exits successfully when there are no flaky comments" do
+    write_comments
+
+    result = run_report("24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(result.stdout).to include("No flaky specs found")
+  end
+
+  it "stays cheap by default, skipping PR and compare lookups" do
+    write_comments(
+      flaky_comment(
+        pull_request_number: 24011,
+        specs: ["./spec/features/projects/lists/filters_spec.rb[1:6:1]"]
+      )
+    )
+    write_branch_dev("d" * 40)
+
+    result = run_report("24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(gh_log).not_to include("branches/dev")
+    expect(gh_log).not_to include("pulls/")
+    expect(gh_log).not_to include("compare/")
+  end
+
+  it "uses exact commit metadata when present and current PR head as an approximate fallback" do
+    fresh_sha = "f" * 40
+    stale_sha = "a" * 40
+
+    write_comments(
+      flaky_comment(
+        pull_request_number: 24011,
+        commit: fresh_sha,
+        specs: ["./spec/features/current_spec.rb[1:1]"]
+      ),
+      flaky_comment(
+        pull_request_number: 24012,
+        specs: ["./spec/features/legacy_spec.rb[1:1]"]
+      )
+    )
+    write_branch_dev("d" * 40)
+    write_pull(24012, stale_sha)
+    write_compare(fresh_sha, behind_by: 0)
+    write_compare(stale_sha, behind_by: 451)
+
+    result = run_report("--freshness-commits", "50", "24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(result.stdout).to match(/\s+1\s+1\s+1\s+0\s+0\s+0\s+\.\/spec\/features\/current_spec\.rb\[1:1\]/)
+    expect(result.stdout).to match(/\s+0\s+1\s+0\s+1\s+0\s+1\s+\.\/spec\/features\/legacy_spec\.rb\[1:1\]/)
+    expect(gh_log).to include("branches/dev")
+    expect(gh_log).to include("pulls/24012")
+    expect(gh_log).not_to include("pulls/24011")
+  end
+
+  it "shows unknown occurrences without adding them to the default ranking count" do
+    write_comments(
+      flaky_comment(
+        pull_request_number: 24013,
+        specs: ["./spec/features/unknown_spec.rb[1:1]"]
+      )
+    )
+    write_branch_dev("d" * 40)
+
+    result = run_report("--freshness", "24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(result.stdout).to match(/\s+0\s+1\s+0\s+0\s+1\s+0\s+\.\/spec\/features\/unknown_spec\.rb\[1:1\]/)
+  end
+
+  it "exits successfully in freshness mode when there are no flaky comments" do
+    write_comments
+
+    result = run_report("--freshness", "24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(result.stdout).to include("No flaky specs found")
+    expect(gh_log).not_to include("branches/dev")
+  end
+
+  it "can rank by total count when stale occurrences are included" do
+    stale_sha = "b" * 40
+
+    write_comments(
+      flaky_comment(
+        pull_request_number: 24014,
+        commit: stale_sha,
+        specs: ["./spec/features/stale_spec.rb[1:1]"]
+      )
+    )
+    write_branch_dev("d" * 40)
+    write_compare(stale_sha, behind_by: 100)
+
+    result = run_report("--include-stale", "24", "opf/openproject")
+
+    expect(result.status).to be_success
+    expect(result.stdout).to match(/\s+1\s+1\s+0\s+1\s+0\s+0\s+\.\/spec\/features\/stale_spec\.rb\[1:1\]/)
+  end
+
+  it "documents commit metadata in the flaky comment template" do
+    template = root.join(".github/flaky-spec-copilot-comment.md").read
+
+    expect(template).to include("<!-- openproject-flaky-specs:")
+    expect(template).to include("commit=${GITHUB_SHA}")
+    expect(template).to include("run_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")
+    expect(template).to include("run_id=${GITHUB_RUN_ID}")
+    expect(template.index("<!-- openproject-flaky-specs:")).to be < template.index("${SPECS}")
+  end
+
+  it "passes GitHub Actions metadata variables through envsubst" do
+    workflow = root.join(".github/workflows/test-core.yml").read
+
+    expect(workflow).to include("$SPECS $PR_NUMBER $PR_AUTHOR $GITHUB_SHA $GITHUB_SERVER_URL $GITHUB_REPOSITORY $GITHUB_RUN_ID")
+  end
+
+  def run_report(*)
+    stdout, stderr, status = Open3.capture3(
+      env,
+      script.to_s,
+      *,
+      chdir: root.to_s
+    )
+
+    Data.define(:stdout, :stderr, :status).new(stdout:, stderr:, status:)
+  end
+
+  def env
+    {
+      "PATH" => "#{bin_dir}:#{ENV.fetch('PATH')}",
+      "GH_STUB_DIR" => stub_dir.to_s,
+      "GH_STUB_LOG" => gh_log_path.to_s
+    }
+  end
+
+  def write_comments(*comments)
+    stub_dir.join("issues_comments.json").write(JSON.pretty_generate(comments))
+  end
+
+  def write_branch_dev(sha)
+    stub_dir.join("branch_dev.json").write(JSON.generate({ "commit" => { "sha" => sha } }))
+  end
+
+  def write_pull(pull_request_number, sha)
+    stub_dir.join("pull_#{pull_request_number}.json").write(JSON.generate({ "head" => { "sha" => sha } }))
+  end
+
+  def write_compare(sha, behind_by:)
+    stub_dir.join("compare_#{sha}.json").write(JSON.generate({ "behind_by" => behind_by }))
+  end
+
+  def flaky_comment(pull_request_number:, specs:, commit: nil, run_id: 9001)
+    {
+      "id" => pull_request_number * 1000,
+      "issue_url" => "https://api.github.com/repos/opf/openproject/issues/#{pull_request_number}",
+      "body" => flaky_body(pull_request_number:, specs:, commit:, run_id:)
+    }
+  end
+
+  def flaky_body(pull_request_number:, specs:, commit:, run_id:)
+    metadata = if commit
+                 <<~MARKDOWN
+                   <!-- openproject-flaky-specs:
+                   commit=#{commit}
+                   run_url=https://github.com/opf/openproject/actions/runs/#{run_id}
+                   run_id=#{run_id}
+                   -->
+                 MARKDOWN
+               else
+                 ""
+               end
+
+    spec_lines = specs.map { |spec| "- `rspec #{spec}`" }.join("\n")
+
+    <<~MARKDOWN
+      > [!WARNING]
+      > Flaky specs
+
+      #{metadata}
+      #{spec_lines}
+
+      <details>
+      <summary>Ask Copilot to investigate</summary>
+
+      ```
+      @copilot The following spec(s) are flaky in CI (first seen on PR ##{pull_request_number}, linked for reference only):
+
+      #{spec_lines}
+      ```
+
+      </details>
+    MARKDOWN
+  end
+
+  def write_gh_stub
+    bin_dir.join("gh").write(<<~'RUBY')
+      #!/usr/bin/env ruby
+      # frozen_string_literal: true
+
+      require "json"
+
+      stub_dir = ENV.fetch("GH_STUB_DIR")
+      File.open(ENV.fetch("GH_STUB_LOG"), "a") { |file| file.puts(ARGV.join(" ")) }
+
+      path = ARGV.find { |arg| arg.start_with?("repos/") }
+      abort "unexpected gh call: #{ARGV.join(' ')}" unless path
+
+      case path
+      when %r{\Arepos/opf/openproject/issues/comments\z}
+        print File.read(File.join(stub_dir, "issues_comments.json"))
+      when %r{\Arepos/opf/openproject/branches/dev\z}
+        print File.read(File.join(stub_dir, "branch_dev.json"))
+      when %r{\Arepos/opf/openproject/pulls/(\d+)\z}
+        print File.read(File.join(stub_dir, "pull_#{$1}.json"))
+      when %r{\Arepos/opf/openproject/compare/(.+)\.\.\.(.+)\z}
+        sha = Regexp.last_match(2)
+        print File.read(File.join(stub_dir, "compare_#{sha}.json"))
+      else
+        abort "unexpected gh api path: #{path}"
+      end
+    RUBY
+    bin_dir.join("gh").chmod(0o755)
+  end
+
+  def gh_log
+    gh_log_path.read
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
# Ticket

No work package — internal tooling. Grew out of a request to cheaply pull the latest list of flaky specs across PRs to prioritise investigation.

# What are you trying to accomplish?

Adds `script/flaky_specs_report`, an on-demand CLI that aggregates flaky specs reported across PRs over a recent time window (24/48/72h).

CI's "Report flaky specs" step posts a PR comment for every run that had to retry failed feature specs, but those comments are scattered across individual PRs. There was no way to see flakiness repo-wide or decide what to investigate first.

Usage:

```bash
script/flaky_specs_report 24                  # last 24h (default)
script/flaky_specs_report 48
script/flaky_specs_report 72
script/flaky_specs_report --freshness 48      # add freshness classification
```

Requires `gh` (authenticated) and `jq`. Handles both BSD (macOS) and GNU date.

# What approach did you choose and why?

Those CI PR comments are issue comments, so the script reads them back via `GET /repos/{owner}/{repo}/issues/comments?since=<ISO>` — paginated, repo-wide, time-filtered. **By default it makes a single (paginated) API call and prints raw recurrence counts**, so it stays cheap and dependency-light: no Actions API, no artifact downloads, no log scraping. The visible spec list is parsed before the embedded Copilot prompt, so each occurrence is counted once.

`--freshness` is an optional, heavier pass that classifies each occurrence against `dev` (one PR/compare lookup per occurrence) to separate flakes on current branches from ones on stale branches. `--freshness-commits N` tunes the staleness threshold and `--include-stale` ranks by total while still showing the split; both imply `--freshness`.

To make that classification exact over time, the flaky CI comment template now embeds a hidden `commit` / `run_url` / `run_id` metadata block (invisible in the rendered comment). Existing historical comments lack it, so freshness for them is approximate (via the PR's current head); future comments will be exact once CI posts the new format.

I kept it as an on-demand CLI rather than a scheduled job posting to Slack/an issue — wanted the data path proven first; a recurring wrapper can come later.

Caveats:

- Count is a frequency proxy (number of PR comments naming the spec), not an exact retry count — good enough for triage ranking.
- Only catches specs CI retried (≤10 failures per run); runs that bail with >10 failures post no comment.
- Fork PRs print to the job summary instead of commenting, so they aren't captured.

# Merge checklist

- [x] Added/updated tests (`spec/scripts/flaky_specs_report_spec.rb`)
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — N/A, CLI tooling
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — N/A, no UI