### PR TITLE
Disable material costs of work packages when no type active

### DIFF
--- a/modules/costs/app/components/projects/settings/cost_types/index_component.html.erb
+++ b/modules/costs/app/components/projects/settings/cost_types/index_component.html.erb
@@ -82,7 +82,7 @@ See COPYRIGHT and LICENSE files for more details.
                     ) do |hover_card|
                       hover_card.with_column do
                         render(Primer::Beta::Text.new) do
-                          t("cost_types.settings.cost_types.for_all_projects_hint")
+                          disabled_hint(cost_type)
                         end
                       end
                     end

--- a/modules/costs/app/components/projects/settings/cost_types/index_component.rb
+++ b/modules/costs/app/components/projects/settings/cost_types/index_component.rb
@@ -49,8 +49,16 @@ module Projects
           @enabled_cost_type_ids ||= ::CostTypesProject.where(project_id: project.id).pluck(:cost_type_id).to_set
         end
 
+        def in_use_cost_type_ids
+          @in_use_cost_type_ids ||= ::CostEntry.where(project_id: project.id).distinct.pluck(:cost_type_id).to_set
+        end
+
         def enabled?(cost_type)
           enabled_cost_type_ids.include?(cost_type.id)
+        end
+
+        def in_use?(cost_type)
+          in_use_cost_type_ids.include?(cost_type.id)
         end
 
         def toggle_path(cost_type)
@@ -61,8 +69,18 @@ module Projects
           cost_type.for_all_projects? || enabled?(cost_type)
         end
 
+        # A cost type is locked either because it applies to all projects, or because
+        # costs have already been logged for it and disabling it would hide them.
         def toggle_disabled?(cost_type)
-          cost_type.for_all_projects?
+          cost_type.for_all_projects? || in_use?(cost_type)
+        end
+
+        def disabled_hint(cost_type)
+          if cost_type.for_all_projects?
+            I18n.t("cost_types.settings.cost_types.for_all_projects_hint")
+          else
+            I18n.t("cost_types.settings.cost_types.in_use_hint")
+          end
         end
 
         def toggle_data_attributes(cost_type)

--- a/modules/costs/app/contracts/cost_types/cost_type_projects/delete_contract.rb
+++ b/modules/costs/app/contracts/cost_types/cost_type_projects/delete_contract.rb
@@ -30,7 +30,15 @@
 
 module CostTypes
   module CostTypeProjects
-    class DeleteService < ::BaseServices::Delete
+    class DeleteContract < BaseContract
+      validate :not_in_use
+
+      # A mapping must not be removed while costs have been logged for the cost
+      # type in the project, otherwise those costs would disappear from the
+      # affected work packages.
+      def not_in_use
+        errors.add :base, :cost_type_in_use_cannot_disable if model.in_use?
+      end
     end
   end
 end

--- a/modules/costs/app/controllers/projects/settings/cost_types_controller.rb
+++ b/modules/costs/app/controllers/projects/settings/cost_types_controller.rb
@@ -39,13 +39,18 @@ class Projects::Settings::CostTypesController < Projects::SettingsController
 
   def toggle
     if @cost_type.for_all_projects?
-      respond_with_status(:unprocessable_entity)
+      reject_toggle("activerecord.errors.messages.is_for_all_cannot_modify")
       return
     end
 
     mapping = CostTypesProject.find_or_initialize_by(project_id: @project.id, cost_type_id: @cost_type.id)
 
     if mapping.persisted?
+      if mapping.in_use?
+        reject_toggle("activerecord.errors.messages.cost_type_in_use_cannot_disable")
+        return
+      end
+
       mapping.destroy!
     else
       mapping.save!
@@ -60,14 +65,18 @@ class Projects::Settings::CostTypesController < Projects::SettingsController
     @cost_type = CostType.active.find(params.expect(:id))
   end
 
-  def respond_with_status(status)
+  def reject_toggle(error_message)
+    respond_with_status(:unprocessable_entity, error_message:)
+  end
+
+  def respond_with_status(status, error_message: nil)
     respond_to do |format|
       format.json { render json: {}, status: }
       format.html do
         if status == :ok
           flash[:notice] = I18n.t(:notice_successful_update)
         else
-          flash[:error] = I18n.t("activerecord.errors.messages.is_for_all_cannot_modify")
+          flash[:error] = I18n.t(error_message)
         end
         redirect_to project_settings_cost_types_path(@project)
       end

