### PR TITLE
[dream-725] Missing space on the right side of the project selector

### DIFF
--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -229,6 +229,12 @@ ul.SegmentedControl,
     .FilterableTreeViewTreeContainer
       scrollbar-gutter: stable
 
+      // Overlay scrollbars can cover the tree content on narrow screens and
+      // touch devices.
+      @media screen and (max-width: $breakpoint-sm), (pointer: coarse)
+        .TreeViewItemContainer
+          width: calc(100% - var(--base-size-16))
+
       // Firefox on Windows can render the scrollbar over the tree content,
       // so keep trailing actions out of that area.
       // see https://bugzilla.mozilla.org/show_bug.cgi?id=1980289

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -222,6 +222,10 @@ ul.SegmentedControl,
 
 // At some point in time, this needs to be extracted into a proper component,
 // something like `FilterableTreeViewSelectPanel`
+@mixin keep-project-select-actions-clear-of-scrollbar
+  .TreeViewItemContainer
+    width: calc(100% - var(--base-size-16))
+
 .op-project-select--body
   .FilterableTreeViewLayout
     > .Stack
@@ -232,12 +236,10 @@ ul.SegmentedControl,
       // Overlay scrollbars can cover the tree content on narrow screens and
       // touch devices.
       @media screen and (max-width: $breakpoint-sm), (pointer: coarse)
-        .TreeViewItemContainer
-          width: calc(100% - var(--base-size-16))
+        @include keep-project-select-actions-clear-of-scrollbar
 
       // Firefox on Windows can render the scrollbar over the tree content,
       // so keep trailing actions out of that area.
       // see https://bugzilla.mozilla.org/show_bug.cgi?id=1980289
       body.-browser-windows.-browser-firefox &
-        .TreeViewItemContainer
-          width: calc(100% - var(--base-size-16))
+        @include keep-project-select-actions-clear-of-scrollbar


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-725

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The width is applied when:

- Firefox on Windows
- The small screen
- The primary input uses a coarse pointer, such as touch devices or Chrome responsive mode

