### PR TITLE
[OP-19606] Preserve move form values on refresh

### DIFF
--- a/app/components/work_packages/moves/form_component.html.erb
+++ b/app/components/work_packages/moves/form_component.html.erb
@@ -77,7 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
                       }
                     ) %>
               </div>
-              <% if unavailable_type_in_target_project %>
+              <% if unavailable_type_in_target_project? %>
                 <div class="op-toast -warning icon-warning">
                   <div class="op-toast--content">
                     <p>
@@ -213,7 +213,7 @@ See COPYRIGHT and LICENSE files for more details.
                     <%= custom_field_tag_for_bulk_edit(
                           "",
                           custom_field,
-                          project,
+                          target_project,
                           selected_custom_field_value(custom_field)
                         ) %>
                   </div>

--- a/app/components/work_packages/moves/form_component.html.erb
+++ b/app/components/work_packages/moves/form_component.html.erb
@@ -97,7 +97,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= styled_select_tag(
                       "status_id",
                       content_tag("option", t(:label_no_change_option), value: "") +
-                        options_from_collection_for_select(available_statuses, :id, :name)
+                        options_from_collection_for_select(available_statuses, :id, :name, selected_value(:status_id))
                     ) %>
               </div>
             </div>
@@ -107,7 +107,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= styled_select_tag(
                       "version_id",
                       content_tag("option", t(:label_no_change_option), value: "") +
-                        version_options_for_select(available_versions)
+                        version_options_for_select(available_versions, selected_version)
                     ) %>
               </div>
             </div>
@@ -117,7 +117,12 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= styled_select_tag(
                       "priority_id",
                       content_tag("option", t(:label_no_change_option), value: "") +
-                        options_from_collection_for_select(IssuePriority.active, :id, :name)
+                        options_from_collection_for_select(
+                          IssuePriority.active,
+                          :id,
+                          :name,
+                          selected_value(:priority_id)
+                        )
                     ) %>
               </div>
             </div>
@@ -126,9 +131,16 @@ See COPYRIGHT and LICENSE files for more details.
               <div class="form--field-container">
                 <%= styled_select_tag(
                       "assigned_to_id",
-                      content_tag("option", t(:label_no_change_option), value: "") +
-                        content_tag("option", t(:label_nobody), value: "none") +
-                        options_from_collection_for_select(Principal.possible_assignee(target_project), :id, :name)
+                      options_for_select(
+                        [[t(:label_no_change_option), ""], [t(:label_nobody), "none"]],
+                        selected_value(:assigned_to_id)
+                      ) +
+                        options_from_collection_for_select(
+                          possible_assignees,
+                          :id,
+                          :name,
+                          selected_value(:assigned_to_id)
+                        )
                     ) %>
               </div>
             </div>
@@ -137,18 +149,36 @@ See COPYRIGHT and LICENSE files for more details.
               <div class="form--field-container">
                 <%= styled_select_tag(
                       "responsible_id",
-                      content_tag("option", t(:label_no_change_option), value: "") +
-                        content_tag("option", t(:label_nobody), value: "none") +
-                        options_from_collection_for_select(Principal.possible_assignee(target_project), :id, :name)
+                      options_for_select(
+                        [[t(:label_no_change_option), ""], [t(:label_nobody), "none"]],
+                        selected_value(:responsible_id)
+                      ) +
+                        options_from_collection_for_select(
+                          possible_assignees,
+                          :id,
+                          :name,
+                          selected_value(:responsible_id)
+                        )
                     ) %>
               </div>
             </div>
             <div class="form--field">
               <%= styled_label_tag :budget_id, Budget.model_name.human %>
               <%= styled_select_tag(
-                    "budget_id", (target_project == project ? content_tag("option", t(:label_no_change_option), value: "") : "") +
-                    content_tag("option", t(:label_none), value: "none") +
-                    options_from_collection_for_select(target_project.budgets, :id, :subject)
+                    "budget_id",
+                    options_for_select(
+                      [
+                        ([t(:label_no_change_option), ""] if target_project == project),
+                        [t(:label_none), "none"]
+                      ].compact,
+                      selected_value(:budget_id)
+                    ) +
+                    options_from_collection_for_select(
+                      target_project.budgets,
+                      :id,
+                      :subject,
+                      selected_value(:budget_id)
+                    )
                   ) %>
             </div>
           </div>
@@ -159,7 +189,8 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= angular_component_tag "opce-basic-single-date-picker",
                                           inputs: {
                                             id: "start_date",
-                                            name: "start_date"
+                                            name: "start_date",
+                                            value: selected_value(:start_date)
                                           } %>
               </div>
             </div>
@@ -169,7 +200,8 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= angular_component_tag "opce-basic-single-date-picker",
                                           inputs: {
                                             id: "due_date",
-                                            name: "due_date"
+                                            name: "due_date",
+                                            value: selected_value(:due_date)
                                           } %>
               </div>
             </div>
@@ -178,7 +210,12 @@ See COPYRIGHT and LICENSE files for more details.
                 <div class="form--field">
                   <%= blank_custom_field_label_tag("", custom_field) %>
                   <div class="form--field-container">
-                    <%= custom_field_tag_for_bulk_edit("", custom_field, project) %>
+                    <%= custom_field_tag_for_bulk_edit(
+                          "",
+                          custom_field,
+                          project,
+                          selected_custom_field_value(custom_field)
+                        ) %>
                   </div>
                 </div>
               <% end %>

--- a/app/components/work_packages/moves/form_component.html.erb
+++ b/app/components/work_packages/moves/form_component.html.erb
@@ -97,7 +97,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= styled_select_tag(
                       "status_id",
                       content_tag("option", t(:label_no_change_option), value: "") +
-                        options_from_collection_for_select(available_statuses, :id, :name, selected_value(:status_id))
+                        options_from_collection_for_select(available_statuses, :id, :name, selected_values[:status_id])
                     ) %>
               </div>
             </div>
@@ -121,7 +121,7 @@ See COPYRIGHT and LICENSE files for more details.
                           IssuePriority.active,
                           :id,
                           :name,
-                          selected_value(:priority_id)
+                          selected_values[:priority_id]
                         )
                     ) %>
               </div>
@@ -133,13 +133,13 @@ See COPYRIGHT and LICENSE files for more details.
                       "assigned_to_id",
                       options_for_select(
                         [[t(:label_no_change_option), ""], [t(:label_nobody), "none"]],
-                        selected_value(:assigned_to_id)
+                        selected_values[:assigned_to_id]
                       ) +
                         options_from_collection_for_select(
                           possible_assignees,
                           :id,
                           :name,
-                          selected_value(:assigned_to_id)
+                          selected_values[:assigned_to_id]
                         )
                     ) %>
               </div>
