### PR TITLE
Fix flaky Gantt timeline dates spec

### DIFF
--- a/modules/gantt/spec/features/timeline/timeline_dates_spec.rb
+++ b/modules/gantt/spec/features/timeline/timeline_dates_spec.rb
@@ -152,6 +152,10 @@ RSpec.describe "Work package timeline date formatting",
            with_settings: { start_of_week: "7", first_week_of_year: "6" } do
     let(:current_user) { create(:admin) }
 
+    before do
+      wp_timeline.expect_timeline!
+    end
+
     it "shows english ISO dates" do
       expect(page).to have_css(".wp-timeline--header-element", text: "01")
       expect(page).to have_css(".wp-timeline--header-element", text: "02")


### PR DESCRIPTION
Stabilises `modules/gantt/spec/features/timeline/timeline_dates_spec.rb[1:2:1]` ("with US/CA settings" > "shows english ISO dates"), one of the top flaky feature specs in CI over the last 24h.

## Root cause

The `"with US/CA settings"` describe group has no render-settle `before`, unlike its sibling `"with default settings"` (which has `before { wp_timeline.expect_timeline! }`). It is also the only example in the file that asserts on the live, client-rendered timeline header DOM — the others use `expect_date_week`, which is pure JS `moment` formatting and never reads the DOM.

The header render pipeline wipes `innerHTML` and re-renders on every refresh, gated behind awaited `requireNonWorkingDays` network calls, with multiple refreshes firing during load. The example asserted on header elements immediately after `visit_query`, racing that teardown/rebuild.

## Fix

Add the same `expect_timeline!` wait the sibling group already uses. It blocks on `.wp-timeline-cell` plus `wait_for_network_idle`, covering the network calls that gate the header renderers — a deterministic render-complete signal rather than a `sleep`.

## Verification

- [ ] `script/bulk_run_rspec modules/gantt/spec/features/timeline/timeline_dates_spec.rb --run-count 20` (pending — relying on CI)

## Known follow-up (separate PR, not in scope here)

The `number_of_weeks` math (lines ~162-167) is derived from `Date.current.year` but the rendered years are the work-package data years (2020-2025). It passes today only by coincidence and becomes a **deterministic failure in any year whose Dec 31 is a Friday (next: 2027)**, where it would assert week 53 is absent while it is still shown. Should be derived from the data years; tracked separately.