### PR TITLE
Implementation/COMMS-848: Adjust Roadmap module and Versions page to use values from target_versions

### DIFF
--- a/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
+++ b/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
@@ -39,7 +39,7 @@ module Projects
         end
 
         def call
-          return unless version.work_packages.any?
+          return unless version.issues_count > 0
 
           widget_wrapper do |widget|
             widget.with_body do

--- a/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
+++ b/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
@@ -39,7 +39,9 @@ module Projects
         end
 
         def call
-          return unless version.issues_count > 0
+          # The graph queries work packages by the single-version filter, so it
+          # is only rendered when that filter finds any.
+          return unless version.work_packages.any?
 
           widget_wrapper do |widget|
             widget.with_body do

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -39,23 +39,15 @@ class VersionsController < ApplicationController
   def index
     @types = @project.types.order(Arel.sql("position"))
     retrieve_selected_type_ids(@types, @types.select(&:is_in_roadmap?))
-    @with_subprojects = params[:with_subprojects].nil? ? Setting.display_subprojects_work_packages? : (params[:with_subprojects].to_i == 1)
-    project_ids = @with_subprojects ? @project.self_and_descendants.includes(:wiki).map(&:id) : [@project.id]
 
-    @versions = find_versions(@with_subprojects, params[:completed])
-
-    @wps_by_version = {}
-    unless @selected_type_ids.empty?
-      @versions.each do |version|
-        @wps_by_version[version] = work_packages_of_version(version, project_ids, @selected_type_ids)
-      end
-    end
-    @versions.reject! { |version| !project_ids.include?(version.project_id) && @wps_by_version[version].blank? }
+    @versions = find_versions(with_subprojects, params[:completed])
+    @wps_by_version = build_wps_by_version(@versions)
+    @versions.reject! { |version| project_ids.exclude?(version.project_id) && @wps_by_version[version].blank? }
   end
 
   def show
     @issues = @version
-      .work_packages
+      .targeted_work_packages
       .visible
       .includes(:status, :type, :priority)
       .order("#{::Type.table_name}.position, #{WorkPackage.table_name}.id")
@@ -119,6 +111,22 @@ class VersionsController < ApplicationController
     @project = @version.project
   end
 
