### PR TITLE
Reuse a type's PDF and subject configuration: Build mode reuse UI and data model

### DIFF
--- a/app/components/work_package_types/configuration_link_component.html.erb
+++ b/app/components/work_package_types/configuration_link_component.html.erb
@@ -27,13 +27,18 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<div data-controller="show-when-value-selected">
-  <%= settings_primer_form_with(**form_options) do |f| %>
-    <%= render(WorkPackageTypes::ConfigurationLinkForm.new(f)) %>
-  <% end %>
+<% if feature_active? %>
+  <div data-controller="show-when-value-selected">
+    <%= settings_primer_form_with(**form_options) do |f| %>
+      <%= render(WorkPackageTypes::ConfigurationLinkForm.new(f)) %>
+    <% end %>
 
-  <% unless linked? %>
-    <%# Independent: the tab's own editor, shown while "Independent" is selected. %>
-    <%= content_tag(:div, content, data: WorkPackageTypes::ConfigurationLinkForm.effect_data("independent")) %>
-  <% end %>
-</div>
+    <% unless linked? %>
+      <%# Independent: the tab's own editor, shown while "Independent" is selected. %>
+      <%= content_tag(:div, content, data: WorkPackageTypes::ConfigurationLinkForm.effect_data("independent")) %>
+    <% end %>
+  </div>
+<% else %>
+  <%# Reuse feature off: the tab manages its own configuration directly. %>
+  <%= content %>
+<% end %>

--- a/app/components/work_package_types/configuration_link_component.html.erb
+++ b/app/components/work_package_types/configuration_link_component.html.erb
@@ -27,10 +27,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
+<div data-controller="show-when-value-selected">
+  <%= settings_primer_form_with(**form_options) do |f| %>
+    <%= render(WorkPackageTypes::ConfigurationLinkForm.new(f)) %>
+  <% end %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
-<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::SUBJECT)) do %>
-  <%= render WorkPackageTypes::SubjectConfigurationComponent
-               .new(@type, subject_configuration_form_data: params[:work_package_types_forms_subject_configuration_form_model]) %>
-<% end %>
+  <% unless linked? %>
+    <%# Independent: the tab's own editor, shown while "Independent" is selected. %>
+    <%= content_tag(:div, content, data: WorkPackageTypes::ConfigurationLinkForm.effect_data("independent")) %>
+  <% end %>
+</div>

--- a/app/components/work_package_types/configuration_link_component.rb
+++ b/app/components/work_package_types/configuration_link_component.rb
@@ -29,40 +29,39 @@
 #++
 
 module WorkPackageTypes
-  # Sets one configuration aspect of a type to Linked (a chosen global source) or
-  # Independent. The source-graph invariants (present, global, not-self) are the
-  # link record's own validations; this service maps the UI mode onto them.
-  class SetConfigurationLinkService
+  # Mode chooser (Independent/Linked) + source picker, shared by the PDF and
+  # subject tabs. When Independent, the tab's own editor (passed as the block
+  # content) shows; picking Linked swaps it for the source picker + Save.
+  # Toggling is client-side via the show-when-value-selected controller.
+  class ConfigurationLinkComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+    include OpPrimer::FormHelpers
+
     def initialize(type:, aspect:)
-      @type = type
       @aspect = aspect
+      super(type)
     end
 
-    def call(mode:, source_id: nil)
-      source = Type.global.find_by(id: source_id)
+    def type = model
 
-      case mode.to_s
-      when "independent"
-        @type.make_independent!(@aspect, source:)
-        ServiceResult.success(result: @type)
-      when "linked"
-        link_to(source)
-      else
-        ServiceResult.failure(result: @type)
-      end
+    def linked? = type.linked?(@aspect)
+
+    def current_source = type.source_for(@aspect)
+
+    def form_options
+      {
+        url: type_configuration_link_path(type_id: type.id, aspect: @aspect),
+        method: :put,
+        linked: linked?,
+        current_source_id: current_source&.id,
+        source_options:
+      }
     end
 
     private
 
-    def link_to(source)
-      link = @type.configuration_links.find_or_initialize_by(aspect: @aspect)
-      link.source = source
-
-      if link.save
-        ServiceResult.success(result: @type)
-      else
-        ServiceResult.failure(result: @type, errors: link.errors)
-      end
+    def source_options
+      Type.global.where.not(id: type.id).order(:name)
     end
   end
 end

--- a/app/controllers/concerns/work_package_types/subtypes_feature.rb
+++ b/app/controllers/concerns/work_package_types/subtypes_feature.rb
@@ -28,42 +28,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+# Shared gating for the work package sub-types feature flag.
 module WorkPackageTypes
-  # Mode chooser (Independent/Linked) + source picker, shared by the PDF and
-  # subject tabs. When Independent, the tab's own editor (passed as the block
-  # content) shows; picking Linked swaps it for the source picker + Save.
-  # Toggling is client-side via the show-when-value-selected controller.
-  class ConfigurationLinkComponent < ApplicationComponent
-    include OpPrimer::ComponentHelpers
-    include OpPrimer::FormHelpers
-
-    def initialize(type:, aspect:)
-      @aspect = aspect
-      super(type)
-    end
-
-    def type = model
-
-    def feature_active? = OpenProject::FeatureDecisions.subtypes_active?
-
-    def linked? = type.linked?(@aspect)
-
-    def current_source = type.source_for(@aspect)
-
-    def form_options
-      {
-        url: type_configuration_link_path(type_id: type.id, aspect: @aspect),
-        method: :put,
-        linked: linked?,
-        current_source_id: current_source&.id,
-        source_options:
-      }
-    end
+  module SubtypesFeature
+    extend ActiveSupport::Concern
 
     private
 
-    def source_options
-      Type.global.where.not(id: type.id).order(:name)
+    def subtypes_enabled?
+      OpenProject::FeatureDecisions.subtypes_active?
+    end
+
+    def require_subtypes_feature
+      render_404 unless subtypes_enabled?
     end
   end
 end

--- a/app/controllers/work_package_types/configuration_links_controller.rb
+++ b/app/controllers/work_package_types/configuration_links_controller.rb
@@ -29,39 +29,37 @@
 #++
 
 module WorkPackageTypes
