### PR TITLE
[OP-19345] Impossible to go back with single click from the user profile to the users list when a filter is added

### DIFF
--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -55,8 +55,18 @@ StreamActions.reloadPage = function reloadPage() {
 // https://github.com/hotwired/turbo/issues/1300
 applyTurboNavigationPatch();
 
+// turbo_power's push_state writes a history entry with an empty state, which Turbo's popstate
+// handler then refuses to render on Back (it only rewrites the URL, leaving stale content on
+// screen). Route through Turbo's own history instead so the entry carries restoration data and
+// Back triggers a proper restoration visit. See https://github.com/marcoroth/turbo_power/issues/11.
+StreamActions.push_state = function pushState() {
+  const url = this.getAttribute('url');
+  if (url) {
+    Turbo.session.history.push(new URL(url, window.location.origin));
+  }
+};
+
 // Register only the turbo-power stream actions we actually use
-TurboPower.register('push_state', TurboPower.Actions.push_state, StreamActions);
 TurboPower.register('turbo_frame_set_src', TurboPower.Actions.turbo_frame_set_src, StreamActions);
 TurboPower.register('turbo_frame_reload', TurboPower.Actions.turbo_frame_reload, StreamActions);
 TurboPower.register('redirect_to', TurboPower.Actions.redirect_to, StreamActions);


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19345

# What are you trying to accomplish?

On the users list (and the other filtered list pages), it took several Back-button clicks to return from a user's page to the list: the address bar updated to the expected URL, but the page content didn't change until an extra click or two.

The live filter/sort/page mechanism updates the list in place via a turbo-stream response that ends with `turbo_stream.push_state(url)` to sync the address bar. That stream action comes from `turbo_power`, which calls raw `window.history.pushState(state, ...)` with an **empty state** — so the entry lacks Turbo's `{ turbo: { restorationIdentifier } }` key. When you press Back onto such an entry, Turbo Drive's `popstate` handler takes the empty-state branch (`historyPoppedWithEmptyState`), which only rewrites the URL and **never renders**. Each filter change adds one of these "dead" entries, so Back has to step through them one URL-change at a time before hitting a real Turbo entry that actually renders.

This overrides the `push_state` stream action so it routes through Turbo's own history (`Turbo.session.history.push`). The entry then carries restoration data, and Back triggers a proper restoration visit that renders the page. Because the action is shared, this fixes all six filtered list pages at once (users, projects, portfolios, meetings, documents, project-reserved-identifiers) with no controller changes — controllers keep emitting `turbo_stream.push_state(url)`.

# What approach did you choose and why?

An earlier iteration fixed only the users page by switching the controller to `turbo_stream.replace_state` (collapsing the list to a single history entry). That was discarded: we want a distinct pushed state per filter change **and** a working Back button — the state-per-filter behaviour is intentional, only its restoration was broken.

Fixing the shared stream action rather than each controller keeps the change in one place and covers all six pages identically. `Turbo.session.history.push` is the public, typed API (`Turbo.navigator.history` is internal and untyped).

This is the same defect and remedy as upstream turbo_power [#11](https://github.com/marcoroth/turbo_power/issues/11) / [#339](https://github.com/marcoroth/turbo_power/pull/339). We override locally instead of waiting on that change, which is unmerged and carries a breaking change (dropping the `state`/`title` attributes).

No infinite-loop risk: a Back-triggered restoration visit is a plain HTML GET, so the controller's `format.html` branch runs and never emits a `push_state` stream.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
