### PR TITLE
[dream-743] First element is not triggered when pressing Enter

### DIFF
--- a/frontend/src/stimulus/controllers/header-project-select.controller.ts
+++ b/frontend/src/stimulus/controllers/header-project-select.controller.ts
@@ -106,13 +106,12 @@ export default class HeaderProjectSelectController extends Controller {
     const links = this.element.querySelectorAll<HTMLAnchorElement>(
       'a[role="treeitem"][href]:not([aria-disabled="true"])',
     );
-    for (const link of links) {
-      if (!link.closest('[hidden]')) {
-        event.preventDefault();
-        link.click();
-        return;
-      }
-    }
+    const visibleLinks = [...links].filter((link) => !link.closest('[hidden]'));
+    const link = visibleLinks.find((candidate) => candidate.getAttribute('aria-current') === 'true') ?? visibleLinks[0];
+    if (!link) return;
+
+    event.preventDefault();
+    link.click();
   };
 
   private onFilterModeClick = (event:MouseEvent):void => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-743

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Correct the behavior when pressing Enter in the project selector:

- If the current project is visible, open that project.
- Otherwise, open the first visible project.
