### PR TITLE
Use registry-based approach to manage MCP tools and resources

### DIFF
--- a/app/services/mcp_resources.rb
+++ b/app/services/mcp_resources.rb
@@ -30,18 +30,12 @@
 
 module McpResources
   class << self
+    def register(*resources)
+      resources.each { |r| all << r }
+    end
+
     def all
-      [
-        CurrentUser,
-        Project,
-        Status,
-        StatusList,
-        Type,
-        TypeList,
-        User,
-        Version,
-        WorkPackage
-      ]
+      @all ||= []
     end
 
     def enabled

--- a/app/services/mcp_tools.rb
+++ b/app/services/mcp_tools.rb
@@ -30,18 +30,12 @@
 
 module McpTools
   class << self
+    def register(*tools)
+      tools.each { |t| all << t }
+    end
+
     def all
-      [
-        McpTools::CurrentUser,
-        McpTools::ListStatuses,
-        McpTools::ListTypes,
-        McpTools::SearchPortfolios,
-        McpTools::SearchPrograms,
-        McpTools::SearchProjects,
-        McpTools::SearchUsers,
-        McpTools::SearchVersions,
-        McpTools::SearchWorkPackages
-      ]
+      @all ||= []
     end
 
     def enabled

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -99,7 +99,8 @@ module McpTools
       # Filters defined here can later be applied by the tool implementation using #apply_filters.
       #
       # @param name [Symbol] The name of the input parameter used for filtering.
-      # @param filter_class [Queries::Filters::Base] A shared filter implementation to be used to perform filtering.
+      # @param filter_class [String] Class name of a shared filter implementation to be used to perform filtering,
+      #                              inheriting from Queries::Filters::Base.
       # @param operator [String] When using a filter_class, this is the operator that will be used for filtering. Default: "="
       # @param filter_proc [Proc] A callback procedure used for filtering that must accept two arguments:
       #                           The base scope that the filter applies to and the value that's used as a filter input.
@@ -117,7 +118,7 @@ module McpTools
         end
 
         if filter_class
-          filter_proc = ->(scope, value) { filter_class.create!(operator:, values: Array(value)).apply_to(scope) }
+          filter_proc = ->(scope, value) { filter_class.constantize.create!(operator:, values: Array(value)).apply_to(scope) }
         elsif !filter_proc
           filter_proc = ->(scope, value) { scope.where(name.to_sym => value) }
         end

--- a/app/services/mcp_tools/search_portfolios.rb
+++ b/app/services/mcp_tools/search_portfolios.rb
@@ -40,7 +40,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
     enable_pagination
 
-    filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
+    filter :name, filter_class: "Queries::Projects::Filters::NameFilter", operator: "~"
     filter :identifier
     filter :status_code
 

--- a/app/services/mcp_tools/search_programs.rb
+++ b/app/services/mcp_tools/search_programs.rb
@@ -40,7 +40,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
     enable_pagination
 
-    filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
+    filter :name, filter_class: "Queries::Projects::Filters::NameFilter", operator: "~"
     filter :identifier
     filter :status_code
 

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -40,7 +40,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
     enable_pagination
 
-    filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
+    filter :name, filter_class: "Queries::Projects::Filters::NameFilter", operator: "~"
     filter :identifier
     filter :status_code
 

--- a/app/services/mcp_tools/search_users.rb
+++ b/app/services/mcp_tools/search_users.rb
@@ -39,7 +39,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
     enable_pagination
 
-    filter :search_term, filter_class: Queries::Users::Filters::AnyNameAttributeFilter, operator: "~"
+    filter :search_term, filter_class: "Queries::Users::Filters::AnyNameAttributeFilter", operator: "~"
 
     input_schema(
       properties: {

--- a/app/services/mcp_tools/search_versions.rb
+++ b/app/services/mcp_tools/search_versions.rb
@@ -40,7 +40,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
     enable_pagination
 
-    filter :name, filter_class: Queries::Versions::Filters::NameFilter, operator: "~"
+    filter :name, filter_class: "Queries::Versions::Filters::NameFilter", operator: "~"
     filter :sharing
 
     input_schema(

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -41,3 +41,25 @@ MCP.configure do |config|
     OpenProject::OpenTelemetry.trace_exception(exception, server_context) if OpenProject::OpenTelemetry.enabled?
   end
 end
+
+Rails.application.config.after_initialize do
+  McpTools.register McpTools::CurrentUser,
+                    McpTools::ListStatuses,
+                    McpTools::ListTypes,
+                    McpTools::SearchPortfolios,
+                    McpTools::SearchPrograms,
+                    McpTools::SearchProjects,
+                    McpTools::SearchUsers,
+                    McpTools::SearchVersions,
+                    McpTools::SearchWorkPackages
+
+  McpResources.register McpResources::CurrentUser,
+                        McpResources::Project,
+                        McpResources::Status,
+                        McpResources::StatusList,
+                        McpResources::Type,
+                        McpResources::TypeList,
+                        McpResources::User,
+                        McpResources::Version,
+                        McpResources::WorkPackage
+end


### PR DESCRIPTION
This makes it easier for plugins to register their own tools and resources much easier, because they don't need to overwrite the #all methods anymore, but can just make a call in an initializer to register what they need.

# Ticket
https://community.openproject.org/wp/AI-75