### PR TITLE
[AGILE-321] move sprint sharing from corporate to basic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,7 +209,7 @@ gem "aws-sdk-core", "~> 3.244"
 # File upload via fog + screenshots on travis
 gem "aws-sdk-s3", "~> 1.217"
 
-gem "openproject-token", "~> 8.10.0"
+gem "openproject-token", "~> 8.11.0"
 
 gem "plaintext", "~> 0.3.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -914,7 +914,7 @@ GEM
       activesupport (>= 7.2.0)
       openproject-octicons (>= 19.34.0)
       view_component (>= 3.1, < 5.0)
-    openproject-token (8.10.0)
+    openproject-token (8.11.0)
       activemodel
     openssl (4.0.2)
     openssl-signature_algorithm (1.3.0)
@@ -1694,7 +1694,7 @@ DEPENDENCIES
   openproject-resource_management!
   openproject-storages!
   openproject-team_planner!
-  openproject-token (~> 8.10.0)
+  openproject-token (~> 8.11.0)
   openproject-two_factor_authentication!
   openproject-webhooks!
   openproject-wikis!
@@ -2076,7 +2076,7 @@ CHECKSUMS
   openproject-resource_management (1.0.0)
   openproject-storages (1.0.0)
   openproject-team_planner (1.0.0)
-  openproject-token (8.10.0) sha256=fc007fee7e3677c77a7e7b9618678f0af7d934d29eca36fe7349380e1a57e37a
+  openproject-token (8.11.0) sha256=c864f8bb4da349cf38c3262355efa58d3b52907ad7efd08b561cf9c0deb4347a
   openproject-two_factor_authentication (1.0.0)
   openproject-webhooks (1.0.0)
   openproject-wikis (1.0.0)

--- a/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
@@ -68,21 +68,21 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
         before { project.sprint_sharing = Project::SHARE_ALL_PROJECTS }
 
         it_behaves_like "contract is invalid",
-                        sprint_sharing: { error: :enterprise_plan_required, plan_name: "corporate enterprise plan" }
+                        sprint_sharing: { error: :enterprise_plan_required, plan_name: "basic enterprise plan" }
       end
 
       context "when sprint sharing is set to 'share_subprojects'" do
         before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
 
         it_behaves_like "contract is invalid",
-                        sprint_sharing: { error: :enterprise_plan_required, plan_name: "corporate enterprise plan" }
+                        sprint_sharing: { error: :enterprise_plan_required, plan_name: "basic enterprise plan" }
       end
 
       context "when sprint sharing is set to 'receive_shared'" do
         before { project.sprint_sharing = Project::RECEIVE_SHARED }
 
         it_behaves_like "contract is invalid",
-                        sprint_sharing: { error: :enterprise_plan_required, plan_name: "corporate enterprise plan" }
+                        sprint_sharing: { error: :enterprise_plan_required, plan_name: "basic enterprise plan" }
       end
 
       context "when sprint sharing remains on 'share_all_projects'" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-321

# What are you trying to accomplish?

Bump the token gem so that sprint sharing is moved from corporate to basic.
