### PR TITLE
Introduce a feature flag for `target_versions` support

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -410,7 +410,8 @@ module WorkPackages
     # While the deprecated single version_id column coexists with target_versions,
     # the two must not contradict each other. This enforces both constraints of
     # that transitional period in one place:
-    #   * target_versions still behaves as a single value (at most one entry), and
+    #   * target_versions behaves as a single value (at most one entry) unless the
+    #     multiple-versions feature is enabled, and
     #   * version_id and target_versions may both be written in one request as
     #     long as they agree; only an actual contradiction is rejected.
     def validate_target_versions_and_legacy_version_id
@@ -421,6 +422,8 @@ module WorkPackages
     end
 
     def validate_target_versions_length
+      return if Setting::WorkPackageMultipleVersions.active?
+
       if model.target_version_ids_replacements.length > 1
         errors.add :base, :target_versions_only_allow_single_value
       end

--- a/app/models/setting/work_package_multiple_versions.rb
+++ b/app/models/setting/work_package_multiple_versions.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Setting
+  # Single gate for the "multiple (target) versions" feature. Every call site
+  # (views, contracts, services) should ask this predicate rather than reading
+  # the flag or the setting directly, so the feature can be rolled out in phases
+  # by changing only this method.
+  #
+  # The user-facing Setting.work_package_multiple_versions is already respected,
+  # but the experimental feature flag takes precedence: while it is active (it is
+  # on by default in development and can be toggled at /admin/settings/experimental)
+  # the feature is enabled regardless of the setting. This lets a developer opt in
+  # via the flag today, while the setting governs everywhere the flag is off.
+  #
+  #   * later (phase 2): build the admin switch for the setting; this predicate
+  #     needs no change, as it already respects the setting.
+  #   * before release (phase 3): drop the flag, leaving just
+  #       Setting.work_package_multiple_versions?
+  module WorkPackageMultipleVersions
+    def self.active?
+      OpenProject::FeatureDecisions.work_package_multiple_versions_active? ||
+        Setting.work_package_multiple_versions?
+    end
+  end
+end

--- a/app/models/setting/work_package_multiple_versions.rb
+++ b/app/models/setting/work_package_multiple_versions.rb
@@ -29,25 +29,11 @@
 #++
 
 class Setting
-  # Single gate for the "multiple (target) versions" feature. Every call site
-  # (views, contracts, services) should ask this predicate rather than reading
-  # the flag or the setting directly, so the feature can be rolled out in phases
-  # by changing only this method.
-  #
-  # Both the user-facing Setting.work_package_multiple_versions and the
-  # experimental feature flag must be enabled for the feature to be active. This
-  # keeps it off by default everywhere (the setting defaults to false), while the
-  # flag gates it out of production until the feature is ready: even if the
-  # setting is switched on, the feature stays off unless the flag is active. The
-  # flag is on by default in development and can be toggled at
-  # /admin/settings/experimental, so a developer opts in by enabling the setting.
-  #
-  # This mirrors Setting::WorkPackageIdentifier.semantic_mode_active?.
-  #
-  #   * later (phase 2): build the admin switch for the setting; this predicate
-  #     needs no change.
-  #   * before release (phase 3): drop the flag, leaving just
-  #       Setting.work_package_multiple_versions?
+  # Single gate for the "multiple (target) versions" feature: active only when
+  # both the user-facing setting and the experimental feature flag are enabled.
+  # Call sites (views, contracts, services) should ask this predicate rather than
+  # reading either gate directly, so the phased rollout (adding the admin switch,
+  # then dropping the flag) only ever touches this method.
   module WorkPackageMultipleVersions
     def self.active?
       Setting.work_package_multiple_versions? &&

--- a/app/models/setting/work_package_multiple_versions.rb
+++ b/app/models/setting/work_package_multiple_versions.rb
@@ -34,20 +34,24 @@ class Setting
   # the flag or the setting directly, so the feature can be rolled out in phases
   # by changing only this method.
   #
-  # The user-facing Setting.work_package_multiple_versions is already respected,
-  # but the experimental feature flag takes precedence: while it is active (it is
-  # on by default in development and can be toggled at /admin/settings/experimental)
-  # the feature is enabled regardless of the setting. This lets a developer opt in
-  # via the flag today, while the setting governs everywhere the flag is off.
+  # Both the user-facing Setting.work_package_multiple_versions and the
+  # experimental feature flag must be enabled for the feature to be active. This
+  # keeps it off by default everywhere (the setting defaults to false), while the
+  # flag gates it out of production until the feature is ready: even if the
+  # setting is switched on, the feature stays off unless the flag is active. The
+  # flag is on by default in development and can be toggled at
+  # /admin/settings/experimental, so a developer opts in by enabling the setting.
+  #
+  # This mirrors Setting::WorkPackageIdentifier.semantic_mode_active?.
   #
   #   * later (phase 2): build the admin switch for the setting; this predicate
-  #     needs no change, as it already respects the setting.
+  #     needs no change.
   #   * before release (phase 3): drop the flag, leaving just
   #       Setting.work_package_multiple_versions?
   module WorkPackageMultipleVersions
     def self.active?
