### PR TITLE
[AGILE-322] Backend support for optimistic reordering

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -716,4 +716,27 @@ describe('Sortable lists controller', () => {
       expect(outsideItemController.root).toBeUndefined();
     });
   });
+
+  it('moves an item down through the optimistic path', async () => {
+    const { root, sourceList, firstSourceItem } = renderFixture();
+    await ctx.nextFrame();
+
+    const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+    controller.moveInDirection(firstSourceItem, 'down');
+    await flushPromises();
+
+    // '1' started first; moving down puts it after '2'.
+    expect(itemIds(sourceList)).toEqual(['2', '1', '3']);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = fetchMock.mock.lastCall?.[1] as { body:FormData };
+    expect(body.body.get('prev_id')).toBe('2');
+  });
+
+  it('reports move position for gating', async () => {
+    const { root, firstSourceItem } = renderFixture();
+    await ctx.nextFrame();
+    const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+
+    expect(controller.itemMovePosition(firstSourceItem)).toEqual({ isFirst: true, isLast: false });
+  });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -732,21 +732,22 @@ describe('Sortable lists controller', () => {
     expect(body.body.get('prev_id')).toBe('2');
   });
 
-  it('reports move position for gating', async () => {
-    const { root, firstSourceItem } = renderFixture();
-    await ctx.nextFrame();
-    const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
-
-    expect(controller.itemMovePosition(firstSourceItem)).toEqual({ isFirst: true, isLast: false });
-  });
-
-  it('reports directional availability for gating', async () => {
+  it('reports per-direction move availability for gating', async () => {
     const { root, firstSourceItem } = renderFixture();
     await ctx.nextFrame();
     const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
 
     // First item: down/bottom available, up/top not.
-    expect(controller.directionalMoveAvailable(firstSourceItem, 'down')).toBe(true);
-    expect(controller.directionalMoveAvailable(firstSourceItem, 'up')).toBe(false);
+    expect(controller.moveAvailability(firstSourceItem)).toEqual({
+      top: false, up: false, down: true, bottom: true,
+    });
+  });
+
+  it('reports null availability for an item outside any owned list', async () => {
+    const { root } = renderFixture();
+    await ctx.nextFrame();
+    const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+
+    expect(controller.moveAvailability(document.createElement('li'))).toBeNull();
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -321,15 +321,27 @@ describe('Sortable lists controller', () => {
     await dropCurrentItemOnList(firstSourceItem, targetList);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/projects/demo/backlogs/work_packages/1/move',
+      '/projects/demo/backlogs/work_packages/1/move?optimistic=true',
       expect.objectContaining({ method: 'PUT' }),
     );
   });
 
+  it('flags the move request as optimistic', async () => {
+    const { targetList, firstSourceItem } = renderFixture({
+      moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+    });
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    const calledUrl = fetchMock.mock.lastCall?.[0] as string;
+    expect(new URL(calledUrl, 'http://localhost').searchParams.get('optimistic')).toBe('true');
+  });
+
   it('ignores the turbo frame query when building the move URL', async () => {
     // The move endpoint does not read filter params, and the active filter is
-    // preserved by the frame reloading its own src. The move URL is therefore
-    // the bare template, even when the frame carries a filtered src.
+    // preserved by the frame reloading its own src. The move URL therefore
+    // carries no frame params, even when the frame has a filtered src.
     fixture.innerHTML = `
       <turbo-frame
         id="backlogs-list"
@@ -357,7 +369,7 @@ describe('Sortable lists controller', () => {
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/projects/demo/backlogs/work_packages/1/move',
+      '/projects/demo/backlogs/work_packages/1/move?optimistic=true',
       expect.objectContaining({ method: 'PUT' }),
     );
   });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -739,4 +739,14 @@ describe('Sortable lists controller', () => {
 
     expect(controller.itemMovePosition(firstSourceItem)).toEqual({ isFirst: true, isLast: false });
   });
+
+  it('reports directional availability for gating', async () => {
+    const { root, firstSourceItem } = renderFixture();
+    await ctx.nextFrame();
+    const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+
+    // First item: down/bottom available, up/top not.
+    expect(controller.directionalMoveAvailable(firstSourceItem, 'down')).toBe(true);
+    expect(controller.directionalMoveAvailable(firstSourceItem, 'up')).toBe(false);
+  });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -317,6 +317,9 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     }
   }
 
+  // The template must expand to a same-origin relative URL: the expansion is
+  // reduced to path + search + hash, so an absolute template's origin would
+  // be dropped silently.
   private resolveMoveUrl(data:{ itemId:string }):string|null {
     if (!this.hasMoveUrlTemplateValue) {
       return null;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -248,7 +248,13 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return null;
     }
 
-    return parseTemplate(this.moveUrlTemplateValue).expand({ id: data.itemId });
+    const expanded = parseTemplate(this.moveUrlTemplateValue).expand({ id: data.itemId });
+    const url = new URL(expanded, window.location.href);
+    // Flag drag moves (already applied in the DOM) so a same-list move skips
+    // the frame reload. Menu moves use a different path and stay unflagged.
+    url.searchParams.set('optimistic', 'true');
+
+    return `${url.pathname}${url.search}${url.hash}`;
   }
 
   private async moveItem({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -47,9 +47,14 @@ import {
 import {
   captureRowPositions,
   reorderRows,
+  resolveDirectionalPreviousItemId,
+  resolveItemId,
+  resolveItemMovePosition,
   restoreRowPositions,
+  rowOf,
   rowsRemainAt,
   sortableListsBusyAttribute,
+  type MoveDirection,
 } from './sortable-lists/list-dom';
 
 type CleanupFn = () => void;
@@ -159,6 +164,51 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     return this.element.hasAttribute(sortableListsBusyAttribute);
   }
 
+  itemMovePosition(itemElement:HTMLElement):{ isFirst:boolean; isLast:boolean }|null {
+    const list = this.ownerListOf(itemElement);
+
+    return list ? resolveItemMovePosition({ itemElement, rowsContainer: list.rowsContainer }) : null;
+  }
+
+  moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void {
+    if (this.busy) {
+      return;
+    }
+
+    const list = this.ownerListOf(itemElement);
+    if (!list) {
+      return;
+    }
+
+    const itemId = resolveItemId(itemElement);
+    if (!itemId) {
+      return;
+    }
+
+    const previousItemId = resolveDirectionalPreviousItemId({ itemElement, direction, rowsContainer: list.rowsContainer });
+    if (previousItemId === undefined) {
+      return;
+    }
+
+    const moveUrl = this.resolveMoveUrl({ itemId });
+    const sourceRow = rowOf(list.rowsContainer, itemElement);
+    if (!moveUrl || !sourceRow) {
+      return;
+    }
+
+    void this.performMove({
+      sourceRow,
+      rowsContainer: list.rowsContainer,
+      listData: list.listData,
+      previousItemId,
+      moveUrl,
+    });
+  }
+
+  private ownerListOf(itemElement:HTMLElement) {
+    return this.sortableListsListOutlets.find((list) => list.element.contains(itemElement)) ?? null;
+  }
+
   private async handleDrop({ location, source }:ElementDropPayload) {
     if (this.busy) {
       debugLog('sortable-lists: ignoring drop, a move is already in progress');
@@ -201,29 +251,47 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    // Move the row optimistically, then persist. The server response (a
-    // turbo-stream) reconciles the list on success; a failure rolls the row
-    // back to where it started.
+    await this.performMove({
+      sourceRow,
+      rowsContainer: intent.rowsContainer,
+      listData: intent.listData,
+      previousItemId: intent.previousItemId,
+      moveUrl,
+    });
+  }
+
+  // Optimistically reorder a single row, persist the move, and roll the row
+  // back (with a FLIP animation and an error toast) if the server rejects it.
+  // Shared by drag drops and programmatic menu moves.
+  private async performMove({
+    sourceRow,
+    rowsContainer,
+    listData,
+    previousItemId,
+    moveUrl,
+  }:{
+    sourceRow:HTMLElement;
+    rowsContainer:HTMLElement;
+    listData:SortableListData;
+    previousItemId:string|null;
+    moveUrl:string;
+  }):Promise<void> {
     const rows = [sourceRow];
     const rollback = captureRowPositions(rows);
-    reorderRows({ rows, rowsContainer: intent.rowsContainer, previousItemId: intent.previousItemId });
+    reorderRows({ rows, rowsContainer, previousItemId });
 
     // The reorder resolving back to the source's current DOM position means
-    // the drop is a no-op — nothing to persist, so no request. Comparing DOM
+    // the move is a no-op — nothing to persist, so no request. Comparing DOM
     // placement (not predecessor ids) keeps non-item rows such as truncation
     // markers out of the equation.
     if (rowsRemainAt(rollback)) {
-      debugLog('sortable-lists: ignoring drop, the item landed at its original position');
+      debugLog('sortable-lists: ignoring move, the item landed at its original position');
       return;
     }
 
     const optimisticPlacement = captureRowPositions(rows);
 
-    const result = await this.moveItem({
-      listData: intent.listData,
-      previousItemId: intent.previousItemId,
-      moveUrl,
-    });
+    const result = await this.moveItem({ listData, previousItemId, moveUrl });
 
     if (!result.ok) {
       try {
@@ -250,8 +318,9 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
     const expanded = parseTemplate(this.moveUrlTemplateValue).expand({ id: data.itemId });
     const url = new URL(expanded, window.location.href);
-    // Flag drag moves (already applied in the DOM) so a same-list move skips
-    // the frame reload. Menu moves use a different path and stay unflagged.
+    // Both drag and menu moves share this path and are flagged optimistic=true
+    // (the move is already applied in the DOM), so the server skips the frame
+    // reload for a same-list move.
     url.searchParams.set('optimistic', 'true');
 
     return `${url.pathname}${url.search}${url.hash}`;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -49,11 +49,12 @@ import {
   reorderRows,
   resolveDirectionalPreviousItemId,
   resolveItemId,
-  resolveItemMovePosition,
+  resolveMoveAvailability,
   restoreRowPositions,
   rowOf,
   rowsRemainAt,
   sortableListsBusyAttribute,
+  type MoveAvailability,
   type MoveDirection,
 } from './sortable-lists/list-dom';
 
@@ -164,23 +165,15 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     return this.element.hasAttribute(sortableListsBusyAttribute);
   }
 
-  itemMovePosition(itemElement:HTMLElement):{ isFirst:boolean; isLast:boolean }|null {
-    const list = this.ownerListOf(itemElement);
-
-    return list ? resolveItemMovePosition({ itemElement, rowsContainer: list.rowsContainer }) : null;
-  }
-
   // Availability mirrors executability: a direction is offered exactly when the
   // move resolver can produce a target for it. This keeps the menu honest about
   // truncated lists, where a one-step move across the hidden block is not
-  // addressable and the resolver returns undefined.
-  directionalMoveAvailable(itemElement:HTMLElement, direction:MoveDirection):boolean {
+  // addressable. Null means the item is not in an owned list (yet). The result
+  // is a snapshot for menu gating; the click path re-resolves the live DOM.
+  moveAvailability(itemElement:HTMLElement):MoveAvailability|null {
     const list = this.ownerListOf(itemElement);
-    if (!list) {
-      return false;
-    }
 
-    return resolveDirectionalPreviousItemId({ itemElement, direction, rowsContainer: list.rowsContainer }) !== undefined;
+    return list ? resolveMoveAvailability({ itemElement, rowsContainer: list.rowsContainer }) : null;
   }
 
   moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -170,6 +170,19 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     return list ? resolveItemMovePosition({ itemElement, rowsContainer: list.rowsContainer }) : null;
   }
 
+  // Availability mirrors executability: a direction is offered exactly when the
+  // move resolver can produce a target for it. This keeps the menu honest about
+  // truncated lists, where a one-step move across the hidden block is not
+  // addressable and the resolver returns undefined.
+  directionalMoveAvailable(itemElement:HTMLElement, direction:MoveDirection):boolean {
+    const list = this.ownerListOf(itemElement);
+    if (!list) {
+      return false;
+    }
+
+    return resolveDirectionalPreviousItemId({ itemElement, direction, rowsContainer: list.rowsContainer }) !== undefined;
+  }
+
   moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void {
     if (this.busy) {
       return;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -37,6 +37,7 @@ import {
   resolveListAppendPreviousItemId,
   resolvePreviousItemId,
   rowOf,
+  type MoveDirection,
 } from './list-dom';
 
 // The Pragmatic DnD payloads exchanged between the sortable-lists root and
@@ -71,6 +72,8 @@ export interface SortableListData extends Record<string|symbol, unknown> {
 export interface SortableListsRoot {
   readonly element:HTMLElement;
   readonly busy:boolean;
+  moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void;
+  itemMovePosition(itemElement:HTMLElement):{ isFirst:boolean; isLast:boolean }|null;
 }
 
 // Implemented by the list, item and scrollable controllers so the root can

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -74,6 +74,7 @@ export interface SortableListsRoot {
   readonly busy:boolean;
   moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void;
   itemMovePosition(itemElement:HTMLElement):{ isFirst:boolean; isLast:boolean }|null;
+  directionalMoveAvailable(itemElement:HTMLElement, direction:MoveDirection):boolean;
 }
 
 // Implemented by the list, item and scrollable controllers so the root can

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -37,6 +37,7 @@ import {
   resolveListAppendPreviousItemId,
   resolvePreviousItemId,
   rowOf,
+  type MoveAvailability,
   type MoveDirection,
 } from './list-dom';
 
@@ -73,8 +74,8 @@ export interface SortableListsRoot {
   readonly element:HTMLElement;
   readonly busy:boolean;
   moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void;
-  itemMovePosition(itemElement:HTMLElement):{ isFirst:boolean; isLast:boolean }|null;
-  directionalMoveAvailable(itemElement:HTMLElement, direction:MoveDirection):boolean;
+  // A snapshot for menu gating; the click path re-resolves against the live DOM.
+  moveAvailability(itemElement:HTMLElement):MoveAvailability|null;
 }
 
 // Implemented by the list, item and scrollable controllers so the root can

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -876,36 +876,8 @@ describe('Sortable lists item controller', () => {
       element: el, busy: false, moveAvailability: () => availability, moveInDirection,
     } as unknown as SortableListsRoot);
 
-    it('disables up/top for a first item and enables the rest', async () => {
+    it('hides up/top for a first item and shows the rest', async () => {
       const { el, menu } = renderItemWithMenu(1);
-      document.body.appendChild(el);
-      const controller = await mountItemController(el);
-      controller.connectRoot(stubRoot(el, { isFirst: true, isLast: false }));
-      controller.moveItemTargetConnected();
-
-      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'top'));
-      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'up'));
-      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'down'));
-      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'bottom'));
-    });
-
-    it('disables a mid-list direction the root reports unavailable (truncation gap)', async () => {
-      const { el, menu } = renderItemWithMenu(1);
-      document.body.appendChild(el);
-      const controller = await mountItemController(el);
-      // Not an extreme (neither first nor last), but the root deems "down"
-      // unavailable because it would cross a hidden block.
-      const gappedAvailability = { top: true, up: true, down: false, bottom: true };
-      controller.connectRoot(stubRoot(el, { isFirst: false, isLast: false }, vi.fn(), gappedAvailability));
-      controller.moveItemTargetConnected();
-
-      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'down'));
-      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'up'));
-    });
-
-    it('hides unavailable items instead of disabling them when hideUnavailable is set', async () => {
-      const { el, menu } = renderItemWithMenu(1);
-      el.setAttribute('data-sortable-lists--item-hide-unavailable-value', 'true');
       document.body.appendChild(el);
       const controller = await mountItemController(el);
       controller.connectRoot(stubRoot(el, { isFirst: true, isLast: false }));
@@ -915,11 +887,39 @@ describe('Sortable lists item controller', () => {
       expect(menu.hideItem).toHaveBeenCalledWith(liFor(el, 'up'));
       expect(menu.showItem).toHaveBeenCalledWith(liFor(el, 'down'));
       expect(menu.showItem).toHaveBeenCalledWith(liFor(el, 'bottom'));
-      expect(menu.disableItem).not.toHaveBeenCalled();
-      expect(menu.enableItem).not.toHaveBeenCalled();
     });
 
-    it('disables the parent submenu when nothing is available (single item)', async () => {
+    it('hides a mid-list direction the root reports unavailable (truncation gap)', async () => {
+      const { el, menu } = renderItemWithMenu(1);
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      // Not an extreme (neither first nor last), but the root deems "down"
+      // unavailable because it would cross a hidden block.
+      const gappedAvailability = { top: true, up: true, down: false, bottom: true };
+      controller.connectRoot(stubRoot(el, { isFirst: false, isLast: false }, vi.fn(), gappedAvailability));
+      controller.moveItemTargetConnected();
+
+      expect(menu.hideItem).toHaveBeenCalledWith(liFor(el, 'down'));
+      expect(menu.showItem).toHaveBeenCalledWith(liFor(el, 'up'));
+    });
+
+    it('disables unavailable items instead of hiding them when hideUnavailable is off', async () => {
+      const { el, menu } = renderItemWithMenu(1);
+      el.setAttribute('data-sortable-lists--item-hide-unavailable-value', 'false');
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      controller.connectRoot(stubRoot(el, { isFirst: true, isLast: false }));
+      controller.moveItemTargetConnected();
+
+      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'top'));
+      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'up'));
+      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'down'));
+      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'bottom'));
+      expect(menu.hideItem).not.toHaveBeenCalled();
+      expect(menu.showItem).not.toHaveBeenCalled();
+    });
+
+    it('hides the parent submenu when nothing is available (single item)', async () => {
       const { el, menu } = renderItemWithMenu(1);
       document.body.appendChild(el);
       const controller = await mountItemController(el);
@@ -927,7 +927,7 @@ describe('Sortable lists item controller', () => {
       controller.moveItemTargetConnected();
 
       const parent = el.querySelector<HTMLElement>('li[data-sortable-lists--item-target="moveMenu"]')!;
-      expect(menu.disableItem).toHaveBeenCalledWith(parent);
+      expect(menu.hideItem).toHaveBeenCalledWith(parent);
     });
 
     it('delegates an enabled click to the root and no-ops a disabled one', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -55,6 +55,7 @@ import type { preventUnhandled as preventUnhandledType } from '@atlaskit/pragmat
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type ItemControllerType from './item.controller';
 import type { SortableListsRoot } from './drag-and-drop';
+import type { MoveDirection } from './list-dom';
 
 describe('Sortable lists item controller', () => {
   let draggable:typeof draggableFn;
@@ -98,6 +99,7 @@ describe('Sortable lists item controller', () => {
       busy,
       moveInDirection: vi.fn(),
       itemMovePosition: vi.fn(() => null),
+      directionalMoveAvailable: vi.fn(() => false),
     };
   }
 
@@ -857,8 +859,29 @@ describe('Sortable lists item controller', () => {
     }
 
     const liFor = (el:HTMLElement, direction:string) => el.querySelector<HTMLElement>(`li[data-move-direction="${direction}"]`)!;
-    const stubRoot = (el:HTMLElement, position:{ isFirst:boolean; isLast:boolean }, moveInDirection = vi.fn()) => ({
-      element: el, busy: false, itemMovePosition: () => position, moveInDirection,
+    // Availability defaults to the first/last extremes so the position-driven
+    // specs read naturally; individual tests can override per direction to
+    // exercise the marker-aware (truncated list) wiring.
+    const availabilityFromPosition = (position:{ isFirst:boolean; isLast:boolean }) =>
+      (_el:HTMLElement, direction:MoveDirection):boolean => {
+        switch (direction) {
+          case 'top':
+          case 'up':
+            return !position.isFirst;
+          case 'down':
+          case 'bottom':
+            return !position.isLast;
+          default:
+            return false;
+        }
+      };
+    const stubRoot = (
+      el:HTMLElement,
+      position:{ isFirst:boolean; isLast:boolean },
+      moveInDirection = vi.fn(),
+      directionalMoveAvailable = availabilityFromPosition(position),
+    ) => ({
+      element: el, busy: false, itemMovePosition: () => position, directionalMoveAvailable, moveInDirection,
     } as unknown as SortableListsRoot);
 
     it('disables up/top for a first item and enables the rest', async () => {
@@ -872,6 +895,20 @@ describe('Sortable lists item controller', () => {
       expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'up'));
       expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'down'));
       expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'bottom'));
+    });
+
+    it('disables a mid-list direction the root reports unavailable (truncation gap)', async () => {
+      const { el, menu } = renderItemWithMenu(1);
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      // Not an extreme (neither first nor last), but the root deems "down"
+      // unavailable because it would cross a hidden block.
+      const gappedAvailability = (_el:HTMLElement, direction:MoveDirection) => direction !== 'down';
+      controller.connectRoot(stubRoot(el, { isFirst: false, isLast: false }, vi.fn(), gappedAvailability));
+      controller.moveItemTargetConnected();
+
+      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'down'));
+      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'up'));
     });
 
     it('disables the parent submenu when nothing is available (single item)', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -903,6 +903,22 @@ describe('Sortable lists item controller', () => {
       expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'up'));
     });
 
+    it('hides unavailable items instead of disabling them when hideUnavailable is set', async () => {
+      const { el, menu } = renderItemWithMenu(1);
+      el.setAttribute('data-sortable-lists--item-hide-unavailable-value', 'true');
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      controller.connectRoot(stubRoot(el, { isFirst: true, isLast: false }));
+      controller.moveItemTargetConnected();
+
+      expect(menu.hideItem).toHaveBeenCalledWith(liFor(el, 'top'));
+      expect(menu.hideItem).toHaveBeenCalledWith(liFor(el, 'up'));
+      expect(menu.showItem).toHaveBeenCalledWith(liFor(el, 'down'));
+      expect(menu.showItem).toHaveBeenCalledWith(liFor(el, 'bottom'));
+      expect(menu.disableItem).not.toHaveBeenCalled();
+      expect(menu.enableItem).not.toHaveBeenCalled();
+    });
+
     it('disables the parent submenu when nothing is available (single item)', async () => {
       const { el, menu } = renderItemWithMenu(1);
       document.body.appendChild(el);

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -55,7 +55,6 @@ import type { preventUnhandled as preventUnhandledType } from '@atlaskit/pragmat
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type ItemControllerType from './item.controller';
 import type { SortableListsRoot } from './drag-and-drop';
-import type { MoveDirection } from './list-dom';
 
 describe('Sortable lists item controller', () => {
   let draggable:typeof draggableFn;
@@ -98,8 +97,7 @@ describe('Sortable lists item controller', () => {
       element,
       busy,
       moveInDirection: vi.fn(),
-      itemMovePosition: vi.fn(() => null),
-      directionalMoveAvailable: vi.fn(() => false),
+      moveAvailability: vi.fn(() => null),
     };
   }
 
@@ -860,28 +858,21 @@ describe('Sortable lists item controller', () => {
 
     const liFor = (el:HTMLElement, direction:string) => el.querySelector<HTMLElement>(`li[data-move-direction="${direction}"]`)!;
     // Availability defaults to the first/last extremes so the position-driven
-    // specs read naturally; individual tests can override per direction to
-    // exercise the marker-aware (truncated list) wiring.
-    const availabilityFromPosition = (position:{ isFirst:boolean; isLast:boolean }) =>
-      (_el:HTMLElement, direction:MoveDirection):boolean => {
-        switch (direction) {
-          case 'top':
-          case 'up':
-            return !position.isFirst;
-          case 'down':
-          case 'bottom':
-            return !position.isLast;
-          default:
-            return false;
-        }
-      };
+    // specs read naturally; individual tests can override the map to exercise
+    // the marker-aware (truncated list) wiring.
+    const availabilityFromPosition = (position:{ isFirst:boolean; isLast:boolean }) => ({
+      top: !position.isFirst,
+      up: !position.isFirst,
+      down: !position.isLast,
+      bottom: !position.isLast,
+    });
     const stubRoot = (
       el:HTMLElement,
       position:{ isFirst:boolean; isLast:boolean },
       moveInDirection = vi.fn(),
-      directionalMoveAvailable = availabilityFromPosition(position),
+      availability = availabilityFromPosition(position),
     ) => ({
-      element: el, busy: false, itemMovePosition: () => position, directionalMoveAvailable, moveInDirection,
+      element: el, busy: false, moveAvailability: () => availability, moveInDirection,
     } as unknown as SortableListsRoot);
 
     it('disables up/top for a first item and enables the rest', async () => {
@@ -903,7 +894,7 @@ describe('Sortable lists item controller', () => {
       const controller = await mountItemController(el);
       // Not an extreme (neither first nor last), but the root deems "down"
       // unavailable because it would cross a hidden block.
-      const gappedAvailability = (_el:HTMLElement, direction:MoveDirection) => direction !== 'down';
+      const gappedAvailability = { top: true, up: true, down: false, bottom: true };
       controller.connectRoot(stubRoot(el, { isFirst: false, isLast: false }, vi.fn(), gappedAvailability));
       controller.moveItemTargetConnected();
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -93,7 +93,12 @@ describe('Sortable lists item controller', () => {
     { busy = false } = {},
   ):SortableListsRoot {
     Object.defineProperty(element, 'isConnected', { value: true, configurable: true });
-    return { element, busy };
+    return {
+      element,
+      busy,
+      moveInDirection: vi.fn(),
+      itemMovePosition: vi.fn(() => null),
+    };
   }
 
   function connectedControllerFor(
@@ -782,6 +787,145 @@ describe('Sortable lists item controller', () => {
 
       expect(container.classList.contains('Box--condensed')).toBe(false);
       expect(container.classList.contains('Box--spacious')).toBe(false);
+    });
+  });
+
+  describe('move menu', () => {
+    let menuCtx:StimulusTestContext|undefined;
+
+    afterEach(() => {
+      menuCtx?.dispose();
+      menuCtx = undefined;
+    });
+
+    // Mounts the element through Stimulus (the same setupStimulusTest harness
+    // the file's other wiring tests use), so targets/actions/elements wire the
+    // way they do in production rather than being newed up directly.
+    async function mountItemController(el:HTMLElement):Promise<InstanceType<typeof ItemControllerType>> {
+      menuCtx = await setupStimulusTest({
+        controllers: {
+          'sortable-lists--item': ItemController,
+        },
+      });
+      menuCtx.container.appendChild(el);
+      await menuCtx.nextFrame();
+
+      return menuCtx.getController<InstanceType<typeof ItemControllerType>>('sortable-lists--item', el);
+    }
+
+    // Builds an item element containing a fake <action-menu> whose four move
+    // items are <li> targets (direction + move action on the li). The menu
+    // stub exposes the Primer item-state API the controller calls;
+    // isItemDisabled is driven by a live class check so the click-guard test
+    // is realistic.
+    interface FakeActionMenu {
+      enableItem:ReturnType<typeof vi.fn>;
+      disableItem:ReturnType<typeof vi.fn>;
+      showItem:ReturnType<typeof vi.fn>;
+      hideItem:ReturnType<typeof vi.fn>;
+      isItemDisabled:ReturnType<typeof vi.fn>;
+      isItemHidden:ReturnType<typeof vi.fn>;
+    }
+
+    function renderItemWithMenu(idNumber:number):{ el:HTMLElement; menu:FakeActionMenu } {
+      const el = document.createElement('div');
+      el.dataset.controller = 'sortable-lists--item';
+      el.setAttribute('data-sortable-lists--item-id-value', String(idNumber));
+      el.setAttribute('data-sortable-lists--item-type-value', 'work_package');
+
+      const menuElement = document.createElement('action-menu');
+      menuElement.innerHTML = ['top', 'up', 'down', 'bottom'].map((direction) => (
+        `<li data-sortable-lists--item-target="moveItem" data-move-direction="${direction}"`
+        + ' data-action="click->sortable-lists--item#move"><button></button></li>'
+      )).join('');
+      const parent = document.createElement('li');
+      parent.setAttribute('data-sortable-lists--item-target', 'moveMenu');
+      menuElement.appendChild(parent);
+      el.appendChild(menuElement);
+
+      const menu:FakeActionMenu = {
+        enableItem: vi.fn((li:Element|null) => li?.classList.remove('ActionListItem--disabled')),
+        disableItem: vi.fn((li:Element|null) => li?.classList.add('ActionListItem--disabled')),
+        showItem: vi.fn(),
+        hideItem: vi.fn(),
+        isItemDisabled: vi.fn((li:Element|null) => !!li?.classList.contains('ActionListItem--disabled')),
+        isItemHidden: vi.fn(() => false),
+      };
+      Object.assign(menuElement, menu);
+
+      return { el, menu };
+    }
+
+    const liFor = (el:HTMLElement, direction:string) => el.querySelector<HTMLElement>(`li[data-move-direction="${direction}"]`)!;
+    const stubRoot = (el:HTMLElement, position:{ isFirst:boolean; isLast:boolean }, moveInDirection = vi.fn()) => ({
+      element: el, busy: false, itemMovePosition: () => position, moveInDirection,
+    } as unknown as SortableListsRoot);
+
+    it('disables up/top for a first item and enables the rest', async () => {
+      const { el, menu } = renderItemWithMenu(1);
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      controller.connectRoot(stubRoot(el, { isFirst: true, isLast: false }));
+      controller.moveItemTargetConnected();
+
+      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'top'));
+      expect(menu.disableItem).toHaveBeenCalledWith(liFor(el, 'up'));
+      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'down'));
+      expect(menu.enableItem).toHaveBeenCalledWith(liFor(el, 'bottom'));
+    });
+
+    it('disables the parent submenu when nothing is available (single item)', async () => {
+      const { el, menu } = renderItemWithMenu(1);
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      controller.connectRoot(stubRoot(el, { isFirst: true, isLast: true }));
+      controller.moveItemTargetConnected();
+
+      const parent = el.querySelector<HTMLElement>('li[data-sortable-lists--item-target="moveMenu"]')!;
+      expect(menu.disableItem).toHaveBeenCalledWith(parent);
+    });
+
+    it('delegates an enabled click to the root and no-ops a disabled one', async () => {
+      const { el } = renderItemWithMenu(2);
+      document.body.appendChild(el);
+      const moveInDirection = vi.fn();
+      const controller = await mountItemController(el);
+      controller.connectRoot(stubRoot(el, { isFirst: false, isLast: false }, moveInDirection));
+      controller.moveItemTargetConnected();
+
+      liFor(el, 'down').click();
+      expect(moveInDirection).toHaveBeenCalledWith(el, 'down');
+
+      liFor(el, 'up').classList.add('ActionListItem--disabled'); // menu.isItemDisabled now returns true for it
+      moveInDirection.mockClear();
+      liFor(el, 'up').click();
+      expect(moveInDirection).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there is no action-menu (drag-only consumer)', async () => {
+      const el = document.createElement('div');
+      el.dataset.controller = 'sortable-lists--item';
+      el.setAttribute('data-sortable-lists--item-id-value', '1');
+      el.setAttribute('data-sortable-lists--item-type-value', 'work_package');
+      document.body.appendChild(el);
+      const controller = await mountItemController(el);
+      const moveInDirection = vi.fn();
+
+      // No moveItem targets and no <action-menu>: the availability refresh
+      // must no-op, not throw.
+      expect(() => {
+        controller.connectRoot(stubRoot(el, { isFirst: true, isLast: true }, moveInDirection));
+        // @ts-expect-error exercising the guard directly
+        controller.refreshMoveMenuAvailability?.();
+      }).not.toThrow();
+
+      // move() must also no-op rather than throw: there is no menu to read
+      // isItemDisabled/isItemHidden from, and no move should reach the root.
+      const moveEvent = new Event('click');
+      Object.defineProperty(moveEvent, 'currentTarget', { value: el });
+
+      expect(() => controller.move(moveEvent)).not.toThrow();
+      expect(moveInDirection).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -53,6 +53,7 @@ import type { draggable as draggableFn, dropTargetForElements as dropTargetForEl
 import type { setCustomNativeDragPreview as setCustomNativeDragPreviewFn } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
 import type { preventUnhandled as preventUnhandledType } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type { ActionEvent } from '@hotwired/stimulus';
 import type ItemControllerType from './item.controller';
 import type { SortableListsRoot } from './drag-and-drop';
 
@@ -835,7 +836,7 @@ describe('Sortable lists item controller', () => {
 
       const menuElement = document.createElement('action-menu');
       menuElement.innerHTML = ['top', 'up', 'down', 'bottom'].map((direction) => (
-        `<li data-sortable-lists--item-target="moveItem" data-move-direction="${direction}"`
+        `<li data-sortable-lists--item-target="moveItem" data-sortable-lists--item-direction-param="${direction}"`
         + ' data-action="click->sortable-lists--item#move"><button></button></li>'
       )).join('');
       const parent = document.createElement('li');
@@ -856,7 +857,7 @@ describe('Sortable lists item controller', () => {
       return { el, menu };
     }
 
-    const liFor = (el:HTMLElement, direction:string) => el.querySelector<HTMLElement>(`li[data-move-direction="${direction}"]`)!;
+    const liFor = (el:HTMLElement, direction:string) => el.querySelector<HTMLElement>(`li[data-sortable-lists--item-direction-param="${direction}"]`)!;
     // Availability defaults to the first/last extremes so the position-driven
     // specs read naturally; individual tests can override the map to exercise
     // the marker-aware (truncated list) wiring.
@@ -949,7 +950,7 @@ describe('Sortable lists item controller', () => {
 
       // move() must also no-op rather than throw: there is no menu to read
       // isItemDisabled/isItemHidden from, and no move should reach the root.
-      const moveEvent = new Event('click');
+      const moveEvent:ActionEvent = Object.assign(new Event('click'), { params: {} });
       Object.defineProperty(moveEvent, 'currentTarget', { value: el });
 
       expect(() => controller.move(moveEvent)).not.toThrow();

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -59,7 +59,7 @@ export default class ItemController extends Controller<HTMLElement> implements R
   static values = {
     id: String,
     type: String,
-    hideUnavailable: { type: Boolean, default: false },
+    hideUnavailable: { type: Boolean, default: true },
   };
 
   declare readonly idValue:string;
@@ -402,7 +402,7 @@ export default class ItemController extends Controller<HTMLElement> implements R
   // Availability goes through the action-menu element's API: disableItem sets the
   // ActionListItem--disabled class plus aria-disabled on the item's content, and
   // hideItem toggles hidden. It operates on any descendant li, including the ones
-  // in the nested move submenu. Default is disable; hideUnavailable switches to hide.
+  // in the nested move submenu. Default is hide; hideUnavailable=false switches to disable.
   private setAvailability(item:HTMLElement, available:boolean):void {
     const menu = this.menuElement;
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -37,7 +37,7 @@ import { preserveOffsetOnSource } from '@atlaskit/pragmatic-drag-and-drop/elemen
 import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
 import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
 import { type Input } from '@atlaskit/pragmatic-drag-and-drop/types';
-import { Controller } from '@hotwired/stimulus';
+import { Controller, type ActionEvent } from '@hotwired/stimulus';
 import type { ActionMenuElement } from '@openproject/primer-view-components/app/components/primer/alpha/action_menu/action_menu_element';
 import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 import {
@@ -47,7 +47,7 @@ import {
   type SortableItemData,
   type SortableListsRoot,
 } from './drag-and-drop';
-import { sortableItemSelector, type MoveDirection } from './list-dom';
+import { isMoveDirection, sortableItemSelector } from './list-dom';
 import { renderDragPreview } from './preview';
 
 type CleanupFn = () => void;
@@ -125,7 +125,7 @@ export default class ItemController extends Controller<HTMLElement> implements R
     this.refreshMoveMenuAvailability();
   }
 
-  move(event:Event):void {
+  move(event:ActionEvent):void {
     const item = event.currentTarget;
     if (!this.hasMenuElement || !(item instanceof HTMLElement)) {
       return;
@@ -135,8 +135,8 @@ export default class ItemController extends Controller<HTMLElement> implements R
       return;
     }
 
-    const direction = item.dataset.moveDirection as MoveDirection|undefined;
-    if (direction) {
+    const { direction } = event.params;
+    if (isMoveDirection(direction)) {
       this.root?.moveInDirection(this.element, direction);
     }
   }
@@ -384,8 +384,10 @@ export default class ItemController extends Controller<HTMLElement> implements R
 
     let available = 0;
     for (const item of this.moveItemTargets) {
-      const direction = item.dataset.moveDirection as MoveDirection|undefined;
-      const enabled = !!direction && availability[direction];
+      // Outside a Stimulus action there is no event.params, so read the
+      // param's backing attribute directly.
+      const direction = item.getAttribute(`data-${this.identifier}-direction-param`);
+      const enabled = isMoveDirection(direction) && availability[direction];
       this.setAvailability(item, enabled);
       if (enabled) {
         available += 1;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -375,16 +375,17 @@ export default class ItemController extends Controller<HTMLElement> implements R
       return;
     }
 
-    // A null position means the item is not in a list yet; leave the menu alone
-    // until the outlet wiring settles.
-    if (!root.itemMovePosition(this.element)) {
+    // Null availability means the item is not in a list yet; leave the menu
+    // alone until the outlet wiring settles.
+    const availability = root.moveAvailability(this.element);
+    if (!availability) {
       return;
     }
 
     let available = 0;
     for (const item of this.moveItemTargets) {
       const direction = item.dataset.moveDirection as MoveDirection|undefined;
-      const enabled = !!direction && root.directionalMoveAvailable(this.element, direction);
+      const enabled = !!direction && availability[direction];
       this.setAvailability(item, enabled);
       if (enabled) {
         available += 1;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -370,14 +370,21 @@ export default class ItemController extends Controller<HTMLElement> implements R
   }
 
   private refreshMoveMenuAvailability():void {
-    const position = this.root?.itemMovePosition(this.element);
-    if (!this.hasMenuElement || !position) {
+    const root = this.root;
+    if (!root || !this.hasMenuElement) {
+      return;
+    }
+
+    // A null position means the item is not in a list yet; leave the menu alone
+    // until the outlet wiring settles.
+    if (!root.itemMovePosition(this.element)) {
       return;
     }
 
     let available = 0;
     for (const item of this.moveItemTargets) {
-      const enabled = this.directionAvailable(item.dataset.moveDirection as MoveDirection|undefined, position);
+      const direction = item.dataset.moveDirection as MoveDirection|undefined;
+      const enabled = !!direction && root.directionalMoveAvailable(this.element, direction);
       this.setAvailability(item, enabled);
       if (enabled) {
         available += 1;
@@ -386,19 +393,6 @@ export default class ItemController extends Controller<HTMLElement> implements R
 
     if (this.hasMoveMenuTarget) {
       this.setAvailability(this.moveMenuTarget, available > 0);
-    }
-  }
-
-  private directionAvailable(direction:MoveDirection|undefined, position:{ isFirst:boolean; isLast:boolean }):boolean {
-    switch (direction) {
-      case 'top':
-      case 'up':
-        return !position.isFirst;
-      case 'down':
-      case 'bottom':
-        return !position.isLast;
-      default:
-        return false;
     }
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -38,6 +38,7 @@ import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/el
 import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
 import { type Input } from '@atlaskit/pragmatic-drag-and-drop/types';
 import { Controller } from '@hotwired/stimulus';
+import type { ActionMenuElement } from '@openproject/primer-view-components/app/components/primer/alpha/action_menu/action_menu_element';
 import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 import {
   isItemFromRoot,
@@ -46,36 +47,60 @@ import {
   type SortableItemData,
   type SortableListsRoot,
 } from './drag-and-drop';
-import { sortableItemSelector } from './list-dom';
+import { sortableItemSelector, type MoveDirection } from './list-dom';
 import { renderDragPreview } from './preview';
 
 type CleanupFn = () => void;
 
 export default class ItemController extends Controller<HTMLElement> implements RootAwareChild {
-  static targets = ['handle', 'preview'];
+  static targets = ['handle', 'preview', 'moveItem', 'moveMenu'];
+  static elements = { menu: 'action-menu' };
 
   static values = {
     id: String,
     type: String,
+    hideUnavailable: { type: Boolean, default: false },
   };
 
   declare readonly idValue:string;
   declare readonly hasIdValue:boolean;
   declare readonly typeValue:string;
   declare readonly hasTypeValue:boolean;
+  declare readonly hideUnavailableValue:boolean;
 
   declare readonly handleTarget:HTMLElement;
   declare readonly hasHandleTarget:boolean;
   declare readonly previewTarget:HTMLElement;
   declare readonly hasPreviewTarget:boolean;
+  declare readonly moveItemTargets:HTMLElement[];
+  declare readonly moveMenuTarget:HTMLElement;
+  declare readonly hasMoveMenuTarget:boolean;
+
+  // Provided by the stimulus-elements blessing; absent when the item is not
+  // inside a Primer action-menu (a drag-only consumer), in which case the move
+  // menu simply does nothing — drag behaviour is unaffected.
+  declare readonly menuElement:ActionMenuElement;
+  declare readonly hasMenuElement:boolean;
 
   private cleanupFn?:CleanupFn;
   private dropIndicatorElement?:HTMLElement;
   private root?:SortableListsRoot;
 
+  private readonly onMenuToggle = (event:Event):void => {
+    // The toggle event does not bubble, so listen in capture phase; recompute
+    // availability whenever the card menu opens, since a reorder can have
+    // shifted siblings meanwhile. Read newState by duck typing rather than
+    // `instanceof ToggleEvent` so a browser without the ToggleEvent global
+    // cannot throw.
+    if ((event as ToggleEvent).newState === 'open') {
+      this.refreshMoveMenuAvailability();
+    }
+  };
+
   connect():void {
     this.warnOnMissingValues();
     this.register();
+    this.element.addEventListener('toggle', this.onMenuToggle, true);
   }
 
   disconnect():void {
@@ -85,7 +110,35 @@ export default class ItemController extends Controller<HTMLElement> implements R
     this.clearDropIndicator();
     this.cleanupFn?.();
     this.cleanupFn = undefined;
+    this.element.removeEventListener('toggle', this.onMenuToggle, true);
     this.disconnectRoot();
+  }
+
+  // A move item entering the DOM (inline or via a deferred fragment) triggers
+  // an availability refresh here, but `this.root` is usually still unset at
+  // this point (the outlet's connectRoot callback runs later), so this call
+  // typically no-ops. The menu-open toggle handler is what actually
+  // establishes correct availability, refreshing on every open once the root
+  // is connected and after any reorder has shifted siblings. No
+  // include-fragment knowledge, so both hooks work for any menu.
+  moveItemTargetConnected():void {
+    this.refreshMoveMenuAvailability();
+  }
+
+  move(event:Event):void {
+    const item = event.currentTarget;
+    if (!this.hasMenuElement || !(item instanceof HTMLElement)) {
+      return;
+    }
+
+    if (this.menuElement.isItemDisabled(item) || this.menuElement.isItemHidden(item)) {
+      return;
+    }
+
+    const direction = item.dataset.moveDirection as MoveDirection|undefined;
+    if (direction) {
+      this.root?.moveInDirection(this.element, direction);
+    }
   }
 
   // Called by the root controller's outlet-connected callback.
@@ -314,5 +367,58 @@ export default class ItemController extends Controller<HTMLElement> implements R
     }
 
     this.dropIndicatorElement = undefined;
+  }
+
+  private refreshMoveMenuAvailability():void {
+    const position = this.root?.itemMovePosition(this.element);
+    if (!this.hasMenuElement || !position) {
+      return;
+    }
+
+    let available = 0;
+    for (const item of this.moveItemTargets) {
+      const enabled = this.directionAvailable(item.dataset.moveDirection as MoveDirection|undefined, position);
+      this.setAvailability(item, enabled);
+      if (enabled) {
+        available += 1;
+      }
+    }
+
+    if (this.hasMoveMenuTarget) {
+      this.setAvailability(this.moveMenuTarget, available > 0);
+    }
+  }
+
+  private directionAvailable(direction:MoveDirection|undefined, position:{ isFirst:boolean; isLast:boolean }):boolean {
+    switch (direction) {
+      case 'top':
+      case 'up':
+        return !position.isFirst;
+      case 'down':
+      case 'bottom':
+        return !position.isLast;
+      default:
+        return false;
+    }
+  }
+
+  // Availability goes through the action-menu element's API: disableItem sets the
+  // ActionListItem--disabled class plus aria-disabled on the item's content, and
+  // hideItem toggles hidden. It operates on any descendant li, including the ones
+  // in the nested move submenu. Default is disable; hideUnavailable switches to hide.
+  private setAvailability(item:HTMLElement, available:boolean):void {
+    const menu = this.menuElement;
+
+    if (this.hideUnavailableValue) {
+      if (available) {
+        menu.showItem(item);
+      } else {
+        menu.hideItem(item);
+      }
+    } else if (available) {
+      menu.enableItem(item);
+    } else {
+      menu.disableItem(item);
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -30,7 +30,7 @@ import {
   captureRowPositions,
   reorderRows,
   resolveDirectionalPreviousItemId,
-  resolveItemMovePosition,
+  resolveMoveAvailability,
   resolveListAppendPreviousItemId,
   restoreRowPositions,
   rowOf,
@@ -328,17 +328,20 @@ describe('directional move helpers', () => {
   }
   const itemAt = (ul:HTMLElement, index:number) => ul.children[index] as HTMLElement;
 
-  it('reports first/last position', () => {
+  it('reports per-direction availability', () => {
     const ul = container(['1', '2', '3']);
-    expect(resolveItemMovePosition({ itemElement: itemAt(ul, 0), rowsContainer: ul })).toEqual({ isFirst: true, isLast: false });
-    expect(resolveItemMovePosition({ itemElement: itemAt(ul, 1), rowsContainer: ul })).toEqual({ isFirst: false, isLast: false });
-    expect(resolveItemMovePosition({ itemElement: itemAt(ul, 2), rowsContainer: ul })).toEqual({ isFirst: false, isLast: true });
+    expect(resolveMoveAvailability({ itemElement: itemAt(ul, 0), rowsContainer: ul }))
+      .toEqual({ top: false, up: false, down: true, bottom: true });
+    expect(resolveMoveAvailability({ itemElement: itemAt(ul, 1), rowsContainer: ul }))
+      .toEqual({ top: true, up: true, down: true, bottom: true });
+    expect(resolveMoveAvailability({ itemElement: itemAt(ul, 2), rowsContainer: ul }))
+      .toEqual({ top: true, up: true, down: false, bottom: false });
   });
 
-  it('returns null when the item is not in the container', () => {
+  it('returns null availability when the item is not in the container', () => {
     const ul = container(['1']);
     const stray = document.createElement('li');
-    expect(resolveItemMovePosition({ itemElement: stray, rowsContainer: ul })).toBeNull();
+    expect(resolveMoveAvailability({ itemElement: stray, rowsContainer: ul })).toBeNull();
   });
 
   it('maps each direction to a previous item id', () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -29,6 +29,8 @@
 import {
   captureRowPositions,
   reorderRows,
+  resolveDirectionalPreviousItemId,
+  resolveItemMovePosition,
   resolveListAppendPreviousItemId,
   restoreRowPositions,
   rowOf,
@@ -315,5 +317,49 @@ describe('sortable lists DOM helpers', () => {
 
       expect(rowsRemainAt(optimistic)).toBe(false);
     });
+  });
+});
+
+describe('directional move helpers', () => {
+  function container(ids:string[]):HTMLElement {
+    const ul = document.createElement('ul');
+    ul.innerHTML = ids.map((id) => `<li data-sortable-lists--item-id-value="${id}"></li>`).join('');
+    return ul;
+  }
+  const itemAt = (ul:HTMLElement, index:number) => ul.children[index] as HTMLElement;
+
+  it('reports first/last position', () => {
+    const ul = container(['1', '2', '3']);
+    expect(resolveItemMovePosition({ itemElement: itemAt(ul, 0), rowsContainer: ul })).toEqual({ isFirst: true, isLast: false });
+    expect(resolveItemMovePosition({ itemElement: itemAt(ul, 1), rowsContainer: ul })).toEqual({ isFirst: false, isLast: false });
+    expect(resolveItemMovePosition({ itemElement: itemAt(ul, 2), rowsContainer: ul })).toEqual({ isFirst: false, isLast: true });
+  });
+
+  it('returns null when the item is not in the container', () => {
+    const ul = container(['1']);
+    const stray = document.createElement('li');
+    expect(resolveItemMovePosition({ itemElement: stray, rowsContainer: ul })).toBeNull();
+  });
+
+  it('maps each direction to a previous item id', () => {
+    const ul = container(['1', '2', '3', '4']);
+    const at = (i:number) => ({ itemElement: itemAt(ul, i), rowsContainer: ul });
+    // item '3' (index 2)
+    expect(resolveDirectionalPreviousItemId({ ...at(2), direction: 'top' })).toBeNull();
+    expect(resolveDirectionalPreviousItemId({ ...at(2), direction: 'up' })).toBe('1');
+    expect(resolveDirectionalPreviousItemId({ ...at(2), direction: 'down' })).toBe('4');
+    expect(resolveDirectionalPreviousItemId({ ...at(2), direction: 'bottom' })).toBe('4');
+    // second item moving up lands at the top
+    expect(resolveDirectionalPreviousItemId({ ...at(1), direction: 'up' })).toBeNull();
+  });
+
+  it('returns undefined when the direction is unavailable', () => {
+    const ul = container(['1', '2']);
+    const first = { itemElement: itemAt(ul, 0), rowsContainer: ul };
+    const last = { itemElement: itemAt(ul, 1), rowsContainer: ul };
+    expect(resolveDirectionalPreviousItemId({ ...first, direction: 'top' })).toBeUndefined();
+    expect(resolveDirectionalPreviousItemId({ ...first, direction: 'up' })).toBeUndefined();
+    expect(resolveDirectionalPreviousItemId({ ...last, direction: 'down' })).toBeUndefined();
+    expect(resolveDirectionalPreviousItemId({ ...last, direction: 'bottom' })).toBeUndefined();
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -411,4 +411,46 @@ describe('directional move helpers', () => {
       expect(resolveDirectionalPreviousItemId({ ...at(ul, 't2'), direction: 'bottom' })).toBeUndefined();
     });
   });
+
+  describe('across an unannotated non-item row (a divider between items)', () => {
+    // Rows: a, b, <divider with no prev-item-id>, c, d. Unlike a truncation
+    // marker the divider gives no anchor, so one-step moves cannot cross or
+    // land next to it; only the extremes stay available.
+    function dividedContainer():HTMLElement {
+      const ul = document.createElement('ul');
+      ul.innerHTML = [
+        '<li data-sortable-lists--item-id-value="a"></li>',
+        '<li data-sortable-lists--item-id-value="b"></li>',
+        '<li class="divider"></li>',
+        '<li data-sortable-lists--item-id-value="c"></li>',
+        '<li data-sortable-lists--item-id-value="d"></li>',
+      ].join('');
+      return ul;
+    }
+    const byId = (ul:HTMLElement, id:string) =>
+      ul.querySelector<HTMLElement>(`[data-sortable-lists--item-id-value="${id}"]`)!;
+    const at = (ul:HTMLElement, id:string) => ({ itemElement: byId(ul, id), rowsContainer: ul });
+
+    it('disables one-step moves whose neighbouring row is the divider', () => {
+      const ul = dividedContainer();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'b'), direction: 'down' })).toBeUndefined();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'c'), direction: 'up' })).toBeUndefined();
+    });
+
+    it('disables a one-step up whose would-be predecessor is the divider', () => {
+      const ul = dividedContainer();
+      // "before c but after the divider" cannot be expressed as a previous
+      // item id, so d moving up one slot is unavailable.
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'd'), direction: 'up' })).toBeUndefined();
+    });
+
+    it('keeps the extremes and same-chunk steps available', () => {
+      const ul = dividedContainer();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'a'), direction: 'down' })).toBe('b');
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'c'), direction: 'down' })).toBe('d');
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'b'), direction: 'top' })).toBeNull();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'a'), direction: 'bottom' })).toBe('d');
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'd'), direction: 'top' })).toBeNull();
+    });
+  });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -362,4 +362,53 @@ describe('directional move helpers', () => {
     expect(resolveDirectionalPreviousItemId({ ...last, direction: 'down' })).toBeUndefined();
     expect(resolveDirectionalPreviousItemId({ ...last, direction: 'bottom' })).toBeUndefined();
   });
+
+  describe('across a truncation marker (sparse list: head + hidden block + tail)', () => {
+    // Rows: h1, h2, <marker prev=last-hidden>, t1, t2. The marker stands in for
+    // a block of hidden work packages the client cannot address one item at a
+    // time.
+    function truncatedContainer():HTMLElement {
+      const ul = document.createElement('ul');
+      ul.innerHTML = [
+        '<li data-sortable-lists--item-id-value="h1"></li>',
+        '<li data-sortable-lists--item-id-value="h2"></li>',
+        '<li data-sortable-lists-prev-item-id="last-hidden"></li>',
+        '<li data-sortable-lists--item-id-value="t1"></li>',
+        '<li data-sortable-lists--item-id-value="t2"></li>',
+      ].join('');
+      return ul;
+    }
+    const byId = (ul:HTMLElement, id:string) =>
+      ul.querySelector<HTMLElement>(`[data-sortable-lists--item-id-value="${id}"]`)!;
+    const at = (ul:HTMLElement, id:string) => ({ itemElement: byId(ul, id), rowsContainer: ul });
+
+    it('disables a one-step move that would cross the hidden block', () => {
+      const ul = truncatedContainer();
+      // "down" from the last head item and "up" from the first tail item would
+      // jump the whole hidden block, so they are unavailable.
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'h2'), direction: 'down' })).toBeUndefined();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 't1'), direction: 'up' })).toBeUndefined();
+    });
+
+    it('keeps one-step moves within a visible chunk', () => {
+      const ul = truncatedContainer();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'h1'), direction: 'down' })).toBe('h2');
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'h2'), direction: 'up' })).toBeNull();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 't1'), direction: 'down' })).toBe('t2');
+    });
+
+    it('anchors a tail item stepping up onto the hidden block via the marker id', () => {
+      const ul = truncatedContainer();
+      // t2 up one slot lands just after the hidden block, before t1.
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 't2'), direction: 'up' })).toBe('last-hidden');
+    });
+
+    it('still allows the addressable extremes across the block', () => {
+      const ul = truncatedContainer();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'h1'), direction: 'top' })).toBeUndefined();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 'h1'), direction: 'bottom' })).toBe('t2');
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 't2'), direction: 'top' })).toBeNull();
+      expect(resolveDirectionalPreviousItemId({ ...at(ul, 't2'), direction: 'bottom' })).toBeUndefined();
+    });
+  });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -201,14 +201,14 @@ function insertAtListTop(rowsContainer:HTMLElement, row:HTMLElement):void {
   }
 }
 
-export type MoveDirection = 'top'|'up'|'down'|'bottom';
+const moveDirections = ['top', 'up', 'down', 'bottom'] as const;
 
-const moveDirections:readonly string[] = ['top', 'up', 'down', 'bottom'];
+export type MoveDirection = typeof moveDirections[number];
 
 // Values crossing the DOM boundary (action params, data attributes) arrive
 // untyped; narrow them instead of casting.
 export function isMoveDirection(value:unknown):value is MoveDirection {
-  return typeof value === 'string' && moveDirections.includes(value);
+  return typeof value === 'string' && (moveDirections as readonly string[]).includes(value);
 }
 
 function isItemRow(row:Element|undefined):boolean {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -203,33 +203,6 @@ function insertAtListTop(rowsContainer:HTMLElement, row:HTMLElement):void {
 
 export type MoveDirection = 'top'|'up'|'down'|'bottom';
 
-// One item element per row of the container, in document order. Mirrors the
-// row model the drag path uses (a row resolves to at most one item element).
-function containerItemElements(rowsContainer:Element):HTMLElement[] {
-  return Array.from(rowsContainer.children)
-    .map((row) => resolveItemElement(row))
-    .filter((item):item is HTMLElement => item !== null);
-}
-
-export function resolveItemMovePosition({
-  itemElement,
-  rowsContainer,
-}:{
-  itemElement:HTMLElement;
-  rowsContainer:Element;
-}):{ isFirst:boolean; isLast:boolean }|null {
-  const items = containerItemElements(rowsContainer);
-  const index = items.indexOf(itemElement);
-
-  if (index === -1) {
-    return null;
-  }
-
-  return { isFirst: index === 0, isLast: index === items.length - 1 };
-}
-
-// A truncation marker is a non-item row that stands in for a block of hidden
-// items, carrying the last omitted item's id on data-sortable-lists-prev-item-id.
 function isItemRow(row:Element|undefined):boolean {
   return !!row && resolveItemElement(row) !== null;
 }
@@ -262,16 +235,63 @@ export function resolveDirectionalPreviousItemId({
   direction:MoveDirection;
   rowsContainer:Element;
 }):string|null|undefined {
+  const context = resolveRowContext(itemElement, rowsContainer);
+
+  return context ? directionalPreviousItemIdIn(context, direction) : undefined;
+}
+
+export type MoveAvailability = Record<MoveDirection, boolean>;
+
+// Availability of all four directional moves for the item, or null when it is
+// not (yet) a row of the container. The row scan happens once; the four
+// per-direction resolutions only index into it.
+export function resolveMoveAvailability({
+  itemElement,
+  rowsContainer,
+}:{
+  itemElement:HTMLElement;
+  rowsContainer:Element;
+}):MoveAvailability|null {
+  const context = resolveRowContext(itemElement, rowsContainer);
+  if (!context) {
+    return null;
+  }
+
+  return {
+    top: directionalPreviousItemIdIn(context, 'top') !== undefined,
+    up: directionalPreviousItemIdIn(context, 'up') !== undefined,
+    down: directionalPreviousItemIdIn(context, 'down') !== undefined,
+    bottom: directionalPreviousItemIdIn(context, 'bottom') !== undefined,
+  };
+}
+
+// The item's row neighbourhood, scanned once and shared by the per-direction
+// resolutions above.
+interface RowContext {
+  rows:Element[];
+  rowIndex:number;
+  itemRows:Element[];
+  itemIndex:number;
+}
+
+function resolveRowContext(itemElement:HTMLElement, rowsContainer:Element):RowContext|null {
   const rows = listRows(rowsContainer);
   const sourceRow = rowOf(rowsContainer, itemElement);
   const rowIndex = sourceRow ? rows.indexOf(sourceRow) : -1;
 
   if (rowIndex === -1) {
-    return undefined;
+    return null;
   }
 
   const itemRows = rows.filter((row) => resolveItemElement(row) !== null);
-  const itemIndex = itemRows.indexOf(sourceRow!);
+
+  return { rows, rowIndex, itemRows, itemIndex: itemRows.indexOf(sourceRow!) };
+}
+
+function directionalPreviousItemIdIn(
+  { rows, rowIndex, itemRows, itemIndex }:RowContext,
+  direction:MoveDirection,
+):string|null|undefined {
   const isFirstItem = itemIndex === 0;
   const isLastItem = itemIndex === itemRows.length - 1;
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -230,8 +230,16 @@ export function resolveItemMovePosition({
 
 // A truncation marker is a non-item row that stands in for a block of hidden
 // items, carrying the last omitted item's id on data-sortable-lists-prev-item-id.
-function isMarkerRow(row:Element|undefined):boolean {
-  return !!row && resolveItemElement(row) === null && row.hasAttribute(sortablePreviousItemIdAttribute);
+function isItemRow(row:Element|undefined):boolean {
+  return !!row && resolveItemElement(row) !== null;
+}
+
+// A row a predecessor id can be read from: an item row, or a non-item row
+// annotated with the id of the last hidden item it stands in for (a
+// truncation marker). Unannotated non-item rows (a divider, a heading) give
+// no anchor, so a move over them cannot be expressed.
+function isAddressableRow(row:Element):boolean {
+  return isItemRow(row) || row.hasAttribute(sortablePreviousItemIdAttribute);
 }
 
 // The previous item id to insert `itemElement` after for a directional move:
@@ -243,7 +251,8 @@ function isMarkerRow(row:Element|undefined):boolean {
 // participates. The hidden block a marker represents cannot be addressed one
 // item at a time, so a single-step up/down that would cross it is unavailable;
 // the addressable extremes (top/bottom) and moves that land next to the block
-// via the marker's id stay available.
+// via the marker's id stay available. Unannotated non-item rows are hard gaps
+// for one-step moves, while top/bottom anchor on item rows and stay available.
 export function resolveDirectionalPreviousItemId({
   itemElement,
   direction,
@@ -274,18 +283,22 @@ export function resolveDirectionalPreviousItemId({
       return isLastItem ? undefined : resolvePreviousItemId(itemRows[itemRows.length - 1]);
     case 'up': {
       if (isFirstItem) return undefined;
-      // One slot up crosses the hidden block when the row above is the marker.
-      if (isMarkerRow(rows[rowIndex - 1])) return undefined;
+      // One slot up crosses a hidden block (marker row above) or an
+      // uncrossable gap (unannotated row above) -- unavailable either way.
+      if (!isItemRow(rows[rowIndex - 1])) return undefined;
       const anchor = rows[rowIndex - 2];
-      // The row two above becomes the predecessor (its own id, or the marker's
-      // hidden id); no such row means the item reaches the top.
+      // The row two above becomes the predecessor (its own id, or a marker's
+      // hidden id); an unannotated row there means "before the item above but
+      // after the gap", which cannot be expressed. No row means the top.
+      if (anchor && !isAddressableRow(anchor)) return undefined;
       return anchor ? resolvePreviousItemId(anchor) : null;
     }
     case 'down': {
       if (isLastItem) return undefined;
       const below = rows[rowIndex + 1];
-      // One slot down crosses the hidden block when the row below is the marker.
-      if (isMarkerRow(below)) return undefined;
+      // One slot down needs the row below as predecessor: a marker row would
+      // mean crossing its hidden block, an unannotated row gives no anchor.
+      if (!isItemRow(below)) return undefined;
       return resolvePreviousItemId(below);
     }
     default:

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -200,3 +200,69 @@ function insertAtListTop(rowsContainer:HTMLElement, row:HTMLElement):void {
     rowsContainer.prepend(row);
   }
 }
+
+export type MoveDirection = 'top'|'up'|'down'|'bottom';
+
+// One item element per row of the container, in document order. Mirrors the
+// row model the drag path uses (a row resolves to at most one item element).
+function containerItemElements(rowsContainer:Element):HTMLElement[] {
+  return Array.from(rowsContainer.children)
+    .map((row) => resolveItemElement(row))
+    .filter((item):item is HTMLElement => item !== null);
+}
+
+export function resolveItemMovePosition({
+  itemElement,
+  rowsContainer,
+}:{
+  itemElement:HTMLElement;
+  rowsContainer:Element;
+}):{ isFirst:boolean; isLast:boolean }|null {
+  const items = containerItemElements(rowsContainer);
+  const index = items.indexOf(itemElement);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return { isFirst: index === 0, isLast: index === items.length - 1 };
+}
+
+// The previous item id to insert `itemElement` after for a directional move:
+//   null      -> top of the list
+//   string    -> after that item id
+//   undefined -> the move is unavailable in this direction (caller no-ops)
+export function resolveDirectionalPreviousItemId({
+  itemElement,
+  direction,
+  rowsContainer,
+}:{
+  itemElement:HTMLElement;
+  direction:MoveDirection;
+  rowsContainer:Element;
+}):string|null|undefined {
+  const items = containerItemElements(rowsContainer);
+  const index = items.indexOf(itemElement);
+
+  if (index === -1) {
+    return undefined;
+  }
+
+  const lastIndex = items.length - 1;
+
+  switch (direction) {
+    case 'top':
+      return index === 0 ? undefined : null;
+    case 'bottom':
+      return index === lastIndex ? undefined : resolveItemId(items[lastIndex]);
+    case 'up':
+      // Up one slot = after the item two above; from the second slot that is the top.
+      if (index === 0) return undefined;
+      return index === 1 ? null : resolveItemId(items[index - 2]);
+    case 'down':
+      // Down one slot = after the next item.
+      return index === lastIndex ? undefined : resolveItemId(items[index + 1]);
+    default:
+      return undefined;
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -228,10 +228,22 @@ export function resolveItemMovePosition({
   return { isFirst: index === 0, isLast: index === items.length - 1 };
 }
 
+// A truncation marker is a non-item row that stands in for a block of hidden
+// items, carrying the last omitted item's id on data-sortable-lists-prev-item-id.
+function isMarkerRow(row:Element|undefined):boolean {
+  return !!row && resolveItemElement(row) === null && row.hasAttribute(sortablePreviousItemIdAttribute);
+}
+
 // The previous item id to insert `itemElement` after for a directional move:
 //   null      -> top of the list
 //   string    -> after that item id
 //   undefined -> the move is unavailable in this direction (caller no-ops)
+//
+// Reasoning happens over rows, not just item elements, so a truncation marker
+// participates. The hidden block a marker represents cannot be addressed one
+// item at a time, so a single-step up/down that would cross it is unavailable;
+// the addressable extremes (top/bottom) and moves that land next to the block
+// via the marker's id stay available.
 export function resolveDirectionalPreviousItemId({
   itemElement,
   direction,
@@ -241,27 +253,41 @@ export function resolveDirectionalPreviousItemId({
   direction:MoveDirection;
   rowsContainer:Element;
 }):string|null|undefined {
-  const items = containerItemElements(rowsContainer);
-  const index = items.indexOf(itemElement);
+  const rows = listRows(rowsContainer);
+  const sourceRow = rowOf(rowsContainer, itemElement);
+  const rowIndex = sourceRow ? rows.indexOf(sourceRow) : -1;
 
-  if (index === -1) {
+  if (rowIndex === -1) {
     return undefined;
   }
 
-  const lastIndex = items.length - 1;
+  const itemRows = rows.filter((row) => resolveItemElement(row) !== null);
+  const itemIndex = itemRows.indexOf(sourceRow!);
+  const isFirstItem = itemIndex === 0;
+  const isLastItem = itemIndex === itemRows.length - 1;
 
   switch (direction) {
     case 'top':
-      return index === 0 ? undefined : null;
+      return isFirstItem ? undefined : null;
     case 'bottom':
-      return index === lastIndex ? undefined : resolveItemId(items[lastIndex]);
-    case 'up':
-      // Up one slot = after the item two above; from the second slot that is the top.
-      if (index === 0) return undefined;
-      return index === 1 ? null : resolveItemId(items[index - 2]);
-    case 'down':
-      // Down one slot = after the next item.
-      return index === lastIndex ? undefined : resolveItemId(items[index + 1]);
+      // After the last visible item; the server appends past the hidden block.
+      return isLastItem ? undefined : resolvePreviousItemId(itemRows[itemRows.length - 1]);
+    case 'up': {
+      if (isFirstItem) return undefined;
+      // One slot up crosses the hidden block when the row above is the marker.
+      if (isMarkerRow(rows[rowIndex - 1])) return undefined;
+      const anchor = rows[rowIndex - 2];
+      // The row two above becomes the predecessor (its own id, or the marker's
+      // hidden id); no such row means the item reaches the top.
+      return anchor ? resolvePreviousItemId(anchor) : null;
+    }
+    case 'down': {
+      if (isLastItem) return undefined;
+      const below = rows[rowIndex + 1];
+      // One slot down crosses the hidden block when the row below is the marker.
+      if (isMarkerRow(below)) return undefined;
+      return resolvePreviousItemId(below);
+    }
     default:
       return undefined;
   }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -203,6 +203,14 @@ function insertAtListTop(rowsContainer:HTMLElement, row:HTMLElement):void {
 
 export type MoveDirection = 'top'|'up'|'down'|'bottom';
 
+const moveDirections:readonly string[] = ['top', 'up', 'down', 'bottom'];
+
+// Values crossing the DOM boundary (action params, data attributes) arrive
+// untyped; narrow them instead of casting.
+export function isMoveDirection(value:unknown):value is MoveDirection {
+  return typeof value === 'string' && moveDirections.includes(value);
+}
+
 function isItemRow(row:Element|undefined):boolean {
   return !!row && resolveItemElement(row) !== null;
 }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -71,7 +71,12 @@ describe('Sortable lists list controller', () => {
     element = document.createElement('div'),
     { busy = false } = {},
   ):SortableListsRoot {
-    return { element, busy };
+    return {
+      element,
+      busy,
+      moveInDirection: vi.fn(),
+      itemMovePosition: vi.fn(() => null),
+    };
   }
 
   async function connectedListFor({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -76,6 +76,7 @@ describe('Sortable lists list controller', () => {
       busy,
       moveInDirection: vi.fn(),
       itemMovePosition: vi.fn(() => null),
+      directionalMoveAvailable: vi.fn(() => false),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -75,8 +75,7 @@ describe('Sortable lists list controller', () => {
       element,
       busy,
       moveInDirection: vi.fn(),
-      itemMovePosition: vi.fn(() => null),
-      directionalMoveAvailable: vi.fn(() => false),
+      moveAvailability: vi.fn(() => null),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
@@ -152,11 +152,11 @@ export default class ListController extends Controller<HTMLElement> implements R
   // Rows sit inside a child rows container (the Box list's <ul>). Lists that
   // render rows directly under their own element have no such child, so fall
   // back to the list element itself.
-  private get rowsContainer():HTMLElement {
+  get rowsContainer():HTMLElement {
     return this.hasRowsContainerElement ? this.rowsContainerElement! : this.element;
   }
 
-  private get listData():SortableListData {
+  get listData():SortableListData {
     return sortableListData({
       type: this.typeValue,
       listId: this.hasIdValue ? this.idValue : null,

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -72,6 +72,7 @@ describe('Sortable lists scrollable controller', () => {
       busy: false,
       moveInDirection: vi.fn(),
       itemMovePosition: vi.fn(() => null),
+      directionalMoveAvailable: vi.fn(() => false),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -71,8 +71,7 @@ describe('Sortable lists scrollable controller', () => {
       element,
       busy: false,
       moveInDirection: vi.fn(),
-      itemMovePosition: vi.fn(() => null),
-      directionalMoveAvailable: vi.fn(() => false),
+      moveAvailability: vi.fn(() => null),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -67,7 +67,12 @@ describe('Sortable lists scrollable controller', () => {
   }
 
   function stubRoot(element:HTMLElement):SortableListsRoot {
-    return { element, busy: false };
+    return {
+      element,
+      busy: false,
+      moveInDirection: vi.fn(),
+      itemMovePosition: vi.fn(() => null),
+    };
   }
 
   function scrollArgs(element:HTMLElement, data:Record<string|symbol, unknown>) {

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
@@ -108,7 +108,8 @@ See COPYRIGHT and LICENSE files for more details.
           component_klass: Primer::Alpha::ActionMenu::SubMenuItem,
           label: t(".action_menu.move_menu"),
           select_variant: :none,
-          form_arguments: {}
+          form_arguments: {},
+          data: { sortable_lists__item_target: "moveMenu" }
         ) do |move_menu|
           move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
 

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
@@ -95,7 +95,7 @@ module Backlogs
         tag: :button,
         data: {
           sortable_lists__item_target: "moveItem",
-          move_direction: direction,
+          sortable_lists__item_direction_param: direction,
           action: "click->sortable-lists--item#move"
         }
       ) do |item|

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
@@ -54,8 +54,7 @@ module Backlogs
     private
 
     def show_move_items?
-      allowed_to_manage_sprint_items? &&
-        !(first_item? && last_item?)
+      allowed_to_manage_sprint_items?
     end
 
     def show_move_to_inbox?
@@ -79,46 +78,29 @@ module Backlogs
     end
 
     def build_move_menu(menu)
-      unless first_item?
-        build_move_item(menu, label: :label_sort_highest, direction: "highest", icon: :"move-to-top")
-        build_move_item(menu, label: :label_sort_higher, prev_id: work_package.prev_prev_id, icon: :"chevron-up")
-      end
-      unless last_item?
-        build_move_item(menu, label: :label_sort_lower, prev_id: work_package.next_id, icon: :"chevron-down")
-        build_move_item(menu, label: :label_sort_lowest, direction: "lowest", icon: :"move-to-bottom")
-      end
+      build_move_item(menu, label: :label_sort_highest, direction: "top", icon: :"move-to-top")
+      build_move_item(menu, label: :label_sort_higher, direction: "up", icon: :"chevron-up")
+      build_move_item(menu, label: :label_sort_lower, direction: "down", icon: :"chevron-down")
+      build_move_item(menu, label: :label_sort_lowest, direction: "bottom", icon: :"move-to-bottom")
     end
 
-    def build_move_item(menu, label:, icon:, direction: nil, prev_id: nil)
-      inputs = if direction
-                 [{ name: "direction", value: direction }]
-               else
-                 current_list_inputs + [{ name: "prev_id", value: prev_id }]
-               end
-
+    def build_move_item(menu, label:, icon:, direction:)
+      # Item-level `data:` renders on the ActionList `<li>` (verify against
+      # Primer::Alpha::ActionList::Item) so the controller's `<li>` targets and
+      # the API's `disableItem`/`enableItem` land on the right element; the click
+      # action rides the same `<li>` and fires on the bubbled button click.
       menu.with_item(
         id: dom_target(work_package, :menu, label),
         label: I18n.t(label),
         tag: :button,
-        href: move_project_backlogs_work_package_path(project, work_package),
-        form_arguments: { method: :put, inputs: }
+        data: {
+          sortable_lists__item_target: "moveItem",
+          move_direction: direction,
+          action: "click->sortable-lists--item#move"
+        }
       ) do |item|
         item.with_leading_visual_icon(icon:)
       end
-    end
-
-    def first_item?
-      work_package.prev_id.nil?
-    end
-
-    def last_item?
-      work_package.next_id.nil?
-    end
-
-    def current_list_inputs
-      target = Backlogs::Target.for_work_package(work_package)
-
-      [{ name: "list_type", value: target.list_type }, { name: "list_id", value: target.list_id }]
     end
 
     def inbox_list_type

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
@@ -85,10 +85,10 @@ module Backlogs
     end
 
     def build_move_item(menu, label:, icon:, direction:)
-      # Item-level `data:` renders on the ActionList `<li>` (verify against
-      # Primer::Alpha::ActionList::Item) so the controller's `<li>` targets and
-      # the API's `disableItem`/`enableItem` land on the right element; the click
-      # action rides the same `<li>` and fires on the bubbled button click.
+      # The `data:` hash must live on the item level so Primer renders it on
+      # the ActionList `<li>`: the controller's `<li>` targets and the
+      # action-menu API's `disableItem`/`enableItem` both address that element,
+      # and the click action rides it via the bubbled button click.
       menu.with_item(
         id: dom_target(work_package, :menu, label),
         label: I18n.t(label),

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -197,7 +197,24 @@ module Backlogs
     # reloads mid-method, wiping the saved_changes _before_last_save needs.
     def optimistic_same_list_move?(call, source_list)
       optimistic_move? && call.success? &&
-        [call.result.sprint_id, call.result.backlog_bucket_id] == source_list
+        [call.result.sprint_id, call.result.backlog_bucket_id] == source_list &&
+        requested_anchor_honored?(call.result)
+    end
+
+    # A nonblank prev_id that has left the target list resolves to nothing, so
+    # move_after silently drops the work package at the top, diverging from the
+    # optimistic client order. Only skip the reload once the requested
+    # predecessor is the persisted one; blank prev_id means top, which always
+    # holds. Nothing sends optimistic position-based moves today, so rather
+    # than guess whether the persisted position matches what such a client
+    # rendered, send them down the reload path.
+    def requested_anchor_honored?(work_package)
+      return false if move_params[:position].present?
+
+      prev_id = move_params[:prev_id].presence
+      return true unless prev_id
+
+      work_package.higher_item&.id == prev_id.to_i
     end
 
     # Kept out of move_params: the service's keyword args reject it.

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -203,18 +203,22 @@ module Backlogs
 
     # A nonblank prev_id that has left the target list resolves to nothing, so
     # move_after silently drops the work package at the top, diverging from the
-    # optimistic client order. Only skip the reload once the requested
-    # predecessor is the persisted one; blank prev_id means top, which always
-    # holds. Nothing sends optimistic position-based moves today, so rather
-    # than guess whether the persisted position matches what such a client
-    # rendered, send them down the reload path.
+    # optimistic client order. Only skip the reload once the requested anchor
+    # is verifiably the persisted one: a nonblank prev_id must be the item
+    # right above, and a blank prev_id (top insert) must have nothing above.
+    # Requests without an anchor -- a missing prev_id, or a position-based
+    # move (nothing sends those optimistically today) -- cannot be verified,
+    # so they reconcile via reload.
     def requested_anchor_honored?(work_package)
       return false if move_params[:position].present?
+      return false unless move_params.key?(:prev_id)
 
       prev_id = move_params[:prev_id].presence
-      return true unless prev_id
-
-      work_package.higher_item&.id == prev_id.to_i
+      if prev_id
+        work_package.higher_item&.id == prev_id.to_i
+      else
+        work_package.higher_item.nil?
+      end
     end
 
     # Kept out of move_params: the service's keyword args reject it.

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -42,7 +42,7 @@ module Backlogs
     def menu
       render(Backlogs::WorkPackageCardMenuComponent.new(
                project: @project,
-               work_package: work_package_with_backlog_neighbours,
+               work_package: @work_package,
                open_sprints_exist: target_open_sprints.exists?,
                other_buckets_exist: target_buckets.exists?,
                current_user:
@@ -102,9 +102,10 @@ module Backlogs
         .call(**move_service_params)
 
       if optimistic_same_list_move?(call, source_list)
-        # A same-list optimistic drag already reordered the row client-side and
-        # changes nothing else visible. Skip the frame reload (it would fight
-        # that order); still emit the moved event for split-view lock refresh.
+        # A same-list optimistic move (drag or menu) already reordered the row
+        # client-side and changes nothing else visible. Skip the frame reload
+        # (it would fight that order); still emit the moved event for split-view
+        # lock refresh.
         dispatch_event_via_turbo_stream(
           WORK_PACKAGE_MOVED_EVENT,
           detail: { work_package_id: call.result.id }
@@ -159,20 +160,6 @@ module Backlogs
       move_project_backlogs_work_package_path(@project, @work_package, backlog_filter_params)
     end
 
-    def displayed_work_packages
-      if @work_package.sprint_id?
-        @work_packages.where(sprint_id: @work_package.sprint_id)
-      elsif @work_package.backlog_bucket_id?
-        @work_packages.merge(@work_package.backlog_bucket.displayed_work_packages)
-      else
-        @work_packages.merge(WorkPackage.in_inbox_for(project: @project))
-      end
-    end
-
-    def work_package_with_backlog_neighbours
-      displayed_work_packages.with_backlogs_neighbours.find(@work_package.id)
-    end
-
     def target_open_sprints
       Sprint.for_project(@project)
         .visible.not_completed
@@ -219,11 +206,11 @@ module Backlogs
     end
 
     def move_params
-      params.permit(:prev_id, :position, :direction, :list_type, :list_id)
+      params.permit(:prev_id, :position, :list_type, :list_id)
     end
 
     # A blank prev_id (drag or menu move to the top of a list) is kept so the
-    # service inserts at the top; nil values (absent prev_id/direction) are
+    # service inserts at the top; nil values (an absent prev_id) are
     # dropped. The service resolves list_type/list_id into the destination list.
     def move_service_params
       move_params.to_h.symbolize_keys.compact

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -95,13 +95,13 @@ module Backlogs
     end
 
     def move
-      source_list = [@work_package.sprint_id, @work_package.backlog_bucket_id]
+      source_target = Backlogs::Target.for_work_package(@work_package)
 
       call = ::Backlogs::WorkPackages::UpdateService
         .new(user: current_user, work_package: @work_package)
         .call(**move_service_params)
 
-      if optimistic_same_list_move?(call, source_list)
+      if optimistic_same_list_move?(call, source_target)
         # A same-list optimistic move (drag or menu) already reordered the row
         # client-side and changes nothing else visible. Skip the frame reload
         # (it would fight that order); still emit the moved event for split-view
@@ -193,11 +193,11 @@ module Backlogs
       end
     end
 
-    # Snapshot the source list before the call, not dirty tracking: move_after
+    # Snapshot the source target before the call, not dirty tracking: move_after
     # reloads mid-method, wiping the saved_changes _before_last_save needs.
-    def optimistic_same_list_move?(call, source_list)
+    def optimistic_same_list_move?(call, source_target)
       optimistic_move? && call.success? &&
-        [call.result.sprint_id, call.result.backlog_bucket_id] == source_list &&
+        Backlogs::Target.for_work_package(call.result) == source_target &&
         requested_anchor_honored?(call.result)
     end
 

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -95,9 +95,22 @@ module Backlogs
     end
 
     def move
+      source_list = [@work_package.sprint_id, @work_package.backlog_bucket_id]
+
       call = ::Backlogs::WorkPackages::UpdateService
         .new(user: current_user, work_package: @work_package)
         .call(**move_service_params)
+
+      if optimistic_same_list_move?(call, source_list)
+        # A same-list optimistic drag already reordered the row client-side and
+        # changes nothing else visible. Skip the frame reload (it would fight
+        # that order); still emit the moved event for split-view lock refresh.
+        dispatch_event_via_turbo_stream(
+          WORK_PACKAGE_MOVED_EVENT,
+          detail: { work_package_id: call.result.id }
+        )
+        return respond_with_turbo_streams(status: call)
+      end
 
       render_update_turbo_streams(call)
     end
@@ -191,6 +204,18 @@ module Backlogs
       else
         !backlog_filters.show_inbox?
       end
+    end
+
+    # Snapshot the source list before the call, not dirty tracking: move_after
+    # reloads mid-method, wiping the saved_changes _before_last_save needs.
+    def optimistic_same_list_move?(call, source_list)
+      optimistic_move? && call.success? &&
+        [call.result.sprint_id, call.result.backlog_bucket_id] == source_list
+    end
+
+    # Kept out of move_params: the service's keyword args reject it.
+    def optimistic_move?
+      ActiveModel::Type::Boolean.new.cast(params[:optimistic])
     end
 
     def move_params

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -36,6 +36,12 @@ class Backlogs::WorkPackages::UpdateService
     @work_package = work_package
   end
 
+  # The transaction turns the attribute change and the reorder into one atomic
+  # move. After-commit callbacks (e.g. the work_package_after_update plugin
+  # hook) therefore fire only once the whole move has committed, and since
+  # move_after reloads the work package mid-method, they observe the final
+  # list and position with `saved_changes` already cleared: consumers cannot
+  # rely on change tracking for backlogs moves.
   def call(list_type: nil, list_id: nil, position: nil, prev_id: nil)
     result = nil
 

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -36,13 +36,15 @@ class Backlogs::WorkPackages::UpdateService
     @work_package = work_package
   end
 
-  def call(direction: nil, list_type: nil, list_id: nil, position: nil, prev_id: nil)
+  def call(list_type: nil, list_id: nil, position: nil, prev_id: nil)
     WorkPackage.transaction do
-      resolve_required_attributes(direction:, list_type:, list_id:)
+      resolve_required_attributes(list_type:, list_id:)
         .bind { |attrs| ::WorkPackages::UpdateService.new(user:, model: work_package).call(**attrs) }
         .on_success do |call|
-          # A blank prev_id is meaningful (insert at the top of the list), a
-          # blank position is not: it would cast to nil and move to the top too.
+          # A blank prev_id ("") is meaningful: it means "insert at the top of
+          # the list", so a truthy check is used here. A blank position is not
+          # meaningful (it would cast to nil and move to the top unintentionally),
+          # so `position.present?` is used instead.
           if prev_id
             call.result.move_after(prev_id:)
           elsif position.present?
@@ -54,15 +56,9 @@ class Backlogs::WorkPackages::UpdateService
 
   private
 
-  def resolve_required_attributes(direction:, list_type:, list_id:)
-    list_given = list_type.present? || list_id.present?
-
-    if list_given && direction
-      ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.ambiguous_target"))
-    elsif list_given
+  def resolve_required_attributes(list_type:, list_id:)
+    if list_type.present? || list_id.present?
       attributes_result_from_list(list_type, list_id)
-    elsif direction
-      attributes_result_from_direction(direction)
     else
       ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.missing_target"))
     end
@@ -75,14 +71,6 @@ class Backlogs::WorkPackages::UpdateService
       ServiceResult.success(result: target.attributes)
     else
       ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.invalid_target_type"))
-    end
-  end
-
-  def attributes_result_from_direction(direction)
-    if direction.in? %w(higher highest lower lowest)
-      ServiceResult.success(result: { move_to: direction })
-    else
-      ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.invalid_direction"))
     end
   end
 end

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -37,8 +37,10 @@ class Backlogs::WorkPackages::UpdateService
   end
 
   def call(list_type: nil, list_id: nil, position: nil, prev_id: nil)
+    result = nil
+
     WorkPackage.transaction do
-      resolve_required_attributes(list_type:, list_id:)
+      result = resolve_required_attributes(list_type:, list_id:)
         .bind { |attrs| ::WorkPackages::UpdateService.new(user:, model: work_package).call(**attrs) }
         .on_success do |call|
           # A blank prev_id ("") is meaningful: it means "insert at the top of
@@ -51,7 +53,15 @@ class Backlogs::WorkPackages::UpdateService
             call.result.move_after(position:)
           end
         end
+
+      # The inner service raises ActiveRecord::Rollback when its result is a
+      # failure, but that raise happens inside its own transaction, which joins
+      # this one and swallows it. Re-raise here so a failure after the work
+      # package row was already written cannot half-commit the move.
+      raise ActiveRecord::Rollback if result.failure?
     end
+
+    result
   end
 
   private

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -37,17 +37,19 @@ class Backlogs::WorkPackages::UpdateService
   end
 
   def call(direction: nil, list_type: nil, list_id: nil, position: nil, prev_id: nil)
-    resolve_required_attributes(direction:, list_type:, list_id:)
-      .bind { |attrs| ::WorkPackages::UpdateService.new(user:, model: work_package).call(**attrs) }
-      .on_success do |call|
-        # A blank prev_id is meaningful (insert at the top of the list), a
-        # blank position is not: it would cast to nil and move to the top too.
-        if prev_id
-          call.result.move_after(prev_id:)
-        elsif position.present?
-          call.result.move_after(position:)
+    WorkPackage.transaction do
+      resolve_required_attributes(direction:, list_type:, list_id:)
+        .bind { |attrs| ::WorkPackages::UpdateService.new(user:, model: work_package).call(**attrs) }
+        .on_success do |call|
+          # A blank prev_id is meaningful (insert at the top of the list), a
+          # blank position is not: it would cast to nil and move to the top too.
+          if prev_id
+            call.result.move_after(prev_id:)
+          elsif position.present?
+            call.result.move_after(position:)
+          end
         end
-      end
+    end
   end
 
   private

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -253,10 +253,8 @@ en:
         invalid_target: "The target you are trying to add to is invalid."
         target_not_found: "The sprint or backlog you are trying to add to was not found."
       update_service:
-        ambiguous_target: "list_type or list_id cannot be combined with direction."
-        invalid_direction: "direction must be one of: higher, highest, lower, lowest."
         invalid_target_type: "list_type must be one of: backlog_bucket with a list_id, sprint with a list_id, or inbox without a list_id."
-        missing_target: "list_type or direction must be present."
+        missing_target: "list_type or list_id must be present."
 
   burndown:
     story_points: "Story points"

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       %w[top up down bottom].each do |direction|
         expect(page).to have_css(
           "li[data-sortable-lists--item-target='moveItem']" \
-          "[data-move-direction='#{direction}']" \
+          "[data-sortable-lists--item-direction-param='#{direction}']" \
           "[data-action='click->sortable-lists--item#move']"
         )
       end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -203,100 +203,41 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       expect(page).to have_octicon(:"move-to-bottom")
     end
 
-    it "carries the work package's current sprint as list_type and list_id on reorder items" do
-      render_component
+    it "always renders the four move items as client targets", :aggregate_failures do
+      render_inline(described_class.new(work_package:, project:, open_sprints_exist: false, other_buckets_exist: false))
 
-      expect(page).to have_field("list_type", type: :hidden, with: "sprint", count: 2)
-      expect(page).to have_field("list_id", type: :hidden, with: sprint.id.to_s, count: 2)
+      # The target, direction, and action live on the item <li>, not the content button.
+      %w[top up down bottom].each do |direction|
+        expect(page).to have_css(
+          "li[data-sortable-lists--item-target='moveItem']" \
+          "[data-move-direction='#{direction}']" \
+          "[data-action='click->sortable-lists--item#move']"
+        )
+      end
+      expect(page).to have_css("li[data-sortable-lists--item-target='moveMenu']")
+      expect(page).to have_no_field("direction", type: :hidden)
+      expect(page).to have_no_field("prev_id", type: :hidden)
     end
 
-    context "when item is first" do
-      let(:work_package) { enrich_with_neighbours(first_story) }
-
-      it "hides Move to top and Move up" do
-        render_component
-
-        expect(page).to have_no_text(I18n.t(:label_sort_highest))
-        expect(page).to have_no_text(I18n.t(:label_sort_higher))
-      end
-
-      it "shows Move down and Move to bottom, sending next_id as prev_id" do
-        render_component
-
-        expect(page).to have_text(I18n.t(:label_sort_lower))
-        expect(page).to have_text(I18n.t(:label_sort_lowest))
-        expect(page).to have_field("prev_id", type: :hidden, count: 1)
-        expect(page).to have_field("prev_id", type: :hidden, with: second_story.id.to_s)
-      end
-    end
-
-    context "when item is in the middle with one predecessor" do
-      it "shows all move options, sending nil prev_id for Move up and next_id as prev_id for Move down" do
-        render_component
-
-        expect(page).to have_text(I18n.t(:label_sort_highest))
-        expect(page).to have_text(I18n.t(:label_sort_higher))
-        expect(page).to have_text(I18n.t(:label_sort_lower))
-        expect(page).to have_text(I18n.t(:label_sort_lowest))
-        expect(page).to have_field("prev_id", type: :hidden, count: 2)
-        expect(page).to have_field("prev_id", type: :hidden, with: third_story.id.to_s)
-      end
-    end
-
-    context "when item is in the middle with two predecessors" do
-      let(:work_package) { enrich_with_neighbours(third_story) }
-
-      it "shows all move options, sending prev_prev_id and next_id as prev_id" do
-        render_component
-
-        expect(page).to have_text(I18n.t(:label_sort_highest))
-        expect(page).to have_text(I18n.t(:label_sort_higher))
-        expect(page).to have_text(I18n.t(:label_sort_lower))
-        expect(page).to have_text(I18n.t(:label_sort_lowest))
-        expect(page).to have_field("prev_id", type: :hidden, with: first_story.id.to_s)
-        expect(page).to have_field("prev_id", type: :hidden, with: fourth_story.id.to_s)
-      end
-    end
-
-    context "when item is last" do
-      let(:work_package) { enrich_with_neighbours(fourth_story) }
-
-      it "hides Move down and Move to bottom" do
-        render_component
-
-        expect(page).to have_no_text(I18n.t(:label_sort_lower))
-        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
-      end
-
-      it "shows Move to top and Move up, sending prev_prev_id as prev_id" do
-        render_component
-
-        expect(page).to have_text(I18n.t(:label_sort_highest))
-        expect(page).to have_text(I18n.t(:label_sort_higher))
-        expect(page).to have_field("prev_id", type: :hidden, count: 1)
-        expect(page).to have_field("prev_id", type: :hidden, with: second_story.id.to_s)
-      end
-    end
-
-    context "when there is only one item" do
+    context "when the work package is the only item in its list" do
       let(:displayed_work_packages) { WorkPackage.where(id: second_story.id).order_by_position }
 
-      it "hides all move options" do
+      it "still shows all four move items; the client disables what does not apply" do
         render_component
 
-        expect(page).to have_no_text(I18n.t(:label_sort_highest))
-        expect(page).to have_no_text(I18n.t(:label_sort_higher))
-        expect(page).to have_no_text(I18n.t(:label_sort_lower))
-        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
+        expect(page).to have_text(I18n.t(:label_sort_highest))
+        expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_text(I18n.t(:label_sort_lower))
+        expect(page).to have_text(I18n.t(:label_sort_lowest))
       end
 
       context "when the work package is already in the inbox" do
         let(:sprint) { nil }
 
-        it "hides the Move to position submenu entirely" do
+        it "still shows the Move to position submenu (permission-gated only)" do
           render_component(open_sprints_exist: false, other_buckets_exist: false)
 
-          expect(page).to have_no_selector(:menuitem, text: "Move to position")
+          expect(page).to have_selector(:menuitem, text: "Move to position")
         end
       end
     end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -45,12 +45,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
   let!(:second_story) { create_story(position: 2) }
   let!(:third_story) { create_story(position: 3) }
   let!(:fourth_story) { create_story(position: 4) }
-  let(:displayed_work_packages) { WorkPackage.where(sprint:).order_by_position }
-  let(:work_package) { enrich_with_neighbours(second_story) }
-
-  def enrich_with_neighbours(work_package, scope: displayed_work_packages)
-    scope.with_backlogs_neighbours.find(work_package.id)
-  end
+  let(:work_package) { second_story }
 
   def create_story(position:, subject: "Test Story", story_points: 5)
     create(:work_package,
@@ -220,7 +215,16 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
     end
 
     context "when the work package is the only item in its list" do
-      let(:displayed_work_packages) { WorkPackage.where(id: second_story.id).order_by_position }
+      let(:work_package) do
+        solo_sprint = create(:sprint, project:, name: "Solo Sprint")
+        create(:work_package,
+               subject: "Solo Story",
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               sprint: solo_sprint)
+      end
 
       it "still shows all four move items; the client disables what does not apply" do
         render_component
@@ -232,7 +236,14 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       end
 
       context "when the work package is already in the inbox" do
-        let(:sprint) { nil }
+        let(:work_package) do
+          create(:work_package,
+                 subject: "Inbox Story",
+                 project:,
+                 type: type_feature,
+                 status: default_status,
+                 priority: default_priority)
+        end
 
         it "still shows the Move to position submenu (permission-gated only)" do
           render_component(open_sprints_exist: false, other_buckets_exist: false)

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
                sprint: solo_sprint)
       end
 
-      it "still shows all four move items; the client disables what does not apply" do
+      it "still shows all four move items; the client hides what does not apply" do
         render_component
 
         expect(page).to have_text(I18n.t(:label_sort_highest))

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -284,6 +284,32 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    context "with an optimistic blank-anchor move that did not land on top" do
+      let!(:other_item) { create(:work_package, status:, sprint:, project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { "" }
+      let(:optimistic) { "true" }
+
+      before do
+        # The real service always prepends on a blank prev_id, so the anchor
+        # check's failure branch is unreachable through it; inject a result
+        # that stayed mid-list (as a concurrent reorder could leave it).
+        other_item.update_column(:position, 1)
+        work_package_in_sprint.update_column(:position, 2)
+
+        service = instance_double(Backlogs::WorkPackages::UpdateService)
+        allow(Backlogs::WorkPackages::UpdateService).to receive(:new).and_return(service)
+        allow(service).to receive(:call).and_return(ServiceResult.success(result: work_package_in_sprint.reload))
+      end
+
+      it "reloads the frame instead of trusting the top insert", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                              target: "backlogs_container"
+      end
+    end
+
     context "with an optimistic same-list move after a valid predecessor" do
       let!(:first_item) { create(:work_package, status:, sprint:, project:) }
       let(:list_type) { "sprint" }

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
-    context "with a same-list move and optimistic=false (menu move)" do
+    context "with a same-list move from a client not flagging it optimistic" do
       let(:list_type) { "sprint" }
       let(:list_id) { sprint.id }
       let(:prev_id) { "" }

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -316,6 +316,24 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    context "with an optimistic same-list move without any anchor (malformed)" do
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:optimistic) { "true" }
+
+      # A nil param still reaches the controller as a blank string, but blank
+      # means "insert at the top"; a missing anchor needs the key to be absent.
+      subject(:response) do
+        put :move, params: { project_id:, id:, list_type:, list_id:, optimistic: }, format: :turbo_stream
+      end
+
+      it "reloads the frame because the claimed order cannot be verified", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                              target: "backlogs_container"
+      end
+    end
+
     context "with an optimistic same-list move by position instead of prev_id" do
       let(:list_type) { "sprint" }
       let(:list_id) { sprint.id }

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -89,13 +89,12 @@ RSpec.describe Backlogs::WorkPackagesController do
     let(:prev_id) { nil }
     let(:position) { nil }
     let(:all) { nil }
-    let(:direction) { nil }
     # The move URL carries the page's active backlog filters (see move_path).
     let(:filter_params) { {} }
     let(:optimistic) { nil }
 
     subject(:response) do
-      put :move, params: { project_id:, id:, list_type:, list_id:, prev_id:, position:, all:, direction:, optimistic:,
+      put :move, params: { project_id:, id:, list_type:, list_id:, prev_id:, position:, all:, optimistic:,
                            **filter_params },
                  format: :turbo_stream
     end
@@ -270,39 +269,6 @@ RSpec.describe Backlogs::WorkPackagesController do
           expect(work_package_in_sprint.reload).to have_attributes(backlog_bucket: bucket, sprint_id: nil, position: 2)
         end
       end
-
-      context "with direction param" do
-        let(:direction) { "highest" }
-
-        it "replaces the sprint component and responds with turbo streams", :aggregate_failures do
-          expect(response).to be_successful
-          expect(response).to have_http_status :ok
-          expect(response).to have_turbo_stream action: "turbo_frame_reload",
-                                                target: "backlogs_container"
-          expect(assigns(:work_package)).to eq(work_package_in_sprint)
-        end
-
-        it "moves the inbox item to the first position" do
-          response
-
-          expect(work_package_in_sprint.reload).to have_attributes(backlog_bucket_id: nil, sprint:, position: 1)
-        end
-
-        context "when service call fails" do
-          before do
-            allow(Backlogs::WorkPackages::UpdateService)
-              .to receive(:new)
-              .and_return(instance_double(Backlogs::WorkPackages::UpdateService, call: ServiceResult.failure(message: "Error")))
-          end
-
-          it "renders an error flash with 422", :aggregate_failures do
-            expect(response).to have_http_status :unprocessable_entity
-            expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
-            expect(response).not_to have_turbo_stream action: "turbo_frame_reload",
-                                                      target: "backlogs_container"
-          end
-        end
-      end
     end
 
     context "with an optimistic same-list move (drag)" do
@@ -410,25 +376,6 @@ RSpec.describe Backlogs::WorkPackagesController do
           expect(inbox_work_package.reload).to have_attributes(backlog_bucket: bucket, sprint_id: nil, position: 2)
         end
       end
-
-      context "with direction param" do
-        let!(:inbox_items) { create_list(:work_package, 4, project:, status:) }
-        let(:direction) { "highest" }
-
-        it "replaces the backlog component and responds with turbo streams", :aggregate_failures do
-          expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "turbo_frame_reload",
-                                                target: "backlogs_container"
-
-          expect(assigns(:work_package)).to eq(inbox_work_package)
-        end
-
-        it "moves the inbox item to the first position" do
-          response
-
-          expect(inbox_work_package.reload).to have_attributes(backlog_bucket_id: nil, sprint_id: nil, position: 1)
-        end
-      end
     end
 
     context "with a Backlog bucket as source" do
@@ -514,23 +461,6 @@ RSpec.describe Backlogs::WorkPackagesController do
           response
 
           expect(bucket_work_package.reload).to have_attributes(backlog_bucket: other_bucket, sprint_id: nil, position: 2)
-        end
-      end
-
-      context "with direction param" do
-        let(:direction) { "highest" }
-
-        it "replaces the backlog component and responds with turbo streams", :aggregate_failures do
-          expect(response).to be_successful
-          expect(response).to have_turbo_stream action: "turbo_frame_reload",
-                                                target: "backlogs_container"
-          expect(assigns(:work_package)).to eq(bucket_work_package)
-        end
-
-        it "moves the work_package to the first position within the bucket" do
-          response
-
-          expect(bucket_work_package.reload).to have_attributes(backlog_bucket_id: bucket.id, sprint_id: nil, position: 1)
         end
       end
     end
@@ -638,120 +568,44 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    # The client-side sortable-lists--item controller now gates first/last availability at
+    # runtime (see AGILE-322); the server always renders all four move items when the user
+    # may manage sprint items, regardless of the work package's position in its list.
     context "with sprint source" do
-      let!(:sprint_items)       { create_list(:work_package, 3, status:, sprint:, project:) }
-      let!(:other_sprint)       { create(:sprint, name: "Other Sprint", project:) }
-      let!(:other_sprint_items) { create_list(:work_package, 10, status:, sprint: other_sprint, project:) }
-      let!(:inbox_items)        { create_list(:work_package, 10, status:, project:) }
+      let!(:sprint_items) { create_list(:work_package, 3, status:, sprint:, project:) }
+      let(:work_package_id) { sprint_items.first.id }
 
-      context "for the first item" do
-        let(:work_package_id) { sprint_items.first.id }
-
-        it "scopes max_position to the sprint (first item has only downward actions)" do
-          expect(body).not_to include(I18n.t(:label_sort_highest))
-          expect(body).to include(I18n.t(:label_sort_lower))
-        end
-      end
-
-      context "for the last item" do
-        let(:work_package_id) { sprint_items.last.id }
-
-        it "scopes max_position to the sprint (last item has only upward actions)" do
-          expect(body).to include(I18n.t(:label_sort_highest))
-          expect(body).not_to include(I18n.t(:label_sort_lower))
-        end
-
-        context "when a closed work package exists in the sprint" do
-          let!(:closed_status) { create(:status, name: "Closed", is_closed: true) }
-          let!(:closed_sprint_item) { create(:work_package, status: closed_status, sprint:, project:) }
-
-          it "includes closed work packages in max_position so the last open item can still move down" do
-            # sprint_items.last is at position 3; closed_sprint_item occupies position 4
-            # max_position = 4 (closed included) → last open item is not at the bottom
-            expect(body).to include(I18n.t(:label_sort_lower))
-          end
-        end
+      it "renders all four move items regardless of position", :aggregate_failures do
+        expect(body).to include(I18n.t(:label_sort_highest))
+        expect(body).to include(I18n.t(:label_sort_higher))
+        expect(body).to include(I18n.t(:label_sort_lower))
+        expect(body).to include(I18n.t(:label_sort_lowest))
       end
     end
 
     context "with inbox source" do
-      let!(:inbox_items)  { create_list(:work_package, 3, status:, project:) }
-      let!(:sprint_items) { create_list(:work_package, 10, status:, project:, sprint:) }
+      let!(:inbox_items) { create_list(:work_package, 3, status:, project:) }
+      let(:work_package_id) { inbox_items.last.id }
 
-      context "for the first item" do
-        let(:work_package_id) { inbox_items.first.id }
-
-        it "scopes max_position to the inbox (first item has only downward actions)" do
-          expect(body).not_to include(I18n.t(:label_sort_highest))
-          expect(body).to include(I18n.t(:label_sort_lower))
-        end
-      end
-
-      context "for the last item" do
-        let(:work_package_id) { inbox_items.last.id }
-
-        it "scopes max_position to the inbox (last item has only upward actions)" do
-          expect(body).to include(I18n.t(:label_sort_highest))
-          expect(body).not_to include(I18n.t(:label_sort_lower))
-        end
-
-        context "when a closed work package exists in the inbox" do
-          let!(:closed_status) { create(:status, name: "Closed", is_closed: true) }
-          let!(:closed_inbox_item) { create(:work_package, status: closed_status, project:) }
-
-          it "excludes closed work packages from max_position so the last open item is at the bottom" do
-            # inbox_items.last is at position 3; closed_inbox_item occupies position 4
-            # max_position = 3 (closed excluded) → last open item is at the bottom
-            expect(body).not_to include(I18n.t(:label_sort_lower))
-          end
-        end
+      it "renders all four move items regardless of position", :aggregate_failures do
+        expect(body).to include(I18n.t(:label_sort_highest))
+        expect(body).to include(I18n.t(:label_sort_higher))
+        expect(body).to include(I18n.t(:label_sort_lower))
+        expect(body).to include(I18n.t(:label_sort_lowest))
       end
     end
 
     context "with backlog bucket source" do
       let!(:backlog_bucket) { create(:backlog_bucket, project:) }
-      let!(:bucket_items) { create_list(:work_package, 3, project:, status:, backlog_bucket:) }
+      let(:lone_item) { create(:work_package, project:, status:, backlog_bucket:) }
+      let(:work_package_id) { lone_item.id }
 
-      context "with a single item" do
-        let(:lone_bucket) { create(:backlog_bucket, project:) }
-        let(:lone_item) { create(:work_package, project:, status:, backlog_bucket: lone_bucket) }
-        let(:work_package_id) { lone_item.id }
-
-        it "scopes max_position to the bucket (lone item has no move actions)" do
-          expect(response).to have_http_status :ok
-          expect(body).not_to include(I18n.t(:label_sort_highest))
-          expect(body).not_to include(I18n.t(:label_sort_lower))
-        end
-      end
-
-      context "for the first item" do
-        let(:work_package_id) { bucket_items.first.id }
-
-        it "scopes max_position to the bucket (first item has only downward actions)" do
-          expect(body).not_to include(I18n.t(:label_sort_highest))
-          expect(body).to include(I18n.t(:label_sort_lower))
-        end
-      end
-
-      context "for the last item" do
-        let(:work_package_id) { bucket_items.last.id }
-
-        it "scopes max_position to the bucket (last item has only upward actions)" do
-          expect(body).to include(I18n.t(:label_sort_highest))
-          expect(body).not_to include(I18n.t(:label_sort_lower))
-        end
-
-        context "when a closed work package exists in the bucket" do
-          let!(:closed_status) { create(:status, name: "Closed", is_closed: true) }
-          let!(:closed_bucket_item) { create(:work_package, status: closed_status, project:, backlog_bucket:) }
-
-          it "excludes closed work packages from max_position so the last open item is at the bottom" do
-            # bucket_items.last is at position 3; closed_bucket_item occupies position 4
-            # max_position = 3 (closed excluded) → last open item is at the bottom
-
-            expect(body).not_to include(I18n.t(:label_sort_lower))
-          end
-        end
+      it "renders all four move items even for a lone item in its list", :aggregate_failures do
+        expect(response).to have_http_status :ok
+        expect(body).to include(I18n.t(:label_sort_highest))
+        expect(body).to include(I18n.t(:label_sort_higher))
+        expect(body).to include(I18n.t(:label_sort_lower))
+        expect(body).to include(I18n.t(:label_sort_lowest))
       end
     end
   end

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -284,6 +284,52 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    context "with an optimistic same-list move after a valid predecessor" do
+      let!(:first_item) { create(:work_package, status:, sprint:, project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { first_item.id }
+      let(:optimistic) { "true" }
+
+      it "skips the reload because the requested anchor was honoured", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "dispatchEvent"
+        expect(response).not_to have_turbo_stream action: "turbo_frame_reload"
+      end
+    end
+
+    context "with an optimistic same-list move whose prev_id has left the list" do
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      # A predecessor that is not in the target sprint: move_after cannot
+      # resolve it and silently falls back to the top, so the persisted order
+      # diverges from the optimistic client order. The frame must reload to
+      # reconcile rather than trust the stale client placement.
+      let(:stray_prev) { create(:work_package, status:, project:) }
+      let(:prev_id) { stray_prev.id }
+      let(:optimistic) { "true" }
+
+      it "reloads the frame instead of trusting the client order", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                              target: "backlogs_container"
+      end
+    end
+
+    context "with an optimistic same-list move by position instead of prev_id" do
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { nil }
+      let(:position) { "1" }
+      let(:optimistic) { "true" }
+
+      it "reloads the frame instead of trusting the client order", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                              target: "backlogs_container"
+      end
+    end
+
     context "with a same-list move and optimistic=false (menu move)" do
       let(:list_type) { "sprint" }
       let(:list_id) { sprint.id }

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -92,9 +92,10 @@ RSpec.describe Backlogs::WorkPackagesController do
     let(:direction) { nil }
     # The move URL carries the page's active backlog filters (see move_path).
     let(:filter_params) { {} }
+    let(:optimistic) { nil }
 
     subject(:response) do
-      put :move, params: { project_id:, id:, list_type:, list_id:, prev_id:, position:, all:, direction:,
+      put :move, params: { project_id:, id:, list_type:, list_id:, prev_id:, position:, all:, direction:, optimistic:,
                            **filter_params },
                  format: :turbo_stream
     end
@@ -301,6 +302,46 @@ RSpec.describe Backlogs::WorkPackagesController do
                                                       target: "backlogs_container"
           end
         end
+      end
+    end
+
+    context "with an optimistic same-list move (drag)" do
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { "" }
+      let(:optimistic) { "true" }
+
+      it "dispatches the moved event and does not reload the frame", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "dispatchEvent"
+        expect(response).not_to have_turbo_stream action: "turbo_frame_reload"
+      end
+    end
+
+    context "with a same-list move and optimistic=false (menu move)" do
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { "" }
+      let(:optimistic) { "false" }
+
+      it "reloads the frame", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                              target: "backlogs_container"
+      end
+    end
+
+    context "with an optimistic cross-list move" do
+      let(:other_sprint) { create(:sprint, name: "Agile Sprint 2", project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { other_sprint.id }
+      let(:prev_id) { "" }
+      let(:optimistic) { "true" }
+
+      it "reloads the frame because the list changed", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "turbo_frame_reload",
+                                              target: "backlogs_container"
       end
     end
 

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       planning_page.expect_inbox_show_more
     end
 
-    it "disables one-step menu moves that would cross the hidden block", :aggregate_failures do
+    it "hides one-step menu moves that would cross the hidden block", :aggregate_failures do
       last_visible_head_item = inbox_wps.second
       only_visible_tail_item = inbox_wps.last
 

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -440,6 +440,45 @@ RSpec.describe "Inbox column in sprint planning view", :js do
     end
   end
 
+  context "with a truncated inbox" do
+    let!(:sprint) { create(:sprint, name: "Sprint 1", project:) }
+    # With TRUNCATE_MIDDLE stubbed to 2 (tail_size 1, threshold 4), five items
+    # truncate to: the first two, a show-more marker standing in for the two
+    # hidden items, then the last one.
+    let!(:inbox_wps) { create_list(:work_package, 5, project:) }
+
+    before do
+      stub_const("Backlogs::InboxComponent::TRUNCATE_MIDDLE", 2)
+      planning_page.visit!
+    end
+
+    it "collapses the hidden items behind a show-more marker" do
+      planning_page.expect_inbox_show_more
+    end
+
+    it "disables one-step menu moves that would cross the hidden block", :aggregate_failures do
+      last_visible_head_item = inbox_wps.second
+      only_visible_tail_item = inbox_wps.last
+
+      planning_page.within_work_package_move_submenu(last_visible_head_item) do |submenu|
+        # Moving down one slot would jump the whole hidden block, so it is
+        # unavailable; moving up within the visible head and the addressable
+        # extreme (bottom) stay available.
+        expect(submenu).to have_no_selector(:menuitem, text: "Move down")
+        expect(submenu).to have_selector(:menuitem, text: "Move up")
+        expect(submenu).to have_selector(:menuitem, text: "Move to bottom")
+      end
+
+      planning_page.within_work_package_move_submenu(only_visible_tail_item) do |submenu|
+        # Moving up one slot would jump the whole hidden block, so it is
+        # unavailable; moving to the top across the block is addressable and
+        # stays available.
+        expect(submenu).to have_no_selector(:menuitem, text: "Move up")
+        expect(submenu).to have_selector(:menuitem, text: "Move to top")
+      end
+    end
+  end
+
   describe "retaining the 'show all' state" do
     let!(:sprint) { create(:sprint, name: "Sprint 1", project:) }
     let!(:inbox_items) { create_list(:work_package, 5, project:, type:) }

--- a/modules/backlogs/spec/features/work_packages/move_via_menu_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_via_menu_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Move a backlog card via its menu",
+               :js, :selenium do
+  include RSpec::Wait
+
+  let!(:project) do
+    create(:project,
+           types: [type],
+           enabled_module_names: %w(work_package_tracking backlogs))
+  end
+  let(:manage_sprint_items_role) do
+    create(:project_role,
+           permissions: %i(view_sprints
+                           manage_sprint_items
+                           view_work_packages
+                           edit_work_packages))
+  end
+
+  let(:type) { create(:type) }
+
+  let!(:sprint) { create(:sprint, project:) }
+
+  let!(:sprint_wp1) { create(:work_package, sprint:, type:, project:) }
+  let!(:sprint_wp2) { create(:work_package, sprint:, type:, project:) }
+  let!(:sprint_wp3) { create(:work_package, sprint:, type:, project:) }
+  let!(:sprint_wp4) { create(:work_package, sprint:, type:, project:) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user, member_with_roles: { project => manage_sprint_items_role })
+  end
+
+  before do
+    backlogs_page.visit!
+  end
+
+  it "moves the card up optimistically and persists" do
+    backlogs_page
+      .expect_work_packages_in_sprint_in_order(sprint,
+                                               work_packages: [sprint_wp1, sprint_wp2, sprint_wp3, sprint_wp4])
+
+    # Arm the reload probe before triggering the move: a full frame reload
+    # (the old behaviour) would still leave the list in the expected order
+    # once it settles, so the order assertion alone can't tell an optimistic
+    # client-side move from a reload that happens to finish within the wait
+    # window. The probe does: it only flips if `#backlogs_container` actually
+    # reloads.
+    backlogs_page.install_backlogs_container_reload_probe
+
+    # `wait: false` skips the turbo-stream/frame-reload wait baked into the
+    # helper: a same-list menu move now settles via a background fetch, not a
+    # frame reload, so the assertion right below has to observe the DOM before
+    # that request has any chance to complete.
+    backlogs_page
+      .click_in_sprint_story_move_menu(sprint_wp2, "Move up", wait: false)
+
+    backlogs_page
+      .expect_work_packages_in_sprint_in_order(sprint,
+                                               work_packages: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
+
+    backlogs_page.expect_backlogs_container_not_reloaded
+
+    wait_for do
+      WorkPackage.where(sprint:).order_by_position.pluck(:id)
+    end.to eq([sprint_wp2.id, sprint_wp1.id, sprint_wp3.id, sprint_wp4.id])
+
+    # Reloading confirms the move was actually persisted server-side, not just
+    # reflected in the client's optimistic DOM state.
+    backlogs_page.visit!
+    backlogs_page
+      .expect_work_packages_in_sprint_in_order(sprint,
+                                               work_packages: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
+  end
+end

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Backlogs::WorkPackages::UpdateService, "persistence", type: :model do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:status) { create(:status, is_default: true) }
+  shared_let(:project) { create(:project) }
+  shared_let(:sprint) { create(:sprint, project:) }
+  shared_let(:other_sprint) { create(:sprint, project:) }
+
+  let(:user) { admin }
+  let!(:work_package) { create(:work_package, status:, sprint:, project:) }
+
+  describe "atomicity of the two-phase move" do
+    it "rolls back the list change when move_after fails", :aggregate_failures do
+      # move_after runs after the list-change save, on the work package itself. Raise so
+      # the whole move must roll back as one unit.
+      allow(work_package).to receive(:move_after).and_raise(ActiveRecord::StatementInvalid, "boom")
+
+      original_sprint_id = work_package.sprint_id
+      original_position = work_package.position
+
+      expect do
+        described_class.new(user:, work_package:).call(list_type: "sprint", list_id: other_sprint.id, prev_id: "")
+      end.to raise_error(ActiveRecord::StatementInvalid)
+
+      work_package.reload
+      expect(work_package.sprint_id).to eq(original_sprint_id)
+      expect(work_package.position).to eq(original_position)
+    end
+  end
+end

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
@@ -84,6 +84,43 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, "persistence", type: :mode
     end
   end
 
+  describe "after-commit hooks around the two-phase move" do
+    it "fires the update hook once, observing the completed move", :aggregate_failures do
+      # An occupant makes the final position discriminating: the top insert
+      # ends at 1, while the plain list-change save would have appended.
+      create(:work_package, status:, sprint: other_sprint, project:)
+
+      observed = []
+      allow(OpenProject::Hook).to receive(:call_hook).and_call_original
+      allow(OpenProject::Hook).to receive(:call_hook).with(:work_package_after_update, anything) do |_hook, context|
+        hooked_work_package = context[:work_package]
+        observed << { sprint_id: hooked_work_package.sprint_id, position: hooked_work_package.position }
+      end
+
+      call = described_class.new(user:, work_package:).call(list_type: "sprint", list_id: other_sprint.id, prev_id: "")
+
+      expect(call).to be_success
+      # Exactly one hook call, and it already sees the final list and top
+      # position: the wrapping transaction defers it past move_after.
+      expect(call.result.position).to eq(1)
+      expect(observed).to eq([{ sprint_id: other_sprint.id, position: 1 }])
+    end
+
+    it "does not fire the update hook when the move rolls back" do
+      inner_service = WorkPackages::UpdateService.new(user:, model: work_package)
+      allow(inner_service).to receive(:after_perform).and_wrap_original do |original, service_call|
+        original.call(service_call).tap { |call| call.success = false }
+      end
+      allow(WorkPackages::UpdateService).to receive(:new).and_return(inner_service)
+      allow(OpenProject::Hook).to receive(:call_hook).and_call_original
+
+      call = described_class.new(user:, work_package:).call(list_type: "sprint", list_id: other_sprint.id, prev_id: "")
+
+      expect(call).to be_failure
+      expect(OpenProject::Hook).not_to have_received(:call_hook).with(:work_package_after_update, anything)
+    end
+  end
+
   describe "dirty tracking after a move (guards the controller's list snapshot)" do
     it "does not expose the list change via _before_last_save (move_after reloads)" do
       call = described_class.new(user:, work_package:).call(list_type: "sprint", list_id: other_sprint.id, prev_id: "")

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, "persistence", type: :mode
       expect(work_package.position).to eq(original_position)
     end
   end
+
+  describe "dirty tracking after a move (guards the controller's list snapshot)" do
+    it "does not expose the list change via _before_last_save (move_after reloads)" do
+      call = described_class.new(user:, work_package:).call(list_type: "sprint", list_id: other_sprint.id, prev_id: "")
+
+      expect(call).to be_success
+      expect(call.result.sprint_id).to eq(other_sprint.id)
+      # The list changed, but move_after's mid-method reload wipes saved_changes
+      # to {}, so _before_last_save comes back nil regardless. Hence the
+      # controller snapshots the source list instead of using dirty tracking.
+      expect(call.result.saved_changes).to eq({})
+      expect(call.result.sprint_id_before_last_save).to be_nil
+    end
+  end
 end

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_persistence_spec.rb
@@ -41,6 +41,31 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, "persistence", type: :mode
   let!(:work_package) { create(:work_package, status:, sprint:, project:) }
 
   describe "atomicity of the two-phase move" do
+    it "rolls back the list change when the update fails after persisting it", :aggregate_failures do
+      # The inner service signals such a failure by raising ActiveRecord::Rollback
+      # from within its own (joined) transaction, where it is silently swallowed.
+      # Fail it in after_perform -- after the work package row is written -- so
+      # the rollback must come from the outer transaction re-raising.
+      inner_service = WorkPackages::UpdateService.new(user:, model: work_package)
+      allow(inner_service).to receive(:after_perform).and_wrap_original do |original, service_call|
+        original.call(service_call).tap { |call| call.success = false }
+      end
+      allow(WorkPackages::UpdateService).to receive(:new).and_return(inner_service)
+      allow(work_package).to receive(:move_after)
+
+      original_sprint_id = work_package.sprint_id
+      original_position = work_package.position
+
+      call = described_class.new(user:, work_package:).call(list_type: "sprint", list_id: other_sprint.id, prev_id: "")
+
+      expect(call).to be_failure
+      expect(work_package).not_to have_received(:move_after)
+
+      reloaded = WorkPackage.find(work_package.id)
+      expect(reloaded.sprint_id).to eq(original_sprint_id)
+      expect(reloaded.position).to eq(original_position)
+    end
+
     it "rolls back the list change when move_after fails", :aggregate_failures do
       # move_after runs after the list-change save, on the work package itself. Raise so
       # the whole move must roll back as one unit.

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_spec.rb
@@ -59,24 +59,6 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
         end
       end
 
-      context "with neither list_type nor direction" do
-        it_behaves_like "returns failure without delegating",
-                        {},
-                        "backlogs.work_packages.update_service.missing_target"
-      end
-
-      context "with both list_type and direction" do
-        it_behaves_like "returns failure without delegating",
-                        { list_type: "inbox", direction: "highest" },
-                        "backlogs.work_packages.update_service.ambiguous_target"
-      end
-
-      context "with both list_id and direction" do
-        it_behaves_like "returns failure without delegating",
-                        { list_id: "42", direction: "highest" },
-                        "backlogs.work_packages.update_service.ambiguous_target"
-      end
-
       context "with a list_id but no list_type" do
         it_behaves_like "returns failure without delegating", { list_id: "42" }
       end
@@ -111,18 +93,11 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
         it_behaves_like "returns failure without delegating", { list_type: "inbox", list_id: "unknown" }
       end
 
-      context "with an invalid direction" do
-        it_behaves_like "returns failure without delegating",
-                        { direction: "sideways" },
-                        "backlogs.work_packages.update_service.invalid_direction"
-      end
-    end
+      it "fails when neither list nor position target is given" do
+        result = instance.call
 
-    context "with direction" do
-      it "delegates with move_to attribute" do
-        instance.call(direction: "highest")
-
-        expect(inner_service).to have_received(:call).with(move_to: "highest")
+        expect(result).to be_failure
+        expect(result.message).to eq(I18n.t("backlogs.work_packages.update_service.missing_target"))
       end
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -623,7 +623,7 @@ module Pages
           [find(sprint_selector(into)), nil]
         end
 
-      wait_for_backlogs_turbo_stream(frame_reload: true) do
+      wait_for_backlogs_turbo_stream(frame_reload: cross_list_drag?(moved, before:, after:, into:)) do
         drag_backlogs_item(source: moved_element, target: target_element, edge:)
       end
     rescue Capybara::Cuprite::ObsoleteNode, Selenium::WebDriver::Error::StaleElementReferenceError
@@ -911,6 +911,27 @@ module Pages
       else
         wait_for_turbo_stream(wait:, &)
       end
+    end
+
+    # A same-list reorder (drag within the same sprint/bucket/inbox) is applied
+    # optimistically and never reloads the `backlogs_container` frame (see
+    # Backlogs::WorkPackagesController#optimistic_same_list_move?), so
+    # {#drag_work_package} must not wait for one. An `into:` drop always targets
+    # a different sprint, and a `before:`/`after:` drop may or may not cross
+    # lists (e.g. dragging a bucket item to just before a sprint item), so list
+    # membership is compared directly.
+    def cross_list_drag?(moved, before:, after:, into:)
+      return true if into
+
+      list_identity(moved) != list_identity(before || after)
+    end
+
+    # Reads the passed record's in-memory list. Callers hand in freshly loaded
+    # records right before the drag, so this reflects the pre-drag list. Do not
+    # reuse the same object across two drags without reloading it first, or a
+    # stale identity would misclassify a same-list reorder as cross-list.
+    def list_identity(work_package)
+      [work_package.sprint_id, work_package.backlog_bucket_id]
     end
 
     def install_backlogs_dnd_probe(source:, target:, edge:)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -933,12 +933,14 @@ module Pages
       list_identity(moved) != list_identity(before || after)
     end
 
-    # Reads the passed record's in-memory list. Callers hand in freshly loaded
-    # records right before the drag, so this reflects the pre-drag list. Do not
-    # reuse the same object across two drags without reloading it first, or a
-    # stale identity would misclassify a same-list reorder as cross-list.
+    # Reads the record's current list from the database rather than trusting
+    # the passed object: specs reuse the same records across consecutive
+    # drags, and a stale in-memory identity would misclassify a cross-list
+    # drag as a same-list reorder, making the drag helper skip the frame
+    # reload wait and race the re-render.
     def list_identity(work_package)
-      [work_package.sprint_id, work_package.backlog_bucket_id]
+      fresh = work_package.class.find(work_package.id)
+      [fresh.sprint_id, fresh.backlog_bucket_id]
     end
 
     def install_backlogs_dnd_probe(source:, target:, edge:)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -354,10 +354,12 @@ module Pages
       end
     end
 
-    # The move submenu items (Move up/down/to top/to bottom) all perform a
-    # successful move, which reloads the `backlogs_container` frame. Wait for that
-    # reload so a subsequent drag does not grab a soon-to-be-detached element.
-    def click_in_work_package_move_submenu(work_package, item_name, wait: true, frame_reload: true)
+    # The move submenu items (Move up/down/to top/to bottom) reorder the row
+    # client-side and persist via a background fetch; a same-list move no
+    # longer reloads the `backlogs_container` frame (see
+    # Backlogs::WorkPackagesController#optimistic_same_list_move?). Wait for
+    # the turbo-stream response instead, which still fires either way.
+    def click_in_work_package_move_submenu(work_package, item_name, wait: true, frame_reload: false)
       within_work_package_move_submenu(work_package) do |submenu|
         wait_for_backlogs_turbo_stream(wait:, frame_reload:) do
           submenu.find(:menuitem, text: item_name, visible: :all).click
@@ -372,6 +374,46 @@ module Pages
       within_backlog_inbox do
         expect(page).to have_no_button(accessible_name: "Inbox actions")
       end
+    end
+
+    # Arms a listener for `turbo:frame-load` on `#backlogs_container` that
+    # fires at most once and latches a flag. A
+    # `reload_frame_via_turbo_stream("backlogs_container")` response (the
+    # non-optimistic move path) fetches and re-renders that frame, firing the
+    # event; an optimistic same-list move never touches the frame, so the
+    # flag stays unset. Call before the action under test, then assert with
+    # {#expect_backlogs_container_not_reloaded}. Each call resets the flag and
+    # arms a fresh listener, so re-arm before probing another action.
+    def install_backlogs_container_reload_probe
+      page.execute_script(<<~JS)
+        window.__opBacklogsContainerReloaded = false;
+        document.getElementById('backlogs_container')?.addEventListener(
+          'turbo:frame-load',
+          () => { window.__opBacklogsContainerReloaded = true; },
+          { once: true }
+        );
+      JS
+    end
+
+    # Confirms the probe armed by {#install_backlogs_container_reload_probe}
+    # never fired. Unlike the client's DOM reorder (synchronous) or the DB
+    # write (already committed by the time the response is received), a frame
+    # reload is a second, independent round trip with no synchronous signal to
+    # key off of -- so this actively waits up to `wait` seconds, long enough
+    # for that round trip to finish on a real (non-optimistic) move, before
+    # asserting the probe stayed unset.
+    def expect_backlogs_container_not_reloaded(wait: Capybara.default_max_wait_time)
+      reloaded = page.evaluate_async_script(<<~JS, wait * 1000)
+        const [timeoutMs, done] = [arguments[0], arguments[arguments.length - 1]];
+
+        if (window.__opBacklogsContainerReloaded) {
+          done(true);
+        } else {
+          setTimeout(() => done(window.__opBacklogsContainerReloaded === true), timeoutMs);
+        }
+      JS
+
+      expect(reloaded).to be(false)
     end
 
     def expect_no_backlog_bucket_menu(bucket)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -376,51 +376,18 @@ module Pages
       end
     end
 
-    # Arms a listener for `turbo:frame-load` on `#backlogs_container` that
-    # fires at most once and latches a flag. A
-    # `reload_frame_via_turbo_stream("backlogs_container")` response (the
-    # non-optimistic move path) fetches and re-renders that frame, firing the
-    # event; an optimistic same-list move never touches the frame, so the
-    # flag stays unset. Call before the action under test, then assert with
-    # {#expect_backlogs_container_not_reloaded}. Each call resets the flag and
-    # arms a fresh listener, so re-arm before probing another action.
+    # Arms a reload probe for the Backlogs container before a move action.
+    #
+    # @see WaitHelpers#install_turbo_frame_reload_probe
     def install_backlogs_container_reload_probe
-      page.execute_script(<<~JS)
-        window.__opBacklogsContainerReloaded = false;
-        document.getElementById('backlogs_container')?.addEventListener(
-          'turbo:frame-load',
-          () => { window.__opBacklogsContainerReloaded = true; },
-          { once: true }
-        );
-      JS
+      install_turbo_frame_reload_probe("backlogs_container")
     end
 
-    # Confirms the probe armed by {#install_backlogs_container_reload_probe}
-    # never fired. Unlike the client's DOM reorder (synchronous) or the DB
-    # write (already committed by the time the response is received), a frame
-    # reload is a second, independent round trip with no synchronous signal to
-    # key off of -- so this actively waits up to `wait` seconds, long enough
-    # for that round trip to finish on a real (non-optimistic) move, before
-    # asserting the probe stayed unset.
+    # Confirms that the Backlogs container did not reload after the move.
+    #
+    # @see WaitHelpers#expect_turbo_frame_not_reloaded
     def expect_backlogs_container_not_reloaded(wait: Capybara.default_max_wait_time)
-      # Capybara caps `evaluate_async_script` at Capybara.default_max_wait_time
-      # (it sets Selenium's script_timeout to it). The in-page probe below waits
-      # `wait` seconds before resolving, so give Selenium a strictly larger
-      # budget -- otherwise the two race at the same instant and CI overhead
-      # lands `done` just past the driver's deadline (ScriptTimeoutError).
-      reloaded = Capybara.using_wait_time(wait + 5) do
-        page.evaluate_async_script(<<~JS, wait * 1000)
-          const [timeoutMs, done] = [arguments[0], arguments[arguments.length - 1]];
-
-          if (window.__opBacklogsContainerReloaded) {
-            done(true);
-          } else {
-            setTimeout(() => done(window.__opBacklogsContainerReloaded === true), timeoutMs);
-          }
-        JS
-      end
-
-      expect(reloaded).to be(false)
+      expect_turbo_frame_not_reloaded("backlogs_container", wait:)
     end
 
     def expect_no_backlog_bucket_menu(bucket)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -939,8 +939,7 @@ module Pages
     # drag as a same-list reorder, making the drag helper skip the frame
     # reload wait and race the re-render.
     def list_identity(work_package)
-      fresh = work_package.class.find(work_package.id)
-      [fresh.sprint_id, fresh.backlog_bucket_id]
+      Backlogs::Target.for_work_package(work_package.class.find(work_package.id))
     end
 
     def install_backlogs_dnd_probe(source:, target:, edge:)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -403,15 +403,22 @@ module Pages
     # for that round trip to finish on a real (non-optimistic) move, before
     # asserting the probe stayed unset.
     def expect_backlogs_container_not_reloaded(wait: Capybara.default_max_wait_time)
-      reloaded = page.evaluate_async_script(<<~JS, wait * 1000)
-        const [timeoutMs, done] = [arguments[0], arguments[arguments.length - 1]];
+      # Capybara caps `evaluate_async_script` at Capybara.default_max_wait_time
+      # (it sets Selenium's script_timeout to it). The in-page probe below waits
+      # `wait` seconds before resolving, so give Selenium a strictly larger
+      # budget -- otherwise the two race at the same instant and CI overhead
+      # lands `done` just past the driver's deadline (ScriptTimeoutError).
+      reloaded = Capybara.using_wait_time(wait + 5) do
+        page.evaluate_async_script(<<~JS, wait * 1000)
+          const [timeoutMs, done] = [arguments[0], arguments[arguments.length - 1]];
 
-        if (window.__opBacklogsContainerReloaded) {
-          done(true);
-        } else {
-          setTimeout(() => done(window.__opBacklogsContainerReloaded === true), timeoutMs);
-        }
-      JS
+          if (window.__opBacklogsContainerReloaded) {
+            done(true);
+          } else {
+            setTimeout(() => done(window.__opBacklogsContainerReloaded === true), timeoutMs);
+          }
+        JS
+      end
 
       expect(reloaded).to be(false)
     end

--- a/spec/features/turbo_wait_helpers_spec.rb
+++ b/spec/features/turbo_wait_helpers_spec.rb
@@ -44,6 +44,93 @@ RSpec.describe "Turbo wait helpers", :js do
   end
 
   shared_examples "blocks until its event fires" do
+    before do
+      page.execute_script(<<~JS)
+        for (const id of ["reload_probe_frame", "unrelated_frame"]) {
+          const frame = document.createElement("turbo-frame");
+          frame.id = id;
+          document.body.appendChild(frame);
+        }
+      JS
+    end
+
+    def dispatch_turbo_frame_load(frame_id)
+      page.execute_script(<<~JS, frame_id)
+        document.getElementById(arguments[0]).dispatchEvent(
+          new CustomEvent("turbo:frame-load", { bubbles: true })
+        );
+      JS
+    end
+
+    it "passes when the named Turbo frame does not reload" do
+      install_turbo_frame_reload_probe("reload_probe_frame")
+
+      expect(expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.1)).to be_nil
+    end
+
+    it "fails when the named Turbo frame reloads" do
+      install_turbo_frame_reload_probe("reload_probe_frame")
+      dispatch_turbo_frame_load("reload_probe_frame")
+
+      expect do
+        expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.1)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+
+    it "fails when the named Turbo frame reloads during the wait" do
+      install_turbo_frame_reload_probe("reload_probe_frame")
+      page.execute_script(<<~JS)
+        setTimeout(() => {
+          document.getElementById("reload_probe_frame").dispatchEvent(
+            new CustomEvent("turbo:frame-load", { bubbles: true })
+          );
+        }, 50);
+      JS
+
+      expect do
+        expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.2)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+
+    it "ignores reloads from other Turbo frames" do
+      install_turbo_frame_reload_probe("reload_probe_frame")
+      dispatch_turbo_frame_load("unrelated_frame")
+
+      expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.1)
+    end
+
+    it "ignores nested frame reloads and remains armed for the named frame" do
+      page.execute_script(<<~JS)
+        const nestedFrame = document.createElement("turbo-frame");
+        nestedFrame.id = "nested_frame";
+        document.getElementById("reload_probe_frame").appendChild(nestedFrame);
+      JS
+      install_turbo_frame_reload_probe("reload_probe_frame")
+
+      dispatch_turbo_frame_load("nested_frame")
+      expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.1)
+
+      dispatch_turbo_frame_load("reload_probe_frame")
+      expect do
+        expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.1)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+
+    it "resets and re-arms a probe for the same Turbo frame" do
+      install_turbo_frame_reload_probe("reload_probe_frame")
+      dispatch_turbo_frame_load("reload_probe_frame")
+
+      install_turbo_frame_reload_probe("reload_probe_frame")
+
+      expect_turbo_frame_not_reloaded("reload_probe_frame", wait: 0.1)
+    end
+
+    it "fails clearly when the Turbo frame is absent" do
+      expect do
+        install_turbo_frame_reload_probe("missing_frame")
+      end.to raise_error(Capybara::ElementNotFound, /missing_frame/)
+    end
+
     it "wait_for_turbo_stream returns only after op:turbo-stream-rendered" do
       page.execute_script("window.__turboWaitFlag = false;")
       wait_for_turbo_stream do

