### PR TITLE
Fix: Derive seeder project identifiers for semantic mode

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -135,6 +135,23 @@ module Projects::Identifier
         ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new.suggest_identifier(name)
       end
     end
+
+    # Unlike suggest_identifier, this ignores existing projects, so a given name
+    # always maps to the same identifier. Only the reserved keywords are excluded.
+    def semantic_identifier_for(name)
+      exclude = ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.model_reserved_identifiers
+      ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator
+        .suggest_identifier(name, exclude:)
+    end
+
+    # The identifier a seed's canonical (classic) value takes in the active mode:
+    # verbatim in classic mode, derived in semantic mode. Callers that reference a
+    # seeded project by identifier use this to resolve the same value seeding produced.
+    def seed_identifier_for(identifier)
+      return identifier if identifier.blank? || Setting::WorkPackageIdentifier.classic?
+
+      semantic_identifier_for(identifier)
+    end
   end
 
   def suggest_identifier(mode: Setting[:work_packages_identifier])

--- a/app/seeders/demo_data/overview_seeder.rb
+++ b/app/seeders/demo_data/overview_seeder.rb
@@ -63,7 +63,7 @@ module DemoData
     def demo_projects_exist?
       identifiers = []
       seed_data.each_data("projects") do |project_data|
-        identifiers << project_data.lookup("identifier")
+        identifiers << seed_project_identifier(project_data.lookup("identifier"))
       end
 
       identifiers.all? { |identifier| Project.exists?(identifier:) }
@@ -81,7 +81,7 @@ module DemoData
     end
 
     def find_project(project_data)
-      Project.find_by!(identifier: project_data.lookup("identifier"))
+      Project.find_by!(identifier: seed_project_identifier(project_data.lookup("identifier")))
     end
 
     def create_overview(overview_data, project_data)

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -83,8 +83,12 @@ module DemoData
     end
 
     def delete_project
-      project_to_delete = Project.find_by(identifier: project_data.lookup("identifier"))
+      project_to_delete = Project.find_by(identifier: project_identifier)
       project_to_delete&.destroy
+    end
+
+    def project_identifier
+      seed_project_identifier(project_data.lookup("identifier"))
     end
 
     def create_project
@@ -181,16 +185,16 @@ module DemoData
       seed_data.lookup("types") || []
     end
 
-    def project_attributes # rubocop:disable Metrics/AbcSize
+    def project_attributes
       {
         name: project_data.lookup("name"),
-        identifier: project_data.lookup("identifier"),
+        identifier: project_identifier,
         status_code: project_data.lookup("status_code"),
         status_explanation: project_data.lookup("status_explanation"),
         description: project_data.lookup("description"),
         enabled_module_names: project_data.lookup("modules"),
         types: Type.all,
-        parent: Project.find_by(identifier: project_data.lookup("parent")),
+        parent: Project.find_by(identifier: seed_project_identifier(project_data.lookup("parent"))),
         workspace_type: "project"
       }
     end

--- a/app/seeders/development_data/projects_seeder.rb
+++ b/app/seeders/development_data/projects_seeder.rb
@@ -43,12 +43,12 @@ module DevelopmentData
 
       print_status "   -Linking custom fields."
 
-      link_custom_fields(projects.detect { |p| p.identifier == "dev-custom-fields" })
+      link_custom_fields(projects.detect { it.identifier == seed_project_identifier("dev-custom-fields") })
     end
 
     def applicable?
       recent_installation? &&
-        Project.where(identifier: project_identifiers).count == 0 &&
+        Project.where(identifier: seeded_identifiers).none? &&
         seed_data.reference_exists?(:default_role_project_admin)
     end
 
@@ -62,13 +62,17 @@ module DevelopmentData
       %w(dev-empty dev-work-package-sharing dev-large dev-large-child dev-custom-fields)
     end
 
+    def seeded_identifiers
+      project_identifiers.map { seed_project_identifier(it) }
+    end
+
     def reset_projects
