### PR TITLE
Ensure template can be completed with an open occurrence

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -423,7 +423,7 @@ class RecurringMeetingsController < ApplicationController
       .not_cancelled
       .exists?(recurrence_start_time: @first_occurrence)
 
-    if is_scheduled
+    if is_scheduled && !@recurring_meeting.template.draft?
       flash[:info] = I18n.t("recurring_meeting.occurrence.first_already_exists")
       redirect_to action: :show, status: :see_other
     end

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -44,6 +44,8 @@ module RecurringMeetings
 
     def perform
       start_time = params.fetch(:start_time)
+      return draft_template_failure if recurring_meeting.template.draft?
+
       in_context(recurring_meeting, send_notifications: false) do
         call = instantiate(start_time)
         if call.success?
@@ -52,6 +54,10 @@ module RecurringMeetings
 
         call
       end
+    end
+
+    def draft_template_failure
+      ServiceResult.failure(message: I18n.t("recurring_meeting.occurrence.error_template_draft"))
     end
 
     def instantiate(start_time)

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -57,6 +57,8 @@ module RecurringMeetings
 
     def perform(recurring_meeting, scheduled_time)
       self.recurring_meeting = recurring_meeting
+      return if recurring_meeting.template.draft?
+
       self.scheduled_time = scheduled_time.in_time_zone(recurring_meeting.time_zone)
 
       # Schedule the next job

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -452,12 +452,13 @@ en:
       message: "This meeting series has come to an end. There are no upcoming meetings. "
       action: "You can still view past occurrences or edit the meeting series to extend it."
     occurrence:
-      infoline: "This meeting is part of a recurring meeting series."
       error_no_next: "There is no next occurrence for this meeting."
+      error_template_draft: "The meeting series template is still in draft mode."
       first_already_exists: "The first occurrence of this meeting series is already instantiated."
       first_created: >
         The first meeting has been successfuly created from template.
         All future meetings will be created automatically at the time of the previous occurrence.
+      infoline: "This meeting is part of a recurring meeting series."
     template:
       button_finalize: "Open first meeting"
       blank_title: "Your meeting series template is empty"

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
@@ -102,6 +102,33 @@ RSpec.describe "Recurring meetings complete template",
     end
   end
 
