### PR TITLE
[AGILE-318] Assign copied work packages to copied sprints

### DIFF
--- a/app/services/projects/copy/categories_dependent_service.rb
+++ b/app/services/projects/copy/categories_dependent_service.rb
@@ -40,16 +40,8 @@ module Projects::Copy
 
     protected
 
-    def copy_dependency(params:)
-      category_id_map = {}
-
-      source.categories.find_each do |category|
-        new_category = target.categories.create category.attributes.dup.except("id", "project_id")
-
-        category_id_map[category.id] = new_category.id
-      end
-
-      state.category_id_lookup = category_id_map
+    def copy_dependency(*)
+      state.category_id_lookup = copy_collection_with_id_map(:categories)
     end
   end
 end

--- a/app/services/projects/copy/dependency.rb
+++ b/app/services/projects/copy/dependency.rb
@@ -47,5 +47,20 @@ module Projects::Copy
 
       params[:only].any? { |key| key.to_sym == check }
     end
+
+    protected
+
+    ##
+    # Copy every record of the named +association+ from the source project to
+    # the target, returning a Hash mapping each source record id to its copy's
+    # id. Uses the non-raising +create+ (as VersionsDependentService does) so a
+    # single invalid record is skipped rather than aborting the whole copy.
+    def copy_collection_with_id_map(association)
+      source.public_send(association).each_with_object({}) do |source_record, id_map|
+        attributes = source_record.attributes.dup.except("id", "project_id", "created_at", "updated_at")
+        copy = target.public_send(association).create(attributes)
+        id_map[source_record.id] = copy.id if copy.persisted?
+      end
+    end
   end
 end

--- a/app/services/projects/copy/dependency.rb
+++ b/app/services/projects/copy/dependency.rb
@@ -62,8 +62,12 @@ module Projects::Copy
     # When a block is given, its return value is merged into the copied
     # attributes, letting a caller carry over child records via nested
     # attributes (see SprintsDependentService copying sprint goals).
-    def copy_collection_with_id_map(association)
-      source.public_send(association).each_with_object({}) do |source_record, id_map|
+    #
+    # +source_scope+ defaults to the whole source association but lets a caller
+    # pass an eager-loaded relation (e.g. +includes(:goals)+) to avoid an N+1
+    # inside the block.
+    def copy_collection_with_id_map(association, source_scope: source.public_send(association))
+      source_scope.each_with_object({}) do |source_record, id_map|
         attributes = copyable_attributes(source_record)
         attributes.merge!(yield(source_record)) if block_given?
         copy = target.public_send(association).create(attributes)

--- a/app/services/projects/copy/dependency.rb
+++ b/app/services/projects/copy/dependency.rb
@@ -53,8 +53,11 @@ module Projects::Copy
     ##
     # Copy every record of the named +association+ from the source project to
     # the target, returning a Hash mapping each source record id to its copy's
-    # id. Uses the non-raising +create+ (as VersionsDependentService does) so a
-    # single invalid record is skipped rather than aborting the whole copy.
+    # id. Uses the non-raising +create+ so a single invalid record is skipped
+    # rather than aborting the whole copy; the skip is surfaced through the
+    # dependency's error set (merged without failing the copy) instead of being
+    # silently dropped, so a work package that referenced it does not lose its
+    # assignment unannounced.
     #
     # When a block is given, its return value is merged into the copied
     # attributes, letting a caller carry over child records via nested
@@ -64,7 +67,12 @@ module Projects::Copy
         attributes = copyable_attributes(source_record)
         attributes.merge!(yield(source_record)) if block_given?
         copy = target.public_send(association).create(attributes)
-        id_map[source_record.id] = copy.id if copy.persisted?
+
+        if copy.persisted?
+          id_map[source_record.id] = copy.id
+        else
+          add_error!(copy, copy.errors)
+        end
       end
     end
 

--- a/app/services/projects/copy/dependency.rb
+++ b/app/services/projects/copy/dependency.rb
@@ -55,12 +55,21 @@ module Projects::Copy
     # the target, returning a Hash mapping each source record id to its copy's
     # id. Uses the non-raising +create+ (as VersionsDependentService does) so a
     # single invalid record is skipped rather than aborting the whole copy.
+    #
+    # When a block is given, its return value is merged into the copied
+    # attributes, letting a caller carry over child records via nested
+    # attributes (see SprintsDependentService copying sprint goals).
     def copy_collection_with_id_map(association)
       source.public_send(association).each_with_object({}) do |source_record, id_map|
-        attributes = source_record.attributes.dup.except("id", "project_id", "created_at", "updated_at")
+        attributes = copyable_attributes(source_record)
+        attributes.merge!(yield(source_record)) if block_given?
         copy = target.public_send(association).create(attributes)
         id_map[source_record.id] = copy.id if copy.persisted?
       end
+    end
+
+    def copyable_attributes(source_record)
+      source_record.attributes.dup.except("id", "project_id", "created_at", "updated_at")
     end
   end
 end

--- a/app/services/projects/copy/versions_dependent_service.rb
+++ b/app/services/projects/copy/versions_dependent_service.rb
@@ -40,14 +40,8 @@ module Projects::Copy
 
     protected
 
-    def copy_dependency(params:)
-      version_id_map = {}
-      source.versions.each do |source_version|
-        version = target.versions.create source_version.attributes.dup.except("id", "project_id", "created_at", "updated_at")
-        version_id_map[source_version.id] = version.id
-      end
-
-      state.version_id_lookup = version_id_map
+    def copy_dependency(*)
+      state.version_id_lookup = copy_collection_with_id_map(:versions)
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/backlog_buckets_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/backlog_buckets_dependent_service.rb
@@ -41,21 +41,7 @@ module Projects::Copy
     protected
 
     def copy_dependency(*)
-      backlog_bucket_id_map = {}
-
-      source.backlog_buckets.each do |source_bucket|
-        attributes = source_bucket.attributes.dup.except("id", "project_id", "created_at", "updated_at")
-        bucket = target.backlog_buckets.create!(attributes)
-        backlog_bucket_id_map[source_bucket.id] = bucket.id
-
-        # Re-assigned on every iteration (rather than once after the loop) because `state` is a
-        # Hashie::Mash: assignment converts the Hash into a new Mash, breaking object identity, so
-        # later mutations of `backlog_bucket_id_map` alone would not be visible through
-        # `state.backlog_bucket_id_lookup`. Keeping the lookup current after each bucket also means a
-        # mid-loop `create!` failure (rescued by `Copy::Dependency#perform`) leaves the partial
-        # mapping intact instead of nil.
-        state.backlog_bucket_id_lookup = backlog_bucket_id_map
-      end
+      state.backlog_bucket_id_lookup = copy_collection_with_id_map(:backlog_buckets)
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/backlog_buckets_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/backlog_buckets_dependent_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Copy
+  class BacklogBucketsDependentService < Dependency
+    def self.human_name
+      I18n.t("projects.copy.backlog_buckets")
+    end
+
+    def source_count
+      source.backlog_buckets.count
+    end
+
+    protected
+
+    def copy_dependency(*)
+      backlog_bucket_id_map = {}
+
+      source.backlog_buckets.each do |source_bucket|
+        attributes = source_bucket.attributes.dup.except("id", "project_id", "created_at", "updated_at")
+        bucket = target.backlog_buckets.create!(attributes)
+        backlog_bucket_id_map[source_bucket.id] = bucket.id
+
+        # Re-assigned on every iteration (rather than once after the loop) because `state` is a
+        # Hashie::Mash: assignment converts the Hash into a new Mash, breaking object identity, so
+        # later mutations of `backlog_bucket_id_map` alone would not be visible through
+        # `state.backlog_bucket_id_lookup`. Keeping the lookup current after each bucket also means a
+        # mid-loop `create!` failure (rescued by `Copy::Dependency#perform`) leaves the partial
+        # mapping intact instead of nil.
+        state.backlog_bucket_id_lookup = backlog_bucket_id_map
+      end
+    end
+  end
+end

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -41,21 +41,26 @@ module Projects::Copy
     protected
 
     def copy_dependency(*)
-      if source.receive_shared_sprints?
-        preserve_sprint_assignments
-      else
-        copy_sprints
-      end
+      state.sprint_id_lookup = copy_owned_sprints.merge(preserved_shared_sprints)
     end
 
-    def preserve_sprint_assignments
-      state.sprint_id_lookup = Sprint.for_project(source).pluck(:id).index_with { |id| id }
-    end
-
-    def copy_sprints
-      state.sprint_id_lookup = copy_collection_with_id_map(:sprints) do |source_sprint|
+    # Sprints owned by the source project are recreated on the copy; the lookup
+    # maps each source id to its copy so the copied work packages follow.
+    def copy_owned_sprints
+      copy_collection_with_id_map(:sprints) do |source_sprint|
         { goals_attributes: copied_goal_attributes(source_sprint) }
       end
