### PR TITLE
simplify robots.txt

### DIFF
--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -45,11 +45,13 @@ class HomescreenController < ApplicationController
   end
 
   def robots
-    if Setting.login_required?
-      render template: "homescreen/robots-login-required", format: :text
-    else
-      @projects = Project.active.public_projects
-    end
+    template = if Setting.login_required?
+                 "homescreen/robots-login-required"
+               else
+                 "homescreen/robots"
+               end
+
+    render template:, format: :text
   end
 
   def jump_to_module

--- a/app/views/homescreen/robots.text.erb
+++ b/app/views/homescreen/robots.text.erb
@@ -27,14 +27,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 User-agent: *
-<% cache @projects.cache_key(:updated_at) do %>
-  <% @projects.flat_map { |p| [p.id, p.identifier] }.each do |identifier| -%>
-Disallow: <%= project_repository_path(identifier) %>
-Disallow: <%= project_work_packages_path(identifier) %>
-Disallow: <%= project_activity_index_path(identifier) %>
-Disallow: <%= search_path(identifier) %>
-  <% end -%>
-<% end %>
+Disallow: <%= project_repository_path("*") %>
+Disallow: <%= project_work_packages_path("*") %>
+Disallow: <%= project_activity_index_path("*") %>
+Disallow: <%= search_path("*") %>
 Disallow: <%= activities_path %>
 Disallow: /activity
 Disallow: <%= search_path %>

--- a/spec/features/homescreen/robots_spec.rb
+++ b/spec/features/homescreen/robots_spec.rb
@@ -31,30 +31,26 @@
 require "spec_helper"
 
 RSpec.describe "robots.txt" do
-  let!(:project) { create(:public_project) }
-
   before do
     visit "/robots.txt"
   end
 
   context "when login_required", with_settings: { login_required: true } do
     it "disallows everything" do
-      expect(page).to have_content("Disallow: /")
+      expect(page).to have_text("Disallow: /")
     end
   end
 
   context "when not login_required", with_settings: { login_required: false } do
-    it "disallows global paths and paths from public project" do
-      expect(page).to have_content("Disallow: /activity")
-      expect(page).to have_content("Disallow: /activities")
-      expect(page).to have_content("Disallow: /search")
+    it "disallows global paths and paths from projects" do
+      expect(page).to have_text("Disallow: /activity")
+      expect(page).to have_text("Disallow: /activities")
+      expect(page).to have_text("Disallow: /search")
 
-      [project.identifier, project.id].each do |identifier|
-        expect(page).to have_content("Disallow: /projects/#{identifier}/repository")
-        expect(page).to have_content("Disallow: /projects/#{identifier}/work_packages")
-        expect(page).to have_content("Disallow: /projects/#{identifier}/activity")
-        expect(page).to have_content("Disallow: /projects/#{identifier}/search")
-      end
+      expect(page).to have_text("Disallow: /projects/*/repository")
+      expect(page).to have_text("Disallow: /projects/*/work_packages")
+      expect(page).to have_text("Disallow: /projects/*/activity")
+      expect(page).to have_text("Disallow: /projects/*/search")
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19744

# What are you trying to accomplish?

Since all project routes specified should be disallowed, a wildcard approach is just as good and does not require loading the projects before.

Since the page is now static, next steps could be to:
* cache the whole page. It will only change on an OP version change
* remove the distinction between the two robot.txts. Since there is no secret information in it any more (all routes are static), we could always deliver the more verbose one.

# Merge checklist

- [x] Added/updated tests