### PR TITLE
[COMMS-852]: Extract version logic into the WorkPackage::Versions concern

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -60,7 +60,6 @@ class WorkPackage < ApplicationRecord
   belongs_to :author, class_name: "User"
   belongs_to :assigned_to, class_name: "Principal", optional: true
   belongs_to :responsible, class_name: "Principal", optional: true
-  belongs_to :version, optional: true
   belongs_to :project_phase_definition, class_name: "Project::PhaseDefinition", optional: true
   belongs_to :priority, class_name: "IssuePriority"
   belongs_to :category, class_name: "Category", optional: true
@@ -68,14 +67,6 @@ class WorkPackage < ApplicationRecord
   has_many :time_entries, dependent: :delete_all, inverse_of: :entity, as: :entity
   has_many :file_links, dependent: :delete_all, class_name: "Storages::FileLink", as: :container
   has_many :storages, through: :project
-  has_many :work_package_versions, dependent: :delete_all
-  has_many :versions, through: :work_package_versions, source: :version
-  has_many :target_versions,
-           -> { where(work_package_versions: { kind: "target" }) },
-           through: :work_package_versions, source: :version
-  has_many :observed_in_versions,
-           -> { where(work_package_versions: { kind: "observed_in" }) },
-           through: :work_package_versions, source: :version
 
   has_and_belongs_to_many :changesets, -> { # rubocop:disable Rails/HasAndBelongsToMany
     order("#{Changeset.table_name}.committed_on ASC, #{Changeset.table_name}.id ASC")
@@ -126,10 +117,6 @@ class WorkPackage < ApplicationRecord
   scope :on_active_project, -> {
     includes(:status, :project, :type)
       .where(projects: { active: true })
-  }
-
-  scope :without_version, -> {
-    where(version_id: nil)
   }
 
   scope :with_query, ->(query) {
@@ -266,24 +253,6 @@ class WorkPackage < ApplicationRecord
   def add_time_entry(attributes = {})
     attributes.reverse_merge!(project:, entity: self)
     time_entries.build(attributes)
-  end
-
-  # Versions that the work_package can be assigned to
-  # A work_package can be assigned to:
-  #   * any open, shared version of the project the wp belongs to
-  #   * the version it was already assigned to
-  #     (to make sure, that you can still update closed tickets)
-  #   * for custom fields only_open: false can be used, if the CF is configured so
-  def assignable_versions(only_open: true)
-    if only_open
-      @assignable_versions ||= begin
-        current_version = version_id_changed? ? Version.find_by(id: version_id_was) : version
-        ((project&.assignable_versions || []) + [current_version]).compact.uniq
-      end
-    else
-      # The called method memoizes the result, no need to memoize it here.
-      project&.assignable_versions(only_open: false)
-    end
   end
 
   def to_s
@@ -429,24 +398,6 @@ class WorkPackage < ApplicationRecord
   # the user is create a work package in
   def self.allowed_target_projects_on_create(user)
     Project.allowed_to(user, :add_work_packages)
-  end
-
-  # Unassigns issues from +version+ if it's no longer shared with issue's project
-  def self.update_versions_from_sharing_change(version)
-    # Update issues assigned to the version
-    update_versions(["#{WorkPackage.table_name}.version_id = ?", version.id])
-  end
-
-  # Unassigns issues from versions that are no longer shared
-  # after +project+ was moved
-  def self.update_versions_from_hierarchy_change(project)
-    moved_project_ids = project.self_and_descendants.reload.map(&:id)
-    # Update issues of the moved projects and issues assigned to a version of a moved project
-    update_versions(
-      ["#{Version.table_name}.project_id IN (?) OR #{WorkPackage.table_name}.project_id IN (?)",
-       moved_project_ids,
-       moved_project_ids]
-    )
   end
 
   # Extracted from the ReportsController.
@@ -628,39 +579,6 @@ class WorkPackage < ApplicationRecord
 
     default_id && attributes.except(key).values.all?(&:blank?)
   end
-
-  def self.having_version_from_other_project
-    where(
-      "#{WorkPackage.table_name}.version_id IS NOT NULL" +
-      " AND #{WorkPackage.table_name}.project_id <> #{Version.table_name}.project_id" +
-      " AND #{Version.table_name}.sharing <> 'system'"
-    )
-  end
-
-  private_class_method :having_version_from_other_project
-
-  # Update issues so their versions are not pointing to a
-  # version that is not shared with the issue's project
-  def self.update_versions(conditions = nil) # rubocop:disable Metrics/AbcSize
-    # Only need to update issues with a version from
-    # a different project and that is not systemwide shared
-    having_version_from_other_project
-      .where(conditions)
-      .includes(:project, :version)
-      .references(:versions).find_each do |issue|
-      next if issue.project.nil? || issue.version.nil?
-
-      unless issue.project.shared_versions.include?(issue.version)
-        # this is path that clears version_id without going through the services,
-        # so we need to manually drop the matching target association here too.
-        issue.target_versions.delete(issue.version)
-        issue.version = nil
-        issue.save
-      end
-    end
-  end
-
-  private_class_method :update_versions
 
   # Default assignment based on category
   def default_assign

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -59,17 +59,19 @@ module WorkPackage::Versions
   end
 
   class_methods do
-    # Unassigns issues from +version+ if it's no longer shared with issue's project
+    # Unassigns work packages from +version+ if it's no longer shared with
+    # the work package's project
     def update_versions_from_sharing_change(version)
-      # Update issues assigned to the version
+      # Update work packages assigned to the version
       update_versions(["#{WorkPackage.table_name}.version_id = ?", version.id])
     end
 
-    # Unassigns issues from versions that are no longer shared
+    # Unassigns work packages from versions that are no longer shared
     # after +project+ was moved
     def update_versions_from_hierarchy_change(project)
       moved_project_ids = project.self_and_descendants.reload.map(&:id)
-      # Update issues of the moved projects and issues assigned to a version of a moved project
+      # Update work packages of the moved projects and work packages assigned
+      # to a version of a moved project
       update_versions(
         ["#{Version.table_name}.project_id IN (?) OR #{WorkPackage.table_name}.project_id IN (?)",
          moved_project_ids,
@@ -87,23 +89,26 @@ module WorkPackage::Versions
       )
     end
 
-    # Update issues so their versions are not pointing to a
-    # version that is not shared with the issue's project
+    # Update work packages so their versions are not pointing to a
+    # version that is not shared with the work package's project
     def update_versions(conditions = nil) # rubocop:disable Metrics/AbcSize
-      # Only need to update issues with a version from
+      # Only need to update work packages with a version from
       # a different project and that is not systemwide shared
       having_version_from_other_project
         .where(conditions)
         .includes(:project, :version)
-        .references(:versions).find_each do |issue|
-        next if issue.project.nil? || issue.version.nil?
+        .references(:versions).find_each do |work_package|
+        next if work_package.project.nil? || work_package.version.nil?
 
-        unless issue.project.shared_versions.include?(issue.version)
-          # this is path that clears version_id without going through the services,
+        unless work_package.project.shared_versions.include?(work_package.version)
+          # this path clears version_id without going through the services,
           # so we need to manually drop the matching target association here too.
-          issue.target_versions.delete(issue.version)
-          issue.version = nil
-          issue.save # rubocop:disable Rails/SaveBang
+          work_package.target_versions.delete(work_package.version)
+          work_package.version = nil
+          unless work_package.save
+            Rails.logger.error "Failed to clear version on work package ##{work_package.id}: " \
+                               "#{work_package.errors.full_messages.to_sentence}"
+          end
         end
       end
     end

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -32,12 +32,99 @@ module WorkPackage::Versions
   extend ActiveSupport::Concern
 
   included do
+    # Deprecated single-version column, kept in sync with the first target
+    # version (see #update_legacy_version_field). Can be dropped once all
+    # subsystems read target_versions instead.
+    belongs_to :version, optional: true
+
+    has_many :work_package_versions, dependent: :delete_all
+    has_many :versions, through: :work_package_versions, source: :version
+    has_many :target_versions,
+             -> { where(work_package_versions: { kind: "target" }) },
+             through: :work_package_versions, source: :version
+    has_many :observed_in_versions,
+             -> { where(work_package_versions: { kind: "observed_in" }) },
+             through: :work_package_versions, source: :version
+
+    scope :without_version, -> {
+      where(version_id: nil)
+    }
+
     # Must be registered before `save_journals` (WorkPackage::Journalized) so
     # that the journal snapshot sees the current version sets in the database.
     after_save :persist_version_associations
 
     attr_accessor :target_version_ids_replacements,
                   :observed_in_version_ids_replacements
+  end
+
+  class_methods do
+    # Unassigns issues from +version+ if it's no longer shared with issue's project
+    def update_versions_from_sharing_change(version)
+      # Update issues assigned to the version
+      update_versions(["#{WorkPackage.table_name}.version_id = ?", version.id])
+    end
+
+    # Unassigns issues from versions that are no longer shared
+    # after +project+ was moved
+    def update_versions_from_hierarchy_change(project)
+      moved_project_ids = project.self_and_descendants.reload.map(&:id)
+      # Update issues of the moved projects and issues assigned to a version of a moved project
+      update_versions(
+        ["#{Version.table_name}.project_id IN (?) OR #{WorkPackage.table_name}.project_id IN (?)",
+         moved_project_ids,
+         moved_project_ids]
+      )
+    end
+
+    private
+
+    def having_version_from_other_project
+      where(
+        "#{WorkPackage.table_name}.version_id IS NOT NULL" +
+        " AND #{WorkPackage.table_name}.project_id <> #{Version.table_name}.project_id" +
+        " AND #{Version.table_name}.sharing <> 'system'"
+      )
+    end
+
+    # Update issues so their versions are not pointing to a
+    # version that is not shared with the issue's project
+    def update_versions(conditions = nil) # rubocop:disable Metrics/AbcSize
+      # Only need to update issues with a version from
+      # a different project and that is not systemwide shared
+      having_version_from_other_project
+        .where(conditions)
+        .includes(:project, :version)
+        .references(:versions).find_each do |issue|
+        next if issue.project.nil? || issue.version.nil?
+
+        unless issue.project.shared_versions.include?(issue.version)
+          # this is path that clears version_id without going through the services,
+          # so we need to manually drop the matching target association here too.
+          issue.target_versions.delete(issue.version)
+          issue.version = nil
+          issue.save # rubocop:disable Rails/SaveBang
+        end
+      end
+    end
+  end
+
+  # Versions that the work_package can be assigned to
+  # A work_package can be assigned to:
+  #   * any open, shared version of the project the wp belongs to
+  #   * the version it was already assigned to
+  #     (to make sure, that you can still update closed tickets)
+  #   * for custom fields only_open: false can be used, if the CF is configured so
+  def assignable_versions(only_open: true)
+    if only_open
+      @assignable_versions ||= begin
+        current_version = version_id_changed? ? Version.find_by(id: version_id_was) : version
+        ((project&.assignable_versions || []) + [current_version]).compact.uniq
+      end
+    else
+      # The called method memoizes the result, no need to memoize it here.
+      project&.assignable_versions(only_open: false)
+    end
   end
 
   # The *_ids_replacements accessors behave according to these rules:


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/COMMS-852

> [!NOTE]
>  Follow-up to #24146. 

# What are you trying to accomplish?

The work package model still carried the version associations, `assignable_versions` and the version sharing cleanup class methods while the `WorkPackage::Versions` concern only held the new persistence logic. This moves all of it into the concern so the version handling lives in one place. Along the way the moved cleanup methods drop their Redmine-era "issue" wording, and a work package that fails to save while clearing an unshared version is logged instead of silently skipped. `by_version` stays in the model with the other reporting helpers it shares `count_and_group_by` with.