+    end
+
+    # Shared sprints (owned by another project) that the source's work packages
+    # reference: keep the assignment only when the copied project will also
+    # receive that sprint, otherwise leave it unmapped so the work-package copy
+    # clears it rather than pointing at a sprint the copy cannot see.
+    def preserved_shared_sprints
+      Sprint.where(id: source.work_packages.select(:sprint_id))
+            .where.not(project_id: source.id)
+            .select { |sprint| Sprint.receiving_projects(sprint).exists?(id: target.id) }
+            .to_h { |sprint| [sprint.id, sprint.id] }
     end
 
     # Only the source project's own goals are carried over; a shared sprint may

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -53,7 +53,17 @@ module Projects::Copy
     end
 
     def copy_sprints
-      state.sprint_id_lookup = copy_collection_with_id_map(:sprints)
+      state.sprint_id_lookup = copy_collection_with_id_map(:sprints) do |source_sprint|
+        { goals_attributes: copied_goal_attributes(source_sprint) }
+      end
+    end
+
+    # Only the source project's own goals are carried over; a shared sprint may
+    # also hold goals owned by other projects, which are not ours to copy.
+    def copied_goal_attributes(source_sprint)
+      source_sprint.goals.where(project_id: source.id).map do |goal|
+        { text: goal.text, project_id: target.id }
+      end
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -45,9 +45,10 @@ module Projects::Copy
     end
 
     # Sprints owned by the source project are recreated on the copy; the lookup
-    # maps each source id to its copy so the copied work packages follow.
+    # maps each source id to its copy so the copied work packages follow. Goals
+    # are eager-loaded so +copied_goal_attributes+ does not query per sprint.
     def copy_owned_sprints
-      copy_collection_with_id_map(:sprints) do |source_sprint|
+      copy_collection_with_id_map(:sprints, source_scope: source.sprints.includes(:goals)) do |source_sprint|
         { goals_attributes: copied_goal_attributes(source_sprint) }
       end
     end
@@ -55,20 +56,24 @@ module Projects::Copy
     # Shared sprints (owned by another project) that the source's work packages
     # reference: keep the assignment only when the copied project will also
     # receive that sprint, otherwise leave it unmapped so the work-package copy
-    # clears it rather than pointing at a sprint the copy cannot see.
+    # clears it rather than pointing at a sprint the copy cannot see. Resolved in
+    # a single query against the sprints the target natively receives (its own
+    # sprint source), producing an id => id identity map.
     def preserved_shared_sprints
-      Sprint.where(id: source.work_packages.select(:sprint_id))
+      Sprint.native_to_sprint_source(target)
+            .where(id: source.work_packages.select(:sprint_id))
             .where.not(project_id: source.id)
-            .select { |sprint| Sprint.receiving_projects(sprint).exists?(id: target.id) }
-            .to_h { |sprint| [sprint.id, sprint.id] }
+            .pluck(:id)
+            .index_with { |id| id }
     end
 
     # Only the source project's own goals are carried over; a shared sprint may
     # also hold goals owned by other projects, which are not ours to copy.
+    # Filtered in Ruby to reuse the eager-loaded goals association.
     def copied_goal_attributes(source_sprint)
-      source_sprint.goals.where(project_id: source.id).map do |goal|
-        { text: goal.text, project_id: target.id }
-      end
+      source_sprint.goals
+                   .select { |goal| goal.project_id == source.id }
+                   .map { |goal| { text: goal.text, project_id: target.id } }
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -47,9 +47,14 @@ module Projects::Copy
         attributes = source_sprint.attributes.dup.except("id", "project_id", "created_at", "updated_at")
         sprint = target.sprints.create!(attributes)
         sprint_id_map[source_sprint.id] = sprint.id
-      end
 
-      state.sprint_id_lookup = sprint_id_map
+        # Re-assigned on every iteration (rather than once after the loop) because `state` is a
+        # Hashie::Mash: assignment converts the Hash into a new Mash, breaking object identity, so
+        # later mutations of `sprint_id_map` alone would not be visible through `state.sprint_id_lookup`.
+        # Keeping the lookup current after each sprint also means a mid-loop `create!` failure (rescued
+        # by `Copy::Dependency#perform`) leaves the partial mapping intact instead of nil.
+        state.sprint_id_lookup = sprint_id_map
+      end
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -53,15 +53,13 @@ module Projects::Copy
       end
     end
 
-    # Shared sprints (owned by another project) that the source's work packages
-    # reference: keep the assignment only when the copied project will also
-    # receive that sprint, otherwise leave it unmapped so the work-package copy
-    # clears it rather than pointing at a sprint the copy cannot see. Resolved in
-    # a single query against the sprints the target natively receives (its own
-    # sprint source), producing an id => id identity map.
+    # Sprints owned by another project that the source's work packages
+    # reference — through sharing, or because a work package moved into the
+    # source while keeping its sprint. That association is valid state, so the
+    # copy keeps it: each foreign sprint id maps to itself, while owned sprints
+    # remap to their copies above.
     def preserved_shared_sprints
-      Sprint.native_to_sprint_source(target)
-            .where(id: source.work_packages.select(:sprint_id))
+      Sprint.where(id: source.work_packages.select(:sprint_id))
             .where.not(project_id: source.id)
             .pluck(:id)
             .index_with { |id| id }

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -49,24 +49,11 @@ module Projects::Copy
     end
 
     def preserve_sprint_assignments
-      state.sprint_id_lookup = Sprint.for_project(source).to_h { |s| [s.id, s.id] }
+      state.sprint_id_lookup = Sprint.for_project(source).pluck(:id).index_with { |id| id }
     end
 
     def copy_sprints
-      sprint_id_map = {}
-
-      source.sprints.each do |source_sprint|
-        attributes = source_sprint.attributes.dup.except("id", "project_id", "created_at", "updated_at")
-        sprint = target.sprints.create!(attributes)
-        sprint_id_map[source_sprint.id] = sprint.id
-
-        # Re-assigned on every iteration (rather than once after the loop) because `state` is a
-        # Hashie::Mash: assignment converts the Hash into a new Mash, breaking object identity, so
-        # later mutations of `sprint_id_map` alone would not be visible through `state.sprint_id_lookup`.
-        # Keeping the lookup current after each sprint also means a mid-loop `create!` failure (rescued
-        # by `Copy::Dependency#perform`) leaves the partial mapping intact instead of nil.
-        state.sprint_id_lookup = sprint_id_map
-      end
+      state.sprint_id_lookup = copy_collection_with_id_map(:sprints)
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -41,6 +41,18 @@ module Projects::Copy
     protected
 
     def copy_dependency(*)
+      if source.receive_shared_sprints?
+        preserve_sprint_assignments
+      else
+        copy_sprints
+      end
+    end
+
+    def preserve_sprint_assignments
+      state.sprint_id_lookup = Sprint.for_project(source).to_h { |s| [s.id, s.id] }
+    end
+
+    def copy_sprints
       sprint_id_map = {}
 
       source.sprints.each do |source_sprint|

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -28,42 +28,28 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject::Backlogs::Patches::CopyServicePatch
-  extend ActiveSupport::Concern
-
-  included do
-    prepend InstanceMethods
-    singleton_class.prepend ClassMethods
-  end
-
-  module ClassMethods
-    def copy_dependencies
-      super.tap do |dependencies|
-        index = dependencies.index(::Projects::Copy::WorkPackagesDependentService)
-        dependencies.insert(index, ::Projects::Copy::SprintsDependentService) if index
-      end
-    end
-  end
-
-  module InstanceMethods
-    def clean_settings_attributes!(settings)
-      # There can be only one project sharing with all projects.
-      if settings["sprint_sharing"] == Projects::SprintSharing::SHARE_ALL_PROJECTS ||
-         !EnterpriseToken.allows_to?(:sprint_sharing)
-        settings.delete("sprint_sharing")
-      end
-
-      super
+module Projects::Copy
+  class SprintsDependentService < Dependency
+    def self.human_name
+      I18n.t("projects.copy.sprints")
     end
 
-    def after_perform(call)
-      super.tap do |result_call|
-        next unless source.backlogs_enabled?
-        next unless result_call.result&.persisted?
+    def source_count
+      source.sprints.count
+    end
 
-        result_call.result.done_statuses = source.done_statuses
-        result_call.result.backlog_excluded_types = source.backlog_excluded_types
+    protected
+
+    def copy_dependency(*)
+      sprint_id_map = {}
+
+      source.sprints.each do |source_sprint|
+        attributes = source_sprint.attributes.dup.except("id", "project_id", "created_at", "updated_at")
+        sprint = target.sprints.create!(attributes)
+        sprint_id_map[source_sprint.id] = sprint.id
       end
+
+      state.sprint_id_lookup = sprint_id_map
     end
   end
 end

--- a/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
+++ b/modules/backlogs/app/services/projects/copy/sprints_dependent_service.rb
@@ -45,11 +45,14 @@ module Projects::Copy
     end
 
     # Sprints owned by the source project are recreated on the copy; the lookup
