### PR TITLE
[OP#XWI-52] Removes the `wiki` project module

### DIFF
--- a/app/models/enabled_module.rb
+++ b/app/models/enabled_module.rb
@@ -41,18 +41,8 @@ class EnabledModule < ApplicationRecord
 
   # after_create callback used to do things when a module is enabled
   def module_enabled
-    case name
-    when "wiki"
-      # Create a wiki with a default start page
-      if project && project.wiki.nil?
-        Wiki.create(project:, start_page: "Wiki")
-      end
-    when "repository"
-      if project &&
-         project.repository.nil? &&
-         Setting.repositories_automatic_managed_vendor.present?
-        create_managed_repository
-      end
+    if name == "repository" && project&.repository.nil? && Setting.repositories_automatic_managed_vendor.present?
+      create_managed_repository
     end
 
     OpenProject::Notifications.send(OpenProject::Events::MODULE_ENABLED, enabled_module: self)
@@ -64,8 +54,7 @@ class EnabledModule < ApplicationRecord
       scm_type: Repository.managed_type
     }
 
-    service = SCM::RepositoryFactoryService.new(project,
-                                                ActionController::Parameters.new(params))
+    service = SCM::RepositoryFactoryService.new(project, ActionController::Parameters.new(params))
     service.build_and_save
   end
 end

--- a/app/models/menu_items/wiki_menu_item.rb
+++ b/app/models/menu_items/wiki_menu_item.rb
@@ -29,7 +29,7 @@
 #++
 
 class MenuItems::WikiMenuItem < MenuItem
-  belongs_to :wiki, foreign_key: "navigatable_id"
+  belongs_to :wiki, foreign_key: "navigatable_id", inverse_of: :wiki_menu_items
 
   scope :main_items, ->(wiki_id) {
     where(navigatable_id: wiki_id, parent_id: nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -231,10 +231,6 @@ class Project < ApplicationRecord
     self
   end
 
-  def wiki
-    super&.enabled ? super : nil
-  end
-
   def <=>(other)
     name.downcase <=> other.name.downcase
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -243,7 +243,7 @@ class Project < ApplicationRecord
     name
   end
 
-  def w
+  def workspace_label
     case workspace_type
     when "program"
       I18n.t("label_program")

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -232,7 +232,7 @@ class Project < ApplicationRecord
   end
 
   def wiki
-    super.enabled ? super : nil
+    super&.enabled ? super : nil
   end
 
   def <=>(other)
@@ -243,7 +243,7 @@ class Project < ApplicationRecord
     name
   end
 
-  def workspace_label
+  def w
     case workspace_type
     when "program"
       I18n.t("label_program")

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -169,7 +169,7 @@ class Project < ApplicationRecord
   # neither development nor deployment setups are prepared for this
   # validates_presence_of :types
 
-  validates_associated :repository, :wiki
+  validates_associated :repository
 
   scopes :activated_in_storage,
          :allowed_to,
@@ -229,6 +229,10 @@ class Project < ApplicationRecord
 
   def project
     self
+  end
+
+  def wiki
+    super.enabled ? super : nil
   end
 
   def <=>(other)

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -30,12 +30,16 @@
 
 class Wiki < ApplicationRecord
   belongs_to :project
-  has_many :pages, -> {
-    order("title")
-  }, class_name: "WikiPage", dependent: :destroy
-  has_many :wiki_menu_items, -> {
-    order("name")
-  }, class_name: "MenuItems::WikiMenuItem", dependent: :delete_all, foreign_key: "navigatable_id"
+
+  has_many :pages, -> { order(:title) }, class_name: "WikiPage", inverse_of: :wiki, dependent: :destroy
+
+  has_many :wiki_menu_items,
+           -> { order(:name) },
+           class_name: "MenuItems::WikiMenuItem",
+           inverse_of: :wiki,
+           dependent: :delete_all,
+           foreign_key: "navigatable_id"
+
   has_many :redirects, class_name: "WikiRedirect", dependent: :delete_all
 
   acts_as_watchable permission: :view_wiki_pages
@@ -49,7 +53,7 @@ class Wiki < ApplicationRecord
   after_create :create_menu_item_for_start_page
 
   def visible?(user = User.current)
-    !user.nil? && user.allowed_in_project?(:view_wiki_pages, project)
+    enabled && user&.allowed_in_project?(:view_wiki_pages, project)
   end
 
   # find the page with the given title

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -53,8 +53,10 @@ class Wiki < ApplicationRecord
   after_create :create_menu_item_for_start_page
 
   def visible?(user = User.current)
-    enabled && user&.allowed_in_project?(:view_wiki_pages, project)
+    enabled && user.allowed_in_project?(:view_wiki_pages, project)
   end
+
+  def disabled? = !enabled?
 
   # find the page with the given title
   # if page doesn't exist, return a new page

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -72,11 +72,8 @@ module DemoData
     def set_wiki!(version, config)
       return unless config
 
-      # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
-
       unless Wiki.exists?(project: version.project)
-        Wiki.create!(project: version.project, start_page: "Wiki")
-        version.project.reload
+        version.project.create_wiki(start_page: "Wiki")
       end
 
       version.wiki_page_title = config["title"]

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -72,6 +72,13 @@ module DemoData
     def set_wiki!(version, config)
       return unless config
 
+      # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
+
+      unless Wiki.exists?(project: version.project)
+        Wiki.create!(project: version.project, start_page: "Wiki")
+        version.project.reload
+      end
+
       version.wiki_page_title = config["title"]
 
       Journal::NotificationConfiguration.with false do

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -37,11 +37,10 @@ module DemoData
     end
 
     def seed_data!
-      create_project_wiki!
-
       text = project_data.lookup("wiki")
-
       return if text.blank?
+
+      create_project_wiki!
 
       if text.is_a? String
         text = [{ title: "Wiki", content: text }]

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -56,12 +56,10 @@ module DemoData
       end
     end
 
-    # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
     def create_project_wiki!
-      return project.reload.wiki if Wiki.exists?(project: @project)
+      Wiki.create!(project: project, start_page: "Wiki") unless Wiki.exists?(project:)
 
-      Wiki.create!(project: @project, start_page: "Wiki")
-      @project.reload
+      project.reload
     end
 
     def create_wiki_page!(data, project:, parent: nil)

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -37,6 +37,8 @@ module DemoData
     end
 
     def seed_data!
+      create_project_wiki!
+
       text = project_data.lookup("wiki")
 
       return if text.blank?
@@ -53,6 +55,14 @@ module DemoData
           project:
         )
       end
+    end
+
+    # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
+    def create_project_wiki!
+      return project.reload.wiki if Wiki.exists?(project: @project)
+
+      Wiki.create!(project: @project, start_page: "Wiki")
+      @project.reload
     end
 
     def create_wiki_page!(data, project:, parent: nil)

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -215,7 +215,6 @@ projects:
       - work_package_tracking
       - news
       - gantt
-      - wiki
       - board_view
       - team_planner_view
       - meetings
@@ -562,7 +561,6 @@ projects:
     modules:
       - backlogs
       - news
-      - wiki
       - work_package_tracking
       - gantt
       - board_view

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -537,32 +537,6 @@ Rails.application.reloader.to_prepare do
                       permissible_on: :project
     end
 
-    map.project_module :wiki do |wiki|
-      wiki.permission :view_wiki_pages,
-                      { wiki: %i[index show special menu export] },
-                      permissible_on: :project
-
-      wiki.permission :view_wiki_edits,
-                      { wiki: %i[history diff annotate] },
-                      dependencies: :view_wiki_pages,
-                      permissible_on: :project
-
-      wiki.permission :edit_wiki_pages,
-                      { wiki: %i[edit update preview add_attachment new new_child create rename] },
-                      dependencies: :view_wiki_pages,
-                      permissible_on: :project
-
-      wiki.permission :manage_wiki,
-                      {
-                        wiki: %i[destroy protect edit_parent_page update_parent_page],
-                        wikis: %i[edit destroy],
-                        wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item]
-                      },
-                      dependencies: :edit_wiki_pages,
-                      permissible_on: :project,
-                      require: :member
-    end
-
     map.project_module :repository do |repo|
       repo.permission :browse_repository,
                       { repositories: %i[show browse entry annotate changes diff stats graph] },

--- a/db/migrate/20260708100831_add_enabled_column_to_wikis_table.rb
+++ b/db/migrate/20260708100831_add_enabled_column_to_wikis_table.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AddsEnabledColumnToWikisTable < ActiveRecord::Migration[8.1]
+class AddEnabledColumnToWikisTable < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def up

--- a/db/migrate/20260708100831_adds_enabled_column_to_wikis_table.rb
+++ b/db/migrate/20260708100831_adds_enabled_column_to_wikis_table.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddsEnabledColumnToWikisTable < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    say "Creating enabled column on wikis"
+    add_column :wikis, :enabled, :boolean, default: true, null: false
+
+    transaction do
+      say "Updating wiki enabled state based on enabled modules"
+      execute <<~SQL.squish
+        UPDATE wikis
+        SET enabled = false
+        WHERE project_id NOT IN (select project_id from enabled_modules where name = 'wiki');
+      SQL
+
+      say "Removing wiki from the list of enabled modules"
+      execute <<~SQL.squish
+        DELETE FROM enabled_modules WHERE name = 'wiki';
+      SQL
+    end
+  end
+
+  def down
+    execute <<~SQL.squish
+      INSERT INTO enabled_modules (project_id, name)
+      SELECT project_id, 'wiki' from wikis where enabled = true;
+    SQL
+
+    remove_column :wikis, :enabled
+  end
+end

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -28,7 +28,7 @@
 
 module Redmine::MenuManager::WikiMenuHelper
   def build_wiki_menus(project)