-  # Sets one configuration aspect of a type to Linked (a chosen global source) or
-  # Independent. The source-graph invariants (present, global, not-self) are the
-  # link record's own validations; this service maps the UI mode onto them.
-  class SetConfigurationLinkService
-    def initialize(type:, aspect:)
-      @type = type
-      @aspect = aspect
+  class ConfigurationLinksController < ApplicationController
+    layout "admin"
+
+    before_action :require_admin
+    before_action :find_type
+
+    current_menu_item do
+      :types
     end
 
-    def call(mode:, source_id: nil)
-      source = Type.global.find_by(id: source_id)
+    def update
+      result = SetConfigurationLinkService
+                 .new(type: @type, aspect: params[:aspect])
+                 .call(mode: params[:mode], source_id: params[:source_id])
 
-      case mode.to_s
-      when "independent"
-        @type.make_independent!(@aspect, source:)
-        ServiceResult.success(result: @type)
-      when "linked"
-        link_to(source)
-      else
-        ServiceResult.failure(result: @type)
-      end
+      message = result.success? ? { notice: I18n.t(:notice_successful_update) } : { alert: result.message }
+      redirect_to tab_path_for(params[:aspect]), **message
     end
 
     private
 
-    def link_to(source)
-      link = @type.configuration_links.find_or_initialize_by(aspect: @aspect)
-      link.source = source
+    def find_type
+      @type = ::Type.find(params.expect(:type_id))
+    end
 
-      if link.save
-        ServiceResult.success(result: @type)
+    def tab_path_for(aspect)
+      case aspect
+      when Type::ConfigurationLink::SUBJECT
+        edit_type_subject_configuration_path(type_id: @type.id)
       else
-        ServiceResult.failure(result: @type, errors: link.errors)
+        edit_type_pdf_export_template_index_path(type_id: @type.id)
       end
     end
   end

--- a/app/controllers/work_package_types/configuration_links_controller.rb
+++ b/app/controllers/work_package_types/configuration_links_controller.rb
@@ -29,11 +29,10 @@
 #++
 
 module WorkPackageTypes
-  class ConfigurationLinksController < ApplicationController
-    layout "admin"
+  class ConfigurationLinksController < BaseTabController
+    include SubtypesFeature
 
-    before_action :require_admin
-    before_action :find_type
+    before_action :require_subtypes_feature
 
     current_menu_item do
       :types
@@ -49,10 +48,6 @@ module WorkPackageTypes
     end
 
     private
-
-    def find_type
-      @type = ::Type.find(params.expect(:type_id))
-    end
 
     def tab_path_for(aspect)
       case aspect

--- a/app/controllers/work_package_types/configuration_links_controller.rb
+++ b/app/controllers/work_package_types/configuration_links_controller.rb
@@ -51,7 +51,7 @@ module WorkPackageTypes
 
     def tab_path_for(aspect)
       case aspect
-      when Type::ConfigurationLink::SUBJECT
+      when Type::ConfigurationLink::PATTERNS
         edit_type_subject_configuration_path(type_id: @type.id)
       else
         edit_type_pdf_export_template_index_path(type_id: @type.id)

--- a/app/controllers/work_package_types/types_controller.rb
+++ b/app/controllers/work_package_types/types_controller.rb
@@ -32,6 +32,7 @@ module WorkPackageTypes
   class TypesController < ApplicationController
     include PaginationHelper
     include OpTurbo::ComponentStream
+    include SubtypesFeature
 
     layout "admin"
 
@@ -140,14 +141,6 @@ module WorkPackageTypes
       params = permitted_params.type.to_unsafe_h
       params = params.except(:parent_id) unless subtypes_enabled?
       params
-    end
-
-    def subtypes_enabled?
-      OpenProject::FeatureDecisions.subtypes_active?
-    end
-
-    def require_subtypes_feature
-      render_404 unless subtypes_enabled?
     end
 
     def load_projects_and_types

--- a/app/forms/work_package_types/configuration_link_form.rb
+++ b/app/forms/work_package_types/configuration_link_form.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  class ConfigurationLinkForm < ApplicationForm
+    # show-when-value-selected wiring keyed on the "mode" radio value. Defined once here
+    # so the component's editor wrapper can reuse the exact same triggers.
+    class << self
+      def cause_data
+        { target_name: "mode", "show-when-value-selected-target": "cause" }
+      end
+
+      def effect_data(value)
+        { target_name: "mode", value:, "show-when-value-selected-target": "effect" }
+      end
+    end
+
+    form do |source_form|
+      source_form.advanced_radio_button_group(name: :mode) do |group|
+        group.radio_button(
+          value: "independent",
+          checked: !linked?,
+          label: I18n.t("types.edit.configuration_link.independent.label"),
+          caption: I18n.t("types.edit.configuration_link.independent.caption"),
+          data: cause_data
+        )
+        group.radio_button(
+          value: "linked",
+          checked: linked?,
+          label: I18n.t("types.edit.configuration_link.linked.label"),
+          caption: I18n.t("types.edit.configuration_link.linked.caption"),
+          data: cause_data
+        )
+      end
+
+      # Persisted Linked: the picker stays visible for both modes — it is the source to
+      # link to, and also the type to copy from when switching to Independent (adopt).
+      # Persisted Independent: it only appears once "Linked" is selected (see point 1).
+      source_form.group(**source_group_options) do |source_group|
+        source_group.select_list(
+          name: :source_id,
+          input_width: :medium,
+          label: I18n.t("types.edit.configuration_link.source.label")
+        ) do |list|
+          source_options.each do |type|
+            list.option(value: type.id, label: type.name, selected: type.id == current_source_id)
+          end
+        end
+      end
+
+      switch_confirmation(source_form)
+    end
+
+    private
+
+    def cause_data = self.class.cause_data
+    def effect_data(value) = self.class.effect_data(value)
+
+    def linked? = @builder.options[:linked]
+    def current_source_id = @builder.options[:current_source_id]
+    def source_options = @builder.options[:source_options]
+
+    def source_group_options
+      return {} if linked?
+
+      { hidden: true, data: effect_data("linked") }
+    end
+
+    # The caution message + Save for the mode the type can switch *to*.
+    def switch_confirmation(source_form)
+      if linked?
+        # -> Independent: copy-on-adopt is explained when "Independent" is picked; Save is always available.
+        source_form.group(hidden: true, data: effect_data("independent")) do |group|
+          group.html_content { warning_flash(I18n.t("types.edit.configuration_link.independent.warning")) }
+        end
+        source_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
+      else
+        # -> Linked: destructive warning and Save appear together only while "Linked" is picked.
+        source_form.group(hidden: true, data: effect_data("linked")) do |group|
+          group.html_content { warning_flash(I18n.t("types.edit.configuration_link.linked.warning")) }
+          group.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
+        end
+      end
+    end
+
+    def warning_flash(message)
+      render(Primer::Beta::Flash.new(scheme: :warning, mb: 3)) { message }
+    end
+  end
+end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -33,6 +33,7 @@ class Type < ApplicationRecord
   # and constraints to specific attributes (by plugins).
   include ::Type::Attributes
   include ::Type::AttributeGroups
