### PR TITLE
[COMMS-850] handle target/observed versions in project copy

### DIFF
--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -63,9 +63,16 @@ module Projects::Copy
     def source_work_packages
       source
         .work_packages
-        .includes(:custom_values, :version, :assigned_to, :responsible)
+        .includes(
+          :custom_values,
+          :version,
+          :target_versions,
+          :observed_in_versions,
+          :assigned_to,
+          :responsible
+        )
         .order_by_ancestors("asc")
-        .order("id ASC")
+        .order(:id)
     end
 
     def copy_work_packages(to_copy)
@@ -134,6 +141,8 @@ module Projects::Copy
         project: target,
         parent_id:,
         version_id: work_package_version_id(source_work_package),
+        target_version_ids: work_package_target_version_ids(source_work_package),
+        observed_in_version_ids: work_package_observed_in_version_ids(source_work_package),
         assigned_to_id: work_package_assigned_to_id(source_work_package),
         responsible_id: work_package_responsible_id(source_work_package),
         custom_field_values: custom_value_attributes(source_work_package, user_cf_ids),
@@ -144,8 +153,25 @@ module Projects::Copy
 
     def work_package_version_id(source_work_package)
       return unless source_work_package.version_id
+      return if state.version_id_lookup.nil?
 
       state.version_id_lookup[source_work_package.version_id]
+    end
+
+    def work_package_target_version_ids(source_work_package)
+      lookup = state.version_id_lookup
+      return if lookup.nil?
+
+      # `.presence` forces return nil instead of an empty array when the source has no target
+      # versions. This skips writing target versions unnecessarily and avoid conflicts with legacy version_id
+      source_work_package.target_versions.filter_map { |v| state.version_id_lookup[v.id] }.presence
+    end
+
+    def work_package_observed_in_version_ids(source_work_package)
+      lookup = state.version_id_lookup
+      return if lookup.nil?
+
+      source_work_package.observed_in_versions.filter_map { |v| state.version_id_lookup[v.id] }.presence
     end
 
     def work_package_assigned_to_id(source_work_package)

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -708,6 +708,101 @@ RSpec.describe(
           end
         end
 
+        context "with target_versions" do
+          let(:only_args) { %i[work_packages versions] }
+          let(:version_one) { create(:version, name: "Target One", project: source, status: "open") }
+          let(:version_two) { create(:version, name: "Target Two", project: source, status: "open") }
+
+          before do
+            source_wp.work_package_versions.where(kind: "target").delete_all
+            # Contract validation rejects more than one target version, so we bypass it
+            # here to exercise the copy remapping of multiple target versions
+            [version_one, version_two].each do |v|
+              source_wp.work_package_versions.create!(version_id: v.id, kind: "target")
+            end
+          end
+
+          it "copies the target_versions remapped to the copied project's versions" do
+            expect(subject).to be_success
+
+            wp = copy_of(source_wp)
+            copied_names = wp.target_versions.map(&:name).sort
+            expect(copied_names).to eq(["Target One", "Target Two"])
+            wp.target_versions.each do |v|
+              expect(v.project_id).to eq(project_copy.id)
+              expect([version_one.id, version_two.id]).not_to include(v.id)
+            end
+          end
+        end
+
+        context "with observed_in_versions" do
+          let(:only_args) { %i[work_packages versions] }
+          let(:observed_one) { create(:version, name: "Observed One", project: source, status: "open") }
+          let(:observed_two) { create(:version, name: "Observed Two", project: source, status: "open") }
+
+          before do
+            source_wp.work_package_versions.where(kind: "observed_in").delete_all
+            [observed_one, observed_two].each do |v|
+              source_wp.work_package_versions.create!(version_id: v.id, kind: "observed_in")
+            end
+          end
+
+          it "copies the observed_in_versions remapped to the copied project's versions" do
+            expect(subject).to be_success
+
+            wp = copy_of(source_wp)
+            copied_names = wp.observed_in_versions.map(&:name).sort
+            expect(copied_names).to eq(["Observed One", "Observed Two"])
+            wp.observed_in_versions.each do |v|
+              expect(v.project_id).to eq(project_copy.id)
+              expect([observed_one.id, observed_two.id]).not_to include(v.id)
+            end
+          end
+        end
+
+        context "when a referenced version is not among the copied versions" do
+          let(:only_args) { %i[work_packages versions] }
+          let(:other_project) { create(:project, name: "Other Project") }
+          let(:foreign_version) { create(:version, name: "Foreign", project: other_project, status: "open") }
+
+          before do
+            source_wp.work_package_versions.delete_all
+            source_wp.work_package_versions.create!(version_id: foreign_version.id, kind: "target")
+            source_wp.work_package_versions.create!(version_id: foreign_version.id, kind: "observed_in")
+          end
+
+          it "drops the unmapped versions instead of copying dangling ids" do
+            expect(subject).to be_success
+
+            wp = copy_of(source_wp)
+            expect(wp.target_versions).to be_empty
+            expect(wp.observed_in_versions).to be_empty
+          end
+        end
+
+        context "when versions are not copied along" do
+          let(:only_args) { %i[work_packages] }
+          let(:assigned_version) { create(:version, name: "Assigned", project: source, status: "open") }
+          let(:observed_version) { create(:version, name: "Observed", project: source, status: "open") }
+
+          before do
+            source_wp.work_package_versions.delete_all
+            source_wp.update!(version: assigned_version)
+            source_wp.work_package_versions.create!(version_id: assigned_version.id, kind: "target")
+            source_wp.work_package_versions.create!(version_id: observed_version.id, kind: "observed_in")
+          end
+
+          it "copies the work package without any version assignments" do
+            expect(subject).to be_success
+
+            wp = copy_of(source_wp)
+            expect(wp).not_to be_nil
+            expect(wp.version).to be_nil
+            expect(wp.target_versions).to be_empty
+            expect(wp.observed_in_versions).to be_empty
+          end
+        end
+
         context "with attachments" do
           before do
             create(:attachment, container: work_package)


### PR DESCRIPTION
# Ticket
[COMMS-850](https://community.openproject.org/projects/COMMS/work_packages/COMMS-850/activity)

# What are you trying to accomplish?
- When copying a project it copies target_versions and observed_in_versions as well
- When copying a project it still copies versions the same way as before
- When copying a project and not including versions, it works as well

## Screenshots
[Videocaptura de pantalla_20260703_142445.webm](https://github.com/user-attachments/assets/5a65d8ae-2afa-4d30-9cb4-da8c7597c320)

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
