### PR TITLE
[MEET-574] Remove ICS export of previous-schedule occurrences for both events and RDATE

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -120,11 +120,6 @@ module Meetings
 
         # Add exceptions for all cancelled recurrences
         set_excluded_recurrence_dates(event: e, recurring_meeting: recurring_meeting)
-
-        # Previous-schedule overrides are outside the current RRULE expansion.
-        # Add them as RDATEs so strict clients can attach their RECURRENCE-ID
-        # overrides to the master event.
-        set_included_recurrence_dates(event: e, recurring_meeting: recurring_meeting)
       end
 
       # Add single events for all occurrences
@@ -317,14 +312,10 @@ module Meetings
     end
 
     def instantiated_occurrences_for_export(recurring_meeting)
-      previous_schedule_occurrences(recurring_meeting) + upcoming_schedule_occurrences(recurring_meeting)
-    end
-
-    def previous_schedule_occurrences(recurring_meeting)
-      instantiated_schedules_partitioned(recurring_meeting)
-        .first
-        .sort_by(&:recurrence_start_time)
-        .last(PAST_OCCURRENCES_LIMIT)
+      # Previous-schedule occurrences are represented as RDATEs on the master VEVENT.
+      # We should not emit them as individual VEVENTs as some implementations (such as OpenXchange)
+      # reject the whole series if an event is < master DTSTART.
+      upcoming_schedule_occurrences(recurring_meeting)
     end
 
     def upcoming_schedule_occurrences(recurring_meeting)
@@ -385,11 +376,6 @@ module Meetings
     def set_excluded_recurrence_dates(event:, recurring_meeting:)
       event.exdate = cancelled_recurrence_dates(recurring_meeting)
                        .map { ical_datetime(it, timezone: recurring_meeting.time_zone) }
-    end
-
-    def set_included_recurrence_dates(event:, recurring_meeting:)
-      event.rdate = previous_schedule_occurrences(recurring_meeting)
-                    .map { ical_datetime(it.recurrence_start_time, timezone: recurring_meeting.time_zone) }
     end
 
     def cancelled_recurrence_dates(recurring_meeting)

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -312,8 +312,7 @@ module Meetings
     end
 
     def instantiated_occurrences_for_export(recurring_meeting)
-      # Previous-schedule occurrences are represented as RDATEs on the master VEVENT.
-      # We should not emit them as individual VEVENTs as some implementations (such as OpenXchange)
+      # We should not emit previous-schedule instances as individual VEVENTs as some implementations (such as OpenXchange)
       # reject the whole series if an event is < master DTSTART.
       upcoming_schedule_occurrences(recurring_meeting)
     end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
@@ -135,32 +135,31 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       end
     end
 
-    it "starts the ical schedule with the updated start time and does not touch the first occurence" do
+    it "starts the ical schedule with the updated start time and drops the previous-schedule occurrence" do
       builder.add_series_event(recurring_meeting: recurring_meeting)
 
-      # we have the recurring meeting event + the first instantiated meeting before the update
-      # and the update service has also made sure that the next occurrence in the schedule is created
-      expect(parsed_calendar.events.count).to eq(3)
-
-      # our recurring event starts at the updated start time
-      event = parsed_calendar.events.first
       # updated start time is the next occurrence of the meeting after the time of our change
       new_start_time = recurring_meeting.next_occurrence(from_time: start_time + 2.days)
-      expect(event.dtstart).to eq(new_start_time)
 
-      rrule = event.rrule.first
+      # the master event + the upcoming occurrence created by the update service.
+      # the first occurrence is from the previous schedule and is no longer emitted.
+      expect(parsed_calendar.events.count).to eq(2)
+
+      # our recurring event starts at the updated start time
+      master_event = parsed_calendar.events.find { |e| e.recurrence_id.nil? }
+      expect(master_event.dtstart).to eq(new_start_time)
+
+      rrule = master_event.rrule.first
       # the RRULE reflects the updated schedule
       expect(rrule.frequency).to eq("WEEKLY")
       expect(rrule.interval).to eq(2)
       expect(rrule.count).to eq(25) # one iteration less since the first already happened
 
-      # the first occurrence is part of the calendar and the start time is not updated
-      first_occurrence_event = parsed_calendar.events.second
-      expect(first_occurrence_event.dtstart).to eq first_meeting.start_time
-      expect(first_occurrence_event.rrule).to be_empty
+      # the previous-schedule occurrence is no longer represented as an RDATE
+      expect(Array(master_event.rdate)).to be_empty
 
-      # the second occurence is already using the new starting times
-      second_occurrence_event = parsed_calendar.events.third
+      # the second occurence is emitted as an override already using the new starting times
+      second_occurrence_event = parsed_calendar.events.find { |e| e.recurrence_id.present? }
       expect(second_occurrence_event.dtstart).to eq new_start_time
       expect(second_occurrence_event.rrule).to be_empty
     end
@@ -186,31 +185,30 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       end
     end
 
-    it "starts the ical schedule with the updated start time and does not touch the first occurence" do
+    it "starts the ical schedule with the updated start time and drops the previous-schedule occurrence" do
       builder.add_series_event(recurring_meeting: recurring_meeting)
 
-      # we have the recurring meeting event + the first instantiated meeting before the update
-      # and the update service has also made sure that the next occurrence in the schedule is created
-      expect(parsed_calendar.events.count).to eq(3)
-
-      # our recurring event starts at the updated start time
-      event = parsed_calendar.events.first
       # updated start time is the next occurrence of the meeting after the time of our change
       new_start_time = recurring_meeting.next_occurrence(from_time: start_time + 2.days)
