### PR TITLE
[JIM-117] Jira Migration stops if multiple Jira accounts have the same email/login

### DIFF
--- a/app/models/import/jira_import.rb
+++ b/app/models/import/jira_import.rb
@@ -114,13 +114,10 @@ module Import
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/PerceivedComplexity
     def handle_create_user_failure(call, user_attrs, jira_user)
-      taken_error = call.errors.find { |error| error.type == :taken }
-      if taken_error.blank?
-        raise "Error creating a user (#{user_attrs.except(:password)}): #{call.message}"
-      end
+      taken_errors = call.errors.select { |error| error.type == :taken }
 
-      if taken_error.attribute == :mail
-        user = User.find_by(["LOWER(mail) = ?", user_attrs[:mail]&.downcase])
+      if taken_errors.any? { |e| e.attribute == :mail }
+        user = jira_user.try_to_find_existing_op_user_by_mail
         if user.blank?
           raise "Existing User is expected to be found, because there was an email " \
                 "collision. See attributes: #{user_attrs.except(:password)}"
@@ -134,27 +131,17 @@ module Import
         return
       end
 
-      user = jira_user.try_to_find_existing_op_users.first
-      if user.blank?
-        raise "Existing User is expected to be found, because there was a login " \
-              "collision. See attributes: #{user_attrs.except(:password)}"
+      if taken_errors.any? { |e| e.attribute == :login }
+        handle_referenced_user_login_conflict(user_attrs, jira_user)
+        return
       end
 
-      if jira_user_already_referenced?(user)
-        raise "Login '#{user_attrs[:login]}' is already taken by an OP user that is referenced by another Jira user. " \
-              "See attributes: #{user_attrs.except(:password)}"
-      end
-
-      create_reference!(
-        op_leg: user,
-        jira_leg: jira_user,
-        jira_import: self,
-        uses_existing: true
-      )
+      raise "Error creating a user (#{user_attrs.except(:password)}): #{call.message}"
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/PerceivedComplexity
 
+    # rubocop:disable Metrics/AbcSize
     def handle_referenced_user_mail_conflict(user_attrs, jira_user)
       unique_mail, reusable_user = resolve_jira_email(user_attrs[:mail], jira_user.jira_user_key)
       if reusable_user
@@ -165,9 +152,14 @@ module Import
           uses_existing: true
         )
       else
+        overrides = {
+          mail: unique_mail,
+          login: resolve_jira_login(user_attrs[:login], jira_user.jira_user_key)
+        }
+
         new_call = Users::CreateService
                      .new(user: User.system, contract_class: EmptyContract)
-                     .call(user_attrs.merge(mail: unique_mail))
+                     .call(user_attrs.merge(overrides))
         unless new_call.success?
           raise "Error creating a user with modified email '#{unique_mail}' " \
                 "(#{user_attrs.except(:password)}): #{new_call.message}"
@@ -180,6 +172,25 @@ module Import
           uses_existing: false
         )
       end
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def handle_referenced_user_login_conflict(user_attrs, jira_user)
+      unique_login = resolve_jira_login(user_attrs[:login], jira_user.jira_user_key)
+      new_call = Users::CreateService
+                   .new(user: User.system, contract_class: EmptyContract)
+                   .call(user_attrs.merge(login: unique_login))
+      unless new_call.success?
+        raise "Error creating a user with modified login '#{unique_login}' " \
+              "(#{user_attrs.except(:password)}): #{new_call.message}"
+      end
+
+      create_reference!(
+        op_leg: new_call.result,
+        jira_leg: jira_user,
+        jira_import: self,
+        uses_existing: false
+      )
     end
 
     def import_user_groups(jira_user)
@@ -241,6 +252,7 @@ module Import
         op_entity_class: op_user.class.to_s
       )
     end
+
     # rubocop:enable Metrics/AbcSize
 
     # Returns [email, existing_user_or_nil].
@@ -259,6 +271,21 @@ module Import
         candidate = "#{local}+#{safe_key}+#{counter}@#{domain}"
         user = User.find_by(["LOWER(mail) = ?", candidate.downcase])
         break [candidate, user] unless user && jira_user_already_referenced?(user)
