### PR TITLE
Nextcloud: Stricter error handling of JSON responses

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/base.rb
@@ -83,10 +83,23 @@ module Storages
           # such as a 404 File Not Found do not cause an error.
           # @return [Dry::Result]
           def fail_on_ocs_error(json, error)
-            if json.dig(:ocs, :meta, :statuscode) < 500
+            if json_fetch(json, :ocs, :meta, :statuscode) < 500
               Success(json)
             else
               Failure(error.with(code: :error))
+            end
+          end
+
+          def json_fetch(json, *path)
+            current_path = []
+            path.inject(json) do |j, key|
+              if j.is_a?(Hash)
+                current_path << key
+                j.fetch(key) { raise "Could not find JSON path #{current_path.join('.')} in response (wanted #{path.join('.')})" }
+              else
+                raise "Object at JSON path #{current_path.join('.')} was expected to be a hash, " \
+                      "but got #{j.class} (wanted #{path.join('.')})"
+              end
             end
           end
         end

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/capabilities_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/capabilities_query.rb
@@ -64,7 +64,8 @@ module Storages
             end
 
             def parse_capabilities(json)
-              app_json = json.dig(:ocs, :data, :capabilities, :integration_openproject)
+              capabilities_json = json_fetch(json, :ocs, :data, :capabilities)
+              app_json = capabilities_json[:integration_openproject]
 
               ProviderResults::Capabilities.build(
                 app_enabled: app_json.present?,

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -82,7 +82,7 @@ module Storages
               parsing_error = Failure(error.with(code: :invalid_response, payload: response.body))
 
               json = response.json(symbolize_keys: true)
-              url = json.dig(:ocs, :data, :url)
+              url = json_fetch(json, :ocs, :data, :url)
               return parsing_error if url.blank?
 
               path = URI.parse(url).path

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/file_info_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/file_info_query.rb
@@ -68,7 +68,7 @@ module Storages
             def validate_response_object(json)
               error = Results::Error.new(source: self.class, payload: json)
 
-              case json.dig(:ocs, :data, :statuscode)
+              case json_fetch(json, :ocs, :data, :statuscode)
               when 200..299
                 Success(json)
               when 403
@@ -81,7 +81,7 @@ module Storages
             end
 
             def create_storage_file_info(json) # rubocop:disable Metrics/AbcSize
-              data = json.dig(:ocs, :data)
+              data = json_fetch(json, :ocs, :data)
               error = Results::Error.new(source: self.class, code: :invalid_file_info)
               Results::StorageFileInfo.build(
                 status: data[:status]&.downcase,

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_info_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_info_query.rb
@@ -68,7 +68,7 @@ module Storages
             end
 
             def create_storage_file_infos(parsed_json)
-              parsed_json.dig(:ocs, :data)&.filter_map do |(key, value)|
+              json_fetch(parsed_json, :ocs, :data)&.filter_map do |(key, value)|
                 if value[:statuscode] == 200
                   build_file_info(value).bind { it }
                 else


### PR DESCRIPTION
Previous error handling was inconsistent due to the use of #dig.
Missing keys resulted in us returning nil and usually some kind of
error handling for that. However, structurally wrong responses (e.g.
returning an array instead of a hash) would raise an error, but not allow
to gather further insights.

This change makes parsing of JSON responses stricter by raising errors
in more cases. It would also be possible to mask these errors as monadic failures,
however, I feel that we should rather understand when and how they happen, before
we do that.

# Ticket
https://community.openproject.org/wp/DEV-33