--- a/modules/costs/app/models/cost_type.rb
+++ b/modules/costs/app/models/cost_type.rb
@@ -37,6 +37,8 @@ class CostType < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   after_update :save_rates
+  after_update :activate_for_projects_with_costs,
+               if: -> { saved_change_to_for_all_projects? && !for_all_projects? }
   after_save :persist_current_rate_input
 
   include ActiveModel::ForbiddenAttributesProtection
@@ -138,5 +140,31 @@ class CostType < ApplicationRecord
     return if value.to_s.strip.empty?
 
     CostRate.parse_number_string_to_number(value.to_s)
+  end
+
+  private
+
+  # When a cost type stops applying to all projects, keep it explicitly enabled
+  # in every active project that already logged costs for it, so those costs stay
+  # visible. Runs inside the update transaction, so a failure rolls back the
+  # for_all_projects change instead of leaving costs orphaned.
+  def activate_for_projects_with_costs
+    projects = Project.active.where(id: project_ids_with_unmapped_costs)
+    return if projects.empty?
+
+    result = CostTypes::CostTypeProjects::BulkCreateService
+               .new(user: User.system, projects:, model: self, include_sub_projects: false)
+               .call
+    return if result.success?
+
+    raise "Failed to enable cost type #{id} for projects with logged costs: " \
+          "#{result.errors.full_messages.to_sentence}"
+  end
+
+  def project_ids_with_unmapped_costs
+    cost_entries
+      .where.not(project_id: cost_types_projects.select(:project_id))
+      .distinct
+      .pluck(:project_id)
   end
 end

--- a/modules/costs/app/models/cost_types_project.rb
+++ b/modules/costs/app/models/cost_types_project.rb
@@ -33,4 +33,11 @@
 class CostTypesProject < ApplicationRecord
   belongs_to :cost_type
   belongs_to :project
+
+  # Whether costs have already been logged for this cost type in this project.
+  # Such a mapping must not be disabled, otherwise the registered costs would
+  # silently disappear from the affected work packages.
+  def in_use?
+    CostEntry.exists?(project_id:, cost_type_id:)
+  end
 end

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -90,6 +90,8 @@ en:
         other: "Time tracking activities"
       rate: "Rate"
     errors:
+      messages:
+        cost_type_in_use_cannot_disable: "cannot be disabled because costs have already been logged for it in this project."
       models:
         time_entry:
           invalid_time: "must be between 00:00 and 23:59."
@@ -276,9 +278,10 @@ en:
     settings:
       time_and_costs: "Time and costs"
       cost_types:
-        heading: "Cost types"
-        none_active: "No cost types are currently active in this project."
         for_all_projects_hint: "This cost type is enabled in all projects."
+        heading: "Cost types"
+        in_use_hint: "This cost type cannot be disabled because costs have already been logged for it in this project."
+        none_active: "No cost types are currently active in this project."
 
   costs:
     widgets:

--- a/modules/costs/lib/api/v3/costs_api_user_permission_check.rb
+++ b/modules/costs/lib/api/v3/costs_api_user_permission_check.rb
@@ -1,7 +1,8 @@
 module API::V3::CostsApiUserPermissionCheck
   def overall_costs_visible?
-    (view_time_entries_allowed? && user_has_hourly_rate_permissions?) ||
-      (user_has_cost_entry_permissions? && user_has_cost_rates_permission?)
+    cost_types_available? &&
+      ((view_time_entries_allowed? && user_has_hourly_rate_permissions?) ||
+        (user_has_cost_entry_permissions? && user_has_cost_rates_permission?))
   end
 
   def labor_costs_visible?
@@ -9,11 +10,11 @@ module API::V3::CostsApiUserPermissionCheck
   end
 
   def material_costs_visible?
-    user_has_cost_entry_permissions? && user_has_cost_rates_permission?
+    cost_types_available? && user_has_cost_entry_permissions? && user_has_cost_rates_permission?
   end
 
   def costs_by_type_visible?
-    user_has_cost_entry_permissions?
+    cost_types_available? && user_has_cost_entry_permissions?
   end
 
   def spent_time_visible?
@@ -21,6 +22,13 @@ module API::V3::CostsApiUserPermissionCheck
   end
 
   private
