### PR TITLE
Allow the creation of Project Wikis using the internal provider

### DIFF
--- a/app/models/enabled_module.rb
+++ b/app/models/enabled_module.rb
@@ -41,18 +41,8 @@ class EnabledModule < ApplicationRecord
 
   # after_create callback used to do things when a module is enabled
   def module_enabled
-    case name
-    when "wiki"
-      # Create a wiki with a default start page
-      if project && project.wiki.nil?
-        Wiki.create(project:, start_page: "Wiki")
-      end
-    when "repository"
-      if project &&
-         project.repository.nil? &&
-         Setting.repositories_automatic_managed_vendor.present?
-        create_managed_repository
-      end
+    if name == "repository" && project&.repository.nil? && Setting.repositories_automatic_managed_vendor.present?
+      create_managed_repository
     end
 
     OpenProject::Notifications.send(OpenProject::Events::MODULE_ENABLED, enabled_module: self)
@@ -64,8 +54,7 @@ class EnabledModule < ApplicationRecord
       scm_type: Repository.managed_type
     }
 
-    service = SCM::RepositoryFactoryService.new(project,
-                                                ActionController::Parameters.new(params))
+    service = SCM::RepositoryFactoryService.new(project, ActionController::Parameters.new(params))
     service.build_and_save
   end
 end

--- a/app/models/menu_items/wiki_menu_item.rb
+++ b/app/models/menu_items/wiki_menu_item.rb
@@ -29,7 +29,7 @@
 #++
 
 class MenuItems::WikiMenuItem < MenuItem
