### PR TITLE
[MEET-567] Add ability to fetch agenda items by WorkPackage ID via the API

### DIFF
--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -162,7 +162,6 @@ class WorkPackageMeetingsTabController < ApplicationController
     agenda_items = agenda_items_linked_to_work_package
         .includes(:meeting)
         .preload(:outcomes)
-        .where(meeting_id: Meeting.not_templated.visible(current_user))
         .order(sort_clause(direction))
 
     comparison = direction == :past ? "<" : ">="
@@ -170,12 +169,7 @@ class WorkPackageMeetingsTabController < ApplicationController
   end
 
   def agenda_items_linked_to_work_package
-    MeetingAgendaItem.where(<<~SQL.squish, wp_id: @work_package.id)
-      meeting_agenda_items.work_package_id = :wp_id OR
-      meeting_agenda_items.id IN (
-        SELECT meeting_agenda_item_id FROM meeting_outcomes WHERE meeting_outcomes.work_package_id = :wp_id
-      )
-    SQL
+    MeetingAgendaItem.visible_linked_to_work_package(current_user, @work_package)
   end
 
   def sort_clause(direction)

--- a/modules/meeting/app/models/meeting_agenda_item.rb
+++ b/modules/meeting/app/models/meeting_agenda_item.rb
@@ -55,6 +55,20 @@ class MeetingAgendaItem < ApplicationRecord
 
   scope :with_includes_to_render, -> { includes(:author, :meeting) }
 
+  def self.linked_to_work_package(work_package)
+    where(<<~SQL.squish, wp_id: work_package.id)
+      meeting_agenda_items.work_package_id = :wp_id OR
+      meeting_agenda_items.id IN (
+        SELECT meeting_agenda_item_id FROM meeting_outcomes WHERE meeting_outcomes.work_package_id = :wp_id
+      )
+    SQL
+  end
+
+  def self.visible_linked_to_work_package(user, work_package)
+    linked_to_work_package(work_package)
+      .where(meeting_id: Meeting.not_templated.visible(user))
+  end
+
   # The primer form depends on meeting_id being validated, even though Rails pattern would suggest
   # to validate only :meeting. When copying meetings however,
   # we build meetings and agenda items together, so meeting_id will stay empty.