+  include ::Type::ConfigurationLinkable
 
   include ::Scopes::Scoped
 
@@ -85,6 +86,9 @@ class Type < ApplicationRecord
 
   scope :roots, -> { where(parent_id: nil) }
   scope :subtypes, -> { where.not(parent_id: nil) }
+  # All types are global until project-owned sub-types exist; this is the seam the
+  # configuration source picker and contract scope against (see FND-103 :manage_subtypes).
+  scope :global, -> { all }
   scope :without_standard, -> { where(is_standard: false).order(:position) }
   scope :default, -> { where(is_default: true) }
   scope :visible, ->(user = User.current) {

--- a/app/models/type/configuration_link.rb
+++ b/app/models/type/configuration_link.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# A single reuse link: a type borrows one configuration aspect from a source type.
+# Absence of a row for (type, aspect) means the type owns that aspect (Independent).
+class Type::ConfigurationLink < ApplicationRecord
+  ASPECTS = [
+    PDF_EXPORT = "pdf_export",
+    SUBJECT = "subject"
+  ].freeze
+
+  belongs_to :type, optional: false
+  belongs_to :source, class_name: "Type", optional: false
+
+  enum :aspect, ASPECTS.index_with(&:itself), validate: true
+
+  validates :type_id, uniqueness: { scope: :aspect }
+  validate :source_differs_from_type
+
+  private
+
+  def source_differs_from_type
+    errors.add(:source, :must_differ_from_type) if source_id.present? && source_id == type_id
+  end
+end

--- a/app/models/type/configuration_link.rb
+++ b/app/models/type/configuration_link.rb
@@ -33,7 +33,7 @@
 class Type::ConfigurationLink < ApplicationRecord
   ASPECTS = [
     PDF_EXPORT = "pdf_export",
-    SUBJECT = "subject"
+    PATTERNS = "patterns"
   ].freeze
 
   belongs_to :type, optional: false

--- a/app/models/type/configuration_linkable.rb
+++ b/app/models/type/configuration_linkable.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Reuse of a type's configuration aspects (PDF export, subject patterns) from a
+# source type. Mode is derived from link presence: a link means Linked, its
+# absence means Independent. This is the shared seam FND-101/102 extend with
+# further aspects, and the deferred resolution/copy/cycle work builds on top of.
+module Type::ConfigurationLinkable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :configuration_links,
+             class_name: "Type::ConfigurationLink",
+             dependent: :destroy
+    has_many :dependent_configuration_links,
+             class_name: "Type::ConfigurationLink",
+             foreign_key: :source_id,
+             inverse_of: :source,
+             dependent: :restrict_with_error
+
+    # A sub-type defaults to Linked-to-parent for every reusable aspect.
+    after_create :seed_default_configuration_links, if: :subtype?
+  end
+
+  def linked?(aspect)
+    configuration_links.exists?(aspect:)
+  end
+
+  def source_for(aspect)
+    configuration_links.find_by(aspect:)&.source
+  end
+
+  def link!(aspect, source:)
+    configuration_links.find_or_initialize_by(aspect:).update!(source:)
+  end
+
+  def make_independent!(aspect)
+    configuration_links.where(aspect:).destroy_all
+  end
+
+  private
+
+  def seed_default_configuration_links
+    Type::ConfigurationLink::ASPECTS.each { |aspect| link!(aspect, source: parent) }
+  end
+end

--- a/app/models/type/configuration_linkable.rb
+++ b/app/models/type/configuration_linkable.rb
@@ -61,8 +61,41 @@ module Type::ConfigurationLinkable
     configuration_links.find_or_initialize_by(aspect:).update!(source:)
   end
 
-  def make_independent!(aspect)
+  # Switch an aspect to Independent. When a source is given, its resolved
+  # configuration is copied onto this type once (adopt) before the link is severed.
+  def make_independent!(aspect, source: nil)
+    copy_configuration_from(source, aspect) if source && source != self
     configuration_links.where(aspect:).destroy_all
+  end
+
+  # Walks the link chain to the type that actually owns the aspect (Independent).
+  # The visited-set guard keeps it terminating even before transitive cycle
+  # prevention lands.
+  def effective_source_for(aspect)
+    node = self
+    seen = Set.new
+    node = node.source_for(aspect) while node.linked?(aspect) && seen.add?(node.id)
+    node
+  end
+
+  def effective_patterns
+    effective_source_for(Type::ConfigurationLink::SUBJECT).patterns
+  end
+
+  def effective_pdf_export_templates
+    effective_source_for(Type::ConfigurationLink::PDF_EXPORT).pdf_export_templates
+  end
+
+  # One-time adoption: copy the source's resolved configuration for one aspect
+  # onto this type. Used when switching to Independent from a chosen source.
+  def copy_configuration_from(source, aspect)
+    case aspect
+    when Type::ConfigurationLink::SUBJECT
+      update!(patterns: source.effective_patterns)
+    when Type::ConfigurationLink::PDF_EXPORT
+      owner = source.effective_source_for(Type::ConfigurationLink::PDF_EXPORT)
+      update!(pdf_export_templates_config: owner.pdf_export_templates_config.deep_dup)
+    end
   end
 
   private

--- a/app/models/type/configuration_linkable.rb
+++ b/app/models/type/configuration_linkable.rb
@@ -79,7 +79,7 @@ module Type::ConfigurationLinkable
   end
 
   def effective_patterns
-    effective_source_for(Type::ConfigurationLink::SUBJECT).patterns
+    effective_source_for(Type::ConfigurationLink::PATTERNS).patterns
   end
 
   def effective_pdf_export_templates
@@ -88,12 +88,13 @@ module Type::ConfigurationLinkable
 
   # One-time adoption: copy the source's resolved configuration for one aspect
   # onto this type. Used when switching to Independent from a chosen source.
+  # deep_dup keeps the copy from aliasing the source's stored value.
   def copy_configuration_from(source, aspect)
+    owner = source.effective_source_for(aspect)
     case aspect
-    when Type::ConfigurationLink::SUBJECT
-      update!(patterns: source.effective_patterns)
+    when Type::ConfigurationLink::PATTERNS
+      update!(patterns: owner.patterns.deep_dup)
     when Type::ConfigurationLink::PDF_EXPORT
-      owner = source.effective_source_for(Type::ConfigurationLink::PDF_EXPORT)
       update!(pdf_export_templates_config: owner.pdf_export_templates_config.deep_dup)
     end
   end

--- a/app/services/work_package_types/set_configuration_link_service.rb
+++ b/app/services/work_package_types/set_configuration_link_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # Sets one configuration aspect of a type to Linked (a chosen global source) or
+  # Independent. The source-graph invariants (present, global, not-self) are the
+  # link record's own validations; this service maps the UI mode onto them.
+  class SetConfigurationLinkService
+    def initialize(type:, aspect:)
+      @type = type
+      @aspect = aspect
+    end
+
+    def call(mode:, source_id: nil)
+      case mode.to_s
+      when "independent"
+        @type.make_independent!(@aspect)
+        ServiceResult.success(result: @type)
+      when "linked"
+        link_to(source_id)
+      else
+        ServiceResult.failure(result: @type)
+      end
+    end
+
+    private
+
+    def link_to(source_id)
+      link = @type.configuration_links.find_or_initialize_by(aspect: @aspect)
+      link.source = Type.global.find_by(id: source_id)
+
+      if link.save
+        ServiceResult.success(result: @type)
+      else
+        ServiceResult.failure(result: @type, errors: link.errors)
+      end
+    end
+  end
+end

--- a/app/views/work_package_types/pdf_export_template/edit.html.erb
+++ b/app/views/work_package_types/pdf_export_template/edit.html.erb
@@ -30,4 +30,6 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
-<%= render WorkPackageTypes::ExportConfigurationComponent.new(@type) %>
+<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::PDF_EXPORT)) do %>
+  <%= render WorkPackageTypes::ExportConfigurationComponent.new(@type) %>
+<% end %>