@@ -151,13 +151,13 @@ See COPYRIGHT and LICENSE files for more details.
                       "responsible_id",
                       options_for_select(
                         [[t(:label_no_change_option), ""], [t(:label_nobody), "none"]],
-                        selected_value(:responsible_id)
+                        selected_values[:responsible_id]
                       ) +
                         options_from_collection_for_select(
                           possible_assignees,
                           :id,
                           :name,
-                          selected_value(:responsible_id)
+                          selected_values[:responsible_id]
                         )
                     ) %>
               </div>
@@ -171,13 +171,13 @@ See COPYRIGHT and LICENSE files for more details.
                         ([t(:label_no_change_option), ""] if target_project == project),
                         [t(:label_none), "none"]
                       ].compact,
-                      selected_value(:budget_id)
+                      selected_values[:budget_id]
                     ) +
                     options_from_collection_for_select(
                       target_project.budgets,
                       :id,
                       :subject,
-                      selected_value(:budget_id)
+                      selected_values[:budget_id]
                     )
                   ) %>
             </div>
@@ -190,7 +190,7 @@ See COPYRIGHT and LICENSE files for more details.
                                           inputs: {
                                             id: "start_date",
                                             name: "start_date",
-                                            value: selected_value(:start_date)
+                                            value: selected_values[:start_date]
                                           } %>
               </div>
             </div>
@@ -201,7 +201,7 @@ See COPYRIGHT and LICENSE files for more details.
                                           inputs: {
                                             id: "due_date",
                                             name: "due_date",
-                                            value: selected_value(:due_date)
+                                            value: selected_values[:due_date]
                                           } %>
               </div>
             </div>

--- a/app/components/work_packages/moves/form_component.html.erb
+++ b/app/components/work_packages/moves/form_component.html.erb
@@ -71,7 +71,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= styled_select_tag(
                       "new_type_id",
                       content_tag("option", t(:label_no_change_option), value: "") +
-                        options_from_collection_for_select(types, "id", "name", target_type&.id),
+                        options_from_collection_for_select(available_types, "id", "name", target_type&.id),
                       data: {
                         action: "change->refresh-on-form-changes#triggerTurboStream"
                       }

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -47,7 +47,6 @@ module WorkPackages
         notes:,
         turbo_stream_url:,
         copy: false,
-        new_type_id: nil,
         selected_values: {},
         current_user: User.current
       )
@@ -58,7 +57,6 @@ module WorkPackages
         @target_project = target_project
         @notes = notes
         @copy = copy
-        @new_type_id = new_type_id
         @selected_values = selected_values.to_h.with_indifferent_access
         @turbo_stream_url = turbo_stream_url
         @current_user = current_user
@@ -67,14 +65,14 @@ module WorkPackages
       private
 
       attr_reader :work_packages, :project, :target_project, :notes, :copy,
-                  :new_type_id, :selected_values, :turbo_stream_url, :current_user
+                  :selected_values, :turbo_stream_url, :current_user
 
       def available_types
         @available_types ||= target_project.types.order(:position)
       end
 
       def target_type
-        @target_type ||= available_types.find { |type| type.id.to_s == new_type_id.to_s }
+        @target_type ||= available_types.find { |type| type.id.to_s == selected_values[:type_id].to_s }
       end
 
       def available_versions

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -88,18 +88,18 @@ module WorkPackages
       def unavailable_type_in_target_project?
         return false if target_project == project
 
-        current_types_missing_in_target? || ancestor_types_missing_in_target?
+        current_types_missing_in_target? || descendant_types_missing_in_target?
       end
 
       def current_types_missing_in_target?
         work_packages.map(&:type_id).uniq.difference(types.pluck(:id)).any?
       end
 
-      def ancestor_types_missing_in_target?
+      def descendant_types_missing_in_target?
         hierarchies = WorkPackageHierarchy
-                        .includes(:ancestor)
+                        .includes(:descendant)
                         .where(ancestor_id: work_packages.map(&:id))
-        Type.where(id: hierarchies.map { it.ancestor.type_id })
+        Type.where(id: hierarchies.map { it.descendant.type_id })
             .select("distinct id")
             .pluck(:id)
             .difference(types.pluck(:id))

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -69,12 +69,12 @@ module WorkPackages
       attr_reader :work_packages, :project, :target_project, :notes, :copy,
                   :new_type_id, :selected_values, :turbo_stream_url, :current_user
 
-      def types
-        @types ||= target_project.types.order(:position)
+      def available_types
+        @available_types ||= target_project.types.order(:position)
       end
 
       def target_type
-        @target_type ||= types.find { |type| type.id.to_s == new_type_id.to_s }
+        @target_type ||= available_types.find { |type| type.id.to_s == new_type_id.to_s }
       end
 
       def available_versions
@@ -92,7 +92,7 @@ module WorkPackages
       end
 
       def current_types_missing_in_target?
-        work_packages.map(&:type_id).uniq.difference(types.pluck(:id)).any?
+        work_packages.map(&:type_id).uniq.difference(available_types.pluck(:id)).any?
       end
 
       def descendant_types_missing_in_target?
@@ -102,7 +102,7 @@ module WorkPackages
         Type.where(id: hierarchies.map { it.descendant.type_id })
             .select("distinct id")
             .pluck(:id)
-            .difference(types.pluck(:id))
+            .difference(available_types.pluck(:id))
             .any?
       end
 

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -87,15 +87,18 @@ module WorkPackages
 
       def unavailable_type_in_target_project?
         return false if target_project == project
-        return types.exclude?(target_type) unless target_type.nil?
 
-        ancestor_types_missing_in_target?
+        current_types_missing_in_target? || ancestor_types_missing_in_target?
+      end
+
+      def current_types_missing_in_target?
+        work_packages.map(&:type_id).uniq.difference(types.pluck(:id)).any?
       end
 
       def ancestor_types_missing_in_target?
         hierarchies = WorkPackageHierarchy
                         .includes(:ancestor)
-                        .where(ancestor_id: work_packages.select(:id))
+                        .where(ancestor_id: work_packages.map(&:id))
         Type.where(id: hierarchies.map { it.ancestor.type_id })
             .select("distinct id")
             .pluck(:id)

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -41,7 +41,8 @@ module WorkPackages
       include OpPrimer::ComponentHelpers
 
       def initialize(work_packages:, project:, target_project:, types:, available_versions:, available_statuses:,
-                     notes:, copy: false, target_type: nil, unavailable_type_in_target_project: false)
+                     notes:, turbo_stream_url:, copy: false, target_type: nil,
+                     unavailable_type_in_target_project: false, selected_values: {})
         super
 
         @work_packages = work_packages