--- a/spec/support/capybara/wait_helpers.rb
+++ b/spec/support/capybara/wait_helpers.rb
@@ -112,6 +112,85 @@ module WaitHelpers
     wait_for_browser_event("turbo:frame-load", target_id: frame&.to_s, wait:, &)
   end
 
+  # Arms a one-shot reload probe for the Turbo frame with `frame_id`.
+  #
+  # The listener latches the probe state when the named frame loads. Each call
+  # resets that state and attaches a fresh one-shot listener, so callers can
+  # re-arm the probe before every action they want to observe.
+  #
+  # @param frame_id [String, Symbol] the DOM id of the Turbo frame to observe
+  # @raise [Capybara::ElementNotFound] if no Turbo frame has `frame_id`
+  # @return [nil] after successfully arming the probe
+  def install_turbo_frame_reload_probe(frame_id)
+    frame_id = frame_id.to_s
+    installed = page.evaluate_script(<<~JS, frame_id)
+      (() => {
+        const frameId = arguments[0];
+        const frame = document.getElementById(frameId);
+
+        if (!frame || frame.tagName !== "TURBO-FRAME") { return false; }
+
+        const probes = (window.__opTurboFrameReloadProbes ||= {});
+        probes[frameId] = false;
+        const onFrameLoad = (event) => {
+          if (event.target !== frame) { return; }
+
+          probes[frameId] = true;
+          frame.removeEventListener("turbo:frame-load", onFrameLoad);
+        };
+        frame.addEventListener("turbo:frame-load", onFrameLoad);
+        return true;
+      })()
+    JS
+
+    return if installed
+
+    raise Capybara::ElementNotFound,
+          "Unable to install Turbo frame reload probe: no turbo-frame##{frame_id}"
+  end
+
+  # Waits for a possible reload and expects the named frame's probe to remain unset.
+  #
+  # The browser-side timer waits `wait` seconds before reporting an unchanged
+  # probe. Capybara caps async scripts at its current maximum wait time, so the
+  # outer budget must exceed that timer. The five-second headroom prevents
+  # Selenium from racing the callback and raising `ScriptTimeoutError` in CI.
+  #
+  # @param frame_id [String, Symbol] the DOM id used to install the probe
+  # @param wait [Numeric] seconds to wait for a possible frame reload
+  # @raise [Capybara::ExpectationNotMet] if no probe is installed for `frame_id`
+  # @raise [RSpec::Expectations::ExpectationNotMetError] if the frame reloaded
+  # @return [nil] after the probe remains unset for the wait period
+  def expect_turbo_frame_not_reloaded(frame_id, wait: Capybara.default_max_wait_time)
+    frame_id = frame_id.to_s
+    result = Capybara.using_wait_time(wait + 5) do
+      page.evaluate_async_script(<<~JS, frame_id, wait * 1000)
+        const [frameId, timeoutMs] = arguments;
+        const done = arguments[arguments.length - 1];
+        const probes = window.__opTurboFrameReloadProbes || {};
+
+        if (!Object.prototype.hasOwnProperty.call(probes, frameId)) {
+          done({ installed: false, reloaded: false });
+        } else if (probes[frameId]) {
+          done({ installed: true, reloaded: true });
+        } else {
+          setTimeout(
+            () => done({ installed: true, reloaded: probes[frameId] === true }),
+            timeoutMs
+          );
+        }
+      JS
+    end
+
+    unless result.fetch("installed")
+      raise Capybara::ExpectationNotMet,
+            "No Turbo frame reload probe installed for ##{frame_id}"
+    end
+
+    expect(result.fetch("reloaded")).to be(false)
+    nil
+  end
+
   private
 
   # Shared implementation for the +wait_for_turbo*+ helpers.


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-322
https://community.openproject.org/wp/AGILE-343

