### PR TITLE
[OP-19622] Multi-select workflows cannot bulk select/unselect rows/columns  

### DIFF
--- a/frontend/src/stimulus/controllers/checkable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/checkable.controller.spec.ts
@@ -72,7 +72,7 @@ describe('CheckableController', () => {
     expect(inputs.every((i) => !i.checked)).toBe(true);
   });
 
-  it('dispatches input event', () => {
+  it('dispatches a bubbling change event', () => {
     const dispatchSpy = vi.spyOn(inputs[0], 'dispatchEvent');
 
     controller.toggleAll(new Event('click'));
@@ -81,9 +81,8 @@ describe('CheckableController', () => {
 
     const eventArg = vi.mocked(dispatchSpy).mock.lastCall![0];
 
-    expect(eventArg.type).toBe('input');
-    expect(eventArg.bubbles).toBe(false);
-    expect(eventArg.cancelable).toBe(true);
+    expect(eventArg.type).toBe('change');
+    expect(eventArg.bubbles).toBe(true);
   });
 
   it('checkAll calls toggleChecked(true)', () => {

--- a/frontend/src/stimulus/controllers/checkable.controller.ts
+++ b/frontend/src/stimulus/controllers/checkable.controller.ts
@@ -147,13 +147,18 @@ export default class CheckableController extends Controller<HTMLElement> {
 
   private toggleChecked(checkboxes:HTMLInputElement[], checked?:boolean) {
     // If all are checked -> uncheck all.
-    // If mixed or none checked -> check all.
-    const allChecked = checkboxes.every((checkbox) => checkbox.checked);
+    // If mixed, indeterminate or none checked -> check all.
+    const allChecked = checkboxes.every((checkbox) => checkbox.checked && !checkbox.indeterminate);
     checked ??= !allChecked;
 
     checkboxes.forEach((checkbox) => {
+      // Programmatically setting `checked` does not clear the indeterminate
+      // flag the way a native click does, so clear it explicitly.
+      checkbox.indeterminate = false;
       checkbox.checked = checked;
-      checkbox.dispatchEvent(new Event('input', { bubbles: false, cancelable: true }));
+      // Dispatch a bubbling `change` so form-level listeners
+      // react just as they would to a native checkbox toggle.
+      checkbox.dispatchEvent(new Event('change', { bubbles: true }));
     });
   }
 }

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -263,6 +263,65 @@ RSpec.describe "Workflow edit with multiple roles", :js do
       click_button "Save"
       expect_flash(message: "Successful update.")
     end
+
+    it "bulk-checks an indeterminate cell when toggling its column" do
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      toggle_select_all_in_column(1)
+
+      expect(page).to have_field workflow_checkbox(0, 1), checked: true
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: true)
+    end
+
+    it "bulk-checks an indeterminate cell when toggling its row" do
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      toggle_select_all_in_row(0)
+
+      expect(page).to have_field workflow_checkbox(0, 1), checked: true
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: true)
+    end
+
+    it "bulk-unchecks an indeterminate cell when toggling its column twice" do
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      toggle_select_all_in_column(1) # check all
+      toggle_select_all_in_column(1) # uncheck all
+
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 0, 1, exist: false)
+      expect_transition(role2, 0, 1, exist: false)
+    end
+
+    it "marks the form dirty when bulk-toggling a column" do
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      toggle_select_all_in_column(1)
+
+      click_link "User is author"
+      expect(page).to have_dialog("Save changes before continuing?")
+    end
   end
 
   context "when deselecting all roles in the select panel" do

--- a/spec/support/workflows/edit_helpers.rb
+++ b/spec/support/workflows/edit_helpers.rb
@@ -69,6 +69,14 @@ module Workflows
       end
     end
 
+    def toggle_select_all_in_column(to_index)
+      find(:button, accessible_name: "Toggle transitions from all old statuses to #{statuses[to_index].name}").click
+    end
+
+    def toggle_select_all_in_row(from_index)
+      find(:button, accessible_name: "Toggle transitions from #{statuses[from_index].name} to all new statuses").click
+    end
+
     def indeterminate?(checkbox_id)
       page.evaluate_script("document.getElementById('#{checkbox_id}')?.indeterminate ?? false")
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-19622

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