-      Project.where(identifier: project_identifiers).destroy_all
+      Project.where(identifier: seeded_identifiers).destroy_all
       project_identifiers.map do |id|
         project = Project.new project_data(id)
 
         if id == "dev-large-child"
-          project.parent_id = Project.find_by(identifier: "dev-large").id
+          project.parent_id = Project.find_by(identifier: seed_project_identifier("dev-large")).id
         end
 
         project.save!
@@ -110,7 +114,7 @@ module DevelopmentData
     def project_data(identifier)
       {
         name: project_name(identifier),
-        identifier:,
+        identifier: seed_project_identifier(identifier),
         enabled_module_names: project_modules,
         types: Type.all,
         workspace_type: "project"

--- a/app/seeders/seeder.rb
+++ b/app/seeders/seeder.rb
@@ -95,6 +95,10 @@ class Seeder
     @admin_user ||= User.not_builtin.admin.first
   end
 
+  def seed_project_identifier(identifier)
+    Project.seed_identifier_for(identifier)
+  end
+
   protected
 
   def print_status(message)

--- a/app/services/projects/concerns/update_demo_data.rb
+++ b/app/services/projects/concerns/update_demo_data.rb
@@ -36,7 +36,7 @@ module Projects::Concerns
       project = call.result
 
       # e.g. when one of the demo projects gets deleted or archived
-      if %w[demo-project].include?(project.identifier)
+      if project.identifier == Project.seed_identifier_for("demo-project")
         Setting.demo_projects_available = !project.destroyed? && !project.archived? && project.public?
       end
 

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -226,6 +226,23 @@ RSpec.describe Projects::Identifier do
     end
   end
 
+  describe ".semantic_identifier_for" do
+    it "derives a semantic identifier from the name" do
+      expect(Project.semantic_identifier_for("My Project")).to eq("MP")
+    end
+
+    it "excludes the reserved keywords without querying existing projects" do
+      allow(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+        .to receive(:suggest_identifier).and_return("MP")
+
+      Project.semantic_identifier_for("My Project")
+
+      expect(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+        .to have_received(:suggest_identifier)
+        .with("My Project", exclude: ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.model_reserved_identifiers)
+    end
+  end
+
   describe "#suggest_identifier" do
     subject(:project) { build(:project, name: "My Project") }
 

--- a/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/spec/seeders/demo_data/project_seeder_spec.rb
@@ -194,6 +194,40 @@ RSpec.describe DemoData::ProjectSeeder do
     end
   end
 
+  context "with a hardcoded project identifier" do
+    let(:project_data) do
+      {
+        "name" => "Demo project",
+        "identifier" => "demo-project"
+      }
+    end
+
+    context "in classic mode", with_settings: { work_packages_identifier: "classic" } do
+      it "seeds the project with the identifier verbatim" do
+        project_seeder.seed!
+
+        expect(Project.find_by(name: "Demo project").identifier).to eq("demo-project")
+      end
+    end
+
+    context "in semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      it "seeds the project with a semantic-compliant identifier" do
+        expect { project_seeder.seed! }.not_to raise_error
+
+        identifier = Project.find_by(name: "Demo project").identifier
+        expect(identifier).to match(/\A[A-Z][A-Z0-9_]*\z/)
+        expect(identifier.length).to be <= Projects::Identifier::SEMANTIC_IDENTIFIER_MAX_LENGTH
+      end
+
+      it "replaces the existing project on re-seed instead of duplicating it" do
+        project_seeder.seed!
+
+        expect { described_class.new(seed_data.lookup("projects.my-project")).seed! }
+          .not_to change(Project.where(name: "Demo project"), :count).from(1)
+      end
+    end
+  end
+
   def a_filter(filter_class, attributes)
     an_instance_of(filter_class).and having_attributes(attributes)
   end

--- a/spec/seeders/seeder_spec.rb
+++ b/spec/seeders/seeder_spec.rb
@@ -47,4 +47,40 @@ RSpec.describe Seeder do
       expect(seeder.admin_user).to be_nil
     end
   end
+
+  describe "#seed_project_identifier" do
+    context "in classic mode", with_settings: { work_packages_identifier: "classic" } do
+      it "returns the given identifier verbatim" do
+        expect(seeder.seed_project_identifier("dev-resource-management")).to eq("dev-resource-management")
+      end
+    end
+
+    context "in semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      it "derives an identifier that satisfies the semantic format" do
+        %w[dev-resource-management demo-project your-scrum-project dev-work-package-sharing].each do |identifier|
+          derived = seeder.seed_project_identifier(identifier)
+
+          expect(derived).to match(/\A[A-Z][A-Z0-9_]*\z/)
+          expect(derived.length).to be <= Projects::Identifier::SEMANTIC_IDENTIFIER_MAX_LENGTH
+        end
+      end
+
+      it "maps a given identifier to the same value on every call" do
+        derived = seeder.seed_project_identifier("demo-construction-project")
+
+        expect(seeder.seed_project_identifier("demo-construction-project")).to eq(derived)
+      end
+
+      it "does not consult existing projects when deriving the value" do
+        first = seeder.seed_project_identifier("demo-project")
+        create(:project, identifier: first)
+
+        expect(seeder.seed_project_identifier("demo-project")).to eq(first)
+      end
+    end
+
+    it "leaves a blank identifier untouched so the model can generate one" do
+      expect(seeder.seed_project_identifier(nil)).to be_nil
+    end
+  end
 end

--- a/spec/services/projects/archive_service_spec.rb
+++ b/spec/services/projects/archive_service_spec.rb
@@ -141,16 +141,31 @@ RSpec.describe Projects::ArchiveService do
   end
 
   context "with the seeded demo project" do
-    let(:demo_project) { create(:project, name: "Demo project", identifier: "demo-project", public: true) }
+    let(:demo_project) do
+      create(:project, name: "Demo project", identifier: demo_identifier, public: true)
+    end
     let(:instance) { described_class.new(user:, model: demo_project) }
 
-    it "saves in a Setting that the demo project was modified (regression #52826)" do
-      # Archive the demo project
-      expect(instance.call).to be_truthy
-      expect(demo_project.reload).to be_archived
+    shared_examples "records the demo project as modified" do
+      before { Setting.demo_projects_available = true }
 
-      # Demo project is not available any more for the onboarding tour
-      expect(Setting.demo_projects_available).to be(false)
+      it "clears demo_projects_available when the demo project is archived (regression #52826)" do
+        expect(instance.call).to be_truthy
+        expect(demo_project.reload).to be_archived
+        expect(Setting.demo_projects_available).to be(false)
+      end
+    end
+
+    context "in classic mode", with_settings: { work_packages_identifier: "classic" } do
+      let(:demo_identifier) { Project.seed_identifier_for("demo-project") }
+
+      include_examples "records the demo project as modified"
+    end
+
+    context "in semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      let(:demo_identifier) { Project.seed_identifier_for("demo-project") }
+
+      include_examples "records the demo project as modified"
     end
   end
 end


### PR DESCRIPTION
On instances where the semantic project identifier setting is enabled, `db:seed` fails permanently: seeders create projects with hardcoded classic identifiers (`demo-project`, `dev-large`, ...) that the semantic format validation rejects, and because the seeders' applicability checks look those same identifiers up, every subsequent seed run retries the failing create. This blocks development seeding and, for demo data, the initial seeding of any instance provisioned with the semantic setting from the start.

Seeders now resolve every hardcoded identifier through a deterministic, mode-aware mapping: classic mode passes the string through unchanged, semantic mode derives a compliant identifier from it. The mapping deliberately ignores existing records so it stays stable across seed reset cycles, and it is applied at lookup sites as well as create sites so identifier cross-references (such as the BIM demo project hierarchy and the demo-project availability toggle) resolve consistently in both modes.