### PR TITLE
[COMMS-883] Support `target_versions` in mailer views

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -134,6 +134,25 @@ module WorkPackagesHelper
       .select { |column| protected_columns.include?(column[:id]) }
   end
 
+  # Label for the version(s) attribute, driven by the multiple-versions feature.
+  # While the feature is off we keep the legacy singular "Version" wording even
+  # though the value now comes from the target_versions association.
+  def work_package_versions_label
+    attribute = Setting::WorkPackageMultipleVersions.active? ? :target_versions : :version
+    WorkPackage.human_attribute_name(attribute)
+  end
+
+  # Presented value for the version(s) attribute, read from target_versions.
+  # Legacy behaviour surfaces the single associated version; with the feature on
+  # it lists all target versions, ordered by name for a stable rendering.
+  def work_package_versions_value(work_package)
+    if Setting::WorkPackageMultipleVersions.active?
+      work_package.target_versions.sort_by(&:name).join(", ")
+    else
+      work_package.target_versions.first
+    end
+  end
+
   private
 
   def truncated_work_package_description(work_package, lines = 3) # rubocop:disable Metrics/AbcSize

--- a/app/views/work_package_mailer/_work_package_details.html.erb
+++ b/app/views/work_package_mailer/_work_package_details.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
   <li><%= WorkPackage.human_attribute_name(:assigned_to) %>: <%= work_package.assigned_to %></li>
   <li><%= WorkPackage.human_attribute_name(:responsible) %>: <%= work_package.responsible %></li>
   <li><%= WorkPackage.human_attribute_name(:category) %>: <%= work_package.category %></li>
-  <li><%= WorkPackage.human_attribute_name(:version) %>: <%= work_package.version %></li>
+  <li><%= work_package_versions_label %>: <%= work_package_versions_value(work_package) %></li>
   <li><%= WorkPackage.human_attribute_name(:start_date) %>: <%= work_package.start_date %></li>
   <li><%= WorkPackage.human_attribute_name(:due_date) %>: <%= work_package.due_date %></li>
   <li><%= WorkPackage.human_attribute_name(:estimated_hours) %>: <%= work_package.estimated_hours %></li>

--- a/app/views/work_package_mailer/_work_package_details.text.erb
+++ b/app/views/work_package_mailer/_work_package_details.text.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= WorkPackage.human_attribute_name(:assigned_to)   %>: <%= work_package.assigned_to   %>
 <%= WorkPackage.human_attribute_name(:responsible)   %>: <%= work_package.responsible   %>
 <%= WorkPackage.human_attribute_name(:category)      %>: <%= work_package.category      %>
-<%= WorkPackage.human_attribute_name(:version) %>: <%= work_package.version %>
+<%= work_package_versions_label %>: <%= work_package_versions_value(work_package) %>
 <%= WorkPackage.human_attribute_name(:start_date)    %>: <%= work_package.start_date    %>
 <%= WorkPackage.human_attribute_name(:due_date)      %>: <%= work_package.due_date      %>
 <%= WorkPackage.human_attribute_name(:estimated_hours)%>: <%= work_package.estimated_hours %>

--- a/spec/mailers/work_package_mailer_spec.rb
+++ b/spec/mailers/work_package_mailer_spec.rb
@@ -273,10 +273,8 @@ RSpec.describe WorkPackageMailer do
         let(:target_versions) { [version_a] }
 
         it "labels the row 'Version' and shows the single target version" do
-          expected = "#{WorkPackage.human_attribute_name(:version)}: #{version_a.name}"
-
-          expect(mail.text_part.body.encoded).to include(expected)
-          expect(mail.html_part.body.encoded).to include(expected)
+          expect(mail.text_part.body.encoded).to include("Version: Alpha")
+          expect(mail.html_part.body.encoded).to include("<li>Version: Alpha</li>")
         end
       end
 
@@ -286,10 +284,8 @@ RSpec.describe WorkPackageMailer do
         let(:target_versions) { [version_b, version_a] }
 
         it "labels the row 'Target versions' and lists all target versions ordered by name" do
-          expected = "#{WorkPackage.human_attribute_name(:target_versions)}: #{version_a.name}, #{version_b.name}"
-
-          expect(mail.text_part.body.encoded).to include(expected)
-          expect(mail.html_part.body.encoded).to include(expected)
+          expect(mail.text_part.body.encoded).to include("Target versions: Alpha, Beta")
+          expect(mail.html_part.body.encoded).to include("<li>Target versions: Alpha, Beta</li>")
         end
       end
     end

--- a/spec/mailers/work_package_mailer_spec.rb
+++ b/spec/mailers/work_package_mailer_spec.rb
@@ -258,6 +258,42 @@ RSpec.describe WorkPackageMailer do
       end
     end
 
+    describe "rendering the version(s) detail from target_versions" do
+      subject(:mail) { described_class.watcher_changed(work_package, recipient, author, "added") }
+
+      let(:version_a) { build_stubbed(:version, name: "Alpha") }
+      let(:version_b) { build_stubbed(:version, name: "Beta") }
+
+      before do
+        allow(work_package).to receive(:target_versions).and_return(target_versions)
+      end
+
+      context "with multiple versions disabled (legacy behaviour)",
+              with_flag: { work_package_multiple_versions: false } do
+        let(:target_versions) { [version_a] }
+
+        it "labels the row 'Version' and shows the single target version" do
+          expected = "#{WorkPackage.human_attribute_name(:version)}: #{version_a.name}"
+
+          expect(mail.text_part.body.encoded).to include(expected)
+          expect(mail.html_part.body.encoded).to include(expected)
+        end
+      end
+
+      context "with multiple versions enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        let(:target_versions) { [version_b, version_a] }
+
+        it "labels the row 'Target versions' and lists all target versions ordered by name" do
+          expected = "#{WorkPackage.human_attribute_name(:target_versions)}: #{version_a.name}, #{version_b.name}"
+
+          expect(mail.text_part.body.encoded).to include(expected)
+          expect(mail.html_part.body.encoded).to include(expected)
+        end
+      end
+    end
+
     describe "rendering the latest comment containing a WP reference" do
       shared_let(:persisted_project) { create(:project, identifier: "demo") }
       shared_let(:persisted_recipient) { create(:admin) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-883

# What are you trying to accomplish?
* Adjust the `_work_package_details` partial to render correct version label & values (single vs. multiple)
* While at it, add a reusable helper for the same.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