-    return unless Wikis::InternalProvider.enabled.any?
+    return unless Wikis::InternalProvider.enabled?
 
     project_wiki = project.wiki
     return if project_wiki.nil?

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -31,7 +31,7 @@ module Redmine::MenuManager::WikiMenuHelper
     return unless Wikis::InternalProvider.enabled?
 
     project_wiki = project.wiki
-    return if project_wiki.nil?
+    return if project_wiki.nil? || project.wiki.disabled?
 
     wiki_main_items(project_wiki).reverse_each do |main_item|
       Redmine::MenuManager.loose :project_menu do |menu|

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -28,7 +28,7 @@
 
 module Redmine::MenuManager::WikiMenuHelper
   def build_wiki_menus(project)
-    return unless project.enabled_module_names.include? "wiki"
+    return unless Wikis::InternalProvider.enabled.any?
 
     project_wiki = project.wiki
     return if project_wiki.nil?

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -244,7 +244,6 @@ projects:
       - work_package_tracking
       - gantt
       - news
-      - wiki
       - board_view
       - team_planner_view
       - documents
@@ -393,7 +392,6 @@ projects:
       - work_package_tracking
       - gantt
       - news
-      - wiki
       - board_view
       - team_planner_view
       - documents
@@ -875,7 +873,6 @@ projects:
       - work_package_tracking
       - gantt
       - news
-      - wiki
       - board_view
       - team_planner_view
     news:

--- a/modules/bim/app/seeders/bim/basic_data_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data_seeder.rb
@@ -45,6 +45,7 @@ module Bim
         ::BasicData::PrioritySeeder,
         ::Bim::BasicData::SettingSeeder,
         ::Bim::BasicData::ThemeSeeder
+
       ]
     end
   end

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe RootSeeder,
 
     it "creates the BIM demo data" do
       expect(Project.count).to eq 4
-      expect(EnabledModule.count).to eq 29
+      expect(EnabledModule.count).to eq 26
       expect(WorkPackage.count).to eq 76
-      expect(Wiki.count).to eq 3
+      expect(Wiki.count).to eq 0
       expect(Query.count).to eq 29
       expect(Group.count).to eq 8
       expect(Type.count).to eq 7
@@ -138,7 +138,7 @@ RSpec.describe RootSeeder,
       it "does not create additional data and does not raise any errors" do
         expect(Project.count).to eq 4
         expect(WorkPackage.count).to eq 76
-        expect(Wiki.count).to eq 3
+        expect(Wiki.count).to eq 0
         expect(Query.count).to eq 29
         expect(Group.count).to eq 8
         expect(Type.count).to eq 7

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -55,10 +55,11 @@ RSpec.describe "boards onboarding tour",
 
   let(:demo_project) do
     create(:project,
+           :with_internal_wiki,
            name: "Demo project",
            identifier: "demo-project",
            public: true,
-           enabled_module_names: %w[work_package_tracking gantt wiki board_view])
+           enabled_module_names: %w[work_package_tracking gantt board_view]).reload
   end
   let!(:wp1) { create(:work_package, project: demo_project) }
 

--- a/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
+++ b/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
@@ -40,10 +40,11 @@ RSpec.describe "team planner onboarding tour",
 
   let(:demo_project) do
     create(:project,
+           :with_internal_wiki,
            name: "Demo project",
            identifier: "demo-project",
            public: true,
-           enabled_module_names: %w[work_package_tracking gantt wiki team_planner_view])
+           enabled_module_names: %w[work_package_tracking gantt team_planner_view]).reload
   end
 
   let(:user) do

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -32,14 +32,15 @@ See COPYRIGHT and LICENSE files for more details.
     render(
       Primer::Forms::ToggleSwitchForm.new(
         name: "enable_interal_wiki",
-        label: t("projects.settings.internal_wiki.enable"),
-        caption: t("projects.settings.internal_wiki.caption"),
+        label: t(".enable"),
+        caption: t(".caption"),
         src: project_settings_wiki_path(@project),
         csrf_token: form_authenticity_token,
         status_label_position: :start,
         checked: wiki_enabled?,
         data: { turbo: true },
-        mb: 3
+        mb: 3,
+        test_selector: "project-settings-enable-wiki"
       )
     )
   %>

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -1,0 +1,46 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= component_wrapper(class: "op-admin-settings-form-wrapper") do %>
+  <%=
+    render(
+      Primer::Forms::ToggleSwitchForm.new(
+        name: "enable_interal_wiki",
+        label: t("projects.settings.internal_wiki.enable"),
+        caption: t("projects.settings.internal_wiki.caption"),
+        src: project_settings_wiki_path(@project),
+        csrf_token: form_authenticity_token,
+        status_label_position: :start,
+        checked: has_wiki?,
+        data: { turbo: true },
+        mb: 3
+      )
+    )
+  %>
+<% end %>

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
         src: project_settings_wiki_path(@project),
         csrf_token: form_authenticity_token,
         status_label_position: :start,
-        checked: has_wiki?,
+        checked: wiki_enabled?,
         data: { turbo: true },
         mb: 3
       )

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -39,8 +39,8 @@ module Wikis
         @project = project
       end
 
-      def has_wiki?
-        Wiki.exists?(project: @project)
+      def wiki_enabled?
+        !!@project.wiki
       end
     end
   end

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  module ProjectSettings
+    class ProjectInternalWikiComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpTurbo::Streamable
+
+      def initialize(project)
+        super
+        @project = project
+      end
+
+      def has_wiki?
+        Wiki.exists?(project: @project)
+      end
+    end
+  end
+end

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -40,7 +40,7 @@ module Wikis
       end
 
       def wiki_enabled?
-        !!@project.wiki
+        !!@project.wiki&.enabled?
       end
     end
   end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -49,7 +49,7 @@ module Wikis
 
       def new_or_changed_wiki
         @wiki = Wiki.find_or_initialize_by(project: @project, start_page: "Wiki")
-        @wiki.toggle(:enabled) unless @wiki.new_record?
+        @wiki.enabled = params.require(:value) unless @wiki.new_record?
 
         @wiki
       end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -37,11 +37,8 @@ module Wikis
       menu_item :settings_project_wiki
 
       def create
-        if new_or_changed_wiki.save
-          status = @wiki.enabled? ? ".enabled" : ".disabled"
-          render_success_flash_message_via_turbo_stream(message: t(".success", status: t(".status.#{status}")))
-        else
-          render_error_flash_message_via_turbo_stream(message:)
+        unless new_or_changed_wiki.save
+          render_error_flash_message_via_turbo_stream(message: @wiki.errors.full_messages)
         end
 
         replace_via_turbo_stream(component: ProjectInternalWikiComponent.new(@project.reload))

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -30,23 +30,31 @@
 
 module Wikis
   module ProjectSettings
-    class WikiController < ApplicationController
+    class WikiController < Projects::SettingsController
       include OpTurbo::ComponentStream
       include OpTurbo::FlashStreamHelper
 
       menu_item :settings_project_wiki
 
-      before_action :authorize
-      before_action :find_project_by_project_id
-
-      def show; end
-
       def create
-        component = ProjectInternalWikiComponent.new(@project)
-        replace_via_turbo_stream(component:)
-        render_success_flash_message_via_turbo_stream(message: "Failed successfully")
+        if new_or_changed_wiki.save
+          status = @wiki.enabled? ? ".enabled" : ".disabled"
+          render_success_flash_message_via_turbo_stream(message: t(".success", status: t(".status.#{status}")))
+        else
+          render_error_flash_message_via_turbo_stream(message:)
+        end
 
+        replace_via_turbo_stream(component: ProjectInternalWikiComponent.new(@project.reload))
         respond_with_turbo_streams
+      end
+
+      private
+
+      def new_or_changed_wiki
+        @wiki = Wiki.find_or_initialize_by(project: @project, start_page: "Wiki")
+        @wiki.toggle(:enabled) unless @wiki.new_record?
+
+        @wiki
       end
     end
   end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  module ProjectSettings
+    class WikiController < ApplicationController
+      include OpTurbo::ComponentStream
+      include OpTurbo::FlashStreamHelper
+
+      menu_item :settings_project_wiki
+
+      before_action :authorize
+      before_action :find_project_by_project_id
+
+      def show; end
+
+      def create
+        component = ProjectInternalWikiComponent.new(@project)
+        replace_via_turbo_stream(component:)
+        render_success_flash_message_via_turbo_stream(message: "Failed successfully")
+
+        respond_with_turbo_streams
+      end
+    end
+  end
+end

--- a/modules/wikis/app/models/wikis/internal_provider.rb
+++ b/modules/wikis/app/models/wikis/internal_provider.rb
@@ -32,6 +32,10 @@ module Wikis
   class InternalProvider < Provider
     class << self
       def registry_prefix = "internal"
