### PR TITLE
[COMMS-886] Adjust WorkPackage list UI to read/write target_versions

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -101,14 +101,14 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
       groupable: "#{WorkPackage.table_name}.category_id"
     },
     version: {
+      if: -> { !Setting::WorkPackageMultipleVersions.active? },
       association: "version",
       sortable: "name",
       groupable: "#{WorkPackage.table_name}.version_id"
     },
     target_versions: {
-      # version will be replaced by target_versions but during the transition
-      # we exclude target_versions from user-facing work package selects
-      if: -> { false }
+      if: -> { Setting::WorkPackageMultipleVersions.active? },
+      association: "target_versions"
     },
     start_date: {
       sortable: "#{WorkPackage.table_name}.start_date"

--- a/app/models/work_package/exports/formatters/target_versions.rb
+++ b/app/models/work_package/exports/formatters/target_versions.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackage::Exports
+  module Formatters
+    class TargetVersions < ::Exports::Formatters::Default
+      def self.apply?(attribute, _export_format)
+        attribute.to_sym == :target_versions
+      end
+
+      def retrieve_value(object)
+        object.target_versions.map(&:name)
+      end
+    end
+  end
+end

--- a/app/models/work_package/exports/query_exporter.rb
+++ b/app/models/work_package/exports/query_exporter.rb
@@ -57,8 +57,16 @@ module WorkPackage::Exports
       query
         .results
         .work_packages
+        .includes(column_associations)
         .page(page)
         .per_page(Setting.work_packages_projects_export_limit.to_i)
+    end
+
+    # Preload only names that are real associations so that a column whose
+    # association metadata does not match one falls back to lazy loading
+    # instead of raising.
+    def column_associations
+      column_objects.filter_map { it.association&.to_sym } & WorkPackage.reflections.keys.map(&:to_sym)
     end
   end
 end

--- a/config/initializers/export_formats.rb
+++ b/config/initializers/export_formats.rb
@@ -50,6 +50,7 @@ Rails.application.configure do |application|
       formatter WorkPackage, WorkPackage::Exports::Formatters::Id
       formatter WorkPackage, WorkPackage::Exports::Formatters::ProjectPhase
       formatter WorkPackage, WorkPackage::Exports::Formatters::SpentUnits
+      formatter WorkPackage, WorkPackage::Exports::Formatters::TargetVersions
 
       list Project, Projects::Exports::CSV
       list Project, Projects::Exports::PDF

--- a/spec/features/work_packages/table/target_versions_column_spec.rb
+++ b/spec/features/work_packages/table/target_versions_column_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package table target versions column", :js do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_work_packages edit_work_packages assign_versions save_queries]
+           })
+  end
+  shared_let(:version_one) { create(:version, project:, name: "1.0") }
+  shared_let(:version_two) { create(:version, project:, name: "2.0") }
+  shared_let(:version_three) { create(:version, project:, name: "3.0") }
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:columns) { Components::WorkPackages::Columns.new }
+
+  let!(:work_package) do
+    create(:work_package, project:).tap do |wp|
+      wp.target_version_ids_replacements = [version_one.id, version_two.id]
+      wp.save!
+    end
+  end
+
+  let!(:query) do
+    create(:query, user:, project:, column_names: %w[id subject target_versions])
+  end
+
+  before do
+    login_as(user)
+  end
+
+  context "with multiple versions active",
+          with_flag: { work_package_multiple_versions: true },
+          with_settings: { work_package_multiple_versions: true } do
+    it "shows all target versions and allows editing them inline" do
+      wp_table.visit_query query
+      wp_table.expect_work_package_listed work_package
+
+      expect(page).to have_css(".wp-table--table-header", text: "TARGET VERSIONS")
+
+      field = wp_table.edit_field(work_package, :targetVersions)
+      field.expect_text version_one.name
+      field.expect_text version_two.name
+
+      field.activate!
+      field.set_value version_three.name
+      field.submit_by_dashboard
+
+      wp_table.expect_and_dismiss_toaster(message: "Successful update.")
+
+      # The cell renders two values in association order (which carries no
+      # order clause) and elides the rest behind a count, so only assert the
+      # elision marker here; the persisted set is checked below.
+      field.expect_text "...3"
+      expect(work_package.reload.target_versions)
+        .to contain_exactly(version_one, version_two, version_three)
+    end
+
+    it "offers the target versions column but not the version column" do
+      wp_table.visit_query query
+      wp_table.expect_work_package_listed work_package
+
+      columns.open_modal
+      columns.expect_checked "Target versions"
+      columns.expect_column_not_available(/^Version$/)
+    end
+  end
+
+  context "with multiple versions inactive" do
+    let!(:query) do
+      create(:query, user:, project:, column_names: %w[id subject version])
+    end
+
+    it "keeps the single version column" do
+      wp_table.visit_query query
+      wp_table.expect_work_package_listed work_package
+
+      expect(page).to have_css(".wp-table--table-header", text: "VERSION")
+
+      field = wp_table.edit_field(work_package, :version)
+      field.expect_text version_one.name
+
+      columns.open_modal
+      columns.expect_checked "Version"
+      columns.expect_column_not_available "Target versions"
+    end
+  end
+end

