### PR TITLE
Bug/agile 306 backlogs non admin user can t sort or group by backlog bucket

### DIFF
--- a/app/models/queries/project_phase_definitions/database_queries.rb
+++ b/app/models/queries/project_phase_definitions/database_queries.rb
@@ -34,15 +34,7 @@ module Queries::ProjectPhaseDefinitions
     # Note that one project might have an active phase while another project has set the phase with the same definition
     # to inactive. Additionally, the permissions to view project phases are considered on a project level, too.
     def join_project_phase_definitions_based_on_permissions_and_active_phases
-      # The project is joined here anew which should not be necessary for many use-cases but is.
-      # The necessity comes from AR's behavior of automatically determining the alias for tables LEFT JOINed via includes.
-      # To avoid conflicts, AR will search strings for occurrences of the table name and if found, an included table
-      # will be aliased (potentially with a numbering). In this case, if the permission checks are part of the query,
-      # it will include a reference to the projects table. Therefore, the include for projects, which happens in
-      # the query itself, will be considered needing an alias. That assumption is wrong in this case as the reference
-      # to projects is in a subquery but AR does not know that.
       <<~SQL.squish
-        LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
         LEFT OUTER JOIN (
           SELECT
             ph.id,

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -153,6 +153,17 @@ class Query::Results
     aliases = include_aliases
     reflections = reflection_includes
 
+    # Build a table_name => alias_name map for substitution in non-association sorts.
+    # When Rails aliases an association table (e.g. "projects" -> "projects_work_packages"),
+    # non-association sortable strings that hardcode the table name (e.g. "projects.identifier"
+    # for the semantic id sort) must use the aliased name, too (-> "projects_work_packages.identifier").
+    table_to_alias = reflection_includes.filter_map do |inc|
+      reflection = WorkPackage.reflections[inc.to_s]
+      table_name = reflection.klass.table_name
+      alias_name = aliases[inc]
+      [table_name, alias_name] if alias_name != table_name
+    end.to_h
+
     sorting_by_column_name.each_with_object({}) do |(column_key, sortable), hash|
       column_is_association = reflections.include?(column_key.to_sym)
       columns_hash = columns_hash_for(column_is_association ? column_key : nil)
@@ -160,8 +171,31 @@ class Query::Results
                            alias_name = aliases[column_key.to_sym]
                            expand_association_columns(alias_name, sortable, columns_hash)
                          else
-                           case_insensitive_condition(column_key, sortable, columns_hash)
+                           resolved = apply_association_table_aliases(sortable, table_to_alias)
+                           case_insensitive_condition(column_key, resolved, columns_hash)
                          end
+    end
+  end
+
+  # Replace association table names in sortable SQL expressions with their actual
+  # aliases. This is needed when a raw SQL join causes Rails to alias an association
+  # table (e.g. "projects" -> "projects_work_packages"), but a non-association column's
+  # sortable expression still hardcodes the unaliased table name.
+  def apply_association_table_aliases(sortable, table_to_alias)
+    return sortable if table_to_alias.empty?
+
+    if sortable.is_a?(Array)
+      sortable.map { |s| substitute_association_table_alias(s, table_to_alias) }
+    else
+      substitute_association_table_alias(sortable, table_to_alias)
+    end
+  end
+
+  def substitute_association_table_alias(str, table_to_alias)
+    return str unless str.is_a?(String)
+
+    table_to_alias.reduce(str) do |s, (table_name, alias_name)|
+      s.gsub(/\b#{Regexp.escape(table_name)}\./, "#{alias_name}.")
     end
   end
 
@@ -227,10 +261,19 @@ class Query::Results
   #
   # There is no handling for cases when the same association is joined/included
   # multiple times as the rest of the code should prevent that.
+  #
+  # Raw SQL joins (e.g. the backlog bucket groupable join) may contain nested
+  # subqueries that reference association tables (e.g. INNER JOIN "projects" ON
+  # inside a permission subquery). Rails's AliasTracker scans these raw strings
+  # and counts such occurrences, which can cause it to alias the projects table
+  # as "projects_work_packages". We pre-count the same way so our ORDER BY
+  # expressions use the matching alias.
   def include_aliases
     counts = Hash.new do |h, key|
       h[key] = 0
     end
+
+    raw_join_table_counts(counts)
 
     reflection_includes.each_with_object({}) do |inc, hash|
       reflection = WorkPackage.reflections[inc.to_s]
@@ -239,6 +282,20 @@ class Query::Results
       hash[inc] = reflection_alias(reflection, counts[table_name])
 
       counts[table_name] += 1
+    end
+  end
+
+  # Scan raw SQL join strings for "JOIN ... table ON" patterns, mirroring
+  # ActiveRecord::Associations::AliasTracker.initial_count_for, and increment
+  # counts for each found table name.
+  def raw_join_table_counts(counts)
+    raw_joins = [sort_criteria_joins, query.group_by_join_statement].flatten.compact
+
+    raw_joins.each do |join_sql|
+      join_sql.to_s.scan(/JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:"(\w+)"|(\w+))\s+ON/i) do |quoted, unquoted|
+        table = quoted || unquoted
+        counts[table] += 1 if table
+      end
     end
   end
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -33,6 +33,13 @@ class Query::Results
   include ::Query::Results::Sums
   include Redmine::I18n
 
+  # Mirrors the scan pattern used by ActiveRecord::Associations::AliasTracker.initial_count_for
+  # to detect table references in raw SQL StringJoin nodes. We use the same regex so that
+  # raw_join_table_counts stays in sync with what Rails counts when building alias decisions.
+  # See spec/models/query/results_alias_tracker_parity_spec.rb — that spec directly compares
+  # this constant against the live AliasTracker implementation and will fail if Rails changes theirs.
+  RAW_JOIN_TABLE_SCAN_REGEX = /JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:"(\w+)"|(\w+))\sON/i
+
   attr_accessor :query
 
   def initialize(query)