@@ -54,15 +55,30 @@ module WorkPackages
         @available_statuses = available_statuses
         @notes = notes
         @copy = copy
+        @selected_values = selected_values
+        @turbo_stream_url = turbo_stream_url
       end
 
       private
 
       attr_reader :work_packages, :project, :target_project, :types, :target_type,
-                  :unavailable_type_in_target_project, :available_versions, :available_statuses, :notes, :copy
+                  :unavailable_type_in_target_project, :available_versions, :available_statuses, :notes, :copy,
+                  :selected_values, :turbo_stream_url
 
-      def turbo_stream_url
-        url_for(action: :refresh_form)
+      def possible_assignees
+        @possible_assignees ||= Principal.possible_assignee(target_project)
+      end
+
+      def selected_value(attribute)
+        selected_values[attribute] || selected_values[attribute.to_s]
+      end
+
+      def selected_version
+        available_versions.find { |version| version.id.to_s == selected_value(:version_id).to_s }
+      end
+
+      def selected_custom_field_value(custom_field)
+        selected_value(:custom_field_values)&.[](custom_field.id.to_s)
       end
     end
   end

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -45,7 +45,6 @@ module WorkPackages
         project:,
         target_project:,
         notes:,
-        turbo_stream_url:,
         copy: false,
         selected_values: {},
         current_user: User.current
@@ -58,14 +57,17 @@ module WorkPackages
         @notes = notes
         @copy = copy
         @selected_values = selected_values.to_h.with_indifferent_access
-        @turbo_stream_url = turbo_stream_url
         @current_user = current_user
       end
 
       private
 
       attr_reader :work_packages, :project, :target_project, :notes, :copy,
-                  :selected_values, :turbo_stream_url, :current_user
+                  :selected_values, :current_user
+
+      def turbo_stream_url
+        url_helpers.refresh_form_move_work_packages_path
+      end
 
       def available_types
         @available_types ||= target_project.types.order(:position)

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -82,7 +82,7 @@ module WorkPackages
       end
 
       def available_statuses
-        @available_statuses ||= Workflow.available_statuses(project, current_user)
+        @available_statuses ||= Workflow.available_statuses(target_project, current_user)
       end
 
       def unavailable_type_in_target_project?

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -59,7 +59,7 @@ module WorkPackages
         @notes = notes
         @copy = copy
         @new_type_id = new_type_id
-        @selected_values = selected_values
+        @selected_values = selected_values.to_h.with_indifferent_access
         @turbo_stream_url = turbo_stream_url
         @current_user = current_user
       end
@@ -110,16 +110,12 @@ module WorkPackages
         @possible_assignees ||= Principal.possible_assignee(target_project)
       end
 
-      def selected_value(attribute)
-        selected_values[attribute] || selected_values[attribute.to_s]
-      end
-
       def selected_version
-        available_versions.find { |version| version.id.to_s == selected_value(:version_id).to_s }
+        available_versions.find { |version| version.id.to_s == selected_values[:version_id].to_s }
       end
 
       def selected_custom_field_value(custom_field)
-        selected_value(:custom_field_values)&.[](custom_field.id.to_s)
+        selected_values.dig(:custom_field_values, custom_field.id.to_s)
       end
     end
   end

--- a/app/components/work_packages/moves/form_component.rb
+++ b/app/components/work_packages/moves/form_component.rb
@@ -40,30 +40,68 @@ module WorkPackages
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
-      def initialize(work_packages:, project:, target_project:, types:, available_versions:, available_statuses:,
-                     notes:, turbo_stream_url:, copy: false, target_type: nil,
-                     unavailable_type_in_target_project: false, selected_values: {})
+      def initialize(
+        work_packages:,
+        project:,
+        target_project:,
+        notes:,
+        turbo_stream_url:,
+        copy: false,
+        new_type_id: nil,
+        selected_values: {},
+        current_user: User.current
+      )
         super
 
         @work_packages = work_packages
         @project = project
         @target_project = target_project
-        @types = types
-        @target_type = target_type
-        @unavailable_type_in_target_project = unavailable_type_in_target_project
-        @available_versions = available_versions
-        @available_statuses = available_statuses
         @notes = notes
         @copy = copy
+        @new_type_id = new_type_id
         @selected_values = selected_values
         @turbo_stream_url = turbo_stream_url
+        @current_user = current_user
       end
 
       private
 
-      attr_reader :work_packages, :project, :target_project, :types, :target_type,
-                  :unavailable_type_in_target_project, :available_versions, :available_statuses, :notes, :copy,
-                  :selected_values, :turbo_stream_url
+      attr_reader :work_packages, :project, :target_project, :notes, :copy,
+                  :new_type_id, :selected_values, :turbo_stream_url, :current_user
+
+      def types
+        @types ||= target_project.types.order(:position)
+      end
+
+      def target_type
+        @target_type ||= types.find { |type| type.id.to_s == new_type_id.to_s }
+      end
+
+      def available_versions
+        @available_versions ||= target_project.assignable_versions
+      end
+
+      def available_statuses
+        @available_statuses ||= Workflow.available_statuses(project, current_user)
+      end
+
+      def unavailable_type_in_target_project?
+        return false if target_project == project
+        return types.exclude?(target_type) unless target_type.nil?
+
+        ancestor_types_missing_in_target?
+      end
+
+      def ancestor_types_missing_in_target?
+        hierarchies = WorkPackageHierarchy
+                        .includes(:ancestor)
+                        .where(ancestor_id: work_packages.select(:id))
+        Type.where(id: hierarchies.map { it.ancestor.type_id })
+            .select("distinct id")
+            .pluck(:id)
+            .difference(types.pluck(:id))
+            .any?
+      end
 
       def possible_assignees
         @possible_assignees ||= Principal.possible_assignee(target_project)

--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -133,7 +133,6 @@ class WorkPackages::MovesController < ApplicationController
       notes: @notes,
       copy: @copy,
       selected_values: permitted_params.move_work_package_form_values,
-      turbo_stream_url: refresh_form_move_work_packages_path,
       current_user:
     )
   end

--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -32,18 +32,6 @@ class WorkPackages::MovesController < ApplicationController
   include WorkPackages::BulkErrorMessage
   include OpTurbo::ComponentStream
 
