### PR TITLE
[COMMS-849] Support `target_versions` in bulk WP edit

### DIFF
--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -131,7 +131,22 @@ class WorkPackages::BulkController < ApplicationController
     attributes = permitted_params.update_work_package
     attributes[:custom_field_values] = transform_attributes(attributes[:custom_field_values])
     attributes = attributes_with_normalized_parent_id(attributes)
-    transform_attributes(attributes)
+    # target_version_ids is an array param and must not be run through the generic
+    # transform below (which is built for scalar "none"/blank magic values), so pull
+    # it out, normalize it separately, and merge the result back in.
+    target_version_ids = normalized_target_version_ids(attributes.delete(:target_version_ids))
+    attributes = transform_attributes(attributes)
+    attributes[:target_version_ids] = target_version_ids unless target_version_ids.nil?
+    attributes
+  end
+
+  # Mirrors the legacy version_id magic values for the array-valued target_version_ids:
+  #   * blank selection  -> nil  (leave existing target_versions untouched)
+  #   * "none" selection -> []   (clear all target_versions)
+  #   * a version id      -> [id]
+  def normalized_target_version_ids(raw)
+    values = Array(raw).compact_blank
+    values == ["none"] ? [] : values.presence
   end
 
   def attributes_with_normalized_parent_id(attributes)

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -570,6 +570,7 @@ class PermittedParams
           :due_date,
           :estimated_hours,
           :version_id,
+          { target_version_ids: [] },
           :budget_id,
           :parent_id,
           :priority_id,

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -135,14 +135,18 @@ See COPYRIGHT and LICENSE files for more details.
               </div>
             </div>
             <%# TODO: allow editing versions when multiple projects %>
+            <%# Always write through target_version_ids (version_id is synced from it on save); the feature only toggles single vs. multiple select. %>
+            <% multiple_versions = Setting::WorkPackageMultipleVersions.active? %>
             <div class="form--field">
-              <%= styled_label_tag :work_package_version_id, WorkPackage.human_attribute_name(:version) %>
+              <%= styled_label_tag :work_package_target_version_ids,
+                                   WorkPackage.human_attribute_name(multiple_versions ? :target_versions : :version) %>
               <div class="form--field-container">
                 <%= styled_select_tag(
-                      "work_package[version_id]",
+                      "work_package[target_version_ids][]",
                       content_tag("option", t(:label_none), value: "none") +
                       version_options_for_select(@project.shared_versions.with_status_open.order(:name)),
-                      include_blank: t(:label_no_change_option)
+                      include_blank: t(:label_no_change_option),
+                      multiple: multiple_versions
                     ) %>
               </div>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2213,6 +2213,7 @@ en:
         spent_hours: "Spent time"
         spent_time: "Spent time"
         subproject: "Subproject"
+        target_versions: "Target versions"
         time_entries: "Log time"
         type: "Type"
         version: "Version"

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -547,6 +547,55 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
             end
           end
 
+          describe "set target_version_ids attribute",
+                   with_settings: { work_package_multiple_versions: true } do
+            shared_let(:target_subproject) do
+              create(:project, parent: project1, types: [type])
+            end
+            shared_let(:target_version) do
+              create(:version, status: "open", sharing: "tree", project: target_subproject)
+            end
+
+            describe "to a version" do
+              before do
+                put :update,
+                    params: {
+                      ids: work_package_ids,
+                      work_package: { target_version_ids: [target_version.id.to_s] }
+                    }
+              end
+
+              it "redirects on success" do
+                expect(response).to be_redirect
+              end
+
+              it "assigns the version as target_versions on every selected work package" do
+                expect(work_packages.map { |wp| wp.target_versions.pluck(:id) }.uniq)
+                  .to contain_exactly([target_version.id])
+              end
+            end
+
+            describe "to none" do
+              before do
+                work_packages.each do |wp|
+                  wp.work_package_versions.create!(version_id: target_version.id, kind: "target")
+                end
+
+                # 'none' is a magic value that clears all target_versions
+                put :update,
+                    params: {
+                      ids: work_package_ids,
+                      work_package: { target_version_ids: ["none"] }
+                    }
+              end
+
+              it "clears the target_versions on every selected work package" do
+                expect(work_packages.map { |wp| wp.target_versions.pluck(:id) }.uniq)
+                  .to contain_exactly([])
+              end
+            end
+          end
+
           describe "set version_id to nil" do
             before do
               # 'none' is a magic value, setting version_id to nil


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/SJF/work_packages/COMMS-849/activity


<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
* For current state, make the UI use _single-valued_ `target_versions` instead of `version`.
* For target versions support (behind feature flag), enable multiple valued fro `target_versions`.

## Screenshots
With feature flag "Work package multiple versions" off:

<img width="995" height="405" alt="Screenshot 2026-07-05 at 23 54 01" src="https://github.com/user-attachments/assets/64a2ea44-ca6d-4f36-a5e3-c89ccc10319f" />
<img width="1167" height="95" alt="Screenshot 2026-07-05 at 23 54 37" src="https://github.com/user-attachments/assets/ebcafccf-d0e2-4d1d-89cd-287d9210ce0a" />

With feature flag "Work package multiple versions" on:

<img width="989" height="463" alt="Screenshot 2026-07-05 at 23 52 19" src="https://github.com/user-attachments/assets/e09e2464-3505-4871-8eab-16ad3ce3ba13" />
<img width="1277" height="99" alt="Screenshot 2026-07-05 at 23 53 36" src="https://github.com/user-attachments/assets/d3e4ea83-2ca6-4c58-8abe-5e8a441bf5ce" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