--- a/app/views/work_package_types/subject_configuration_tab/edit.html.erb
+++ b/app/views/work_package_types/subject_configuration_tab/edit.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
-<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::SUBJECT)) do %>
+<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::PATTERNS)) do %>
   <%= render WorkPackageTypes::SubjectConfigurationComponent
                .new(@type, subject_configuration_form_data: params[:work_package_types_forms_subject_configuration_form_model]) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5974,6 +5974,17 @@ en:
 
   types:
     edit:
+      configuration_link:
+        independent:
+          caption: "These settings belong to this type and are edited here. They are not linked to any other type."
+          label: "Independent"
+          warning: "Switching to Independent copies the selected source type's current settings onto this type, then removes the link. You can edit them freely afterwards. Please proceed with caution."
+        linked:
+          caption: "These settings are reused from a source type and stay in sync with it. To change them, edit the source type."
+          label: "Linked"
+          warning: "Linking replaces this type's own settings with the source type's. The current settings are discarded and work packages of this type may be affected. Please proceed with caution."
+        source:
+          label: "Source type"
       export_configuration:
         intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."
         pdf_export_templates:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,12 +334,15 @@ en:
         attribute_groups: "Form configuration"
         children: "Sub-types"
         color: "Color"
+        dependent_configuration_links: "Linked types"
         description: "Default text for description"
         is_default: "Activated for new projects by default"
         is_in_roadmap: "Displayed in roadmap by default"
         is_milestone: "Is milestone"
         parent: "Parent type"
         patterns: "Patterns"
+      type/configuration_link:
+        source: "Source type"
       user:
         admin: "Administrator"
         auth_source: "Authentication source"
@@ -804,6 +807,10 @@ en:
               standard_type_must_be_root: "can't be set for the standard type."
             patterns:
               invalid_tokens: "One or more attributes inside the field are not valid. Please, fix the attributes before saving."
+        type/configuration_link:
+          attributes:
+            source:
+              must_differ_from_type: "can't be the type itself."
         user:
           attributes:
             base:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,8 @@ Rails.application.routes.draw do
     resource :settings, controller: "settings_tab", only: %i[update edit]
     resource :subject_configuration, controller: "subject_configuration_tab", only: %i[update edit]
 
+    resources :configuration_links, only: %i[update], param: :aspect
+
     resources :pdf_export_template, only: %i[],
                                     controller: "pdf_export_template",
                                     path: "pdf_export_template" do

--- a/db/migrate/20260707120000_create_type_configuration_links.rb
+++ b/db/migrate/20260707120000_create_type_configuration_links.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CreateTypeConfigurationLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :type_configuration_links do |t|
+      t.references :type, null: false, foreign_key: { to_table: :types }
+      t.references :source, null: false, foreign_key: { to_table: :types }
+      t.string :aspect, null: false
+
+      t.timestamps
+    end
+
+    add_index :type_configuration_links, %i[type_id aspect], unique: true
+  end
+end

--- a/spec/factories/type_configuration_link_factory.rb
+++ b/spec/factories/type_configuration_link_factory.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :type_configuration_link, class: "Type::ConfigurationLink" do
+    type
+    source factory: :type
+    aspect { Type::ConfigurationLink::PDF_EXPORT }
+  end
+end