--- a/spec/models/queries/work_packages/selects/property_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/property_select_spec.rb
@@ -46,5 +46,60 @@ RSpec.describe Queries::WorkPackages::Selects::PropertySelect do
         expect(described_class.instances.map(&:name)).to include :duration
       end
     end
+
+    describe "version and target_versions columns" do
+      context "with the feature flag and the setting enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        it "replaces the version column with the target_versions column" do
+          names = described_class.instances.map(&:name)
+
+          expect(names).to include :target_versions
+          expect(names).not_to include :version
+        end
+
+        it "is displayable but neither sortable nor groupable" do
+          column = described_class.instances.find { it.name == :target_versions }
+
+          expect(column).to be_displayable
+          expect(column).not_to be_sortable
+          expect(column).not_to be_groupable
+          expect(column.caption).to eq WorkPackage.human_attribute_name(:target_versions)
+        end
+      end
+
+      context "with the feature flag disabled",
+              with_flag: { work_package_multiple_versions: false },
+              with_settings: { work_package_multiple_versions: true } do
+        it "keeps the version column" do
+          names = described_class.instances.map(&:name)
+
+          expect(names).to include :version
+          expect(names).not_to include :target_versions
+        end
+      end
+
+      context "with the setting disabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: false } do
+        it "keeps the version column" do
+          names = described_class.instances.map(&:name)
+
+          expect(names).to include :version
+          expect(names).not_to include :target_versions
+        end
+      end
+
+      context "with the feature flag and the setting disabled",
+              with_flag: { work_package_multiple_versions: false },
+              with_settings: { work_package_multiple_versions: false } do
+        it "keeps the version column" do
+          names = described_class.instances.map(&:name)
+
+          expect(names).to include :version
+          expect(names).not_to include :target_versions
+        end
+      end
+    end
   end
 end

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -181,6 +181,26 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
       # the association carries no order, so compare the cell as a set
       expect(pairs["Target versions"].split("; ")).to match_array %w[1.0 2.0]
     end
+
+    it "preloads target versions so cell rendering does not query per row" do
+      loaded = instance.work_packages.to_a
+
+      expect { loaded.each { it.target_versions.map(&:name) } }.to have_a_query_limit(0)
+    end
+  end
+
+  context "when no displayed column has a backing association" do
+    let!(:work_package) { create(:work_package, project:, type: type_a, subject: "No associations") }
+    let(:query) do
+      create(:query, project:, user:, column_names: %i(subject start_date))
+    end
+
+    it "exports successfully with an empty preload list" do
+      headers, values = CSV.parse instance.export!.content
+
+      expect(headers.first).to eq "#{byte_order_mark}Subject"
+      expect(values.first).to eq "No associations"
+    end
   end
 
   context "with multiple work packages" do

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -178,7 +178,8 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
       headers, values = CSV.parse instance.export!.content
       pairs = headers.zip(values).to_h
 
-      expect(pairs["Target versions"]).to eq "1.0; 2.0"
+      # the association carries no order, so compare the cell as a set
+      expect(pairs["Target versions"].split("; ")).to match_array %w[1.0 2.0]
     end
   end
 

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -158,6 +158,30 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
     end
   end
 
+  context "with the target versions column",
+          with_flag: { work_package_multiple_versions: true },
+          with_settings: { work_package_multiple_versions: true } do
+    let(:version_one) { create(:version, project:, name: "1.0") }
+    let(:version_two) { create(:version, project:, name: "2.0") }
+    let!(:work_package) do
+      create(:work_package, project:, type: type_a).tap do |wp|
+        wp.target_version_ids_replacements = [version_one.id, version_two.id]
+        wp.save!
+      end
+    end
+    let(:options) { {} }
+    let(:query) do
+      create(:query, project:, user:, column_names: %i(subject target_versions))
+    end
+
+    it "exports the joined target version names" do
+      headers, values = CSV.parse instance.export!.content
+      pairs = headers.zip(values).to_h
+
+      expect(pairs["Target versions"]).to eq "1.0; 2.0"
+    end
+  end
+
   context "with multiple work packages" do
     shared_let(:wp1) { create(:work_package, project:, done_ratio: 25, subject: "WP1", type: type_a, id: 1) }
     shared_let(:wp2) { create(:work_package, project:, done_ratio: 0, subject: "WP2", type: type_a, id: 2) }

