### PR TITLE
Bug/agile 325 missing counter for sprints wrong colour hierarchy

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_component.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
         concat t(:label_backlog)
         concat render(
           Primer::Beta::Counter.new(
-            scheme: :default,
+            scheme: :primary,
             count: total,
             round: true,
             limit: 1_000,

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -46,7 +46,12 @@ See COPYRIGHT and LICENSE files for more details.
         }
       )
     ) do |list|
-      list.with_header(title: t(".title"), count: work_packages.size, title_arguments: { font_size: 4 })
+      list.with_header(
+        title: t(".title"),
+        count: work_packages.size,
+        count_arguments: { scheme: :secondary },
+        title_arguments: { font_size: 4 }
+      )
 
       list.with_empty_state(
         title: t(".blankslate_title"),

--- a/modules/backlogs/app/components/backlogs/sprints_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.html.erb
@@ -34,9 +34,18 @@ See COPYRIGHT and LICENSE files for more details.
       size: :medium,
       font_weight: :bold,
       display: :inline_flex,
-      align_items: :center
+      align_items: :center,
+      classes: "gap-2"
     ) do
-      Sprint.human_plural_model_name
+      concat(Sprint.human_plural_model_name)
+      counter_options = {
+        scheme: :primary,
+        count: total,
+        round: true,
+        limit: 1_000,
+        hide_if_zero: true
+      }
+      concat render(Primer::Beta::Counter.new(**counter_options))
     end
 
     if sprint_creation_allowed?

--- a/modules/backlogs/app/components/backlogs/sprints_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.html.erb
@@ -27,62 +27,67 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
 
-<%=
-  render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
-    head.with_heading(
-      tag: :h3,
-      size: :medium,
-      font_weight: :bold,
-      display: :inline_flex,
-      align_items: :center,
-      classes: "gap-2"
-    ) do
-      concat(Sprint.human_plural_model_name)
-      concat render(
-        Primer::Beta::Counter.new(
-          scheme: :primary,
-          count: total,
-          round: true,
-          limit: 1_000,
-          hide_if_zero: true
+<%= component_wrapper(tag: "turbo-frame", refresh: :morph, style: "display:contents") do %>
+  <%=
+    render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
+      head.with_heading(
+        tag: :h3,
+        size: :medium,
+        font_weight: :bold,
+        display: :inline_flex,
+        align_items: :center,
+        classes: "gap-2"
+      ) do
+        concat(Sprint.human_plural_model_name)
+        concat render(
+          Primer::Beta::Counter.new(
+            scheme: :primary,
+            count: total,
+            round: true,
+            limit: 1_000,
+            hide_if_zero: true,
+            data: { test_selector: "op-sprints--total-counter" }
+          )
         )
-      )
-    end
+      end
 
-    if sprint_creation_allowed?
-      head.with_actions do
-        render Primer::Beta::Button.new(
-          tag: :a,
-          label: Sprint.human_model_name,
-          href: new_dialog_project_backlogs_sprints_path(project, all_backlogs_params),
-          data: {
-            controller: "async-dialog",
-            test_selector: "op-sprints--new-sprint-button"
-          }
-        ) do |button|
-          button.with_leading_visual_icon(icon: :plus)
-          Sprint.human_model_name
+      if sprint_creation_allowed?
+        head.with_actions do
+          render Primer::Beta::Button.new(
+            tag: :a,
+            label: Sprint.human_model_name,
+            href: new_dialog_project_backlogs_sprints_path(project, all_backlogs_params),
+            data: {
+              controller: "async-dialog",
+              test_selector: "op-sprints--new-sprint-button"
+            }
+          ) do |button|
+            button.with_leading_visual_icon(icon: :plus)
+            Sprint.human_model_name
+          end
         end
       end
     end
-  end
-%>
-
-<% if sprints.empty? %>
-  <%=
-    render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
-      blankslate.with_visual_icon(icon: :zap)
-      blankslate.with_heading(tag: :h4).with_content(t(".blankslate.title"))
-      blankslate.with_description_content(blankslate_description)
-    end
   %>
-<% else %>
-  <% sprints.each do |sprint| %>
-    <%= render Backlogs::SprintComponent.new(
+
+  <% if sprints.empty? %>
+    <%=
+      render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
+        blankslate.with_visual_icon(icon: :zap)
+        blankslate.with_heading(tag: :h4).with_content(t(".blankslate.title"))
+        blankslate.with_description_content(blankslate_description)
+      end
+    %>
+  <% else %>
+    <% sprints.each do |sprint| %>
+      <%=
+        render Backlogs::SprintComponent.new(
           sprint:,
           project:,
           work_packages: work_packages_by_sprint_id[sprint.id] || [],
           active_sprint_ids: active_sprint_ids
-        ) %>
+        )
+      %>
+    <% end %>
   <% end %>
 <% end %>

--- a/modules/backlogs/app/components/backlogs/sprints_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.html.erb
@@ -38,14 +38,15 @@ See COPYRIGHT and LICENSE files for more details.
       classes: "gap-2"
     ) do
       concat(Sprint.human_plural_model_name)