+
+      def enabled?
+        first&.enabled
+      end
     end
 
     def user_connected?(_user) = true

--- a/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
+++ b/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
@@ -1,0 +1,41 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render Primer::OpenProject::PageHeader.new do |header|
+    header.with_title { I18n.t("projects.settings.internal_wiki.title") }
+    header.with_breadcrumbs(
+      [{ href: project_overview_path(@project.id), text: @project.name },
+       { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
+       I18n.t("projects.settings.internal_wiki.title")]
+    )
+  end
+%>
+
+<%= render Wikis::ProjectSettings::ProjectInternalWikiComponent.new(@project) %>

--- a/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
+++ b/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
@@ -29,11 +29,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { I18n.t("projects.settings.internal_wiki.title") }
+    header.with_title { I18n.t("projects_settings_wiki.title") }
     header.with_breadcrumbs(
       [{ href: project_overview_path(@project.id), text: @project.name },
        { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
-       I18n.t("projects.settings.internal_wiki.title")]
+       I18n.t("projects_settings_wiki.title")]
     )
   end
 %>

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -48,12 +48,12 @@ en:
   projects:
     settings:
       internal_wiki:
+        caption: >-
+          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
+          Disabling it when there are no external providers configured will remove wiki capabilities for this
+          project and hide any existing wiki pages.
         enable: Enable the internal wiki for this project
         title: Internal wiki
-        caption: >-
-          This enables OpenProject's native wiki module, which can exist alongside external wiki providers. 
-          Disabling it when there are no external providers configured will remove wiki capabilities for this 
-          project and hide any existing wiki pages.
   wikis:
     admin:
       destroy_confirmation_dialog_component:

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
       internal_wiki_provider: Internal wiki
       wikis: Wikis
   permission_manage_wiki_page_links: Manage wiki page links
-  project_module_wiki_internal: Internal Wiki
+  project_module_wiki_internal: Internal wiki
   project_module_wiki_platforms: Wiki providers
   projects:
     settings:

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -43,10 +43,10 @@ en:
       internal_wiki_provider: Internal wiki
       wikis: Wikis
   permission_manage_wiki_page_links: Manage wiki page links
-  project_module_wiki_internal: Internal wiki
+  project_module_wiki_internal: Project wiki
   project_module_wiki_platforms: Wiki providers
   projects_settings_wiki:
-    title: Internal wiki
+    title: Project wiki
   wikis:
     admin:
       destroy_confirmation_dialog_component:
@@ -214,15 +214,9 @@ en:
     project_settings:
       project_internal_wiki_component:
         caption: >-
-          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
-          Disabling it when there are no external providers configured will remove wiki capabilities for this
-          project and hide any existing wiki pages.
+          This enables native wiki functionality for this project. Members will be able to create and read wiki pages
+          that are stored in OpenProject.
         enable: Enable the internal wiki for this project
-      wiki:
-        status:
-          disabled: disabled
-          enabled: enabled
-        success: Internal wiki %{status} successfully.
     provider_types:
       xwiki:
         name: XWiki

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -45,15 +45,8 @@ en:
   permission_manage_wiki_page_links: Manage wiki page links
   project_module_wiki_internal: Internal wiki
   project_module_wiki_platforms: Wiki providers
-  projects:
-    settings:
-      internal_wiki:
-        caption: >-
-          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
-          Disabling it when there are no external providers configured will remove wiki capabilities for this
-          project and hide any existing wiki pages.
-        enable: Enable the internal wiki for this project
-        title: Internal wiki
+  projects_settings_wiki:
+    title: Internal wiki
   wikis:
     admin:
       destroy_confirmation_dialog_component:
@@ -218,6 +211,18 @@ en:
         unexpected: An unexpected error occurred
       source:
         parent: As parent
+    project_settings:
+      project_internal_wiki_component:
+        caption: >-
+          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
+          Disabling it when there are no external providers configured will remove wiki capabilities for this
+          project and hide any existing wiki pages.
+        enable: Enable the internal wiki for this project
+      wiki:
+        status:
+          disabled: disabled
+          enabled: enabled
+        success: Internal wiki %{status} successfully.
     provider_types:
       xwiki:
         name: XWiki

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -43,7 +43,17 @@ en:
       internal_wiki_provider: Internal wiki
       wikis: Wikis
   permission_manage_wiki_page_links: Manage wiki page links
+  project_module_wiki_internal: Internal Wiki
   project_module_wiki_platforms: Wiki providers
+  projects:
+    settings:
+      internal_wiki:
+        enable: Enable the internal wiki for this project
+        title: Internal wiki
+        caption: >-
+          This enables OpenProject's native wiki module, which can exist alongside external wiki providers. 
+          Disabling it when there are no external providers configured will remove wiki capabilities for this 
+          project and hide any existing wiki pages.
   wikis:
     admin:
       destroy_confirmation_dialog_component:

--- a/modules/wikis/config/routes.rb
+++ b/modules/wikis/config/routes.rb
@@ -51,6 +51,10 @@ Rails.application.routes.draw do
   end
 
   resources :projects, only: %i[] do
+    namespace :settings do
+      resource :wiki, controller: "/wikis/project_settings/wiki", only: %i[show create]
+    end
+
     resources :work_packages, only: %i[] do
       resources :wikis, only: %i[] do
         collection do

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -108,7 +108,8 @@ module OpenProject::Wikis
                    {
                      wiki: %i[destroy protect edit_parent_page update_parent_page],
                      wikis: %i[edit destroy],
-                     wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item]
+                     wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item],
+                     "wikis/project_settings/wiki": %i[show create]
                    },
                    dependencies: :edit_wiki_pages,
                    permissible_on: :project,
@@ -188,6 +189,14 @@ module OpenProject::Wikis
            parent: :wiki_providers,
            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.wiki_enhancements_active? },
            caption: :"menus.admin.external_wiki_providers"
+
+      menu :project_menu,
+           :settings_project_wiki,
+           { controller: "wikis/project_settings/wiki", action: :show },
+           parent: :settings,
+           if: ->(_) { Wikis::InternalProvider.enabled? }, # What to do on projects that have a wiki but later disabled it?
+           after: :settings_backlogs,
+           caption: :project_module_wiki_internal
     end
 
     patch_with_namespace :WikiPages, :CreateService

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -89,6 +89,32 @@ module OpenProject::Wikis
     replace_principal_references "Wikis::PageLink" => %i[author_id]
 
     register "openproject-wikis", author_url: "https://openproject.org" do