+  def with_subprojects
+    @with_subprojects ||= if params[:with_subprojects].nil?
+                            Setting.display_subprojects_work_packages?
+                          else
+                            params[:with_subprojects].to_i == 1
+                          end
+  end
+
+  def project_ids
+    @project_ids ||= if with_subprojects
+                       @project.self_and_descendants.includes(:wiki).map(&:id)
+                     else
+                       [@project.id]
+                     end
+  end
+
   def archived_project_mesage
     if current_user.admin?
       ApplicationController.helpers.sanitize(
@@ -180,10 +188,16 @@ class VersionsController < ApplicationController
 
   def work_packages_of_version(version, project_ids, selected_type_ids)
     version
-      .work_packages
+      .targeted_work_packages
       .visible
       .includes(:project, :status, :type, :priority)
       .where(type_id: selected_type_ids, project_id: project_ids)
       .order("#{Project.table_name}.lft, #{::Type.table_name}.position, #{WorkPackage.table_name}.id")
+  end
+
+  def build_wps_by_version(versions)
+    return {} if @selected_type_ids.empty?
+
+    versions.index_with { |version| work_packages_of_version(version, project_ids, @selected_type_ids) }
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -87,7 +87,7 @@ class Version < ApplicationRecord
     systemwide? ||
       user.allowed_in_project?(:view_work_packages, project) ||
       user.allowed_in_project?(:manage_versions, project) ||
-      work_packages.visible(user).exists?
+      targeted_work_packages.visible(user).exists?
   end
 
   def due_date
@@ -97,15 +97,14 @@ class Version < ApplicationRecord
   # Returns the total estimated time for this version
   # (sum of leaves estimated_hours)
   def estimated_hours
-    @estimated_hours ||= work_packages.leaves.sum(:estimated_hours).to_f
+    @estimated_hours ||= targeted_work_packages.leaves.sum(:estimated_hours).to_f
   end
 
   # Returns the total reported time for this version
   def spent_hours
     @spent_hours ||= TimeEntry
       .not_ongoing
-      .joins("INNER JOIN work_packages ON entity_type = 'WorkPackage' AND work_packages.id = entity_id")
-      .where(work_packages: { version_id: id }, entity_type: "WorkPackage")
+      .where(entity_type: "WorkPackage", entity_id: targeted_work_packages.select(:id))
       .sum(:hours)
       .to_f
   end
@@ -155,17 +154,17 @@ class Version < ApplicationRecord
 
   # Returns assigned issues count
   def issues_count
-    @issue_count ||= work_packages.count
+    @issues_count ||= targeted_work_packages.count
   end
 
   # Returns the total amount of open issues for this version.
   def open_issues_count
-    @open_issues_count ||= work_packages.merge(WorkPackage.with_status_open).size
+    @open_issues_count ||= targeted_work_packages.merge(WorkPackage.with_status_open).size
   end
 
   # Returns the total amount of closed issues for this version.
   def closed_issues_count
-    @closed_issues_count ||= work_packages.merge(WorkPackage.with_status_closed).size
+    @closed_issues_count ||= targeted_work_packages.merge(WorkPackage.with_status_closed).size
   end
 
   def wiki_page
@@ -214,7 +213,7 @@ class Version < ApplicationRecord
   # Used to weight unestimated issues in progress calculation
   def estimated_average
     if @estimated_average.nil?
-      average = work_packages.average(:estimated_hours).to_f
+      average = targeted_work_packages.average(:estimated_hours).to_f
       if average.zero?
         average = 1
       end
@@ -240,7 +239,7 @@ class Version < ApplicationRecord
           "COALESCE(#{WorkPackage.table_name}.estimated_hours, ?) * #{ratio}", estimated_average
         )
 
-        done = work_packages
+        done = targeted_work_packages
           .where(statuses: { is_closed: !open })
           .includes(:status)
           .sum(sum_sql)

--- a/app/views/versions/_overview.html.erb
+++ b/app/views/versions/_overview.html.erb
@@ -53,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
   </ul>
 <% end %>
 
-<% if version.work_packages.count > 0 %>
+<% if version.issues_count > 0 %>
   <% closed = version.closed_percent %>
   <% done = version.completed_percent - closed %>
   <%= progress_bar([closed, done], width: "40%", legend: ("%0.0f" % version.completed_percent)) %>
@@ -63,14 +63,14 @@ See COPYRIGHT and LICENSE files for more details.
           t(:label_x_closed_work_packages_abbr, count: version.closed_issues_count),
           project_work_packages_closed_version_path(version)
         ) %>
-    (<%= "%0.0f" % (version.closed_issues_count.to_f / version.work_packages.count * 100) %>%)
+    (<%= "%0.0f" % (version.closed_issues_count.to_f / version.issues_count * 100) %>%)
     &#160;
     <%= link_to_if(
           version.open_issues_count > 0,
           t(:label_x_open_work_packages_abbr, count: version.open_issues_count),
           project_work_packages_open_version_path(version)
         ) %>
-    (<%= "%0.0f" % (version.open_issues_count.to_f / version.work_packages.count * 100) %>%)
+    (<%= "%0.0f" % (version.open_issues_count.to_f / version.issues_count * 100) %>%)
     <% if version.projects.archived.exists? %>
       <%= op_icon("icon-warning", title: I18n.t("versions.overview.work_packages_in_archived_projects")) %>
     <% end %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -97,7 +97,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if @issues.present? %>
     <% grid.with_widget(Projects::Settings::Versions::RelatedIssuesWidgetComponent, version: @version, issues: @issues) %>
   <% end %>