-      counter_options = {
-        scheme: :primary,
-        count: total,
-        round: true,
-        limit: 1_000,
-        hide_if_zero: true
-      }
-      concat render(Primer::Beta::Counter.new(**counter_options))
+      concat render(
+        Primer::Beta::Counter.new(
+          scheme: :primary,
+          count: total,
+          round: true,
+          limit: 1_000,
+          hide_if_zero: true
+        )
+      )
     end
 
     if sprint_creation_allowed?

--- a/modules/backlogs/app/components/backlogs/sprints_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.rb
@@ -31,6 +31,7 @@
 module Backlogs
   class SprintsComponent < ApplicationComponent
     include Primer::AttributesHelper
+    include OpTurbo::Streamable
     include CommonHelper
 
     attr_reader :sprints, :work_packages_by_sprint_id, :active_sprint_ids, :project, :current_user
@@ -47,6 +48,10 @@ module Backlogs
       @active_sprint_ids = active_sprint_ids
       @project = project
       @current_user = current_user
+    end
+
+    def wrapper_uniq_by
+      project
     end
 
     private

--- a/modules/backlogs/app/components/backlogs/sprints_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.rb
@@ -51,6 +51,10 @@ module Backlogs
 
     private
 
+    def total
+      @total ||= work_packages_by_sprint_id.values.sum(&:count)
+    end
+
     def blankslate_description
       if sprint_management_allowed?
         description_with_settings_link

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
@@ -78,6 +78,7 @@ module Backlogs
       title:,
       count: work_packages.size,
       count_label: default_count_label(count),
+      count_arguments: { scheme: :secondary },
       **system_arguments,
       &
     )
@@ -88,6 +89,7 @@ module Backlogs
         title:,
         count:,
         count_label:,
+        count_arguments:,
         **system_arguments,
         &
       )

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -103,25 +103,37 @@ module Backlogs
     private
 
     def move_work_package_to_target_component_via_turbo_stream(source_sprint:, target_sprint:)
-      if source_sprint != target_sprint
-        replace_component_via_turbo_stream(sprint: source_sprint)
+      if source_sprint.present? && target_sprint.present?
+        # Sprint to sprint: replace only the two affected sprint components
+        replace_component_via_turbo_stream(sprint: source_sprint) if source_sprint != target_sprint
+        replace_component_via_turbo_stream(sprint: target_sprint)
+      elsif source_sprint.present? || target_sprint.present?
+        # Crossing the sprint/backlog boundary: replace SprintsComponent/BacklogComponent so their total counter updates
+        replace_via_turbo_stream(component: sprints_component, method: :morph)
+        replace_via_turbo_stream(component: backlog_component, method: :morph)
+      else
+        # Backlog to backlog: only the BacklogComponent needs updating
+        replace_via_turbo_stream(component: backlog_component, method: :morph)
       end
-
-      replace_component_via_turbo_stream(sprint: target_sprint)
     end
 
     def replace_component_via_turbo_stream(sprint:)
-      component = if sprint
-                    sprint_component(sprint:)
-                  else
-                    backlog_component
-                  end
-
-      replace_via_turbo_stream(component:, method: :morph)
+      replace_via_turbo_stream(component: sprint_component(sprint:), method: :morph)
     end
 
     def sprint_component(sprint:)
       Backlogs::SprintComponent.new(sprint:, project: @project)
+    end
+
+    def sprints_component
+      load_sprint_data
+
+      Backlogs::SprintsComponent.new(
+        sprints: @sprints,
+        work_packages_by_sprint_id: @work_packages_by_sprint_id,
+        active_sprint_ids: @active_sprint_ids,
+        project: @project
+      )
     end
 
     def backlog_component

--- a/modules/backlogs/spec/components/backlogs/sprints_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprints_component_spec.rb
@@ -32,7 +32,6 @@ require "rails_helper"
 
 RSpec.describe Backlogs::SprintsComponent, type: :component do
   shared_let(:sprints) { [] }