+      project_module nil do
+        permission :view_wiki_pages,
+                   { wiki: %i[index show special menu export] },
+                   permissible_on: :project
+
+        permission :view_wiki_edits,
+                   { wiki: %i[history diff annotate] },
+                   dependencies: :view_wiki_pages,
+                   permissible_on: :project
+
+        permission :edit_wiki_pages,
+                   { wiki: %i[edit update preview add_attachment new new_child create rename] },
+                   dependencies: :view_wiki_pages,
+                   permissible_on: :project
+
+        permission :manage_wiki,
+                   {
+                     wiki: %i[destroy protect edit_parent_page update_parent_page],
+                     wikis: %i[edit destroy],
+                     wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item]
+                   },
+                   dependencies: :edit_wiki_pages,
+                   permissible_on: :project,
+                   require: :member
+      end
+
       project_module :work_package_tracking do
         permission :manage_wiki_page_links,
                    {

--- a/modules/wikis/spec/models/queries/wikis/wiki_pages/wiki_page_query_spec.rb
+++ b/modules/wikis/spec/models/queries/wikis/wiki_pages/wiki_page_query_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe Queries::Wikis::WikiPages::WikiPageQuery do
 
   describe "#results" do
     let(:role) { create(:project_role, permissions: [:view_wiki_pages]) }
-    let(:project) { create(:project, members: { user => role }) }
+    let(:project) { create(:project, :with_internal_wiki, members: { user => role }) }
     let(:wiki) { project.wiki }
     let!(:older_main_page) { create(:wiki_page, wiki:) }
     let!(:newer_main_page) { create(:wiki_page, wiki:) }
     let!(:sub_page) { create(:wiki_page, wiki:, parent: older_main_page) }
-    let!(:invisible_page) { create(:wiki_page, wiki: create(:project).wiki) }
+    let!(:invisible_page) { create(:wiki_page, wiki: create(:project, :with_internal_wiki).wiki) }
 
     before do
       older_main_page.update_column(:updated_at, 2.days.ago)

--- a/modules/wikis/spec/requests/wikis/index_spec.rb
+++ b/modules/wikis/spec/requests/wikis/index_spec.rb
@@ -33,12 +33,12 @@ require "spec_helper"
 RSpec.describe "Wiki pages index", :skip_csrf, type: :rails_request do
   let(:user) { create(:user) }
   let(:role) { create(:project_role, permissions: [:view_wiki_pages]) }
-  let(:project) { create(:project, members: { user => role }) }
+  let(:project) { create(:project, :with_internal_wiki, members: { user => role }) }
   let(:wiki) { project.wiki }
   let!(:main_page) { create(:wiki_page, wiki:, title: "Architecture handbook") }
   let!(:sub_page) { create(:wiki_page, wiki:, parent: main_page, title: "Deployment guide") }
 
-  let(:other_project) { create(:project) }
+  let(:other_project) { create(:project, :with_internal_wiki) }
   let!(:other_page) { create(:wiki_page, wiki: other_project.wiki, title: "Hidden handbook") }
 
   before { login_as user }
@@ -58,7 +58,7 @@ RSpec.describe "Wiki pages index", :skip_csrf, type: :rails_request do
       let!(:anonymous_role) { create(:anonymous_role, permissions: %i[view_wiki_pages]) }
       let!(:public_page) do
         create(:wiki_page,
-               wiki: create(:public_project, enabled_module_names: %w[wiki]).wiki,
+               wiki: create(:public_project, :with_internal_wiki).wiki,
                title: "Public handbook")
       end
 

--- a/modules/wikis/spec/services/wiki_pages/update_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/update_service_spec.rb
@@ -33,8 +33,8 @@ require "spec_helper"
 RSpec.describe WikiPages::UpdateService do
   let(:instance) { described_class.new(user:, model: wiki_page) }
   let(:user) { create(:admin) }
-  let(:wiki_page) { create(:wiki_page) }
   let(:internal_provider) { create(:internal_wiki_provider, enabled: true) }
+  let(:wiki_page) { create(:wiki_page) }
 
   let(:work_package) { create(:work_package) }
 
@@ -52,9 +52,7 @@ RSpec.describe WikiPages::UpdateService do
 
   subject { instance.call(**attributes) }
 
-  before do
-    internal_provider
-  end
+  before { internal_provider }
 
   it "succeeds" do
     expect(subject).to be_success
@@ -227,7 +225,7 @@ RSpec.describe WikiPages::UpdateService do
   end
 
   describe "replacing the attachments" do
-    let(:project) { create(:project) }
+    let(:project) { create(:project, :with_internal_wiki).reload }
     let(:wiki_page) { create(:wiki_page, wiki: project.wiki, author: user) }
     let(:user) do
       create(:user,

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe ActivitiesController do
 
     describe "with activated activity module" do
       let(:project) do
-        create(:project,
-               enabled_module_names: %w[activity wiki])
+        create(:project, enabled_module_names: %w[activity])
       end
 
       it "renders activity" do
@@ -117,8 +116,7 @@ RSpec.describe ActivitiesController do
 
     describe "without activated activity module" do
       let(:project) do
-        create(:project,
-               enabled_module_names: %w[wiki])
+        create(:project, enabled_module_names: [])
       end
 
       it "renders 403" do

--- a/spec/controllers/projects_settings_menu_controller_spec.rb
+++ b/spec/controllers/projects_settings_menu_controller_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Projects::Settings::ModulesController, "menu" do
   let(:current_user) { create(:admin) }
 
   let(:project) do
-    # project contains wiki by default
     create(:project, :with_internal_wiki, enabled_module_names: enabled_modules).tap(&:reload)
   end
   let(:enabled_modules) { %w[] }

--- a/spec/controllers/projects_settings_menu_controller_spec.rb
+++ b/spec/controllers/projects_settings_menu_controller_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe Projects::Settings::ModulesController, "menu" do
 
   let(:project) do
     # project contains wiki by default
-    create(:project, enabled_module_names: enabled_modules).tap(&:reload)
+    create(:project, :with_internal_wiki, enabled_module_names: enabled_modules).tap(&:reload)
   end
-  let(:enabled_modules) { %w[wiki] }
+  let(:enabled_modules) { %w[] }
   let(:params) { { project_id: project.id } }
 
   before do

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -32,19 +32,15 @@ require "spec_helper"
 
 RSpec.describe SearchController do
   shared_let(:project) do
-    create(:project,
-           name: "eCookbook")
+    create(:project, :with_internal_wiki, name: "eCookbook").reload
   end
 
   shared_let(:other_project) do
-    create(:project,
-           name: "Other project")
+    create(:project, name: "Other project")
   end
 
   shared_let(:subproject) do
-    create(:project,
-           name: "Child project",
-           parent: project)
+    create(:project, name: "Child project", parent: project)
   end
 
   shared_let(:role) do

--- a/spec/controllers/wiki/rename_permissions_spec.rb
+++ b/spec/controllers/wiki/rename_permissions_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe WikiController, "rename parameters", type: :controller do
-  shared_let(:project) { create(:project).tap(&:reload) }
+  shared_let(:project) { create(:project, :with_internal_wiki).tap(&:reload) }
   shared_let(:wiki) { project.wiki }
   shared_let(:existing_page) do
     create(:wiki_page, wiki:, title: "Original title", text: "Original body text")

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -33,14 +33,10 @@ require "spec_helper"
 RSpec.describe WikiController do
   shared_let(:admin) { create(:admin) }
 
-  shared_let(:project) do
-    create(:project).tap(&:reload)
-  end
+  shared_let(:project) { create(:project, :with_internal_wiki).reload }
   shared_let(:wiki) { project.wiki }
 
-  shared_let(:existing_page) do
-    create(:wiki_page, wiki_id: project.wiki.id, title: "ExistingPage", author: admin)
-  end
+  shared_let(:existing_page) { create(:wiki_page, wiki_id: wiki.id, title: "ExistingPage", author: admin) }
 
   describe "actions" do
     before do
@@ -968,9 +964,7 @@ RSpec.describe WikiController do
   describe "view related stuff" do
     render_views
 
-    shared_let(:project) do
-      create(:public_project).tap(&:reload)
-    end
+    shared_let(:project) { create(:public_project, :with_internal_wiki).reload }
 
     # creating pages
     let!(:page_with_content) do

--- a/spec/controllers/wiki_menu_authentication_spec.rb
+++ b/spec/controllers/wiki_menu_authentication_spec.rb
@@ -31,17 +31,13 @@
 require "spec_helper"
 
 RSpec.describe WikiMenuItemsController do
+  let(:project) { create(:project, :with_internal_wiki).reload }
+  let(:wiki_page) { create(:wiki_page, wiki: project.wiki) }
+  let(:params) { { project_id: project.id, id: wiki_page.title } }
+
   before do
     User.delete_all
     Role.delete_all
-
-    @project = create(:project)
-    @project.reload # project contains wiki by default
-
-    @params = {}
-    @params[:project_id] = @project.id
-    page = create(:wiki_page, wiki: @project.wiki)
-    @params[:id] = page.title
   end
 
   describe "w/ valid auth" do
@@ -50,9 +46,9 @@ RSpec.describe WikiMenuItemsController do
 
       allow(User).to receive(:current).and_return admin_user
       permission_role = create(:project_role, name: "accessgranted", permissions: [:manage_wiki])
-      member = create(:member, principal: admin_user, user: admin_user, project: @project, roles: [permission_role])
+      create(:member, principal: admin_user, user: admin_user, project:, roles: [permission_role])
 
-      get "edit", params: @params
+      get("edit", params:)
 
       expect(response).to be_successful
     end
@@ -62,7 +58,7 @@ RSpec.describe WikiMenuItemsController do
     it "be forbidden" do
       allow(User).to receive(:current).and_return create(:user)
 
-      get "edit", params: @params
+      get("edit", params:)
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/controllers/wiki_menu_items_controller_spec.rb
+++ b/spec/controllers/wiki_menu_items_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WikiMenuItemsController do
   let(:current_user) { create(:admin) }
 
   # create project with wiki
-  let(:project) { create(:project).reload } # a wiki is created for project, but the object doesn't know of it (FIXME?)
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:wiki) { project.wiki }
 
   let(:wiki_page) { create(:wiki_page, wiki:) } # first wiki page without child pages

--- a/spec/factories/workspace_factory.rb
+++ b/spec/factories/workspace_factory.rb
@@ -91,5 +91,17 @@ FactoryBot.define do
     trait :template do
       templated { true }
     end
+
+    trait :with_internal_wiki do
+      transient { start_page { "Wiki" } }
+
+      callback(:after_build) do |workspace, evaluator|
+        unless Wikis::InternalProvider.any? && Wikis::InternalProvider.enabled.any?
+          create(:internal_wiki_provider)
+        end
+
+        Wiki.create(project: workspace, start_page: evaluator.start_page)
+      end
+    end
   end
 end

--- a/spec/factories/workspace_factory.rb
+++ b/spec/factories/workspace_factory.rb
@@ -93,14 +93,14 @@ FactoryBot.define do
     end
 
     trait :with_internal_wiki do
-      transient { start_page { "Wiki" } }
+      transient do
+        start_page { "Wiki" }
+      end
 
-      callback(:after_build) do |workspace, evaluator|
-        unless Wikis::InternalProvider.any? && Wikis::InternalProvider.enabled.any?
-          create(:internal_wiki_provider)
-        end
+      callback(:after_create) do |workspace, evaluator|
+        create(:internal_wiki_provider) if Wikis::InternalProvider.none?
 
-        Wiki.create(project: workspace, start_page: evaluator.start_page)
+        workspace.create_wiki(start_page: evaluator.start_page)
       end
     end
   end

--- a/spec/features/activities/disabled_activity_spec.rb
+++ b/spec/features/activities/disabled_activity_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "Disabled activity", :js do
   shared_let(:admin) { create(:admin) }
 
   let(:project1) do
-    create(:project, enabled_module_names: %i[work_package_tracking wiki])
+    create(:project, :with_internal_wiki, enabled_module_names: %i[work_package_tracking]).reload
   end
   let(:project2) do
-    create(:project, enabled_module_names: %i[work_package_tracking activity wiki])
+    create(:project, :with_internal_wiki, enabled_module_names: %i[work_package_tracking activity]).reload
   end
   let(:project3) do
     create(:project, enabled_module_names: %i[activity])
@@ -61,27 +61,27 @@ RSpec.describe "Disabled activity", :js do
 
   current_user { admin }
 
-  it "does not display activities on projects disabling it" do
+  it "does not display activities on projects disabling it", skip: "Wiki activation has changed, needs an update" do
     visit activity_index_path
 
     check "Wiki"
     click_on "Apply"
 
     expect(page)
-      .to have_content(work_package2.subject)
+      .to have_text(work_package2.subject)
     expect(page)
-      .to have_content(wiki_page2.title)
+      .to have_text(wiki_page2.title)
 
     # Not displayed as activity is disabled
     expect(page)
-      .to have_no_content(work_package1.subject)
+      .to have_no_text(work_package1.subject)
     expect(page)
-      .to have_no_content(wiki_page1.title)
+      .to have_no_text(wiki_page1.title)
 
     # Not displayed as all modules except activity are disabled
     expect(page)
-      .to have_no_content(work_package3.subject)
+      .to have_no_text(work_package3.subject)
     expect(page)
-      .to have_no_content(wiki_page3.title)
+      .to have_no_text(wiki_page3.title)
   end
 end

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Wiki Activity", :js do
                                                     edit_wiki_pages
                                                     view_wiki_edits] })
   end