@@ -292,7 +299,7 @@ class Query::Results
     raw_joins = [sort_criteria_joins, query.group_by_join_statement].flatten.compact
 
     raw_joins.each do |join_sql|
-      join_sql.to_s.scan(/JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:"(\w+)"|(\w+))\s+ON/i) do |quoted, unquoted|
+      join_sql.to_s.scan(RAW_JOIN_TABLE_SCAN_REGEX) do |quoted, unquoted|
         table = quoted || unquoted
         counts[table] += 1 if table
       end

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -155,21 +155,12 @@ class Query::Results
     criteria.map_each { |c| c.map { |raw| Arel.sql raw } }
   end
 
-  def aliased_sorting_by_column_name
+  def aliased_sorting_by_column_name # rubocop:disable Metrics/AbcSize
     sorting_by_column_name = query.sortable_key_by_column_name
     aliases = include_aliases
     reflections = reflection_includes
 
-    # Build a table_name => alias_name map for substitution in non-association sorts.
-    # When Rails aliases an association table (e.g. "projects" -> "projects_work_packages"),
-    # non-association sortable strings that hardcode the table name (e.g. "projects.identifier"
-    # for the semantic id sort) must use the aliased name, too (-> "projects_work_packages.identifier").
-    table_to_alias = reflection_includes.filter_map do |inc|
-      reflection = WorkPackage.reflections[inc.to_s]
-      table_name = reflection.klass.table_name
-      alias_name = aliases[inc]
-      [table_name, alias_name] if alias_name != table_name
-    end.to_h
+    table_to_alias = table_to_alias_map(reflections, aliases)
 
     sorting_by_column_name.each_with_object({}) do |(column_key, sortable), hash|
       column_is_association = reflections.include?(column_key.to_sym)
@@ -275,7 +266,7 @@ class Query::Results
   # and counts such occurrences, which can cause it to alias the projects table
   # as "projects_work_packages". We pre-count the same way so our ORDER BY
   # expressions use the matching alias.