--- a/spec/models/type/configuration_link_spec.rb
+++ b/spec/models/type/configuration_link_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Type::ConfigurationLink do
+  describe "aspect enum" do
+    it "is string-backed with the two configured aspects" do
+      expect(subject).to define_enum_for(:aspect)
+        .with_values(pdf_export: "pdf_export", subject: "subject")
+        .backed_by_column_of_type(:string)
+    end
+
+    it "exposes the aspect identifiers as constants" do
+      expect(described_class::ASPECTS)
+        .to contain_exactly(described_class::PDF_EXPORT, described_class::SUBJECT)
+    end
+
+    it "rejects an unknown aspect" do
+      link = build(:type_configuration_link, aspect: "nonsense")
+
+      expect(link).not_to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "links a type to the source type it borrows from" do
+      type = create(:type)
+      source = create(:type)
+      link = create(:type_configuration_link, type:, source:, aspect: described_class::SUBJECT)
+
+      expect(link.type).to eq(type)
+      expect(link.source).to eq(source)
+    end
+  end
+
+  describe "validations" do
+    let(:type) { create(:type) }
+
+    it "requires a source" do
+      link = build(:type_configuration_link, type:, source: nil, aspect: described_class::SUBJECT)
+
+      expect(link).not_to be_valid
+    end
+
+    it "rejects a link whose source is the type itself" do
+      link = build(:type_configuration_link, type:, source: type, aspect: described_class::SUBJECT)
+
+      expect(link).not_to be_valid
+    end
+  end
+
+  describe "uniqueness of (type, aspect)" do
+    let(:type) { create(:type) }
+    let(:source) { create(:type) }
+
+    before { create(:type_configuration_link, type:, source:, aspect: described_class::PDF_EXPORT) }
+
+    it "forbids a second link for the same type and aspect" do
+      duplicate = build(:type_configuration_link, type:, source:, aspect: described_class::PDF_EXPORT)
+
+      expect(duplicate).not_to be_valid
+    end
+
+    it "allows the other aspect to coexist for the same type" do
+      other = build(:type_configuration_link, type:, source:, aspect: described_class::SUBJECT)
+
+      expect(other).to be_valid
+    end
+  end
+end

--- a/spec/models/type/configuration_link_spec.rb
+++ b/spec/models/type/configuration_link_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe Type::ConfigurationLink do
   describe "aspect enum" do
     it "is string-backed with the two configured aspects" do
       expect(subject).to define_enum_for(:aspect)
-        .with_values(pdf_export: "pdf_export", subject: "subject")
+        .with_values(pdf_export: "pdf_export", patterns: "patterns")
         .backed_by_column_of_type(:string)
     end
 
     it "exposes the aspect identifiers as constants" do
       expect(described_class::ASPECTS)
-        .to contain_exactly(described_class::PDF_EXPORT, described_class::SUBJECT)
+        .to contain_exactly(described_class::PDF_EXPORT, described_class::PATTERNS)
     end
 
     it "rejects an unknown aspect" do
@@ -54,7 +54,7 @@ RSpec.describe Type::ConfigurationLink do
     it "links a type to the source type it borrows from" do
       type = create(:type)
       source = create(:type)
-      link = create(:type_configuration_link, type:, source:, aspect: described_class::SUBJECT)
+      link = create(:type_configuration_link, type:, source:, aspect: described_class::PATTERNS)
 
       expect(link.type).to eq(type)
       expect(link.source).to eq(source)
@@ -65,13 +65,13 @@ RSpec.describe Type::ConfigurationLink do
     let(:type) { create(:type) }
 
     it "requires a source" do
-      link = build(:type_configuration_link, type:, source: nil, aspect: described_class::SUBJECT)
+      link = build(:type_configuration_link, type:, source: nil, aspect: described_class::PATTERNS)
 
       expect(link).not_to be_valid
     end
 
     it "rejects a link whose source is the type itself" do
-      link = build(:type_configuration_link, type:, source: type, aspect: described_class::SUBJECT)
+      link = build(:type_configuration_link, type:, source: type, aspect: described_class::PATTERNS)
 
       expect(link).not_to be_valid
     end
@@ -90,7 +90,7 @@ RSpec.describe Type::ConfigurationLink do
     end
 
     it "allows the other aspect to coexist for the same type" do
-      other = build(:type_configuration_link, type:, source:, aspect: described_class::SUBJECT)
+      other = build(:type_configuration_link, type:, source:, aspect: described_class::PATTERNS)
 
       expect(other).to be_valid
     end

--- a/spec/models/type/configuration_linkable_spec.rb
+++ b/spec/models/type/configuration_linkable_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe Type::ConfigurationLinkable do
   let(:type) { create(:type) }
   let(:source) { create(:type) }
-  let(:aspect) { Type::ConfigurationLink::SUBJECT }
+  let(:aspect) { Type::ConfigurationLink::PATTERNS }
 
   describe "#linked? and #source_for" do
     it "reports Independent (no link) by default" do
@@ -49,9 +49,9 @@ RSpec.describe Type::ConfigurationLinkable do
     end
 
     it "tracks each aspect independently" do
-      type.link!(Type::ConfigurationLink::SUBJECT, source:)
+      type.link!(Type::ConfigurationLink::PATTERNS, source:)
 
-      expect(type).to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type).to be_linked(Type::ConfigurationLink::PATTERNS)
       expect(type).not_to be_linked(Type::ConfigurationLink::PDF_EXPORT)
     end
   end
@@ -69,22 +69,22 @@ RSpec.describe Type::ConfigurationLinkable do
 
   describe "#make_independent!" do
     it "removes the link for that aspect only" do
-      type.link!(Type::ConfigurationLink::SUBJECT, source:)
+      type.link!(Type::ConfigurationLink::PATTERNS, source:)
       type.link!(Type::ConfigurationLink::PDF_EXPORT, source:)
 
-      type.make_independent!(Type::ConfigurationLink::SUBJECT)
+      type.make_independent!(Type::ConfigurationLink::PATTERNS)
 
-      expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type).not_to be_linked(Type::ConfigurationLink::PATTERNS)
       expect(type).to be_linked(Type::ConfigurationLink::PDF_EXPORT)
     end
 
     it "adopts the source's configuration before severing when given a source" do
       configured = create(:type, patterns: { subject: { blueprint: "Adopted {{id}}", enabled: true } })
-      type.link!(Type::ConfigurationLink::SUBJECT, source:)
+      type.link!(Type::ConfigurationLink::PATTERNS, source:)
 
-      type.make_independent!(Type::ConfigurationLink::SUBJECT, source: configured)
+      type.make_independent!(Type::ConfigurationLink::PATTERNS, source: configured)
 
-      expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type).not_to be_linked(Type::ConfigurationLink::PATTERNS)
       expect(type.reload.patterns.subject.blueprint).to eq("Adopted {{id}}")
     end
   end
@@ -95,14 +95,14 @@ RSpec.describe Type::ConfigurationLinkable do
       child = create(:type, parent:)
 
       expect(child.source_for(Type::ConfigurationLink::PDF_EXPORT)).to eq(parent)