+
+  # Unit costs (material, overall total and costs by type) are meaningless without
+  # a cost type, so they are hidden when none is available in the project. Mirrors the
+  # schema representer's `unit_costs_visible` gating.
+  def cost_types_available?
+    represented.project&.cost_types_available?
+  end
 
   def user_has_hourly_rate_permissions?
     current_user.allowed_in_project?(:view_hourly_rates, represented.project) ||

--- a/modules/costs/lib/costs/patches/project_patch.rb
+++ b/modules/costs/lib/costs/patches/project_patch.rb
@@ -51,7 +51,9 @@ module Costs::Patches::ProjectPatch
     end
 
     def cost_types_available?
-      CostType.available_for_project(self).active.exists?
+      return @cost_types_available if defined?(@cost_types_available)
+
+      @cost_types_available = CostType.available_for_project(self).active.exists?
     end
   end
 end

--- a/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
+++ b/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
   let(:view_own_cost_entries) { false }
   let(:view_cost_entries) { false }
   let(:view_budgets) { false }
+  let(:cost_types_available) { true }
   let(:project) { build_stubbed(:project) }
   let(:work_package) { build_stubbed(:work_package, project:) }
 
@@ -55,6 +56,8 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
     without_partial_double_verification do
       allow(subject).to receive_messages(current_user: user, represented: work_package) # rubocop:disable RSpec/SubjectStub
     end
+
+    allow(project).to receive(:cost_types_available?).and_return(cost_types_available)
 
     mock_permissions_for(user) do |mock|
       mock.allow_in_project :view_time_entries, project: work_package.project if view_time_entries
@@ -129,6 +132,14 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
 
         it_behaves_like "is visible"
       end
+
+      context "when no cost type is available" do
+        let(:view_cost_entries) { true }
+        let(:view_cost_rates) { true }
+        let(:cost_types_available) { false }
+
+        it_behaves_like "not visible"
+      end
     end
 
     describe :labor_costs_visible? do
@@ -158,6 +169,14 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
       context "has view_own_time_entries and view_hourly_rates" do
         let(:view_own_time_entries) { true }
         let(:view_hourly_rates) { true }
+
+        it_behaves_like "is visible"
+      end
+
+      context "when no cost type is available" do
+        let(:view_time_entries) { true }
+        let(:view_hourly_rates) { true }
+        let(:cost_types_available) { false }
 
         it_behaves_like "is visible"
       end
@@ -193,6 +212,14 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
 
         it_behaves_like "is visible"
       end
+
+      context "when no cost type is available" do
+        let(:view_cost_entries) { true }
+        let(:view_cost_rates) { true }
+        let(:cost_types_available) { false }
+
+        it_behaves_like "not visible"
+      end
     end
 
     describe :costs_by_type_visible? do
@@ -222,6 +249,13 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
         let(:view_own_cost_entries) { true }
 
         it_behaves_like "is visible"
+      end
+
+      context "when no cost type is available" do
+        let(:view_cost_entries) { true }
+        let(:cost_types_available) { false }
+
+        it_behaves_like "not visible"
       end
     end
 

--- a/modules/costs/spec/models/cost_type_for_all_projects_toggle_spec.rb
+++ b/modules/costs/spec/models/cost_type_for_all_projects_toggle_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative "../spec_helper"
+
+RSpec.describe CostType, "disabling for_all_projects" do
+  subject(:disable_for_all) { cost_type.update!(for_all_projects: false) }
+
+  shared_let(:cost_type) { create(:cost_type, for_all_projects: true) }
+  shared_let(:project_with_costs) { create(:project) }
+
+  def log_costs_in(project, type: cost_type)
+    work_package = create(:work_package, project:)
+    create(:cost_entry, cost_type: type, entity: work_package)
+  end
+
+  it "enables the cost type in projects that already logged costs for it" do
+    log_costs_in(project_with_costs)
+
+    expect { disable_for_all }
+      .to change { CostTypesProject.where(cost_type:, project: project_with_costs).count }
+      .from(0).to(1)
+  end
+
+  it "does not enable it in projects without logged costs" do
+    other_project = create(:project)
+    log_costs_in(project_with_costs)
+
+    disable_for_all
+
+    expect(CostTypesProject.where(cost_type:, project: other_project)).not_to exist
+  end
+
+  it "ignores costs logged for a different cost type" do
+    log_costs_in(project_with_costs, type: create(:cost_type, for_all_projects: true))
+
+    disable_for_all
+
+    expect(CostTypesProject.where(cost_type:, project: project_with_costs)).not_to exist
+  end
+
+  it "does not enable it in archived projects" do
+    log_costs_in(project_with_costs)
+    project_with_costs.update!(active: false)
+
+    disable_for_all
+
+    expect(CostTypesProject.where(cost_type:, project: project_with_costs)).not_to exist
+  end
+
+  it "does not create mappings when re-enabling for_all_projects" do
+    log_costs_in(project_with_costs)
+
+    expect { cost_type.update!(for_all_projects: true) }
+      .not_to change(CostTypesProject, :count)
+  end
+
+  context "when a mapping already exists (disabled, re-enabled, disabled again)" do
+    before do
+      log_costs_in(project_with_costs)
+      cost_type.update!(for_all_projects: false) # creates the mapping
+      cost_type.update!(for_all_projects: true)  # no-op, mapping remains
+    end
+
+    it "does not raise a uniqueness error and keeps a single mapping" do
+      expect { disable_for_all }.not_to raise_error
+      expect(CostTypesProject.where(cost_type:, project: project_with_costs).count).to eq(1)
+    end
+  end
+end

