### PR TITLE
[OP-19618] Consolidate CSP script-nonce enforcement

### DIFF
--- a/frontend/src/turbo/csp-script-nonce.spec.ts
+++ b/frontend/src/turbo/csp-script-nonce.spec.ts
@@ -1,0 +1,104 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi } from 'vitest';
+import { readScriptNonce, scrubScriptElements } from './csp-script-nonce';
+
+describe('readScriptNonce', () => {
+  afterEach(() => {
+    document.querySelector('meta[name="csp-nonce"]')?.remove();
+  });
+
+  it('returns the csp-nonce meta content', () => {
+    document.head.insertAdjacentHTML('beforeend', '<meta name="csp-nonce" content="nonce-abc">');
+
+    expect(readScriptNonce()).toBe('nonce-abc');
+  });
+
+  it('returns an empty string when no csp-nonce meta is present', () => {
+    expect(readScriptNonce()).toBe('');
+  });
+});
+
+describe('scrubScriptElements', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function scriptWithNonce(nonce:string | null):HTMLScriptElement {
+    const script = document.createElement('script');
+    if (nonce !== null) {
+      script.setAttribute('nonce', nonce);
+    }
+    return script;
+  }
+
+  it('removes a script whose nonce does not match', () => {
+    const container = document.createElement('div');
+    const script = scriptWithNonce('wrong-nonce');
+    container.append(script);
+
+    scrubScriptElements(container, 'our-nonce');
+
+    expect(container.contains(script)).toBe(false);
+  });
+
+  it('removes a script with no nonce attribute', () => {
+    const container = document.createElement('div');
+    const script = scriptWithNonce(null);
+    container.append(script);
+
+    scrubScriptElements(container, 'our-nonce');
+
+    expect(container.contains(script)).toBe(false);
+  });
+
+  it('keeps a script whose nonce matches', () => {
+    const container = document.createElement('div');
+    const script = scriptWithNonce('our-nonce');
+    container.append(script);
+
+    scrubScriptElements(container, 'our-nonce');
+
+    expect(container.contains(script)).toBe(true);
+  });
+
+  it('operates on a DocumentFragment', () => {
+    const fragment = document.createDocumentFragment();
+    const script = scriptWithNonce('wrong-nonce');
+    fragment.append(script);
+
+    scrubScriptElements(fragment, 'our-nonce');
+
+    expect(fragment.contains(script)).toBe(false);
+  });
+});

--- a/frontend/src/turbo/csp-script-nonce.ts
+++ b/frontend/src/turbo/csp-script-nonce.ts
@@ -1,0 +1,55 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { getMetaContent } from 'core-app/core/setup/globals/global-helpers';
+
+export function readScriptNonce():string {
+  return getMetaContent('csp-nonce');
+}
+
+// Turbo re-adds nonces to all scripts, even though we want to explicitly
+// control which ones run: https://github.com/hotwired/turbo/issues/294#issuecomment-2633216052
+// Removes every <script> in a freshly-rendered fragment whose nonce does not
+// match ours, so an unauthenticated or stale inline script never executes.
+// The nonce is read per call because Turbo merges <head> across visits, so the
+// meta can change; a stale boot-time read would scrub the wrong scripts.
+export function scrubScriptElements(
+  fragment:HTMLElement | DocumentFragment,
+  nonce:string = readScriptNonce(),
+):void {
+  fragment
+    .querySelectorAll('script')
+    .forEach((script) => {
+      const scriptNonce = script.getAttribute('nonce');
+
+      if (!(scriptNonce && scriptNonce === nonce)) {
+        console.warn('Removing script element %O because it does not match our nonce', script);
+        script.remove();
+      }
+    });
+}

--- a/frontend/src/turbo/helpers.ts
+++ b/frontend/src/turbo/helpers.ts
@@ -24,19 +24,4 @@ export namespace TurboHelpers {
       progressBarTimeout = undefined;
     }
   }
-
-  export function scrubScriptElements(element:HTMLElement|DocumentFragment) {
-    const cspNonce = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') || '';
-
-    element
-      .querySelectorAll('script')
-      .forEach((script) => {
-        const nonce = script.getAttribute('nonce');
-
-        if (!(nonce && nonce === cspNonce)) {
-          console.warn('Removing script element %O because it does not match our nonce', script);
-          script.remove();
-        }
-      });
-  }
 }

--- a/frontend/src/turbo/turbo-event-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-event-listeners.spec.ts
@@ -117,3 +117,74 @@ describe('addTurboEventListeners — Turbo nonce header on fetch requests', () =
     expect(headers['X-Turbo-Nonce']).toBe('nonce-xyz');
   });
 });