-      expect(child.source_for(Type::ConfigurationLink::SUBJECT)).to eq(parent)
+      expect(child.source_for(Type::ConfigurationLink::PATTERNS)).to eq(parent)
     end
 
     it "leaves a root type Independent for both aspects" do
       root = create(:type)
 
       expect(root).not_to be_linked(Type::ConfigurationLink::PDF_EXPORT)
-      expect(root).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(root).not_to be_linked(Type::ConfigurationLink::PATTERNS)
     end
   end
 
@@ -150,7 +150,7 @@ RSpec.describe Type::ConfigurationLinkable do
     let(:owner) { create(:type, patterns: { subject: { blueprint: "X {{id}}", enabled: true } }) }
 
     it "resolves patterns from the linked owner" do
-      type.link!(Type::ConfigurationLink::SUBJECT, source: owner)
+      type.link!(Type::ConfigurationLink::PATTERNS, source: owner)
 
       expect(type.effective_patterns.subject.blueprint).to eq("X {{id}}")
     end
@@ -164,7 +164,7 @@ RSpec.describe Type::ConfigurationLinkable do
     it "copies the source's subject patterns onto the type" do
       source = create(:type, patterns: { subject: { blueprint: "Copied {{id}}", enabled: true } })
 
-      type.copy_configuration_from(source, Type::ConfigurationLink::SUBJECT)
+      type.copy_configuration_from(source, Type::ConfigurationLink::PATTERNS)
 
       expect(type.reload.patterns.subject.blueprint).to eq("Copied {{id}}")
     end

--- a/spec/models/type/configuration_linkable_spec.rb
+++ b/spec/models/type/configuration_linkable_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Type::ConfigurationLinkable do
+  let(:type) { create(:type) }
+  let(:source) { create(:type) }
+  let(:aspect) { Type::ConfigurationLink::SUBJECT }
+
+  describe "#linked? and #source_for" do
+    it "reports Independent (no link) by default" do
+      expect(type).not_to be_linked(aspect)
+      expect(type.source_for(aspect)).to be_nil
+    end
+
+    it "reports Linked once a link exists" do
+      type.link!(aspect, source:)
+
+      expect(type).to be_linked(aspect)
+      expect(type.source_for(aspect)).to eq(source)
+    end
+
+    it "tracks each aspect independently" do
+      type.link!(Type::ConfigurationLink::SUBJECT, source:)
+
+      expect(type).to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type).not_to be_linked(Type::ConfigurationLink::PDF_EXPORT)
+    end
+  end
+
+  describe "#link!" do
+    it "re-points an existing link rather than creating a duplicate" do
+      other_source = create(:type)
+      type.link!(aspect, source:)
+
+      expect { type.link!(aspect, source: other_source) }
+        .not_to change { type.configuration_links.where(aspect:).count }.from(1)
+      expect(type.source_for(aspect)).to eq(other_source)
+    end
+  end
+
+  describe "#make_independent!" do
+    it "removes the link for that aspect only" do
+      type.link!(Type::ConfigurationLink::SUBJECT, source:)
+      type.link!(Type::ConfigurationLink::PDF_EXPORT, source:)
+
+      type.make_independent!(Type::ConfigurationLink::SUBJECT)
+
+      expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type).to be_linked(Type::ConfigurationLink::PDF_EXPORT)
+    end
+  end
+
+  describe "sub-type default seeding" do
+    it "links both aspects to the parent when a sub-type is created" do
+      parent = create(:type)
+      child = create(:type, parent:)
+
+      expect(child.source_for(Type::ConfigurationLink::PDF_EXPORT)).to eq(parent)
+      expect(child.source_for(Type::ConfigurationLink::SUBJECT)).to eq(parent)
+    end
+
+    it "leaves a root type Independent for both aspects" do
+      root = create(:type)
+
+      expect(root).not_to be_linked(Type::ConfigurationLink::PDF_EXPORT)
+      expect(root).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+    end
+  end
+
+  describe "deletion" do
+    it "destroys the type's own links when the type is destroyed" do
+      type.link!(aspect, source:)
+
+      type.destroy
+
+      expect(Type::ConfigurationLink.where(type_id: type.id)).to be_empty
+    end
+
+    it "prevents destroying a type that is still a source for another type" do
+      type.link!(aspect, source:)
+
+      expect(source.destroy).to be_falsey
+      expect(source.errors[:base]).to be_present
+    end
+  end
+end

--- a/spec/models/type/configuration_linkable_spec.rb
+++ b/spec/models/type/configuration_linkable_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe Type::ConfigurationLinkable do
       expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
       expect(type).to be_linked(Type::ConfigurationLink::PDF_EXPORT)
     end
+
+    it "adopts the source's configuration before severing when given a source" do
+      configured = create(:type, patterns: { subject: { blueprint: "Adopted {{id}}", enabled: true } })
+      type.link!(Type::ConfigurationLink::SUBJECT, source:)
+
+      type.make_independent!(Type::ConfigurationLink::SUBJECT, source: configured)
+
+      expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type.reload.patterns.subject.blueprint).to eq("Adopted {{id}}")
+    end
   end
 
   describe "sub-type default seeding" do
@@ -110,6 +120,63 @@ RSpec.describe Type::ConfigurationLinkable do
 
       expect(source.destroy).to be_falsey
       expect(source.errors[:base]).to be_present