-      OpenProject::FeatureDecisions.work_package_multiple_versions_active? ||
-        Setting.work_package_multiple_versions?
+      Setting.work_package_multiple_versions? &&
+        OpenProject::FeatureDecisions.work_package_multiple_versions_active?
     end
   end
 end

--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -55,3 +55,7 @@ OpenProject::FeatureDecisions.add :wiki_enhancements,
 
 OpenProject::FeatureDecisions.add :subtypes,
                                   description: "Enables work package subtypes."
+
+OpenProject::FeatureDecisions.add :work_package_multiple_versions,
+                                  description: "Enables assigning multiple (target) versions to a work package. " \
+                                               "Experimental; the user-facing setting and admin switch follow later."

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1353,6 +1353,34 @@ RSpec.describe WorkPackages::BaseContract do
       end
     end
 
+    describe "target versions length" do
+      let(:other_assignable_version) { build_stubbed(:version) }
+
+      before do
+        allow(work_package).to receive(:assignable_versions)
+          .and_return([assignable_version, other_assignable_version])
+        work_package.target_version_ids_replacements = [assignable_version.id, other_assignable_version.id]
+      end
+
+      context "when the multiple-versions feature is disabled" do
+        before { contract.validate }
+
+        it "rejects more than one target version" do
+          expect(contract.errors.symbols_for(:base)).to include(:target_versions_only_allow_single_value)
+        end
+      end
+
+      context "when the multiple-versions feature is enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        before { contract.validate }
+
+        it "allows more than one target version" do
+          expect(contract.errors.symbols_for(:base)).not_to include(:target_versions_only_allow_single_value)
+        end
+      end
+    end
+
     describe "observed_in versions assignability" do
       context "with assignable IDs" do
         before do

--- a/spec/models/setting/work_package_multiple_versions_spec.rb
+++ b/spec/models/setting/work_package_multiple_versions_spec.rb
@@ -31,18 +31,20 @@
 require "spec_helper"
 
 RSpec.describe Setting::WorkPackageMultipleVersions do
-  # The feature flag takes precedence: while it is active the feature is enabled
-  # regardless of the setting.
+  # Both the setting and the feature flag must be enabled for the feature to be active.
   context "when the feature flag is active", with_flag: { work_package_multiple_versions: true } do
-    context "and the setting is disabled", with_settings: { work_package_multiple_versions: false } do
+    context "and the setting is enabled", with_settings: { work_package_multiple_versions: true } do
       it { expect(described_class.active?).to be true }
+    end
+
+    context "and the setting is disabled", with_settings: { work_package_multiple_versions: false } do
+      it { expect(described_class.active?).to be false }
     end
   end
 
-  # With the flag off, the user-facing setting governs.
   context "when the feature flag is inactive", with_flag: { work_package_multiple_versions: false } do
     context "and the setting is enabled", with_settings: { work_package_multiple_versions: true } do
-      it { expect(described_class.active?).to be true }
+      it { expect(described_class.active?).to be false }
     end
 
     context "and the setting is disabled", with_settings: { work_package_multiple_versions: false } do

--- a/spec/models/setting/work_package_multiple_versions_spec.rb
+++ b/spec/models/setting/work_package_multiple_versions_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Setting::WorkPackageMultipleVersions do
+  # The feature flag takes precedence: while it is active the feature is enabled
+  # regardless of the setting.
+  context "when the feature flag is active", with_flag: { work_package_multiple_versions: true } do
+    context "and the setting is disabled", with_settings: { work_package_multiple_versions: false } do
+      it { expect(described_class.active?).to be true }
+    end
+  end
+
+  # With the flag off, the user-facing setting governs.
+  context "when the feature flag is inactive", with_flag: { work_package_multiple_versions: false } do
+    context "and the setting is enabled", with_settings: { work_package_multiple_versions: true } do
+      it { expect(described_class.active?).to be true }
+    end
+
+    context "and the setting is disabled", with_settings: { work_package_multiple_versions: false } do
+      it { expect(described_class.active?).to be false }
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/opf/openproject/pull/24058

The above implemented a Setting switch (which is assumed to be used later in a new admin page).

WIthout that admin page, it's actually a bit of a pain to turn this on.

Let's also add in a feature flag, which provides a way to toggle this at runtime: 
* Set `OPENPROJECT_WORK__PACKAGE__MULTIPLE__VERSIONS=true`
* Then, toggle target versions support at `/admin/settings/experimental`

We may remove the feature flag after `target_versions` are fully implemented.

```
┌─────────────┬──────────┬─────────┐
│             │ flag off │ flag on │
├─────────────┼──────────┼─────────┤
│ setting off │ off      │ off     │
├─────────────┼──────────┼─────────┤
│ setting on  │ off      │ on      │
└─────────────┴──────────┴─────────┘
```

<img width="655" height="647" alt="Screenshot 2026-07-06 at 0 21 01" src="https://github.com/user-attachments/assets/35000913-9e27-44cb-99b2-7b6a18cb60f8" />