-  belongs_to :wiki, foreign_key: "navigatable_id"
+  belongs_to :wiki, foreign_key: "navigatable_id", inverse_of: :wiki_menu_items
 
   scope :main_items, ->(wiki_id) {
     where(navigatable_id: wiki_id, parent_id: nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -231,10 +231,6 @@ class Project < ApplicationRecord
     self
   end
 
-  def wiki
-    super&.enabled ? super : nil
-  end
-
   def <=>(other)
     name.downcase <=> other.name.downcase
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -243,7 +243,7 @@ class Project < ApplicationRecord
     name
   end
 
-  def w
+  def workspace_label
     case workspace_type
     when "program"
       I18n.t("label_program")

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -232,7 +232,7 @@ class Project < ApplicationRecord
   end
 
   def wiki
-    super.enabled ? super : nil
+    super&.enabled ? super : nil
   end
 
   def <=>(other)
@@ -243,7 +243,7 @@ class Project < ApplicationRecord
     name
   end
 
-  def workspace_label
+  def w
     case workspace_type
     when "program"
       I18n.t("label_program")

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -169,7 +169,7 @@ class Project < ApplicationRecord
   # neither development nor deployment setups are prepared for this
   # validates_presence_of :types
 
-  validates_associated :repository, :wiki
+  validates_associated :repository
 
   scopes :activated_in_storage,
          :allowed_to,
@@ -229,6 +229,10 @@ class Project < ApplicationRecord
 
   def project
     self
+  end
+
+  def wiki
+    super.enabled ? super : nil
   end
 
   def <=>(other)

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -30,12 +30,16 @@
 
 class Wiki < ApplicationRecord
   belongs_to :project
-  has_many :pages, -> {
-    order("title")
-  }, class_name: "WikiPage", dependent: :destroy
-  has_many :wiki_menu_items, -> {
-    order("name")
-  }, class_name: "MenuItems::WikiMenuItem", dependent: :delete_all, foreign_key: "navigatable_id"
+
+  has_many :pages, -> { order(:title) }, class_name: "WikiPage", inverse_of: :wiki, dependent: :destroy
+
+  has_many :wiki_menu_items,
+           -> { order(:name) },
+           class_name: "MenuItems::WikiMenuItem",
+           inverse_of: :wiki,
+           dependent: :delete_all,
+           foreign_key: "navigatable_id"
+
   has_many :redirects, class_name: "WikiRedirect", dependent: :delete_all
 
   acts_as_watchable permission: :view_wiki_pages
@@ -49,7 +53,7 @@ class Wiki < ApplicationRecord
   after_create :create_menu_item_for_start_page
 
   def visible?(user = User.current)
-    !user.nil? && user.allowed_in_project?(:view_wiki_pages, project)
+    enabled && user&.allowed_in_project?(:view_wiki_pages, project)
   end
 
   # find the page with the given title

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -53,8 +53,10 @@ class Wiki < ApplicationRecord
   after_create :create_menu_item_for_start_page
 
   def visible?(user = User.current)
-    enabled && user&.allowed_in_project?(:view_wiki_pages, project)
+    enabled && user.allowed_in_project?(:view_wiki_pages, project)
   end
+
+  def disabled? = !enabled?
 
   # find the page with the given title
   # if page doesn't exist, return a new page

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -72,11 +72,8 @@ module DemoData
     def set_wiki!(version, config)
       return unless config
 
-      # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
-
       unless Wiki.exists?(project: version.project)
-        Wiki.create!(project: version.project, start_page: "Wiki")
-        version.project.reload
+        version.project.create_wiki(start_page: "Wiki")
       end
 
       version.wiki_page_title = config["title"]

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -72,6 +72,13 @@ module DemoData
     def set_wiki!(version, config)
       return unless config
 
+      # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
+
+      unless Wiki.exists?(project: version.project)
+        Wiki.create!(project: version.project, start_page: "Wiki")
+        version.project.reload
+      end
+
       version.wiki_page_title = config["title"]
 
       Journal::NotificationConfiguration.with false do

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -37,11 +37,10 @@ module DemoData
     end
 
     def seed_data!
-      create_project_wiki!
-
       text = project_data.lookup("wiki")
-
       return if text.blank?
+
+      create_project_wiki!
 
       if text.is_a? String
         text = [{ title: "Wiki", content: text }]

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -56,12 +56,10 @@ module DemoData
       end
     end
 
-    # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
     def create_project_wiki!
-      return project.reload.wiki if Wiki.exists?(project: @project)
+      Wiki.create!(project: project, start_page: "Wiki") unless Wiki.exists?(project:)
 
-      Wiki.create!(project: @project, start_page: "Wiki")
-      @project.reload
+      project.reload
     end
 
     def create_wiki_page!(data, project:, parent: nil)

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -37,6 +37,8 @@ module DemoData
     end
 
     def seed_data!
+      create_project_wiki!
+
       text = project_data.lookup("wiki")
 
       return if text.blank?
@@ -53,6 +55,14 @@ module DemoData
           project:
         )
       end
+    end
+
+    # FIXME: find a better solution to handle all things wiki seeding. - @mereghost
+    def create_project_wiki!
+      return project.reload.wiki if Wiki.exists?(project: @project)
+
+      Wiki.create!(project: @project, start_page: "Wiki")
+      @project.reload
     end
 
     def create_wiki_page!(data, project:, parent: nil)

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -215,7 +215,6 @@ projects:
       - work_package_tracking
       - news
       - gantt
-      - wiki
       - board_view
       - team_planner_view
       - meetings
@@ -538,7 +537,6 @@ projects:
     modules:
       - backlogs
       - news
-      - wiki
       - work_package_tracking
       - gantt
       - board_view

--- a/db/migrate/20260708100831_add_enabled_column_to_wikis_table.rb
+++ b/db/migrate/20260708100831_add_enabled_column_to_wikis_table.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AddsEnabledColumnToWikisTable < ActiveRecord::Migration[8.1]
+class AddEnabledColumnToWikisTable < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def up

--- a/db/migrate/20260708100831_adds_enabled_column_to_wikis_table.rb
+++ b/db/migrate/20260708100831_adds_enabled_column_to_wikis_table.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddsEnabledColumnToWikisTable < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    say "Creating enabled column on wikis"
+    add_column :wikis, :enabled, :boolean, default: true, null: false
+
+    transaction do
+      say "Updating wiki enabled state based on enabled modules"
+      execute <<~SQL.squish
+        UPDATE wikis
+        SET enabled = false
+        WHERE project_id NOT IN (select project_id from enabled_modules where name = 'wiki');
+      SQL
+
+      say "Removing wiki from the list of enabled modules"
+      execute <<~SQL.squish
+        DELETE FROM enabled_modules WHERE name = 'wiki';
+      SQL
+    end
+  end
+
+  def down
+    execute <<~SQL.squish
+      INSERT INTO enabled_modules (project_id, name)
+      SELECT project_id, 'wiki' from wikis where enabled = true;
+    SQL
+
+    remove_column :wikis, :enabled
+  end
+end

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -31,7 +31,7 @@ module Redmine::MenuManager::WikiMenuHelper
     return unless Wikis::InternalProvider.enabled?
 
     project_wiki = project.wiki
-    return if project_wiki.nil?
+    return if project_wiki.nil? || project.wiki.disabled?
 
     wiki_main_items(project_wiki).reverse_each do |main_item|
       Redmine::MenuManager.loose :project_menu do |menu|

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -244,7 +244,6 @@ projects:
       - work_package_tracking
       - gantt
       - news
-      - wiki
       - board_view
       - team_planner_view
       - documents
@@ -393,7 +392,6 @@ projects:
       - work_package_tracking
       - gantt
       - news
-      - wiki
       - board_view
       - team_planner_view
       - documents
@@ -875,7 +873,6 @@ projects:
       - work_package_tracking
       - gantt
       - news
-      - wiki
       - board_view
       - team_planner_view
     news:

--- a/modules/bim/app/seeders/bim/basic_data_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data_seeder.rb
@@ -45,6 +45,7 @@ module Bim
         ::BasicData::PrioritySeeder,
         ::Bim::BasicData::SettingSeeder,
         ::Bim::BasicData::ThemeSeeder
+
       ]
     end
   end

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe RootSeeder,
 
     it "creates the BIM demo data" do
       expect(Project.count).to eq 4
-      expect(EnabledModule.count).to eq 29
+      expect(EnabledModule.count).to eq 26
       expect(WorkPackage.count).to eq 76
-      expect(Wiki.count).to eq 3
+      expect(Wiki.count).to eq 0
       expect(Query.count).to eq 29
       expect(Group.count).to eq 8
       expect(Type.count).to eq 7
@@ -138,7 +138,7 @@ RSpec.describe RootSeeder,
       it "does not create additional data and does not raise any errors" do
         expect(Project.count).to eq 4
         expect(WorkPackage.count).to eq 76
