### PR TITLE
[op-19671] Deleting project specific notifications results in 404

### DIFF
--- a/app/controllers/concerns/notifications/notification_settings_actions.rb
+++ b/app/controllers/concerns/notifications/notification_settings_actions.rb
@@ -77,10 +77,10 @@ module Notifications
     def destroy_project_settings
       @user.notification_settings.find_by!(project_id: params[:project_id]).destroy!
       flash[:notice] = I18n.t(:notice_successful_delete)
-      redirect_back_or_to(notifications_settings_path)
+      redirect_back_or_to(notifications_settings_path, status: :see_other)
     rescue ActiveRecord::RecordNotFound
       flash[:error] = t(:notice_bad_request)
-      redirect_back_or_to(notifications_settings_path)
+      redirect_back_or_to(notifications_settings_path, status: :see_other)
     end
 
     private

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe MyController do
     login_as(user)
   end
 
+  describe "DELETE destroy_project_settings" do
+    let(:project) { create(:project) }
+    let!(:notification_setting) { create(:notification_setting, user:, project:) }
+
+    it "deletes the setting and redirects with see other" do
+      delete :destroy_project_settings, params: { project_id: project.id }
+
+      expect(response).to redirect_to(my_notifications_path)
+      expect(response).to have_http_status(:see_other)
+      expect { notification_setting.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe "password change" do
     describe "security" do
       render_views

--- a/spec/features/users/notifications/shared_examples.rb
+++ b/spec/features/users/notifications/shared_examples.rb
@@ -123,6 +123,18 @@ RSpec.shared_examples "notification settings workflow" do
       expect(page).to have_no_css(".ng-option", text: project.name)
     end
 
+    it "deletes project-specific notification settings without a routing error" do
+      create(:notification_setting, user:, project:)
+      settings_page.visit!
+
+      settings_page.delete_project project
+      settings_page.expect_and_dismiss_flash
+
+      expect(page).to have_current_path(settings_page.path)
+      expect(user.reload.notification_settings.where(project:)).to be_empty
+      expect(page).to have_no_test_selector("project-specific-settings-list", text: project.name)
+    end
+
     context "when overdue alerts are disabled for one project, enabled for another" do
       let!(:setting) { build(:notification_setting, user:, project:) }
       let!(:setting_alt) { build(:notification_setting, user:, project: project_alt) }

--- a/spec/support/pages/notifications/settings.rb
+++ b/spec/support/pages/notifications/settings.rb
@@ -118,6 +118,15 @@ module Pages
         click_on "Edit"
       end
 
+      def delete_project(project)
+        within_test_selector "project-specific-settings-list", text: project.name do
+          within_test_selector("project-specific-settings-list--action-menu") do
+            click_on
+          end
+        end
+        accept_confirm { click_on "Delete" }
+      end
+
       def save_project
         within_test_selector "project-specific-settings-form" do
           click_button "Save"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19671

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Turbo followed the previous 302 redirect while preserving the DELETE method, resulting in DELETE /my/notifications. The redirect now uses 303 See Other, ensuring the notifications page is requested with GET.
Adds regression coverage for the deletion flow.
