### PR TITLE
[MEET-572] "New work package" outcome form does not update placeholder description on changing types  

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -230,14 +230,10 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     # And the type was changed
     return unless work_package.type_id_changed?
 
-    # And the new type has a default text
-    default_description = work_package.type&.description
-    return if default_description.blank?
-
     # And the current description matches ANY current default text
     return unless work_package.description.blank? || default_description?
 
-    work_package.description = default_description
+    work_package.description = work_package.type&.description
   end
 
   def default_description?

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -2388,4 +2388,51 @@ RSpec.describe WorkPackages::SetAttributesService,
       expect(work_package.override_target_versions?).to be true
     end
   end
+
+  describe "setting the templated description when the type changes on a new work package" do
+    subject(:service_result) { instance.call(call_attributes) }
+
+    let(:work_package) { new_work_package }
+    let(:type_with_template) { create(:type, description: "Some default template text") }
+    let(:type_without_template) { create(:type, description: nil) }
+
+    before { allow(work_package).to receive(:save) }
+
+    context "when changing to a type that has a default description template" do
+      let(:call_attributes) { { type: type_with_template } }
+
+      it "sets the description to the type's template" do
+        service_result
+        expect(work_package.description).to eq("Some default template text")
+      end
+    end
+
+    context "when changing from a templated type to one without a template" do
+      let(:call_attributes) { { type: type_without_template } }
+
+      before do
+        work_package.description = type_with_template.description
+        work_package.clear_changes_information
+      end
+
+      it "clears the previous type's template" do
+        service_result
+        expect(work_package.description).to be_blank
+      end
+    end
+
+    context "when the description was authored by the user" do
+      let(:call_attributes) { { type: type_without_template } }
+
+      before do
+        work_package.description = "Something the user typed"
+        work_package.clear_changes_information
+      end
+
+      it "keeps the user's description" do
+        service_result
+        expect(work_package.description).to eq("Something the user typed")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-572

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