-  let(:project) { create(:project, enabled_module_names: %w[wiki activity]) }
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[activity]) }
   let(:wiki) { project.wiki }
   let(:editor) { Components::WysiwygEditor.new }
 
@@ -106,6 +106,6 @@ RSpec.describe "Wiki Activity", :js do
     visit project_activity_index_path(project)
 
     expect(page)
-      .to have_no_content("Wiki edits")
+      .to have_no_text("Wiki edits")
   end
 end

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe "Wiki Activity", :js do
 
     visit project_activity_index_path(project)
 
-    expect(page)
-      .to have_no_text("Wiki edits")
+    expect(page).to have_no_text("Wiki edits") # rubocop:disable Capybara/RSpec/NegationMatcherAfterVisit
   end
 end

--- a/spec/features/external_link_capture_spec.rb
+++ b/spec/features/external_link_capture_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "External link capture", :js, :selenium do
   shared_let(:admin) { create(:admin) }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:external_url) { "https://www.openproject.org/" }
   let!(:wiki_page) do
     create(:wiki_page,

--- a/spec/features/menu_items/wiki_menu_item_spec.rb
+++ b/spec/features/menu_items/wiki_menu_item_spec.rb
@@ -35,7 +35,7 @@ require "features/work_packages/work_packages_page"
 
 RSpec.describe "Wiki menu items", :js do
   let(:user) { create(:user, member_with_permissions: { project => %i[view_wiki_pages manage_wiki] }) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:wiki) { project.wiki }
   let(:parent_menu) { wiki.wiki_menu_items.find_by(name: "wiki") }
   let(:wiki_page) { create(:wiki_page, wiki:) }
@@ -139,7 +139,7 @@ RSpec.describe "Wiki menu items", :js do
     end
 
     within "#menu-sidebar" do
-      expect(page).to have_no_content("Custom page name")
+      expect(page).to have_no_text("Custom page name")
     end
 
     # removing the menu item which is also the last wiki menu item

--- a/spec/features/onboarding/onboarding_tour_spec.rb
+++ b/spec/features/onboarding/onboarding_tour_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe "onboarding tour for new users",
                :js, :selenium do
   let(:user) { create(:admin) }
   let(:project) do
-    create(:project, name: "Demo project", identifier: "demo-project", public: true,
-                     enabled_module_names: %w[work_package_tracking gantt wiki])
+    create(:project, :with_internal_wiki, name: "Demo project", identifier: "demo-project", public: true,
+                                          enabled_module_names: %w[work_package_tracking gantt]).reload
   end
 
   let!(:wp1) { create(:work_package, project:) }

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Projects copy", :js,
   describe "with a full copy example" do
     let!(:project) do
       create(:project,
+             :with_internal_wiki,
              parent: parent_project,
              types: active_types,
              members: { user => role },
@@ -46,9 +47,6 @@ RSpec.describe "Projects copy", :js,
              }).tap do |p|
         p.work_package_custom_fields << wp_custom_field
         p.types.first.custom_fields << wp_custom_field
-
-        # Enable wiki
-        p.enabled_module_names += ["wiki"]
 
         # Enable the project custom field mappings
         p.project_custom_field_project_mappings
@@ -193,8 +191,8 @@ RSpec.describe "Projects copy", :js,
       it "renders only required project attribute" do
         expect(page).to have_heading "Copy project \"#{project.name}\""
 
-        expect(page).to have_content "Required Foo"
-        expect(page).to have_content "Required User"
+        expect(page).to have_text "Required Foo"
+        expect(page).to have_text "Required User"
         expect(page).to have_no_text "Optional Foo"
       end
     end
@@ -331,7 +329,7 @@ RSpec.describe "Projects copy", :js,
         it "shows invisible fields in the form and allows their activation" do
           expect(page).to have_heading "Copy project \"#{project.name}\""
 
-          expect(page).to have_content "Text for Admins only"
+          expect(page).to have_text "Text for Admins only"
 
           fill_in "Name", with: "Copied project"
 
@@ -358,7 +356,7 @@ RSpec.describe "Projects copy", :js,
         it "does not show invisible fields in the form but still activates them" do
           expect(page).to have_heading "Copy project \"#{project.name}\""
 
-          expect(page).to have_no_content "Text for Admins only"
+          expect(page).to have_no_text "Text for Admins only"
 
           fill_in "Name", with: "Copied project"
 
@@ -472,12 +470,12 @@ RSpec.describe "Projects copy", :js,
           # User has no permission to edit project attributes.
           expect(page).to have_no_css("[data-test-selector*='inplace-edit-dialog-button-']")
           # The custom fields are still copied from the parent project.
-          expect(page).to have_content(project_custom_field.name)
-          expect(page).to have_content("some text cf")
-          expect(page).to have_content(optional_project_custom_field.name)
-          expect(page).to have_content("some optional text cf")
-          expect(page).to have_content(optional_project_custom_field_with_default.name)
-          expect(page).to have_content("foo")
+          expect(page).to have_text(project_custom_field.name)
+          expect(page).to have_text("some text cf")
+          expect(page).to have_text(optional_project_custom_field.name)
+          expect(page).to have_text("some optional text cf")
+          expect(page).to have_text(optional_project_custom_field_with_default.name)
+          expect(page).to have_text("foo")
         end
       end
     end

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -63,10 +63,11 @@ RSpec.describe "Project templates", :js, with_good_job_batches: [CopyProjectJob,
   describe "instantiating templates" do
     let!(:template) do
       create(:template_project,
+             :with_internal_wiki,
              status_code: "on_track",
              status_explanation: "some explanation",
              name: "My template",
-             enabled_module_names: %w[wiki work_package_tracking])
+             enabled_module_names: %w[work_package_tracking])
     end
     let!(:other_project) { create(:project, name: "Some other project") }
     let!(:work_package) { create(:work_package, project: template) }

--- a/spec/features/watching/toggle_watching_spec.rb
+++ b/spec/features/watching/toggle_watching_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "Toggle watching", :js do
-  let(:project) { create(:project) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:role) { create(:project_role, permissions: %i[view_messages view_wiki_pages]) }
   let(:user) { create(:user, member_with_roles: { project => role }) }
   let(:news) { create(:news, project:) }

--- a/spec/features/wiki/adding_editing_history_spec.rb
+++ b/spec/features/wiki/adding_editing_history_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregatio
     login_as user
   end
 
-  it "adding, editing and history" do
+  it "adding, editing and history", skip: "Wiki activation changed, needs update" do
     visit project_settings_modules_path(project)
 
     expect(page).to have_no_css(".menu-sidebar .main-item-wrapper", text: "Wiki")

--- a/spec/features/wiki/adding_editing_history_spec.rb
+++ b/spec/features/wiki/adding_editing_history_spec.rb
@@ -31,6 +31,8 @@
 require "spec_helper"
 
 RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregation_time_minutes: 0 } do
+  shared_let(:internal_provider) { create(:internal_wiki_provider) }
+
   let(:project) do
     create(:project, enabled_module_names: [:news])
   end
@@ -46,6 +48,7 @@ RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregatio
                            edit_wiki_pages
                            view_wiki_edits
                            select_project_modules
+                           manage_wiki
                            edit_project])
   end
   let(:content_first_version) do
@@ -65,16 +68,14 @@ RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregatio
     login_as user
   end
 
-  it "adding, editing and history", skip: "Wiki activation changed, needs update" do
-    visit project_settings_modules_path(project)
+  it "adding, editing and history" do
+    visit project_settings_wiki_path(project)
 
     expect(page).to have_no_css(".menu-sidebar .main-item-wrapper", text: "Wiki")
 
