### PR TITLE
Update op-blocknote-extensions

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.3.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -4127,9 +4127,9 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.5",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
-      "integrity": "sha512-cc3j0BP2R1VmxSjo7st9GRSpysFxF6qsVE09jwI78WxJ2pcOxqewoWIBPPa3l6c5sZDYd3oRVxR03h29shGL0w==",
+      "version": "0.2.0",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
+      "integrity": "sha512-qbRABOjnuKx8RTuheFhg4BPY9AFMaeQsxkrRo1orXgzWOJUDAjvqv7wFQtYx/x1mmDdKfhuxqD7cNuOvmUtTBw==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.3.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
     "tsx": "^4.21.0"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.3.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
         "openapi-explorer": "^2.4.801",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -13754,9 +13754,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.5",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
-      "integrity": "sha512-cc3j0BP2R1VmxSjo7st9GRSpysFxF6qsVE09jwI78WxJ2pcOxqewoWIBPPa3l6c5sZDYd3oRVxR03h29shGL0w==",
+      "version": "0.2.0",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
+      "integrity": "sha512-qbRABOjnuKx8RTuheFhg4BPY9AFMaeQsxkrRo1orXgzWOJUDAjvqv7wFQtYx/x1mmDdKfhuxqD7cNuOvmUtTBw==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -152,7 +152,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.3.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.5/op-blocknote-extensions-0.1.5.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
     "openapi-explorer": "^2.4.801",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -41,8 +41,6 @@ import {
   openProjectWorkPackageBlockSpec,
   openProjectWorkPackageInlineSpec,
   workPackageSlashMenu,
-  useOpBlockNoteExtensions,
-  PasteDeduplicateInstanceIdsExtension,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -119,7 +117,6 @@ export function OpBlockNoteEditor({
       dictionary: localeDictionary,
       ...(attachmentsEnabled && { uploadFile }),
       extensions: [
-        PasteDeduplicateInstanceIdsExtension,
         ExternalLinkA11yExtension,
         ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
       ],
@@ -131,7 +128,6 @@ export function OpBlockNoteEditor({
   // the editor (wiping `Y.UndoManager` history) whenever a fresh `activeUser` reference
   // reached this component, e.g. on Stimulus reconnect / Turbo morph.
   const editor = useCreateBlockNote(editorParams, []);
-  useOpBlockNoteExtensions(editor);
   type EditorType = typeof editor;
   const theme = useOpTheme();
 

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -181,6 +181,29 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         editor.wait_for_autosave { document.reload.description&.include?("####{work_package.id}") }
       end
 
+      it "allows deleting text with Backspace after inserting an inline work package link (bugfix STC-806)" do
+        visit document_path(document)
+        expect(page).to have_test_selector("blocknote-document-description")
+
+        editor.element.send_keys("#tiger")
+        editor.wait_for_shadow_content("pet a tiger")
+        send_keys(:enter)
+        expect(editor.element).to have_no_text("#tiger")
+        expect(editor.element).to have_no_text("…")
+        expect(editor.element).to have_text(/##{work_package.display_id}/)
+
+        # Type right after the chip and delete it again with Backspace. Do NOT click / move the caret
+        # first — the bug only manifested when typing immediately after insertion (moving the caret
+        # elsewhere "fixed" it). send_keys (session-level) targets the already-focused editor.
+        send_keys("abc")
+        expect(editor.element).to have_text("abc")
+
+        send_keys(:backspace, :backspace, :backspace)
+
+        expect(editor.element).to have_no_text("abc")
+        expect(editor.element).to have_text(/##{work_package.display_id}/)
+      end
+
       describe "CTRL-Z undo behavior" do
         it "undoes typed text with CTRL-Z" do
           visit document_path(document)


### PR DESCRIPTION
This includes:
- [BNE-118] Wrong placement of context menu if inline work package link spans multiple lines
- [COMMS-806] Allow to delete characters after adding work package link
- [BNE-117] Low contrast text in documents inline work package links that makes it hard to read
- [BNE-99] Replace pastededuplicate
- [BNE-113] Inline work package links which the user can not access should have a speaking message

# Tickets
https://community.openproject.org/wp/BNE-118
https://community.openproject.org/wp/COMMS-806
https://community.openproject.org/wp/BNE-117
https://community.openproject.org/wp/BNE-99
https://community.openproject.org/wp/BNE-113

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

Matching PR in op-blocknote-extensions: https://github.com/opf/op-blocknote-extensions/pull/176