### PR TITLE
Cleanup comments after reordering i18n yamls alphabetically

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2305,18 +2305,12 @@ en:
 
     errors:
       messages:
-        # Common error messages
         access_denied: "The resource owner or authorization server denied the request."
         admin_authenticator_not_configured: "Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured."
-        # Configuration error messages
         credential_flow_not_configured: "Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured."
-
         forbidden_token:
           missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
-
-        # Access token errors
         invalid_client: "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
-
         invalid_code_challenge_method: "The code challenge method must be plain or S256."
         invalid_grant: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
         invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
@@ -2329,7 +2323,6 @@ en:
           expired: "The access token expired"
           revoked: "The access token was revoked"
           unknown: "The access token is invalid"
-
         resource_owner_authenticator_not_configured: "Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured."
         revoke:
           unauthorized: "You are not authorized to revoke this token."
@@ -2338,8 +2331,6 @@ en:
         unauthorized_client: "The client is not authorized to perform this request using this method."
         unsupported_grant_type: "The authorization grant type is not supported by the authorization server."
         unsupported_response_mode: "The authorization server does not support this response mode."
-
-        # Access grant errors
         unsupported_response_type: "The authorization server does not support this response type."
     pre_authorization:
       status: "Pre-authorization"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2131,10 +2131,10 @@ en:
         "Friday",
         "Saturday",
       ]
+    # Use the strftime parameters for formats.
+    # When no format has been given, it uses default.
+    # You can provide other formats here if you like!
     formats:
-      # Use the strftime parameters for formats.
-      # When no format has been given, it uses default.
-      # You can provide other formats here if you like!
       default: "%m/%d/%Y"
       long: "%B %d, %Y"
       short: "%b %d"
@@ -4801,8 +4801,8 @@ en:
   project_module_work_package_tracking: "Work packages"
 
   projects:
+    # Contains custom strings for options when copying a project that cannot be found elsewhere.
     copy:
-      # Contains custom strings for options when copying a project that cannot be found elsewhere.
       members: "Project members"
       overviews: "Project overview"
       queries: "Work packages: saved views"

--- a/modules/avatars/config/locales/en.yml
+++ b/modules/avatars/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   are_you_sure_delete_avatar: "Are you sure you want to delete your avatar?"

--- a/modules/avatars/config/locales/js-en.yml
+++ b/modules/avatars/config/locales/js-en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   js:

--- a/modules/bim/config/locales/en.yml
+++ b/modules/bim/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here for Rails i18n
 ---
 en:
   activerecord:

--- a/modules/bim/config/locales/js-en.yml
+++ b/modules/bim/config/locales/js-en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   js:

--- a/modules/boards/config/locales/en.yml
+++ b/modules/boards/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   boards:

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   ee:

--- a/modules/calendar/config/locales/en.yml
+++ b/modules/calendar/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   label_calendar: "Calendar"

--- a/modules/calendar/config/locales/js-en.yml
+++ b/modules/calendar/config/locales/js-en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   js:

--- a/modules/gantt/config/locales/en.yml
+++ b/modules/gantt/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   project_module_gantt: "Gantt charts"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -26,7 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# English strings go here for Rails i18n
 ---
 en:
   activerecord:

--- a/modules/recaptcha/config/locales/en.yml
+++ b/modules/recaptcha/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here for Rails i18n
 ---
 en:
   plugin_openproject_recaptcha:

--- a/modules/storages/config/locales/js-en.yml
+++ b/modules/storages/config/locales/js-en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   js:

--- a/modules/team_planner/config/locales/en.yml
+++ b/modules/team_planner/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   ee:

--- a/modules/team_planner/config/locales/js-en.yml
+++ b/modules/team_planner/config/locales/js-en.yml
@@ -1,4 +1,3 @@
-# English strings go here
 ---
 en:
   js:

--- a/modules/two_factor_authentication/config/locales/en.yml
+++ b/modules/two_factor_authentication/config/locales/en.yml
@@ -1,4 +1,3 @@
-# English strings go here for Rails i18n
 ---
 en:
   activerecord:


### PR DESCRIPTION
# Ticket
Follow up for https://community.openproject.org/wp/INTERNAL-942  / #24160

# What are you trying to accomplish?
* Remove comments that don't really add value
* Move comments to be before relevant key instead of before the value
* Remove comments that were for groups of keys, which aren't relevant afetr reordering keys alphabetically

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