-        expect(Wiki.count).to eq 3
+        expect(Wiki.count).to eq 0
         expect(Query.count).to eq 29
         expect(Group.count).to eq 8
         expect(Type.count).to eq 7

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -32,14 +32,15 @@ See COPYRIGHT and LICENSE files for more details.
     render(
       Primer::Forms::ToggleSwitchForm.new(
         name: "enable_interal_wiki",
-        label: t("projects.settings.internal_wiki.enable"),
-        caption: t("projects.settings.internal_wiki.caption"),
+        label: t(".enable"),
+        caption: t(".caption"),
         src: project_settings_wiki_path(@project),
         csrf_token: form_authenticity_token,
         status_label_position: :start,
         checked: wiki_enabled?,
         data: { turbo: true },
-        mb: 3
+        mb: 3,
+        test_selector: "project-settings-enable-wiki"
       )
     )
   %>

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -1,0 +1,46 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= component_wrapper(class: "op-admin-settings-form-wrapper") do %>
+  <%=
+    render(
+      Primer::Forms::ToggleSwitchForm.new(
+        name: "enable_interal_wiki",
+        label: t("projects.settings.internal_wiki.enable"),
+        caption: t("projects.settings.internal_wiki.caption"),
+        src: project_settings_wiki_path(@project),
+        csrf_token: form_authenticity_token,
+        status_label_position: :start,
+        checked: has_wiki?,
+        data: { turbo: true },
+        mb: 3
+      )
+    )
+  %>
+<% end %>

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
         src: project_settings_wiki_path(@project),
         csrf_token: form_authenticity_token,
         status_label_position: :start,
-        checked: has_wiki?,
+        checked: wiki_enabled?,
         data: { turbo: true },
         mb: 3
       )

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -39,8 +39,8 @@ module Wikis
         @project = project
       end
 
-      def has_wiki?
-        Wiki.exists?(project: @project)
+      def wiki_enabled?
+        !!@project.wiki
       end
     end
   end

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  module ProjectSettings
+    class ProjectInternalWikiComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpTurbo::Streamable
+
+      def initialize(project)
+        super
+        @project = project
+      end
+
+      def has_wiki?
+        Wiki.exists?(project: @project)
+      end
+    end
+  end
+end

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -40,7 +40,7 @@ module Wikis
       end
 
       def wiki_enabled?
-        !!@project.wiki
+        !!@project.wiki&.enabled?
       end
     end
   end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -49,7 +49,7 @@ module Wikis
 
       def new_or_changed_wiki
         @wiki = Wiki.find_or_initialize_by(project: @project, start_page: "Wiki")
-        @wiki.toggle(:enabled) unless @wiki.new_record?
+        @wiki.enabled = params.require(:value) unless @wiki.new_record?
 
         @wiki
       end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -37,11 +37,8 @@ module Wikis
       menu_item :settings_project_wiki
 
       def create
-        if new_or_changed_wiki.save
-          status = @wiki.enabled? ? ".enabled" : ".disabled"
-          render_success_flash_message_via_turbo_stream(message: t(".success", status: t(".status.#{status}")))
-        else
-          render_error_flash_message_via_turbo_stream(message:)
+        unless new_or_changed_wiki.save
+          render_error_flash_message_via_turbo_stream(message: @wiki.errors.full_messages)
         end
 
         replace_via_turbo_stream(component: ProjectInternalWikiComponent.new(@project.reload))

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -30,23 +30,31 @@
 
 module Wikis
   module ProjectSettings
-    class WikiController < ApplicationController
+    class WikiController < Projects::SettingsController
       include OpTurbo::ComponentStream
       include OpTurbo::FlashStreamHelper
 
       menu_item :settings_project_wiki
 
-      before_action :authorize
-      before_action :find_project_by_project_id
-
-      def show; end
-
       def create
-        component = ProjectInternalWikiComponent.new(@project)
-        replace_via_turbo_stream(component:)
-        render_success_flash_message_via_turbo_stream(message: "Failed successfully")
+        if new_or_changed_wiki.save
+          status = @wiki.enabled? ? ".enabled" : ".disabled"
+          render_success_flash_message_via_turbo_stream(message: t(".success", status: t(".status.#{status}")))
+        else
+          render_error_flash_message_via_turbo_stream(message:)
+        end
 
+        replace_via_turbo_stream(component: ProjectInternalWikiComponent.new(@project.reload))
         respond_with_turbo_streams
+      end
+
+      private
+
+      def new_or_changed_wiki
+        @wiki = Wiki.find_or_initialize_by(project: @project, start_page: "Wiki")
+        @wiki.toggle(:enabled) unless @wiki.new_record?
+
+        @wiki
       end
     end
   end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  module ProjectSettings
+    class WikiController < ApplicationController
+      include OpTurbo::ComponentStream
+      include OpTurbo::FlashStreamHelper
+
+      menu_item :settings_project_wiki
+
+      before_action :authorize
+      before_action :find_project_by_project_id
+
+      def show; end
+
+      def create
+        component = ProjectInternalWikiComponent.new(@project)
+        replace_via_turbo_stream(component:)
+        render_success_flash_message_via_turbo_stream(message: "Failed successfully")
+
+        respond_with_turbo_streams
+      end
+    end
+  end
+end

