### PR TITLE
[OP-18695] Improve type deactivation message

### DIFF
--- a/app/controllers/concerns/work_package_types/type_deactivation_error_message.rb
+++ b/app/controllers/concerns/work_package_types/type_deactivation_error_message.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module WorkPackageTypes::TypeDeactivationErrorMessage
+  extend ActiveSupport::Concern
+
+  private
+
+  def type_deactivation_error_messages(types, project_ids:)
+    types.map do |type|
+      type_deactivation_error_message(type, project_ids:)
+    end
+  end
+
+  def type_deactivation_error_message(type, project_ids:)
+    project_ids = Array(project_ids)
+    visible_project_ids = visible_project_ids(project_ids)
+
+    helpers.sanitize(
+      I18n.t(:error_can_not_deactivate_type,
+             type: type.name,
+             work_packages_link: helpers.link_to(
+               I18n.t(:label_work_package_plural).downcase,
+               affected_work_packages_path(type, project_ids: visible_project_ids),
+               target: "_blank",
+               rel: "noopener"
+             )) + invisible_projects_message(project_ids, visible_project_ids),
+      attributes: %w[href target rel]
+    )
+  end
+
+  def affected_work_packages_path(type, project_ids:)
+    filters = [{ n: "type", o: "=", v: [type.id] }]
+    filters << { n: "project", o: "=", v: project_ids.map(&:to_s) } if project_ids.present?
+
+    work_packages_path query_props: { f: filters }.to_json
+  end
+
+  def visible_project_ids(project_ids)
+    Project
+      .visible
+      .where(id: project_ids)
+      .pluck(:id)
+  end
+
+  def invisible_projects_message(project_ids, visible_project_ids)
+    return "" unless project_ids.size > visible_project_ids.size
+
+    " #{I18n.t(:error_can_not_deactivate_type_invisible_projects)}"
+  end
+end

--- a/app/controllers/work_package_types/projects_tab_controller.rb
+++ b/app/controllers/work_package_types/projects_tab_controller.rb
@@ -31,6 +31,7 @@
 module WorkPackageTypes
   class ProjectsTabController < BaseTabController
     include OpTurbo::ComponentStream
+    include TypeDeactivationErrorMessage
 
     before_action :load_projects, only: %i[edit enable_all_projects]
 
@@ -74,7 +75,13 @@ module WorkPackageTypes
     private
 
     def flash_error(result)
-      flash.now[:error] = result.errors.messages_for(:project_ids).to_sentence
+      deactivated_project_ids = deactivated_project_ids_with_work_packages(permitted_project_params[:project_ids])
+
+      flash.now[:error] = if deactivated_project_ids.any?
+                            type_deactivation_error_message(@type, project_ids: deactivated_project_ids)
+                          else
+                            result.errors.messages_for(:project_ids).to_sentence
+                          end
     end
 
     def load_projects
@@ -85,6 +92,15 @@ module WorkPackageTypes
       # TODO: once the input is correctly delivered just return: params.expect(type: [:project_ids])
 
       { project_ids: JSON.parse(params.expect(type: [:project_ids])[:project_ids]) }
+    end
+
+    def deactivated_project_ids_with_work_packages(project_ids)
+      deactivated_project_ids = @type.project_ids - Array(project_ids).compact_blank.map(&:to_i)
+
+      WorkPackage
+        .where(type_id: @type.id, project_id: deactivated_project_ids)
+        .distinct
+        .pluck(:project_id)
     end
   end
 end

--- a/app/services/work_package_types/update_service.rb
+++ b/app/services/work_package_types/update_service.rb
@@ -41,6 +41,8 @@ module WorkPackageTypes
         return result if result.failure?
       end
 
+      return type_deactivation_failure if type_deactivation_invalid?
+
       set_active_custom_fields
       set_active_custom_fields_for_project_ids(params[:project_ids]) if params[:project_ids].present?
 
