### PR TITLE
[COMMS-829] Remove the Beta label from semantic identifier mode

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5630,7 +5630,7 @@ en:
   setting_welcome_on_homescreen: "Display welcome block on homescreen"
   setting_work_packages_identifier_classic: Instance-wide numerical sequence (default)
   setting_work_packages_identifier_classic_caption: "Every work package gets a sequential number starting with 1 (for example, #1234). The numbers are unique within the instance and remain the same even if work packages are moved between projects."
-  setting_work_packages_identifier_semantic: "Project-based semantic identifiers (Beta)"
+  setting_work_packages_identifier_semantic: "Project-based semantic identifiers"
   setting_work_packages_identifier_semantic_caption: "Every project has a unique project identifier prefixed to a number (for example, PROJ-11). The numbering of each project starts at 1. If a work package is moved to another project, a new identifier is generated but the old one will continue to function."
   setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
   setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"

--- a/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
@@ -13,9 +13,6 @@ Work package identifiers are used throughout OpenProject to uniquely reference w
 
 By default, OpenProject uses an instance-wide numerical sequence (for example, `#12345`). Starting with OpenProject 17.5, administrators can choose between instance-wide numerical identifiers and project-based identifiers. Project-based identifiers combine a project identifier with a sequential number, such as `PROJ-123`.
 
-> [!NOTE]
-> Project-based identifiers are currently available as a Beta feature (starting with OpenProject 17.5). If you notice any inconsistencies or unexpected behavior, we welcome your feedback.
-
 ## Overview
 
 OpenProject supports two identifier modes:
@@ -23,7 +20,7 @@ OpenProject supports two identifier modes:
 | Mode                                       | Example    |
 | ------------------------------------------ | ---------- |
 | Instance-wide numerical sequence (default) | `#12345`   |
-| Project-based identifiers (Beta)           | `PROJ-123` |
+| Project-based identifiers                  | `PROJ-123` |
 
 Project-based identifiers make it easier to identify the project a work package belongs to and can help organizations migrating from Jira preserve familiar issue references.
 
@@ -33,7 +30,7 @@ To configure work package identifiers navigate to **Administration** → **Work 
 
 - **Instance-wide numerical sequence (default)**
      Every work package receives a unique sequential number (for example, `#1234`). The identifier remains unchanged even if the work package is moved to another project.
-- **Project-based semantic identifiers (Beta)**
+- **Project-based semantic identifiers**
     Every work package receives an identifier consisting of the project identifier and a sequential number (for example, `PROJ-11`). Numbering starts at 1 for each project. If a work package is moved to another project, it receives a new project-based identifier while previous identifiers continue to resolve correctly.
 
  ![Administration settings for work package identifiers in OpenProject](openproject_system_guide_wp_identifiers_settings.png)

--- a/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
@@ -20,7 +20,7 @@ OpenProject supports two identifier modes:
 | Mode                                       | Example    |
 | ------------------------------------------ | ---------- |
 | Instance-wide numerical sequence (default) | `#12345`   |
-| Project-based identifiers                  | `PROJ-123` |
+| Project-based semantic identifiers         | `PROJ-123` |
 
 Project-based identifiers make it easier to identify the project a work package belongs to and can help organizations migrating from Jira preserve familiar issue references.
 

--- a/docs/system-admin-guide/manage-work-packages/work-packages-faq/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-packages-faq/README.md
@@ -39,7 +39,7 @@ Historical references remain functional. OpenProject continues to resolve refere
 
 ## Are project-based work package identifiers available everywhere in OpenProject?
 
-Project-based identifiers are supported in many areas of OpenProject. Because the feature is currently available as a Beta feature (as of OpenProject 17.5), some areas of the application may still display numerical identifiers. In these cases, numerical identifiers remain fully functional and continue to resolve to the same work packages.
+Project-based identifiers are supported in many areas of OpenProject. Some areas of the application may still display numerical identifiers; in these cases, numerical identifiers remain fully functional and continue to resolve to the same work packages.
 
 ## Do integrations support project-based work package identifiers?
 

--- a/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
     it "renders the radio buttons as disabled" do
       render_component(component)
       expect(page).to have_field("Instance-wide numerical sequence (default)", disabled: true)
-      expect(page).to have_field("Project-based semantic identifiers (Beta)", disabled: true)
+      expect(page).to have_field("Project-based semantic identifiers", disabled: true)
     end
 
     it "does not render the save or autofix buttons" do
@@ -136,7 +136,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
     it "renders the radio buttons as enabled" do
       render_component(component)
       expect(page).to have_field("Instance-wide numerical sequence (default)", disabled: false)
-      expect(page).to have_field("Project-based semantic identifiers (Beta)", disabled: false)
+      expect(page).to have_field("Project-based semantic identifiers", disabled: false)
     end
 
     it "does not call PreviewQuery" do
@@ -147,7 +147,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
     context "with semantic setting", with_settings: { work_packages_identifier: "semantic" } do
       it "shows semantic as selected" do
         render_component(component)
-        expect(page).to have_field("Project-based semantic identifiers (Beta)", checked: true)
+        expect(page).to have_field("Project-based semantic identifiers", checked: true)
         expect(page).to have_field("Instance-wide numerical sequence (default)", checked: false)
       end
     end
@@ -156,7 +156,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
       it "shows classic as selected" do
         render_component(component)
         expect(page).to have_field("Instance-wide numerical sequence (default)", checked: true)
-        expect(page).to have_field("Project-based semantic identifiers (Beta)", checked: false)
+        expect(page).to have_field("Project-based semantic identifiers", checked: false)
       end
     end
   end

--- a/spec/features/admin/settings/work_packages_identifier_spec.rb
+++ b/spec/features/admin/settings/work_packages_identifier_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Work packages identifier admin settings", :js do
   context "when no projects have problematic identifiers" do
     it "saves the setting without showing a dialog" do
       visit_settings
-      choose "Project-based semantic identifiers (Beta)"
+      choose "Project-based semantic identifiers"
 
       click_button "Convert identifiers"
 
@@ -80,7 +80,7 @@ RSpec.describe "Work packages identifier admin settings", :js do
     context "when switching to semantic" do
       before do
         visit_settings
-        choose "Project-based semantic identifiers (Beta)"
+        choose "Project-based semantic identifiers"
       end
 
       it "shows the autofix section after selecting semantic" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-829

# What are you trying to accomplish?
The semantic identifiers are now finished and stable. So they are not "beta" any more. The UI should reflect that.

## Screenshots
<img width="1214" height="178" alt="image" src="https://github.com/user-attachments/assets/add6db89-52a2-4faa-a71e-6118a8c55580" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