--- a/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
+++ b/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
@@ -1,0 +1,41 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render Primer::OpenProject::PageHeader.new do |header|
+    header.with_title { I18n.t("projects.settings.internal_wiki.title") }
+    header.with_breadcrumbs(
+      [{ href: project_overview_path(@project.id), text: @project.name },
+       { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
+       I18n.t("projects.settings.internal_wiki.title")]
+    )
+  end
+%>
+
+<%= render Wikis::ProjectSettings::ProjectInternalWikiComponent.new(@project) %>

--- a/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
+++ b/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
@@ -29,11 +29,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { I18n.t("projects.settings.internal_wiki.title") }
+    header.with_title { I18n.t("projects_settings_wiki.title") }
     header.with_breadcrumbs(
       [{ href: project_overview_path(@project.id), text: @project.name },
        { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
-       I18n.t("projects.settings.internal_wiki.title")]
+       I18n.t("projects_settings_wiki.title")]
     )
   end
 %>

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -48,12 +48,12 @@ en:
   projects:
     settings:
       internal_wiki:
+        caption: >-
+          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
+          Disabling it when there are no external providers configured will remove wiki capabilities for this
+          project and hide any existing wiki pages.
         enable: Enable the internal wiki for this project
         title: Internal wiki
-        caption: >-
-          This enables OpenProject's native wiki module, which can exist alongside external wiki providers. 
-          Disabling it when there are no external providers configured will remove wiki capabilities for this 
-          project and hide any existing wiki pages.
   wikis:
     admin:
       destroy_confirmation_dialog_component:

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -43,10 +43,10 @@ en:
       internal_wiki_provider: Internal wiki
       wikis: Wikis
   permission_manage_wiki_page_links: Manage Wiki Page Links
-  project_module_wiki_internal: Internal wiki
+  project_module_wiki_internal: Project wiki
   project_module_wiki_platforms: Wiki providers
   projects_settings_wiki:
-    title: Internal wiki
+    title: Project wiki
   wikis:
     admin:
       destroy_confirmation_dialog_component:
@@ -190,15 +190,9 @@ en:
     project_settings:
       project_internal_wiki_component:
         caption: >-
-          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
-          Disabling it when there are no external providers configured will remove wiki capabilities for this
-          project and hide any existing wiki pages.
+          This enables native wiki functionality for this project. Members will be able to create and read wiki pages
+          that are stored in OpenProject.
         enable: Enable the internal wiki for this project
-      wiki:
-        status:
-          disabled: disabled
-          enabled: enabled
-        success: Internal wiki %{status} successfully.
     provider_types:
       xwiki:
         name: XWiki

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
       internal_wiki_provider: Internal wiki
       wikis: Wikis
   permission_manage_wiki_page_links: Manage Wiki Page Links
-  project_module_wiki_internal: Internal Wiki
+  project_module_wiki_internal: Internal wiki
   project_module_wiki_platforms: Wiki providers
   projects:
     settings:

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -45,15 +45,8 @@ en:
   permission_manage_wiki_page_links: Manage Wiki Page Links
   project_module_wiki_internal: Internal wiki
   project_module_wiki_platforms: Wiki providers
-  projects:
-    settings:
-      internal_wiki:
-        caption: >-
-          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
-          Disabling it when there are no external providers configured will remove wiki capabilities for this
-          project and hide any existing wiki pages.
-        enable: Enable the internal wiki for this project
-        title: Internal wiki
+  projects_settings_wiki:
+    title: Internal wiki
   wikis:
     admin:
       destroy_confirmation_dialog_component:
@@ -194,6 +187,18 @@ en:
         page_access_forbidden: You do not have permission to access this wiki page
         page_not_found: Linked wiki page no longer available
         unexpected: An unexpected error occurred
+    project_settings:
+      project_internal_wiki_component:
+        caption: >-
+          This enables OpenProject's native wiki module, which can exist alongside external wiki providers.
+          Disabling it when there are no external providers configured will remove wiki capabilities for this
+          project and hide any existing wiki pages.
+        enable: Enable the internal wiki for this project
+      wiki:
+        status:
+          disabled: disabled
+          enabled: enabled
+        success: Internal wiki %{status} successfully.
     provider_types:
       xwiki:
         name: XWiki

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -43,7 +43,17 @@ en:
       internal_wiki_provider: Internal wiki
       wikis: Wikis
   permission_manage_wiki_page_links: Manage Wiki Page Links
+  project_module_wiki_internal: Internal Wiki
   project_module_wiki_platforms: Wiki providers
+  projects:
+    settings:
+      internal_wiki:
+        enable: Enable the internal wiki for this project
+        title: Internal wiki
+        caption: >-
+          This enables OpenProject's native wiki module, which can exist alongside external wiki providers. 
+          Disabling it when there are no external providers configured will remove wiki capabilities for this 
+          project and hide any existing wiki pages.
   wikis:
     admin:
       destroy_confirmation_dialog_component:

--- a/modules/wikis/config/routes.rb
+++ b/modules/wikis/config/routes.rb
@@ -51,6 +51,10 @@ Rails.application.routes.draw do
   end
 
   resources :projects, only: %i[] do
+    namespace :settings do
+      resource :wiki, controller: "/wikis/project_settings/wiki", only: %i[show create]
+    end
+
     resources :work_packages, only: %i[] do
       resources :wikis, only: %i[] do
         collection do

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -99,7 +99,8 @@ module OpenProject::Wikis
                    {
                      wiki: %i[destroy protect edit_parent_page update_parent_page],
                      wikis: %i[edit destroy],
-                     wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item]
+                     wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item],
+                     "wikis/project_settings/wiki": %i[show create]
                    },
                    dependencies: :edit_wiki_pages,
                    permissible_on: :project,
@@ -151,6 +152,14 @@ module OpenProject::Wikis
            parent: :wiki_providers,
            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.wiki_enhancements_active? },
            caption: :"menus.admin.external_wiki_providers"
+
+      menu :project_menu,
+           :settings_project_wiki,
+           { controller: "wikis/project_settings/wiki", action: :show },
+           parent: :settings,
+           if: ->(_) { Wikis::InternalProvider.enabled? }, # What to do on projects that have a wiki but later disabled it?
+           after: :settings_backlogs,
+           caption: :project_module_wiki_internal
     end
 
     patch_with_namespace :WikiPages, :CreateService

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe ActivitiesController do
 
     describe "with activated activity module" do
       let(:project) do
-        create(:project,
-               enabled_module_names: %w[activity wiki])
+        create(:project, enabled_module_names: %w[activity])
       end
 
       it "renders activity" do