-  MOVE_FORM_VALUE_PARAMS = %i[
-    assigned_to_id
-    responsible_id
-    start_date
-    due_date
-    status_id
-    version_id
-    priority_id
-    budget_id
-    custom_field_values
-  ].freeze
-
   default_search_scope :work_packages
   before_action :find_work_packages, :check_project_uniqueness
   before_action :authorize_move_or_copy
@@ -145,14 +133,10 @@ class WorkPackages::MovesController < ApplicationController
       notes: @notes,
       copy: @copy,
       new_type_id: params[:new_type_id],
-      selected_values: selected_move_form_values,
+      selected_values: permitted_params.move_work_package_form_values,
       turbo_stream_url: refresh_form_move_work_packages_path,
       current_user:
     )
-  end
-
-  def selected_move_form_values
-    params.slice(*MOVE_FORM_VALUE_PARAMS)
   end
 
   def prepare_for_work_package_move

--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -32,6 +32,18 @@ class WorkPackages::MovesController < ApplicationController
   include WorkPackages::BulkErrorMessage
   include OpTurbo::ComponentStream
 
+  MOVE_FORM_VALUE_PARAMS = %i[
+    assigned_to_id
+    responsible_id
+    start_date
+    due_date
+    status_id
+    version_id
+    priority_id
+    budget_id
+    custom_field_values
+  ].freeze
+
   default_search_scope :work_packages
   before_action :find_work_packages, :check_project_uniqueness
   before_action :authorize_move_or_copy
@@ -39,6 +51,8 @@ class WorkPackages::MovesController < ApplicationController
 
   def new
     prepare_for_work_package_move
+
+    @move_form_component = move_form_component
   end
 
   def create
@@ -134,8 +148,14 @@ class WorkPackages::MovesController < ApplicationController
       available_versions: @available_versions,
       available_statuses: @available_statuses,
       notes: @notes,
-      copy: @copy
+      copy: @copy,
+      selected_values: selected_move_form_values,
+      turbo_stream_url: refresh_form_move_work_packages_path
     )
+  end
+
+  def selected_move_form_values
+    params.slice(*MOVE_FORM_VALUE_PARAMS)
   end
 
   def prepare_for_work_package_move

--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -132,7 +132,6 @@ class WorkPackages::MovesController < ApplicationController
       target_project: @target_project,
       notes: @notes,
       copy: @copy,
-      new_type_id: params[:new_type_id],
       selected_values: permitted_params.move_work_package_form_values,
       turbo_stream_url: refresh_form_move_work_packages_path,
       current_user:

--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -142,15 +142,12 @@ class WorkPackages::MovesController < ApplicationController
       work_packages: @work_packages,
       project: @project,
       target_project: @target_project,
-      types: @types,
-      target_type: @target_type,
-      unavailable_type_in_target_project: @unavailable_type_in_target_project,
-      available_versions: @available_versions,
-      available_statuses: @available_statuses,
       notes: @notes,
       copy: @copy,
+      new_type_id: params[:new_type_id],
       selected_values: selected_move_form_values,
-      turbo_stream_url: refresh_form_move_work_packages_path
+      turbo_stream_url: refresh_form_move_work_packages_path,
+      current_user:
     )
   end
 
@@ -160,32 +157,11 @@ class WorkPackages::MovesController < ApplicationController
 
   def prepare_for_work_package_move
     @copy = params.has_key? :copy
-    @allowed_projects = WorkPackage.allowed_target_projects_on_move(current_user)
-    @target_project = @allowed_projects.detect { |p| p.id.to_s == params[:new_project_id].to_s } if params[:new_project_id]
-    @target_project ||= @project
-    @types = @target_project.types.order(:position)
-    @target_type = @types.find { |t| t.id.to_s == params[:new_type_id].to_s }
-    @unavailable_type_in_target_project = set_unavailable_type_in_target_project
-    @available_versions = @target_project.assignable_versions
-    @available_statuses = Workflow.available_statuses(@project)
-    @notes = params[:notes] || ""
-  end
-
-  def set_unavailable_type_in_target_project
-    if @target_project == @project
-      false
-    elsif @target_type.nil?
-      hierarchies = WorkPackageHierarchy
-                      .includes(:ancestor)
-                      .where(ancestor_id: @work_packages.select(:id))
-      Type.where(id: hierarchies.map { it.ancestor.type_id })
-          .select("distinct id")
-          .pluck(:id)
-          .difference(@types.pluck(:id))
-          .any?
-    else
-      @types.exclude?(@target_type)
+    if params[:new_project_id]
+      @target_project = WorkPackage.allowed_target_projects_on_move(current_user).find_by(id: params[:new_project_id])
     end
+    @target_project ||= @project
+    @notes = params[:notes] || ""
   end
 
   def attributes_for_create

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -73,7 +73,7 @@ module CustomFieldsHelper
                 class: "form--label"
   end
 
-  def custom_field_tag_for_bulk_edit(name, custom_field, project = nil) # rubocop:disable Metrics/AbcSize
+  def custom_field_tag_for_bulk_edit(name, custom_field, project = nil, value = nil) # rubocop:disable Metrics/AbcSize
     field_name = name.present? ? "#{name}[custom_field_values][#{custom_field.id}]" : "custom_field_values[#{custom_field.id}]"
     field_id = "#{name}_custom_field_values_#{custom_field.id}"
     field_format = OpenProject::CustomFieldFormat.find_by(name: custom_field.field_format)
@@ -84,20 +84,21 @@ module CustomFieldsHelper
                             inputs: {
                               required: custom_field.required?,
                               id: field_id,
-                              name: field_name
+                              name: field_name,
+                              value:
                             }
     when "text"
-      styled_text_area_tag(field_name, "", id: field_id, rows: 3, with_text_formatting: true)
+      styled_text_area_tag(field_name, value, id: field_id, rows: 3, with_text_formatting: true)
     when "bool"
       styled_select_tag(field_name,
                         options_for_select([([I18n.t(:label_none), "none"] unless custom_field.required?),
                                             [I18n.t(:general_text_yes), "1"],
-                                            [I18n.t(:general_text_no), "0"]].compact),
+                                            [I18n.t(:general_text_no), "0"]].compact, value),
                         id: field_id,
                         include_blank: I18n.t(:label_no_change_option))
     when "list"
       styled_select_tag(field_name,
-                        options_for_list(custom_field, project),
+                        options_for_list(custom_field, project, value),
                         id: field_id,
                         multiple: custom_field.multi_value?,
                         include_blank: I18n.t(:label_no_change_option))
