### PR TITLE
[DREAM-330] Low contrast in dark mode: markdown-text editor

### DIFF
--- a/frontend/src/global_styles/content/editor/_codemirror.sass
+++ b/frontend/src/global_styles/content/editor/_codemirror.sass
@@ -6,6 +6,12 @@
   color: var(--codeMirror-fgColor) !important
   background-color: var(--codeMirror-bgColor) !important
 
+.CodeMirror-selected
+  background: var(--codeMirror-selection-bgColor) !important
+
+.CodeMirror-linenumbers
+  color: var(--codeMirror-lineNumber-fgColor) !important
+
 .CodeMirror-gutters
   background-color: var(--codeMirror-gutters-bgColor) !important
 
@@ -15,3 +21,17 @@
 // can still be clicked. The two interfere as both have position: relative
 .CodeMirror-code
   pointer-events: none
+
+// Syntax highlighting
+.cm-header
+  color: var(--codeMirror-syntax-fgColor-constant) !important
+.cm-tag
+  color: var(--codeMirror-syntax-fgColor-entity) !important
+.cm-comment
+  color: var(--codeMirror-syntax-fgColor-string) !important
+.cm-variable-2
+  color: var(--codeMirror-syntax-fgColor-variable) !important
+.cm-keyword
+  color: var(--codeMirror-syntax-fgColor-keyword) !important
+.cm-link
+  color: var(--codeMirror-syntax-fgColor-support) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-330

# What are you trying to accomplish?
Add correct highlighting for codeMirror elements in ckEditor markdown view

## Screenshots

<img width="698" height="422" alt="Bildschirmfoto 2026-07-13 um 11 23 52" src="https://github.com/user-attachments/assets/d3857ce8-d92c-47b8-8f7e-f6edaec0ef12" />
<img width="442" height="409" alt="Bildschirmfoto 2026-07-13 um 11 24 03" src="https://github.com/user-attachments/assets/1b8fcc54-1de1-491f-918b-83597024cc30" />
