### PR TITLE
[OP-19677] Permit budget on work package move

### DIFF
--- a/modules/budgets/lib/budgets/engine.rb
+++ b/modules/budgets/lib/budgets/engine.rb
@@ -58,6 +58,9 @@ module Budgets
 
     patch_with_namespace :Projects, :RowComponent
 
+    # Allow assigning a budget when moving work packages
+    additional_permitted_attributes move_work_package: %i[budget_id]
+
     add_api_path :budget do |id|
       "#{root}/budgets/#{id}"
     end

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -312,6 +312,25 @@ RSpec.describe WorkPackages::MovesController, with_settings: { journal_aggregati
         end
       end
 
+      context "with another budget" do
+        let(:target_budget) { create(:budget, project:) }
+
+        before do
+          post :create,
+               params: {
+                 ids: [work_package.id, work_package_2.id],
+                 budget_id: target_budget.id
+               }
+          work_package.reload
+          work_package_2.reload
+        end
+
+        it "assigns the budget to the work packages" do
+          expect(work_package.budget_id).to eq(target_budget.id)
+          expect(work_package_2.budget_id).to eq(target_budget.id)
+        end
+      end
+
       shared_examples_for "single note for moved work package" do
         it { expect(moved_work_package.journals.count).to eq(2) }
 


### PR DESCRIPTION
> [!NOTE]
> This PR has two other PRs stacked on it (#23938, #24062). **Please review/merge this first**.

# Ticket

https://community.openproject.org/wp/OP-19677

# What are you trying to accomplish?

The Budget field on the move/copy work package form is silently ignored: `PermittedParams#move_work_package` never permitted `budget_id`, so the budget selected in the form is stripped by strong params before the bulk move runs — no error, no notification. Long-standing bug found during the SC-272 review.

# What approach did you choose and why?

- Permit `budget_id` for moves from the budgets engine via `additional_permitted_attributes`, keeping the core permitted list free of module attributes.
- Controller spec covering budget assignment on a bulk move.

Bottom of a small stack: #23938 ([SC-272]) and #24062 ([OP-19606]) are based on this branch, since preserving the budget value across form refreshes relies on `budget_id` being permitted.

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