@@ -114,12 +115,12 @@ module CustomFieldsHelper
         [label, item.id]
       end
       styled_select_tag(field_name,
-                        options_for_select(options),
+                        options_for_select(options, value),
                         id: field_id,
                         multiple: custom_field.multi_value?,
                         include_blank: I18n.t(:label_no_change_option))
     else
-      styled_text_field_tag(field_name, "", id: field_id)
+      styled_text_field_tag(field_name, value, id: field_id)
     end
   end
 
@@ -142,7 +143,7 @@ module CustomFieldsHelper
     format.label.is_a?(Proc) ? format.label.call : I18n.t(format.label)
   end
 
-  def options_for_list(custom_field, project)
+  def options_for_list(custom_field, project, selected = nil)
     base_options = []
     unless custom_field.required?
       unset_label = custom_field.field_format == "user" ? :label_nobody : :label_none
@@ -151,11 +152,11 @@ module CustomFieldsHelper
 
     possible_values = custom_field.possible_values_options(project)
     options = if custom_field.version?
-                grouped_options_for_select(possible_values.group_by(&:last).to_a)
+                grouped_options_for_select(possible_values.group_by(&:last).to_a, selected)
               else
-                options_for_select(possible_values)
+                options_for_select(possible_values, selected)
               end
 
-    options_for_select(base_options) + options
+    options_for_select(base_options, selected) + options
   end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -128,9 +128,7 @@ class PermittedParams
 
   def move_work_package(args = {})
     move_work_package_form_values(args)
-      .merge(type_id: params[:new_type_id],
-             project_id: params[:new_project_id],
-             journal_notes: params[:notes])
+      .merge(journal_notes: params[:notes])
   end
 
   def move_work_package_form_values(args = {})
@@ -138,6 +136,8 @@ class PermittedParams
     params
       .permit(*permitted)
       .merge(custom_field_values(required: false))
+      .merge(type_id: params[:new_type_id],
+             project_id: params[:new_project_id])
   end
 
   def member

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -716,7 +716,9 @@ class PermittedParams
     # thus we do it by hand
     object = required ? params.require(key_to_fetch) : params.fetch(key_to_fetch, {})
     values = key ? object[:custom_field_values] : object
-    values || ActionController::Parameters.new
+    return ActionController::Parameters.new unless values.is_a?(ActionController::Parameters)
+
+    values
   end
 
   def nilify_params!(hash, *keys)

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -127,13 +127,17 @@ class PermittedParams
   end
 
   def move_work_package(args = {})
-    permitted = permitted_attributes(:move_work_package, args)
-    permitted_params = params.permit(*permitted)
-    permitted_params
-      .merge(custom_field_values(required: false))
+    move_work_package_form_values(args)
       .merge(type_id: params[:new_type_id],
              project_id: params[:new_project_id],
              journal_notes: params[:notes])
+  end
+
+  def move_work_package_form_values(args = {})
+    permitted = permitted_attributes(:move_work_package, args)
+    params
+      .permit(*permitted)
+      .merge(custom_field_values(required: false))
   end
 
   def member

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -55,18 +55,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end -%>
 </ul>
 
-<%= render WorkPackages::Moves::FormComponent.new(
-      work_packages: @work_packages,
-      project: @project,
-      target_project: @target_project,
-      types: @types,
-      target_type: @target_type,
-      unavailable_type_in_target_project: @unavailable_type_in_target_project,
-      available_versions: @available_versions,
-      available_statuses: @available_statuses,
-      notes: @notes,
-      copy: @copy
-    ) %>
+<%= render @move_form_component %>
 <% content_for :header_tags do %>
   <%= robot_exclusion_tag %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1646,12 +1646,12 @@ en:
       no_common_statuses_exists: "There is no status available for all selected work packages. Their status cannot be changed."
       unsupported_for_multiple_projects: "Bulk move/copy is not supported for work packages from multiple projects"
       current_type_not_available_in_target_project: >
-        The current type of the work package is not enabled in the target project.
-        Please enable the type in the target project if you'd like it to remain unchanged.
+        The type of this work package or one of its descendants is not enabled in the target project.
+        Please enable the missing types in the target project if you'd like them to remain unchanged.
         Otherwise, select an available type in the target project from the list.
       bulk_current_type_not_available_in_target_project: >
-        The current types of the work packages aren't enabled in the target project.
-        Please enable the types in the target project if you'd like them to remain unchanged.
+        The types of the work packages or their descendants aren't enabled in the target project.
+        Please enable the missing types in the target project if you'd like them to remain unchanged.
         Otherwise, select an available type in the target project from the list.
     sharing:
       missing_workflow_warning:

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
       available_versions: [version],
       available_statuses: [status],
       notes: "Move notes",
+      turbo_stream_url: "/work_packages/move/refresh_form",
       **params
     )
   end
@@ -76,6 +77,24 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
       "form[data-controller='refresh-on-form-changes']" \
       "[data-refresh-on-form-changes-target='form']"
     )
+  end
+
+  context "with selected values" do
+    let(:component) do
+      build_component(
+        selected_values: {
+          status_id: status.id.to_s,
+          version_id: version.id.to_s,
+          priority_id: priority.id.to_s
+        }
+      )
+    end
+
+    it "preserves the selected form values" do
+      expect(rendered_component).to have_select(:status_id, selected: status.name)
+      expect(rendered_component).to have_select(:version_id, selected: version.name)
+      expect(rendered_component).to have_select(:priority_id, selected: priority.name)
+    end
   end
 
   context "with a required custom field on the target type" do

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
       target_project:,
       notes: "Move notes",
       selected_values: { type_id: type.id.to_s },
-      turbo_stream_url: "/work_packages/move/refresh_form",
       current_user: user,
       **params
     )
@@ -75,7 +74,8 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
   it "wires the refresh-on-form-changes controller" do
     expect(rendered_component).to have_css(
       "form[data-controller='refresh-on-form-changes']" \
-      "[data-refresh-on-form-changes-target='form']"
+      "[data-refresh-on-form-changes-target='form']" \
+      "[data-refresh-on-form-changes-turbo-stream-url-value='/work_packages/move/refresh_form']"
     )
   end
 

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -127,6 +127,21 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
     end
   end
 
