### PR TITLE
Actually delete DeltedUser participants

### DIFF
--- a/modules/meeting/db/migrate/20260706065400_remove_deleted_user_meeting_participants.rb
+++ b/modules/meeting/db/migrate/20260706065400_remove_deleted_user_meeting_participants.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RemoveDeletedUserMeetingParticipants < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL.squish
+      DELETE FROM meeting_participant_journals
+      USING users
+      WHERE meeting_participant_journals.user_id = users.id
+        AND users.type = 'DeletedUser'
+    SQL
+
+    execute <<~SQL.squish
+      DELETE FROM meeting_participants
+      USING users
+      WHERE meeting_participants.user_id = users.id
+        AND users.type = 'DeletedUser'
+    SQL
+  end
+
+  def down
+    # Nothing to do here
+  end
+end


### PR DESCRIPTION
They cause more issues, such as trying to send out an email when the meeting is cancelled. We need to clean up all existing DeletedUser instances

https://community.openproject.org/work_packages/MEET-576