--- a/spec/models/work_package/exports/formatters/target_versions_spec.rb
+++ b/spec/models/work_package/exports/formatters/target_versions_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackage::Exports::Formatters::TargetVersions do
+  let(:formatter_instance) { described_class.new(:target_versions) }
+
+  describe ".apply?" do
+    it "returns true for :target_versions with any export format" do
+      expect(described_class.apply?(:target_versions, :pdf)).to be true
+      expect(described_class.apply?(:target_versions, :csv)).to be true
+      expect(described_class.apply?(:target_versions, :xls)).to be true
+    end
+
+    it "returns false for other attributes" do
+      expect(described_class.apply?(:version, :pdf)).to be false
+    end
+  end
+
+  describe "#format" do
+    let(:versions) { [build_stubbed(:version, name: "1.0"), build_stubbed(:version, name: "2.0")] }
+    let(:work_package) do
+      build_stubbed(:work_package) do |wp|
+        allow(wp)
+          .to receive(:target_versions)
+                .and_return(versions)
+      end
+    end
+
+    it "returns the joined version names" do
+      expect(formatter_instance.format(work_package)).to eq("1.0, 2.0")
+    end
+
+    it "honors the array_separator option" do
+      expect(formatter_instance.format(work_package, array_separator: "; ")).to eq("1.0; 2.0")
+    end
+
+    context "without target versions" do
+      let(:versions) { [] }
+
+      it "returns an empty string" do
+        expect(formatter_instance.format(work_package)).to eq("")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/queries/columns/query_columns_resource_spec.rb
+++ b/spec/requests/api/v3/queries/columns/query_columns_resource_spec.rb
@@ -77,5 +77,43 @@ RSpec.describe "API v3 Query Column resource" do
         expect(last_response).to have_http_status(404)
       end
     end
+
+    context "with multiple versions inactive" do
+      context "for the version column" do
+        let(:column_name) { "version" }
+
+        it "succeeds" do
+          expect(last_response).to have_http_status(200)
+        end
+      end
+
+      context "for the targetVersions column" do
+        let(:column_name) { "targetVersions" }
+
+        it "returns 404" do
+          expect(last_response).to have_http_status(404)
+        end
+      end
+    end
+
+    context "with multiple versions active",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      context "for the targetVersions column" do
+        let(:column_name) { "targetVersions" }
+
+        it "succeeds" do
+          expect(last_response).to have_http_status(200)
+        end
+      end
+
+      context "for the version column" do
+        let(:column_name) { "version" }
+
+        it "returns 404" do
+          expect(last_response).to have_http_status(404)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-886

# What are you trying to accomplish?
Make the work package list read and write versions through `target_versions`. While the `WorkPackageMultipleVersions` switch is off nothing changes: the list keeps the single-valued "Version" column with its sorting and grouping. With the switch on, that column is replaced by a "Target versions" column that shows all target versions of a work package and can be edited inline as a multi-select.

## Screenshots
Switch off, the single Version column as before:

<img width="1440" height="820" alt="switch-off-column" src="https://github.com/user-attachments/assets/7d226fb9-6bd8-48f8-9e89-b91e26482116" />

Switch on, the Target versions column showing all values:

<img width="1440" height="820" alt="switch-on-column" src="https://github.com/user-attachments/assets/fecf3432-1d12-4475-b47f-847e5149f500" />

Inline editing in the table cell as a multi-select:

<img width="1440" height="820" alt="switch-on-edit" src="https://github.com/user-attachments/assets/9fbf7983-9eca-46f2-bc49-a5cacc578b8d" />

Export (PDF)

<img width="1301" height="391" alt="Screenshot 2026-07-13 at 9 49 56 AM" src="https://github.com/user-attachments/assets/985a5cf7-c005-41fa-875e-c14eef342766" />

# What approach did you choose and why?

This boils down to a query-column swap: the `version` select is only offered while the switch is off, and the previously hidden `target_versions` select is offered while it is on. The frontend needs no changes because the schema already exposes `targetVersions` and the display/edit fields for it exist since COMMS-877. A small export formatter joins the version names so CSV/XLS/PDF cells render readable text instead of a raw collection.

Sorting and grouping by target versions, and migrating saved queries that reference the version column, are handled separately in COMMS-855.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

