### PR TITLE
[DREAM-714] Button to leave the current project is misaligned on mobile (2)

### DIFF
--- a/app/helpers/header/projects_helper.rb
+++ b/app/helpers/header/projects_helper.rb
@@ -37,7 +37,7 @@ module Header
       parts << workspace_type_badge(project) if show_workspace_type_badge?(project)
 
       text = parts.length == 1 ? parts.first : safe_join(parts)
-      render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :center)) { text }
+      render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :baseline)) { text }
     end
 
     private
@@ -92,14 +92,17 @@ module Header
     end
 
     def favorite_icon
-      render(Primer::Beta::Octicon.new(icon: :"star-fill", size: :small, classes: "op-primer--star-icon", ml: 2))
+      render(Primer::BaseComponent.new(tag: :span)) do
+        render(Primer::Beta::Octicon.new(icon: :"star-fill", size: :small, classes: "op-primer--star-icon", ml: 2))
+      end
     end
 
     def workspace_type_badge(project)
-      render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :center,
+      render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :baseline,
                                        color: :subtle, font_size: :small, ml: 2, classes: "description")) do
         safe_join([
-                    render(Primer::Beta::Octicon.new(icon: workspace_icon(project.workspace_type), size: :xsmall, mr: 1)),
+                    render(Primer::Beta::Octicon.new(icon: workspace_icon(project.workspace_type),
+                                                     size: :xsmall, mr: 1, align_self: :center)),
                     content_tag(:span, I18n.t(:"label_#{project.workspace_type}"))
                   ])
       end


### PR DESCRIPTION


# Ticket
https://community.openproject.org/projects/DREAM/work_packages/DREAM-714/activity#comment-1695883

# What are you trying to accomplish?
Align star icon and workspace lable at the first row of a multiline project name. 

## Screenshots
<img width="566" height="330" alt="Bildschirmfoto 2026-07-01 um 13 51 16" src="https://github.com/user-attachments/assets/f4b25422-27e0-451c-8e7c-5818e45d281b" />

<img width="569" height="469" alt="Bildschirmfoto 2026-07-01 um 13 48 10" src="https://github.com/user-attachments/assets/53fd6031-9db2-4041-8307-ba7489ba5d3c" />
