### PR TITLE
Remove output schema from MCP tools

### DIFF
--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -86,12 +86,6 @@ module McpTools
         @input_schema
       end
 
-      def output_schema(schema = nil)
-        @output_schema = schema if schema.present?
-
-        @output_schema
-      end
-
       ##
       # Defines a filter for selecting results through input parameters. Only one of filter_proc and filter_class are allowed at
       # the same time. If none is provided, a default where-based filter is created, using name as the filtered attribute name.
@@ -156,7 +150,6 @@ module McpTools
           title: config.title,
           description: config.description,
           input_schema:,
-          output_schema:,
           annotations: read_annotations
         ) do |server_context: {}, **opts|
           implementation.new(server_context:, tool_context: self).handle_request(**opts)
@@ -171,12 +164,6 @@ module McpTools
 
     def handle_request(**)
       result = call(**)
-
-      if Rails.env.local? && @tool_context.output_schema
-        # We are only validating the output during development, so we can see errors during dev, but do not break the
-        # API in production due to minor schema differences.
-        @tool_context.output_schema.validate_result(JSON.parse(result.to_json))
-      end
 
       format_response(result)
     end

--- a/app/services/mcp_tools/current_user.rb
+++ b/app/services/mcp_tools/current_user.rb
@@ -36,7 +36,6 @@ module McpTools
     name "current_user"
 
     resource McpResources::CurrentUser
-    resource_schema "user_model"
     resource_annotations
   end
 end

--- a/app/services/mcp_tools/list_statuses.rb
+++ b/app/services/mcp_tools/list_statuses.rb
@@ -37,7 +37,6 @@ module McpTools
     name "list_statuses"
 
     resource McpResources::StatusList
-    resource_schema "status_collection_model"
     resource_annotations
   end
 end

--- a/app/services/mcp_tools/list_types.rb
+++ b/app/services/mcp_tools/list_types.rb
@@ -36,7 +36,6 @@ module McpTools
     name "list_types"
 
     resource McpResources::TypeList
-    resource_schema "types_model"
     resource_annotations
   end
 end

--- a/app/services/mcp_tools/resource_proxy_tool.rb
+++ b/app/services/mcp_tools/resource_proxy_tool.rb
@@ -39,10 +39,6 @@ module McpTools
         @resource
       end
 
-      def resource_schema(schema_definition)
-        output_schema(JsonSchemaLoader.new.load(schema_definition))
-      end
-
       def resource_annotations
         annotations read_only: true, idempotent: true, destructive: false
       end

--- a/app/services/mcp_tools/search_portfolios.rb
+++ b/app/services/mcp_tools/search_portfolios.rb
@@ -53,17 +53,6 @@ module McpTools
       }
     )
 
-    output_schema(
-      type: :object,
-      required: ["items"],
-      properties: {
-        items: {
-          type: :array,
-          items: JsonSchemaLoader.new.load("portfolio_model")
-        }
-      }
-    )
-
     def call(page: nil, **filters)
       filtered = apply_filters(Project.portfolio.visible, filters)
       portfolios = apply_pagination(filtered, page)

--- a/app/services/mcp_tools/search_programs.rb
+++ b/app/services/mcp_tools/search_programs.rb
@@ -53,17 +53,6 @@ module McpTools
       }
     )
 
-    output_schema(
-      type: :object,
-      required: ["items"],
-      properties: {
-        items: {
-          type: :array,
-          items: JsonSchemaLoader.new.load("program_model")
-        }
-      }
-    )
-
     def call(page: nil, **filters)
       filtered = apply_filters(Project.program.visible, filters)
       programs = apply_pagination(filtered, page)

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -53,17 +53,6 @@ module McpTools
       }
     )
 
-    output_schema(
-      type: :object,
-      required: ["items"],
-      properties: {
-        items: {
-          type: :array,
-          items: JsonSchemaLoader.new.load("project_model")
-        }
-      }
-    )
-
     def call(page: nil, **filters)
       filtered = apply_filters(Project.project.visible, filters)
       projects = apply_pagination(filtered, page)

--- a/app/services/mcp_tools/search_users.rb
+++ b/app/services/mcp_tools/search_users.rb
@@ -51,17 +51,6 @@ module McpTools
       }
     )
 
-    output_schema(
-      type: :object,
-      required: ["items"],
-      properties: {
-        items: {
-          type: :array,
-          items: JsonSchemaLoader.new.load("user_model")
-        }
-      }
-    )
-
     def call(page: nil, **filters)
       users = apply_filters(User.visible.not_builtin, filters)
       users = apply_pagination(users, page)

--- a/app/services/mcp_tools/search_versions.rb
+++ b/app/services/mcp_tools/search_versions.rb
@@ -55,17 +55,6 @@ module McpTools
       }
     )
 
-    output_schema(
-      type: :object,
-      required: ["items"],
-      properties: {
-        items: {
-          type: :array,
-          items: JsonSchemaLoader.new.load("version_read_model")
-        }
-      }
-    )
-
     def call(page: nil, **filters)
       filtered = apply_filters(Version.visible, filters)
       versions = apply_pagination(filtered, page)

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -75,17 +75,6 @@ module McpTools
       }
     )
 
-    output_schema(
-      type: :object,
-      required: ["items"],
-      properties: {
-        items: {
-          type: :array,
-          items: JsonSchemaLoader.new.load("work_package_model")
-        }
-      }
-    )
-
     def call(page: nil, **filters)
       filtered = apply_filters(WorkPackage.visible, filters)
       work_packages = apply_pagination(filtered, page)


### PR DESCRIPTION
As far as I learned recently, most MCP clients don't consume the output schema at all and try to make sense of JSON responses by reading them bare.

On the other hand, we already had concerns about the context window of LLMs consuming our MCP endpoints to be filled to the brim with our output schema.

While at most one can be true at the same time, it indicates an interesting direction to me: Either it's useless to have the output schema or if it's not useless it may still be considered harmful. On the other hand, maintaining the schema makes our life harder, because we have to abide by the schema to not create errors purely by violating the schema slightly.

Thus we'll not advertise the output schema anymore and see how well that works.

# Ticket
https://community.openproject.org/wp/AI-67