### PR TITLE
[AGILE-315] Status labels are cut off on mobile

### DIFF
--- a/app/components/work_packages/info_line_component.sass
+++ b/app/components/work_packages/info_line_component.sass
@@ -10,6 +10,7 @@
     align-items: center
     .Label
       line-height: 14px
+      @include text-shortener
 
   &--id
     white-space: nowrap


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-315

# What are you trying to accomplish?
Truncate the status label if there is not enough space

## Screenshots

<img width="675" height="383" alt="Bildschirmfoto 2026-07-02 um 08 13 11" src="https://github.com/user-attachments/assets/ae39572d-084f-4670-8c37-62f517b8bce6" />