-  <% if @version.work_packages.any? %>
+  <% if @version.issues_count > 0 %>
     <% grid.with_widget(Projects::Settings::Versions::WorkPackagesGraphWidgetComponent, version: @version) %>
   <% end %>
 <% end %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -97,7 +97,9 @@ See COPYRIGHT and LICENSE files for more details.
   <% if @issues.present? %>
     <% grid.with_widget(Projects::Settings::Versions::RelatedIssuesWidgetComponent, version: @version, issues: @issues) %>
   <% end %>
-  <% if @version.issues_count > 0 %>
+  <%# The graph queries work packages by the single-version filter, so it is
+      only shown when that filter finds any. %>
+  <% if @version.work_packages.any? %>
     <% grid.with_widget(Projects::Settings::Versions::WorkPackagesGraphWidgetComponent, version: @version) %>
   <% end %>
 <% end %>

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe VersionsController do
       end
     end
 
+    context "with a work package targeting multiple versions" do
+      let!(:work_package) { create(:work_package, project:, version: version1) }
+
+      before do
+        work_package.work_package_versions.create!(version: version2, kind: "target")
+
+        login_as(user)
+        get :index, params: { project_id: project, completed: "1" }
+      end
+
+      it "lists the work package under every targeted version" do
+        wps_by_version = assigns(:wps_by_version)
+
+        expect(wps_by_version[version1]).to include work_package
+        expect(wps_by_version[version2]).to include work_package
+      end
+    end
+
     context "with showing completed versions" do
       before do
         login_as(user)
@@ -237,6 +255,25 @@ RSpec.describe VersionsController do
     subject { assigns(:version) }
 
     it { is_expected.to eq(version2) }
+
+    context "with a work package targeting the version without carrying its version_id" do
+      let(:work_package) do
+        create(:work_package, project:).tap do |wp|
+          wp.work_package_versions.create!(version: version2, kind: "target")
+        end
+      end
+
+      # The outer before block has already fired the request, so the work
+      # package needs a request of its own after it is created.
+      before do
+        work_package
+        get :show, params: { id: version2.id }
+      end
+
+      it "includes the work package in the related work packages" do
+        expect(assigns(:issues)).to include work_package
+      end
+    end
   end
 
   describe "#new" do

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -273,6 +273,23 @@ RSpec.describe VersionsController do
       it "includes the work package in the related work packages" do
         expect(assigns(:issues)).to include work_package
       end
+
+      it "does not render the work packages graph, which still queries by the single-version filter" do
+        expect(response.body).not_to include("opce-wp-overview-graph")
+      end
+    end
+
+    context "with a work package carrying the version_id" do
+      let(:work_package) { create(:work_package, project:, version: version2) }
+
+      before do
+        work_package
+        get :show, params: { id: version2.id }
+      end
+
+      it "renders the work packages graph" do
+        expect(response.body).to include("opce-wp-overview-graph")
+      end
     end
   end
 

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -97,6 +97,15 @@ FactoryBot.define do
       end
     end
 
+    # The persistence services mirror version_id into a kind: "target" join row,
+    # so every saved work package with a version also has one. Factories skip
+    # the services, so the row is created here to match.
+    callback(:after_create) do |work_package|
+      if work_package.version_id
+        work_package.work_package_versions.find_or_create_by!(version_id: work_package.version_id, kind: "target")
+      end
+    end
+
     callback(:after_create) do |work_package, evaluator|
       if evaluator.journals.present?
         work_package.journals.destroy_all

--- a/spec/migrations/backfill_target_versions_from_work_package_spec.rb
+++ b/spec/migrations/backfill_target_versions_from_work_package_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe BackfillTargetVersionsFromWorkPackage, type: :model do
   let!(:work_package_with_version) { create(:work_package, project:, version:) }
   let!(:work_package_without_version) { create(:work_package, project:, version: nil) }
 
+  # The migration targets work packages that only carry version_id, so remove
+  # the join rows the factory already created.
+  before { WorkPackageVersion.delete_all }
+
   it "succeeds" do
     expect { migrate }.not_to raise_error
   end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -337,6 +337,65 @@ RSpec.describe Version do
     end
   end
 
