### PR TITLE
[OP-19666] Consolidate custom-element morph policy

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.spec.ts
@@ -67,18 +67,37 @@ describe('Date picker preview controller', () => {
 
   async function renderDialog() {
     await ctx.mount(`
-      <div data-controller="work-packages--date-picker--preview">
-        <form action="/work_packages/dialog" data-work-packages--date-picker--preview-target="form">
-          <input type="text" id="work_package_start_date" name="work_package[start_date]" value=""
-                 data-work-packages--date-picker--preview-target="fieldInput">
-        </form>
-      </div>
+      <turbo-frame id="content-frame" disabled>
+        <div data-controller="work-packages--date-picker--preview">
+          <form action="/work_packages/dialog" data-work-packages--date-picker--preview-target="form">
+            <input type="text" id="work_package_start_date" name="work_package[start_date]" value=""
+                   data-work-packages--date-picker--preview-target="fieldInput">
+          </form>
+        </div>
+      </turbo-frame>
     `);
     return ctx.getController<PreviewControllerType>('work-packages--date-picker--preview');
   }
 
   function flatpickrDatesChanged(dates:Date[]) {
     document.dispatchEvent(new CustomEvent('date-picker:flatpickr-dates-changed', { detail: { dates } }));
+  }
+
+  async function morphFrame(src:string) {
+    await renderDialog();
+    const turboFrame = ctx.container.querySelector('turbo-frame')!;
+    turboFrame.setAttribute('src', src);
+
+    const currentElement = document.createElement('turbo-frame');
+    currentElement.innerHTML = '<opce-test-marker data-marker="old"></opce-test-marker><div data-marker="old">old</div>';
+    const newElement = document.createElement('turbo-frame');
+    newElement.innerHTML = '<opce-test-marker data-marker="new"></opce-test-marker><div data-marker="new">new</div>';
+
+    const detail:{ render?:(current:Element, next:Element) => void } = {};
+    turboFrame.dispatchEvent(new CustomEvent('turbo:before-frame-render', { detail }));
+    detail.render!(currentElement, newElement);
+
+    return currentElement;
   }
 
   it('binds the declared timezone service after connect', async () => {
@@ -121,5 +140,21 @@ describe('Date picker preview controller', () => {
 
     expect(input.value).toBe('');
     expect(utcDateToISODateString).not.toHaveBeenCalled();
+  });
+
+  it('skips morphing an OPCE-* node when scheduling has not changed', async () => {
+    const currentElement = await morphFrame('/work_packages/123/dialog/preview');
+
+    expect(currentElement.querySelector('opce-test-marker')!.getAttribute('data-marker')).toBe('old');
+    expect(currentElement.querySelector('div')!.getAttribute('data-marker')).toBe('new');
+  });
+
+  it('replaces an OPCE-* node when scheduling has changed', async () => {
+    const currentElement = await morphFrame('/work_packages/123/dialog/preview?schedule_manually=true');
+
+    // The `<div>` sibling is NOT expected to morph here: oldNode.replaceWith()
+    // detaches the OPCE node from the DOM, which breaks idiomorph's sibling walk
+    // for anything that follows it. Pre-existing bug, tracked as OP-19669.
+    expect(currentElement.querySelector('opce-test-marker')!.getAttribute('data-marker')).toBe('new');
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -31,6 +31,7 @@
 import { Controller } from '@hotwired/stimulus';
 import type { FrameElement, TurboBeforeFrameRenderEvent } from '@hotwired/turbo';
 import { Idiomorph } from 'idiomorph';
+import { isOpenProjectCustomElement } from 'core-turbo/openproject-custom-element';
 
 export abstract class DialogPreviewController extends Controller {
   static targets = [
@@ -79,7 +80,7 @@ export abstract class DialogPreviewController extends Controller {
             beforeNodeMorphed: (oldNode, newNode) => {
               // In case the element is an OpenProject custom dom element, prevent morphing and
               // replace the angular tag with the new version.
-              if (oldNode.tagName?.startsWith('OPCE-')) {
+              if (isOpenProjectCustomElement(oldNode)) {
                 if (schedulingChanged) {
                   oldNode.replaceWith(newNode);
                 }

--- a/frontend/src/turbo/openproject-custom-element.spec.ts
+++ b/frontend/src/turbo/openproject-custom-element.spec.ts
@@ -1,0 +1,53 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { isOpenProjectCustomElement } from './openproject-custom-element';
+
+describe('isOpenProjectCustomElement', () => {
+  it('returns true for an element whose tag starts with OPCE-', () => {
+    const element = document.createElement('opce-test-marker');
+
+    expect(isOpenProjectCustomElement(element)).toBe(true);
+  });
+
+  it('returns false for a plain element', () => {
+    const element = document.createElement('div');
+
+    expect(isOpenProjectCustomElement(element)).toBe(false);
+  });
+
+  it('returns false for a non-Element node such as a text node', () => {
+    const textNode = document.createTextNode('hello');
+
+    expect(isOpenProjectCustomElement(textNode)).toBe(false);
+  });
+
+  it('returns false for a null event target', () => {
+    expect(isOpenProjectCustomElement(null)).toBe(false);
+  });
+});

--- a/frontend/src/turbo/openproject-custom-element.ts
+++ b/frontend/src/turbo/openproject-custom-element.ts
@@ -1,0 +1,31 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+export function isOpenProjectCustomElement(node:EventTarget | null):node is HTMLElement{
+  return node instanceof HTMLElement && node.tagName.startsWith('OPCE-');
+}

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -11,6 +11,7 @@ import {
   focusFirstErroneousField,
   initMainMenuExpandStatus,
 } from 'core-app/core/setup/globals/global-listeners/setup-server-response';
+import { isOpenProjectCustomElement } from './openproject-custom-element';
 
 export function addTurboGlobalListeners(target:Document = document, signal?:AbortSignal) {
   const runOnRenderAndLoad = () => {
@@ -60,10 +61,8 @@ export function addTurboGlobalListeners(target:Document = document, signal?:Abor
   target.addEventListener('DOMContentLoaded', runOnRenderAndLoad, { signal });
 
   target.addEventListener('turbo:before-morph-element', (event) => {
-    const element = event.target as HTMLElement;
-
     // In case the element is an OpenProject custom dom element, morphing is prevented.
-    if (element.tagName.toUpperCase().startsWith('OPCE-')) {
+    if (isOpenProjectCustomElement(event.target)) {
       event.preventDefault();
     }
   }, { signal });


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19666

# What are you trying to accomplish?

Two files each re-implemented the same `OPCE-*` tag-name check that decides whether Turbo's idiomorph may morph an element: a global `preventDefault()` guard in `turbo-global-listeners.ts`, and a frame-local `beforeNodeMorphed` callback (with a scheduling-change exception) in `dialog/preview.controller.ts`. Neither the shared logic nor the controller's morph behaviour had test coverage.

# What approach did you choose and why?

Three commits:

1. **Add a custom-element morph predicate.** New `frontend/src/turbo/openproject-custom-element.ts` exports `isOpenProjectCustomElement(node): node is HTMLElement` — one tested source of truth. It's a type guard over `EventTarget | null` that checks `instanceof HTMLElement` internally, so no call site needs a cast (custom elements only upgrade in the HTML namespace, so `HTMLElement` is exact). Purely additive, TDD.

2. **Route turbo morph guard to predicate.** `turbo-global-listeners.ts` swaps its inline check for the shared predicate. Behaviour-preserving; the existing morph-guard tests (from OP-19617) are the regression net.

3. **Route dialog morph guard to predicate.** `DialogPreviewController` (the abstract base for the `date-picker/` and `progress/` preview controllers) does the same and gains the morph coverage this path never had. The scheduling-changed replace exception is untouched — date-picker domain logic, not generic morph policy.

Out of scope: `action-menu-morph-remount.ts` (post-morph remount, not a skip) and PR #23218's `pragmatic-dnd-morph-attributes.ts` (attribute preservation, different event) solve different problems; a shared interface would only distort to fit them.

While adding coverage, a pre-existing `dev` bug surfaced: `oldNode.replaceWith(newNode)` in the scheduling-changed branch detaches the node, breaking idiomorph's sibling walk so a sibling following a replaced `OPCE-*` node is left stale. Filed as https://community.openproject.org/wp/OP-19669, not fixed here; the test asserts only the correct `OPCE-*` replacement, with a comment pointing at the ticket.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