-  shared_let(:work_packages_by_sprint_id) { WorkPackage.all.group_by(&:sprint_id) }
   shared_let(:active_sprint_ids) { [] }
 
   let(:permissions) { %i[create_sprints] }
@@ -44,7 +43,11 @@ RSpec.describe Backlogs::SprintsComponent, type: :component do
   def render_component
     render_inline(
       described_class.new(
-        sprints:, work_packages_by_sprint_id:, active_sprint_ids:, project:, current_user:
+        sprints:,
+        work_packages_by_sprint_id: WorkPackage.all.group_by(&:sprint_id),
+        active_sprint_ids:,
+        project:,
+        current_user:
       )
     )
   end
@@ -53,6 +56,7 @@ RSpec.describe Backlogs::SprintsComponent, type: :component do
 
   it "renders the sprints heading" do
     expect(page).to have_css("h3", text: "Sprints")
+    expect(page).to have_no_css(".Counter")
   end
 
   describe "new sprint button" do
@@ -149,8 +153,20 @@ RSpec.describe Backlogs::SprintsComponent, type: :component do
   describe "with sprints" do
     let(:sprints) { create_list(:sprint, 2, project:) }
 
+    before do
+      create(:work_package, sprint_id: sprints.first.id, project:)
+      create(:work_package, sprint_id: sprints.last.id, project:)
+
+      render_component
+    end
+
     it "does not render the blankslate" do
       expect(page).to have_no_text("No sprints present yet")
+    end
+
+    it "renders the sprints heading with the work package count" do
+      expect(page).to have_css("h3", text: "Sprints")
+      expect(page).to have_css(".Counter", text: "2")
     end
 
     it "renders a SprintComponent for each sprint" do

--- a/modules/backlogs/spec/components/backlogs/sprints_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprints_component_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Backlogs::SprintsComponent, type: :component do
 
     it "renders the sprints heading with the work package count" do
       expect(page).to have_css("h3", text: "Sprints")
-      expect(page).to have_css(".Counter", text: "2")
+      expect(page).to have_css(".Counter.Counter--primary", text: "2")
     end
 
     it "renders a SprintComponent for each sprint" do

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
@@ -198,10 +198,20 @@ RSpec.describe Backlogs::WorkPackageCardListComponent, type: :component do
 
       it "renders the provided count and accessible label" do
         expect(rendered_component).to have_css(
-          ".Counter",
+          ".Counter.Counter--secondary",
           text: "7",
           aria: { label: "7 backlog stories" }
         )
+      end
+    end
+
+    context "when the count arguments are overridden" do
+      let(:header_arguments) do
+        { title: "Sprint 1", count: 7, count_arguments: { scheme: :primary } }
+      end
+
+      it "renders the counter with the provided arguments" do
+        expect(rendered_component).to have_css(".Counter.Counter--primary", text: "7")
       end
     end
   end

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -177,13 +177,13 @@ RSpec.describe Backlogs::WorkPackagesController do
         let(:target_id) { "inbox" }
         let(:prev_id) { existing_inbox_item.id }
 
-        it "replaces the sprint and backlog components without a flash", :aggregate_failures do
+        it "replaces the sprints and backlog components without a flash", :aggregate_failures do
           subject
 
           expect(response).to be_successful
           expect(response).to have_http_status :ok
           expect(response)
-            .to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}", method: "morph"
+            .to have_turbo_stream action: "replace", target: "backlogs-sprints-component-#{project.id}", method: "morph"
           expect(response)
             .to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{project.id}", method: "morph"
           expect(assigns(:project)).to eq(project)
@@ -221,15 +221,16 @@ RSpec.describe Backlogs::WorkPackagesController do
         let(:target_id) { "backlog_bucket:#{bucket.id}" }
         let(:prev_id) { bucket_items.first.id }
 
-        it "replaces the sprint and backlog components without a flash", :aggregate_failures do
+        it "replaces the sprints and backlog components without a flash", :aggregate_failures do
           subject
 
           expect(response).to be_successful
           expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{sprint.id}",
+                                                target: "backlogs-sprints-component-#{project.id}",
                                                 method: "morph"
           expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+                                                target: "backlogs-backlog-component-#{project.id}",
+                                                method: "morph"
         end
 
         context "when the project is configured to exclude the work packages status from backlogs" do