-    # maps each source id to its copy so the copied work packages follow. Goals
-    # are eager-loaded so +copied_goal_attributes+ does not query per sprint.
+    # maps each source id to its copy so the copied work packages follow. Only
+    # the source's own goal is carried over (a shared sprint may hold goals
+    # owned by other projects); a sprint without one is handled by the model's
+    # +reject_if+ on blank text. Goals are eager-loaded so +goal_text_for+ does
+    # not query per sprint.
     def copy_owned_sprints
       copy_collection_with_id_map(:sprints, source_scope: source.sprints.includes(:goals)) do |source_sprint|
-        { goals_attributes: copied_goal_attributes(source_sprint) }
+        { goals_attributes: [{ text: source_sprint.goal_text_for(source), project_id: target.id }] }
       end
     end
 
@@ -63,15 +66,6 @@ module Projects::Copy
             .where.not(project_id: source.id)
             .pluck(:id)
             .index_with { |id| id }
-    end
-
-    # Only the source project's own goals are carried over; a shared sprint may
-    # also hold goals owned by other projects, which are not ours to copy.
-    # Filtered in Ruby to reuse the eager-loaded goals association.
-    def copied_goal_attributes(source_sprint)
-      source_sprint.goals
-                   .select { |goal| goal.project_id == source.id }
-                   .map { |goal| { text: goal.text, project_id: target.id } }
     end
   end
 end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -279,6 +279,7 @@ en:
 
   projects:
     copy:
+      backlog_buckets: "Backlog buckets"
       sprints: "Sprints"
     settings:
       backlog_sharing:

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -278,6 +278,8 @@ en:
   project_module_backlogs: "Backlogs"
 
   projects:
+    copy:
+      sprints: "Sprints"
     settings:
       backlog_sharing:
         options:

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -145,7 +145,7 @@ module OpenProject::Backlogs
     patch_with_namespace :WorkPackages, :SetAttributesService
     patch_with_namespace :WorkPackages, :BaseContract
     patch_with_namespace :WorkPackages, :UpdateContract
-    patch_with_namespace :Projects, :CopyService
+    patch_with_namespace :Projects, :Copy, :WorkPackagesDependentService
     patch_with_namespace :API, :V3, :WorkPackages, :EagerLoading, :Checksum
     patch_with_namespace :API, :V3, :WorkPackages, :Schema, :SpecificWorkPackageSchema
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -146,6 +146,7 @@ module OpenProject::Backlogs
     patch_with_namespace :WorkPackages, :BaseContract
     patch_with_namespace :WorkPackages, :UpdateContract
     patch_with_namespace :Projects, :Copy, :WorkPackagesDependentService
+    patch_with_namespace :Queries, :Copy, :FiltersMapper
     patch_with_namespace :API, :V3, :WorkPackages, :EagerLoading, :Checksum
     patch_with_namespace :API, :V3, :WorkPackages, :Schema, :SpecificWorkPackageSchema
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/copy_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/copy_service_patch.rb
@@ -38,16 +38,11 @@ module OpenProject::Backlogs::Patches::CopyServicePatch
 
   module ClassMethods
     def copy_dependencies
-      super.tap do |dependencies|
-        index = dependencies.index(::Projects::Copy::WorkPackagesDependentService)
-        next unless index
-
-        # Both must precede the work packages so their id maps are ready when the
-        # work packages are copied and their sprint/bucket ids remapped.
-        dependencies.insert(index,
-                            ::Projects::Copy::SprintsDependentService,
-                            ::Projects::Copy::BacklogBucketsDependentService)
-      end
+      # Sprints and backlog buckets must precede the `WorkPackagesDependentService`
+      # so their id maps are ready when the work packages are copied and their
+      # sprint/bucket ids remapped.
+      [::Projects::Copy::SprintsDependentService,
+       ::Projects::Copy::BacklogBucketsDependentService] + super
     end
   end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/copy_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/copy_service_patch.rb
@@ -40,7 +40,13 @@ module OpenProject::Backlogs::Patches::CopyServicePatch
     def copy_dependencies
       super.tap do |dependencies|
         index = dependencies.index(::Projects::Copy::WorkPackagesDependentService)
-        dependencies.insert(index, ::Projects::Copy::SprintsDependentService) if index
+        next unless index
+
+        # Both must precede the work packages so their id maps are ready when the
+        # work packages are copied and their sprint/bucket ids remapped.
+        dependencies.insert(index,
+                            ::Projects::Copy::SprintsDependentService,
+                            ::Projects::Copy::BacklogBucketsDependentService)
       end
     end
   end

--- a/modules/backlogs/lib/open_project/backlogs/patches/filters_mapper_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/filters_mapper_patch.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Backlogs::Patches::FiltersMapperPatch
+  extend ActiveSupport::Concern
+
+  included do
+    prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    protected
+
+    # Sprints and backlog buckets are recreated with new ids when a project is
+    # copied (see Projects::Copy::SprintsDependentService and
+    # BacklogBucketsDependentService). A copied query's sprint_id /
+    # backlog_bucket_id filters must be remapped to those copies just like
+    # version_id, otherwise they keep pointing at the source project's records
+    # and the copied query matches nothing.
+    def build_filter_mappers
+      super.merge(
+        sprint_id: state_mapper(:sprint_id_lookup),
+        backlog_bucket_id: state_mapper(:backlog_bucket_id_lookup)
+      )
+    end
+  end
+end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
@@ -45,6 +45,7 @@ module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
     def copy_work_package_attribute_overrides(source_work_package, parent_id, user_cf_ids)
       super.merge(
         sprint_id: work_package_sprint_id(source_work_package),
+        backlog_bucket_id: work_package_backlog_bucket_id(source_work_package),
         position: source_work_package.position
       )
     end
@@ -52,7 +53,19 @@ module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
     def work_package_sprint_id(source_work_package)
       return unless source_work_package.sprint_id
 
+      # Falling back to the source sprint id (rather than nil) keeps assignments to
+      # sprints shared from another project, which are visible to the source but not
+      # copied here. Owned sprints are always in the lookup once sprints are copied.
       (state.sprint_id_lookup || {}).fetch(source_work_package.sprint_id, source_work_package.sprint_id)
+    end
+
+    def work_package_backlog_bucket_id(source_work_package)
+      return unless source_work_package.backlog_bucket_id
+
+      # No fallback to the source id: buckets are never shared across projects, so a
+      # bucket missing from the lookup was simply not copied. Keeping the source id
+      # would dangle the copy into the source project's bucket.
+      (state.backlog_bucket_id_lookup || {})[source_work_package.backlog_bucket_id]
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
+  extend ActiveSupport::Concern
+
+  included do
+    prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def copy_work_package_attribute_overrides(source_work_package, parent_id, user_cf_ids)
+      super.merge(sprint_id: work_package_sprint_id(source_work_package))
+    end
+
+    def work_package_sprint_id(source_work_package)
+      return unless source_work_package.sprint_id
+
+      (state.sprint_id_lookup || {}).fetch(source_work_package.sprint_id, source_work_package.sprint_id)
+    end
+  end
+end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
@@ -37,12 +37,16 @@ module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
 
   module InstanceMethods
     def copy_work_package(source_work_package, parent_id, user_cf_ids)
-      # Disabling the acts_as_list callbacks to make sure the position is carried
-      # over from the source work package without any alternation.
+      return super unless source.backlogs_enabled?
+
+      # Disable the acts_as_list callbacks so the position is carried over from
+      # the source work package unchanged instead of being reappended.
       WorkPackage.acts_as_list_no_update { super }
     end
 
     def copy_work_package_attribute_overrides(source_work_package, parent_id, user_cf_ids)
+      return super unless source.backlogs_enabled?
+
       super.merge(
         sprint_id: work_package_sprint_id(source_work_package),
         backlog_bucket_id: work_package_backlog_bucket_id(source_work_package),
@@ -53,13 +57,13 @@ module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
     def work_package_sprint_id(source_work_package)
       return unless source_work_package.sprint_id
 
-      (state.sprint_id_lookup || {})[source_work_package.sprint_id]
+      state.sprint_id_lookup&.[](source_work_package.sprint_id)
     end
 
     def work_package_backlog_bucket_id(source_work_package)
       return unless source_work_package.backlog_bucket_id
 
-      (state.backlog_bucket_id_lookup || {})[source_work_package.backlog_bucket_id]
+      state.backlog_bucket_id_lookup&.[](source_work_package.backlog_bucket_id)
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
@@ -36,8 +36,17 @@ module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
   end
 
   module InstanceMethods
+    def copy_work_package(source_work_package, parent_id, user_cf_ids)
+      # Disabling the acts_as_list callbacks to make sure the position is carried
+      # over from the source work package without any alternation.
+      WorkPackage.acts_as_list_no_update { super }
+    end
+
     def copy_work_package_attribute_overrides(source_work_package, parent_id, user_cf_ids)
-      super.merge(sprint_id: work_package_sprint_id(source_work_package))
+      super.merge(
+        sprint_id: work_package_sprint_id(source_work_package),
+        position: source_work_package.position
+      )
     end
 
     def work_package_sprint_id(source_work_package)

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages_dependent_service_patch.rb
@@ -53,18 +53,12 @@ module OpenProject::Backlogs::Patches::WorkPackagesDependentServicePatch
     def work_package_sprint_id(source_work_package)
       return unless source_work_package.sprint_id
 
-      # Falling back to the source sprint id (rather than nil) keeps assignments to
-      # sprints shared from another project, which are visible to the source but not
-      # copied here. Owned sprints are always in the lookup once sprints are copied.
-      (state.sprint_id_lookup || {}).fetch(source_work_package.sprint_id, source_work_package.sprint_id)
+      (state.sprint_id_lookup || {})[source_work_package.sprint_id]
     end
 
     def work_package_backlog_bucket_id(source_work_package)
       return unless source_work_package.backlog_bucket_id
 
-      # No fallback to the source id: buckets are never shared across projects, so a
-      # bucket missing from the lookup was simply not copied. Keeping the source id
-      # would dangle the copy into the source project's bucket.
       (state.backlog_bucket_id_lookup || {})[source_work_package.backlog_bucket_id]
     end
   end

--- a/modules/backlogs/spec/features/projects/copy_backlogs_spec.rb
+++ b/modules/backlogs/spec/features/projects/copy_backlogs_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Project copy with sprints", :js,
+RSpec.describe "Project copy with sprints and buckets", :js,
                with_good_job_batches: [CopyProjectJob,
                                        Storages::CopyProjectFoldersJob,
                                        SendCopyProjectStatusEmailJob] do
@@ -42,8 +42,12 @@ RSpec.describe "Project copy with sprints", :js,
            types: [type])
   end
   shared_let(:sprint) { create(:sprint, project:, name: "Sprint A") }