+  context "when a descendant's type is unavailable in the target project" do
+    let(:child_type) { create(:type, name: "Phase") }
+    let(:project) { create(:project, types: [type, child_type]) }
+
+    before do
+      create(:work_package, project:, type: child_type, parent: work_package)
+    end
+
+    it "renders the unavailable-type warning" do
+      expect(rendered_component)
+        .to have_css(".op-toast.-warning",
+                     text: I18n.t("work_packages.move.current_type_not_available_in_target_project"))
+    end
+  end
+
   context "when all moved work package types exist in the target project" do
     it "does not render the unavailable-type warning" do
       expect(rendered_component).to have_no_css(".op-toast.-warning")

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -114,6 +114,25 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
     end
   end
 
+  context "when a moved work package's current type is unavailable in the target project" do
+    let(:other_type) { create(:type, name: "Phase") }
+    let(:project) { create(:project, types: [other_type]) }
+    let(:target_project) { create(:project, types: [type]) }
+    let(:work_package) { create(:work_package, project:, type: other_type) }
+
+    it "renders the unavailable-type warning" do
+      expect(rendered_component)
+        .to have_css(".op-toast.-warning",
+                     text: I18n.t("work_packages.move.current_type_not_available_in_target_project"))
+    end
+  end
+
+  context "when all moved work package types exist in the target project" do
+    it "does not render the unavailable-type warning" do
+      expect(rendered_component).to have_no_css(".op-toast.-warning")
+    end
+  end
+
   context "with a required project-scoped custom field on the target type" do
     let!(:source_version) { create(:version, project:, name: "Source milestone") }
     let!(:target_version) { create(:version, project: target_project, name: "Target milestone") }

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
   let!(:priority) { create(:priority, name: "High") }
   let(:version) { create(:version, project: target_project) }
   let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