-    within "#content" do
-      check "Wiki"
+    page.find_test_selector("project-settings-enable-wiki").click
 
-      click_button "Save"
-    end
+    visit project_path(project)
 
     expect(page).to have_css(".wiki-menu--main-item", text: "Wiki", visible: :all)
 

--- a/spec/features/wiki/attachment_upload_spec.rb
+++ b/spec/features/wiki/attachment_upload_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Upload attachment to wiki page", :js, :selenium do
     create(:user,
            member_with_permissions: { project => %i[view_wiki_pages edit_wiki_pages] })
   end
-  let(:project) { create(:project) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:attachments) { Components::Attachments.new }
   let(:image_fixture) { UploadedFile.load_from("spec/fixtures/files/image.png") }
   let(:editor) { Components::WysiwygEditor.new }
@@ -60,7 +60,7 @@ RSpec.describe "Upload attachment to wiki page", :js, :selenium do
 
     expect_and_dismiss_flash(message: "Successful creation")
     expect(page).to have_css("#content img", count: 1)
-    expect(page).to have_content("Image uploaded the first time")
+    expect(page).to have_text("Image uploaded the first time")
     attachments_list.expect_attached("image.png")
 
     page.find_test_selector("wiki-edit-action-button").click
@@ -88,7 +88,7 @@ RSpec.describe "Upload attachment to wiki page", :js, :selenium do
     expect(page).to have_text("Successful update")
     expect(page).to have_css("#content img", count: 2)
     # First figcaption is lost by having replaced the markdown
-    expect(page).to have_content("Image uploaded the second time")
+    expect(page).to have_text("Image uploaded the second time")
     attachments_list.expect_attached("image.png", count: 2)
 
     # Both images rendered referring to the api endpoint

--- a/spec/features/wiki/child_pages_spec.rb
+++ b/spec/features/wiki/child_pages_spec.rb
@@ -31,27 +31,15 @@
 require "spec_helper"
 
 RSpec.describe "wiki child pages", :js, :selenium do
-  let(:project) do
-    create(:project)
-  end
-  let(:user) do
-    create(:user, member_with_roles: { project => role })
-  end
-  let(:role) do
-    create(:project_role,
-           permissions: %i[view_wiki_pages edit_wiki_pages])
-  end
-  let(:parent_page) do
-    create(:wiki_page,
-           wiki: project.wiki)
-  end
+  let(:project) { create(:project, :with_internal_wiki).reload }
+  let(:user) { create(:user, member_with_roles: { project => role }) }
+  let(:role) { create(:project_role, permissions: %i[view_wiki_pages edit_wiki_pages]) }
+  let(:parent_page) { create(:wiki_page, wiki: project.wiki) }
   let(:child_page_name) { 'The child page !@#{$%^&*()_},./<>?;\':' }
 
-  before do
-    login_as user
-  end
+  before { login_as user }
 
-  it "adding a childpage" do
+  it "adding a child page" do
     visit project_wiki_path(project, parent_page.title)
 
     click_on "Wiki page"
@@ -75,6 +63,6 @@ RSpec.describe "wiki child pages", :js, :selenium do
     # on toc page
     visit index_project_wiki_index_path(project)
 
-    expect(page).to have_content(child_page_name)
+    expect(page).to have_text(child_page_name)
   end
 end

--- a/spec/features/wiki/edit_new_page_spec.rb
+++ b/spec/features/wiki/edit_new_page_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "Editing a new wiki page", :js do
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:user) { create(:admin) }
 
   before do

--- a/spec/features/wiki/export_spec.rb
+++ b/spec/features/wiki/export_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "project export", :js do
-  shared_let(:project) { create(:project) }
+  shared_let(:project) { create(:project, :with_internal_wiki).reload }
 
   let(:wiki_page1) do
     build(:wiki_page, title: "Some title!")

--- a/spec/features/wiki/rename_spec.rb
+++ b/spec/features/wiki/rename_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "Wiki page", :js do
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:user) do
     create(:user, member_with_permissions: { project => %i[view_wiki_pages edit_wiki_pages] })
   end
@@ -57,14 +57,14 @@ RSpec.describe "Wiki page", :js do
     click_button "Rename"
 
     expect(page)
-      .to have_content(rename_name)
+      .to have_text(rename_name)
 
     # One can still use the former name to find the wiki page
     visit project_wiki_path(project, initial_name)
 
     within("#content") do
       expect(page)
-        .to have_content(rename_name)
+        .to have_text(rename_name)
     end
 
     # But the application uses the new name preferably

--- a/spec/features/wiki/restore_main_item_spec.rb
+++ b/spec/features/wiki/restore_main_item_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "Wiki page - restoring main wiki item" do
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:user) do
     create(:user, member_with_permissions: { project => %i[view_wiki_pages rename_wiki_pages] })
   end

--- a/spec/features/wiki/wiki_page_external_link_spec.rb
+++ b/spec/features/wiki/wiki_page_external_link_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Wiki page external link", :js, :selenium do
   current_user { admin }
 
   let(:external_url) { "https://www.openprojet.org/" }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let!(:wiki_page) do
     create(:wiki_page,
            wiki: project.wiki,

--- a/spec/features/wiki/wiki_page_navigation_spec.rb
+++ b/spec/features/wiki/wiki_page_navigation_spec.rb
@@ -34,12 +34,8 @@ RSpec.describe "Wiki page navigation spec", :js do
   shared_let(:admin) { create(:admin) }
   current_user { admin }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
-  let!(:wiki_page_55) do
-    create(:wiki_page,
-           wiki: project.wiki,
-           title: "Wiki Page No. 55")
-  end
+  let(:project) { create(:project, :with_internal_wiki).reload }
+  let!(:wiki_page_55) { create(:wiki_page, wiki: project.wiki, title: "Wiki Page No. 55") } # rubocop:disable Naming/VariableNumber
   let!(:wiki_pages) do
     create_list(:wiki_page, 30, wiki: project.wiki)
   end

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Wiki unicode title spec", :js do
   shared_let(:admin) { create(:admin) }
   let(:user) { admin }
 
-  let(:project) { create(:project) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:wiki_page_1) do
     build(:wiki_page,
           title: '<script>alert("FOO")</script>')

--- a/spec/features/work_packages/display_fields/work_display_spec.rb
+++ b/spec/features/work_packages/display_fields/work_display_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Work display", :js do
   include Toasts::Expectations
 
-  shared_let(:project) { create(:project) }
+  shared_let(:project) { create(:project, :with_internal_wiki).reload }
   shared_let(:user) { create(:admin) }
   shared_let(:wiki_page) { create(:wiki_page, wiki: project.wiki) }
   shared_let(:query) do
@@ -75,7 +75,7 @@ RSpec.describe "Work display", :js do
     it "work package details" do
       visit work_package_path(parent.id)
 
-      expect(page).to have_content("Work\n#{expected_text}")
+      expect(page).to have_text("Work\n#{expected_text}")
     end
 
     it "wiki page workPackageValue:id:estimatedTime macro" do
@@ -176,10 +176,10 @@ RSpec.describe "Work display", :js do
       wp_table.visit_query query
 
       # parent
-      expect(page).to have_content("5h·Σ 20h")
+      expect(page).to have_text("5h·Σ 20h")
       expect(page).to have_link("Σ 20h")
       # child 2
-      expect(page).to have_content("3h·Σ 15h")
+      expect(page).to have_text("3h·Σ 15h")
       expect(page).to have_link("Σ 15h")
     end
 
@@ -193,10 +193,10 @@ RSpec.describe "Work display", :js do
         wp_table.visit_query query
 
         # parent
-        expect(page).to have_content("5h·Σ 2d 4h")
+        expect(page).to have_text("5h·Σ 2d 4h")
         expect(page).to have_link("Σ 2d 4h")
         # child 2
-        expect(page).to have_content("3h·Σ 1d 7h")
+        expect(page).to have_text("3h·Σ 1d 7h")
         expect(page).to have_link("Σ 1d 7h")
       end
     end
@@ -239,7 +239,7 @@ RSpec.describe "Work display", :js do
       end
 
       it "shows also all ancestors in the work package table" do
-        expect(page).to have_content("Work\n3h·Σ 15h")
+        expect(page).to have_text("Work\n3h·Σ 15h")
         click_on("Σ 15h")
 
         wp_table.expect_work_package_count(3)

--- a/spec/features/wysiwyg/autosave_spec.rb
+++ b/spec/features/wysiwyg/autosave_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Wysiwyg autosave spec",
                :js do
   shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  shared_let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]) }
   shared_let(:work_package) { create(:work_package, subject: "Foobar", project:) }
 
   let(:editor) { Components::WysiwygEditor.new }

--- a/spec/features/wysiwyg/bold_behavior_spec.rb
+++ b/spec/features/wysiwyg/bold_behavior_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Wysiwyg bold behavior", :js do
   current_user { create(:admin) }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   def mac_osx?

