### PR TITLE
[COMMS-806] Documents: impossible to delete characters with backspace…

### DIFF
--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -181,6 +181,29 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         editor.wait_for_autosave { document.reload.description&.include?("####{work_package.id}") }
       end
 
+      it "allows deleting text with Backspace after inserting an inline work package link (bugfix STC-806)" do
+        visit document_path(document)
+        expect(page).to have_test_selector("blocknote-document-description")
+
+        editor.element.send_keys("#tiger")
+        editor.wait_for_shadow_content("pet a tiger")
+        send_keys(:enter)
+        expect(editor.element).to have_no_text("#tiger")
+        expect(editor.element).to have_no_text("…")
+        expect(editor.element).to have_text(/##{work_package.display_id}/)
+
+        # Type right after the chip and delete it again with Backspace. Do NOT click / move the caret
+        # first — the bug only manifested when typing immediately after insertion (moving the caret
+        # elsewhere "fixed" it). send_keys (session-level) targets the already-focused editor.
+        send_keys("abc")
+        expect(editor.element).to have_text("abc")
+
+        send_keys(:backspace, :backspace, :backspace)
+
+        expect(editor.element).to have_no_text("abc")
+        expect(editor.element).to have_text(/##{work_package.display_id}/)
+      end
+
       describe "CTRL-Z undo behavior" do
         it "undoes typed text with CTRL-Z" do
           visit document_path(document)


### PR DESCRIPTION
… after adding a wp link

This was fixed in op-blocknote-extension; however, we can't have a spec for it there since it needs yjs / hocuspocus to reproduce.

ATTENTION: Tests will be red until the fix is released for op-blocknote-extensions and its version is updated.

# Ticket
https://community.openproject.org/wp/COMMS-806

# What are you trying to accomplish?
Add test for https://github.com/opf/op-blocknote-extensions/pull/175

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