+
+        counter += 1
+      end
+    end
+
+    def resolve_jira_login(original_login, jira_user_key)
+      safe_key = jira_user_key.gsub(/[^a-zA-Z0-9._-]/, "_")
+
+      candidate = "#{original_login}+#{safe_key}"
+      return candidate unless User.by_login(candidate).exists?
+
+      counter = 1
+      loop do
+        candidate = "#{original_login}+#{safe_key}+#{counter}"
+        break candidate unless User.by_login(candidate).exists?
 
         counter += 1
       end

--- a/app/models/import/jira_user.rb
+++ b/app/models/import/jira_user.rb
@@ -53,11 +53,12 @@ module Import
       }
     end
 
-    def try_to_find_existing_op_users
-      op_attributes = to_op_attributes
-      User.by_login(op_attributes[:login]).or(
-        User.where("LOWER(mail) = ?", op_attributes[:mail]&.downcase)
-      )
+    def try_to_find_existing_op_user_by_mail
+      User.where("LOWER(mail) = ?", to_op_attributes[:mail]&.downcase).first
+    end
+
+    def try_to_find_existing_op_user_by_login
+      User.by_login(to_op_attributes[:login]).first
     end
 
     private

--- a/spec/models/import/jira_import_spec.rb
+++ b/spec/models/import/jira_import_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe Import::JiraImport do
         create(:jira_user,
                jira:,
                jira_import:,
+               jira_user_key: "JIRAUSER10102",
                payload: jira_user_payload(
                  key: "JIRAUSER10102",
                  name: login,
@@ -274,21 +275,41 @@ RSpec.describe Import::JiraImport do
                ))
       end
 
-      it "does not create a new user" do
-        expect { jira_import.import_users }.not_to change(User, :count)
+      it "creates a new user with a unique login" do
+        expect { jira_import.import_users }.to change(User, :count).by(1)
       end
 
-      it "creates a reference to the existing user with uses_existing flag" do
+      it "assigns a Jira-key-based login to the new user" do
         jira_import.import_users
 
         reference = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user.id)
-        expect(reference).to have_attributes(
-          jira_entity_id: jira_user.id.to_s,
-          jira_entity_class: "Import::JiraUser",
-          op_entity_id: existing_user.id.to_s,
-          op_entity_class: "User",
-          uses_existing: true
-        )
+        new_user = User.find(reference.op_entity_id)
+        expect(new_user.login).to eq("login+JIRAUSER10102")
+        expect(new_user.mail).to eq(email)
+      end
+
+      it "marks the reference as not using an existing user" do
+        jira_import.import_users
+
+        reference = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user.id)
+        expect(reference.uses_existing).to be false
+      end
+
+      context "when the Jira-key-based login is already taken" do
+        before do
+          create(:user,
+                 login: "login+JIRAUSER10102",
+                 mail: "another@example.com",
+                 password: existing_user_password,
+                 password_confirmation: existing_user_password)
+        end
+
+        it "falls back to a counter suffix" do
+          jira_import.import_users
+
+          reference = Import::JiraOpenProjectReference.find_by(jira_entity_id: jira_user.id)
+          expect(User.find(reference.op_entity_id).login).to eq("login+JIRAUSER10102+1")
+        end
       end
     end
 

--- a/spec/models/import/jira_user_spec.rb
+++ b/spec/models/import/jira_user_spec.rb
@@ -110,65 +110,62 @@ RSpec.describe Import::JiraUser do
     end
   end
 
-  describe "#try_to_find_existing_op_users" do
-    subject(:result) { jira_user.try_to_find_existing_op_users }
-
+  describe "#try_to_find_existing_op_user_by_mail" do
     let(:payload) { { "displayName" => "Test User", "name" => "testuser", "emailAddress" => "test@example.com" } }
 