@@ -95,6 +97,28 @@ module WorkPackageTypes
       model.errors.add(:attribute_groups, I18n.t("types.edit.form_configuration.invalid_attribute_groups"))
 
       ServiceResult.failure(result: model, errors: model.errors)
+    end
+
+    def type_deactivation_invalid?
+      params.key?(:project_ids) && deactivated_project_ids_with_work_packages.any?
+    end
+
+    def type_deactivation_failure
+      model.errors.add(:project_ids,
+                       I18n.t(:error_can_not_deactivate_type,
+                              type: model.name,
+                              work_packages_link: I18n.t(:label_work_package_plural).downcase))
+
+      ServiceResult.failure(result: model, errors: model.errors)
+    end
+
+    def deactivated_project_ids_with_work_packages
+      deactivated_project_ids = model.project_ids - Array(params[:project_ids]).compact_blank.map(&:to_i)
+
+      WorkPackage
+        .where(type_id: model.id, project_id: deactivated_project_ids)
+        .distinct
+        .pluck(:project_id)
     end
 
     ##

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3449,6 +3449,8 @@ en:
   error_can_not_delete_in_use_archived_work_packages: "There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the attribute of the respective work packages: %{archived_projects_urls}"
   error_can_not_delete_type:
     explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" href="%{url}">this view</a>.'
+  error_can_not_deactivate_type: "Unable to deactivate type %{type} because it's still in use by %{work_packages_link}"
+  error_can_not_deactivate_type_invisible_projects: "There are also work packages in projects you cannot see."
   error_can_not_delete_standard_type: "Standard types cannot be deleted."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."

--- a/spec/controllers/projects/settings/work_packages/types_controller_spec.rb
+++ b/spec/controllers/projects/settings/work_packages/types_controller_spec.rb
@@ -28,43 +28,41 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Projects::Settings::WorkPackages::TypesController < Projects::SettingsController
-  include WorkPackageTypes::TypeDeactivationErrorMessage
+require "spec_helper"
 
-  menu_item :settings_work_packages
+RSpec.describe Projects::Settings::WorkPackages::TypesController do
+  shared_let(:user) { create(:admin) }
 
-  def show
-    @types = ::Type.all
-  end
+  current_user { user }
 
-  def update
-    type_ids = permitted_params.projects_type_ids
+  describe "PATCH #update" do
+    let(:type) { create(:type_bug) }
+    let(:other_type) { create(:type_task) }
+    let(:project) { create(:project, types: [type, other_type]) }
+    let!(:work_package) { create(:work_package, project:, type:) }
 
-    if UpdateProjectsTypesService.new(@project).call(type_ids)
-      flash[:notice] = success_message
-    else
-      flash[:error] = type_deactivation_error_messages(types_missing_from(type_ids), project_ids: [@project.id])
+    before do
+      patch :update,
+            params: {
+              project_id: project.identifier,
+              project: { type_ids: [other_type.id.to_s] }
+            }
     end
 
-    redirect_to project_settings_types_path(@project.identifier)
-  end
+    it { expect(response).to redirect_to(project_settings_types_path(project.identifier)) }
 
-  private
+    it "shows an error message with a link to the affected work packages" do
+      expect(sanitize_string(flash[:error]))
+        .to include("Unable to deactivate type #{type.name} because it's still in use by work packages")
+      expect(flash[:error].first)
+        .to include(work_packages_path(query_props: { f: [
+          { n: "type", o: "=", v: [type.id] },
+          { n: "project", o: "=", v: [project.id.to_s] }
+        ] }.to_json))
+    end
 
-  def success_message
-    ApplicationController.helpers.sanitize(
-      t(:notice_successful_update_custom_fields_added_to_project, url: project_settings_custom_fields_path(@project)),
-      attributes: %w(href target)
-    )
-  end
-
-  def types_missing_from(type_ids)
-    @project
-      .types_used_by_work_packages
-      .where.not(id: type_ids.presence || standard_type_ids)
-  end
-
-  def standard_type_ids
-    [::Type.standard_type&.id].compact
+    it "keeps the type active in the project" do
+      expect(project.reload.types).to include(type)
+    end
   end
 end

