### PR TITLE
[AGILE-323] Backlogs card keyboard and accessibility follow-ups

### DIFF
--- a/app/components/open_project/common/border_box_list_component/work_package_item.rb
+++ b/app/components/open_project/common/border_box_list_component/work_package_item.rb
@@ -105,7 +105,12 @@ module OpenProject
         #
         # @return [ApplicationComponent]
         def build_card
-          WorkPackageCardComponent.new(work_package:, classes: card_classes)
+          WorkPackageCardComponent.new(work_package:, **card_arguments)
+        end
+
+        # @return [Hash] keyword arguments forwarded to the card component.
+        def card_arguments
+          { classes: card_classes }
         end
 
         def card_classes

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -293,13 +293,20 @@ class WorkPackage < ApplicationRecord
     end
   end
 
-  def to_s
-    "#{type.name unless type.is_standard} #{formatted_id}: #{subject}"
-  end
+  def to_s = to_fs
 
-  def infoline(show_standard_type: true)
-    type_name = show_standard_type || !type.is_standard ? type.name : ""
-    "#{type_name}: #{subject} (#{formatted_id})"
+  # Human-readable label composed from the work package's type, id and subject.
+  #
+  # @param style [Symbol]
+  #   :heading => "Bug #42: Fix login" (non-standard type; type name omitted for standard types)
+  #   :caption => "Bug: Fix login (#42)" (type name always shown, even for standard types)
+  # @return [String]
+  def to_fs(style = :heading)
+    case style
+    when :heading then "#{type.name unless type.is_standard} #{formatted_id}: #{subject}"
+    when :caption then "#{type.name}: #{subject} (#{formatted_id})"
+    else raise ArgumentError, "unknown format style: #{style.inspect}"
+    end
   end
 
   # Return true if the work_package is closed, otherwise false