--- a/modules/costs/spec/models/cost_types_project_spec.rb
+++ b/modules/costs/spec/models/cost_types_project_spec.rb
@@ -55,4 +55,26 @@ RSpec.describe CostTypesProject do
     expect { described_class.create!(project:, cost_type:) }
       .to raise_error(ActiveRecord::RecordNotUnique)
   end
+
+  describe "#in_use?" do
+    subject(:mapping) { described_class.create!(project:, cost_type:) }
+
+    it "is false when no costs are logged for the cost type in the project" do
+      expect(mapping).not_to be_in_use
+    end
+
+    it "is true when costs are logged for the cost type in the project" do
+      work_package = create(:work_package, project:)
+      create(:cost_entry, cost_type:, entity: work_package)
+
+      expect(mapping).to be_in_use
+    end
+
+    it "ignores costs of the same cost type logged in other projects" do
+      other_work_package = create(:work_package)
+      create(:cost_entry, cost_type:, entity: other_work_package)
+
+      expect(mapping).not_to be_in_use
+    end
+  end
 end

--- a/modules/costs/spec/requests/projects/settings/cost_types_controller_spec.rb
+++ b/modules/costs/spec/requests/projects/settings/cost_types_controller_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe Projects::Settings::CostTypesController, :skip_csrf, type: :rails
         expect(flash[:error]).to be_present
       end
     end
+
+    context "with a cost type that already has logged costs in the project" do
+      let(:work_package) { create(:work_package, project:) }
+
+      before do
+        CostTypesProject.create!(project:, cost_type: scoped_ct)
+        create(:cost_entry, cost_type: scoped_ct, entity: work_package)
+      end
+
+      it "refuses to disable the mapping" do
+        expect do
+          post toggle_project_settings_cost_type_path(project, scoped_ct)
+        end.not_to change { CostTypesProject.where(project:, cost_type: scoped_ct).count }
+        expect(flash[:error]).to be_present
+      end
+    end
   end
 
   context "when user lacks :manage_project_activities" do

--- a/modules/costs/spec/services/cost_types/cost_type_projects/delete_service_spec.rb
+++ b/modules/costs/spec/services/cost_types/cost_type_projects/delete_service_spec.rb
@@ -69,4 +69,19 @@ RSpec.describe CostTypes::CostTypeProjects::DeleteService do
       expect(CostTypesProject.where(id: mapping.id)).to exist
     end
   end
+
+  context "when costs have already been logged for the cost type in the project" do
+    let(:user) { create(:admin) }
+    let(:work_package) { create(:work_package, project:) }
+
+    before { create(:cost_entry, cost_type:, entity: work_package) }
+
+    it "refuses to delete the mapping" do
+      result = described_class.new(user:, model: mapping).call
+
+      expect(result).to be_failure
+      expect(result.errors.symbols_for(:base)).to include(:cost_type_in_use_cannot_disable)
+      expect(CostTypesProject.where(id: mapping.id)).to exist
+    end
+  end
 end


### PR DESCRIPTION
When no cost types are active in a project, we don't need to show material cost types.

However, if cost entries still exist for this type, we cannot disable them yet.

https://community.openproject.org/work_packages/OP-19609