-  def include_aliases
+  def include_aliases # rubocop:disable Metrics/AbcSize
     counts = Hash.new do |h, key|
       h[key] = 0
     end
@@ -304,6 +295,19 @@ class Query::Results
         counts[table] += 1 if table
       end
     end
+  end
+
+  # Build a table_name => alias_name map for substitution in non-association sorts.
+  # When Rails aliases an association table (e.g. "projects" -> "projects_work_packages"),
+  # non-association sortable strings that hardcode the table name (e.g. "projects.identifier"
+  # for the semantic id sort) must use the aliased name, too (-> "projects_work_packages.identifier").
+  def table_to_alias_map(reflection_includes, aliases)
+    reflection_includes.filter_map do |inc|
+      reflection = WorkPackage.reflections[inc.to_s]
+      table_name = reflection.klass.table_name
+      alias_name = aliases[inc]
+      [table_name, alias_name] if alias_name != table_name
+    end.to_h
   end
 
   def reflection_includes

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -296,7 +296,7 @@ class Query::Results
   # ActiveRecord::Associations::AliasTracker.initial_count_for, and increment
   # counts for each found table name.
   def raw_join_table_counts(counts)
-    raw_joins = [sort_criteria_joins, query.group_by_join_statement].flatten.compact
+    raw_joins = [sort_criteria_joins, query.group_by_join_statement, all_filter_joins].flatten.compact
 
     raw_joins.each do |join_sql|
       join_sql.to_s.scan(RAW_JOIN_TABLE_SCAN_REGEX) do |quoted, unquoted|

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -267,19 +267,21 @@ class Query::Results
   # as "projects_work_packages". We pre-count the same way so our ORDER BY
   # expressions use the matching alias.
   def include_aliases # rubocop:disable Metrics/AbcSize
-    counts = Hash.new do |h, key|
-      h[key] = 0
-    end
+    @include_aliases ||= begin
+      counts = Hash.new do |h, key|
+        h[key] = 0
+      end
 
-    raw_join_table_counts(counts)
+      raw_join_table_counts(counts)
 
-    reflection_includes.each_with_object({}) do |inc, hash|
-      reflection = WorkPackage.reflections[inc.to_s]
-      table_name = reflection.klass.table_name
+      reflection_includes.each_with_object({}) do |inc, hash|
+        reflection = WorkPackage.reflections[inc.to_s]
+        table_name = reflection.klass.table_name
 
-      hash[inc] = reflection_alias(reflection, counts[table_name])
+        hash[inc] = reflection_alias(reflection, counts[table_name])
 
-      counts[table_name] += 1
+        counts[table_name] += 1
+      end
     end
   end
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -193,7 +193,8 @@ class Query::Results
     return str unless str.is_a?(String)
 
     table_to_alias.reduce(str) do |s, (table_name, alias_name)|
