### PR TITLE
[COMMS-854] Properly seed `WorkPackage.target_versions`

### DIFF
--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -88,6 +88,7 @@ module DemoData
     def create_work_package(attributes)
       wp_attr = base_work_package_attributes attributes
 
+      # TODO(COMMS-863): remove once the version_id column is dropped in favor of target_versions.
       set_version! wp_attr, attributes
       set_time_tracking_attributes! wp_attr, attributes
       set_backlogs_attributes! wp_attr, attributes
@@ -171,11 +172,6 @@ module DemoData
       end
     end
 
-    # Mirrors the first target version into the deprecated single version_id
-    # column, matching what the service layer does (see
-    # WorkPackages::Shared::Versions#update_legacy_version_field) so seeded data
-    # stays consistent with work packages created through the app.
-    # TODO: remove once the version_id column is dropped in favor of target_versions.
     def set_version!(wp_attr, attributes)
       reference = Array(attributes["target_versions"]).first
       version = seed_data.find_reference(reference)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -94,6 +94,7 @@ module DemoData
 
       work_package = WorkPackage.create! wp_attr
 
+      set_target_versions! work_package, attributes
       create_children! work_package, attributes
       create_attachments! work_package, attributes
       update_description! work_package
@@ -170,10 +171,25 @@ module DemoData
       end
     end
 
+    # Mirrors the first target version into the deprecated single version_id
+    # column, matching what the service layer does (see
+    # WorkPackages::Shared::Versions#update_legacy_version_field) so seeded data
+    # stays consistent with work packages created through the app.
+    # TODO: remove once the version_id column is dropped in favor of target_versions.
     def set_version!(wp_attr, attributes)
-      version = seed_data.find_reference(attributes["version"])
+      reference = Array(attributes["target_versions"]).first
+      version = seed_data.find_reference(reference)
       if version
         wp_attr[:version] = version
+      end
+    end
+
+    def set_target_versions!(work_package, attributes)
+      Array(attributes["target_versions"]).each do |reference|
+        version = seed_data.find_reference(reference)
+        next unless version
+
+        work_package.work_package_versions.create!(version_id: version.id, kind: "target")
       end
     end
 

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -765,12 +765,14 @@ projects:
         reference: :new_login_screen
         status: :default_status_in_specification
         type: :default_type_user_story
-        version: :scrum_project__version__product_backlog
+        target_versions:
+          - :scrum_project__version__product_backlog
         position: 3
       - t_subject: Password reset does not send email
         status: :default_status_confirmed
         type: :default_type_bug
-        version: :scrum_project__version__bug_backlog
+        target_versions:
+          - :scrum_project__version__bug_backlog
         position: 1
       - t_subject: New website
         reference: :new_website
@@ -783,17 +785,20 @@ projects:
           - t_subject: Newsletter registration form
             status: :default_status_in_progress
             type: :default_type_user_story
-            version: :scrum_project__version__product_backlog
+            target_versions:
+              - :scrum_project__version__product_backlog
             position: 6
           - t_subject: Implement product tour
             status: :default_status_in_specification
             type: :default_type_user_story
-            version: :scrum_project__version__product_backlog
+            target_versions:
+              - :scrum_project__version__product_backlog
             position: 4
           - t_subject: New landing page
             status: :default_status_specified
             type: :default_type_user_story
-            version: :scrum_project__version__sprint_1
+            target_versions:
+              - :scrum_project__version__sprint_1
             position: 2
             story_points: 3
             start: 28
@@ -803,13 +808,15 @@ projects:
               - t_subject: Create wireframes for new landing page
                 status: :default_status_in_progress
                 type: :default_type_task
-                version: :scrum_project__version__sprint_1
+                target_versions:
+                  - :scrum_project__version__sprint_1
                 start: 28
                 duration: 1
       - t_subject: Contact form
         status: :default_status_specified
         type: :default_type_user_story
-        version: :scrum_project__version__sprint_1
+        target_versions:
+          - :scrum_project__version__sprint_1
         position: 5
         start: 21
         duration: 1
@@ -817,7 +824,8 @@ projects:
       - t_subject: Feature carousel
         status: :default_status_specified
         type: :default_type_user_story
-        version: :scrum_project__version__sprint_1
+        target_versions:
+          - :scrum_project__version__sprint_1
         position: 3
         story_points: 5
         schedule_manually: false
@@ -825,12 +833,14 @@ projects:
           - t_subject: Make screenshots for feature tour
             status: :default_status_closed
             type: :default_type_task
-            version: :scrum_project__version__sprint_1
+            target_versions:
+              - :scrum_project__version__sprint_1
       - t_subject: Wrong hover color
         reference: :wrong_hover_color
         status: :default_status_rejected
         type: :default_type_bug
-        version: :scrum_project__version__sprint_1
+        target_versions:
+          - :scrum_project__version__sprint_1
         position: 4
         story_points: 1
         start: 21
@@ -839,7 +849,8 @@ projects:
         reference: :ssl_certificate
         status: :default_status_specified
         type: :default_type_user_story
-        version: :scrum_project__version__product_backlog
+        target_versions:
+          - :scrum_project__version__product_backlog
         position: 1
         start: 22
         duration: 1
@@ -847,7 +858,8 @@ projects:
         reference: :set_up_staging_environment
         status: :default_status_in_specification
         type: :default_type_user_story
-        version: :scrum_project__version__product_backlog
+        target_versions:
+          - :scrum_project__version__product_backlog
         position: 2
         start: 23
         duration: 1
@@ -855,14 +867,16 @@ projects:
         reference: :choose_content_management_system
         status: :default_status_specified
         type: :default_type_user_story