@@ -117,8 +116,7 @@ RSpec.describe ActivitiesController do
 
     describe "without activated activity module" do
       let(:project) do
-        create(:project,
-               enabled_module_names: %w[wiki])
+        create(:project, enabled_module_names: [])
       end
 
       it "renders 403" do

--- a/spec/controllers/projects_settings_menu_controller_spec.rb
+++ b/spec/controllers/projects_settings_menu_controller_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Projects::Settings::ModulesController, "menu" do
   let(:current_user) { create(:admin) }
 
   let(:project) do
-    # project contains wiki by default
     create(:project, :with_internal_wiki, enabled_module_names: enabled_modules).tap(&:reload)
   end
   let(:enabled_modules) { %w[] }

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Wiki Activity", :js do
                                                     edit_wiki_pages
                                                     view_wiki_edits] })
   end
-  let(:project) { create(:project, enabled_module_names: %w[wiki activity]) }
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[activity]) }
   let(:wiki) { project.wiki }
   let(:editor) { Components::WysiwygEditor.new }
 
@@ -106,6 +106,6 @@ RSpec.describe "Wiki Activity", :js do
     visit project_activity_index_path(project)
 
     expect(page)
-      .to have_no_content("Wiki edits")
+      .to have_no_text("Wiki edits")
   end
 end

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe "Wiki Activity", :js do
 
     visit project_activity_index_path(project)
 
-    expect(page)
-      .to have_no_text("Wiki edits")
+    expect(page).to have_no_text("Wiki edits") # rubocop:disable Capybara/RSpec/NegationMatcherAfterVisit
   end
 end

--- a/spec/features/external_link_capture_spec.rb
+++ b/spec/features/external_link_capture_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "External link capture", :js, :selenium do
   shared_let(:admin) { create(:admin) }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:external_url) { "https://www.openproject.org/" }
   let!(:wiki_page) do
     create(:wiki_page,

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Projects copy", :js,
   describe "with a full copy example" do
     let!(:project) do
       create(:project,
+             :with_internal_wiki,
              parent: parent_project,
              types: active_types,
              members: { user => role },
@@ -46,9 +47,6 @@ RSpec.describe "Projects copy", :js,
              }).tap do |p|
         p.work_package_custom_fields << wp_custom_field
         p.types.first.custom_fields << wp_custom_field
-
-        # Enable wiki
-        p.enabled_module_names += ["wiki"]
 
         # Enable the project custom field mappings
         p.project_custom_field_project_mappings
@@ -193,8 +191,8 @@ RSpec.describe "Projects copy", :js,
       it "renders only required project attribute" do
         expect(page).to have_heading "Copy project \"#{project.name}\""
 
-        expect(page).to have_content "Required Foo"
-        expect(page).to have_content "Required User"
+        expect(page).to have_text "Required Foo"
+        expect(page).to have_text "Required User"
         expect(page).to have_no_text "Optional Foo"
       end
     end
@@ -331,7 +329,7 @@ RSpec.describe "Projects copy", :js,
         it "shows invisible fields in the form and allows their activation" do
           expect(page).to have_heading "Copy project \"#{project.name}\""
 
-          expect(page).to have_content "Text for Admins only"
+          expect(page).to have_text "Text for Admins only"
 
           fill_in "Name", with: "Copied project"
 
@@ -358,7 +356,7 @@ RSpec.describe "Projects copy", :js,
         it "does not show invisible fields in the form but still activates them" do
           expect(page).to have_heading "Copy project \"#{project.name}\""
 
-          expect(page).to have_no_content "Text for Admins only"
+          expect(page).to have_no_text "Text for Admins only"
 
           fill_in "Name", with: "Copied project"
 
@@ -472,12 +470,12 @@ RSpec.describe "Projects copy", :js,
           # User has no permission to edit project attributes.
           expect(page).to have_no_css("[data-test-selector*='inplace-edit-dialog-button-']")
           # The custom fields are still copied from the parent project.
-          expect(page).to have_content(project_custom_field.name)
-          expect(page).to have_content("some text cf")
-          expect(page).to have_content(optional_project_custom_field.name)
-          expect(page).to have_content("some optional text cf")
-          expect(page).to have_content(optional_project_custom_field_with_default.name)
-          expect(page).to have_content("foo")
+          expect(page).to have_text(project_custom_field.name)
+          expect(page).to have_text("some text cf")
+          expect(page).to have_text(optional_project_custom_field.name)
+          expect(page).to have_text("some optional text cf")
+          expect(page).to have_text(optional_project_custom_field_with_default.name)
+          expect(page).to have_text("foo")
         end
       end
     end

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -63,10 +63,11 @@ RSpec.describe "Project templates", :js, with_good_job_batches: [CopyProjectJob,
   describe "instantiating templates" do
     let!(:template) do
       create(:template_project,
+             :with_internal_wiki,
              status_code: "on_track",
              status_explanation: "some explanation",
              name: "My template",
-             enabled_module_names: %w[wiki work_package_tracking])
+             enabled_module_names: %w[work_package_tracking])
     end
     let!(:other_project) { create(:project, name: "Some other project") }
     let!(:work_package) { create(:work_package, project: template) }

--- a/spec/features/wiki/adding_editing_history_spec.rb
+++ b/spec/features/wiki/adding_editing_history_spec.rb
@@ -31,6 +31,8 @@
 require "spec_helper"
 
 RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregation_time_minutes: 0 } do
+  shared_let(:internal_provider) { create(:internal_wiki_provider) }
+
   let(:project) do
     create(:project, enabled_module_names: [:news])
   end
@@ -46,6 +48,7 @@ RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregatio
                            edit_wiki_pages
                            view_wiki_edits
                            select_project_modules