-      s.gsub(/\b#{Regexp.escape(table_name)}\./, "#{alias_name}.")
+      # Replaces the unquoted (projects.identifier) and quoted ("projects".identifier) table name:
+      s.gsub(/(?:"#{Regexp.escape(table_name)}"|\b#{Regexp.escape(table_name)})\./, "#{alias_name}.")
     end
   end
 
@@ -289,7 +290,7 @@ class Query::Results
   # ActiveRecord::Associations::AliasTracker.initial_count_for, and increment
   # counts for each found table name.
   def raw_join_table_counts(counts)
-    raw_joins = [sort_criteria_joins, query.group_by_join_statement, all_filter_joins].flatten.compact
+    raw_joins = [sort_criteria_joins, query.group_by_join_statement, all_filter_joins].flatten.compact.uniq
 
     raw_joins.each do |join_sql|
       join_sql.to_s.scan(RAW_JOIN_TABLE_SCAN_REGEX) do |quoted, unquoted|

--- a/modules/backlogs/spec/models/query_results_group_by_bucket_spec.rb
+++ b/modules/backlogs/spec/models/query_results_group_by_bucket_spec.rb
@@ -40,7 +40,7 @@ require "rails_helper"
 # pre-count, so the ORDER BY still referenced "projects.identifier" (the
 # semantic-id tiebreaker) instead of "projects_work_packages.identifier",
 # causing a PG::UndefinedTable error.
-RSpec.describe Query::Results, "group by backlog bucket" do
+RSpec.describe Query::Results, "group by bucket" do # rubocop:disable RSpec/SpecFilePathFormat
   shared_let(:project) do
     create(:project, enabled_module_names: %i[work_package_tracking backlogs])
   end

--- a/modules/backlogs/spec/models/query_results_group_by_bucket_spec.rb
+++ b/modules/backlogs/spec/models/query_results_group_by_bucket_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+# Regression spec for AGILE-306: non-admin users could not group by backlog bucket when
+# project-based semantic identifiers (Beta) were enabled.
+#
+# Root cause: the backlog bucket join SQL embeds a subquery containing
+# `INNER JOIN "projects" ON` for permission checks (non-admin path). Rails's
+# AliasTracker scanned that raw string and aliased the projects association as
+# "projects_work_packages". OpenProject's include_aliases didn't mirror this
+# pre-count, so the ORDER BY still referenced "projects.identifier" (the
+# semantic-id tiebreaker) instead of "projects_work_packages.identifier",
+# causing a PG::UndefinedTable error.
+RSpec.describe Query::Results, "group by backlog bucket" do
+  shared_let(:project) do
+    create(:project, enabled_module_names: %i[work_package_tracking backlogs])
+  end
+  shared_let(:bucket) { create(:backlog_bucket, project:, name: "My Bucket") }
+  shared_let(:work_package) { create(:work_package, project:, backlog_bucket: bucket) }
+
+  let(:user) do
+    create(:user,
+           member_with_permissions: { project => %i[view_work_packages view_sprints] })
+  end
+  let(:query) do
+    build(:query,
+          user:,
+          project:,
+          show_hierarchies: false,
+          group_by: "backlog_bucket",
+          column_names: %i[id subject backlog_bucket])
+  end
+
+  current_user { user }
+
+  context "with semantic identifiers enabled",
+          with_settings: { work_packages_identifier: "semantic" } do
+    it "does not raise a SQL error (Regression AGILE-306)" do
+      expect { described_class.new(query).work_packages.to_a }.not_to raise_error
+    end
+
+    it "returns the work package" do
+      expect(described_class.new(query).work_packages).to include(work_package)
+    end
+  end
+
+  context "with classic identifiers enabled",
+          with_settings: { work_packages_identifier: "classic" } do
+    it "does not raise a SQL error" do
+      expect { described_class.new(query).work_packages.to_a }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/query/results_alias_tracker_parity_spec.rb
+++ b/spec/models/query/results_alias_tracker_parity_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Guards against Query::Results::RAW_JOIN_TABLE_SCAN_REGEX drifting away from
+# ActiveRecord::Associations::AliasTracker.initial_count_for's scan pattern.
+#
+# AliasTracker is a private Rails API that counts how many times a table name
+# appears as a JOIN target in raw SQL strings. Query::Results#raw_join_table_counts
+# mirrors this counting so that include_aliases computes the same aliases Rails
+# will actually use. If Rails changes their regex, this spec fails and tells us
+# to update RAW_JOIN_TABLE_SCAN_REGEX accordingly.
+RSpec.describe Query::Results, "RAW_JOIN_TABLE_SCAN_REGEX parity with AliasTracker" do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  def alias_tracker_count(table_name, sql)
+    node = Arel::Nodes::StringJoin.new(Arel.sql(sql))
+    ActiveRecord::Associations::AliasTracker.initial_count_for(connection, table_name, [node])
+  end
+
+  def our_count(table_name, sql)
+    sql.scan(described_class::RAW_JOIN_TABLE_SCAN_REGEX).count do |quoted, unquoted|
+      (quoted || unquoted) == table_name
+    end
+  end
+
+  # Each entry is [table_name, sql_string].
+  # Cover the main patterns we encounter so a Rails regex change is caught early.
+  cases = [
+    # Direct quoted join — the standard Rails-generated form
+    ["projects", 'INNER JOIN "projects" ON "projects"."id" = "members"."project_id"'],
+    # Unquoted join
+    ["projects", "INNER JOIN projects ON projects.id = work_packages.project_id"],
+    # Left outer join
+    ["projects", 'LEFT OUTER JOIN "projects" ON "projects"."id" = x.id'],
+    # Different table
+    ["enabled_modules", 'INNER JOIN "enabled_modules" ON "enabled_modules"."project_id" = "projects"."id"'],
+    # Table referenced in ON clause only — should NOT be counted
+    ["projects", 'INNER JOIN "enabled_modules" ON "enabled_modules"."project_id" = "projects"."id"'],
+    # Nested subquery — mirrors the backlog bucket permission join for non-admin users,
+    # where projects_with_view_sprints.to_sql embeds INNER JOIN "projects" ON inside a subquery.
+    # AliasTracker scans the whole raw string and counts this even though it is nested.
+    ["projects", <<~SQL.squish],
+      LEFT OUTER JOIN (SELECT bb.* FROM backlog_buckets bb) AS visible_buckets
+      ON visible_buckets.id = work_packages.backlog_bucket_id
+      AND work_packages.project_id IN (
+        SELECT "projects"."id" FROM "projects"
+        INNER JOIN "members" ON "members"."project_id" = "projects"."id"
+        INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
+        WHERE "members"."user_id" = 42
+      )
+    SQL
+    # Admin permission path — joins enabled_modules, not projects; projects should be 0
+    ["projects", <<~SQL.squish],
+      INNER JOIN "enabled_modules"
+      ON "enabled_modules"."project_id" = "projects"."id"
+      AND "enabled_modules"."name" = 'backlogs'
+    SQL
+    # Multiple occurrences of the same table
+    ["projects", 'INNER JOIN "projects" ON "projects"."id" = x.id LEFT OUTER JOIN "projects" ON "projects"."id" = y.id'],
+    # Empty string
+    ["projects", ""]
+  ].freeze
+
+  cases.each do |table_name, sql|
+    it "counts #{table_name.inspect} identically to AliasTracker in: #{sql[0, 70]}#{'...' if sql.length > 70}" do
+      expect(our_count(table_name, sql)).to eq(alias_tracker_count(table_name, sql))
+    end
+  end
+end

--- a/spec/models/query/results_project_phase_filter_integration_spec.rb
+++ b/spec/models/query/results_project_phase_filter_integration_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Query::Results, "project phase filter" do
+  shared_let(:definition) { create(:project_phase_definition) }
+  shared_let(:project) { create(:project) }
+  shared_let(:phase) { create(:project_phase, project:, definition:, active: true) }
+  shared_let(:wp_with_phase) { create(:work_package, project:, project_phase_definition: definition) }
+  shared_let(:wp_without_phase) { create(:work_package, project:) }
+
+  let(:user) do
+    create(:user,
+           member_with_permissions: { project => %i[view_work_packages view_project_phases] })
+  end
+
+  current_user { user }
+
+  def build_query(filter_values: [definition.id.to_s])
+    build(:query,
+          user:,
+          project:,
+          show_hierarchies: false,
+          column_names: %i[id subject]).tap do |q|
+      q.add_filter("project_phase_definition_id", "=", filter_values)
+    end
+  end
+
+  context "with semantic identifiers enabled",
+          with_settings: { work_packages_identifier: "semantic" } do
+    it "does not raise a SQL error for a non-admin user (Regression: explicit projects join removal)" do
+      expect { described_class.new(build_query).work_packages.to_a }.not_to raise_error
+    end
+
+    it "returns only the work package with the matching phase" do
+      results = described_class.new(build_query).work_packages
+      expect(results).to include(wp_with_phase)
+      expect(results).not_to include(wp_without_phase)
+    end
+  end
+
+  context "with classic identifiers enabled",
+          with_settings: { work_packages_identifier: "classic" } do
+    it "does not raise a SQL error" do
+      expect { described_class.new(build_query).work_packages.to_a }.not_to raise_error
+    end
+
+    it "returns only the work package with the matching phase" do
+      results = described_class.new(build_query).work_packages
+      expect(results).to include(wp_with_phase)
+      expect(results).not_to include(wp_without_phase)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-306

Grouping by buckets would fail for non-admin users if (and only if) semantic work package identifiers were enabled.

This happens because: `Query::Results` always eagerly loads the project association via `WorkPackage.includes(:project)`. Rails internally runs [AliasTracker](https://github.com/rails/rails/blob/e2c7935ab2e217c88cf2acfb8c5c03719361e311/activerecord/lib/active_record/associations/alias_tracker.rb) to decide whether to alias the resulting join. It does this by text-scanning every raw SQL string already in the query for `JOIN ... "table" ON` patterns. If the table was seen at least once, Rails aliases its generated join — so `projects` becomes `projects_work_packages`. So far, no problem.

The backlog bucket grouping adds a raw SQL join that embeds a permission subquery ([projects_with_view_sprints.to_sql](https://github.com/opf/openproject/blob/32df391a52826f70a0e9144c85645f863fdff21e/modules/backlogs/lib/open_project/backlogs/work_package_bucket_select.rb#L64)). For non-admin users, that subquery internally contains `INNER JOIN "projects" ON (member permission check)`. This references the projects table -> table was seen once. Admin users take a different code path that only joins `enabled_modules`, so their subquery never mentions projects and aliasing never triggers -> projects table was not seen.

For non-admin users, Rails aliases the outmost projects join to `projects_work_packages`. As a result, the ORDER BY of the query breaks. The reason is that with semantic identifiers enabled, it will sort via a [hardcoded project table name](https://github.com/opf/openproject/blob/32df391a52826f70a0e9144c85645f863fdff21e/app/models/queries/work_packages/selects/property_select.rb#L42) that is only defined deep down in the permission check subquery and thus unknown.

```ruby
        if Setting::WorkPackageIdentifier.semantic?
          ["#{Project.table_name}.identifier", "#{WorkPackage.table_name}.sequence_number"]
        else
          "#{WorkPackage.table_name}.id"
        end
```

`Queries::Results#include_aliases` tries to predict which alias will be used by Rails for each table name, in order to build the correct ORDER BY expressions. But, it misses table references inside raw SQL join strings, so our aliases and the aliases defined by Rails can diverge in some cases. Here, this diversion caused the bug.

# What approach did you choose and why?

`Query::Results#include_aliases` now pre-scans all raw SQL join strings (sort criteria joins, group-by join, filter joins) using the same regex pattern as `AliasTracker`, before computing aliases. This ensures its alias prediction matches what Rails will generate.

The regex was copied from Rails (to `Query::Results::RAW_JOIN_TABLE_SCAN_REGEX`). To avoid that a change to Rails silently breaks our application, there is a spec that directly compares our regex against the live `AliasTracker.initial_count_for` implementation, so any future change to the Rails implementation will cause it to go red.

`Query::Results#aliased_sorting_by_column_name` now also applies the computed aliases to non-association sort expressions — replacing hardcoded table names like `projects.identifier` with their actual aliases like `projects_work_packages.identifier`.

As a drive-by cleanup, the project phase definitions join previously worked around the same aliasing issue by adding an explicit `LEFT OUTER JOIN "projects"` to keep the table accessible regardless of the alias. This workaround could now be removed 👏

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
