### PR TITLE
[MEET-513] Add caption to recurring meeting create/edit forms to show end date/no. of occurrences 

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.spec.ts
@@ -70,6 +70,9 @@ describe('Recurring meetings form controller', () => {
       <form data-controller="recurring-meetings--form">
         <input name="meeting[start_date]" value="2026-06-11">
         <input name="meeting[frequency]" value="weekly">
+        <input name="meeting[end_after]" value="specific_date">
+        <input name="meeting[end_date]" value="2026-08-11">
+        <input name="meeting[iterations]" value="7">
       </form>
     `);
     return ctx.getController<RecurringMeetingsFormControllerType>('recurring-meetings--form');
@@ -95,6 +98,9 @@ describe('Recurring meetings form controller', () => {
     expect(url).toContain('/op/recurring_meetings/humanize_schedule?');
     expect(url).toContain('2026-06-11');
     expect(url).toContain('weekly');
+    expect(url).toContain('specific_date');
+    expect(url).toContain('2026-08-11');
+    expect(url).toContain('iterations');
   });
 
   it('does not request when disconnected before the context resolves', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
@@ -19,6 +19,9 @@ export default class OpRecurringMeetingsFormController extends OpMeetingsFormCon
       'monthly_ordinal',
       'monthly_weekday',
       'time_zone',
+      'end_after',
+      'end_date',
+      'iterations',
     ].forEach((name) => {
       const key = `meeting[${name}]`;
       urlSearchParams.append(key, data.get(key) as string);

--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -111,7 +111,14 @@
                       "show-when-value-selected-target": "effect"
                     }
                   ) do
-                    render(RecurringMeeting::SpecificDate.new(f, meeting: @meeting))
+                    flex_layout do |specific_date|
+                      specific_date.with_row do
+                        render(RecurringMeeting::SpecificDate.new(f, meeting: @meeting))
+                      end
+                      specific_date.with_row(mt: 1) do
+                        render(RecurringMeetings::OccurrenceCountCaptionComponent.new(recurring_meeting: @meeting))
+                      end
+                    end
                   end
 
                   end_after.with_row(
@@ -122,7 +129,14 @@
                       "show-when-value-selected-target": "effect"
                     }
                   ) do
-                    render(RecurringMeeting::Iterations.new(f))
+                    flex_layout do |iterations|
+                      iterations.with_row do
+                        render(RecurringMeeting::Iterations.new(f))
+                      end
+                      iterations.with_row(mt: 1) do
+                        render(RecurringMeetings::EndDateCaptionComponent.new(recurring_meeting: @meeting))
+                      end
+                    end
                   end
                 end
               end

--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -99,9 +99,7 @@
                 render(RecurringMeeting::EndAfter.new(f))
               end
 
-              frequency_row.with_column(
-                flex: 1
-              ) do
+              frequency_row.with_column(flex: 1) do
                 flex_layout do |end_after|
                   end_after.with_row(
                     hidden: !@meeting.end_after_specific_date?,
@@ -111,14 +109,7 @@
                       "show-when-value-selected-target": "effect"
                     }
                   ) do
-                    flex_layout do |specific_date|
-                      specific_date.with_row do
-                        render(RecurringMeeting::SpecificDate.new(f, meeting: @meeting))
-                      end
-                      specific_date.with_row(mt: 1) do
-                        render(RecurringMeetings::OccurrenceCountCaptionComponent.new(recurring_meeting: @meeting))
-                      end
-                    end
+                    render(RecurringMeeting::SpecificDate.new(f, meeting: @meeting))
                   end
 
                   end_after.with_row(
@@ -129,14 +120,7 @@
                       "show-when-value-selected-target": "effect"
                     }
                   ) do
-                    flex_layout do |iterations|
-                      iterations.with_row do
-                        render(RecurringMeeting::Iterations.new(f))
-                      end
-                      iterations.with_row(mt: 1) do
-                        render(RecurringMeetings::EndDateCaptionComponent.new(recurring_meeting: @meeting))
-                      end
-                    end
+                    render(RecurringMeeting::Iterations.new(f))
                   end
                 end
               end

--- a/modules/meeting/app/components/recurring_meetings/end_date_caption_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/end_date_caption_component.html.erb
@@ -1,0 +1,11 @@
+<%=
+  component_wrapper do
+    render(
+      Primer::Beta::Text.new(
+        id: "recurring-meeting-end-date-caption",
+        font_size: :small,
+        color: :subtle
+      )
+    ) { caption_text }
+  end
+%>

--- a/modules/meeting/app/components/recurring_meetings/end_date_caption_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/end_date_caption_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,21 +28,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class RecurringMeeting::EndAfter < ApplicationForm
-  form do |meeting_form|
-    meeting_form.select_list(
-      name: "end_after",
-      required: true,
-      label: I18n.t("activerecord.attributes.recurring_meeting.end_after"),
-      data: {
-        target_name: "end_after",
-        "show-when-value-selected-target": "cause",
-        action: "input->recurring-meetings--form#updateFrequencyText"
-      }
-    ) do |list|
-      list.option(value: "never", label: I18n.t("recurring_meeting.end_after.never"))
-      list.option(value: "specific_date", label: I18n.t("recurring_meeting.end_after.specific_date"))
-      list.option(value: "iterations", label: I18n.t("recurring_meeting.end_after.iterations"))
+module RecurringMeetings
+  class EndDateCaptionComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+    include Redmine::I18n
+
+    def initialize(recurring_meeting:)
+      super
+
+      @recurring_meeting = recurring_meeting
+    end
+
+    def caption_text
+      end_date = @recurring_meeting.end_date_for_iterations
+      return "" if end_date.nil?
+
+      I18n.t("recurring_meeting.caption.ends_on", date: format_date(end_date))
     end
   end
 end

--- a/modules/meeting/app/components/recurring_meetings/occurrence_count_caption_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/occurrence_count_caption_component.html.erb
@@ -1,0 +1,11 @@
+<%=
+  component_wrapper do
+    render(
+      Primer::Beta::Text.new(
+        id: "recurring-meeting-occurrence-count-caption",
+        font_size: :small,
+        color: :subtle
+      )
+    ) { caption_text }
+  end
+%>

--- a/modules/meeting/app/components/recurring_meetings/occurrence_count_caption_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/occurrence_count_caption_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,21 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class RecurringMeeting::EndAfter < ApplicationForm
-  form do |meeting_form|
-    meeting_form.select_list(
-      name: "end_after",
-      required: true,
-      label: I18n.t("activerecord.attributes.recurring_meeting.end_after"),
-      data: {
-        target_name: "end_after",
-        "show-when-value-selected-target": "cause",
-        action: "input->recurring-meetings--form#updateFrequencyText"
-      }
-    ) do |list|
-      list.option(value: "never", label: I18n.t("recurring_meeting.end_after.never"))
-      list.option(value: "specific_date", label: I18n.t("recurring_meeting.end_after.specific_date"))
-      list.option(value: "iterations", label: I18n.t("recurring_meeting.end_after.iterations"))
+module RecurringMeetings
+  class OccurrenceCountCaptionComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+    include Redmine::I18n
+
+    def initialize(recurring_meeting:)
+      super
+
+      @recurring_meeting = recurring_meeting
+    end
+
+    def caption_text
+      count = @recurring_meeting.occurrence_count_until_end_date
+      return "" if count.nil? || count.zero?
+
+      if count > RecurringMeeting::MAX_ITERATIONS
+        I18n.t("recurring_meeting.caption.occurrences_capped", count: RecurringMeeting::MAX_ITERATIONS)
+      else
+        I18n.t("recurring_meeting.caption.occurrences", count:)
+      end
     end
   end
 end

--- a/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
@@ -8,8 +8,14 @@ module RecurringMeetings
     no_authorization_required! :humanize_schedule
 
     def humanize_schedule
-      component = RecurringMeetings::HumanScheduleComponent.new(recurring_meeting: @recurring_meeting)
-      update_via_turbo_stream(component:)
+      [
+        RecurringMeetings::HumanScheduleComponent,
+        RecurringMeetings::OccurrenceCountCaptionComponent,
+        RecurringMeetings::EndDateCaptionComponent
+      ].each do |component|
+        update_via_turbo_stream(component: component.new(recurring_meeting: @recurring_meeting))
+      end
+
       respond_with_turbo_streams
     end
 
@@ -25,7 +31,7 @@ module RecurringMeetings
 
     def schedule_params
       params.expect(meeting: %i[start_date start_time_hour frequency interval monthly_day monthly_ordinal
-                                monthly_weekday time_zone])
+                                monthly_weekday time_zone end_after end_date iterations])
     end
   end
 end

--- a/modules/meeting/app/forms/recurring_meeting/iterations.rb
+++ b/modules/meeting/app/forms/recurring_meeting/iterations.rb
@@ -34,7 +34,10 @@ class RecurringMeeting::Iterations < ApplicationForm
       type: :number,
       step: 1,
       max: RecurringMeeting::MAX_ITERATIONS,
-      label: I18n.t("activerecord.attributes.recurring_meeting.iterations")
+      label: I18n.t("activerecord.attributes.recurring_meeting.iterations"),
+      data: {
+        action: "input->recurring-meetings--form#updateFrequencyText"
+      }
     )
   end
 end

--- a/modules/meeting/app/forms/recurring_meeting/iterations/iterations_caption.html.erb
+++ b/modules/meeting/app/forms/recurring_meeting/iterations/iterations_caption.html.erb
@@ -1,0 +1,1 @@
+<%= render(RecurringMeetings::EndDateCaptionComponent.new(recurring_meeting: model)) %>

--- a/modules/meeting/app/forms/recurring_meeting/specific_date.rb
+++ b/modules/meeting/app/forms/recurring_meeting/specific_date.rb
@@ -35,7 +35,10 @@ class RecurringMeeting::SpecificDate < ApplicationForm
       value: @value,
       label: I18n.t("activerecord.attributes.recurring_meeting.end_date"),
       required: false,
-      autofocus: false
+      autofocus: false,
+      data: {
+        action: "input->recurring-meetings--form#updateFrequencyText"
+      }
     )
   end
 

--- a/modules/meeting/app/forms/recurring_meeting/specific_date/end_date_caption.html.erb
+++ b/modules/meeting/app/forms/recurring_meeting/specific_date/end_date_caption.html.erb
@@ -1,0 +1,1 @@
+<%= render(RecurringMeetings::OccurrenceCountCaptionComponent.new(recurring_meeting: model)) %>

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -393,6 +393,22 @@ class RecurringMeeting < ApplicationRecord
     first_occurrence != start_time
   end
 
+  def occurrence_count_until_end_date
+    return unless end_after_specific_date?
+    return if end_date.blank? || start_time.blank?
+    return if parsed_start_date.present? && end_date < parsed_start_date
+
+    schedule.next_occurrences(MAX_ITERATIONS + 1, Time.current).size
+  end
+
+  def end_date_for_iterations
+    return unless end_after_iterations?
+    return if iterations.blank? || start_time.blank?
+    return unless iterations.between?(1, MAX_ITERATIONS)
+
+    last_occurrence
+  end
+
   private
 
   def unset_schedule

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -504,6 +504,12 @@ en:
         fourth: "Fourth"
         last: "Last"
     actual_first_occurrence_mismatch_html: "The first occurrence of this series will be %{first_occurrence}"
+    caption:
+      ends_on: "This results in a series ending on %{date}"
+      occurrences:
+        one: "This results in 1 meeting occurrence"
+        other: "This results in %{count} meeting occurrences"
+      occurrences_capped: "This results in more than %{count} meeting occurrences"
     day_of_month_skipping_info: "Months with fewer than %{monthly_day} days will be skipped"
     end_after:
       never: "Never"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -507,9 +507,9 @@ en:
     caption:
       ends_on: "This results in a series ending on %{date}"
       occurrences:
-        one: "This results in 1 meeting occurrence"
-        other: "This results in %{count} meeting occurrences"
-      occurrences_capped: "This results in more than %{count} meeting occurrences"
+        one: "This results in 1 upcoming occurrence"
+        other: "This results in %{count} upcoming occurrences"
+      occurrences_capped: "This results in more than %{count} upcoming occurrences"
     day_of_month_skipping_info: "Months with fewer than %{monthly_day} days will be skipped"
     end_after:
       never: "Never"

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -453,4 +453,80 @@ RSpec.describe RecurringMeeting,
       expect(series.uid).to include "@#{Setting.host_name}"
     end
   end
+
+  describe "#occurrence_count_until_end_date" do
+    it "counts the remaining occurrences up to the end date" do
+      series = build(:recurring_meeting,
+                     start_time: Time.zone.tomorrow + 10.hours,
+                     frequency: "daily",
+                     end_after: "specific_date",
+                     end_date: Time.zone.tomorrow + 1.week)
+
+      expect(series.occurrence_count_until_end_date).to eq 8
+    end
+
+    it "counts the remaining occurrences for a non-daily frequency" do
+      series = build(:recurring_meeting,
+                     start_time: Time.zone.tomorrow + 10.hours,
+                     frequency: "weekly",
+                     end_after: "specific_date",
+                     end_date: Time.zone.tomorrow + 4.weeks)
+
+      expect(series.occurrence_count_until_end_date).to eq 5
+    end
+
+    it "returns nil when the end date is before the start date" do
+      series = build(:recurring_meeting,
+                     start_time: Time.zone.tomorrow + 10.days + 10.hours,
+                     frequency: "daily",
+                     end_after: "specific_date",
+                     end_date: Time.zone.tomorrow)
+
+      expect(series.occurrence_count_until_end_date).to be_nil
+    end
+
+    it "caps the count for far-future end dates" do
+      series = build(:recurring_meeting,
+                     start_time: Time.zone.tomorrow + 10.hours,
+                     frequency: "daily",
+                     end_after: "specific_date",
+                     end_date: Time.zone.tomorrow + 5.years)
+
+      expect(series.occurrence_count_until_end_date).to eq RecurringMeeting::MAX_ITERATIONS + 1
+    end
+
+    it "returns nil when the series does not end on a specific date" do
+      series = build(:recurring_meeting, end_after: "iterations", iterations: 3)
+
+      expect(series.occurrence_count_until_end_date).to be_nil
+    end
+  end
+
+  describe "#end_date_for_iterations" do
+    it "returns the last occurrence for the given number of iterations" do
+      series = build(:recurring_meeting,
+                     start_time: Time.zone.tomorrow + 10.hours,
+                     frequency: "daily",
+                     end_after: "iterations",
+                     iterations: 3)
+
+      expect(series.end_date_for_iterations).to eq Time.zone.tomorrow + 2.days + 10.hours
+    end
+
+    it "returns nil when the series does not end after iterations" do
+      series = build(:recurring_meeting,
+                     end_after: "specific_date",
+                     end_date: Time.zone.tomorrow + 1.week)
+
+      expect(series.end_date_for_iterations).to be_nil
+    end
+
+    it "returns nil when iterations exceed the maximum" do
+      series = build(:recurring_meeting,
+                     end_after: "iterations",
+                     iterations: RecurringMeeting::MAX_ITERATIONS + 1)
+
+      expect(series.end_date_for_iterations).to be_nil
+    end
+  end
 end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe "Recurring meetings schedule text",
         it "returns the resulting occurrence count" do
           expect(subject).to have_http_status(:ok)
           expect(subject.body).to include("target=\"recurring-meetings-occurrence-count-caption-component\"")
-          expect(subject.body).to include("This results in 5 meeting occurrences")
+          expect(subject.body).to include("This results in 5 upcoming occurrences")
         end
 
         context "when the end date is before the start date" do
@@ -239,7 +239,7 @@ RSpec.describe "Recurring meetings schedule text",
 
           it "reports the capped count" do
             expect(subject).to have_http_status(:ok)
-            expect(subject.body).to include("This results in more than 1000 meeting occurrences")
+            expect(subject.body).to include("This results in more than 1000 upcoming occurrences")
           end
         end
       end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
@@ -207,6 +207,71 @@ RSpec.describe "Recurring meetings schedule text",
         end
       end
     end
+
+    describe "setting the end condition" do
+      context "when ending after a specific date" do
+        let(:start_date) { "2099-01-01" }
+        let(:end_date) { "2099-01-05" }
+        let(:params) do
+          { meeting: { start_time_hour:, start_date:, frequency:, interval:,
+                       end_after: "specific_date", end_date: } }
+        end
+
+        it "returns the resulting occurrence count" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("target=\"recurring-meetings-occurrence-count-caption-component\"")
+          expect(subject.body).to include("This results in 5 meeting occurrences")
+        end
+
+        context "when the end date is before the start date" do
+          let(:start_date) { "2099-01-10" }
+          let(:end_date) { "2099-01-05" }
+
+          it "renders the caption target without any occurrence count" do
+            expect(subject).to have_http_status(:ok)
+            expect(subject.body).to include("target=\"recurring-meetings-occurrence-count-caption-component\"")
+            expect(subject.body).not_to include("This results in")
+          end
+        end
+
+        context "when the range exceeds the maximum count" do
+          let(:end_date) { "2105-01-01" }
+
+          it "reports the capped count" do
+            expect(subject).to have_http_status(:ok)
+            expect(subject.body).to include("This results in more than 1000 meeting occurrences")
+          end
+        end
+      end
+
+      context "when ending after a number of occurrences" do
+        let(:start_date) { "2099-01-01" }
+        let(:params) do
+          { meeting: { start_time_hour:, start_date:, frequency:, interval:,
+                       end_after: "iterations", iterations: "3" } }
+        end
+
+        it "returns the resulting end date" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("target=\"recurring-meetings-end-date-caption-component\"")
+          expect(subject.body).to include("This results in a series ending on")
+          expect(subject.body).to include("2099")
+        end
+      end
+
+      context "when the series never ends" do
+        let(:params) do
+          { meeting: { start_time_hour:, start_date:, frequency:, interval:, end_after: "never" } }
+        end
+
+        it "renders both caption targets without any resulting text" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("target=\"recurring-meetings-occurrence-count-caption-component\"")
+          expect(subject.body).to include("target=\"recurring-meetings-end-date-caption-component\"")
+          expect(subject.body).not_to include("This results in")
+        end
+      end
+    end
   end
 
   context "when not logged in" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
 https://community.openproject.org/wp/MEET-513

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Add captions to make it easier to understand when a series runs until 

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
- Reused what we already have for the humanized schedule

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