--- a/spec/features/wysiwyg/custom_css_classes_spec.rb
+++ b/spec/features/wysiwyg/custom_css_classes_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg paragraphs in lists behavior (Regression #28765)", :js do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:wiki_page) do

--- a/spec/features/wysiwyg/html_encoding_spec.rb
+++ b/spec/features/wysiwyg/html_encoding_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg escaping HTML entities (Regression #28906)", :js do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   before do

--- a/spec/features/wysiwyg/linking_spec.rb
+++ b/spec/features/wysiwyg/linking_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg linking", :js do
   shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  shared_let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]) }
   let(:editor) { Components::WysiwygEditor.new }
 
   before do

--- a/spec/features/wysiwyg/macros/attribute_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/attribute_macros_spec.rb
@@ -82,9 +82,10 @@ RSpec.describe "Wysiwyg attribute macros", :js do
   end
   shared_let(:project) do
     create(:project,
+           :with_internal_wiki,
            identifier: "some-project",
            types: [type_milestone, type_task],
-           enabled_module_names: %w[wiki work_package_tracking],
+           enabled_module_names: %w[work_package_tracking],
            parent: parent_project)
   end
   shared_let(:work_package) do

--- a/spec/features/wysiwyg/macros/child_pages_spec.rb
+++ b/spec/features/wysiwyg/macros/child_pages_spec.rb
@@ -32,8 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg child pages spec", :js do
   let(:project) do
-    create(:project,
-           enabled_module_names: %w[wiki])
+    create(:project, :with_internal_wiki)
   end
   let(:editor) { Components::WysiwygEditor.new }
   let(:role) { create(:project_role, permissions: %i[view_wiki_pages edit_wiki_pages]) }

--- a/spec/features/wysiwyg/macros/code_block_macro_spec.rb
+++ b/spec/features/wysiwyg/macros/code_block_macro_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Wysiwyg code block macro", :js, :selenium do
   shared_let(:admin) { create(:admin) }
   let(:user) { admin }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:snippet) do

--- a/spec/features/wysiwyg/macros/embedded_tables_spec.rb
+++ b/spec/features/wysiwyg/macros/embedded_tables_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Wysiwyg embedded work package tables",
   shared_let(:type_task) { create(:type_task) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do
-    create(:project, types: [type_task, type_bug], enabled_module_names: %w[wiki work_package_tracking])
+    create(:project, :with_internal_wiki, types: [type_task, type_bug], enabled_module_names: %w[work_package_tracking])
   end
   shared_let(:wp_task) { create(:work_package, project:, type: type_task) }
   shared_let(:wp_bug) { create(:work_package, project:, type: type_bug) }
@@ -114,7 +114,7 @@ RSpec.describe "Wysiwyg embedded work package tables",
 
       context "with a subproject that gets deleted" do
         let!(:subproject) do
-          create(:project, parent: project, enabled_module_names: %w[wiki])
+          create(:project, :with_internal_wiki, parent: project)
         end
 
         it "can still edit the embedded table widget" do

--- a/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg work package quicklink macros", :js do
   shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project_with_types) }
