### PR TITLE
do not manually cleanup newlines when ordering yamls

### DIFF
--- a/script/order_yaml
+++ b/script/order_yaml
@@ -88,8 +88,7 @@ ARGV.each do |file|
     *sorted(target, lines),
     *lines[content_end(target)..]
   ].join
-  output.gsub!(/\n{3,}/, "\n\n")
-  output.sub!(/\n{2,}\z/, "\n")
+
   before = Psych.unsafe_load(content)
   after = Psych.unsafe_load(output)
   abort "ordering changed content of #{file}:\n#{divergence(before, after)}" unless after == before

--- a/spec/scripts/order_yaml_spec.rb
+++ b/spec/scripts/order_yaml_spec.rb
@@ -60,12 +60,14 @@ RSpec.describe "script/order_yaml", :aggregate_failures do # rubocop:disable RSp
           folded: >
             first
 
+
             second
           label_who: Who?
           # before changed
           changed: "changed"
           literal: |
             first
+
 
             second
           created: "created"
@@ -88,6 +90,7 @@ RSpec.describe "script/order_yaml", :aggregate_failures do # rubocop:disable RSp
           folded: >
             first
 
+
             second
           label_sort_asc: "Newest at the bottom"
           label_sort_desc: "Newest on top"
@@ -95,7 +98,10 @@ RSpec.describe "script/order_yaml", :aggregate_failures do # rubocop:disable RSp
           literal: |
             first
 
+
             second
+
+
 
         xindex:
           no_results: no activity in this time frame
@@ -103,6 +109,8 @@ RSpec.describe "script/order_yaml", :aggregate_failures do # rubocop:disable RSp
       let_this_be_here: 1
       no_results: >
         nothing to display
+
+
   YAML
 
   let(:unexpected) { <<~YAML }
@@ -191,11 +199,10 @@ RSpec.describe "script/order_yaml", :aggregate_failures do # rubocop:disable RSp
 
   it "aborts when the parsed result is not the same" do
     stdout, stderr, status = run_script(<<~YAML)
-      path:
-        to:
-          a:
-            problem: |+ # next newline is important, but will be deleted in output
+      b: 1
 
+      a: |+ # blank line above moves below this block and changes its value
+        text
     YAML
 
     expect(status).not_to be_success


### PR DESCRIPTION
# Ticket
Follow up for https://community.openproject.org/wp/INTERNAL-942 / https://github.com/opf/openproject/pull/24160

# What are you trying to accomplish?
Do not try to cleanup newlines after carefully ordering yamls

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