+  context "when first occurrence is already created while the template is still a draft" do
+    let!(:meeting) do
+      create(:meeting,
+             recurring_meeting:,
+             start_time: recurring_meeting.start_time,
+             recurrence_start_time: recurring_meeting.start_time)
+    end
+
+    before do
+      recurring_meeting.template.update!(state: :draft)
+    end
+
+    it "opens the template without creating a duplicate occurrence" do
+      expect { subject }.not_to change(recurring_meeting.meetings.not_templated, :count)
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('action="redirect_to"')
+      expect(response.body).to include(project_recurring_meeting_path(project, recurring_meeting))
+
+      expect(recurring_meeting.template.reload).to be_open
+      expect(recurring_meeting.meetings.not_templated.first).to eq(meeting)
+      expect(RecurringMeetings::InitNextOccurrenceJob)
+        .to have_been_enqueued.with(recurring_meeting, DateTime.parse("2024-12-06T10:00:00Z"))
+                              .at(DateTime.parse("2024-12-05T10:00:00Z"))
+    end
+  end
+
   context "when first occurrence is cancelled" do
     let!(:cancelled_occurrence) do
       create(:meeting,

--- a/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_spec.rb
@@ -56,6 +56,23 @@ RSpec.describe RecurringMeetings::InitOccurrenceService, type: :model do
   describe "instantiating an occurrence for a slot" do
     let(:start_time) { series.start_time + 3.days }
 
+    context "when the template is still in draft mode" do
+      before do
+        series.template.update!(state: :draft)
+      end
+
+      it "does not create an occurrence" do
+        expect(service_result).not_to be_success
+        expect(service_result.message).to eq(I18n.t("recurring_meeting.occurrence.error_template_draft"))
+        expect(created_meeting).to be_nil
+      end
+
+      it "does not add an occurrence" do
+        expect { instance.call(**params) }
+          .not_to change { series.meetings.not_templated.count }
+      end
+    end
+
     context "when no occurrence exists yet for the slot" do
       it "creates a new occurrence for the series" do
         expect(service_result).to be_success

--- a/modules/meeting/spec/workers/recurring_meetings/init_next_occurrence_job_spec.rb
+++ b/modules/meeting/spec/workers/recurring_meetings/init_next_occurrence_job_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe RecurringMeetings::InitNextOccurrenceJob, type: :model do
 
   subject { described_class.perform_now(series, scheduled_time) }
 
+  context "when the template is still in draft mode" do
+    before do
+      series.template.update!(state: :draft)
+    end
+
+    it "does not schedule or instantiate occurrences" do
+      result = nil
+
+      expect { result = subject }
+        .not_to change { series.meetings.not_templated.count }
+      expect(result).to be_nil
+      expect(described_class).not_to have_been_enqueued
+    end
+  end
+
   it "schedules the first occurrence" do
     expect { subject }.to change(Meeting, :count).by(1)
     expect(subject).to be_success

--- a/modules/meeting/spec/workers/recurring_meetings/init_next_occurrence_watchdog_job_spec.rb
+++ b/modules/meeting/spec/workers/recurring_meetings/init_next_occurrence_watchdog_job_spec.rb
@@ -28,27 +28,40 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class RecurringMeetings::InitNextOccurrenceWatchdogJob < ApplicationJob
-  queue_with_priority :low
+require "spec_helper"
+require_module_spec_helper
 
-  def perform
-    key = RecurringMeetings::InitNextOccurrenceJob::CONCURRENCY_KEY_BASE
+RSpec.describe RecurringMeetings::InitNextOccurrenceWatchdogJob, type: :model do
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  shared_let(:user) { create(:user) }
 
-    RecurringMeeting
-      .includes(:template)
-      .joins("LEFT JOIN good_jobs ON good_jobs.concurrency_key = CONCAT('#{key}', recurring_meetings.id)")
-      .where(good_jobs: { id: nil })
-      .find_each do |series|
-      next if series.template.draft?
+  let(:series) do
+    create(:recurring_meeting,
+           project:,
+           author: user,
+           start_time: Time.zone.tomorrow + 10.hours,
+           frequency: "daily",
+           interval: 1,
+           end_after: "specific_date",
+           end_date: 1.month.from_now)
+  end
 
-      next_occurrence = series.next_occurrence
+  subject(:perform) { described_class.perform_now }
 
-      if next_occurrence
-        Rails.logger.warn { "Meeting series ##{series.id} lost its InitNextOccurrenceJob. Re-scheduling." }
-        RecurringMeetings::InitNextOccurrenceJob.perform_later(series, next_occurrence)
-      else
-        Rails.logger.debug { "Meeting series ##{series.id} has no next occurrence. Skipping resetting init job" }
-      end
+  it "re-schedules missing init jobs for open series" do
+    expect { perform }
+      .to have_enqueued_job(RecurringMeetings::InitNextOccurrenceJob)
+      .with(series, series.next_occurrence)
+  end
+
+  context "when the template is still in draft mode" do
+    before do
+      series.template.update!(state: :draft)
+    end
+
+    it "does not schedule an init job" do
+      expect { perform }
+        .not_to have_enqueued_job(RecurringMeetings::InitNextOccurrenceJob)
     end
   end
 end


### PR DESCRIPTION
Adds some safeguards to ensure a series occurrence is not instantiated while template is in draft:

- InitOccurrenceService refuses to instantiate an occurrence if the  template is still in draft
- InitNextOccurrenceJob adds a condition to check draft templates, preventing jobs from opening occurrences
- template_completed can always recover the broken state: if the first occurrence already exists but the template is still draft, it opens the template instead of redirecting into the loop.

https://community.openproject.org/projects/MEET/work_packages/MEET-557/activity
