### PR TITLE
[OP-18093] Arrow for switching years barely visible in dark mode on the calendar

### DIFF
--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -77,12 +77,6 @@ $datepicker--selected-border-radius: 5px
   box-shadow: none !important
   @include spot-caption
 
-  &.open.arrowTop
-    &:before
-      border-bottom-color: var(--borderColor-default)
-    &:after
-      border-bottom-color: var(--body-background)
-
   .flatpickr-months
     min-height: 45px
 
@@ -239,6 +233,22 @@ $datepicker--selected-border-radius: 5px
             color: var(--fgColor-muted)
             background: var(--label-yellow-bgColor-active)
             border-color: var(--label-yellow-bgColor-active)
+
+  .numInputWrapper
+    .arrowUp
+      border-color: var(--borderColor-default)
+      &:after
+        // flatpickr models the arrow as a border
+        border-bottom-color: var(--body-font-color) !important
+
+    .arrowDown
+      border-color: var(--borderColor-default)
+      &:after
+        // flatpickr models the arrow as a border
+        border-top-color: var(--body-font-color) !important
+
+    &:hover
+      background: var(--bgColor-neutral-muted)
 
 .flatpickr-calendar.flatpickr-container-suppress-hover
   .flatpickr-day


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-18093

# What are you trying to accomplish?
Adapt flatpickr arrows to dark mode

## Screenshots

<img width="343" height="317" alt="Bildschirmfoto 2026-07-13 um 10 40 00" src="https://github.com/user-attachments/assets/eb2d2586-1b96-4529-85be-a2ad2cee953e" />
