### PR TITLE
Destroy the MeetingParticipant on user destroy, not replace reference

### DIFF
--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -181,7 +181,6 @@ module OpenProject::Meeting
     replace_principal_references "Meeting" => %i[author_id],
                                  "MeetingAgendaItem" => %i[author_id presenter_id],
                                  "MeetingOutcome" => :author_id,
-                                 "MeetingParticipant" => :user_id,
                                  "RecurringMeeting" => :author_id
 
     extend_api_response(:v3, :work_packages, :work_package,

--- a/modules/meeting/spec/services/principals/delete_job_integration_spec.rb
+++ b/modules/meeting/spec/services/principals/delete_job_integration_spec.rb
@@ -55,4 +55,27 @@ RSpec.describe Principals::DeleteJob, "Meetings", type: :model do
       expect(recurring_meeting.reload.author).to eq deleted_user
     end
   end
+
+  context "with a meeting participant" do
+    let!(:meeting) { create(:meeting) }
+    let!(:participant) { create(:meeting_participant, meeting:, user: principal) }
+
+    it "deletes the participant instead of replacing it with the deleted user" do
+      job
+
+      expect(MeetingParticipant.exists?(participant.id)).to be(false)
+      expect(meeting.reload.participants.where(user: deleted_user)).to be_empty
+    end
+
+    context "when the meeting already has a deleted-user participant" do
+      let!(:existing_deleted_participant) { create(:meeting_participant, meeting:, user: deleted_user) }
+
+      it "does not fail on the unique [meeting_id, user_id] index and keeps a single deleted-user participant" do
+        expect { job }.not_to raise_error
+
+        expect(MeetingParticipant.exists?(participant.id)).to be(false)
+        expect(meeting.reload.participants.where(user: deleted_user)).to contain_exactly(existing_deleted_participant)
+      end
+    end
+  end
 end

--- a/spec/services/principals/replace_references_service_call_integration_spec.rb
+++ b/spec/services/principals/replace_references_service_call_integration_spec.rb
@@ -197,12 +197,6 @@ RSpec.describe Principals::ReplaceReferencesService, "#call", type: :model do
       end
     end
 
-    context "with MeetingParticipant" do
-      it_behaves_like "rewritten record",
-                      MeetingParticipant,
-                      :user_id
-    end
-
     context "with News" do
       it_behaves_like "rewritten record",
                       News,


### PR DESCRIPTION
Otherwise, we end up with possibly multiple DeletedUser participants, breaking the meeting

https://community.openproject.org/projects/MEET/work_packages/MEET-576/activity