-        version: :scrum_project__version__product_backlog
+        target_versions:
+          - :scrum_project__version__product_backlog
         position: 7
         start: 24
         duration: 1
       - t_subject: Website navigation structure
         status: :default_status_specified
         type: :default_type_user_story
-        version: :scrum_project__version__sprint_1
+        target_versions:
+          - :scrum_project__version__sprint_1
         position: 7
         story_points: 3
         start: 25
@@ -872,13 +886,15 @@ projects:
           - t_subject: Set up navigation concept for website.
             status: :default_status_in_specification
             type: :default_type_task
-            version: :scrum_project__version__sprint_1
+            target_versions:
+              - :scrum_project__version__sprint_1
             start: 25
             duration: 1
       - t_subject: Internal link structure
         status: :default_status_closed
         type: :default_type_user_story
-        version: :scrum_project__version__product_backlog
+        target_versions:
+          - :scrum_project__version__product_backlog
         position: 5
         start: 25
         duration: 1

--- a/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/spec/seeders/demo_data/project_seeder_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe DemoData::ProjectSeeder do
             "subject" => "Some work package",
             "status" => :default_status_new,
             "type" => :default_type_task,
-            "version" => :product_backlog
+            "target_versions" => [:product_backlog]
           }
         ]
       )
@@ -109,7 +109,7 @@ RSpec.describe DemoData::ProjectSeeder do
       project_seeder.seed!
       version = Version.find_by!(name: "The product backlog")
       work_package = WorkPackage.find_by!(subject: "Some work package")
-      expect(work_package.version).to eq(version)
+      expect(work_package.target_versions).to contain_exactly(version)
     end
   end
 

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -361,6 +361,58 @@ RSpec.describe DemoData::WorkPackageSeeder do
     end
   end
 
+  describe "target_versions" do
+    let(:version_alpha) { create(:version, project:, name: "Alpha") }
+    let(:version_beta) { create(:version, project:, name: "Beta") }
+    let(:seed_data) do
+      seed_data = basic_seed_data.merge(Source::SeedData.new("work_packages" => work_packages_data))
+      seed_data.store_reference(:version_alpha, version_alpha)
+      seed_data.store_reference(:version_beta, version_beta)
+      seed_data
+    end
+
+    context "without target_versions" do
+      let(:work_packages_data) do
+        [work_package_data(subject: "no versions")]
+      end
+
+      it "creates no work_package_versions rows and leaves the legacy version unset" do
+        wp = WorkPackage.find_by(subject: "no versions")
+        expect(wp.work_package_versions).to be_empty
+        expect(wp.target_versions).to be_empty
+        expect(wp.version).to be_nil
+      end
+    end
+
+    context "with a single target_versions reference" do
+      let(:work_packages_data) do
+        [work_package_data(subject: "single", target_versions: [:version_alpha])]
+      end
+
+      it "creates one kind: 'target' associated version row and mirrors it into the legacy version" do
+        wp = WorkPackage.find_by(subject: "single")
+        expect(wp.work_package_versions.pluck(:kind, :version_id))
+          .to contain_exactly(["target", version_alpha.id])
+        expect(wp.target_versions).to contain_exactly(version_alpha)
+        expect(wp.version).to eq(version_alpha)
+      end
+    end
+
+    context "with multiple target_versions references" do
+      let(:work_packages_data) do
+        [work_package_data(subject: "multi", target_versions: %i[version_alpha version_beta])]
+      end
+
+      it "creates one kind: 'target' row per resolved version and mirrors the first into the legacy version" do
+        wp = WorkPackage.find_by(subject: "multi")
+        expect(wp.work_package_versions.pluck(:kind, :version_id))
+          .to contain_exactly(["target", version_alpha.id], ["target", version_beta.id])
+        expect(wp.target_versions).to contain_exactly(version_alpha, version_beta)
+        expect(wp.version).to eq(version_alpha)
+      end
+    end
+  end
+
   describe "assigned_to" do
     let(:seed_data) do
       seed_data = basic_seed_data.merge(Source::SeedData.new("work_packages" => work_packages_data))

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe RootSeeder,
     end
 
     it "links work packages to their version" do
-      count_by_version = WorkPackage.joins(:version).group("versions.name").count
+      count_by_version = WorkPackage.joins(:target_versions).group("versions.name").count
       # testing with strings would fail for the German language test
       # 'Bug Backlog' => 1,
       # 'Sprint 1' => 8,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-854/activity

# What are you trying to accomplish?
Make the seed procedure generate `WorkPackage` `target_versions` _alongside_ the legacy `versions`. 

The latter will go away once we completely switch away from using the field.

## Manual QA
`development` smoke test:
```
~/r/openproject ❯❯❯ git co dev
~/r/openproject ❯❯❯ bin/compose exec -e RAILS_ENV=development backend bundle exec rails db:seed:replant &>/dev/null
~/r/openproject ❯❯❯ bin/compose exec -e RAILS_ENV=development backend bundle exec rails runner '
puts "legacy version:  #{WorkPackage.where.not(version_id: nil).count}"
puts "target_versions: #{WorkPackage.joins(:target_versions).distinct.count}"'
legacy version:  16
target_versions: 0
~/r/openproject ❯❯❯ git co implementation/comms-854-adjust-seeders-to-properly-create-target_versions
Switched to branch 'implementation/comms-854-adjust-seeders-to-properly-create-target_versions'
~/r/openproject ❯❯❯ bin/compose exec -e RAILS_ENV=development backend bundle exec rails db:seed:replant &>/dev/null
~/r/openproject ❯❯❯ bin/compose exec -e RAILS_ENV=development backend bundle exec rails runner '
puts "legacy version:  #{WorkPackage.where.not(version_id: nil).count}"
puts "target_versions: #{WorkPackage.joins(:target_versions).distinct.count}"'
legacy version:  16
target_versions: 16
```

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