+  shared_let(:bucket) { create(:backlog_bucket, project:, name: "Bucket A") }
   shared_let(:work_package) do
     create(:work_package, project:, type:, subject: "Sprint story", sprint:)
+  end
+  shared_let(:bucket_work_package) do
+    create(:work_package, project:, type:, subject: "Bucket story", backlog_bucket: bucket)
   end
 
   let(:general_settings_page) { Pages::Projects::Settings::General.new(project) }
@@ -56,7 +60,7 @@ RSpec.describe "Project copy with sprints", :js,
     login_as admin
   end
 
-  it "assigns the copied work package to the copied sprint, not the source sprint" do
+  it "assigns copied work packages to the copied sprint and bucket, not the source ones" do
     general_settings_page.visit!
     general_settings_page.click_copy_action
 
@@ -76,6 +80,13 @@ RSpec.describe "Project copy with sprints", :js,
 
     copied_work_package = copied_project.work_packages.find_by(subject: "Sprint story")
     expect(copied_work_package.sprint).to eq(copied_sprint)
+
+    copied_bucket = copied_project.backlog_buckets.find_by(name: "Bucket A")
+    expect(copied_bucket).to be_present
+    expect(copied_bucket.id).not_to eq(bucket.id)
+
+    copied_bucket_work_package = copied_project.work_packages.find_by(subject: "Bucket story")
+    expect(copied_bucket_work_package.backlog_bucket).to eq(copied_bucket)
   end
 
   def wait_for_copy_to_finish

--- a/modules/backlogs/spec/features/projects/copy_backlogs_spec.rb
+++ b/modules/backlogs/spec/features/projects/copy_backlogs_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Project copy with sprints and buckets", :js,
     fill_in "Name", with: "Copied project"
     click_on "Copy"
 
-    wait_for_copy_to_finish
+    general_settings_page.wait_for_copy_to_finish
 
     copied_project = Project.find_by(name: "Copied project")
     expect(copied_project).to be_present
@@ -87,17 +87,5 @@ RSpec.describe "Project copy with sprints and buckets", :js,
 
     copied_bucket_work_package = copied_project.work_packages.find_by(subject: "Bucket story")
     expect(copied_bucket_work_package.backlog_bucket).to eq(copied_bucket)
-  end
-
-  def wait_for_copy_to_finish
-    expect(page).to have_dialog "Background job status"
-
-    within_dialog "Background job status" do
-      expect(page).to have_heading "Copy project"
-      expect(page).to have_text "The job has been queued and will be processed shortly."
-    end
-
-    # Ensure all jobs are run, especially emails which might be sent later on.
-    GoodJob.perform_inline
   end
 end

--- a/modules/backlogs/spec/features/projects/copy_sprints_spec.rb
+++ b/modules/backlogs/spec/features/projects/copy_sprints_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project copy with sprints", :js,
+               with_good_job_batches: [CopyProjectJob,
+                                       Storages::CopyProjectFoldersJob,
+                                       SendCopyProjectStatusEmailJob] do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:type) { create(:type) }
+  shared_let(:project) do
+    create(:project,
+           enabled_module_names: %w[work_package_tracking backlogs],
+           types: [type])
+  end
+  shared_let(:sprint) { create(:sprint, project:, name: "Sprint A") }
+  shared_let(:work_package) do
+    create(:work_package, project:, type:, subject: "Sprint story", sprint:)
+  end
+
+  let(:general_settings_page) { Pages::Projects::Settings::General.new(project) }
+
+  before do
+    # Clear jobs enqueued during object creation so they don't interfere with the copy.
+    clear_enqueued_jobs
+    clear_performed_jobs
+
+    login_as admin
+  end
+
+  it "assigns the copied work package to the copied sprint, not the source sprint" do
+    general_settings_page.visit!
+    general_settings_page.click_copy_action
+
+    expect(page).to have_heading "Copy project \"#{project.name}\""
+
+    fill_in "Name", with: "Copied project"
+    click_on "Copy"
+
+    wait_for_copy_to_finish
+
+    copied_project = Project.find_by(name: "Copied project")
+    expect(copied_project).to be_present
+
+    copied_sprint = copied_project.sprints.find_by(name: "Sprint A")
+    expect(copied_sprint).to be_present
+    expect(copied_sprint.id).not_to eq(sprint.id)
+
+    copied_work_package = copied_project.work_packages.find_by(subject: "Sprint story")
+    expect(copied_work_package.sprint).to eq(copied_sprint)
+  end
+
+  def wait_for_copy_to_finish
+    expect(page).to have_dialog "Background job status"
+
+    within_dialog "Background job status" do
+      expect(page).to have_heading "Copy project"
+      expect(page).to have_text "The job has been queued and will be processed shortly."
+    end
+
+    # Ensure all jobs are run, especially emails which might be sent later on.
+    GoodJob.perform_inline
+  end
+end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -449,4 +449,31 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       end
     end
   end
+
+  describe "when a sprint cannot be copied", with_ee: %i[sprint_sharing] do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[sprints] }
+    end
+    let!(:valid_sprint) { create(:sprint, project: source, name: "Valid") }
+    let!(:invalid_sprint) { create(:sprint, project: source, name: "Invalid") }
+
+    subject { instance.call(params) }
+
+    before do
+      # Simulate stale data whose copy fails validation (blank name). The copy
+      # should stay tolerant and skip it rather than aborting.
+      invalid_sprint.update_column(:name, "")
+    end
+
+    it "still copies the valid sprints" do
+      expect(subject).to be_success
+      expect(project_copy.sprints.pluck(:name)).to contain_exactly("Valid")
+    end
+
+    it "surfaces the skipped sprint as an error instead of dropping it silently" do
+      expect(subject.errors.full_messages).not_to be_empty
+    end
+  end
 end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -450,6 +450,51 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
   end
 
+  describe "query filter remapping", with_ee: %i[sprint_sharing] do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[members work_packages sprints backlog_buckets queries] }
+    end
+    let!(:source_sprint) { create(:sprint, project: source, name: "Sprint A") }
+    let!(:source_bucket) { create(:backlog_bucket, project: source, name: "Bucket A") }
+    let!(:sprint_query) do
+      build(:query, project: source, name: "By sprint").tap do |q|
+        q.add_filter("sprint_id", "=", [source_sprint.id.to_s])
+        q.save!(validate: false)
+        create(:view_work_packages_table, query: q)
+      end
+    end
+    let!(:bucket_query) do
+      build(:query, project: source, name: "By bucket").tap do |q|
+        q.add_filter("backlog_bucket_id", "=", [source_bucket.id.to_s])
+        q.save!(validate: false)
+        create(:view_work_packages_table, query: q)
+      end
+    end
+
+    subject { instance.call(params) }
+
+    def copied_filter(query_name, filter_name)
+      query = project_copy.queries.find_by(name: query_name)
+      query.filters.find { |filter| filter.name.to_sym == filter_name }
+    end
+
+    it "remaps the sprint_id filter to the copied sprint" do
+      expect(subject).to be_success
+
+      copied_sprint = project_copy.sprints.find_by(name: "Sprint A")
+      expect(copied_filter("By sprint", :sprint_id).values).to eq [copied_sprint.id.to_s]
+    end
+
+    it "remaps the backlog_bucket_id filter to the copied bucket" do
+      expect(subject).to be_success
+
+      copied_bucket = project_copy.backlog_buckets.find_by(name: "Bucket A")
+      expect(copied_filter("By bucket", :backlog_bucket_id).values).to eq [copied_bucket.id.to_s]
+    end
+  end
+
   describe "when a sprint cannot be copied", with_ee: %i[sprint_sharing] do
     let(:admin) { create(:admin) }
     let(:instance) { described_class.new(source:, user: admin) }

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -240,6 +240,13 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
         copied_sprint = project_copy.sprints.find_by(name: "Sprint A")
         expect(copied_sprint.goals.pluck(:text)).to contain_exactly("Ship it")
       end