+  describe "aggregations via target versions" do
+    let(:project) { create(:project) }
+    let(:version) { create(:version, project:) }
+    let(:other_version) { create(:version, project:) }
+
+    context "when a work package targets two versions" do
+      let!(:work_package) { create(:work_package, project:, version:, estimated_hours: 3) }
+
+      before do
+        work_package.work_package_versions.create!(version: other_version, kind: "target")
+      end
+
+      it "counts the work package for both versions" do
+        expect(version.issues_count).to eq 1
+        expect(other_version.issues_count).to eq 1
+      end
+
+      it "sums estimated hours for both versions" do
+        expect(version.estimated_hours).to eq 3.0
+        expect(other_version.estimated_hours).to eq 3.0
+      end
+
+      it "sums spent time for both versions" do
+        create(:time_entry, entity: work_package, project:, hours: 2)
+
+        expect(version.spent_hours).to eq 2.0
+        expect(other_version.spent_hours).to eq 2.0
+      end
+    end
+
+    context "when a work package only carries the legacy version_id without a target row" do
+      let!(:work_package) { create(:work_package, project:, version:, estimated_hours: 3) }
+
+      before do
+        create(:time_entry, entity: work_package, project:, hours: 2)
+        WorkPackageVersion.delete_all
+      end
+
+      it "is not counted" do
+        expect(version.issues_count).to eq 0
+        expect(version.estimated_hours).to eq 0.0
+        expect(version.spent_hours).to eq 0.0
+      end
+    end
+
+    context "when a work package only observed the version" do
+      let!(:work_package) { create(:work_package, project:, estimated_hours: 3) }
+
+      before do
+        work_package.work_package_versions.create!(version:, kind: "observed_in")
+      end
+
+      it "is not counted" do
+        expect(version.issues_count).to eq 0
+        expect(version.estimated_hours).to eq 0.0
+      end
+    end
+  end
+
   describe "#start_date" do
     context "with a value saved and a work package with its own start_date" do
       let(:version) { create(:version, start_date: "2010-01-05") }

--- a/spec/models/work_package/work_package_update_versions_spec.rb
+++ b/spec/models/work_package/work_package_update_versions_spec.rb
@@ -36,10 +36,6 @@ RSpec.describe WorkPackage, ".update_versions keeping target_versions consistent
   let(:shared_version) { create(:version, project: parent_project, sharing: "descendants") }
   let!(:work_package) { create(:work_package, project: child_project, version: shared_version) }
 
-  before do
-    work_package.target_versions << shared_version
-  end
-
   def target_version_ids(work_package)
     work_package.work_package_versions.where(kind: "target").pluck(:version_id)
   end


### PR DESCRIPTION
Ticket: https://community.openproject.org/work_packages/COMMS-848

The Roadmap and Version pages still aggregated work packages through the legacy `version_id` column. With target versions in place a work package can belong to several versions, so counts, progress percentages and hour sums now aggregate over the `targeted_work_packages` association instead, and a work package targeting several versions appears under each of them. Spec data gets the same treatment: the work package factory now creates the `kind: "target"` join row the persistence services create in production, so factory-built records match real data without per-spec setup.

Reads built on the `version` query filter stay on `version_id` on purpose: the closed/open work package links on the version overview and the embedded work packages graph (both the widget guard and its initial filters). COMMS-855 translates that filter to target versions, including persisted queries, so the links resolve themselves there and the graph guard can then move to the target-based count.

## Screenshots

The work package targets both Sprint A and Sprint B; its single `version` field points at Sprint A.

<img width="1440" height="913" alt="comms848_roadmap" src="https://github.com/user-attachments/assets/57c10083-a5aa-4264-b2d9-cf95d96087c3" />

<img width="1440" height="913" alt="comms848_version_page" src="https://github.com/user-attachments/assets/9d90c6be-dd81-442c-936a-06d5346a7e23" />