### PR TITLE
Add yamllint and fix commands to lefthook config

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -45,3 +45,39 @@ pre-commit:
         else
           echo "warning: yamllint is not installed, skipping" >&2
         fi
+
+# Autofix counterpart of the pre-commit checks. Run explicitly:
+#
+#     # fix staged files
+#     lefthook run fix
+#
+#     # fix files changed since origin/dev (excluding deleted ones)
+#     lefthook run fix --files-from-stdin < <(git diff --name-only --diff-filter=d origin/dev)
+#
+#     # fix all files in the repository
+#     lefthook run fix --all-files
+fix:
+  parallel: true
+  commands:
+    eslint:
+      root: "frontend/"
+      files: git diff --name-only --staged
+      glob: "*.{js,ts,jsx,tsx}"
+      run: npx eslint --fix {files}
+    rubocop:
+      files: git diff --name-only --staged
+      glob: "*.rb"
+      run: bin/dirty-rubocop --uncommitted --force-exclusion -a {files}
+    erb_lint:
+      files: git diff --name-only --staged
+      glob: "*.erb"
+      run: erb_lint --autocorrect {files}
+    order_yaml:
+      files: git diff --name-only --staged
+      glob:
+        - ".yamllint.yml"
+        - "config/locales/en.yml"
+        - "config/locales/js-en.yml"
+        - "modules/*/config/locales/en.yml"
+        - "modules/*/config/locales/js-en.yml"
+      run: script/order_yaml -i {files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,3 +31,17 @@ pre-commit:
       files: git diff --name-only --staged
       glob: "{Gemfile.lock,frontend/package.json}"
       run: script/check_same_primer_view_components_version_everywhere
+    yamllint:
+      files: git diff --name-only --staged
+      glob:
+        - ".yamllint.yml"
+        - "config/locales/en.yml"
+        - "config/locales/js-en.yml"
+        - "modules/*/config/locales/en.yml"
+        - "modules/*/config/locales/js-en.yml"
+      run: |
+        if command -v yamllint > /dev/null 2>&1; then
+          yamllint {files}
+        else
+          echo "warning: yamllint is not installed, skipping" >&2
+        fi


### PR DESCRIPTION
# Ticket
Follow up for https://community.openproject.org/wp/INTERNAL-942 / https://github.com/opf/openproject/pull/24160

# What are you trying to accomplish?
* Add yamllint to lefthook pre-commit commands
* Add run commands to lefthook to have a simple way to run linters in autofix mode

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
