### PR TITLE
[OP-19752] Use Label component to indicate user status

### DIFF
--- a/app/forms/users/form/attributes_form.rb
+++ b/app/forms/users/form/attributes_form.rb
@@ -72,9 +72,18 @@ module Users
       # The current status (e.g. active, locked) as a read-only line rather than
       # folded into the section title.
       def account_status(group)
-        status = "#{User.human_attribute_name(:status)}: #{helpers.full_user_status(@user, true)}"
+        status = helpers.full_user_status(@user, true)
+        scheme = if @user.active?
+                   :success
+                 elsif @user.invited?
+                   :accent
+                 elsif @user.locked? || @user.deleted?
+                   :attention
+                 else
+                   :secondary
+                 end
         group.html_content do
-          render(Primer::Beta::Text.new(tag: :p)) { status }
+          render(Primer::Beta::Label.new(scheme:, align_self: :start)) { status }
         end
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19752

# What are you trying to accomplish?
Use Label component instead of plain text

## Screenshots

<img width="212" height="154" alt="Bildschirmfoto 2026-07-13 um 09 56 07" src="https://github.com/user-attachments/assets/2b0f27bf-588b-4c11-b07b-e8b14e9952d6" />
<img width="207" height="148" alt="Bildschirmfoto 2026-07-13 um 09 56 19" src="https://github.com/user-attachments/assets/819d33eb-442c-4ab1-8a62-be5cd12b61e5" />
<img width="170" height="146" alt="Bildschirmfoto 2026-07-13 um 09 56 27" src="https://github.com/user-attachments/assets/e4e435a7-993e-450b-9804-2e40e0527ca8" />
