### PR TITLE
[OP-19738] Include groups in the Principal.visible scope

### DIFF
--- a/app/models/principals/scopes/visible.rb
+++ b/app/models/principals/scopes/visible.rb
@@ -35,7 +35,8 @@
 # - Other users can see Principals if:
 #   - they are a member of the same project as the Principal, or
 #   - they are the same user, or
-#   - they share a group with the Principal.
+#   - they share a group with the Principal, or
+#   - the Principal is a group they belong to.
 module Principals::Scopes
   module Visible
     extend ActiveSupport::Concern
@@ -46,6 +47,7 @@ module Principals::Scopes
           all
         else
           in_visible_project_or_me_or_same_groups(user)
+            .or(where(id: Group.containing_user(user).select(:id)))
         end
       end
     end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -169,6 +169,25 @@ RSpec.describe MembersController do
         end
       end
 
+      context "when searching for a group the user belongs to" do
+        let!(:visible_group) { create(:group, lastname: "Visible group", members: [user]) }
+        let!(:hidden_group) { create(:group, lastname: "Hidden group") }
+        let(:query) { "Visible group" }
+
+        it "returns the group even if it is not a member of the project" do
+          subject
+
+          expect(json_response).to include(
+            {
+              "id" => visible_group.id,
+              "name" => visible_group.name,
+              "href" => "/api/v3/groups/#{visible_group.id}"
+            }
+          )
+          expect(json_response.pluck("id")).not_to include(hidden_group.id)
+        end
+      end
+
       context "when the user is authorized to see email addresses" do
         let(:global_permissions) { [:view_user_email] }
 

--- a/spec/models/principals/scopes/visible_spec.rb
+++ b/spec/models/principals/scopes/visible_spec.rb
@@ -119,8 +119,12 @@ RSpec.describe Principals::Scopes::Visible do
     context "when user has no permission" do
       current_user { create(:user, firstname: "current user") }
 
-      it "sees only themself" do
-        expect(subject).to contain_exactly(current_user)
+      let!(:current_user_group) do
+        create(:group, firstname: "current user group", members: [current_user])
+      end
+
+      it "sees only themself and groups they belong to" do
+        expect(subject).to contain_exactly(current_user, current_user_group)
       end
     end
   end


### PR DESCRIPTION
Fix Principal.visible excluding groups the current user belongs to when they lack view_all_principals.

For reduced visibility, Principal.visible relied on in_visible_project_or_me_or_same_groups, that uses in_same_groups to finder _users_ in the same group. That check however never returned the group itself as a visible principal.

This commit adds an explicit check to include groups that contain the current user, matching the behavior already present in Group.visible.

https://community.openproject.org/work_packages/OP-19738