### PR TITLE
[SC-258] Introduce separate contracts for the InitOccurrenceService

### DIFF
--- a/modules/meeting/app/contracts/recurring_meetings/init_occurrence_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/init_occurrence_contract.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module RecurringMeetings
+  class InitOccurrenceContract < BaseContract
+    validate :user_allowed_to_init
+
+    private
+
+    def user_allowed_to_init
+      return if model.project.nil?
+
+      unless user.allowed_in_project?(:create_meetings, model.project)
+        errors.add :base, :error_unauthorized
+      end
+    end
+  end
+end

--- a/modules/meeting/app/contracts/recurring_meetings/reset_to_template_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/reset_to_template_contract.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module RecurringMeetings
+  class ResetToTemplateContract < Meetings::BaseContract
+    validate :user_allowed_to_reset
+
+    private
+
+    def user_allowed_to_reset
+      project = model.recurring_meeting&.project || model.project
+      return if project.nil?
+
+      permission = options[:reopening] ? :create_meetings : :edit_meetings
+      return if user.allowed_in_project?(permission, project)
+
+      errors.add :base, :error_unauthorized
+    end
+  end
+end

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -31,18 +31,23 @@
 module RecurringMeetings
   class InitOccurrenceService < ::BaseServices::BaseCallable
     include ::Shared::ServiceContext
+    include ::Contracted
 
     attr_reader :user, :recurring_meeting
 
-    def initialize(user:, recurring_meeting:)
+    def initialize(user:, recurring_meeting:, contract_class: RecurringMeetings::InitOccurrenceContract)
       super()
       @user = user
       @recurring_meeting = recurring_meeting
+      self.contract_class = contract_class
     end
 
     protected
 
     def perform
+      contract_result = validate_contract
+      return contract_result unless contract_result.success?
+
       start_time = params.fetch(:start_time)
       return draft_template_failure if recurring_meeting.template.draft?
 
@@ -58,6 +63,13 @@ module RecurringMeetings
 
     def draft_template_failure
       ServiceResult.failure(message: I18n.t("recurring_meeting.occurrence.error_template_draft"))
+    end
+
+    def validate_contract
+      success, errors = validate(recurring_meeting, user)
+      return ServiceResult.failure(errors:) unless success
+
+      ServiceResult.success
     end
 
     def instantiate(start_time)

--- a/modules/meeting/app/services/recurring_meetings/reset_to_template_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/reset_to_template_service.rb
@@ -38,19 +38,25 @@ module RecurringMeetings
   #   ResetToTemplateService.new(user:, meeting:, params: { state: :open })
   class ResetToTemplateService < ::BaseServices::BaseCallable
     include ::Shared::ServiceContext
+    include ::Contracted
 
     attr_reader :user, :meeting, :extra_params
 
-    def initialize(user:, meeting:, params: {})
+    def initialize(user:, meeting:, params: {}, contract_class: RecurringMeetings::ResetToTemplateContract)
       super()
       @user = user
       @meeting = meeting
       @extra_params = params
+      self.contract_class = contract_class
+      self.contract_options = { reopening: reopening?(params) }
     end
 
     protected
 
     def perform
+      contract_result = validate_contract
+      return contract_result unless contract_result.success?
+
       in_context(meeting, send_notifications: false) do
         ServiceResult.new(success: reset_to_template!, result: meeting)
       rescue ActiveRecord::RecordInvalid => e
@@ -59,6 +65,17 @@ module RecurringMeetings
     end
 
     private
+
+    def reopening?(params)
+      params[:state].to_s == "open"
+    end
+
+    def validate_contract
+      success, errors = validate(meeting, user, options: contract_options)
+      return ServiceResult.failure(errors:) unless success
+
+      ServiceResult.success
+    end
 
     def template
       meeting.recurring_meeting.template

--- a/modules/meeting/spec/contracts/recurring_meetings/init_occurrence_contract_spec.rb
+++ b/modules/meeting/spec/contracts/recurring_meetings/init_occurrence_contract_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe RecurringMeetings::InitOccurrenceContract do
+  include_context "ModelContract shared context"
+
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  let(:recurring_meeting) { create(:recurring_meeting, project:) }
+  let(:contract) { described_class.new(recurring_meeting, user) }
+
+  context "with create_meetings permission" do
+    let(:user) do
+      create(:user, member_with_permissions: { project => %i[view_meetings create_meetings] })
+    end
+
+    it_behaves_like "contract is valid"
+  end
+
+  context "with only view_meetings permission" do
+    let(:user) do
+      create(:user, member_with_permissions: { project => %i[view_meetings] })
+    end
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+
+  context "without permission" do
+    let(:user) { build_stubbed(:user) }
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+end

