### PR TITLE
[SPPM-309] Overview widget for project phases and gates

### DIFF
--- a/app/models/project/phase.rb
+++ b/app/models/project/phase.rb
@@ -51,6 +51,13 @@ class Project::Phase < ApplicationRecord
   attr_readonly :definition_id
 
   scope :active, -> { where(active: true) }
+  scope :with_timeline_content, -> {
+    joins(:definition).where(
+      "(project_phases.start_date IS NOT NULL AND project_phases.finish_date IS NOT NULL) OR " \
+      "(project_phase_definitions.start_gate = TRUE AND project_phases.start_date IS NOT NULL) OR " \
+      "(project_phase_definitions.finish_gate = TRUE AND project_phases.finish_date IS NOT NULL)"
+    )
+  }
   scopes :order_by_position,
          :covering_dates_or_days_of_week
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -124,7 +124,9 @@
         "turbo_power": "^0.7.1",
         "typedjson": "^1.5.1",
         "urijs": "^1.19.11",
-        "uuid": "^14.0.1"
+        "uuid": "^14.0.1",
+        "vis-data": "^8.0.4",
+        "vis-timeline": "^8.5.1"
       },
       "devDependencies": {
         "@angular-builders/custom-esbuild": "^22.0.0",
@@ -16887,6 +16889,41 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vis-data": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.4.tgz",
+      "integrity": "sha512-TsN0sMHqIRpdfg6TNPtfdINpkgxtnQP6JNWCaiSwvou5seXqKiP5eERkaBg+Y56wyJ4FZTeOEs/dEmWEPrpltQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-timeline": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-8.5.1.tgz",
+      "integrity": "sha512-6pqx4Zl/xHCEy5nXRaz9xCOx1HtZWkxSIt1oHJmDZy/UxT09kwq1eA4eKRAzhHey3PN1Ee3DsxuxHm7yI2G2mQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "moment": "^2.24.0",
+        "propagating-hammerjs": "^1.4.0 || ^2.0.0 || ^3.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0",
+        "xss": "^1.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -169,7 +169,9 @@
     "turbo_power": "^0.7.1",
     "typedjson": "^1.5.1",
     "urijs": "^1.19.11",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "vis-data": "^8.0.4",
+    "vis-timeline": "^8.5.1"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -205,6 +205,7 @@ import { DashboardComponent } from './features/overview/dashboard.component';
 import { BurndownChartComponent } from './features/backlogs/burndown-chart.component';
 import { BudgetByCostTypeComponent } from './shared/components/budget-graphs/overview/budget-by-cost-type.component';
 import { ActualCostsComponent } from './shared/components/budget-graphs/overview/actual-costs.component';
+import { ProjectTimelineGraphComponent } from './shared/components/project-timeline-graph/project-timeline-graph.component';
 
 export function initializeServices(injector:Injector) {
   return () => {
@@ -421,5 +422,6 @@ export class OpenProjectModule implements DoBootstrap {
     registerCustomElement('opce-burndown-chart', BurndownChartComponent, { injector });
     registerCustomElement('opce-budget-by-cost-type', BudgetByCostTypeComponent, { injector });
     registerCustomElement('opce-actual-costs', ActualCostsComponent, { injector });
+    registerCustomElement('opce-project-timeline-graph', ProjectTimelineGraphComponent, { injector });
   }
 }

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.html
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.html
@@ -1,0 +1,1 @@
+<div #container class="op-project-timeline-graph"></div>

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -1,0 +1,78 @@
+@import "vis-timeline/styles/vis-timeline-graph2d.css"
+@import "helpers"
+
+.op-project-timeline-graph
+  width: 100%
+
+  // Timeline border and grid lines
+  .vis-timeline
+    border-color: transparent
+  .vis-grid.vis-minor,
+  .vis-grid.vis-major,
+  .vis-panel,
+  .vis-foreground .vis-group
+    border-color: var(--borderColor-default)
+
+  .vis-text
+    color: var(--body-font-color)
+
+  // Hide the group label column — groups are for layout only
+  .vis-labelset
+    display: none
+
+  // Tooltip
+  .vis-tooltip
+    background: var(--body-background)
+    color: var(--fgColor-default)
+    border: 1px solid var(--borderColor-default)
+    border-radius: var(--borderRadius-default)
+    box-shadow: var(--shadow-floating-small)
+    padding: var(--base-size-12)
+
+  .op-timeline-tooltip--meta-row
+    display: inline-flex
+    align-items: center
+    column-gap: var(--base-size-4)
+    font-size: var(--text-body-size-small)
+
+    i
+      display: flex
+      margin-left: var(--base-size-4)
+
+  .op-timeline-tooltip--type
+    color: var(--fgColor-muted)
+
+  .op-timeline-tooltip--name
+    font-weight: var(--base-text-weight-semibold)
+    margin-top: var(--base-size-4)
+
+  // Phase bars
+  .vis-item.vis-range
+    border-width: 0
+    border-radius: var(--borderRadius-default)
+    font-size: var(--text-body-size-small)
+    overflow: hidden
+
+    .vis-item-content
+      display: block
+      max-width: 100%
+      padding: 0 var(--base-size-6)
+      @include text-shortener
+      line-height: inherit
+
+  // The highlight class uses `background: ... !important`, so we need !important
+  // to suppress it on the point container (vis-timeline applies className to both
+  // .vis-point and .vis-dot, but we only want the color on the dot).
+  .vis-item.vis-point.op-timeline-gate
+    background: none !important
+    border-color: transparent !important
+
+  // Gates: diamond shape via `rotate` (CSS Transforms Level 2).
+  // vis-timeline sets `transform: translateX()` on the dot via JS inline style —
+  // `rotate` is a separate CSS property and is not affected by that.
+  .vis-item.vis-dot.op-timeline-gate
+    width: 10px
+    height: 10px
+    border-width: 0
+    border-radius: 0
+    rotate: 45deg

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -81,3 +81,14 @@
   .vis-item.vis-point.op-timeline-gate--finish
     .vis-item-content
       transform: translateX(-100%)
+
+  // Cluster items
+  .vis-item.vis-cluster
+    background: var(--body-background)
+    border: 1px solid var(--borderColor-default)
+    border-radius: var(--borderRadius-large)
+    color: var(--fgColor-default)
+    font-size: var(--text-body-size-small)
+    font-weight: var(--base-text-weight-semibold)
+    cursor: pointer
+    padding: 0 var(--base-size-6)

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -60,19 +60,24 @@
       @include text-shortener
       line-height: inherit
 
-  // The highlight class uses `background: ... !important`, so we need !important
-  // to suppress it on the point container (vis-timeline applies className to both
-  // .vis-point and .vis-dot, but we only want the color on the dot).
+  // Gates: show the gate SVG icon instead of the default vis-timeline dot.
+  // vis-timeline applies className to both .vis-point and .vis-dot, so we
+  // suppress the background highlight and dot on the container/dot elements
+  // and let the icon in .vis-item-content carry the color via __hl_inline_*.
   .vis-item.vis-point.op-timeline-gate
     background: none !important
     border-color: transparent !important
 
-  // Gates: diamond shape via `rotate` (CSS Transforms Level 2).
-  // vis-timeline sets `transform: translateX()` on the dot via JS inline style —
-  // `rotate` is a separate CSS property and is not affected by that.
+    .vis-item-content
+      display: flex
+      align-items: center
+      padding: 0
+
   .vis-item.vis-dot.op-timeline-gate
-    width: 10px
-    height: 10px
-    border-width: 0
-    border-radius: 0
-    rotate: 45deg
+    display: none
+
+  // Finish gate: shift the icon left so its right edge aligns with the phase end date,
+  // matching the right edge of the phase bar.
+  .vis-item.vis-point.op-timeline-gate--finish
+    .vis-item-content
+      transform: translateX(-100%)

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -28,6 +28,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { ProjectTimelineItem, ProjectTimelineGraphComponent } from './project-timeline-graph.component';
 
 describe('ProjectTimelineGraphComponent', () => {
@@ -38,6 +39,10 @@ describe('ProjectTimelineGraphComponent', () => {
         'js.grid.widgets.project_timeline.tooltip_type_gate': 'Gate',
       }[key] ?? key;
     },
+  };
+
+  const timezoneStub = {
+    formattedDate(date:string):string { return date; },
   };
 
   const phaseWithDates = {
@@ -64,6 +69,18 @@ describe('ProjectTimelineGraphComponent', () => {
     finishGateName: 'Build End',
   };
 
+  const oneDayPhase = {
+    id: 4,
+    definitionId: 9,
+    name: 'Kickoff',
+    startDate: '2024-05-15',
+    endDate: '2024-05-15',
+    startGate: false,
+    startGateName: null,
+    finishGate: false,
+    finishGateName: null,
+  };
+
   const phaseWithoutDates = {
     id: 3,
     definitionId: 7,
@@ -87,6 +104,7 @@ describe('ProjectTimelineGraphComponent', () => {
       imports: [ProjectTimelineGraphComponent],
       providers: [
         { provide: I18nService, useValue: i18nStub },
+        { provide: TimezoneService, useValue: timezoneStub },
       ],
     }).compileComponents();
 
@@ -144,6 +162,37 @@ describe('ProjectTimelineGraphComponent', () => {
       expect(items.find((i) => i.id === 'gate-finish-1')).toBeUndefined();
     });
 
+    describe('for a one-day phase', () => {
+      let item:ProjectTimelineItem;
+
+      beforeEach(() => {
+        ({ items: [item] } = buildData([oneDayPhase]));
+      });
+
+      it('creates a range item', () => {
+        expect(item).toBeDefined();
+        expect(item.type).toBe('range');
+      });
+
+      it('sets start to previous day local noon', () => {
+        expect(item.start instanceof Date).toBe(true);
+        const start = item.start as Date;
+        expect(start.getHours()).toBe(12);
+        expect(start.getDate()).toBe(14); // day before May 15
+      });
+
+      it('sets end to same day local noon', () => {
+        expect(item.end instanceof Date).toBe(true);
+        const end = item.end as Date;
+        expect(end.getHours()).toBe(12);
+        expect(end.getDate()).toBe(15);
+      });
+
+      it('stores originalEnd as the original date string', () => {
+        expect(item.originalEnd).toBe('2024-05-15');
+      });
+    });
+
     it('always creates gates and lifecycle groups', () => {
       const { groups } = buildData([]);
       expect(groups.map((g) => g.id)).toEqual(['gates', 'lifecycle']);
@@ -189,6 +238,35 @@ describe('ProjectTimelineGraphComponent', () => {
 
       it('applies the highlight class to the type indicator', () => {
         expect(result.querySelector('.__hl_inline_project_phase_definition_3')).toBeTruthy();
+      });
+    });
+
+    describe('for a one-day phase item', () => {
+      let result:HTMLElement;
+
+      beforeEach(() => {
+        result = tooltipTemplate({
+          id: 'phase-4',
+          group: 'lifecycle',
+          type: 'range',
+          start: new Date('2024-05-14T12:00:00'),
+          end: new Date('2024-05-15T12:00:00'),
+          originalEnd: '2024-05-15',
+          content: 'Kickoff',
+          title: 'Kickoff',
+          className: '__hl_background_project_phase_definition_9',
+          definitionId: 9,
+        }) as HTMLElement;
+      });
+
+      it('shows only a single date (no range)', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).not.toContain('–');
+      });
+
+      it('shows the phase name', () => {
+        const name = result.querySelector('.op-timeline-tooltip--name');
+        expect(name?.textContent).toBe('Kickoff');
       });
     });
 

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -130,6 +130,8 @@ describe('ProjectTimelineGraphComponent', () => {
       expect(startGate!.group).toBe('gates');
       expect(startGate!.title).toBe('Build Start');
       expect(startGate!.className).toContain('op-timeline-gate');
+      expect(startGate!.content instanceof HTMLElement).toBe(true);
+      expect((startGate!.content as HTMLElement).querySelector('.__hl_inline_project_phase_definition_5')).toBeTruthy();
 
       const finishGate = items.find((i) => i.id === 'gate-finish-2');
       expect(finishGate).toBeDefined();
@@ -199,7 +201,7 @@ describe('ProjectTimelineGraphComponent', () => {
           group: 'gates',
           type: 'point',
           start: new Date('2024-04-01'),
-          content: '',
+          content: document.createElement('i'),
           title: 'Build Start',
           className: 'op-timeline-gate __hl_background_project_phase_definition_5',
           definitionId: 5,

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -1,0 +1,229 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ProjectTimelineItem, ProjectTimelineGraphComponent } from './project-timeline-graph.component';
+
+describe('ProjectTimelineGraphComponent', () => {
+  const i18nStub = {
+    t(key:string):string {
+      return {
+        'js.grid.widgets.project_timeline.tooltip_type_phase': 'Phase',
+        'js.grid.widgets.project_timeline.tooltip_type_gate': 'Gate',
+      }[key] ?? key;
+    },
+  };
+
+  const phaseWithDates = {
+    id: 1,
+    definitionId: 3,
+    name: 'Design',
+    startDate: '2024-01-01',
+    endDate: '2024-03-31',
+    startGate: false,
+    startGateName: null,
+    finishGate: false,
+    finishGateName: null,
+  };
+
+  const phaseWithGates = {
+    id: 2,
+    definitionId: 5,
+    name: 'Build',
+    startDate: '2024-04-01',
+    endDate: '2024-06-30',
+    startGate: true,
+    startGateName: 'Build Start',
+    finishGate: true,
+    finishGateName: 'Build End',
+  };
+
+  const phaseWithoutDates = {
+    id: 3,
+    definitionId: 7,
+    name: 'Undated',
+    startDate: null,
+    endDate: null,
+    startGate: false,
+    startGateName: null,
+    finishGate: false,
+    finishGateName: null,
+  };
+
+  let fixture:ComponentFixture<ProjectTimelineGraphComponent>;
+  let component:ProjectTimelineGraphComponent;
+
+  let buildData:(phases:unknown[]) => { items:ProjectTimelineItem[]; groups:{ id:string; content:string }[] };
+  let tooltipTemplate:(item:ProjectTimelineItem) => HTMLElement|string;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectTimelineGraphComponent],
+      providers: [
+        { provide: I18nService, useValue: i18nStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectTimelineGraphComponent);
+    component = fixture.componentInstance;
+
+    // Set required input before detectChanges triggers ngAfterViewInit
+    fixture.componentRef.setInput('phasesData', '[]');
+    fixture.detectChanges();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
+    buildData = (component as any).buildData.bind(component);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
+    tooltipTemplate = (component as any).tooltipTemplate.bind(component);
+  });
+
+  describe('buildData', () => {
+    it('creates a range item for a phase with dates', () => {
+      const { items } = buildData([phaseWithDates]);
+      const item = items.find((i) => i.id === 'phase-1');
+
+      expect(item).toBeDefined();
+      expect(item!.type).toBe('range');
+      expect(item!.group).toBe('lifecycle');
+      expect(item!.content).toBe('Design');
+      expect(item!.className).toContain('__hl_background_project_phase_definition_3');
+      expect(item!.definitionId).toBe(3);
+    });
+
+    it('skips a phase without dates', () => {
+      const { items } = buildData([phaseWithoutDates]);
+      expect(items.find((i) => i.id === 'phase-3')).toBeUndefined();
+    });
+
+    it('creates start and finish gate items when configured', () => {
+      const { items } = buildData([phaseWithGates]);
+
+      const startGate = items.find((i) => i.id === 'gate-start-2');
+      expect(startGate).toBeDefined();
+      expect(startGate!.type).toBe('point');
+      expect(startGate!.group).toBe('gates');
+      expect(startGate!.title).toBe('Build Start');
+      expect(startGate!.className).toContain('op-timeline-gate');
+
+      const finishGate = items.find((i) => i.id === 'gate-finish-2');
+      expect(finishGate).toBeDefined();
+      expect(finishGate!.title).toBe('Build End');
+    });
+
+    it('does not create gate items when gates are disabled', () => {
+      const { items } = buildData([phaseWithDates]);
+      expect(items.find((i) => i.id === 'gate-start-1')).toBeUndefined();
+      expect(items.find((i) => i.id === 'gate-finish-1')).toBeUndefined();
+    });
+
+    it('always creates gates and lifecycle groups', () => {
+      const { groups } = buildData([]);
+      expect(groups.map((g) => g.id)).toEqual(['gates', 'lifecycle']);
+    });
+  });
+
+  describe('tooltipTemplate', () => {
+    it('returns an empty string for background items', () => {
+      const result = tooltipTemplate({ type: 'background' } as ProjectTimelineItem);
+      expect(result).toBe('');
+    });
+
+    describe('for a phase item', () => {
+      let result:HTMLElement;
+
+      beforeEach(() => {
+        result = tooltipTemplate({
+          id: 'phase-1',
+          group: 'lifecycle',
+          type: 'range',
+          start: new Date('2024-01-01'),
+          end: new Date('2024-03-31'),
+          content: 'Design',
+          title: 'Design',
+          className: '__hl_background_project_phase_definition_3',
+          definitionId: 3,
+        }) as HTMLElement;
+      });
+
+      it('returns an HTMLElement', () => {
+        expect(result instanceof HTMLElement).toBe(true);
+      });
+
+      it('shows the date range in the meta row', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('Phase');
+      });
+
+      it('shows the phase name', () => {
+        const name = result.querySelector('.op-timeline-tooltip--name');
+        expect(name?.textContent).toBe('Design');
+      });
+
+      it('applies the highlight class to the type indicator', () => {
+        expect(result.querySelector('.__hl_inline_project_phase_definition_3')).toBeTruthy();
+      });
+    });
+
+    describe('for a gate item', () => {
+      let result:HTMLElement;
+
+      beforeEach(() => {
+        result = tooltipTemplate({
+          id: 'gate-start-2',
+          group: 'gates',
+          type: 'point',
+          start: new Date('2024-04-01'),
+          content: '',
+          title: 'Build Start',
+          className: 'op-timeline-gate __hl_background_project_phase_definition_5',
+          definitionId: 5,
+        }) as HTMLElement;
+      });
+
+      it('shows "Gate" as the type label', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('Gate');
+      });
+
+      it('shows only a single date (no range)', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).not.toContain('–');
+      });
+
+      it('shows the gate name', () => {
+        const name = result.querySelector('.op-timeline-tooltip--name');
+        expect(name?.textContent).toBe('Build Start');
+      });
+
+      it('applies the highlight class', () => {
+        expect(result.querySelector('.__hl_inline_project_phase_definition_5')).toBeTruthy();
+      });
+    });
+  });
+});

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -1,0 +1,228 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnDestroy,
+  ViewChild,
+  ViewEncapsulation,
+  computed,
+  effect,
+  inject,
+  input,
+} from '@angular/core';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DataSet } from 'vis-data';
+import { Timeline } from 'vis-timeline/standalone';
+import { opGateIconData, opPhaseIconData } from '@openproject/octicons-angular';
+import { octiconElement } from 'core-app/shared/helpers/op-icon-builder';
+
+interface ProjectPhaseData {
+  id:number;
+  definitionId:number;
+  name:string;
+  startDate:string|null;
+  endDate:string|null;
+  startGate:boolean;
+  startGateName:string|null;
+  finishGate:boolean;
+  finishGateName:string|null;
+}
+export interface ProjectTimelineItem {
+  id:string;
+  group:string;
+  start:Date|string;
+  end?:Date|string;
+  content:string;
+  title:string;
+  type:'range'|'point'|'background';
+  className:string;
+  definitionId?:number;
+}
+
+const GROUP_GATES = 'gates';
+const GROUP_LIFECYCLE = 'lifecycle';
+
+@Component({
+  selector: 'opce-project-timeline-graph',
+  templateUrl: './project-timeline-graph.component.html',
+  styleUrls: ['./project-timeline-graph.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('container') containerRef!:ElementRef<HTMLDivElement>;
+
+  readonly phasesData = input.required<string>();
+
+  readonly phases = computed<ProjectPhaseData[]>(
+    () => JSON.parse(this.phasesData()) as ProjectPhaseData[],
+  );
+
+  private readonly i18n = inject(I18nService);
+
+  private timeline:Timeline | null = null;
+
+  constructor() {
+    effect(() => {
+      const phases = this.phases();
+      if (this.timeline) {
+        this.updateTimeline(phases);
+      }
+    });
+  }
+
+  ngAfterViewInit():void {
+    this.initTimeline(this.phases());
+  }
+
+  ngOnDestroy():void {
+    this.timeline?.destroy();
+    this.timeline = null;
+  }
+
+  private buildData(phases:ProjectPhaseData[]) {
+    const items:ProjectTimelineItem[] = [];
+
+    for (const phase of phases) {
+      const hlClass = `__hl_background_project_phase_definition_${phase.definitionId}`;
+
+      if (phase.startDate && phase.endDate) {
+        items.push({
+          id: `phase-${phase.id}`,
+          group: GROUP_LIFECYCLE,
+          start: phase.startDate,
+          end: phase.endDate,
+          content: phase.name,
+          title: phase.name,
+          type: 'range',
+          className: hlClass,
+          definitionId: phase.definitionId,
+        });
+      }
+
+      if (phase.startGate && phase.startDate) {
+        items.push({
+          id: `gate-start-${phase.id}`,
+          group: GROUP_GATES,
+          start: phase.startDate,
+          content: '',
+          title: phase.startGateName ?? phase.name,
+          type: 'point',
+          className: `op-timeline-gate ${hlClass}`,
+          definitionId: phase.definitionId,
+        });
+      }
+
+      if (phase.finishGate && phase.endDate) {
+        items.push({
+          id: `gate-finish-${phase.id}`,
+          group: GROUP_GATES,
+          start: phase.endDate,
+          content: '',
+          title: phase.finishGateName ?? phase.name,
+          type: 'point',
+          className: `op-timeline-gate ${hlClass}`,
+          definitionId: phase.definitionId,
+        });
+      }
+    }
+
+    const groups = [
+      { id: GROUP_GATES, content: '' },
+      { id: GROUP_LIFECYCLE, content: '' },
+    ];
+
+    return { items, groups };
+  }
+
+  private initTimeline(phases:ProjectPhaseData[]):void {
+    const { items, groups } = this.buildData(phases);
+
+    this.timeline = new Timeline(
+      this.containerRef.nativeElement,
+      new DataSet(items),
+      new DataSet(groups),
+      {
+        editable: false,
+        selectable: false,
+        stack: false,
+        orientation: { axis: 'top' },
+        groupHeightMode: 'fixed',
+        showMajorLabels: true,
+        showMinorLabels: true,
+        margin: { item: { horizontal: 0, vertical: 24 }, axis: 32 },
+        zoomMin: 7 * 24 * 60 * 60 * 1000, // 7 days minimum zoom
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
+        tooltip: { template: this.tooltipTemplate.bind(this) } as any,
+      },
+    );
+  }
+
+  private tooltipTemplate(item:ProjectTimelineItem):HTMLElement | string {
+    if (item.type === 'background') return '';
+
+    const isGate = item.type === 'point';
+    const formatDate = (d:Date | string) => new Date(d).toLocaleDateString();
+    const dateStr = isGate
+      ? formatDate(item.start)
+      : `${formatDate(item.start)} – ${formatDate(item.end!)}`;
+    const typeLabel = isGate
+      ? this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_gate')
+      : this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_phase');
+
+    const hlInlineClass = `__hl_inline_project_phase_definition_${item.definitionId!}`;
+
+    const icon = octiconElement(isGate ? opGateIconData : opPhaseIconData, 'small', `octicon ${hlInlineClass}`);
+    const typeSpan = document.createElement('span');
+    typeSpan.className = 'op-timeline-tooltip--type';
+    typeSpan.append(typeLabel);
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'op-timeline-tooltip--meta-row';
+    metaRow.append(`${dateStr} `, icon, typeSpan);
+
+    const name = document.createElement('div');
+    name.className = 'op-timeline-tooltip--name';
+    name.textContent = item.title;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'op-timeline-tooltip';
+    wrapper.append(metaRow, name);
+
+    return wrapper;
+  }
+
+  private updateTimeline(phases:ProjectPhaseData[]):void {
+    const { items, groups } = this.buildData(phases);
+    this.timeline!.setData({ items: new DataSet(items), groups: new DataSet(groups) });
+  }
+}

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -40,6 +40,7 @@ import {
   input,
 } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DataSet } from 'vis-data';
 import { Timeline } from 'vis-timeline/standalone';
 import type { DataItem } from 'vis-timeline/standalone';
@@ -62,6 +63,7 @@ export interface ProjectTimelineItem {
   group:string;
   start:Date|string;
   end?:Date|string;
+  originalEnd?:Date|string;
   content:string|HTMLElement;
   title:string;
   type:'range'|'point'|'background';
@@ -89,6 +91,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
   );
 
   private readonly i18n = inject(I18nService);
+  private readonly timezone = inject(TimezoneService);
 
   private timeline:Timeline | null = null;
 
@@ -118,11 +121,21 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
       const hlInlineClass = `__hl_inline_project_phase_definition_${phase.definitionId}`;
 
       if (phase.startDate && phase.endDate) {
+        const isOneDay = phase.startDate === phase.endDate;
+        let visualStart:Date | string = phase.startDate;
+        let visualEnd:Date | string = phase.endDate;
+        if (isOneDay) {
+          const startNoon = new Date(`${phase.startDate}T12:00:00`);
+          startNoon.setDate(startNoon.getDate() - 1);
+          visualStart = startNoon;
+          visualEnd = new Date(`${phase.endDate}T12:00:00`);
+        }
         items.push({
           id: `phase-${phase.id}`,
           group: GROUP_LIFECYCLE,
-          start: phase.startDate,
-          end: phase.endDate,
+          start: visualStart,
+          end: visualEnd,
+          originalEnd: isOneDay ? phase.endDate : undefined,
           content: phase.name,
           title: phase.name,
           type: 'range',
@@ -185,6 +198,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
         showMinorLabels: true,
         margin: { item: { horizontal: 0, vertical: 16 } },
         zoomMin: 7 * 24 * 60 * 60 * 1000, // 7 days minimum zoom
+        cluster: { maxItems: 1, clusterCriteria: this.shouldCluster.bind(this) },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
         tooltip: { template: this.tooltipTemplate.bind(this) } as any,
       },
@@ -195,10 +209,12 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
     if (item.type === 'background') return '';
 
     const isGate = item.type === 'point';
-    const formatDate = (d:Date | string) => new Date(d).toLocaleDateString();
+    const formatDate = (d:Date | string) => this.timezone.formattedDate(d as string);
     const dateStr = isGate
       ? formatDate(item.start)
-      : `${formatDate(item.start)} – ${formatDate(item.end!)}`;
+      : item.originalEnd
+        ? formatDate(item.originalEnd)
+        : `${formatDate(item.start)} – ${formatDate(item.end!)}`;
     const typeLabel = isGate
       ? this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_gate')
       : this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_phase');
@@ -223,6 +239,13 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
     wrapper.append(metaRow, name);
 
     return wrapper;
+  }
+
+  private shouldCluster(a:ProjectTimelineItem, b:ProjectTimelineItem):boolean {
+    if (a.group !== GROUP_GATES || b.group !== GROUP_GATES) return false;
+
+    const diff = Math.abs(new Date(a.start).getTime() - new Date(b.start).getTime());
+    return diff <= 24 * 60 * 60 * 1000; // 24 hours
   }
 
   private updateTimeline(phases:ProjectPhaseData[]):void {

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -42,6 +42,7 @@ import {
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DataSet } from 'vis-data';
 import { Timeline } from 'vis-timeline/standalone';
+import type { DataItem } from 'vis-timeline/standalone';
 import { opGateIconData, opPhaseIconData } from '@openproject/octicons-angular';
 import { octiconElement } from 'core-app/shared/helpers/op-icon-builder';
 
@@ -61,7 +62,7 @@ export interface ProjectTimelineItem {
   group:string;
   start:Date|string;
   end?:Date|string;
-  content:string;
+  content:string|HTMLElement;
   title:string;
   type:'range'|'point'|'background';
   className:string;
@@ -114,6 +115,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
     for (const phase of phases) {
       const hlClass = `__hl_background_project_phase_definition_${phase.definitionId}`;
+      const hlInlineClass = `__hl_inline_project_phase_definition_${phase.definitionId}`;
 
       if (phase.startDate && phase.endDate) {
         items.push({
@@ -130,11 +132,12 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
       }
 
       if (phase.startGate && phase.startDate) {
+        const icon = octiconElement(opGateIconData, 'small', `octicon ${hlInlineClass}`);
         items.push({
           id: `gate-start-${phase.id}`,
           group: GROUP_GATES,
           start: phase.startDate,
-          content: '',
+          content: icon,
           title: phase.startGateName ?? phase.name,
           type: 'point',
           className: `op-timeline-gate ${hlClass}`,
@@ -143,14 +146,15 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
       }
 
       if (phase.finishGate && phase.endDate) {
+        const icon = octiconElement(opGateIconData, 'small', `octicon ${hlInlineClass}`);
         items.push({
           id: `gate-finish-${phase.id}`,
           group: GROUP_GATES,
           start: phase.endDate,
-          content: '',
+          content: icon,
           title: phase.finishGateName ?? phase.name,
           type: 'point',
-          className: `op-timeline-gate ${hlClass}`,
+          className: `op-timeline-gate op-timeline-gate--finish ${hlClass}`,
           definitionId: phase.definitionId,
         });
       }
@@ -169,7 +173,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
     this.timeline = new Timeline(
       this.containerRef.nativeElement,
-      new DataSet(items),
+      new DataSet(items as unknown as DataItem[]),
       new DataSet(groups),
       {
         editable: false,
@@ -179,7 +183,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
         groupHeightMode: 'fixed',
         showMajorLabels: true,
         showMinorLabels: true,
-        margin: { item: { horizontal: 0, vertical: 24 }, axis: 32 },
+        margin: { item: { horizontal: 0, vertical: 16 } },
         zoomMin: 7 * 24 * 60 * 60 * 1000, // 7 days minimum zoom
         // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
         tooltip: { template: this.tooltipTemplate.bind(this) } as any,
@@ -223,6 +227,6 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
   private updateTimeline(phases:ProjectPhaseData[]):void {
     const { items, groups } = this.buildData(phases);
-    this.timeline!.setData({ items: new DataSet(items), groups: new DataSet(groups) });
+    this.timeline!.setData({ items: new DataSet(items as unknown as DataItem[]), groups: new DataSet(groups) });
   }
 }

--- a/modules/grids/app/components/grids/widgets/project_timeline.html.erb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.html.erb
@@ -1,4 +1,5 @@
 <%#-- copyright
+
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -27,18 +28,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%=
-  render(Grids::WidgetGridComponent.new) do |grid|
-    grid.with_widget(Grids::Widgets::Description, @program)
-    grid.with_widget(Grids::Widgets::ProjectStatus, @program)
-    grid.with_widget(Grids::Widgets::ProjectTimeline, @program)
-    grid.with_widget(Grids::Widgets::Subitems, @program)
-    grid.with_widget(Meetings::Widgets::Meetings, @program)
-    grid.with_widget(Grids::Widgets::Members, @program)
-    grid.with_widget(Budgets::Widgets::BudgetTotals, @program)
-    grid.with_widget(Budgets::Widgets::BudgetByCostType, @program)
-    grid.with_widget(Costs::Widgets::ActualCosts, @program)
-
-    grid.with_widget(Grids::ProjectAttributeWidgets, @program)
-  end
-%>
+<%= widget_wrapper(test_selector: "op-overview-widget--project-timeline") do %>
+  <% if any_phases? %>
+    <%= helpers.angular_component_tag(
+          "opce-project-timeline-graph",
+          "phases-data": phases_data
+        ) %>
+  <% else %>
+    <%= render(Primer::Beta::Blankslate.new(test_selector: "project-timeline-widget-empty")) do |blankslate| %>
+      <% blankslate.with_visual_icon(icon: :workflow) %>
+      <% blankslate.with_heading(tag: :h3) { t("grids.widgets.project_timeline.no_lifecycle_results") } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Grids
+  module Widgets
+    class ProjectTimeline < Grids::WidgetComponent
+      param :project
+
+      def title
+        t("grids.widgets.project_timeline.title")
+      end
+
+      def phases_data
+        project.phases.active
+               .eager_load(definition: :color)
+               .order("project_phase_definitions.position")
+               .map { |phase| phase_data(phase) }
+               .to_json
+      end
+
+      def any_phases?
+        project.phases.active.exists?
+      end
+
+      def render?
+        User.current.allowed_in_project?(:view_project_phases, project)
+      end
+
+      def wrapper_arguments
+        { full_width: true }
+      end
+
+      private
+
+      def phase_data(phase) # rubocop:disable Metrics/AbcSize
+        {
+          id: phase.id,
+          definitionId: phase.definition.id,
+          name: phase.definition.name,
+          startDate: phase.start_date&.iso8601,
+          endDate: phase.finish_date&.iso8601,
+          startGate: phase.definition.start_gate,
+          startGateName: phase.definition.start_gate_name,
+          finishGate: phase.definition.finish_gate,
+          finishGateName: phase.definition.finish_gate_name
+        }
+      end
+    end
+  end
+end

--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -34,7 +34,13 @@ module Grids
       param :project
 
       def title
-        t("grids.widgets.project_timeline.title")
+        if project.portfolio?
+          t("grids.widgets.project_timeline.title_portfolio")
+        elsif project.program?
+          t("grids.widgets.project_timeline.title_program")
+        else
+          t("grids.widgets.project_timeline.title")
+        end
       end
 
       def phases_data
@@ -46,7 +52,7 @@ module Grids
       end
 
       def any_phases?
-        project.phases.active.exists?
+        project.phases.active.with_timeline_content.exists?
       end
 
       def render?

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
       news:
         no_results: "Nothing new to report."
       not_available: "This widget is not available."
+      project_timeline:
+        title: "Project timeline"
+        no_lifecycle_results: "No project life cycle phases configured"
       subitems:
         button_text: "Subitem"
         no_results: "There are no visible children."

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -32,8 +32,8 @@ en:
         no_results: "Nothing new to report."
       not_available: "This widget is not available."
       project_timeline:
-        title: "Project timeline"
         no_lifecycle_results: "No project life cycle phases configured"
+        title: "Project timeline"
       subitems:
         button_text: "Subitem"
         no_results: "There are no visible children."

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
       project_timeline:
         no_lifecycle_results: "No project life cycle phases configured"
         title: "Project timeline"
+        title_portfolio: "Portfolio timeline"
+        title_program: "Program timeline"
       subitems:
         button_text: "Subitem"
         no_results: "There are no visible children."

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -42,6 +42,9 @@ en:
         time_entries_list:
           no_results: 'No time entries for the last 7 days.'
           title: 'Spent time (last 7 days)'
+        project_timeline:
+          tooltip_type_phase: 'Phase'
+          tooltip_type_gate: 'Phase gate'
         work_packages_accountable:
           title: "Work packages I am accountable for"
         work_packages_assigned:

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -34,6 +34,9 @@ en:
           off_track: 'Off track'
           on_track: 'On track'
           title: 'Status'
+        project_timeline:
+          tooltip_type_gate: 'Phase gate'
+          tooltip_type_phase: 'Phase'
         subprojects:
           title: 'Subitems'
         time_entries_current_user:
@@ -42,9 +45,6 @@ en:
         time_entries_list:
           no_results: 'No time entries for the last 7 days.'
           title: 'Spent time (last 7 days)'
-        project_timeline:
-          tooltip_type_phase: 'Phase'
-          tooltip_type_gate: 'Phase gate'
         work_packages_accountable:
           title: "Work packages I am accountable for"
         work_packages_assigned:

--- a/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:role) { create(:project_role, permissions: [:view_project_phases]) }
+  let(:component) { described_class.new(project) }
+
+  before { login_as(user) }
+
+  describe "#render?" do
+    context "with view_project_phases permission" do
+      before { create(:member, user:, project:, roles: [role]) }
+
+      it { expect(component.render?).to be(true) }
+    end
+
+    context "without permission" do
+      it { expect(component.render?).to be(false) }
+    end
+  end
+
+  describe "#any_phases?" do
+    context "with no phases" do
+      it { expect(component.any_phases?).to be(false) }
+    end
+
+    context "with an active phase" do
+      before { create(:project_phase, project:) }
+
+      it { expect(component.any_phases?).to be(true) }
+    end
+
+    context "with only an inactive phase" do
+      before { create(:project_phase, :inactive, project:) }
+
+      it { expect(component.any_phases?).to be(false) }
+    end
+  end
+
+  describe "#phases_data" do
+    let(:definition) { create(:project_phase_definition, :with_start_gate, :with_finish_gate) }
+    let!(:phase) { create(:project_phase, project:, definition:) }
+
+    subject(:data) { JSON.parse(component.phases_data) }
+
+    it "includes all required fields" do
+      expect(data.first).to include(
+        "id" => phase.id,
+        "definitionId" => definition.id,
+        "name" => definition.name,
+        "startDate" => phase.start_date.iso8601,
+        "endDate" => phase.finish_date.iso8601,
+        "startGate" => true,
+        "startGateName" => definition.start_gate_name,
+        "finishGate" => true,
+        "finishGateName" => definition.finish_gate_name
+      )
+    end
+
+    context "with an additional inactive phase" do
+      before { create(:project_phase, :inactive, project:) }
+
+      it "excludes inactive phases" do
+        expect(data.size).to eq(1)
+      end
+    end
+  end
+
+  describe "rendering" do
+    before { create(:member, user:, project:, roles: [role]) }
+
+    context "with no phases" do
+      it "renders a blankslate" do
+        render_inline(component)
+        expect(page).to have_test_selector("project-timeline-widget-empty")
+        expect(page).to have_no_css("opce-project-timeline-graph")
+      end
+    end
+
+    context "with phases" do
+      before { create(:project_phase, project:) }
+
+      it "renders the Angular component with phases-data" do
+        render_inline(component)
+        expect(page).to have_css("opce-project-timeline-graph[phases-data]")
+      end
+
+      it "does not render a blankslate" do
+        render_inline(component)
+        expect(page).to have_no_test_selector("project-timeline-widget-empty")
+      end
+    end
+  end
+end

--- a/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
@@ -31,6 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Grids::WidgetGridComponent.new) do |grid|
     grid.with_widget(Grids::Widgets::Description, @portfolio)
     grid.with_widget(Grids::Widgets::ProjectStatus, @portfolio)
+    grid.with_widget(Grids::Widgets::ProjectTimeline, @portfolio)
     grid.with_widget(Grids::Widgets::Subitems, @portfolio)
     grid.with_widget(Meetings::Widgets::Meetings, @portfolio)
     grid.with_widget(Grids::Widgets::Members, @portfolio)

--- a/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.html.erb
@@ -31,6 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Grids::WidgetGridComponent.new) do |grid|
     grid.with_widget(Grids::Widgets::Description, @project)
     grid.with_widget(Grids::Widgets::ProjectStatus, @project)
+    grid.with_widget(Grids::Widgets::ProjectTimeline, @project)
     grid.with_widget(Grids::Widgets::Subitems, @project)
     grid.with_widget(Meetings::Widgets::Meetings, @project)
     grid.with_widget(Grids::Widgets::Members, @project)

--- a/spec/models/project/phase_spec.rb
+++ b/spec/models/project/phase_spec.rb
@@ -48,6 +48,52 @@ RSpec.describe Project::Phase do
     it { is_expected.to have_many(:work_packages).through(:definition) }
   end
 
+  describe ".with_timeline_content" do
+    let(:project) { create(:project) }
+
+    let!(:phase_with_both_dates) do
+      create(:project_phase, project:, start_date: Time.zone.today, finish_date: Time.zone.today + 5)
+    end
+    let!(:phase_without_dates) do
+      create(:project_phase, project:, start_date: nil, finish_date: nil)
+    end
+    let!(:phase_with_only_start_date) do
+      create(:project_phase, project:, start_date: Time.zone.today, finish_date: nil)
+    end
+    let!(:phase_with_start_gate_and_start_date) do
+      create(:project_phase, project:,
+                             definition: create(:project_phase_definition, :with_start_gate),
+                             start_date: Time.zone.today, finish_date: nil)
+    end
+    let!(:phase_with_finish_gate_and_finish_date) do
+      create(:project_phase, project:,
+                             definition: create(:project_phase_definition, :with_finish_gate),
+                             start_date: nil, finish_date: Time.zone.today + 5)
+    end
+
+    subject { described_class.with_timeline_content }
+
+    it "includes phases with both dates" do
+      expect(subject).to include(phase_with_both_dates)
+    end
+
+    it "includes phases with a start gate and start date" do
+      expect(subject).to include(phase_with_start_gate_and_start_date)
+    end
+
+    it "includes phases with a finish gate and finish date" do
+      expect(subject).to include(phase_with_finish_gate_and_finish_date)
+    end
+
+    it "excludes phases without any dates" do
+      expect(subject).not_to include(phase_without_dates)
+    end
+
+    it "excludes phases with only a start date" do
+      expect(subject).not_to include(phase_with_only_start_date)
+    end
+  end
+
   describe ".visible" do
     let(:project) { create(:project) }
     let(:development_project) { create(:project) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-309

# What are you trying to accomplish?

- [x] On the project overview, there is a new widget called "Project lifecycle"
- [x] It contains a timeline chart representing the following objects: Project phase and Phase gates
  - [x] The elements use the configured colors for each phase/gate
  - [x] It is read-only
- [x] On hover, a hover card is shown with the name of the phase/gate and the date(s) 
- [x] If there are no phases and gates, there is a Blankslate shown
- [x] If the user has no permissions to view project attributes, the widget is hidden

## Screenshots


<img width="1469" height="208" alt="Bildschirmfoto 2026-07-08 um 13 40 04" src="https://github.com/user-attachments/assets/ce06a567-eb1b-4300-b834-ca6d884cc52d" />
