### PR TITLE
[chore] fix UI texts in inline wiki page modals

### DIFF
--- a/modules/wikis/app/components/wikis/inline_wiki_page_dialog.html.erb
+++ b/modules/wikis/app/components/wikis/inline_wiki_page_dialog.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     Primer::Alpha::Dialog.new(
       id: DIALOG_ID,
-      title: t(".title"),
+      title:,
       size: :large,
       data: { "keep-open-on-submit": keep_dialog_open? },
       **system_arguments

--- a/modules/wikis/app/components/wikis/inline_wiki_page_dialog.rb
+++ b/modules/wikis/app/components/wikis/inline_wiki_page_dialog.rb
@@ -43,7 +43,7 @@ module Wikis
       when :inline_existing_wiki_page
         t(".title_add")
       else
-        t(".title")
+        raise ArgumentError, "#{model.key} is not a supported key."
       end
     end
 

--- a/modules/wikis/app/components/wikis/inline_wiki_page_dialog.rb
+++ b/modules/wikis/app/components/wikis/inline_wiki_page_dialog.rb
@@ -36,6 +36,17 @@ module Wikis
 
     def form_id = "#{DIALOG_ID}-form"
 
+    def title
+      case model.key
+      when :inline_new_wiki_page
+        t(".title_create")
+      when :inline_existing_wiki_page
+        t(".title_add")
+      else
+        t(".title")
+      end
+    end
+
     def form_options
       if model.final_step?
         {

--- a/modules/wikis/app/forms/wikis/inline_new_wiki_page_form.rb
+++ b/modules/wikis/app/forms/wikis/inline_new_wiki_page_form.rb
@@ -37,7 +37,7 @@ module Wikis
 
         f.filterable_tree_view(
           name: "wiki_page_selection",
-          label: I18n.t("wikis.page_link_forms.labels.wiki_page"),
+          label: I18n.t("wikis.page_link_forms.labels.parent"),
           src: helpers.search_wiki_pages_path(provider_id: model.provider_id, name: "wiki_page_selection"),
           filter_mode_control_arguments: { hidden: true },
           filter_input_arguments: { placeholder: I18n.t("wikis.page_link_forms.search.placeholder") },

--- a/modules/wikis/app/models/wikis/forms/inline_existing_wiki_page_form_model.rb
+++ b/modules/wikis/app/models/wikis/forms/inline_existing_wiki_page_form_model.rb
@@ -41,6 +41,8 @@ module Wikis
         @provider_id = provider_id
       end
 
+      def key = :inline_existing_wiki_page
+
       def final_step?
         provider_id.present?
       end

--- a/modules/wikis/app/models/wikis/forms/inline_new_wiki_page_form_model.rb
+++ b/modules/wikis/app/models/wikis/forms/inline_new_wiki_page_form_model.rb
@@ -42,6 +42,8 @@ module Wikis
         @page_title = page_title
       end
 
+      def key = :inline_new_wiki_page
+
       def final_step?
         provider_id.present? && page_title.present?
       end

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -155,8 +155,9 @@ en:
         xwiki_oauth_request_error: An unexpected error occured when trying to communicate with the XWiki instance.
         xwiki_oauth_token_missing: OpenProject cannot test the user-level communication with XWiki as the user did not yet connect their XWiki account.
         xwiki_oauth_unauthorized: The user token was not recognized by XWiki.
-    inline_existing_wiki_page_dialog:
-      title: Add existing wiki page
+    inline_wiki_page_dialog:
+      title_add: Add existing wiki page
+      title_create: Create new wiki page
     instructions:
       xwiki:
         integration: XWiki Administration


### PR DESCRIPTION
# What are you trying to accomplish?
- fix expected UI texts in inline modals
- they should be the same as in modals triggered from the wikis tab

# What approach did you choose and why?
- add the missing code
