### PR TITLE
[DEVOPS-510] Use available git tags to prevent outputting major tag for older releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,8 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set version outputs and convert tags
         id: extract_version
         env:

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "optparse"
+require "rubygems"
 
 class Tag
   def initialize(tag)
@@ -26,11 +27,16 @@ class Tag
 
   def to_semver_docker_tags
     if semver?
-      [
+      tags = [
         "type=semver,pattern={{version}},value=#{version}",
-        "type=semver,pattern={{major}}.{{minor}},value=#{version}",
-        "type=semver,pattern={{major}},value=#{version}"
+        "type=semver,pattern={{major}}.{{minor}},value=#{version}"
       ]
+
+      if latest_patch_for_major?
+        tags << "type=semver,pattern={{major}},value=#{version}"
+      end
+
+      tags
     elsif rc?
       [
         "type=raw,value=#{major}.#{minor}-rc",
@@ -51,6 +57,31 @@ class Tag
     return unless semver? || rc?
 
     version.split(".")[1]
+  end
+
+  private
+
+  def latest_patch_for_major?
+    return false unless stable_semver?
+
+    latest = git_stable_semver_tags
+      .select { |tag_version| tag_version.segments[0].to_s == major }
+      .max
+
+    latest == Gem::Version.new(version)
+  end
+
+  def stable_semver?
+    @tag.match?(/^v\d+\.\d+\.\d+$/)
+  end
+
+  def git_stable_semver_tags
+    @git_stable_semver_tags ||= begin
+      tags = `git tag --list 'v*'`.lines.map(&:strip)
+      tags
+        .select { |raw| raw.match?(/^v\d+\.\d+\.\d+$/) }
+        .map { |raw| Gem::Version.new(raw.delete_prefix("v")) }
+    end
   end
 end
 


### PR DESCRIPTION
If we were to release 17.4.x and 17.5.x alongside 17.6.0, we only want 17.6.0 (the newest tag) to bump the major tag.

In the past, we had an issue with the docker build on an older version, causing the 17-slim tag to be retagged with an older release

https://community.openproject.org/work_packages/DEVOPS-510