+    end
+  end
+
+  describe "#effective_source_for" do
+    it "returns itself when Independent" do
+      expect(type.effective_source_for(aspect)).to eq(type)
+    end
+
+    it "walks the link chain to the owning Independent type" do
+      owner = create(:type)
+      middle = create(:type)
+      middle.link!(aspect, source: owner)
+      type.link!(aspect, source: middle)
+
+      expect(type.effective_source_for(aspect)).to eq(owner)
+    end
+
+    it "terminates on a cycle instead of looping forever" do
+      other = create(:type)
+      type.link!(aspect, source: other)
+      other.link!(aspect, source: type)
+
+      expect { type.effective_source_for(aspect) }.not_to raise_error
+    end
+  end
+
+  describe "effective configuration" do
+    let(:owner) { create(:type, patterns: { subject: { blueprint: "X {{id}}", enabled: true } }) }
+
+    it "resolves patterns from the linked owner" do
+      type.link!(Type::ConfigurationLink::SUBJECT, source: owner)
+
+      expect(type.effective_patterns.subject.blueprint).to eq("X {{id}}")
+    end
+
+    it "resolves its own patterns when Independent" do
+      expect(type.effective_patterns).to eq(type.patterns)
+    end
+  end
+
+  describe "#copy_configuration_from" do
+    it "copies the source's subject patterns onto the type" do
+      source = create(:type, patterns: { subject: { blueprint: "Copied {{id}}", enabled: true } })
+
+      type.copy_configuration_from(source, Type::ConfigurationLink::SUBJECT)
+
+      expect(type.reload.patterns.subject.blueprint).to eq("Copied {{id}}")
+    end
+
+    it "copies the source's PDF export config onto the type" do
+      source = create(:type)
+      source.pdf_export_templates.disable_all
+      source.save!
+
+      type.copy_configuration_from(source, Type::ConfigurationLink::PDF_EXPORT)
+
+      expect(type.reload.export_templates_disabled).to eq(source.export_templates_disabled)
     end
   end
 end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -283,6 +283,10 @@ RSpec.describe Type do
       it ".subtypes returns only nested types" do
         expect(described_class.subtypes).to contain_exactly(child)
       end