-  let(:user) { create(:user, member_with_roles: { project => role }) }
+  let(:user) { create(:user, member_with_roles: { project => role, target_project => role }) }
 
   def build_component(**params)
     described_class.new(
@@ -96,6 +96,26 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
       expect(rendered_component).to have_select(:status_id, selected: status.name)
       expect(rendered_component).to have_select(:version_id, selected: version.name)
       expect(rendered_component).to have_select(:priority_id, selected: priority.name)
+    end
+  end
+
+  context "when the user's roles differ between source and target project" do
+    let(:source_status) { create(:status, name: "Source only") }
+    let(:target_status) { create(:status, name: "Target only") }
+    let(:source_role) { create(:project_role, permissions: %i[view_work_packages]) }
+    let(:target_role) { create(:project_role, permissions: %i[view_work_packages]) }
+    let(:user) do
+      create(:user, member_with_roles: { project => source_role, target_project => target_role })
+    end
+
+    before do
+      create(:workflow, type:, role: source_role, old_status: work_package.status, new_status: source_status)
+      create(:workflow, type:, role: target_role, old_status: work_package.status, new_status: target_status)
+    end
+
+    it "offers the statuses available in the target project" do
+      expect(rendered_component).to have_select(:status_id, with_options: [target_status.name])
+      expect(rendered_component).to have_no_select(:status_id, with_options: [source_status.name])
     end
   end
 

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -49,18 +49,18 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
   let(:status) { create(:status) }
   let!(:priority) { create(:priority, name: "High") }
   let(:version) { create(:version, project: target_project) }
+  let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
+  let(:user) { create(:user, member_with_roles: { project => role }) }
 
   def build_component(**params)
     described_class.new(
       work_packages: [work_package],
       project:,
       target_project:,
-      types: target_project.types,
-      target_type: type,
-      available_versions: [version],
-      available_statuses: [status],
       notes: "Move notes",
+      new_type_id: type.id,
       turbo_stream_url: "/work_packages/move/refresh_form",
+      current_user: user,
       **params
     )
   end
@@ -80,6 +80,8 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
   end
 
   context "with selected values" do
+    let!(:workflow) { create(:workflow, type:, role:, old_status: work_package.status, new_status: status) }
+
     let(:component) do
       build_component(
         selected_values: {
@@ -109,6 +111,25 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
     it "renders the required marker as an HTML element, not escaped text" do
       expect(rendered_component).to have_css("label.form--label span.required", text: "*")
       expect(rendered_component).to have_no_text('<span class="required">')
+    end
+  end
+
+  context "with a required project-scoped custom field on the target type" do
+    let!(:source_version) { create(:version, project:, name: "Source milestone") }
+    let!(:target_version) { create(:version, project: target_project, name: "Target milestone") }
+    let!(:custom_field) do
+      create(:version_wp_custom_field,
+             name: "Milestone",
+             is_required: true,
+             types: [type],
+             projects: [project, target_project])
+    end
+
+    it "scopes the custom field options to the target project" do
+      cf_select = "custom_field_values[#{custom_field.id}]"
+
+      expect(rendered_component).to have_select(cf_select, with_options: ["Target milestone"])
+      expect(rendered_component).to have_no_select(cf_select, with_options: ["Source milestone"])
     end
   end
 end

--- a/spec/components/work_packages/moves/form_component_spec.rb
+++ b/spec/components/work_packages/moves/form_component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe WorkPackages::Moves::FormComponent, type: :component do
       project:,
       target_project:,
       notes: "Move notes",
-      new_type_id: type.id,
+      selected_values: { type_id: type.id.to_s },
       turbo_stream_url: "/work_packages/move/refresh_form",
       current_user: user,
       **params

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -192,6 +192,44 @@ RSpec.describe "Moving a work package through Rails view", :js do
     end
   end
 
+  it "preserves move form values when refreshing after a project change", :js do
+    assignable_role = create(:project_role, permissions: %i[view_work_packages work_package_assigned])
+    assignee = create(:user, member_with_roles: { project => assignable_role, project2 => assignable_role })
+    new_status = create(:status, name: "Ready")
+    priority = create(:priority, name: "High")
+    required_cf = create(:integer_wp_custom_field,
+                         name: "Risk score",
+                         is_required: true,
+                         projects: [project, project2])
+    create(:workflow, type:, old_status: status, new_status:, role: mover_role)
+    create(:workflow, type: type2, old_status: status, new_status:, role: mover_role)
+    type2.custom_fields << required_cf
+
+    visit new_move_work_packages_path(ids: work_packages.map(&:id))
+
+    select type2.name, from: "Type"
+    expect(page).to have_field(required_cf.name)
+    select new_status.name, from: "Status"
+    select priority.name, from: "Priority"
+    select assignee.name, from: "Assignee"
+    select "nobody", from: "Accountable"
+    fill_in required_cf.name, with: "42"
+
+    wait_for_turbo_stream do
+      select_autocomplete page.find_test_selector("new_project_id"),
+                          query: project2.name,
+                          select_text: project2.name,
+                          results_selector: "body"
+    end
+
+    expect(page).to have_select("Type", selected: type2.name)
+    expect(page).to have_select("Status", selected: new_status.name)
+    expect(page).to have_select("Priority", selected: priority.name)
+    expect(page).to have_select("Assignee", selected: assignee.name)
+    expect(page).to have_select("Accountable", selected: "nobody")
+    expect(page).to have_field(required_cf.name, with: "42")
+  end
+
   describe "moving an unmovable (e.g. readonly status) and a movable work package", with_ee: %i[readonly_work_packages] do
     let(:work_packages) { [work_package, work_package2] }
     let(:work_package2_status) { create(:status, is_readonly: true) }

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe "Moving a work package through Rails view", :js do
   end
 
   it "preserves move form values when refreshing after a project change", :js do
+    notes_editor = Components::WysiwygEditor.new
     assignable_role = create(:project_role, permissions: %i[view_work_packages work_package_assigned])
     assignee = create(:user, member_with_roles: { project => assignable_role, project2 => assignable_role })
     new_status = create(:status, name: "Ready")
@@ -214,6 +215,7 @@ RSpec.describe "Moving a work package through Rails view", :js do
     select assignee.name, from: "Assignee"
     select "nobody", from: "Accountable"
     fill_in required_cf.name, with: "42"
+    notes_editor.set_markdown "Keep this note"
 
     wait_for_turbo_stream do
       select_autocomplete page.find_test_selector("new_project_id"),
@@ -228,6 +230,7 @@ RSpec.describe "Moving a work package through Rails view", :js do
     expect(page).to have_select("Assignee", selected: assignee.name)
     expect(page).to have_select("Accountable", selected: "nobody")
     expect(page).to have_field(required_cf.name, with: "42")
+    notes_editor.expect_value "Keep this note"
   end
 
   describe "moving an unmovable (e.g. readonly status) and a movable work package", with_ee: %i[readonly_work_packages] do

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -668,6 +668,27 @@ RSpec.describe PermittedParams do
         "journal_notes" => "Move notes"
       )
     end
+
+    context "with array-shaped custom field values" do
+      let(:params) do
+        ActionController::Parameters.new(
+          assigned_to_id: "1",
+          custom_field_values: ["Malformed"],
+          new_project_id: "3",
+          new_type_id: "4",
+          notes: "Move notes"
+        )
+      end
+
+      it "ignores them" do
+        expect(permitted).to eq(
+          "assigned_to_id" => "1",
+          "type_id" => "4",
+          "project_id" => "3",
+          "journal_notes" => "Move notes"
+        )
+      end
+    end
   end
 
   describe "#move_work_package_form_values" do
@@ -717,6 +738,19 @@ RSpec.describe PermittedParams do
 
       it "removes them" do
         expect(permitted).to eq({})
+      end
+    end
+
+    context "with array-shaped custom field values" do
+      let(:params) do
+        ActionController::Parameters.new(
+          assigned_to_id: "1",
+          custom_field_values: ["Malformed"]
+        )
+      end
+
+      it "ignores them" do
+        expect(permitted).to eq("assigned_to_id" => "1")
       end
     end
   end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe PermittedParams do
       )
     end
 
-    it "permits move form values without operation-only normalization" do
+    it "permits move form values and normalizes operation-only keys" do
       expect(permitted).to eq(
         "assigned_to_id" => "1",
         "responsible_id" => "2",
@@ -722,7 +722,9 @@ RSpec.describe PermittedParams do
         "version_id" => "4",
         "priority_id" => "5",
         "budget_id" => "6",
-        "custom_field_values" => { "7" => "Keep me" }
+        "custom_field_values" => { "7" => "Keep me" },
+        "type_id" => "9",
+        "project_id" => "8"
       )
     end
 
@@ -737,7 +739,7 @@ RSpec.describe PermittedParams do
       end
 
       it "removes them" do
-        expect(permitted).to eq({})
+        expect(permitted).to eq("type_id" => nil, "project_id" => nil)
       end
     end
 
@@ -750,7 +752,9 @@ RSpec.describe PermittedParams do
       end
 
       it "ignores them" do
-        expect(permitted).to eq("assigned_to_id" => "1")
+        expect(permitted).to eq("assigned_to_id" => "1",
+                                "type_id" => nil,
+                                "project_id" => nil)
       end
     end
   end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -645,6 +645,82 @@ RSpec.describe PermittedParams do
     end
   end
 
+  describe "#move_work_package" do
+    subject(:permitted) { described_class.new(params, user).move_work_package.to_h }
+
+    let(:params) do
+      ActionController::Parameters.new(
+        assigned_to_id: "1",
+        custom_field_values: { "2" => "Keep me" },
+        new_project_id: "3",
+        new_type_id: "4",
+        notes: "Move notes",
+        subject: "Do not keep me"
+      )
+    end
+
+    it "permits move params and normalizes operation-only keys" do
+      expect(permitted).to eq(
+        "assigned_to_id" => "1",
+        "custom_field_values" => { "2" => "Keep me" },
+        "type_id" => "4",
+        "project_id" => "3",
+        "journal_notes" => "Move notes"
+      )
+    end
+  end
+
+  describe "#move_work_package_form_values" do
+    subject(:permitted) { described_class.new(params, user).move_work_package_form_values.to_h }
+
+    let(:params) do
+      ActionController::Parameters.new(
+        assigned_to_id: "1",
+        responsible_id: "2",
+        start_date: "2026-07-01",
+        due_date: "2026-07-31",
+        status_id: "3",
+        version_id: "4",
+        priority_id: "5",
+        budget_id: "6",
+        custom_field_values: { "7" => "Keep me" },
+        new_project_id: "8",
+        new_type_id: "9",
+        notes: "Keep me elsewhere",
+        subject: "Do not keep me"
+      )
+    end
+
+    it "permits move form values without operation-only normalization" do
+      expect(permitted).to eq(
+        "assigned_to_id" => "1",
+        "responsible_id" => "2",
+        "start_date" => "2026-07-01",
+        "due_date" => "2026-07-31",
+        "status_id" => "3",
+        "version_id" => "4",
+        "priority_id" => "5",
+        "budget_id" => "6",
+        "custom_field_values" => { "7" => "Keep me" }
+      )
+    end
+
+    context "with custom field values that do not follow the schema 'id as string' => 'value as string'" do
+      let(:params) do
+        ActionController::Parameters.new(
+          custom_field_values: {
+            "blubs" => "5",
+            "5" => { "1" => "2" }
+          }
+        )
+      end
+
+      it "removes them" do
+        expect(permitted).to eq({})
+      end
+    end
+  end
+
   describe "#time_entry_activities_project" do
     let(:attribute) { :time_entry_activities_project }
     let(:hash) do

--- a/spec/requests/work_packages/moves_spec.rb
+++ b/spec/requests/work_packages/moves_spec.rb
@@ -32,9 +32,10 @@ require "spec_helper"
 
 RSpec.describe "Work package moves", :webmock, type: :rails_request do
   shared_let(:user) { create(:admin) }
-  shared_let(:source) { create(:project, name: "Source") }
-  shared_let(:target) { create(:project, name: "Target") }
-  shared_let(:work_package) { create(:work_package, project: source) }
+  shared_let(:type) { create(:type) }
+  shared_let(:source) { create(:project, name: "Source", types: [type]) }
+  shared_let(:target) { create(:project, name: "Target", types: [type]) }
+  shared_let(:work_package) { create(:work_package, project: source, type:) }
 
   before { login_as(user) }
 
@@ -53,9 +54,11 @@ RSpec.describe "Work package moves", :webmock, type: :rails_request do
       response.parsed_body.at_css("meta[name='csrf-token']")["content"]
     end
 
+    let(:params) { { "ids[]" => work_package.id, new_project_id: target.id, notes: "secret note" } }
+
     subject(:request) do
       post refresh_form_move_work_packages_path,
-           params: { "ids[]" => work_package.id, new_project_id: target.id, notes: "secret note" },
+           params:,
            headers: { "X-CSRF-Token" => current_csrf_token },
            as: :turbo_stream
     end
@@ -68,9 +71,51 @@ RSpec.describe "Work package moves", :webmock, type: :rails_request do
       expect(response.body).to include("secret note")
     end
 
-    it "does not respond to GET" do
-      expect { get "/work_packages/move/refresh_form" }
-        .to raise_error(ActionController::RoutingError)
+    context "with current move form values" do
+      let(:version) { create(:version, project: target) }
+      let(:priority) { create(:priority, name: "High") }
+      let(:assignee_role) { create(:project_role, permissions: %i[view_work_packages work_package_assigned]) }
+      let(:assignee) { create(:user, member_with_roles: { target => assignee_role }) }
+      let(:status) { create(:status) }
+      let(:custom_field) do
+        create(:string_wp_custom_field, is_required: true, types: [type], projects: [source, target])
+      end
+
+      let(:params) do
+        {
+          "ids[]" => work_package.id,
+          new_project_id: target.id,
+          new_type_id: type.id,
+          status_id: status.id,
+          version_id: version.id,
+          priority_id: priority.id,
+          assigned_to_id: assignee.id,
+          responsible_id: "none",
+          start_date: "2026-07-01",
+          due_date: "2026-07-15",
+          custom_field_values: { custom_field.id => "Keep me" }
+        }
+      end
+
+      before do
+        create(:workflow, type:, old_status: work_package.status, new_status: status, role: assignee_role)
+      end
+
+      it "preserves them in the refreshed form" do
+        request
+
+        expect(response).to have_http_status(:ok)
+        expect_turbo_streamed_move_form
+        expect(response.body)
+          .to include(%(option selected="selected" value="#{status.id}"))
+          .and include(%(option selected="selected" value="#{version.id}"))
+          .and include(%(option selected="selected" value="#{priority.id}"))
+          .and include(%(option selected="selected" value="#{assignee.id}"))
+          .and include(%(option selected="selected" value="none"))
+          .and include(%(data-value="&quot;2026-07-01&quot;"))
+          .and include(%(data-value="&quot;2026-07-15&quot;"))
+          .and match(/name="custom_field_values\[#{custom_field.id}\]"[^>]+value="Keep me"/)
+      end
     end
   end
 end

--- a/spec/requests/work_packages/moves_spec.rb
+++ b/spec/requests/work_packages/moves_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe "Work package moves", :webmock, type: :rails_request do
       expect(response.body).to include("secret note")
     end
 
+    context "with malformed custom field values" do
+      let(:params) do
+        {
+          "ids[]" => work_package.id,
+          new_project_id: target.id,
+          custom_field_values: ["Malformed"]
+        }
+      end
+
+      it "ignores them and renders the refreshed form" do
+        request
+
+        expect(response).to have_http_status(:ok)
+        expect_turbo_streamed_move_form
+      end
+    end
+
     context "with current move form values" do
       let(:version) { create(:version, project: target) }
       let(:priority) { create(:priority, name: "High") }


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #23938 and #24061. Please review/merge those PRs first.

# Ticket

https://community.openproject.org/wp/OP-19606

# What are you trying to accomplish?

On the move/copy work package form, changing the target project or type triggers a form refresh that wiped every previously filled field (dates, assignee, priority, custom fields, …) — even when those fields were still applicable in the target project.

## Screen recording

https://github.com/user-attachments/assets/e225dcdf-9ebe-4b96-bf35-e4e6e865c880


# What approach did you choose and why?

- The submitted values are passed back into `WorkPackages::Moves::FormComponent` as `selected_values` (rendering only), so the refreshed form keeps the user's current selections; the persisted move/copy attributes stay on the existing permitted-params path.
- The permitted form values are defined centrally in `PermittedParams#move_work_package_form_values`, shared by the refresh and the move itself; malformed custom-field params are guarded.
- The component derives its own type/version/status collections (with `current_user` injected) and warns when a moved work package's current type does not exist in the target project.

## Review follow-ups

- Renamed `types` → `available_types` and let the component compute its own refresh URL.
- `new_type_id`/`new_project_id` are now normalized inside `PermittedParams#move_work_package_form_values` instead of being passed separately.
- The unavailable-type warning copy now also mentions descendants.
- **Drive-by fix** (separate commit): the status dropdown was populated from the user's roles in the *source* project, although the chosen status is applied in the *target* project. It now derives statuses from the target project. Pre-existing issue raised by @EinLama in review.

> [!IMPORTANT]
> **Note for QA:** the move/copy form's status dropdown now lists statuses from the user's workflows in the **target** project (previously: source project). No visible change for admins; non-admin users with differing roles between source and target will see a different status list after picking a target project.

## Stacked PRs (split per work package)

Stacks on #23938 ([SC-272] streamable form component + POST refresh), which is based on #24061 ([OP-19677] — preserving the Budget field relies on `budget_id` being permitted). Merge order: #24061 → #23938 → this PR.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