# What are you trying to accomplish?

A Backlogs drag reorder is applied optimistically in the client DOM (#23218). Today the server answers every move with a full `backlogs_container` frame reload, which re-renders the rows the client already reordered — fighting the optimistic order and forcing an avoidable round-trip re-render.

For a **successful, same-list, optimistic** move the controller now returns a turbo-stream that dispatches `WORK_PACKAGE_MOVED_EVENT` **without** re-rendering the frame. The optimistic order stands, and split-view `lock_version` refresh still rides the event. Cross-list moves keep the full frame reload; a failed move returns an error response and the client restores the original order itself (ownership-aware rollback plus an error toast) rather than relying on a frame reload.

The card menu's directional moves (Move up / down / to top / to bottom) are now rendered client-side and take the same optimistic path as a drag: the client reorders the DOM, sends `optimistic=true` with the resolved `prev_id`, and the frame stays untouched on success.

Extracted from the closed #24104 (its controller/topology rework is parked), incorporating @ulferts' review from that PR.

# What approach did you choose and why?

The reload decision cannot be inferred server-side: whether the client already applied the move in the DOM is client knowledge, so the client flags optimistic moves with `optimistic=true` on both the drag and the directional-menu path. Requests without the flag (or from pages rendered before this change) keep the reload behaviour.

Same-list is detected by comparing `Backlogs::Target` values snapshotted before the call rather than dirty tracking, because `move_after` reloads mid-method and wipes the `saved_changes` a `_before_last_save` check would need. A guard spec pins this behaviour. On top of that, the server only skips the reload when the requested anchor verifiably matches the persisted order: a nonblank `prev_id` must be the item directly above after the move, a blank `prev_id` (top insert) must end up with nothing above, and anchorless or `position`-based optimistic requests always reconcile via reload.

The whole two-phase move (`WorkPackages::UpdateService` save + `move_after`) runs in one transaction, and the wrapping service re-raises `ActiveRecord::Rollback` when the inner service fails after the row was already written — the inner service's own rollback joins the outer transaction and would otherwise be swallowed, half-committing the move while the client rolled back. As a consequence, `after_commit` callbacks (e.g. the `work_package_after_update` plugin hook) fire only once the whole move committed, observing the final list and position with `saved_changes` cleared; a spec pins that hooks fire exactly once on success and not at all on rollback.

Menu availability is computed client-side: the server always renders all four move items, and the item controller enables/disables them (or the whole submenu) from a single `moveAvailability` snapshot on every menu open. The gating is truncation-aware — in a truncated list (head items + "Show N more" marker + tail items) one-step moves across the hidden block are disabled while top/bottom stay addressable, and unannotated non-item rows are treated as hard gaps. The direction travels as a Stimulus action parameter (`data-sortable-lists--item-direction-param`), validated by a runtime guard.

An earlier draft (#24104) answered with `head :no_content`. That was rejected: a `204` has no body to carry `WORK_PACKAGE_MOVED_EVENT`, so it would regress split-view `lock_version` refresh, and it cannot address the stale card menu. The event-only turbo-stream keeps the frame untouched while still signalling what changed.

# Compatibility note

Pages rendered before this change submit `direction=highest|lowest` (without list params) for the top/bottom menu moves. That parameter is no longer accepted, so those actions fail with a `missing_target` error until the page is refreshed. This affects stale open tabs and mixed-version rolling deployments and is accepted deliberately — a refresh recovers, and a compatibility shim was considered and rejected to keep the wire format single-shaped.

# Deferred follow-up

A DOM-cached card menu keeps stale move options after a same-list move; the fix is to invalidate/refetch the deferred menu on `WORK_PACKAGE_MOVED_EVENT` (overlaps #23962). This is pre-existing on the base branch, not a regression introduced here. Further follow-ups from review (generic turbo-frame reload probe helper, shared four-direction menu descriptor, sortable-lists DOM contract doc, `with_backlogs_neighbours` deprecation) are tracked as work packages under AGILE-291.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