+
+      it ".global returns every type (all types are global until project-owned types exist)" do
+        expect(described_class.global).to include(parent, child)
+      end
     end
 
     describe "#root" do

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package type configuration source",
+               :skip_csrf,
+               type: :rails_request do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:type) { create(:type) }
+  shared_let(:source) { create(:type) }
+
+  let(:aspect) { Type::ConfigurationLink::PDF_EXPORT }
+
+  before { login_as admin }
+
+  describe "rendering the tabs" do
+    it "renders the PDF tab with the mode toggle" do
+      get edit_type_pdf_export_template_index_path(type_id: type.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Independent")
+    end
+
+    it "renders the subject tab with the mode toggle" do
+      get edit_type_subject_configuration_path(type_id: type.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Independent")
+    end
+
+    it "shows the type's own editor when Independent" do
+      get edit_type_pdf_export_template_index_path(type_id: type.id)
+
+      expect(response.body).to include("PDF Export templates")
+    end
+
+    it "includes the irreversibility warning for switching an Independent type to Linked" do
+      get edit_type_pdf_export_template_index_path(type_id: type.id)
+
+      expect(response.body).to include("The current settings are discarded and work packages of this type may be affected.")
+    end
+
+    it "hides the editor and shows the source picker when Linked" do
+      type.link!(Type::ConfigurationLink::PDF_EXPORT, source:)
+
+      get edit_type_pdf_export_template_index_path(type_id: type.id)
+
+      expect(response.body).to include("Source type")
+      expect(response.body).not_to include("PDF Export templates")
+    end
+
+    it "explains the copy-on-adopt when a Linked type may switch to Independent" do
+      type.link!(Type::ConfigurationLink::PDF_EXPORT, source:)
+
+      get edit_type_pdf_export_template_index_path(type_id: type.id)
+
+      expect(response.body).to include("then removes the link. You can edit them freely afterwards.")
+    end
+  end
+
+  describe "PUT update" do
+    it "links the aspect to the chosen source" do
+      put type_configuration_link_path(type_id: type.id, aspect:),
+          params: { mode: "linked", source_id: source.id }
+
+      expect(response).to be_redirect
+      expect(type.source_for(aspect)).to eq(source)
+    end
+
+    it "switches the aspect back to independent" do
+      type.link!(aspect, source:)
+
+      put type_configuration_link_path(type_id: type.id, aspect:),
+          params: { mode: "independent" }
+
+      expect(response).to be_redirect
+      expect(type.reload).not_to be_linked(aspect)
+    end
+
+    it "adopts a source's config when switching to independent with a source" do
+      configured = create(:type)
+      configured.pdf_export_templates.disable_all
+      configured.save!
+
+      put type_configuration_link_path(type_id: type.id, aspect:),
+          params: { mode: "independent", source_id: configured.id }
+
+      expect(type.reload).not_to be_linked(aspect)
+      expect(type.export_templates_disabled).to eq(configured.export_templates_disabled)
+    end
+
+    it "does not persist an invalid (self) source and flashes an alert" do
+      put type_configuration_link_path(type_id: type.id, aspect:),
+          params: { mode: "linked", source_id: type.id }
+
+      expect(type).not_to be_linked(aspect)
+      expect(flash[:alert]).to be_present
+      expect(flash[:notice]).to be_blank
+    end
+
+    it "requires admin" do
+      login_as create(:user)
+
+      put type_configuration_link_path(type_id: type.id, aspect:),
+          params: { mode: "linked", source_id: source.id }
+
+      expect(response).not_to be_successful
+      expect(type).not_to be_linked(aspect)
+    end
+  end
+end

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -32,7 +32,8 @@ require "spec_helper"
 
 RSpec.describe "Work package type configuration source",
                :skip_csrf,
-               type: :rails_request do
+               type: :rails_request,
+               with_flag: { subtypes: true } do
   shared_let(:admin) { create(:admin) }
   shared_let(:type) { create(:type) }
   shared_let(:source) { create(:type) }
@@ -40,6 +41,23 @@ RSpec.describe "Work package type configuration source",
   let(:aspect) { Type::ConfigurationLink::PDF_EXPORT }
 
   before { login_as admin }
+
+  context "when the subtypes feature is disabled", with_flag: { subtypes: false } do
+    it "renders the tab's own editor without the reuse mode toggle" do
+      get edit_type_pdf_export_template_index_path(type_id: type.id)
+
+      expect(response.body).to include("PDF Export templates")
+      expect(response.body).not_to include("These settings belong to this type")
+    end
+
+    it "blocks the update endpoint" do
+      put type_configuration_link_path(type_id: type.id, aspect:),
+          params: { mode: "linked", source_id: source.id }
+
+      expect(response).to have_http_status(:not_found)
+      expect(type).not_to be_linked(aspect)
+    end
+  end
 
   describe "rendering the tabs" do
     it "renders the PDF tab with the mode toggle" do

--- a/spec/services/work_package_types/set_configuration_link_service_spec.rb
+++ b/spec/services/work_package_types/set_configuration_link_service_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
+  let(:type) { create(:type) }
+  let(:source) { create(:type) }
+  let(:aspect) { Type::ConfigurationLink::PDF_EXPORT }
+
+  subject(:service) { described_class.new(type:, aspect:) }
+
+  describe "linked mode" do
+    it "links the aspect to the chosen source" do
+      result = service.call(mode: "linked", source_id: source.id)
+
+      expect(result).to be_success
+      expect(type.source_for(aspect)).to eq(source)
+    end
+
+    it "re-points an existing link to a new source" do
+      service.call(mode: "linked", source_id: source.id)
+      other = create(:type)
+
+      result = service.call(mode: "linked", source_id: other.id)
+
+      expect(result).to be_success
+      expect(type.reload.source_for(aspect)).to eq(other)
+    end
+
+    it "fails when no source is given" do
+      result = service.call(mode: "linked", source_id: nil)
+
+      expect(result).not_to be_success
+      expect(type).not_to be_linked(aspect)
+    end
+
+    it "fails when the source is the type itself" do
+      result = service.call(mode: "linked", source_id: type.id)
+
+      expect(result).not_to be_success
+      expect(type).not_to be_linked(aspect)
+    end
+  end
+
+  describe "independent mode" do
+    it "removes an existing link" do
+      service.call(mode: "linked", source_id: source.id)
+
+      result = service.call(mode: "independent")
+
+      expect(result).to be_success
+      expect(type.reload).not_to be_linked(aspect)
+    end
+
+    it "is a no-op when already independent" do
+      result = service.call(mode: "independent")
+
+      expect(result).to be_success
+      expect(type).not_to be_linked(aspect)
+    end
+  end
+end

--- a/spec/services/work_package_types/set_configuration_link_service_spec.rb
+++ b/spec/services/work_package_types/set_configuration_link_service_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
   end
 
   describe "independent mode adopting a source" do
-    subject(:service) { described_class.new(type:, aspect: Type::ConfigurationLink::SUBJECT) }
+    subject(:service) { described_class.new(type:, aspect: Type::ConfigurationLink::PATTERNS) }
 
     it "copies the source's config onto the type once and creates no link" do
       configured = create(:type, patterns: { subject: { blueprint: "Adopt {{id}}", enabled: true } })
@@ -97,7 +97,7 @@ RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
       result = service.call(mode: "independent", source_id: configured.id)
 
       expect(result).to be_success
-      expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type).not_to be_linked(Type::ConfigurationLink::PATTERNS)
       expect(type.reload.patterns.subject.blueprint).to eq("Adopt {{id}}")
     end
   end

--- a/spec/services/work_package_types/set_configuration_link_service_spec.rb
+++ b/spec/services/work_package_types/set_configuration_link_service_spec.rb
@@ -87,4 +87,18 @@ RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
       expect(type).not_to be_linked(aspect)
     end
   end
+
+  describe "independent mode adopting a source" do
+    subject(:service) { described_class.new(type:, aspect: Type::ConfigurationLink::SUBJECT) }
+
+    it "copies the source's config onto the type once and creates no link" do
+      configured = create(:type, patterns: { subject: { blueprint: "Adopt {{id}}", enabled: true } })
+
+      result = service.call(mode: "independent", source_id: configured.id)
+
+      expect(result).to be_success
+      expect(type).not_to be_linked(Type::ConfigurationLink::SUBJECT)
+      expect(type.reload.patterns.subject.blueprint).to eq("Adopt {{id}}")
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/FND-129

# What are you trying to accomplish?

Lay the foundation for reusing a work package type's configuration via a **Linked / Independent** mode, for two aspects: **PDF export templates** and **subject / identifier patterns**. This is the foundation slice of [FND-103](https://community.openproject.org/wp/FND-103); siblings [FND-101](https://community.openproject.org/wp/FND-101) (workflow) and [FND-102](https://community.openproject.org/wp/FND-102) (form configuration) reuse the same primitive.

> ⚠️ **The UI is WIP** — it's here to exercise the flow in a browser, not in its final visual/UX state. The data model and write path are the parts meant for review.

**In this PR:**
- **`Type::ConfigurationLink`** (join table `type_configuration_links`) + **`Type::ConfigurationLinkable`** concern — `linked?` / `source_for` / `link!` / `make_independent!(source:)`, cycle-safe `effective_*` chain resolution, and copy-on-adopt when switching to Independent from a source. Mode is *derived from row presence*, so there is no stored state to keep in sync.
- Sub-types default to Linked-to-parent; a type still used as a source can't be deleted.
- **`WorkPackageTypes::SetConfigurationLinkService`** + **`ConfigurationLinksController`** (`PUT /types/:type_id/configuration_links/:aspect`), admin-only.
- Gated behind the **`:subtypes`** feature flag — when it's off, each tab shows its own editor as before and the endpoint 404s.
- **(WIP UI)** Mode cards (Independent/Linked) + a global-type source picker on the **Generate PDF** and **Subject configuration** tabs. Independent shows the tab's own editor; Linked shows the picker; the swap is client-side (`show-when-value-selected`); each switch shows a caution banner.

**Deferred to sibling WPs:** rewiring the app's runtime read sites to `effective_*`, transitive cycle *prevention* (only the self-link is blocked), and the workflow / form-configuration aspects.

## Screenshots

<img width="1365" height="537" alt="Screenshot for independent configuration" src="https://github.com/user-attachments/assets/188a0aec-8ab6-4a98-a954-cb077fd89ed9" />

<img width="1365" height="567" alt="Screen shot for linked configuration" src="https://github.com/user-attachments/assets/713c0fe8-20bb-4321-9795-7a402ab81608" />

# What approach did you choose and why?

- **One reusable primitive** — a `(type, aspect, source)` row with mode derived from presence, so FND-101/102 add aspects as data (an enum value), not new schema or plumbing.
- **A join table gives the link room to grow** — a row can later carry metadata about *how* a source is reused (limits, overrides) without another migration per aspect.
- **Namespacing follows the codebase** — the model nests under `Type` (`Type::ConfigurationLink`, table auto-inferred), and the interaction layer sits under `WorkPackageTypes::` like the other type-admin controllers/forms/components.
- **Minimal runtime footprint** — PDF edits stay immediate and the subject keeps its form; the mode swap is client-side, so no runtime resolution is needed yet.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