+                           manage_wiki
                            edit_project])
   end
   let(:content_first_version) do
@@ -65,16 +68,14 @@ RSpec.describe "wiki pages", :js, :selenium, with_settings: { journal_aggregatio
     login_as user
   end
 
-  it "adding, editing and history", skip: "Wiki activation changed, needs update" do
-    visit project_settings_modules_path(project)
+  it "adding, editing and history" do
+    visit project_settings_wiki_path(project)
 
     expect(page).to have_no_css(".menu-sidebar .main-item-wrapper", text: "Wiki")
 
-    within "#content" do
-      check "Wiki"
+    page.find_test_selector("project-settings-enable-wiki").click
 
-      click_button "Save"
-    end
+    visit project_path(project)
 
     expect(page).to have_css(".wiki-menu--main-item", text: "Wiki", visible: :all)
 

--- a/spec/features/wiki/edit_new_page_spec.rb
+++ b/spec/features/wiki/edit_new_page_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "Editing a new wiki page", :js do
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:user) { create(:admin) }
 
   before do

--- a/spec/features/wiki/wiki_page_external_link_spec.rb
+++ b/spec/features/wiki/wiki_page_external_link_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Wiki page external link", :js, :selenium do
   current_user { admin }
 
   let(:external_url) { "https://www.openprojet.org/" }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let!(:wiki_page) do
     create(:wiki_page,
            wiki: project.wiki,

--- a/spec/features/wysiwyg/autosave_spec.rb
+++ b/spec/features/wysiwyg/autosave_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Wysiwyg autosave spec",
                :js do
   shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  shared_let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]) }
   shared_let(:work_package) { create(:work_package, subject: "Foobar", project:) }
 
   let(:editor) { Components::WysiwygEditor.new }

--- a/spec/features/wysiwyg/bold_behavior_spec.rb
+++ b/spec/features/wysiwyg/bold_behavior_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Wysiwyg bold behavior", :js do
   current_user { create(:admin) }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   def mac_osx?

--- a/spec/features/wysiwyg/custom_css_classes_spec.rb
+++ b/spec/features/wysiwyg/custom_css_classes_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg paragraphs in lists behavior (Regression #28765)", :js do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:wiki_page) do

--- a/spec/features/wysiwyg/html_encoding_spec.rb
+++ b/spec/features/wysiwyg/html_encoding_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg escaping HTML entities (Regression #28906)", :js do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   before do

--- a/spec/features/wysiwyg/linking_spec.rb
+++ b/spec/features/wysiwyg/linking_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg linking", :js do
   shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  shared_let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]) }
   let(:editor) { Components::WysiwygEditor.new }
 
   before do

--- a/spec/features/wysiwyg/macros/attribute_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/attribute_macros_spec.rb
@@ -82,9 +82,10 @@ RSpec.describe "Wysiwyg attribute macros", :js do
   end
   shared_let(:project) do
     create(:project,
+           :with_internal_wiki,
            identifier: "some-project",
            types: [type_milestone, type_task],
-           enabled_module_names: %w[wiki work_package_tracking],
+           enabled_module_names: %w[work_package_tracking],
            parent: parent_project)
   end
   shared_let(:work_package) do

--- a/spec/features/wysiwyg/macros/child_pages_spec.rb
+++ b/spec/features/wysiwyg/macros/child_pages_spec.rb
@@ -32,8 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg child pages spec", :js do
   let(:project) do
-    create(:project,
-           enabled_module_names: %w[wiki])
+    create(:project, :with_internal_wiki)
   end
   let(:editor) { Components::WysiwygEditor.new }
   let(:role) { create(:project_role, permissions: %i[view_wiki_pages edit_wiki_pages]) }

--- a/spec/features/wysiwyg/macros/code_block_macro_spec.rb
+++ b/spec/features/wysiwyg/macros/code_block_macro_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe "Wysiwyg code block macro", :js, :selenium do
   shared_let(:admin) { create(:admin) }
   let(:user) { admin }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:snippet) do

--- a/spec/features/wysiwyg/macros/embedded_tables_spec.rb
+++ b/spec/features/wysiwyg/macros/embedded_tables_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Wysiwyg embedded work package tables",
   shared_let(:type_task) { create(:type_task) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do
-    create(:project, types: [type_task, type_bug], enabled_module_names: %w[wiki work_package_tracking])
+    create(:project, :with_internal_wiki, types: [type_task, type_bug], enabled_module_names: %w[work_package_tracking])
   end
   shared_let(:wp_task) { create(:work_package, project:, type: type_task) }
   shared_let(:wp_bug) { create(:work_package, project:, type: type_bug) }
@@ -114,7 +114,7 @@ RSpec.describe "Wysiwyg embedded work package tables",
 
       context "with a subproject that gets deleted" do
         let!(:subproject) do
-          create(:project, parent: project, enabled_module_names: %w[wiki])
+          create(:project, :with_internal_wiki, parent: project)
         end
 
         it "can still edit the embedded table widget" do

--- a/spec/features/wysiwyg/macros/work_package_button_spec.rb
+++ b/spec/features/wysiwyg/macros/work_package_button_spec.rb
@@ -37,8 +37,9 @@ RSpec.describe "Wysiwyg work package button spec", :js do
   let!(:type) { create(:type, name: "MyTaskName") }
   let(:project) do
     create(:valid_project,
+           :with_internal_wiki,
            identifier: "my-project",
-           enabled_module_names: %w[wiki work_package_tracking],
+           enabled_module_names: %w[work_package_tracking],
            name: "My project name",
            types: [type])
   end

--- a/spec/features/wysiwyg/paragraphs_in_lists_spec.rb
+++ b/spec/features/wysiwyg/paragraphs_in_lists_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg paragraphs in lists behavior (Regression #28765)", :js do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:wiki_page) do

--- a/spec/features/wysiwyg/tables_spec.rb
+++ b/spec/features/wysiwyg/tables_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Wysiwyg tables", :js do
   shared_let(:admin) { create(:admin) }
   let(:user) { admin }
 
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   before do

--- a/spec/features/wysiwyg/ui_localization_spec.rb
+++ b/spec/features/wysiwyg/ui_localization_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "WYSIWYG UI localization", :js do
   let(:user) { create(:admin, language:) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:project) { create(:project, :with_internal_wiki) }
   let(:editor) { Components::WysiwygEditor.new }
 
   let(:wiki_page) do

--- a/spec/features/wysiwyg/work_package_linking_spec.rb
+++ b/spec/features/wysiwyg/work_package_linking_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Wysiwyg work package linking", :js, :selenium do
   let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: %w[work_package_tracking]) }
   let(:work_package) { create(:work_package, subject: "Foobar", project:) }
   let(:editor) { Components::WysiwygEditor.new }
 