--- a/spec/controllers/work_package_types/projects_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/projects_tab_controller_spec.rb
@@ -71,16 +71,75 @@ RSpec.describe WorkPackageTypes::ProjectsTabController do
         }
       end
 
-      before do
+      def update_projects
         put :update, params:
       end
 
-      it { expect(response).to redirect_to(edit_type_projects_path(type_id: type.id)) }
+      it "redirects to the projects tab" do
+        update_projects
+
+        expect(response).to redirect_to(edit_type_projects_path(type_id: type.id))
+      end
 
       context "if the project id does not exist" do
         let(:project_ids) { ["not_here"] }
 
+        it "responds with an error" do
+          update_projects
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "if the project contains work packages of the type" do
+        let(:project) { create(:project, types: [type]) }
+        let!(:work_package) { create(:work_package, project:, type:) }
+        let(:project_ids) { [] }
+
+        before do
+          update_projects
+        end
+
         it { expect(response).to have_http_status(:unprocessable_entity) }
+
+        it "shows an error message with a link to the affected work packages" do
+          expect(sanitize_string(flash[:error]))
+            .to include("Unable to deactivate type #{type.name} because it's still in use by work packages")
+          expect(flash[:error])
+            .to include(work_packages_path(query_props: { f: [
+              { n: "type", o: "=", v: [type.id] },
+              { n: "project", o: "=", v: [project.id.to_s] }
+            ] }.to_json))
+        end
+
+        it "keeps the type active in the project" do
+          expect(project.reload.types).to include(type)
+        end
+      end
+
+      context "if visible and invisible projects contain work packages of the type" do
+        let(:project) { create(:project, types: [type]) }
+        let(:archived_project) { create(:project, :archived, types: [type]) }
+        let!(:work_package) { create(:work_package, project:, type:) }
+        let!(:archived_work_package) { create(:work_package, project: archived_project, type:) }
+        let(:project_ids) { [] }
+
+        before do
+          update_projects
+        end
+
+        it "does not include invisible project ids in the work packages link" do
+          expect(flash[:error])
+            .to include(work_packages_path(query_props: { f: [
+              { n: "type", o: "=", v: [type.id] },
+              { n: "project", o: "=", v: [project.id.to_s] }
+            ] }.to_json))
+        end
+
+        it "informs the user that some projects are not visible" do
+          expect(flash[:error])
+            .to include(I18n.t(:error_can_not_deactivate_type_invisible_projects))
+        end
       end
     end
   end

--- a/spec/services/work_package_types/update_service_spec.rb
+++ b/spec/services/work_package_types/update_service_spec.rb
@@ -234,5 +234,23 @@ module WorkPackageTypes
                                                       .from([])
       end
     end
+
+    context "when removing the type from a project with work packages" do
+      let(:contract_class) { UpdateProjectsContract }
+      let(:project) { create(:project, types: [type]) }
+      let!(:work_package) { create(:work_package, project:, type:) }
+      let(:params) { { project_ids: [] } }
+
+      subject(:service) { described_class.new(user:, model:, contract_class:) }
+
+      it "fails and keeps the type active in the project" do
+        expect(service_call).to be_failure
+        expect(service_call.errors.messages_for(:project_ids))
+          .to contain_exactly(I18n.t(:error_can_not_deactivate_type,
+                                     type: type.name,
+                                     work_packages_link: I18n.t(:label_work_package_plural).downcase))
+        expect(project.reload.types).to include(type)
+      end
+    end
   end
 end


### PR DESCRIPTION
Link to affected work packages in their respective projects when trying to delete a type that's still in use. In case the project is archived (and not visitable even by admins), inform about that, too.

https://community.openproject.org/work_packages/OP-18695


<img width="1548" height="246" alt="2026-07-02_14-56-43@2x" src="https://github.com/user-attachments/assets/a6e4099f-7ff2-424e-890c-9a355d3af82f" />
