### PR TITLE
[MEET-566] Fix meetings API caching

### DIFF
--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -40,7 +40,8 @@ module API
 
         self.to_eager_load = [:author, { project: :enabled_modules }, { participants: :user }]
 
-        cached_representer key_parts: %i(project participants)
+        cached_representer key_parts: %i(project participants),
+                           dependencies: ->(*) { represented.notify? }
 
         self_link title_getter: ->(*) { represented.title }
 

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_representer.rb
@@ -37,7 +37,7 @@ module API
         include API::Decorators::DateProperty
         include ::API::Caching::CachedRepresenter
 
-        cached_representer key_parts: %i[project]
+        cached_representer key_parts: %i[project template]
 
         self.to_eager_load = [:author, :template, { project: :enabled_modules }]
 

--- a/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
@@ -106,5 +106,14 @@ RSpec.describe API::V3::Meetings::MeetingRepresenter do
 
       expect(generated).to be_json_eql(true.to_json).at_path("notify")
     end
+
+    it "invalidates the cache key when the resolved notify status changes" do
+      allow(meeting).to receive(:notify?).and_return(true)
+      cache_key_when_notifying = representer.json_cache_key
+
+      allow(meeting).to receive(:notify?).and_return(false)
+
+      expect(representer.json_cache_key).not_to eql cache_key_when_notifying
+    end
   end
 end

--- a/modules/meeting/spec/lib/api/v3/recurring_meetings/recurring_meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/recurring_meetings/recurring_meeting_representer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::V3::RecurringMeetings::RecurringMeetingRepresenter do
+  let(:project) { build_stubbed(:project) }
+  let(:current_user) { build_stubbed(:user) }
+  let(:template) { build_stubbed(:meeting, project:, notify: true) }
+  let(:recurring_meeting) do
+    build_stubbed(:recurring_meeting, project:, author: current_user).tap do |rm|
+      allow(rm).to receive(:template).and_return(template)
+    end
+  end
+  let(:representer) { described_class.new(recurring_meeting, current_user:) }
+
+  describe "#json_cache_key" do
+    it "changes when the template changes" do
+      key_before = representer.json_cache_key
+
+      template.updated_at = template.updated_at + 1.hour
+
+      expect(representer.json_cache_key).not_to eql key_before
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-566

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- In spite of the earlier change in https://github.com/opf/openproject/pull/23939, updating `notify` never invalidated the cache for the template. Adding it as a dependency ensures that changes to `template.notify` also update the meeting representer cache
- I also added `template` to the `cached_representer` for the recurring meeting representer since there would be similar caching issues there too otherwise

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
