### PR TITLE
[op-19662] Misplaced success banner when locking / unlocking user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -436,7 +436,7 @@ class UsersController < ApplicationController
     update_via_turbo_stream(component: Users::UserFilterButtonComponent.new(query: @query))
     replace_via_turbo_stream(component: Users::TableComponent.new(rows: @query, current_user:))
     turbo_streams << turbo_stream.push_state(url_for(params.permit(:filters, :sortBy, :sort, :page, :per_page, :columns)))
-    turbo_streams << turbo_stream.replace("primerized-flash-messages", helpers.render_flash_messages)
+    turbo_streams << helpers.render_flash_messages_as_turbo_streams
     render turbo_stream: turbo_streams
   end
 

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe "index users", :js do
       index_page.expect_listed(current_user, active_user)
 
       index_page.lock_user(active_user)
+      expect_and_dismiss_flash(message: "Successful update.")
       expect(active_user.reload).to be_locked
 
       index_page.filter_by_status(I18n.t(:status_locked))
@@ -130,6 +131,7 @@ RSpec.describe "index users", :js do
 
       index_page.filter_by_status(I18n.t(:status_locked))
       index_page.unlock_user(active_user)
+      expect_and_dismiss_flash(message: "Successful update.")
       index_page.expect_non_listed
 
       index_page.filter_by_status(I18n.t(:status_active))
@@ -146,16 +148,19 @@ RSpec.describe "index users", :js do
       index_page.expect_listed(current_user, active_user)
 
       index_page.reset_failed_logins(active_user)
+      expect_and_dismiss_flash(message: "Successful update.")
       # still listed — reset doesn't change status
       index_page.expect_listed(current_user, active_user)
 
       # Lock and unlock — failed logins were reset above, so the user is locked
       # but not blocked, and the row exposes the plain "Unlock" action.
       index_page.lock_user(active_user)
+      expect_and_dismiss_flash(message: "Successful update.")
       index_page.filter_by_status(I18n.t(:status_locked))
       index_page.expect_listed(active_user)
 
       index_page.unlock_user(active_user)
+      expect_and_dismiss_flash(message: "Successful update.")
       index_page.expect_non_listed
 
       index_page.filter_by_status(I18n.t(:status_active))
@@ -166,6 +171,7 @@ RSpec.describe "index users", :js do
       index_page.expect_listed(registered_user)
 
       index_page.activate_user(registered_user)
+      expect_and_dismiss_flash(message: "Successful update.")
       index_page.filter_by_status(I18n.t(:status_active))
       index_page.expect_listed(current_user, active_user, registered_user)
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19662

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Render user index flash messages through the dedicated Turbo Stream flash action instead of replacing the page-level flash container.