--- a/modules/meeting/spec/contracts/recurring_meetings/reset_to_template_contract_spec.rb
+++ b/modules/meeting/spec/contracts/recurring_meetings/reset_to_template_contract_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe RecurringMeetings::ResetToTemplateContract do
+  include_context "ModelContract shared context"
+
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  let(:recurring_meeting) { create(:recurring_meeting, project:) }
+  let(:meeting) do
+    create(:meeting,
+           project:,
+           recurring_meeting:,
+           start_time: recurring_meeting.start_time + 1.day,
+           recurrence_start_time: recurring_meeting.start_time + 1.day,
+           state: :cancelled)
+  end
+  let(:contract_options) { {} }
+  let(:contract) { described_class.new(meeting, user, options: contract_options) }
+
+  context "when reopening a cancelled occurrence" do
+    let(:contract_options) { { reopening: true } }
+
+    context "with create_meetings permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings] })
+      end
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "with only edit_meetings permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings edit_meetings] })
+      end
+
+      it_behaves_like "contract is invalid", base: :error_unauthorized
+    end
+
+    context "with only view_meetings permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+
+      it_behaves_like "contract is invalid", base: :error_unauthorized
+    end
+
+    context "when the occurrence project differs from the series project" do
+      let(:other_project) { create(:project, enabled_module_names: %i[meetings]) }
+      let(:meeting) do
+        create(:meeting,
+               project: other_project,
+               recurring_meeting:,
+               start_time: recurring_meeting.start_time + 1.day,
+               recurrence_start_time: recurring_meeting.start_time + 1.day,
+               state: :cancelled)
+      end
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings] })
+      end
+
+      it_behaves_like "contract is valid"
+    end
+  end
+
+  context "when resetting content without reopening" do
+    let(:contract_options) { { reopening: false } }
+
+    context "with edit_meetings permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings edit_meetings] })
+      end
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "with only create_meetings permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings] })
+      end
+
+      it_behaves_like "contract is invalid", base: :error_unauthorized
+    end
+
+    context "with only view_meetings permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+
+      it_behaves_like "contract is invalid", base: :error_unauthorized
+    end
+  end
+end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
@@ -131,11 +131,10 @@ RSpec.describe "Recurring meetings complete template",
 
   context "when first occurrence is cancelled" do
     let!(:cancelled_occurrence) do
-      create(:meeting,
+      create(:recurring_meeting_occurrence,
+             :cancelled,
              recurring_meeting:,
-             start_time: recurring_meeting.start_time,
-             recurrence_start_time: recurring_meeting.start_time,
-             state: :cancelled)
+             start_time: recurring_meeting.start_time)
     end
 
     it "restores that occurrence" do

--- a/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_permissions_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_permissions_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe RecurringMeetings::InitOccurrenceService, "permissions", type: :model do
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  shared_let(:author) do
+    create(:user, member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings] })
+  end
+  shared_let(:series, refind: true) do
+    create(:recurring_meeting,
+           project:,
+           author:,
+           start_time: Time.zone.tomorrow + 10.hours,
+           frequency: "daily",
+           interval: 1,
+           end_after: "specific_date",
+           end_date: 1.month.from_now)
+  end
+
+  let(:start_time) { series.start_time + 3.days }
+  let(:viewer) { create(:user, member_with_permissions: { project => %i[view_meetings] }) }
+  let(:service) { described_class.new(recurring_meeting: series, user: viewer) }
+  let(:service_result) { service.call(start_time:) }
+
+  context "when initializing a new occurrence slot" do
+    it "is not allowed for a view-only user" do
+      expect(service_result).not_to be_success
+      expect(service_result.errors.symbols_for(:base)).to include(:error_unauthorized)
+    end
+  end
+
+  context "when restoring a cancelled occurrence for the slot" do
+    let!(:cancelled_occurrence) do
+      create(:recurring_meeting_occurrence, :cancelled, recurring_meeting: series, start_time:)
+    end
+
+    it "is not allowed for a view-only user" do
+      expect(service_result).not_to be_success
+      expect(service_result.errors.symbols_for(:base)).to include(:error_unauthorized)
+    end
+
+    it "does not change the occurrence state" do
+      service_result
+      expect(cancelled_occurrence.reload).to be_cancelled
+    end
+
+    context "with create_meetings permission" do
+      let(:creator) { create(:user, member_with_permissions: { project => %i[view_meetings create_meetings] }) }
+      let(:service) { described_class.new(recurring_meeting: series, user: creator) }
+
+      it "restores the cancelled occurrence" do
+        expect(service_result).to be_success
+        expect(service_result.result).to eq(cancelled_occurrence)
+        expect(cancelled_occurrence.reload).to be_open
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce a contract to check whether users are allowed to open a new occurrence that is applied both on controller and API endpoints

https://community.openproject.org/work_packages/SC-258