--- a/app/views/work_packages/show.html.erb
+++ b/app/views/work_packages/show.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title h(work_package.infoline) %>
+<% html_title h(work_package.to_fs(:caption)) %>
 
 <% content_for :sidebar do %>
   <%= render partial: 'sidebar' %>

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/work-package.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/work-package.controller.spec.ts
@@ -93,13 +93,13 @@ describe('Backlogs work package controller', () => {
     return event;
   }
 
-  it('prevents Space from scrolling the page without activating the card', async () => {
+  it('lets Space scroll the page natively without hijacking it', async () => {
     const workPackage = renderWorkPackage();
 
     await nextFrame();
     const event = keydown(workPackage, ' ');
 
-    expect(event.defaultPrevented).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
     expect(navigation.openSplitPane).not.toHaveBeenCalled();
     expect(navigation.openFullPane).not.toHaveBeenCalled();
   });

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/work-package.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/work-package.controller.ts
@@ -160,7 +160,7 @@ export default class WorkPackageController extends Controller<HTMLElement> imple
   }
 
   private onKeydown(event:KeyboardEvent):void {
-    if (event.key !== 'Enter' && event.key !== ' ') return;
+    if (event.key !== 'Enter') return;
 
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
@@ -168,7 +168,6 @@ export default class WorkPackageController extends Controller<HTMLElement> imple
     if (this.shouldIgnoreKeyboardTarget(target)) return;
 
     event.preventDefault();
-    if (event.key === ' ') return;
 
     if (event.shiftKey) {
       this.openFullPane();

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
@@ -58,12 +58,17 @@ module Backlogs
       url_helpers.menu_project_backlogs_work_package_path(project, work_package)
     end
 
+    # @return [Hash] card arguments carrying the Backlogs-only keyboard wiring.
+    #   `tabindex` lives here rather than in the base because only this subclass
+    #   attaches the `backlogs--work-package` Enter handler; a focusable base card
+    #   would be a dead tab stop. The `:has(> .Box-card:focus-visible)` row rule
+    #   depends on this focusability.
     def card_arguments
-      {
-        classes: card_classes,
-        tabindex: 0,
-        data: card_data
-      }
+      arguments = super
+      arguments[:tabindex] = 0
+      arguments[:data] = merge_data(arguments, { data: card_data })
+      arguments[:aria] = merge_aria(arguments, { aria: card_aria })
+      arguments
     end
 
     def card_data
@@ -79,6 +84,17 @@ module Backlogs
       return data unless draggable?
 
       data.merge(sortable_lists__item_target: "preview handle")
+    end
+
+    # @return [Hash] ARIA wiring announcing the card's Enter activation without
+    #   claiming button or draggable semantics. Lives in the subclass because
+    #   only here is the `backlogs--work-package` Enter handler attached; the
+    #   base card is focusable for styling alone and must not claim a shortcut.
+    def card_aria
+      {
+        keyshortcuts: "Enter",
+        label: work_package.to_fs(:caption)
+      }
     end
 
     def draggable_data

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
       )
     end
 
+    it "announces Enter activation to assistive tech without a button or drag role" do
+      expect(rendered_card).to have_css(
+        ".op-work-package-card",
+        role: "article",
+        aria: {
+          keyshortcuts: "Enter",
+          label: work_package.to_fs(:caption),
+          roledescription: nil
+        }
+      )
+    end
+
     it "does not wire the card as the draggable item" do
       expect(rendered_card).to have_css(
         ".op-work-package-card[data-controller~='backlogs--work-package']"

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -527,6 +527,15 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
         expect(rendered_component).to have_no_css(".Box-card--draggable")
       end
 
+      it "does not claim Enter activation on the base card (no Enter handler there)" do
+        expect(rendered_component).to have_css(".Box-card", aria: { keyshortcuts: nil })
+      end
+
+      it "does not make the base card keyboard-focusable (no Enter handler there)" do
+        expect(rendered_component).to have_css(".op-work-package-card")
+        expect(rendered_component).to have_no_css(".op-work-package-card[tabindex]")
+      end
+
       it "sets the test selector" do
         item = described_class::WorkPackageItem.new(
           work_package:,

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Work package navigation", :js, :selenium do
   let(:work_package) { build(:work_package, project:) }
   let(:global_html_title) { Components::HtmlTitle.new }
   let(:project_html_title) { Components::HtmlTitle.new project }
-  let(:wp_title_segment) { work_package.infoline }
+  let(:wp_title_segment) { work_package.to_fs(:caption) }
 
   let!(:query) do
     query = build(:query, user:, project:)

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -920,55 +920,83 @@ RSpec.describe WorkPackage do
     end
   end
 
-  describe "#infoline" do
-    let(:infoline_type) { create(:type, name: "Task") }
-    let(:infoline_work_package) do
-      create(:work_package, subject: "Hello world", project: infoline_project, type: infoline_type)
-    end
+  describe "#to_fs" do
+    describe ":heading style (the default, used by #to_s)" do
+      let(:task_type) { create(:type_task) }
 
-    context "when semantic mode is active",
-            with_settings: { work_packages_identifier: "semantic" } do
-      let(:infoline_project) { create(:project, identifier: "MYPROJ") }
+      context "in classic mode",
+              with_settings: { work_packages_identifier: "classic" } do
+        let(:work_package) { create(:work_package, project:, type: task_type, subject: "Hello world") }
 
-      before { infoline_work_package }
+        it "renders the type, the `#`-prefixed numeric id and the subject" do
+          expect(work_package.to_fs(:heading)).to eq("Task ##{work_package.id}: Hello world")
+        end
 
-      it "renders the semantic identifier without a hash prefix" do
-        expect(infoline_work_package.reload.infoline).to eq("Task: Hello world (MYPROJ-1)")
+        it "is the default style, and #to_s delegates to it" do
+          expect(work_package.to_fs).to eq("Task ##{work_package.id}: Hello world")
+          expect(work_package.to_s).to eq(work_package.to_fs(:heading))
+        end
+
+        it "omits the type name for standard types (leading space preserved)" do
+          standard_wp = create(:work_package, project:, type:, subject: "Hello world")
+          expect(standard_wp.to_fs(:heading)).to eq(" ##{standard_wp.id}: Hello world")
+        end
+      end
+
+      context "in semantic mode",
+              with_settings: { work_packages_identifier: "semantic" } do
+        let(:project) { create(:project, identifier: "MACROPROJ", types: [task_type]) }
+        let(:work_package) { create(:work_package, project:, type: task_type, subject: "Hello world") }
+
+        it "renders the semantic identifier without a `#` prefix" do
+          wp = work_package.reload
+          expect(wp.to_fs(:heading)).to eq("Task #{wp.display_id}: Hello world")
+          expect(wp.to_fs(:heading)).not_to include("##{wp.id}")
+        end
       end
     end
 
-    context "when semantic mode is not active",
-            with_settings: { work_packages_identifier: "classic" } do
-      let(:infoline_project) { create(:project) }
+    describe ":caption style" do
+      let(:caption_type) { create(:type, name: "Task") }
+      let(:caption_work_package) do
+        create(:work_package, subject: "Hello world", project: caption_project, type: caption_type)
+      end
 
-      it "renders the hash-prefixed numeric id" do
-        expect(infoline_work_package.infoline).to eq("Task: Hello world (##{infoline_work_package.id})")
+      context "in semantic mode",
+              with_settings: { work_packages_identifier: "semantic" } do
+        let(:caption_project) { create(:project, identifier: "MYPROJ") }
+
+        before { caption_work_package }
+
+        it "renders the type, subject and the semantic id in parentheses" do
+          expect(caption_work_package.reload.to_fs(:caption)).to eq("Task: Hello world (MYPROJ-1)")
+        end
+      end
+
+      context "in classic mode",
+              with_settings: { work_packages_identifier: "classic" } do
+        let(:caption_project) { create(:project) }
+
+        it "renders the type, subject and the `#`-prefixed numeric id in parentheses" do
+          expect(caption_work_package.to_fs(:caption))
+            .to eq("Task: Hello world (##{caption_work_package.id})")
+        end
+      end
+
+      context "with a standard type",
+              with_settings: { work_packages_identifier: "classic" } do
+        let(:standard_work_package) { create(:work_package, project:, type:, subject: "Hello world") }
+
+        it "still shows the type name in the caption" do
+          expect(standard_work_package.to_fs(:caption))
+            .to eq("#{type.name}: Hello world (##{standard_work_package.id})")
+        end
       end
     end
-  end
 
-  describe "#to_s" do
-    let(:task_type) { create(:type_task) }
-
-    context "in classic mode",
-            with_settings: { work_packages_identifier: "classic" } do
-      let(:work_package) { create(:work_package, project:, type: task_type, subject: "Hello world") }
-
-      it "renders the numeric id with a `#` prefix" do
-        expect(work_package.to_s).to eq("Task ##{work_package.id}: Hello world")
-      end
-    end
-
-    context "in semantic mode",
-            with_settings: { work_packages_identifier: "semantic" } do
-      let(:project) { create(:project, identifier: "MACROPROJ", types: [task_type]) }
-      let(:work_package) { create(:work_package, project:, type: task_type, subject: "Hello world") }
-
-      it "renders the semantic identifier without a `#` prefix" do
-        wp = work_package.reload
-        expect(wp.to_s).to eq("Task #{wp.display_id}: Hello world")
-        expect(wp.to_s).not_to include("##{wp.id}")
-      end
+    it "raises ArgumentError for an unknown style" do
+      expect { work_package.to_fs(:bogus) }
+        .to raise_error(ArgumentError, /unknown format style/)
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-323

# What are you trying to accomplish?

Keyboard and screen-reader follow-ups for the backlogs cards introduced in #23218 (stacked on `implementation/74970-backlogs-pragmatic-dnd`).

- Base `BorderBoxListComponent::WorkPackageItem` cards are keyboard-focusable again. The generic `with_work_package_item` path rendered clickable cards without a `tabindex`, so keyboard users could not reach them and the `:has(> .Box-card:focus-visible)` row styling never fired; only the backlogs subclass re-added the attribute.

- Space is no longer hijacked on backlogs cards. The keydown handler prevented Space's default and then ignored the key, leaving Space dead while also killing native page scroll. Enter (and Shift+Enter) remain the only activation keys; Space is left to the browser.

- Backlogs cards announce their Enter activation to assistive tech via `aria-keyshortcuts="Enter"` and an `aria-label` (`<display id> <subject>`).

> [!NOTE]
> The Space change effectively reverts #23524 (https://community.openproject.org/wp/AGILE-271): pressing Space on a focused card scrolls the page again, as it does elsewhere in OpenProject. That fix traded a scroll quirk for a dead key; suppressing native Space behavior on a non-widget element (the card is an `article`, not a button) is the bigger accessibility smell. Space stays reserved in case cards later gain selection semantics.

# What approach did you choose and why?

`tabindex` lives in the base `card_arguments` because focusability is a property of every clickable card, while the ARIA announcement lives only in the backlogs subclass: only there is the `backlogs--work-package` Enter handler attached, and the base card must not claim a shortcut it does not honor.

The cards deliberately do not get `role="button"`: they render as `article` elements whose Enter/double-click activation is a shortcut on top of normal document content, not button semantics. Specs assert the computed role and ARIA attributes through Capybara accessible selectors' `role:`/`aria:` filters rather than raw CSS attribute selectors.

Card arguments are merged with Primer's `merge_data`/`merge_aria` helpers, matching how other components compose system arguments.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