--- a/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_items_by_work_package_api.rb
+++ b/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_items_by_work_package_api.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module MeetingAgendaItems
+      class MeetingAgendaItemsByWorkPackageAPI < ::API::OpenProjectAPI
+        resources :meeting_agenda_items do
+          get do
+            items = MeetingAgendaItem
+                      .visible_linked_to_work_package(current_user, @work_package)
+                      .includes(:author, :presenter, :work_package, :meeting_section, :outcomes)
+                      .eager_load(:meeting)
+                      .reorder(Meeting.arel_table[:start_time].asc)
+
+            MeetingAgendaItemCollectionRepresenter.new(
+              items,
+              self_link: api_v3_paths.meeting_agenda_items_by_work_package(@work_package.id),
+              current_user:
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -192,6 +192,10 @@ module OpenProject::Meeting
       mount ::API::V3::RecurringMeetings::RecurringMeetingsAPI
     end
 
+    add_api_endpoint "API::V3::WorkPackages::WorkPackagesAPI", :id do
+      mount ::API::V3::MeetingAgendaItems::MeetingAgendaItemsByWorkPackageAPI
+    end
+
     config.to_prepare do
       OpenProject::ProjectLatestActivity.register on: "Meeting"
 
@@ -247,6 +251,10 @@ module OpenProject::Meeting
       else
         "#{root}/meeting_agenda_items"
       end
+    end
+
+    add_api_path :meeting_agenda_items_by_work_package do |work_package_id|
+      "#{work_package(work_package_id)}/meeting_agenda_items"
     end
 
     add_api_path :meeting_agenda_item do |id, meeting_id: nil|

--- a/modules/meeting/spec/models/meeting_agenda_item_spec.rb
+++ b/modules/meeting/spec/models/meeting_agenda_item_spec.rb
@@ -286,4 +286,78 @@ RSpec.describe MeetingAgendaItem do
       end
     end
   end
+
+  describe "WP linking methods" do
+    shared_let(:project) { create(:project) }
+    shared_let(:work_package) { create(:work_package, project:) }
+    shared_let(:other_work_package) { create(:work_package, project:) }
+    shared_let(:user) do
+      create(:user, member_with_permissions: { project => %i[view_meetings view_work_packages] })
+    end
+    shared_let(:meeting) { create(:meeting, project:) }
+
+    shared_let(:directly_linked_item) do
+      create(:wp_meeting_agenda_item, meeting:, work_package:)
+    end
+
+    shared_let(:outcome_linked_item) do
+      create(:meeting_agenda_item, meeting:).tap do |item|
+        create(:meeting_outcome, meeting_agenda_item: item, kind: :work_package, work_package:)
+      end
+    end
+
+    shared_let(:unrelated_item) do
+      create(:wp_meeting_agenda_item, meeting:, work_package: other_work_package)
+    end
+
+    describe ".linked_to_work_package" do
+      subject { described_class.linked_to_work_package(work_package) }
+
+      it "includes items linked directly and via outcomes" do
+        expect(subject).to contain_exactly(directly_linked_item, outcome_linked_item)
+      end
+    end
+
+    describe ".visible_linked_to_work_package" do
+      subject { described_class.visible_linked_to_work_package(user, work_package) }
+
+      it "returns linked items in meetings visible to the user" do
+        expect(subject).to contain_exactly(directly_linked_item, outcome_linked_item)
+      end
+
+      context "when the meeting is not visible to the user" do
+        shared_let(:invisible_meeting) { create(:meeting, project: create(:project)) }
+        shared_let(:invisible_item) do
+          create(:wp_meeting_agenda_item, meeting: invisible_meeting, work_package:)
+        end
+
+        it "excludes items from meetings the user cannot see" do
+          expect(subject).not_to include(invisible_item)
+        end
+      end
+
+      context "when the meeting is a template" do
+        shared_let(:template_item) do
+          create(:wp_meeting_agenda_item, meeting: create(:meeting, project:, template: true), work_package:)
+        end
+
+        it "excludes items" do
+          expect(subject).not_to include(template_item)
+        end
+      end
+
+      context "when an outcome WP is visible, but the containing agenda item WP is not" do
+        shared_let(:inaccessible_work_package) { create(:work_package, project: create(:project)) }
+        shared_let(:item_with_inaccessible_wp) do
+          create(:wp_meeting_agenda_item, meeting:, work_package: inaccessible_work_package).tap do |item|
+            create(:meeting_outcome, meeting_agenda_item: item, kind: :work_package, work_package:)
+          end
+        end
+
+        it "still returns the item even though its work package is not visible to the user" do
+          expect(subject).to include(item_with_inaccessible_wp)
+        end
+      end
+    end
+  end
 end

--- a/modules/meeting/spec/models/meeting_agenda_item_spec.rb
+++ b/modules/meeting/spec/models/meeting_agenda_item_spec.rb
@@ -316,6 +316,19 @@ RSpec.describe MeetingAgendaItem do
       it "includes items linked directly and via outcomes" do
         expect(subject).to contain_exactly(directly_linked_item, outcome_linked_item)
       end
+
+      context "when an item is linked to the work package both directly and via multiple outcomes" do
+        shared_let(:multiply_linked_item) do
+          create(:wp_meeting_agenda_item, meeting:, work_package:).tap do |item|
+            create(:meeting_outcome, meeting_agenda_item: item, kind: :work_package, work_package:)
+            create(:meeting_outcome, meeting_agenda_item: item, kind: :work_package, work_package:)
+          end
+        end
+
+        it "returns the item exactly once" do
+          expect(subject.where(id: multiply_linked_item.id).count).to eq(1)
+        end
+      end
     end
 
     describe ".visible_linked_to_work_package" do

--- a/modules/meeting/spec/requests/api/v3/meeting_agenda_items/agenda_items_by_work_package_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meeting_agenda_items/agenda_items_by_work_package_resource_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 meeting agenda items by work package", content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[work_package_tracking meetings]) }
+  shared_let(:work_package) { create(:work_package, project:) }
+  shared_let(:other_work_package) { create(:work_package, project:) }
+
+  let(:permissions) { %i[view_work_packages view_meetings] }
+  let(:current_user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:meeting) { create(:meeting, project:, author: current_user) }
+
+  let!(:directly_linked_item) do
+    create(:wp_meeting_agenda_item, meeting:, work_package:, author: current_user)
+  end
+  let!(:outcome_linked_item) do
+    create(:meeting_agenda_item, meeting:, author: current_user).tap do |item|
+      create(:meeting_outcome, meeting_agenda_item: item, kind: :work_package, work_package:, author: current_user)
+    end
+  end
+  let!(:unrelated_item) do
+    create(:wp_meeting_agenda_item, meeting:, work_package: other_work_package, author: current_user)
+  end
+
+  let(:path) { api_v3_paths.meeting_agenda_items_by_work_package(work_package.id) }
+  let(:element_ids) { JSON.parse(last_response.body).dig("_embedded", "elements").pluck("id") }
+
+  before do
+    login_as current_user
+    get path
+  end
+
+  subject(:response) { last_response }
+
+  it "returns 200 with a collection" do
+    expect(response).to have_http_status(:ok)
+
+    expect(response.body)
+      .to be_json_eql("Collection".to_json)
+      .at_path("_type")
+  end
+
+  it "includes items linked directly and via outcomes, excluding unrelated items" do
+    expect(element_ids).to contain_exactly(directly_linked_item.id, outcome_linked_item.id)
+  end
+
+  context "when an item is in a meeting the user cannot see" do
+    let(:invisible_meeting) { create(:meeting, project: create(:project, enabled_module_names: %w[meetings])) }
+    let!(:invisible_item) do
+      create(:wp_meeting_agenda_item, meeting: invisible_meeting, work_package:)
+    end
+
+    it "excludes it from the collection" do
+      expect(element_ids).not_to include(invisible_item.id)
+    end
+  end
+
+  context "when a returned item links a work package the user cannot see through an outcome" do
+    let(:inaccessible_work_package) { create(:work_package, project: create(:project)) }
+    let!(:item_with_inaccessible_wp) do
+      create(:wp_meeting_agenda_item, meeting:, work_package: inaccessible_work_package, author: current_user).tap do |item|
+        create(:meeting_outcome, meeting_agenda_item: item, kind: :work_package, work_package:, author: current_user)
+      end
+    end
+
+    before { get path }
+
+    it "includes the item but discloses nothing about the inaccessible work package" do
+      expect(element_ids).to include(item_with_inaccessible_wp.id)
+
+      element = JSON.parse(last_response.body).dig("_embedded", "elements")
+                    .find { |e| e["id"] == item_with_inaccessible_wp.id }
+
+      expect(element.dig("_links", "workPackage", "href")).to eq(API::V3::URN_UNDISCLOSED)
+      expect(element.dig("_embedded", "workPackage")).to be_nil
+
+      expect(element["title"]).to be_nil
+      expect(last_response.body).not_to include(inaccessible_work_package.subject)
+    end
+  end
+
+  context "when no agenda items are linked to the work package" do
+    let(:unlinked_work_package) { create(:work_package, project:) }
+    let(:path) { api_v3_paths.meeting_agenda_items_by_work_package(unlinked_work_package.id) }
+
+    it "returns an empty collection" do
+      expect(response).to have_http_status(:ok)
+      expect(element_ids).to be_empty
+    end
+  end
+
+  context "without view_work_packages permission" do
+    let(:permissions) { %i[view_meetings] }
+
+    it "returns 404" do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
 https://community.openproject.org/wp/MEET-567

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
