### PR TITLE
Validate wiki universal identifier, disallow updating it

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/validators/configuration_validator.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/validators/configuration_validator.rb
@@ -40,10 +40,12 @@ module Wikis
 
             def validate
               register_checks(
-                :provider_configured
+                :provider_configured,
+                :universal_id_known
               )
 
               provider_configured
+              universal_id_known
               # TODO: check dependencies (e.g. OpenProject extension) and version requirements
             end
 
@@ -52,6 +54,17 @@ module Wikis
                 pass_check(:provider_configured)
               else
                 fail_check(:provider_configured, :not_configured)
+              end
+            end
+
+            def universal_id_known
+              result = XWikiProviders::FetchInstanceIdService.new(provider: subject).call
+              fail_check(:universal_id_known, :connection_error) if result.failure?
+
+              if result.value! == subject.universal_identifier
+                pass_check(:universal_id_known)
+              else
+                warn_check(:universal_id_known, :uid_mismatch)
               end
             end
           end

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -151,8 +151,11 @@ en:
       base_configuration:
         header: Configuration
         provider_configured: Configuration complete
+        universal_id_known: Provider recognized
       errors:
+        connection_error: OpenProject could not connect to the wiki provider.
         not_configured: The connection could not be validated. Please finish configuration first.
+        uid_mismatch: The universal identifier reported by the wiki provider does not match the identifier that OpenProject recorded during setup.
         xwiki_oauth_connection_error: OpenProject could not connect to the configured XWiki instance.
         xwiki_oauth_request_error: An unexpected error occured when trying to communicate with the XWiki instance.
         xwiki_oauth_token_missing: OpenProject cannot test the user-level communication with XWiki as the user did not yet connect their XWiki account.

--- a/modules/wikis/spec/factories/wiki_provider_factory.rb
+++ b/modules/wikis/spec/factories/wiki_provider_factory.rb
@@ -79,6 +79,10 @@ FactoryBot.define do
       connected_user_token { ENV.fetch("XWIKI_LOCAL_OAUTH_CLIENT_ACCESS_TOKEN", "TOKEN_NOT_CONFIGURED") }
       oauth_client_id { ENV.fetch("XWIKI_LOCAL_OAUTH_CLIENT_ID", "CLIENT_ID_NOT_CONFIGURED") }
       oauth_client_secret { ENV.fetch("XWIKI_LOCAL_OAUTH_CLIENT_SECRET", "CLIENT_SECRET_NOT_CONFIGURED") }
+
+      after(:create) do |provider, _evaluator|
+        create(:oauth_application, integration: provider)
+      end
     end
 
     trait :with_oauth_configured do

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/validators/configuration_validator_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/validators/configuration_validator_spec.rb
@@ -30,10 +30,16 @@
 
 require "spec_helper"
 
-RSpec.describe Wikis::Adapters::Providers::XWiki::Validators::ConfigurationValidator do
+RSpec.describe Wikis::Adapters::Providers::XWiki::Validators::ConfigurationValidator, :webmock do
   subject(:validation_result) { described_class.new(provider).call }
 
-  let(:provider) { create(:xwiki_provider, :with_oauth_configured) }
+  let(:provider) { create(:xwiki_provider, :for_local_connection, universal_identifier: instance_id) }
+  let(:instance_id) { "xwiki-instance-abc123" }
+
+  before do
+    stub_request(:get, "https://xwiki.local/rest/openproject/metadata")
+      .to_return(status: 200, body: { instanceId: instance_id }.to_json, headers: { "Content-Type" => "application/json" })
+  end
 
   it "returns a ResultGroup" do
     expect(validation_result).to be_a(HealthReport::ResultGroup)
@@ -49,6 +55,28 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Validators::ConfigurationValid
 
     it "indicates that the provider is not configured" do
       expect(validation_result[:provider_configured].code).to eq(:not_configured)
+    end
+  end
+
+  context "when the XWiki instance can't be reached" do
+    before do
+      stub_request(:get, "https://xwiki.local/rest/openproject/metadata").to_timeout
+    end
+
+    it { is_expected.to be_failure }
+
+    it "indicates that the provider could not be reached" do
+      expect(validation_result[:universal_id_known].code).to eq(:connection_error)
+    end
+  end
+
+  context "when the XWiki instance reports a different installation ID" do
+    let(:provider) { create(:xwiki_provider, :for_local_connection, universal_identifier: "different-known-id") }
+
+    it { is_expected.to be_warning }
+
+    it "indicates that the ID mismatched the known ID" do
+      expect(validation_result[:universal_id_known].code).to eq(:uid_mismatch)
     end
   end
 end


### PR DESCRIPTION
Adding a health check to confirm that the ID didn't change compared to setup and stop updating it during provider updates.

(see commits for more details)