@@ -302,14 +303,16 @@ RSpec.describe Backlogs::WorkPackagesController do
         let(:target_sprint) { create(:sprint, name: "Target Sprint", project:) }
         let(:target_id) { "sprint:#{target_sprint.id}" }
 
-        it "replaces inbox and target sprint components without a flash", :aggregate_failures do
+        it "replaces the sprints and backlog components without a flash", :aggregate_failures do
           subject
 
           expect(response).to be_successful
           expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+                                                target: "backlogs-sprints-component-#{project.id}",
+                                                method: "morph"
           expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{target_sprint.id}"
+                                                target: "backlogs-backlog-component-#{project.id}",
+                                                method: "morph"
 
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
@@ -400,14 +403,16 @@ RSpec.describe Backlogs::WorkPackagesController do
         let(:target_sprint) { create(:sprint, name: "Target Sprint", project:) }
         let(:target_id) { "sprint:#{target_sprint.id}" }
 
-        it "replaces the backlog and sprint components without a flash", :aggregate_failures do
+        it "replaces the sprints and backlog components without a flash", :aggregate_failures do
           subject
 
           expect(response).to be_successful
           expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-backlog-component-#{project.id}"
+                                                target: "backlogs-sprints-component-#{project.id}",
+                                                method: "morph"
           expect(response).to have_turbo_stream action: "replace",
-                                                target: "backlogs-sprint-component-#{target_sprint.id}"
+                                                target: "backlogs-backlog-component-#{project.id}",
+                                                method: "morph"
           expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         end
 

--- a/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
@@ -59,10 +59,13 @@ RSpec.describe "Move to backlog", :js do
 
       it "moves the work package to the backlog inbox" do
         planning_page.visit!
+        planning_page.expect_sprints_total_count(1)
+
         planning_page.click_in_work_package_menu(work_package, "Move to backlog inbox")
 
         planning_page.expect_work_package_not_in_sprint(work_package, sprint)
         planning_page.expect_inbox_item(work_package)
+        planning_page.expect_no_sprints_total_counter
       end
     end
 
@@ -173,6 +176,8 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog and moves the work package to the selected sprint" do
         planning_page.visit!
+        planning_page.expect_no_sprints_total_counter
+
         planning_page.click_in_work_package_menu(work_package, "Move to sprint")
 
         within_modal "Move to sprint" do
@@ -184,6 +189,7 @@ RSpec.describe "Move to backlog", :js do
 
         planning_page.expect_no_inbox_item(work_package)
         planning_page.expect_work_package_in_sprint(work_package, sprint)
+        planning_page.expect_sprints_total_count(1)
       end
     end
 
@@ -192,6 +198,8 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog and moves the work package to the selected sprint" do
         planning_page.visit!
+        planning_page.expect_no_sprints_total_counter
+
         planning_page.click_in_work_package_menu(work_package, "Move to sprint", wait: false)
 
         within_modal "Move to sprint" do
@@ -203,6 +211,7 @@ RSpec.describe "Move to backlog", :js do
 
         planning_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
         planning_page.expect_work_package_in_sprint(work_package, sprint)
+        planning_page.expect_sprints_total_count(1)
       end
     end
   end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -226,6 +226,14 @@ module Pages
       end
     end
 
+    def expect_sprints_total_count(count)
+      expect(page).to have_test_selector("op-sprints--total-counter", text: count.to_s)
+    end
+
+    def expect_no_sprints_total_counter
+      expect(page).to have_no_test_selector("op-sprints--total-counter")
+    end
+
     def expect_sprint_work_package_count(sprint, count)
       within(sprint_selector(sprint)) do
         expect(page).to have_css(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-325

# What are you trying to accomplish?

- [x] Show the work package item counter in the `SprintsComponent` header
- [x] Sprints and backlog top level headers should have primary colored counters (was secondary colored before)
- [x] Individual list entries (sprints, buckets & inbox) should have secondary colored counters (was primary colored before)

## Screenshots

| Before | After |
| ------- | ----- |
| <img width="1263" height="902" alt="image" src="https://github.com/user-attachments/assets/303fdb3b-2951-4842-84b5-b7b1271c0a5a" /> | <img width="1263" height="902" alt="image" src="https://github.com/user-attachments/assets/52fa3702-2215-474a-93e9-e883f8c9837f" /> |

# How did you do it?

Copied and slightly adjusted the implementation from the BacklogComponent for the SprintsComponent. It might have been better to generalize some of this. But it is shortly before the release and I want to KISS.


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