+
+      it "leaves the goal on the source sprint intact" do
+        expect(subject).to be_success
+
+        expect(source_sprint.reload.goals.pluck(:text, :project_id))
+          .to contain_exactly(["Ship it", source.id])
+      end
     end
   end
 

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -160,14 +160,22 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
     let!(:owned_sprint) { create(:sprint, project: source, name: "Owned Sprint") }
     let!(:shared_sprint) { create(:sprint, project: other_project, name: "Shared Sprint") }
-    let!(:wp_in_owned) { create(:work_package, project: source, subject: "In owned") }
+    let!(:wp_owned1) { create(:work_package, project: source, subject: "In owned") }
+    let!(:wp_owned2) { create(:work_package, project: source, subject: "Second in owned") }
     let!(:wp_in_shared) { create(:work_package, project: source, subject: "In shared") }
+    let!(:wp_inbox1) { create(:work_package, project: source, subject: "Inbox 1") }
+    let!(:wp_inbox2) { create(:work_package, project: source, subject: "Inbox 2") }
+    let!(:wp_inbox3) { create(:work_package, project: source, subject: "Inbox 3") }
 
     subject { instance.call(params) }
 
     before do
-      wp_in_owned.update_column(:sprint_id, owned_sprint.id)
+      wp_owned1.update_columns(sprint_id: owned_sprint.id, position: 2)
+      wp_owned2.update_columns(sprint_id: owned_sprint.id, position: 1)
       wp_in_shared.update_column(:sprint_id, shared_sprint.id)
+      wp_inbox1.update_column(:position, 3)
+      wp_inbox2.update_column(:position, 1)
+      wp_inbox3.update_column(:position, 2)
     end
 
     def copied_wp(subject_text)
@@ -192,7 +200,19 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     it "does not add the copied work package to the source sprint" do
       expect(subject).to be_success
 
-      expect(owned_sprint.reload.work_packages.pluck(:subject)).to eq(["In owned"])
+      expect(owned_sprint.reload.work_packages.pluck(:subject)).to contain_exactly("In owned", "Second in owned")
+    end
+
+    it "preserves the position of each copied work package" do
+      expect(subject).to be_success
+
+      # Sprint
+      expect(copied_wp("In owned").position).to eq(2)
+      expect(copied_wp("Second in owned").position).to eq(1)
+      # Backlog Inbox
+      expect(copied_wp("Inbox 1").position).to eq(3)
+      expect(copied_wp("Inbox 2").position).to eq(1)
+      expect(copied_wp("Inbox 3").position).to eq(2)
     end
   end
 end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -132,6 +132,15 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     let(:params) do
       { target_project_params:, send_notifications: false, only: %w[sprints] }
     end
+    # Scoped to this describe so each context picks its sharing mode via
+    # +sprint_sharing+ instead of mutating the outer shared_let project.
+    let(:sprint_sharing) { Projects::SprintSharing::NO_SHARING }
+    let(:source) do
+      create(:project,
+             name: "Source Project Name",
+             enabled_module_names: %i[work_package_tracking backlogs],
+             sprint_sharing:)
+    end
     let(:sprint_project) { source }
     let!(:source_sprint) { create(:sprint, project: sprint_project, name: "Sprint A") }
 
@@ -157,19 +166,19 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
 
     context "when source has NO_SHARING" do
-      before { source.update!(sprint_sharing: Projects::SprintSharing::NO_SHARING) }
+      let(:sprint_sharing) { Projects::SprintSharing::NO_SHARING }
 
       include_examples "copies sprints decoupled from the source"
     end
 
     context "when source has SHARE_SUBPROJECTS" do
-      before { source.update!(sprint_sharing: Projects::SprintSharing::SHARE_SUBPROJECTS) }
+      let(:sprint_sharing) { Projects::SprintSharing::SHARE_SUBPROJECTS }
 
       include_examples "copies sprints decoupled from the source"
     end
 
     context "when source has SHARE_ALL_PROJECTS" do
-      before { source.update!(sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS) }
+      let(:sprint_sharing) { Projects::SprintSharing::SHARE_ALL_PROJECTS }
 
       # The project copy is set to NO_SHARING in the
       # OpenProject::Backlogs::Patches::CopyServicePatch#clean_settings_attributes!,
@@ -178,13 +187,12 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
 
     context "when source has RECEIVE_SHARED" do