+
+describe('addTurboEventListeners — CSP script-nonce enforcement', () => {
+  let controller:AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    document.head.insertAdjacentHTML('beforeend', '<meta name="csp-nonce" content="nonce-abc">');
+    addTurboEventListeners(document, controller.signal);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    controller.abort();
+    document.querySelector('meta[name="csp-nonce"]')?.remove();
+    vi.restoreAllMocks();
+  });
+
+  function scriptWithNonce(nonce:string | null):HTMLScriptElement {
+    const script = document.createElement('script');
+    if (nonce !== null) {
+      script.setAttribute('nonce', nonce);
+    }
+    return script;
+  }
+
+  it('strips a mismatched-nonce script from a Turbo Drive page render', () => {
+    const newBody = document.createElement('body');
+    const badScript = scriptWithNonce('wrong-nonce');
+    const goodScript = scriptWithNonce('nonce-abc');
+    newBody.append(badScript, goodScript);
+
+    document.dispatchEvent(new CustomEvent('turbo:before-render', {
+      detail: { newBody },
+    }));
+
+    expect(newBody.contains(badScript)).toBe(false);
+    expect(newBody.contains(goodScript)).toBe(true);
+  });
+
+  it('strips a mismatched-nonce script from a Turbo Frame render', () => {
+    const newFrame = document.createElement('turbo-frame');
+    const badScript = scriptWithNonce('wrong-nonce');
+    const goodScript = scriptWithNonce('nonce-abc');
+    newFrame.append(badScript, goodScript);
+
+    document.dispatchEvent(new CustomEvent('turbo:before-frame-render', {
+      detail: { newFrame },
+    }));
+
+    expect(newFrame.contains(badScript)).toBe(false);
+    expect(newFrame.contains(goodScript)).toBe(true);
+  });
+
+  it('strips a mismatched-nonce script from a Turbo Stream render', async () => {
+    const content = document.createDocumentFragment();
+    const badScript = scriptWithNonce('wrong-nonce');
+    const goodScript = scriptWithNonce('nonce-abc');
+    content.append(badScript, goodScript);
+
+    const streamElement = { templateElement: { content } };
+    const fallbackToDefaultActions = vi.fn().mockResolvedValue(undefined);
+    const detail = { render: fallbackToDefaultActions };
+
+    document.dispatchEvent(new CustomEvent('turbo:before-stream-render', { detail }));
+    await detail.render(streamElement);
+
+    expect(content.contains(badScript)).toBe(false);
+    expect(content.contains(goodScript)).toBe(true);
+    expect(fallbackToDefaultActions).toHaveBeenCalledWith(streamElement);
+  });
+});

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -1,4 +1,4 @@
-import { TurboHelpers } from './helpers';
+import { readScriptNonce, scrubScriptElements } from './csp-script-nonce';
 
 export function addTurboEventListeners(doc:Document = document, signal?:AbortSignal) {
   // Close the primer dialog when the form inside has been submitted with a success response.
@@ -30,24 +30,21 @@ export function addTurboEventListeners(doc:Document = document, signal?:AbortSig
     // Turbo Drive does not send a referrer like turbolinks used to, so let's simulate it here
     const { headers } = event.detail.fetchOptions;
     headers['Turbo-Referrer'] = window.location.href;
-    headers['X-Turbo-Nonce'] = doc.getElementsByName('csp-nonce')[0]?.getAttribute('content') ?? '';
+    headers['X-Turbo-Nonce'] = readScriptNonce();
   }, { signal });
 
-  // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces
-  // https://github.com/hotwired/turbo/issues/294#issuecomment-2633216052
-  // We remove them manually as a workaround
-  // in Handle Turbo Drive page loads (full reloads)
+  // Scrub mismatched-nonce scripts from a Turbo Drive page load (full reload)
   doc.addEventListener('turbo:before-render', (event) => {
-    TurboHelpers.scrubScriptElements(event.detail.newBody);
+    scrubScriptElements(event.detail.newBody);
   }, { capture: true, signal });
 
-  // in Turbo Streams (partial updates)
+  // Scrub mismatched-nonce scripts from a Turbo Stream (partial update)
   doc.addEventListener('turbo:before-stream-render', (event) => {
     const fallbackToDefaultActions = event.detail.render;
 
     event.detail.render = async (streamElement) => {
       const content = streamElement.templateElement.content;
-      TurboHelpers.scrubScriptElements(content);
+      scrubScriptElements(content);
 
       const result = await fallbackToDefaultActions(streamElement);
       doc.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
@@ -55,8 +52,8 @@ export function addTurboEventListeners(doc:Document = document, signal?:AbortSig
     };
   }, { signal });
 
-  // in Turbo Frames (when they load new content)
+  // Scrub mismatched-nonce scripts from a Turbo Frame render
   doc.addEventListener('turbo:before-frame-render', (event) => {
-    TurboHelpers.scrubScriptElements(event.detail.newFrame);
+    scrubScriptElements(event.detail.newFrame);
   }, { capture: true, signal });
 }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19618

# What are you trying to accomplish?

CSP script-nonce enforcement is the security-critical half of the Turbo integration, and it was scattered: the nonce was read in two independent places (the `X-Turbo-Nonce` request header and a render-hook scrub helper), the scrub policy lived inside an unrelated `TurboHelpers` namespace alongside progress-bar code, and none of it had test coverage.

# What approach did you choose and why?

1. **A CSP script-nonce module.** New `frontend/src/turbo/csp-script-nonce.ts` exports `readScriptNonce()` and `scrubScriptElements(fragment, nonce?)` — the single owner of "what is our nonce" and "which scripts violate it". `readScriptNonce` delegates to the shared `getMetaContent` helper, hardening the lookup from `getElementsByName('csp-nonce')[0]` to the `csp-nonce` `<meta>` in `<head>`. TDD throughout, 6 new tests.

2. **Wiring it in.** Routes the `X-Turbo-Nonce` header and all three script-scrub render hooks (`turbo:before-render`, `turbo:before-stream-render`, `turbo:before-frame-render`) in `turbo-event-listeners.ts` through the new module, and removes the now-duplicate `scrubScriptElements` from `helpers.ts`. Adds regression coverage for all three hooks, none of which existed before.

Behaviour is unchanged — this is a consolidation, hardening, and coverage pass, not a policy change.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
