### PR TITLE
Create error correctly

### DIFF
--- a/modules/storages/app/common/storages/adapters/authentication_strategies/oauth_user_token.rb
+++ b/modules/storages/app/common/storages/adapters/authentication_strategies/oauth_user_token.rb
@@ -93,7 +93,7 @@ module Storages
         def handle_timeout(token, exception)
           error("Timeout while refreshing OAuth token. - Payload: #{exception.message}")
           token.destroy!
-          Failure(@error_data.with(error: :timeout_on_refresh, payload: exception))
+          Failure(@error_data.with(code: :timeout_on_refresh, payload: exception))
         end
 
         def handle_http_error(token, exception)


### PR DESCRIPTION
This was the only instance where creating the error was broken. All other callers around this one correctly used `code: :some_symbol`, but this one used `error: :some_symbol` instead.

# Ticket
https://appsignal.com/openproject-gmbh/sites/673c529383eb67b55471dda2/exceptions/incidents/1327