-      expect(event.dtstart).to eq(new_start_time)
 
-      rrule = event.rrule.first
+      # the master event + the upcoming occurrence created by the update service.
+      # the first occurrence is from the previous schedule and is no longer emitted.
+      expect(parsed_calendar.events.count).to eq(2)
+
+      # our recurring event starts at the updated start time
+      master_event = parsed_calendar.events.find { |e| e.recurrence_id.nil? }
+      expect(master_event.dtstart).to eq(new_start_time)
+
+      rrule = master_event.rrule.first
       # the RRULE reflects the updated schedule
       expect(rrule.frequency).to eq("DAILY")
       expect(rrule.count).to eq(24) # two iterations less since the first two already happened
 
-      # the first occurrence is part of the calendar and the start time is not updated
-      first_occurrence_event = parsed_calendar.events.second
-      expect(first_occurrence_event.dtstart).to eq first_meeting.start_time
-      expect(first_occurrence_event.rrule).to be_empty
+      # the previous-schedule occurrence is no longer represented as an RDATE
+      expect(Array(master_event.rdate)).to be_empty
 
-      # the second occurence is already using the new starting times
-      second_occurrence_event = parsed_calendar.events.third
+      # the second occurence is emitted as an override already using the new starting times
+      second_occurrence_event = parsed_calendar.events.find { |e| e.recurrence_id.present? }
       expect(second_occurrence_event.dtstart).to eq new_start_time
       expect(second_occurrence_event.rrule).to be_empty
     end
@@ -241,12 +239,11 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       recurring_meeting.update!(current_schedule_start: new_schedule_start)
     end
 
-    it "emits only the 10 most recent previous-schedule occurrences as RDATE-backed overrides" do
+    it "does not emit previous-schedule occurrences as RDATEs or overrides" do
       builder.add_series_event(recurring_meeting: recurring_meeting)
 
       master_event = parsed_calendar.events.find { |event| event.recurrence_id.nil? }
       override_events = parsed_calendar.events.select { |event| event.recurrence_id.present? }
-      previous_schedule_start_times = past_occurrence_start_times.last(10).map(&:to_time)
 
       expect(master_event.dtstart).to eq(new_schedule_start)
       expect(master_event.dtend).to eq(new_schedule_start + recurring_meeting.template.duration.hours)
@@ -254,12 +251,14 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       # EXDATE is reserved for cancelled meetings still in the RRULE expansion.
       # Previous-schedule occurrences are already outside it, so EXDATE'ing them would be a no-op.
       expect(Array(master_event.exdate)).to be_empty
-      expect(Array(master_event.rdate).map { |date| date.value.to_time })
-        .to match_array(previous_schedule_start_times)
 
-      expect(override_events.count).to eq(10)
-      expect(override_events.map { |evt| evt.recurrence_id.to_time })
-        .to match_array(previous_schedule_start_times)
+      # RDATEs before the master DTSTART are ignored by common clients (OpenXchange,
+      # Apple Calendar), so we no longer emit previous-schedule occurrences at all.
+      expect(Array(master_event.rdate)).to be_empty
+      expect(override_events).to be_empty
+
+      # only the master event remains
+      expect(parsed_calendar.events.count).to eq(1)
     end
   end
 end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -261,11 +261,43 @@ RSpec.describe Meetings::IcalendarBuilder,
       meeting
     end
 
+    context "when emitting an instantiated occurrence within the current schedule" do
+      subject(:builder) { described_class.new(timezone:) }
+
+      it "emits it as a RECURRENCE-ID override keyed to its original slot" do
+        builder.add_series_event(recurring_meeting:)
+
+        parsed_calendar = Icalendar::Calendar.parse(builder.to_ical).first
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+        # third_occurence is a past occurrence that still belongs to the current
+        # schedule, so it must be emitted (unlike previous-schedule occurrences).
+        expect(overrides.size).to eq(1)
+        override = overrides.first
+        expect(override.recurrence_id).to eq(third_occurence.recurrence_start_time)
+        expect(override.dtstart).to eq(third_occurence.start_time)
+        expect(override.rrule).to be_empty
+      end
+    end
+
     context "when using the cache" do
       subject(:builder) { described_class.new(timezone:) }
 
       before do
         builder.preload_for_recurring_meetings(recurring_meetings: [recurring_meeting])
+      end
+
+      it "emits the instantiated occurrence within the current schedule as an override" do
+        builder.add_series_event(recurring_meeting:)
+
+        parsed_calendar = Icalendar::Calendar.parse(builder.to_ical).first
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+        expect(overrides.size).to eq(1)
+        override = overrides.first
+        expect(override.recurrence_id).to eq(third_occurence.recurrence_start_time)
+        expect(override.dtstart).to eq(third_occurence.start_time)
+        expect(override.rrule).to be_empty
       end
 
       it "preloads the correct caches" do


### PR DESCRIPTION
When a recurring meeting's schedule is changed, we keep track of it using a current_schedule_start attribute.

The ICS master event will be output as DTSART=current_schedule_start, so the older events are no longer
valid for the new RRULE.

But a recent change to output 10 previous meetings were output as an RDATE (exception to the RRULE which can be in the past) and VEVENTs (which can not be earlier than the master DTSTART).

This prevented some clients from parsing the ICS file at all.
We instead do not output any meetings from the previous schedule

https://community.openproject.org/work_packages/MEET-574