+      let(:sprint_sharing) { Projects::SprintSharing::RECEIVE_SHARED }
       let(:sprint_project) do
         create(:project,
                enabled_module_names: %i[work_package_tracking backlogs],
                sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
       end
-
-      before { source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
 
       it "does not copy the shared sprint it only receives" do
         expect(subject).to be_success
@@ -211,14 +219,12 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     context "when a RECEIVE_SHARED source still owns a sprint (stale data)" do
       # source_sprint is owned by source (created through the factory, which
       # bypasses the create contract that forbids sprints on a receiving project).
-      before { source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
+      let(:sprint_sharing) { Projects::SprintSharing::RECEIVE_SHARED }
 
       include_examples "copies sprints decoupled from the source"
     end
 
     context "when the source sprint has goals" do
-      before { source.update!(sprint_sharing: Projects::SprintSharing::NO_SHARING) }
-
       let!(:owned_goal) do
         create(:sprint_goal, sprint: source_sprint, project: source, text: "Ship it")
       end
@@ -256,6 +262,13 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     let(:params) do
       { target_project_params:, send_notifications: false, only: %w[work_packages sprints] }
     end
+    let(:sprint_sharing) { Projects::SprintSharing::NO_SHARING }
+    let(:source) do
+      create(:project,
+             name: "Source Project Name",
+             enabled_module_names: %i[work_package_tracking backlogs],
+             sprint_sharing:)
+    end
     let!(:work_package) { create(:work_package, project: source, subject: "On shared") }
 
     subject { instance.call(params) }
@@ -265,6 +278,7 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
 
     context "when the sprint is shared with all projects and the copy receives it" do
+      let(:sprint_sharing) { Projects::SprintSharing::RECEIVE_SHARED }
       let!(:sharer) do
         create(:project,
                enabled_module_names: %i[work_package_tracking backlogs],
@@ -272,10 +286,7 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       end
       let!(:shared_sprint) { create(:sprint, project: sharer, name: "Global Sprint") }
 
-      before do
-        source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED)
-        work_package.update_column(:sprint_id, shared_sprint.id)
-      end
+      before { work_package.update_column(:sprint_id, shared_sprint.id) }
 
       it "preserves the assignment to the shared sprint" do
         expect(subject).to be_success

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -125,4 +125,24 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       end
     end
   end
+
+  describe "sprint copying" do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[sprints] }
+    end
+    let!(:source_sprint) { create(:sprint, project: source, name: "Sprint A") }
+
+    subject { instance.call(params) }
+
+    it "copies owned sprints to the target, decoupled from the source" do
+      expect(subject).to be_success
+
+      expect(project_copy.sprints.pluck(:name)).to contain_exactly("Sprint A")
+      copied_sprint = project_copy.sprints.first
+      expect(copied_sprint.id).not_to eq(source_sprint.id)
+      expect(copied_sprint.project).to eq(project_copy)
+    end
+  end
 end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -156,18 +156,6 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       end
     end
 
-    shared_examples "does not copy sprints to the target" do
-      it "does not copy sprints to the target" do
-        expect(subject).to be_success
-        expect(project_copy.sprints).to be_empty
-      end
-
-      it "identity-maps the sprint id in state" do
-        expect(subject).to be_success
-        expect(subject.state.sprint_id_lookup[source_sprint.id]).to eq(source_sprint.id)
-      end
-    end
-
     context "when source has NO_SHARING" do
       before { source.update!(sprint_sharing: Projects::SprintSharing::NO_SHARING) }
 
@@ -198,7 +186,18 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
 
       before { source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
 
-      include_examples "does not copy sprints to the target"
+      it "does not copy the shared sprint it only receives" do
+        expect(subject).to be_success
+        expect(project_copy.sprints).to be_empty
+      end
+    end
+
+    context "when a RECEIVE_SHARED source still owns a sprint (stale data)" do
+      # source_sprint is owned by source (created through the factory, which
+      # bypasses the create contract that forbids sprints on a receiving project).
+      before { source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
+
+      include_examples "copies sprints decoupled from the source"
     end
 
     context "when the source sprint has goals" do
@@ -224,6 +223,80 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
 
         copied_sprint = project_copy.sprints.find_by(name: "Sprint A")
         expect(copied_sprint.goals.pluck(:text)).to contain_exactly("Ship it")
+      end
+    end
+  end
+
+  describe "shared sprint preservation", with_ee: %i[sprint_sharing] do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[work_packages sprints] }
+    end
+    let!(:work_package) { create(:work_package, project: source, subject: "On shared") }
+
+    subject { instance.call(params) }
+
+    def copied_wp(subject_text)
+      project_copy.work_packages.find_by(subject: subject_text)
+    end
+
+    context "when the sprint is shared with all projects and the copy receives it" do
+      let!(:sharer) do
+        create(:project,
+               enabled_module_names: %i[work_package_tracking backlogs],
+               sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
+      end
+      let!(:shared_sprint) { create(:sprint, project: sharer, name: "Global Sprint") }
+
+      before do
+        source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED)
+        work_package.update_column(:sprint_id, shared_sprint.id)
+      end
+
+      it "preserves the assignment to the shared sprint" do
+        expect(subject).to be_success
+        expect(copied_wp("On shared").sprint_id).to eq(shared_sprint.id)
+      end
+
+      it "does not copy the shared sprint into the target" do
+        expect(subject).to be_success
+        expect(project_copy.sprints).to be_empty
+      end
+    end
+
+    context "when the sprint is shared through an ancestor" do
+      let!(:ancestor) do
+        create(:project,
+               enabled_module_names: %i[work_package_tracking backlogs],
+               sprint_sharing: Projects::SprintSharing::SHARE_SUBPROJECTS)
+      end
+      let(:source) do
+        create(:project,
+               parent: ancestor,
+               enabled_module_names: %i[work_package_tracking backlogs],
+               sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED)
+      end
+      let!(:shared_sprint) { create(:sprint, project: ancestor, name: "Subtree Sprint") }
+
+      before { work_package.update_column(:sprint_id, shared_sprint.id) }
+
+      it "preserves the assignment when the copy stays within the sharing subtree" do
+        # The copy inherits the source's parent, so it remains a descendant of
+        # the sharing ancestor and keeps receiving the sprint.
+        expect(subject).to be_success
+        expect(copied_wp("On shared").sprint_id).to eq(shared_sprint.id)
+      end
+
+      context "and the copy is moved out of the subtree" do
+        let(:target_project_params) do
+          { name: "Target Project Name", identifier: "some-identifier", parent_id: nil }
+        end
+
+        it "clears the assignment because the copy no longer receives the sprint" do
+          expect(subject).to be_success
+          expect(copied_wp("On shared").sprint_id).to be_nil
+        end
       end
     end
   end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -126,26 +126,79 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
   end
 
-  describe "sprint copying" do
+  describe "sprint copying", with_ee: %i[sprint_sharing] do
     let(:admin) { create(:admin) }
     let(:instance) { described_class.new(source:, user: admin) }
     let(:params) do
       { target_project_params:, send_notifications: false, only: %w[sprints] }
     end
-    let!(:source_sprint) { create(:sprint, project: source, name: "Sprint A") }
+    let(:sprint_project) { source }
+    let!(:source_sprint) { create(:sprint, project: sprint_project, name: "Sprint A") }
 
     subject { instance.call(params) }
 
-    it "copies owned sprints to the target, decoupled from the source" do
-      expect(subject).to be_success
+    shared_examples "copies sprints decoupled from the source" do
+      it "copies owned sprints to the target, decoupled from the source" do
+        expect(subject).to be_success
 
-      expect(project_copy.sprints.pluck(:name)).to contain_exactly("Sprint A")
-      copied_sprint = project_copy.sprints.first
-      expect(copied_sprint.id).not_to eq(source_sprint.id)
-      expect(copied_sprint.project).to eq(project_copy)
+        expect(project_copy.sprints.pluck(:name)).to contain_exactly("Sprint A")
+        copied_sprint = project_copy.sprints.first
+        expect(copied_sprint.id).not_to eq(source_sprint.id)
+        expect(copied_sprint.project).to eq(project_copy)
 
-      copied_sprint.update!(name: "Renamed Copy")
-      expect(source_sprint.reload.name).to eq("Sprint A")
+        copied_sprint.update!(name: "Renamed Copy")
+        expect(source_sprint.reload.name).to eq("Sprint A")
+      end
+
+      it "maps the source sprint id to the new sprint id in state" do
+        expect(subject).to be_success
+        expect(subject.state.sprint_id_lookup[source_sprint.id]).to eq(project_copy.sprints.first.id)
+      end
+    end
+
+    shared_examples "does not copy sprints to the target" do
+      it "does not copy sprints to the target" do
+        expect(subject).to be_success
+        expect(project_copy.sprints).to be_empty
+      end
+
+      it "identity-maps the sprint id in state" do
+        expect(subject).to be_success
+        expect(subject.state.sprint_id_lookup[source_sprint.id]).to eq(source_sprint.id)
+      end
+    end
+
+    context "when source has NO_SHARING" do
+      before { source.update!(sprint_sharing: Projects::SprintSharing::NO_SHARING) }
+
+      include_examples "copies sprints decoupled from the source"
+    end
+
+    context "when source has SHARE_SUBPROJECTS" do
+      before { source.update!(sprint_sharing: Projects::SprintSharing::SHARE_SUBPROJECTS) }
+
+      include_examples "copies sprints decoupled from the source"
+    end
+
+    context "when source has SHARE_ALL_PROJECTS" do
+      before { source.update!(sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS) }
+
+      # The project copy is set to NO_SHARING in the
+      # OpenProject::Backlogs::Patches::CopyServicePatch#clean_settings_attributes!,
+      # hence it has to have it's own sprints copied.
+      include_examples "copies sprints decoupled from the source"
+    end
+
+    context "when source has RECEIVE_SHARED" do
+      let(:sprint_project) do
+        create(:project,
+               enabled_module_names: %i[work_package_tracking backlogs],
+               sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
+      end
+
+      before { source.update!(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
+
+      include_examples "does not copy sprints to the target"
     end
   end
 
@@ -191,10 +244,10 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       expect(copied.sprint.project).to eq(project_copy)
     end
 
-    it "keeps the original sprint when it is shared (not owned by the source)" do
+    it "clears the sprint when it belongs to another project (anomalous data for NO_SHARING)" do
       expect(subject).to be_success
 
-      expect(copied_wp("In shared").sprint_id).to eq(shared_sprint.id)
+      expect(copied_wp("In shared").sprint_id).to be_nil
     end
 
     it "does not add the copied work package to the source sprint" do
@@ -213,6 +266,18 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       expect(copied_wp("Inbox 1").position).to eq(3)
       expect(copied_wp("Inbox 2").position).to eq(1)
       expect(copied_wp("Inbox 3").position).to eq(2)
+    end
+
+    context "when sprints are not copied" do
+      let(:params) do
+        { target_project_params:, send_notifications: false, only: %w[work_packages] }
+      end
+
+      it "clears the sprint rather than keeping the source sprint id" do
+        expect(subject).to be_success
+
+        expect(copied_wp("In owned").sprint_id).to be_nil
+      end
     end
   end
 

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -215,4 +215,74 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       expect(copied_wp("Inbox 3").position).to eq(2)
     end
   end
+
+  describe "backlog bucket copying" do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[backlog_buckets] }
+    end
+    let!(:source_bucket) { create(:backlog_bucket, project: source, name: "Bucket A") }
+
+    subject { instance.call(params) }
+
+    it "copies owned backlog buckets to the target, decoupled from the source" do
+      expect(subject).to be_success
+
+      expect(project_copy.backlog_buckets.pluck(:name)).to contain_exactly("Bucket A")
+      copied_bucket = project_copy.backlog_buckets.first
+      expect(copied_bucket.id).not_to eq(source_bucket.id)
+      expect(copied_bucket.project).to eq(project_copy)
+
+      copied_bucket.update!(name: "Renamed Copy")
+      expect(source_bucket.reload.name).to eq("Bucket A")
+    end
+  end
+
+  describe "work package backlog bucket reassignment" do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[work_packages backlog_buckets] }
+    end
+    let!(:source_bucket) { create(:backlog_bucket, project: source, name: "Bucket A") }
+    let!(:wp_in_bucket) { create(:work_package, project: source, subject: "In bucket") }
+
+    subject { instance.call(params) }
+
+    before do
+      wp_in_bucket.update_column(:backlog_bucket_id, source_bucket.id)
+    end
+
+    def copied_wp(subject_text)
+      project_copy.work_packages.find_by(subject: subject_text)
+    end
+
+    it "assigns the copied work package to the copied backlog bucket" do
+      expect(subject).to be_success
+
+      copied = copied_wp("In bucket")
+      expect(copied.backlog_bucket.name).to eq("Bucket A")
+      expect(copied.backlog_bucket_id).not_to eq(source_bucket.id)
+      expect(copied.backlog_bucket.project).to eq(project_copy)
+    end
+
+    it "does not add the copied work package to the source backlog bucket" do
+      expect(subject).to be_success
+
+      expect(source_bucket.reload.work_packages.pluck(:subject)).to contain_exactly("In bucket")
+    end
+
+    context "when the buckets are not copied" do
+      let(:params) do
+        { target_project_params:, send_notifications: false, only: %w[work_packages] }
+      end
+
+      it "clears the backlog bucket rather than keeping the source id" do
+        expect(subject).to be_success
+
+        expect(copied_wp("In bucket").backlog_bucket_id).to be_nil
+      end
+    end
+  end
 end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -143,6 +143,9 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       copied_sprint = project_copy.sprints.first
       expect(copied_sprint.id).not_to eq(source_sprint.id)
       expect(copied_sprint.project).to eq(project_copy)
+
+      copied_sprint.update!(name: "Renamed Copy")
+      expect(source_sprint.reload.name).to eq("Sprint A")
     end
   end
 

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -145,4 +145,51 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       expect(copied_sprint.project).to eq(project_copy)
     end
   end
+
+  describe "work package sprint reassignment" do
+    let(:admin) { create(:admin) }
+    let(:instance) { described_class.new(source:, user: admin) }
+    let(:params) do
+      { target_project_params:, send_notifications: false, only: %w[work_packages sprints] }
+    end
+    let(:other_project) do
+      create(:project, enabled_module_names: %i[work_package_tracking backlogs])
+    end
+    let!(:owned_sprint) { create(:sprint, project: source, name: "Owned Sprint") }
+    let!(:shared_sprint) { create(:sprint, project: other_project, name: "Shared Sprint") }
+    let!(:wp_in_owned) { create(:work_package, project: source, subject: "In owned") }
+    let!(:wp_in_shared) { create(:work_package, project: source, subject: "In shared") }
+
+    subject { instance.call(params) }
+
+    before do
+      wp_in_owned.update_column(:sprint_id, owned_sprint.id)
+      wp_in_shared.update_column(:sprint_id, shared_sprint.id)
+    end
+
+    def copied_wp(subject_text)
+      project_copy.work_packages.find_by(subject: subject_text)
+    end
+
+    it "assigns the copied work package to the copied sprint for owned sprints" do
+      expect(subject).to be_success
+
+      copied = copied_wp("In owned")
+      expect(copied.sprint.name).to eq("Owned Sprint")
+      expect(copied.sprint_id).not_to eq(owned_sprint.id)
+      expect(copied.sprint.project).to eq(project_copy)
+    end
+
+    it "keeps the original sprint when it is shared (not owned by the source)" do
+      expect(subject).to be_success
+
+      expect(copied_wp("In shared").sprint_id).to eq(shared_sprint.id)
+    end
+
+    it "does not add the copied work package to the source sprint" do
+      expect(subject).to be_success
+
+      expect(owned_sprint.reload.work_packages.pluck(:subject)).to eq(["In owned"])
+    end
+  end
 end

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -200,6 +200,32 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
 
       include_examples "does not copy sprints to the target"
     end
+
+    context "when the source sprint has goals" do
+      before { source.update!(sprint_sharing: Projects::SprintSharing::NO_SHARING) }
+
+      let!(:owned_goal) do
+        create(:sprint_goal, sprint: source_sprint, project: source, text: "Ship it")
+      end
+
+      it "copies the owned goal onto the copied sprint, remapped to the copy" do
+        expect(subject).to be_success
+
+        copied_sprint = project_copy.sprints.find_by(name: "Sprint A")
+        expect(copied_sprint.goals.pluck(:text, :project_id))
+          .to contain_exactly(["Ship it", project_copy.id])
+      end
+
+      it "does not copy goals owned by other projects" do
+        other_project = create(:project)
+        create(:sprint_goal, sprint: source_sprint, project: other_project, text: "Not mine")
+
+        expect(subject).to be_success
+
+        copied_sprint = project_copy.sprints.find_by(name: "Sprint A")
+        expect(copied_sprint.goals.pluck(:text)).to contain_exactly("Ship it")
+      end
+    end
   end
 
   describe "work package sprint reassignment" do

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -190,6 +190,22 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
         expect(subject).to be_success
         expect(project_copy.sprints).to be_empty
       end
+
+      context "and work packages are copied along" do
+        let(:params) do
+          { target_project_params:, send_notifications: false, only: %w[work_packages sprints] }
+        end
+        let!(:work_package) { create(:work_package, project: source, subject: "On received") }
+
+        before { work_package.update_column(:sprint_id, source_sprint.id) }
+
+        it "keeps the copied work package on the original shared sprint" do
+          expect(subject).to be_success
+
+          copied = project_copy.work_packages.find_by(subject: "On received")
+          expect(copied.sprint_id).to eq(source_sprint.id)
+        end
+      end
     end
 
     context "when a RECEIVE_SHARED source still owns a sprint (stale data)" do
@@ -293,9 +309,11 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
           { name: "Target Project Name", identifier: "some-identifier", parent_id: nil }
         end
 
-        it "clears the assignment because the copy no longer receives the sprint" do
+        it "keeps the assignment to the borrowed sprint" do
+          # The copy no longer receives the sprint through sharing, but the
+          # borrowed association is valid state and is carried over as-is.
           expect(subject).to be_success
-          expect(copied_wp("On shared").sprint_id).to be_nil
+          expect(copied_wp("On shared").sprint_id).to eq(shared_sprint.id)
         end
       end
     end
@@ -343,10 +361,12 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       expect(copied.sprint.project).to eq(project_copy)
     end
 
-    it "clears the sprint when it belongs to another project (anomalous data for NO_SHARING)" do
+    it "keeps the sprint when it belongs to another project" do
+      # A work package can legitimately borrow a sprint from another project,
+      # e.g. after being moved between projects; the copy keeps that link.
       expect(subject).to be_success
 
-      expect(copied_wp("In shared").sprint_id).to be_nil
+      expect(copied_wp("In shared").sprint_id).to eq(shared_sprint.id)
     end
 
     it "does not add the copied work package to the source sprint" do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe ProjectsController do
                .with(user: admin, model: template)
                .and_return(copy_service)
         dependencies = %w[
-          boards storages storage_project_folders forums phases members overview sprints
+          backlog_buckets boards storages storage_project_folders forums phases members overview sprints
           versions wiki wiki_page_attachments work_packages work_package_attachments
           categories file_links queries work_package_shares
         ]

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe ProjectsController do
                .with(user: admin, model: template)
                .and_return(copy_service)
         dependencies = %w[
-          boards storages storage_project_folders forums phases members overview
+          boards storages storage_project_folders forums phases members overview sprints
           versions wiki wiki_page_attachments work_packages work_package_attachments
           categories file_links queries work_package_shares
         ]

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe "Projects copy", :js,
     end
 
     let(:parent_field) { FormFields::SelectFormField.new :parent }
+    let(:general_settings_page) { Pages::Projects::Settings::General.new(project) }
 
     let(:storage) { create(:nextcloud_storage) }
     let(:project_storage) do
@@ -185,7 +186,6 @@ RSpec.describe "Projects copy", :js,
       end
 
       before do
-        general_settings_page = Pages::Projects::Settings::General.new(project)
         general_settings_page.visit!
         general_settings_page.click_copy_action
       end
@@ -201,7 +201,6 @@ RSpec.describe "Projects copy", :js,
 
     context "with correct project custom field activations" do
       before do
-        general_settings_page = Pages::Projects::Settings::General.new(project)
         general_settings_page.visit!
         general_settings_page.click_copy_action
       end
@@ -219,7 +218,7 @@ RSpec.describe "Projects copy", :js,
 
         click_on "Copy"
 
-        wait_for_copy_to_finish
+        general_settings_page.wait_for_copy_to_finish
 
         copied_project = Project.find_by(name: "Copied project")
 
@@ -243,7 +242,6 @@ RSpec.describe "Projects copy", :js,
           optional_project_custom_field_with_default.id
         )
 
-        general_settings_page = Pages::Projects::Settings::General.new(project)
         general_settings_page.visit!
         general_settings_page.click_copy_action
 
@@ -253,7 +251,7 @@ RSpec.describe "Projects copy", :js,
 
         click_on "Copy"
 
-        wait_for_copy_to_finish
+        general_settings_page.wait_for_copy_to_finish
 
         copied_project = Project.find_by(name: "Copied project")
 
@@ -293,7 +291,7 @@ RSpec.describe "Projects copy", :js,
 
           click_on "Copy"
 
-          wait_for_copy_to_finish
+          general_settings_page.wait_for_copy_to_finish
 
           copied_project = Project.find_by(name: "Copied project")
 
@@ -320,7 +318,6 @@ RSpec.describe "Projects copy", :js,
       end
 
       before do
-        general_settings_page = Pages::Projects::Settings::General.new(project)
         general_settings_page.visit!
         general_settings_page.click_copy_action
       end
@@ -339,7 +336,7 @@ RSpec.describe "Projects copy", :js,
 
           click_on "Copy"
 
-          wait_for_copy_to_finish
+          general_settings_page.wait_for_copy_to_finish
 
           copied_project = Project.find_by(name: "Copied project")
 
@@ -364,7 +361,7 @@ RSpec.describe "Projects copy", :js,
 
           click_on "Copy"
 
-          wait_for_copy_to_finish
+          general_settings_page.wait_for_copy_to_finish
 
           copied_project = Project.find_by(name: "Copied project")
 
@@ -409,7 +406,6 @@ RSpec.describe "Projects copy", :js,
       end
 
       before do
-        general_settings_page = Pages::Projects::Settings::General.new(project)
         general_settings_page.visit!
         general_settings_page.click_copy_action
       end
@@ -427,7 +423,7 @@ RSpec.describe "Projects copy", :js,
 
         click_on "Copy"
 
-        wait_for_copy_to_finish
+        general_settings_page.wait_for_copy_to_finish
 
         copied_project = Project.find_by(name: "Copied project")
         typed_values =
@@ -451,7 +447,6 @@ RSpec.describe "Projects copy", :js,
       end
 
       it "copies the project attributes" do
-        general_settings_page = Pages::Projects::Settings::General.new(project)
         general_settings_page.visit!
         general_settings_page.click_copy_action
 
@@ -460,7 +455,7 @@ RSpec.describe "Projects copy", :js,
         fill_in "Name", with: "Copied project"
         click_on "Copy"
 
-        wait_for_copy_to_finish
+        general_settings_page.wait_for_copy_to_finish
 
         copied_project = Project.find_by(name: "Copied project")
         expect(copied_project).to be_present
@@ -483,7 +478,6 @@ RSpec.describe "Projects copy", :js,
     end
 
     it "copies projects and the associated objects" do
-      general_settings_page = Pages::Projects::Settings::General.new(project)
       general_settings_page.visit!
       general_settings_page.click_copy_action
 
@@ -496,7 +490,7 @@ RSpec.describe "Projects copy", :js,
 
       click_on "Copy"
 
-      wait_for_copy_to_finish
+      general_settings_page.wait_for_copy_to_finish
 
       copied_project = Project.find_by(name: "Copied project")
 
@@ -617,7 +611,7 @@ RSpec.describe "Projects copy", :js,
       fill_in "Name", with: "Copied project"
       click_on "Copy"
 
-      wait_for_copy_to_finish
+      general_settings_page.wait_for_copy_to_finish
 
       expect(copied_project)
         .to be_present
@@ -656,6 +650,7 @@ RSpec.describe "Projects copy", :js,
     TABLE
 
     let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+    let(:general_settings_page) { Pages::Projects::Settings::General.new(project) }
 
     before do
       # Clear all jobs that would later on to having emails send.
@@ -667,7 +662,6 @@ RSpec.describe "Projects copy", :js,
     end
 
     it "copies work packages preserving original dates and scheduling modes" do
-      general_settings_page = Pages::Projects::Settings::General.new(project)
       general_settings_page.visit!
       general_settings_page.click_copy_action
 
@@ -676,7 +670,7 @@ RSpec.describe "Projects copy", :js,
       fill_in "Name", with: "Copied project"
       click_on "Copy"
 
-      wait_for_copy_to_finish
+      general_settings_page.wait_for_copy_to_finish
 
       copied_project = Project.find_by(name: "Copied project")
       expect(copied_project).to be_present
@@ -698,15 +692,4 @@ RSpec.describe "Projects copy", :js,
     end
   end
 
-  def wait_for_copy_to_finish
-    expect(page).to have_dialog "Background job status"
-
-    within_dialog "Background job status" do
-      expect(page).to have_heading "Copy project"
-      expect(page).to have_text "The job has been queued and will be processed shortly."
-    end
-
-    # ensure all jobs are run especially emails which might be sent later on
-    GoodJob.perform_inline
-  end
 end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -103,23 +103,23 @@ RSpec.describe(
     it "includes the list of dependencies" do
       expect(described_class.copyable_dependencies.pluck(:identifier)).to match_array(
         %w(
-          members
-          versions
-          categories
-          sprints
-          work_packages
-          work_package_attachments
-          work_package_shares
-          wiki
-          wiki_page_attachments
-          forums
-          queries
           boards
+          categories
+          file_links
+          forums
+          members
           overview
           phases
-          storages
+          queries
+          sprints
           storage_project_folders
-          file_links
+          storages
+          versions
+          wiki
+          wiki_page_attachments
+          work_package_attachments
+          work_package_shares
+          work_packages
         )
       )
     end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe(
     it "includes the list of dependencies" do
       expect(described_class.copyable_dependencies.pluck(:identifier)).to match_array(
         %w(
+          backlog_buckets
           boards
           categories
           file_links

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe(
           members
           versions
           categories
+          sprints
           work_packages
           work_package_attachments
           work_package_shares

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe(
 
   describe ".copyable_dependencies" do
     it "includes the list of dependencies" do
-      expect(described_class.copyable_dependencies.pluck(:identifier)).to eq(
+      expect(described_class.copyable_dependencies.pluck(:identifier)).to match_array(
         %w(
           members
           versions

--- a/spec/support/pages/projects/settings/general.rb
+++ b/spec/support/pages/projects/settings/general.rb
@@ -51,6 +51,22 @@ module Pages
           page.find(:menuitem, "Copy").click # TODO: scope to More menu
         end
 
+        # Waits for the "Background job status" dialog shown after a copy is
+        # triggered, then runs the enqueued jobs inline. The dialog is rendered on
+        # its own page rather than this one, but the copy is always kicked off from
+        # here, so the helper lives with the action that triggers it.
+        def wait_for_copy_to_finish
+          expect(page).to have_dialog "Background job status"
+
+          within_dialog "Background job status" do
+            expect(page).to have_heading "Copy project"
+            expect(page).to have_text "The job has been queued and will be processed shortly."
+          end
+
+          # Ensure all jobs are run, especially emails which might be sent later on.
+          GoodJob.perform_inline
+        end
+
         def click_delete_action
           page.find_test_selector("project-settings-more-menu").click
           page.find(:menuitem, "Delete").click # TODO: scope to More menu


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-318

# What are you trying to accomplish?

When a project is copied, work packages in the copy kept a `sprint_id` pointing at the **original** project's sprint instead of a copy of it. The stray assignment is invisible on the source sprint's board but surfaces in the sprint-completion modal, where the copied work package is listed among the sprint's items. Saved queries and boards filtered on a sprint or backlog bucket had the same problem: their filter values were carried over verbatim and kept matching the source project's records.

Since 17.6 made sprints their own model (a `sprints` table with a `sprint_id` FK on work packages, parallel to versions), the project-copy path remapped `version_id` but had no equivalent for `sprint_id` / `backlog_bucket_id`.

## Screenshots

<img width="711" height="701" alt="image" src="https://github.com/user-attachments/assets/e67d2734-959c-41ce-bcce-4ff645d07001" />

# What approach did you choose and why?

Mirror the existing version-copy path, entirely within `modules/backlogs`:

- New `SprintsDependentService` and `BacklogBucketsDependentService` copy the source project's owned sprints and backlog buckets, each recording a source→copy id lookup, injected into the copy dependency list immediately before work packages are copied.
- A patch on the work-packages copy override remaps each copied work package's `sprint_id` and `backlog_bucket_id` through those lookups and carries the source `position` over unchanged (with `acts_as_list` callbacks suppressed). Owned sprints/buckets are always recreated; a shared assignment (a sprint owned by another project) is kept only when the copied project will still receive that sprint given its placement, and cleared otherwise.
- A `Queries::Copy::FiltersMapper` patch remaps `sprint_id` / `backlog_bucket_id` query filters through the same lookups, as already done for `version_id`, so copied queries and boards follow the copied records.
- Copying runs through a shared `copy_collection_with_id_map` helper on `Projects::Copy::Dependency`; the existing version copy reuses it too.

## Additional hardening (review follow-ups)

- Records skipped because their copy fails validation are now merged into the dependency's error set instead of being dropped silently, so a work package no longer loses its assignment unannounced while the copy still reports success.
- Shared-sprint preservation resolves in a single query against the sprints the target receives, instead of firing the `receiving_projects` CTE once per sprint; sprint goals are eager-loaded.
- Owned sprint goals are copied (remapped to the copy); goals owned by other projects on a shared sprint are left alone.
- `CategoriesDependentService` now reuses the shared `copy_collection_with_id_map` helper, which also drops a stray mapping to a `nil` id when a category fails to persist.

# Out of scope / follow-ups

- **Broader foreign-sprint leak — product-confirmed follow-up WP.** The same "sprint not receivable by its project" class exists outside copy, e.g. moving a work package to a project that cannot receive its sprint. The plain single move is already cleared today, but the invariant is enforced per write-path by two divergent implementations that carry a self-referential branch, so a leak can persist once introduced. Agreed direction: enforce one central `receivable_by?` invariant plus a data migration to heal existing rows. Tracked separately.
- **Copy-form checkbox visibility** (follow-up to @dombesz review, point 2 + the "module disabled" note). The execution leak is fixed: sprints and backlog buckets are not copied when the source lacks the backlogs module or the acting user cannot view sprints. What remains is cosmetic — the checkboxes are still shown — and hiding them is a framework change affecting every module dependency, so it belongs in a separate change.
- Narrowing the backlogs `position` / `acts_as_list` override is left as a separate cleanup.
- Task boards are not copied.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — N/A (backend, no UI)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — N/A (backend)