--- a/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
@@ -40,18 +40,13 @@ RSpec.describe "OpenProject child pages macro" do
   end
 
   shared_let(:project) do
-    create(:valid_project,
-           enabled_module_names: %w[wiki])
+    create(:valid_project, :with_internal_wiki)
   end
   shared_let(:member_project) do
-    create(:valid_project,
-           identifier: "member-project",
-           enabled_module_names: %w[wiki])
+    create(:valid_project, :with_internal_wiki, identifier: "member-project")
   end
   shared_let(:invisible_project) do
-    create(:valid_project,
-           identifier: "other-project",
-           enabled_module_names: %w[wiki])
+    create(:valid_project, :with_internal_wiki, identifier: "other-project")
   end
   shared_let(:user) do
     create(:user, member_with_permissions: { project => [:view_wiki_pages],

--- a/spec/models/enabled_module_spec.rb
+++ b/spec/models/enabled_module_spec.rb
@@ -102,46 +102,6 @@ RSpec.describe EnabledModule do
     end
   end
 
-  describe "#wiki" do
-    let(:modules) { %w[wiki] }
-
-    it "creates a wiki" do
-      expect(project.wiki).not_to be_nil
-      expect(project.wiki.start_page).to eq("Wiki")
-    end
-
-    it "does not create a separate wiki when one exists already" do
-      expect(project.wiki).not_to be_nil
-
-      expect do
-        project.enabled_module_names = []
-        project.reload
-      end.not_to change(Wiki, :count)
-
-      expect do
-        project.enabled_module_names = ["wiki"]
-      end.not_to change(Wiki, :count)
-
-      expect(project.wiki).not_to be_nil
-    end
-
-    context "with disabled module" do
-      let(:modules) { [] }
-
-      it "does not create a wiki" do
-        expect(project.wiki).to be_nil
-      end
-
-      it "creates a wiki when the module is enabled at a later time" do
-        project.enabled_module_names = ["wiki"]
-        project.reload
-
-        expect(project.wiki).not_to be_nil
-        expect(project.wiki.start_page).to eq("Wiki")
-      end
-    end
-  end
-
   describe "#repository" do
     let(:modules) { %w[repository] }
 

--- a/spec/models/menu_items/wiki_menu_item_spec.rb
+++ b/spec/models/menu_items/wiki_menu_item_spec.rb
@@ -31,20 +31,19 @@
 require "spec_helper"
 
 RSpec.describe MenuItems::WikiMenuItem do
-  before do
-    @project = create(:project, enabled_module_names: %w[activity])
-    @current = create(:user, login: "user1", mail: "user1@users.com")
+  let(:project) { create(:project, :with_internal_wiki, enabled_module_names: ["activity"]) }
+  let(:user) { create(:user) }
 
-    allow(User).to receive(:current).and_return(@current)
+  before do
+    allow(User).to receive(:current).and_return(user)
   end
 
-  it "creates a default wiki menu item when enabling the wiki" do
-    expect(MenuItems::WikiMenuItem.all).not_to be_any
+  it "creates a default wiki menu item when an internal wiki is added" do
+    expect(described_class.count).to eq(0)
 
-    @project.enabled_modules << EnabledModule.new(name: "wiki")
-    @project.reload
+    expect { project }.to change(described_class, :count).by(1)
 
-    wiki_item = @project.wiki.wiki_menu_items.first
+    wiki_item = project.wiki.wiki_menu_items&.first
     expect(wiki_item.name).to eql "wiki"
     expect(wiki_item.title).to eql "Wiki"
     expect(wiki_item.slug).to eql "wiki"
@@ -52,64 +51,46 @@ RSpec.describe MenuItems::WikiMenuItem do
     expect(wiki_item.options[:new_wiki_page]).to be true
   end
 
-  it "changes title when a wikipage is renamed" do
-    wikipage = create(:wiki_page, title: "Oldtitle")
+  it "changes title when a wiki_page is renamed" do
+    wiki_page = create(:wiki_page, title: "Oldtitle")
 
-    menu_item_1 = create(:wiki_menu_item, navigatable_id: wikipage.wiki.id,
-                                          title: "Item 1",
-                                          name: wikipage.slug)
+    menu_item = create(:wiki_menu_item, navigatable_id: wiki_page.wiki.id, title: "Item 1", name: wiki_page.slug)
 
-    wikipage.title = "Newtitle"
-    wikipage.save!
+    wiki_page.update!(title: "Newtitle")
 
-    menu_item_1.reload
-    expect(menu_item_1.title).to eq(wikipage.title)
+    expect(menu_item.reload.title).to eq(wiki_page.title)
   end
 
   it "does not allow duplicate sibling entries" do
-    wikipage = create(:wiki_page, title: "Parent Page")
+    wiki_page = create(:wiki_page, title: "Parent Page")
 
     parent = create(
-      :wiki_menu_item, navigatable_id: wikipage.wiki.id, title: "Item 1", name: wikipage.slug
+      :wiki_menu_item, navigatable_id: wiki_page.wiki.id, title: "Item 1", name: wiki_page.slug
     )
-    child_1 = parent.children.create name: "child-1", title: "Child 1"
-
+    parent.children.create name: "child-1", title: "Child 1"
     child_2 = parent.children.build name: "child-1", title: "Child 2"
 
     expect { child_2.save! }.to raise_error /Name has already been taken/
   end
 
   describe "it should destroy" do
-    before do
-      @project.enabled_modules << EnabledModule.new(name: "wiki")
-      @project.reload
-
-      @menu_item_1 = create(:wiki_menu_item, wiki: @project.wiki,
-                                             name: "Item 1",
-                                             title: "Item 1")
-
-      @menu_item_2 = create(:wiki_menu_item, wiki: @project.wiki,
-                                             name: "Item 2",
-                                             parent_id: @menu_item_1.id,
-                                             title: "Item 2")
-    end
+    let!(:first_menu_item) { create(:wiki_menu_item, wiki: project.wiki) }
+    let!(:second_menu_item) { create(:wiki_menu_item, wiki: project.wiki, parent: first_menu_item) }
 
     it "all children when deleting the parent" do
-      @menu_item_1.destroy
+      first_menu_item.destroy
 
-      expect { MenuItems::WikiMenuItem.find(@menu_item_1.id) }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { MenuItems::WikiMenuItem.find(@menu_item_2.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.find(first_menu_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.find(second_menu_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     describe "all items when destroying" do
       it "the associated project" do
-        @project.destroy
-        expect(MenuItems::WikiMenuItem.all).not_to be_any
+        expect { project.destroy }.to change(described_class, :count).to(0)
       end
 
       it "the associated wiki" do
-        @project.wiki.destroy
-        expect(MenuItems::WikiMenuItem.all).not_to be_any
+        expect { project.wiki.destroy }.to change(described_class, :count).to(0)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -133,25 +133,6 @@ RSpec.describe Project do
     end
   end
 
-  context "when the wiki module is enabled" do
-    let(:project) { create(:project, disable_modules: "wiki") }
-
-    before do
-      project.enabled_module_names = project.enabled_module_names | ["wiki"]
-      project.save
-      project.reload
-    end
-
-    it "creates a wiki" do
-      expect(project.wiki).to be_present
-    end
-
-    it "creates a wiki menu item named like the default start page" do
-      expect(project.wiki.wiki_menu_items).to be_one
-      expect(project.wiki.wiki_menu_items.first.title).to eq(project.wiki.start_page)
-    end
-  end
-
   describe "#copy_allowed?" do
     let(:user) { build_stubbed(:user) }
     let(:project) { build_stubbed(:project) }

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
   shared_let(:source_project) do
     create(:project,
-           enabled_module_names: %w[work_package_tracking wiki],
+           :with_internal_wiki,
+           enabled_module_names: %w[work_package_tracking],
            custom_field_values: {
              text_custom_field.id => "source text",
              list_custom_field.id => list_custom_field.custom_options.last.id
@@ -158,7 +159,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
         expect(project).to be_present
 
         expect(source_project.wiki.pages.count).to eq 1
-        expect(project.wiki.pages.count).to eq 0
+        expect(project.wiki).to be_nil
 
         expect(source_project.work_packages.count).to eq 1
         expect(project.work_packages.count).to eq 1

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RootSeeder,
 
     it "creates the demo data" do # rubocop:disable RSpec/MultipleExpectations
       expect(Project.count).to eq 2
-      expect(EnabledModule.count).to eq 19
+      expect(EnabledModule.count).to eq 17
       expect(WorkPackage.count).to eq 37
       expect(Wiki.count).to eq 2
       expect(Query.having_views.count).to eq 8

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -40,8 +40,9 @@ RSpec.describe(
   shared_let(:status_locked) { create(:status, is_readonly: true) }
   shared_let(:source) do
     create(:project,
+           :with_internal_wiki,
            name: "Source Project Name",
-           enabled_module_names: %i[wiki work_package_tracking storages])
+           enabled_module_names: %i[work_package_tracking storages])
   end
   shared_let(:source_wp) { create(:work_package, project: source, subject: "source wp") }
   shared_let(:source_wp_locked) do
@@ -1202,9 +1203,7 @@ RSpec.describe(
         expect(project_copy.work_packages.count).to eq 0
         expect(project_copy.forums.count).to eq 0
         # Default wiki page
-        expect(project_copy.wiki).to be_present
-        expect(project_copy.wiki.pages.count).to eq 0
-        expect(project_copy.wiki.wiki_menu_items.count).to eq 1
+        expect(project_copy.wiki).to be_nil
         expect(project_copy.queries.count).to eq 0
         expect(project_copy.versions.count).to eq 0
         expect(project_copy.phases.count).to eq 0


### PR DESCRIPTION
This covers parts of OP#XWI-52, OP#XWI-53 and OP#XWI-54 on the OP#XWI-42 feature.

What is missing at this moment:
- Updated Wiki enable/disable tests.
- Update flash messages