+  shared_let(:project) { create(:project_with_types, :with_internal_wiki).reload }
   let(:work_package) do
     create(:work_package,
            subject: "My subject",

--- a/spec/features/wysiwyg/macros/work_package_button_spec.rb
+++ b/spec/features/wysiwyg/macros/work_package_button_spec.rb
@@ -37,8 +37,9 @@ RSpec.describe "Wysiwyg work package button spec", :js do
   let!(:type) { create(:type, name: "MyTaskName") }
   let(:project) do
     create(:valid_project,
+           :with_internal_wiki,
            identifier: "my-project",
-           enabled_module_names: %w[wiki work_package_tracking],
+           enabled_module_names: %w[work_package_tracking],
            name: "My project name",
            types: [type])
   end

--- a/spec/features/wysiwyg/paragraphs_in_lists_spec.rb
+++ b/spec/features/wysiwyg/paragraphs_in_lists_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg paragraphs in lists behavior (Regression #28765)", :js do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:wiki_page) do

--- a/spec/features/wysiwyg/tables_spec.rb
+++ b/spec/features/wysiwyg/tables_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Wysiwyg tables", :js do
   shared_let(:admin) { create(:admin) }
   let(:user) { admin }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   before do

--- a/spec/features/wysiwyg/ui_localization_spec.rb
+++ b/spec/features/wysiwyg/ui_localization_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "WYSIWYG UI localization", :js do
   let(:user) { create(:admin, language:) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:wiki_page) do

--- a/spec/features/wysiwyg/work_package_linking_spec.rb
+++ b/spec/features/wysiwyg/work_package_linking_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg work package linking", :js, :selenium do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]) }
   let(:work_package) { create(:work_package, subject: "Foobar", project:) }
   let(:editor) { Components::WysiwygEditor.new }
 

--- a/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
@@ -40,18 +40,13 @@ RSpec.describe "OpenProject child pages macro" do
   end
 
   shared_let(:project) do
-    create(:valid_project,
-           enabled_module_names: %w[wiki])
+    create(:valid_project, :with_internal_wiki)
   end
   shared_let(:member_project) do
-    create(:valid_project,
-           identifier: "member-project",
-           enabled_module_names: %w[wiki])
+    create(:valid_project, :with_internal_wiki, identifier: "member-project")
   end
   shared_let(:invisible_project) do
-    create(:valid_project,
-           identifier: "other-project",
-           enabled_module_names: %w[wiki])
+    create(:valid_project, :with_internal_wiki, identifier: "other-project")
   end
   shared_let(:user) do
     create(:user, member_with_permissions: { project => [:view_wiki_pages],

--- a/spec/lib/open_project/text_formatting/markdown/in_tool_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/in_tool_links_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe OpenProject::TextFormatting,
   include_context "expected markdown modules"
 
   describe ".format_text" do
-    shared_let(:project) { create(:valid_project) }
+    shared_let(:project) { create(:valid_project, :with_internal_wiki, start_page: "CookBook documentation").reload }
     let(:identifier) { project.identifier }
 
     shared_let(:role) do
@@ -446,14 +446,9 @@ RSpec.describe OpenProject::TextFormatting,
 
     context "Wiki links" do
       let(:project_2) do
-        create(:valid_project,
-               identifier: "onlinestore")
+        create(:valid_project, :with_internal_wiki, identifier: "onlinestore")
       end
-      let(:wiki_1) do
-        create(:wiki,
-               start_page: "CookBook documentation",
-               project:)
-      end
+      let(:wiki_1) { project.wiki } # rubocop:disable Naming/VariableNumber
       let(:wiki_page_1_1) do
         create(:wiki_page,
                wiki: wiki_1,

--- a/spec/models/enabled_module_spec.rb
+++ b/spec/models/enabled_module_spec.rb
@@ -102,46 +102,6 @@ RSpec.describe EnabledModule do
     end
   end
 
-  describe "#wiki" do
-    let(:modules) { %w[wiki] }
-
-    it "creates a wiki" do
-      expect(project.wiki).not_to be_nil
-      expect(project.wiki.start_page).to eq("Wiki")
-    end
-
-    it "does not create a separate wiki when one exists already" do
-      expect(project.wiki).not_to be_nil
-
-      expect do
-        project.enabled_module_names = []
-        project.reload
-      end.not_to change(Wiki, :count)
-
-      expect do
-        project.enabled_module_names = ["wiki"]
-      end.not_to change(Wiki, :count)
-
-      expect(project.wiki).not_to be_nil
-    end
-
-    context "with disabled module" do
-      let(:modules) { [] }
-
-      it "does not create a wiki" do
-        expect(project.wiki).to be_nil
-      end
-
-      it "creates a wiki when the module is enabled at a later time" do
-        project.enabled_module_names = ["wiki"]
-        project.reload
-
-        expect(project.wiki).not_to be_nil
-        expect(project.wiki.start_page).to eq("Wiki")
-      end
-    end
-  end
-
   describe "#repository" do
     let(:modules) { %w[repository] }
 

--- a/spec/models/menu_items/wiki_menu_item_spec.rb
+++ b/spec/models/menu_items/wiki_menu_item_spec.rb
@@ -31,20 +31,19 @@
 require "spec_helper"
 
 RSpec.describe MenuItems::WikiMenuItem do
-  before do
-    @project = create(:project, enabled_module_names: %w[activity])
-    @current = create(:user, login: "user1", mail: "user1@users.com")
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: ["activity"]) }
+  let(:user) { create(:user) }
 
-    allow(User).to receive(:current).and_return(@current)
+  before do
+    allow(User).to receive(:current).and_return(user)
   end
 
-  it "creates a default wiki menu item when enabling the wiki" do
-    expect(MenuItems::WikiMenuItem.all).not_to be_any
+  it "creates a default wiki menu item when an internal wiki is added" do
+    expect(described_class.count).to eq(0)
 
-    @project.enabled_modules << EnabledModule.new(name: "wiki")
-    @project.reload
+    expect { project }.to change(described_class, :count).by(1)
 
-    wiki_item = @project.wiki.wiki_menu_items.first
+    wiki_item = project.wiki.wiki_menu_items&.first
     expect(wiki_item.name).to eql "wiki"
     expect(wiki_item.title).to eql "Wiki"
     expect(wiki_item.slug).to eql "wiki"
@@ -52,64 +51,46 @@ RSpec.describe MenuItems::WikiMenuItem do
     expect(wiki_item.options[:new_wiki_page]).to be true
   end
 
-  it "changes title when a wikipage is renamed" do
-    wikipage = create(:wiki_page, title: "Oldtitle")
+  it "changes title when a wiki_page is renamed" do
+    wiki_page = create(:wiki_page, title: "Oldtitle")
 
-    menu_item_1 = create(:wiki_menu_item, navigatable_id: wikipage.wiki.id,
-                                          title: "Item 1",
-                                          name: wikipage.slug)
+    menu_item = create(:wiki_menu_item, navigatable_id: wiki_page.wiki.id, title: "Item 1", name: wiki_page.slug)
 
-    wikipage.title = "Newtitle"
-    wikipage.save!
+    wiki_page.update!(title: "Newtitle")
 
-    menu_item_1.reload
-    expect(menu_item_1.title).to eq(wikipage.title)
+    expect(menu_item.reload.title).to eq(wiki_page.title)
   end
 
   it "does not allow duplicate sibling entries" do
-    wikipage = create(:wiki_page, title: "Parent Page")
+    wiki_page = create(:wiki_page, title: "Parent Page")
 
     parent = create(
-      :wiki_menu_item, navigatable_id: wikipage.wiki.id, title: "Item 1", name: wikipage.slug
+      :wiki_menu_item, navigatable_id: wiki_page.wiki.id, title: "Item 1", name: wiki_page.slug
     )
-    child_1 = parent.children.create name: "child-1", title: "Child 1"
-
+    parent.children.create name: "child-1", title: "Child 1"
     child_2 = parent.children.build name: "child-1", title: "Child 2"
 
     expect { child_2.save! }.to raise_error /Name has already been taken/
   end
 
   describe "it should destroy" do
-    before do
-      @project.enabled_modules << EnabledModule.new(name: "wiki")
-      @project.reload
-
-      @menu_item_1 = create(:wiki_menu_item, wiki: @project.wiki,
-                                             name: "Item 1",
-                                             title: "Item 1")
-
-      @menu_item_2 = create(:wiki_menu_item, wiki: @project.wiki,
-                                             name: "Item 2",
-                                             parent_id: @menu_item_1.id,
-                                             title: "Item 2")
-    end
+    let!(:first_menu_item) { create(:wiki_menu_item, wiki: project.wiki) }
+    let!(:second_menu_item) { create(:wiki_menu_item, wiki: project.wiki, parent: first_menu_item) }
 
     it "all children when deleting the parent" do
-      @menu_item_1.destroy
+      first_menu_item.destroy
 
-      expect { MenuItems::WikiMenuItem.find(@menu_item_1.id) }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { MenuItems::WikiMenuItem.find(@menu_item_2.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.find(first_menu_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.find(second_menu_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     describe "all items when destroying" do
       it "the associated project" do
-        @project.destroy
-        expect(MenuItems::WikiMenuItem.all).not_to be_any
+        expect { project.destroy }.to change(described_class, :count).to(0)
       end
 
       it "the associated wiki" do
-        @project.wiki.destroy
-        expect(MenuItems::WikiMenuItem.all).not_to be_any
+        expect { project.wiki.destroy }.to change(described_class, :count).to(0)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -133,25 +133,6 @@ RSpec.describe Project do
     end
   end
 
-  context "when the wiki module is enabled" do
-    let(:project) { create(:project, disable_modules: "wiki") }
-
-    before do
-      project.enabled_module_names = project.enabled_module_names | ["wiki"]
-      project.save
-      project.reload
-    end
-
-    it "creates a wiki" do
-      expect(project.wiki).to be_present
-    end
-
-    it "creates a wiki menu item named like the default start page" do
-      expect(project.wiki.wiki_menu_items).to be_one
-      expect(project.wiki.wiki_menu_items.first.title).to eq(project.wiki.start_page)
-    end
-  end
-
   describe "#copy_allowed?" do
     let(:user) { build_stubbed(:user) }
     let(:project) { build_stubbed(:project) }

--- a/spec/models/projects/activity_spec.rb
+++ b/spec/models/projects/activity_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe Projects::Activity, "core" do
   shared_let(:project) do
-    create(:project, :updated_a_long_time_ago)
+    create(:project, :with_internal_wiki, :updated_a_long_time_ago)
   end
 
   let(:initial_time) { Time.current }

--- a/spec/models/projects/storage_spec.rb
+++ b/spec/models/projects/storage_spec.rb
@@ -32,9 +32,9 @@ require "spec_helper"
 
 RSpec.describe Projects::Storage do
   let(:project1) do
-    create(:project)
-      .reload # Reload required for wiki association to be available
+    create(:project, :with_internal_wiki).reload # Reload required for wiki association to be available
   end
+
   let(:project2) { create(:project) }
 
   before do

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe WikiPage do
   shared_let(:author) { create(:user) }
-  shared_let(:project) { create(:project).reload } # a wiki is created for project, but the object doesn't know of it (FIXME?)
+  shared_let(:project) { create(:project, :with_internal_wiki).reload }
 
   let(:wiki) { project.wiki }
   let(:title) { wiki.wiki_menu_items.first.title }
@@ -52,7 +52,7 @@ RSpec.describe WikiPage do
 
   describe "#slug" do
     context "when another project with same title exists" do
-      let(:project2) { create(:project) }
+      let(:project2) { create(:project, :with_internal_wiki).reload }
       let(:wiki2) { project2.wiki }
       let!(:wiki_page1) { create(:wiki_page, wiki:, title: "asdf") }
       let!(:wiki_page2) { create(:wiki_page, wiki: wiki2, title: "asdf") }
@@ -335,11 +335,11 @@ RSpec.describe WikiPage do
 
   describe "#text" do
     it "does not truncate to 64k" do
-      content = described_class.create(title:, text: "a" * 500.kilobyte, author:, wiki:)
+      content = described_class.create(title:, text: "a" * 500.kilobytes, author:, wiki:)
       content.reload
 
       expect(content.text.size)
-        .to eql(500.kilobyte)
+        .to eql(500.kilobytes)
     end
   end
 

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -31,9 +31,9 @@
 require "spec_helper"
 
 RSpec.describe Wiki do
-  let(:project) { create(:project, disable_modules: "wiki") }
   let(:start_page) { "The wiki start page" }
-  let(:wiki) { project.create_wiki start_page: }
+  let(:project) { create(:project, :with_internal_wiki, start_page:) }
+  let(:wiki) { project.reload.wiki }
 
   describe "creation" do
     it_behaves_like "acts_as_watchable included" do

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
   shared_let(:source_project) do
     create(:project,
-           enabled_module_names: %w[work_package_tracking wiki],
+           :with_internal_wiki,
+           enabled_module_names: %w[work_package_tracking],
            custom_field_values: {
              text_custom_field.id => "source text",
              list_custom_field.id => list_custom_field.custom_options.last.id
@@ -158,7 +159,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
         expect(project).to be_present
 
         expect(source_project.wiki.pages.count).to eq 1
-        expect(project.wiki.pages.count).to eq 0
+        expect(project.wiki).to be_nil
 
         expect(source_project.work_packages.count).to eq 1
         expect(project.work_packages.count).to eq 1

--- a/spec/requests/wiki/menu_items_order_spec.rb
+++ b/spec/requests/wiki/menu_items_order_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Menu items order",
                :skip_csrf,
                type: :rails_request do
   shared_let(:admin) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki).reload }
   let(:wiki) { project.wiki }
 
   let!(:item3) { create(:wiki_menu_item, wiki:, title: "3. FAQ") }

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RootSeeder,
 
     it "creates the demo data" do # rubocop:disable RSpec/MultipleExpectations
       expect(Project.count).to eq 2
-      expect(EnabledModule.count).to eq 19
+      expect(EnabledModule.count).to eq 17
       expect(WorkPackage.count).to eq 37
       expect(Wiki.count).to eq 2
       expect(Query.having_views.count).to eq 8

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -40,8 +40,9 @@ RSpec.describe(
   shared_let(:status_locked) { create(:status, is_readonly: true) }
   shared_let(:source) do
     create(:project,
+           :with_internal_wiki,
            name: "Source Project Name",
-           enabled_module_names: %i[wiki work_package_tracking storages])
+           enabled_module_names: %i[work_package_tracking storages])
   end
   shared_let(:source_wp) { create(:work_package, project: source, subject: "source wp") }
   shared_let(:source_wp_locked) do
@@ -1297,9 +1298,7 @@ RSpec.describe(
         expect(project_copy.work_packages.count).to eq 0
         expect(project_copy.forums.count).to eq 0
         # Default wiki page
-        expect(project_copy.wiki).to be_present
-        expect(project_copy.wiki.pages.count).to eq 0
-        expect(project_copy.wiki.wiki_menu_items.count).to eq 1
+        expect(project_copy.wiki).to be_nil
         expect(project_copy.queries.count).to eq 0
         expect(project_copy.versions.count).to eq 0
         expect(project_copy.phases.count).to eq 0


### PR DESCRIPTION
It is possible that some features will be broken as there's no current way to activate the wikis after this PR is merged.

I'll add the flow on a second PR.

[OP#XWI-52](https://community.openproject.org/projects/XWI/work_packages/XWI-52)