-    context "when no matching user exists" do
-      it "returns an empty relation" do
-        expect(result).to be_empty
+    context "when no user with that mail exists" do
+      it "returns nil" do
+        expect(jira_user.try_to_find_existing_op_user_by_mail).to be_nil
       end
     end
 
-    context "when a user with matching login exists (case-insensitive)" do
-      let!(:existing_user) { create(:user, login: "TestUser", mail: "other@example.com") }
-
-      it "finds the user" do
-        expect(result).to contain_exactly(existing_user)
-      end
-    end
-
-    context "when a user with matching email exists (case-insensitive)" do
+    context "when a user with a matching mail exists (case-insensitive)" do
       let!(:existing_user) { create(:user, login: "otherlogin", mail: "TEST@EXAMPLE.COM") }
 
-      it "finds the user" do
-        expect(result).to contain_exactly(existing_user)
+      it "returns that user" do
+        expect(jira_user.try_to_find_existing_op_user_by_mail).to eq(existing_user)
       end
     end
 
-    context "when a user matches both login and email" do
-      let!(:existing_user) { create(:user, login: "TESTUSER", mail: "TEST@example.com") }
-
-      it "finds the user once" do
-        expect(result).to contain_exactly(existing_user)
-      end
-    end
-
-    context "when different users match login and email respectively" do
-      let!(:user_by_login) { create(:user, login: "TESTUSER", mail: "different@example.com") }
-      let!(:user_by_email) { create(:user, login: "differentlogin", mail: "TEST@EXAMPLE.COM") }
-
-      it "finds both users" do
-        expect(result).to contain_exactly(user_by_login, user_by_email)
-      end
-    end
-
-    context "when email is nil in payload" do
+    context "when emailAddress is nil in payload" do
       let(:payload) { { "displayName" => "Test User", "name" => "testuser", "emailAddress" => nil } }
-      let!(:existing_user) { create(:user, login: "TESTUSER", mail: "any@example.com") }
 
-      it "still finds users by login" do
-        expect(result).to contain_exactly(existing_user)
+      it "returns nil because the generated noemail address will not match any real user" do
+        expect(jira_user.try_to_find_existing_op_user_by_mail).to be_nil
       end
     end
 
-    context "when email separator is used" do
-      let(:payload) { { "displayName" => "Test User", "name" => "othername", "emailAddress" => "any@example.com" } }
-      let!(:existing_user) { create(:user, login: "testname", mail: "any+test@example.com") }
+    context "when a user has a plus-addressed variant of that mail" do
+      let!(:existing_user) { create(:user, login: "otherlogin", mail: "test+tag@example.com") }
 
-      it "considers the email to be different and does not find it this user account" do
-        expect(result).to be_empty
+      it "does not find that user" do
+        expect(jira_user.try_to_find_existing_op_user_by_mail).to be_nil
+      end
+    end
+  end
+
+  describe "#try_to_find_existing_op_user_by_login" do
+    let(:payload) { { "displayName" => "Test User", "name" => "testuser", "emailAddress" => "test@example.com" } }
+
+    context "when no user with that login exists" do
+      it "returns nil" do
+        expect(jira_user.try_to_find_existing_op_user_by_login).to be_nil
+      end
+    end
+
+    context "when a user with a matching login exists (case-insensitive)" do
+      let!(:existing_user) { create(:user, login: "TestUser", mail: "other@example.com") }
+
+      it "returns that user" do
+        expect(jira_user.try_to_find_existing_op_user_by_login).to eq(existing_user)
+      end
+    end
+
+    context "when only the mail matches but not the login" do
+      let!(:existing_user) { create(:user, login: "otherlogin", mail: "test@example.com") }
+
+      it "returns nil" do
+        expect(jira_user.try_to_find_existing_op_user_by_login).to be_nil
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-117

# What are you trying to achieve?

This is a follow-up to #24021

a) fixes a regression that users with matching email AND login would not be reused but resulted in an error message about duplicated logins
b) applies the same logic for unique logins (with the Jira key as suffix)
c) disables user reusing by matching login, only matching email is allowed and used now

# Merge checklist

- [x] Added/updated tests
