### PR TITLE
[COMMS-835] Enforce canonical WP IDs in shortlink redirects

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -290,14 +290,19 @@ class WorkPackagesController < ApplicationController
   end
 
   def redirect_to_complete_route
-    # redirect /work_packages/:id to a full route with project and tab
+    # Redirect to the canonical show route: the work package's *current* display
+    # identifier and its project's current slug. Upgrades historical semantic
+    # aliases (and numeric ids in semantic mode) to the present identifier, and
+    # fills in a missing project or tab.
     redirect_to action: "show",
-                id: params[:id],
-                project_id: params[:project_id] || work_package.project.identifier,
+                id: work_package.display_id,
+                project_id: work_package.project.identifier,
                 tab: params[:tab] || "activity"
   end
 
   def show_route_incomplete?
-    params[:project_id].blank? || params[:tab].blank?
+    params[:project_id].blank? ||
+      params[:tab].blank? ||
+      params[:id].to_s != work_package.display_id.to_s
   end
 end

--- a/spec/requests/work_packages/show_spec.rb
+++ b/spec/requests/work_packages/show_spec.rb
@@ -83,5 +83,31 @@ RSpec.describe "GET work package show", type: :rails_request do
 
       include_examples "includes canonical link tag"
     end
+
+    context "when accessed via a historical alias" do
+      let!(:old_alias) do
+        create(:work_package_semantic_alias,
+               work_package:,
+               identifier: "OLD-#{work_package.sequence_number}")
+      end
+
+      it "redirects to the current-identifier URL" do
+        get "/projects/#{project.identifier}/work_packages/#{old_alias.identifier}/activity"
+
+        expect(response).to redirect_to(
+          "/projects/#{project.identifier}/work_packages/#{work_package.display_id}/activity"
+        )
+      end
+    end
+
+    context "when accessed via the numeric ID" do
+      it "redirects to the semantic-identifier URL" do
+        get "/projects/#{project.identifier}/work_packages/#{work_package.id}/activity"
+
+        expect(response).to redirect_to(
+          "/projects/#{project.identifier}/work_packages/#{work_package.display_id}/activity"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-835/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Make sure that WP shortlinks redirect to "fresh" canonical URLs.

e.g. `/work_packages/OLDPROJ-123` => `/projects/NEWPROJ/work_packages/NEWPROJ-123`

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
