### PR TITLE
[DREAM-755] Draggable autocompleter on Pragmatic DnD (new sortable-lists engine + directives)

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.html
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.html
@@ -49,9 +49,11 @@
               <button
                 type="button"
                 (click)="remove(item)"
-                class="op-draggable-autocomplete--remove-item icon-remove"
+                class="op-draggable-autocomplete--remove-item"
                 [attr.aria-label]="removeLabel(item)"
-              ></button>
+              >
+                <svg octicon icon="x" size="xsmall" aria-hidden="true"></svg>
+              </button>
             }
           </div>
         }

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.html
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.html
@@ -32,23 +32,26 @@
 
       <div
         class="op-draggable-autocomplete--selected"
-        dragula="columns"
-        [(dragulaModel)]="selectedOptions"
+        opSortableLists
+        opSortableListsAxis="horizontal"
+        (opSortableListsDrop)="reorder($event)"
         >
-        @for (item of selectedOptions; track item) {
-          <div class="op-draggable-autocomplete--item">
+        @for (item of selectedOptions; track item.id) {
+          <div
+            class="op-draggable-autocomplete--item"
+            [opSortableListsItem]="item.id"
+          >
             <span
               class="op-draggable-autocomplete--item-text"
               [textContent]="item.name"
             ></span>
             @if (isRemovable(item)) {
-              <div
-                tabindex="0"
+              <button
+                type="button"
                 (click)="remove(item)"
-                (keydown.enter)="remove(item)"
-                (keydown.space)="remove(item)"
                 class="op-draggable-autocomplete--remove-item icon-remove"
-              ></div>
+                [attr.aria-label]="removeLabel(item)"
+              ></button>
             }
           </div>
         }

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
@@ -5,6 +5,7 @@
     padding-bottom: 1rem
 
   &--item
+    position: relative
     padding: 5px
     margin-right: 5px
     margin-bottom: 5px
@@ -16,11 +17,35 @@
     align-items: center
     justify-content: space-between
 
+    &[data-dragging]
+      opacity: 0.4
+
+    // Drop indicator: a vertical accent line on the left/right edge of the
+    // chip the dragged item would be inserted next to. Driven by the
+    // data-drop-position host attribute of the sortable-lists item directive.
+    &[data-drop-position]::after
+      content: ''
+      position: absolute
+      top: 0
+      bottom: 0
+      width: 2px
+      background: var(--fgColor-accent)
+      pointer-events: none
+      z-index: 1
+
+    &[data-drop-position="left"]::after
+      left: -4px
+
+    &[data-drop-position="right"]::after
+      right: -4px
+
   &--remove-item
     font-size: 8px
     color: #999
-    padding-left: 5px
+    padding: 0 0 0 5px
     cursor: pointer
+    border: none
+    background: transparent
 
 // Hack to allow the ng-select dropdown bound to this id to be positioned correctly.
 // The ng-select needs to be bound to the id because the component is currently used in a modal.

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
@@ -1,8 +1,25 @@
 .op-draggable-autocomplete
   &--selected
+    position: relative
     display: flex
     flex-wrap: wrap
     padding-bottom: 1rem
+    padding-inline-end: 6px
+
+    // Container-append cue: an accent line in the list's inline-end padding
+    // while the sortable-lists engine flags this root as the active drop
+    // container (data-drop-container="active"), meaning the drag would
+    // append at the end of the list rather than land next to a chip.
+    &[data-drop-container]::after
+      content: ''
+      position: absolute
+      top: 0
+      bottom: 1rem
+      inset-inline-end: 0
+      width: 2px
+      background: var(--fgColor-accent)
+      pointer-events: none
+      z-index: 1
 
   &--item
     position: relative

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
@@ -29,10 +29,14 @@
     min-width: 50px
     border: 1px solid var(--borderColor-default)
     background: var(--button-default-bgColor-rest)
-    cursor: move
+    cursor: grab
+    user-select: none
     display: flex
     align-items: center
     justify-content: space-between
+
+    &:active
+      cursor: grabbing
 
     &[data-dragging]
       opacity: 0.4
@@ -56,13 +60,30 @@
     &[data-drop-position="right"]::after
       right: -4px
 
+  // Colors and the round hover target are borrowed from Primer's Token remove
+  // button, so the action reads as its own target rather than part of the
+  // chip's drag surface.
   &--remove-item
-    font-size: 8px
-    color: #999
-    padding: 0 0 0 5px
-    cursor: pointer
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    width: 16px
+    height: 16px
+    margin-inline-start: 5px
+    padding: 0
     border: none
+    border-radius: var(--borderRadius-full)
     background: transparent
+    color: var(--fgColor-muted)
+    cursor: pointer
+
+    &:hover,
+    &:focus-visible
+      background-color: var(--control-transparent-bgColor-hover)
+      color: var(--fgColor-default)
+
+    &:active
+      background-color: var(--control-transparent-bgColor-active)
 
 // Hack to allow the ng-select dropdown bound to this id to be positioned correctly.
 // The ng-select needs to be bound to the id because the component is currently used in a modal.

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.spec.ts
@@ -38,9 +38,25 @@ import {
 import { OpSortableListsDirective } from 'core-app/shared/directives/sortable-lists/sortable-lists.directive';
 import {
   NativeDragSimulation,
+  centerOf,
   towardsEdgeOf,
 } from 'core-common/drag-and-drop/testing/native-drag-simulation';
+import { type Edge } from 'core-common/drag-and-drop/reorder';
+import { type SortableListsDropEvent } from 'core-app/shared/directives/sortable-lists/sortable-lists.directive';
 import { DraggableAutocompleteComponent, DraggableOption } from './draggable-autocomplete.component';
+
+// `component.reorder` only reads `sourceId`/`targetId`/`edge`; the
+// transaction bookkeeping fields are irrelevant to these unit tests but
+// still required by the type, so this factory fills them with inert
+// defaults.
+function dropEvent(overrides:{ sourceId:string; targetId:string; edge:Edge }):SortableListsDropEvent {
+  return {
+    transactionId: 'test-transaction',
+    sourceListId: 'test-list',
+    complete: () => undefined,
+    ...overrides,
+  };
+}
 
 describe('DraggableAutocompleteComponent', () => {
   let fixture:ComponentFixture<DraggableAutocompleteComponent>;
@@ -68,12 +84,30 @@ describe('DraggableAutocompleteComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DraggableAutocompleteComponent);
     component = fixture.componentInstance;
+    mountInScrollableAncestor(fixture);
 
     // Avoid focusing the ng-select during ngAfterViewInit in the test DOM.
     component.autofocus = false;
     component.options = [a, b, c];
     component.selected = [a, b];
   });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  // Real embeddings (a Primer Dialog or a scrolling page) give the collapsed
+  // sortable root's closest-scrollable-ancestor fallback something to find.
+  // Mirrors that here — attached to the document, like drag simulation
+  // already requires for `elementFromPoint` — so registering autoscroll
+  // doesn't warn about the component's own `overflow: visible` root.
+  function mountInScrollableAncestor(of:ComponentFixture<DraggableAutocompleteComponent>):void {
+    const scrollWrapper = document.createElement('div');
+    scrollWrapper.style.overflow = 'auto';
+    scrollWrapper.style.height = '400px';
+    scrollWrapper.appendChild(of.nativeElement);
+    document.body.appendChild(scrollWrapper);
+  }
 
   function chips() {
     return fixture.debugElement.queryAll(By.css('.op-draggable-autocomplete--item'));
@@ -197,14 +231,14 @@ describe('DraggableAutocompleteComponent', () => {
       const emitted:DraggableOption[][] = [];
       component.onChange.subscribe((value) => emitted.push(value));
 
-      component.reorder({ sourceId: 'c', targetId: 'a', edge: 'left' });
+      component.reorder(dropEvent({ sourceId: 'c', targetId: 'a', edge: 'left' }));
 
       expect(component.selected).toEqual([c, a, b]);
       expect(emitted).toEqual([[c, a, b]]);
     });
 
     it('moves an item after the target on a right-edge drop', () => {
-      component.reorder({ sourceId: 'a', targetId: 'c', edge: 'right' });
+      component.reorder(dropEvent({ sourceId: 'a', targetId: 'c', edge: 'right' }));
 
       expect(component.selected).toEqual([b, c, a]);
     });
@@ -213,7 +247,7 @@ describe('DraggableAutocompleteComponent', () => {
       const emitted:DraggableOption[][] = [];
       component.onChange.subscribe((value) => emitted.push(value));
 
-      component.reorder({ sourceId: 'a', targetId: 'b', edge: 'left' });
+      component.reorder(dropEvent({ sourceId: 'a', targetId: 'b', edge: 'left' }));
 
       expect(component.selected).toEqual([a, b, c]);
       expect(emitted).toEqual([]);
@@ -223,8 +257,8 @@ describe('DraggableAutocompleteComponent', () => {
       const emitted:DraggableOption[][] = [];
       component.onChange.subscribe((value) => emitted.push(value));
 
-      component.reorder({ sourceId: 'missing', targetId: 'a', edge: 'left' });
-      component.reorder({ sourceId: 'a', targetId: 'missing', edge: 'left' });
+      component.reorder(dropEvent({ sourceId: 'missing', targetId: 'a', edge: 'left' }));
+      component.reorder(dropEvent({ sourceId: 'a', targetId: 'missing', edge: 'left' }));
 
       expect(component.selected).toEqual([a, b, c]);
       expect(emitted).toEqual([]);
@@ -238,6 +272,11 @@ describe('DraggableAutocompleteComponent', () => {
 
     it('reorders the selection through a native drag', async () => {
       component.selected = [a, b, c];
+      // The collapsed root's closest-scrollable-ancestor fallback (see
+      // `mountInScrollableAncestor`) must resolve to a real scroll target,
+      // not the component's own `overflow: visible` root — otherwise
+      // Pragmatic's autoscroll adapter warns on every registration.
+      const warnSpy = vi.spyOn(console, 'warn');
       fixture.detectChanges();
 
       const emitted:DraggableOption[][] = [];
@@ -251,6 +290,10 @@ describe('DraggableAutocompleteComponent', () => {
 
       expect(component.selected).toEqual([c, a, b]);
       expect(emitted).toEqual([[c, a, b]]);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('not to be scrollable'),
+        expect.anything(),
+      );
     });
 
     it('cannot mutate or emit from another autocompleter with overlapping ids', async () => {
@@ -261,6 +304,7 @@ describe('DraggableAutocompleteComponent', () => {
       otherComponent.autofocus = false;
       otherComponent.options = [a, b, c];
       otherComponent.selected = [a, b];
+      mountInScrollableAncestor(otherFixture);
       otherFixture.detectChanges();
 
       const emitted:DraggableOption[][] = [];
@@ -279,6 +323,83 @@ describe('DraggableAutocompleteComponent', () => {
       expect(otherComponent.selected).toEqual([a, b]);
       expect(emitted).toEqual([]);
       expect(otherEmitted).toEqual([]);
+    });
+
+    it('drops beyond the last chip to append the dragged item at the end', async () => {
+      component.selected = [a, b, c];
+      fixture.detectChanges();
+
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+      const reorderSpy = vi.spyOn(component, 'reorder');
+
+      const container = (fixture.nativeElement as HTMLElement)
+        .querySelector<HTMLElement>('.op-draggable-autocomplete--selected')!;
+      const [first, , third] = chipElements(fixture);
+      const simulation = new NativeDragSimulation(first);
+      const lastRect = third.getBoundingClientRect();
+      const midSpanPoint = centerOf(third);
+
+      await simulation.start();
+      // Same handoff the engine relies on to resolve a container-append
+      // drop: pass over the last item first, then move past its far edge
+      // while still within the list container.
+      await simulation.dragOver(third, midSpanPoint);
+      await simulation.dragOver(container, midSpanPoint);
+
+      const beyondSpan = { x: lastRect.right + 30, y: midSpanPoint.y };
+      await simulation.dragOver(container, beyondSpan);
+      await simulation.drop(container, beyondSpan);
+
+      expect(component.selected).toEqual([b, c, a]);
+      expect(emitted).toEqual([[b, c, a]]);
+      expect(reorderSpy.mock.calls[0][0].targetId).toBeNull();
+    });
+
+    it('does not start a drag when initiated on a remove button', async () => {
+      component.selected = [a, b, c];
+      fixture.detectChanges();
+
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+
+      const [first, , third] = chipElements(fixture);
+      const removeButton = first.querySelector<HTMLElement>('.op-draggable-autocomplete--remove-item')!;
+      const simulation = new NativeDragSimulation(first);
+
+      await simulation.start(centerOf(removeButton));
+      fixture.detectChanges();
+
+      expect(first.hasAttribute('data-dragging')).toBe(false);
+
+      await simulation.drop(third, towardsEdgeOf(third, 'left'));
+
+      expect(component.selected).toEqual([a, b, c]);
+      expect(emitted).toEqual([]);
+    });
+
+    it('applies two consecutive drags without the second being blocked', async () => {
+      component.selected = [a, b, c];
+      fixture.detectChanges();
+
+      const firstDrag = new NativeDragSimulation(chipElements(fixture)[2]);
+      await firstDrag.start();
+      await firstDrag.drop(chipElements(fixture)[0], towardsEdgeOf(chipElements(fixture)[0], 'left'));
+
+      // [a, b, c] -> [c, a, b]: same move already proven correct above; the
+      // point of this case is that a second drag right after still works,
+      // which only holds if the first transaction was completed.
+      expect(component.selected).toEqual([c, a, b]);
+
+      fixture.detectChanges();
+      const secondDrag = new NativeDragSimulation(chipElements(fixture)[0]);
+      await secondDrag.start();
+      await secondDrag.drop(chipElements(fixture)[2], towardsEdgeOf(chipElements(fixture)[2], 'left'));
+
+      // [c, a, b] -> [a, c, b]: the exact result matters less than the fact
+      // that it changed at all — this only holds if the first transaction
+      // completed and released the engine for a second drag.
+      expect(component.selected).toEqual([a, c, b]);
     });
   });
 });

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.spec.ts
@@ -1,0 +1,284 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NgSelectModule } from '@ng-select/ng-select';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { AlternativeSearchService } from 'core-app/shared/components/work-packages/alternative-search.service';
+import {
+  OpSortableListsItemDirective,
+} from 'core-app/shared/directives/sortable-lists/sortable-lists-item.directive';
+import { OpSortableListsDirective } from 'core-app/shared/directives/sortable-lists/sortable-lists.directive';
+import {
+  NativeDragSimulation,
+  towardsEdgeOf,
+} from 'core-common/drag-and-drop/testing/native-drag-simulation';
+import { DraggableAutocompleteComponent, DraggableOption } from './draggable-autocomplete.component';
+
+describe('DraggableAutocompleteComponent', () => {
+  let fixture:ComponentFixture<DraggableAutocompleteComponent>;
+  let component:DraggableAutocompleteComponent;
+
+  const a:DraggableOption = { id: 'a', name: 'Alpha' };
+  const b:DraggableOption = { id: 'b', name: 'Bravo' };
+  const c:DraggableOption = { id: 'c', name: 'Charlie' };
+
+  const i18nStub = { t: (_key:string) => 'label' };
+  const alternativeSearchStub = { searchFunction: () => true };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DraggableAutocompleteComponent],
+      imports: [NgSelectModule, OpSortableListsDirective, OpSortableListsItemDirective],
+      providers: [
+        { provide: I18nService, useValue: i18nStub },
+        { provide: AlternativeSearchService, useValue: alternativeSearchStub },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DraggableAutocompleteComponent);
+    component = fixture.componentInstance;
+
+    // Avoid focusing the ng-select during ngAfterViewInit in the test DOM.
+    component.autofocus = false;
+    component.options = [a, b, c];
+    component.selected = [a, b];
+  });
+
+  function chips() {
+    return fixture.debugElement.queryAll(By.css('.op-draggable-autocomplete--item'));
+  }
+
+  function chipTexts() {
+    return chips().map((chip) => {
+      const text = chip.query(By.css('.op-draggable-autocomplete--item-text')).nativeElement as HTMLElement;
+      return text.textContent?.trim() ?? '';
+    });
+  }
+
+  it('creates', () => {
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('renders a chip per selected option in order', () => {
+    fixture.detectChanges();
+
+    expect(chipTexts()).toEqual(['Alpha', 'Bravo']);
+  });
+
+  it('exposes only the not-yet-selected options as available', () => {
+    fixture.detectChanges();
+
+    expect(component.availableOptions).toEqual([c]);
+  });
+
+  it('adds an option on select, updating available options and emitting', () => {
+    fixture.detectChanges();
+    const emitted:DraggableOption[][] = [];
+    component.onChange.subscribe((value) => emitted.push(value));
+
+    component.select(c);
+
+    expect(component.selected).toEqual([a, b, c]);
+    expect(component.availableOptions).toEqual([]);
+    expect(emitted).toEqual([[a, b, c]]);
+  });
+
+  it('removes an option, updating available options and emitting', () => {
+    fixture.detectChanges();
+    const emitted:DraggableOption[][] = [];
+    component.onChange.subscribe((value) => emitted.push(value));
+
+    component.remove(a);
+
+    expect(component.selected).toEqual([b]);
+    expect(component.availableOptions).toEqual([a, c]);
+    expect(emitted).toEqual([[b]]);
+  });
+
+  it('does not render a remove control for protected options', () => {
+    component.protected = [a];
+    fixture.detectChanges();
+
+    expect(component.isRemovable(a)).toBe(false);
+    expect(component.isRemovable(b)).toBe(true);
+
+    const removeControls = fixture.debugElement.queryAll(By.css('.op-draggable-autocomplete--remove-item'));
+
+    expect(removeControls.length).toBe(1);
+  });
+
+  it('renders a single hidden input with a space-joined value for scalar names', () => {
+    component.name = 'columns';
+    fixture.detectChanges();
+
+    expect(component.isArrayOfValues).toBe(false);
+    expect(component.hiddenValue).toBe('a b');
+
+    const hidden = fixture.debugElement.queryAll(By.css('input[type=hidden]'));
+
+    expect(hidden.length).toBe(1);
+    expect((hidden[0].nativeElement as HTMLInputElement).value).toBe('a b');
+  });
+
+  it('renders one hidden input per value for array names', () => {
+    component.name = 'columns[]';
+    fixture.detectChanges();
+
+    expect(component.isArrayOfValues).toBe(true);
+    expect(component.hiddenValues).toEqual(['a', 'b']);
+
+    const hidden = fixture.debugElement.queryAll(By.css('input[type=hidden]'));
+
+    expect(hidden.map((input) => (input.nativeElement as HTMLInputElement).value)).toEqual(['a', 'b']);
+  });
+
+  it('flags an error only when required and nothing is selected', () => {
+    component.required = true;
+    component.selected = [];
+    fixture.detectChanges();
+
+    expect(component.hasError).toBe(true);
+
+    component.selected = [a];
+
+    expect(component.hasError).toBe(false);
+  });
+
+  it('labels the remove button with the option name', () => {
+    fixture.detectChanges();
+
+    const removeButton = fixture.debugElement.query(By.css('.op-draggable-autocomplete--remove-item'))
+      .nativeElement as HTMLButtonElement;
+
+    expect(removeButton.tagName).toBe('BUTTON');
+    expect(removeButton.getAttribute('aria-label')).toBe('label');
+  });
+
+  describe('reordering through the sortable-lists drop output', () => {
+    beforeEach(() => {
+      component.selected = [a, b, c];
+      fixture.detectChanges();
+    });
+
+    it('moves an item before the target on a left-edge drop', () => {
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+
+      component.reorder({ sourceId: 'c', targetId: 'a', edge: 'left' });
+
+      expect(component.selected).toEqual([c, a, b]);
+      expect(emitted).toEqual([[c, a, b]]);
+    });
+
+    it('moves an item after the target on a right-edge drop', () => {
+      component.reorder({ sourceId: 'a', targetId: 'c', edge: 'right' });
+
+      expect(component.selected).toEqual([b, c, a]);
+    });
+
+    it('does not emit for an adjacent no-op drop', () => {
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+
+      component.reorder({ sourceId: 'a', targetId: 'b', edge: 'left' });
+
+      expect(component.selected).toEqual([a, b, c]);
+      expect(emitted).toEqual([]);
+    });
+
+    it('does not emit when either id is unknown', () => {
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+
+      component.reorder({ sourceId: 'missing', targetId: 'a', edge: 'left' });
+      component.reorder({ sourceId: 'a', targetId: 'missing', edge: 'left' });
+
+      expect(component.selected).toEqual([a, b, c]);
+      expect(emitted).toEqual([]);
+    });
+  });
+
+  describe('dragging chips', () => {
+    function chipElements(of:ComponentFixture<DraggableAutocompleteComponent>):HTMLElement[] {
+      return Array.from((of.nativeElement as HTMLElement).querySelectorAll('.op-draggable-autocomplete--item'));
+    }
+
+    it('reorders the selection through a native drag', async () => {
+      component.selected = [a, b, c];
+      fixture.detectChanges();
+
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+
+      const [first, , third] = chipElements(fixture);
+      const simulation = new NativeDragSimulation(third);
+
+      await simulation.start();
+      await simulation.drop(first, towardsEdgeOf(first, 'left'));
+
+      expect(component.selected).toEqual([c, a, b]);
+      expect(emitted).toEqual([[c, a, b]]);
+    });
+
+    it('cannot mutate or emit from another autocompleter with overlapping ids', async () => {
+      fixture.detectChanges();
+
+      const otherFixture = TestBed.createComponent(DraggableAutocompleteComponent);
+      const otherComponent = otherFixture.componentInstance;
+      otherComponent.autofocus = false;
+      otherComponent.options = [a, b, c];
+      otherComponent.selected = [a, b];
+      otherFixture.detectChanges();
+
+      const emitted:DraggableOption[][] = [];
+      component.onChange.subscribe((value) => emitted.push(value));
+      const otherEmitted:DraggableOption[][] = [];
+      otherComponent.onChange.subscribe((value) => otherEmitted.push(value));
+
+      const source = chipElements(fixture)[0];
+      const foreignTarget = chipElements(otherFixture)[1];
+      const simulation = new NativeDragSimulation(source);
+
+      await simulation.start();
+      await simulation.drop(foreignTarget, towardsEdgeOf(foreignTarget, 'right'));
+
+      expect(component.selected).toEqual([a, b]);
+      expect(otherComponent.selected).toEqual([a, b]);
+      expect(emitted).toEqual([]);
+      expect(otherEmitted).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
@@ -123,6 +123,13 @@ export class DraggableAutocompleteComponent implements OnInit, AfterViewInit {
     if (reordered !== this.selectedOptions) {
       this.selectedOptions = reordered;
     }
+
+    // Completion is synchronous: there is no server round-trip here, the
+    // reordered chips simply persist on the next form submit. Completing
+    // unconditionally (even for a no-op) is essential — the engine keeps its
+    // transaction "busy" until `complete` runs, which blocks the *next*
+    // drag from starting if this call is skipped.
+    event.complete(true);
   }
 
   select(item:DraggableOption|undefined) {

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
@@ -1,17 +1,16 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, OnDestroy, Output, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { NgSelectComponent } from '@ng-select/ng-select';
-import { DragulaService, Group } from 'ng2-dragula';
-import { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-autoscroll.service';
-import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
-import { setBodyCursor } from 'core-app/shared/helpers/dom/set-window-cursor.helper';
 import {
   repositionDropdownBugfix,
 } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 import { QueryFilterResource } from 'core-app/features/hal/resources/query-filter-resource';
 import { AlternativeSearchService } from 'core-app/shared/components/work-packages/alternative-search.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
-import { merge } from 'rxjs';
+import { reorderById } from 'core-common/drag-and-drop/reorder';
+import {
+  SortableListsDropEvent,
+} from 'core-app/shared/directives/sortable-lists/sortable-lists.directive';
 
 export interface DraggableOption {
   name:string;
@@ -23,15 +22,11 @@ export interface DraggableOption {
   templateUrl: './draggable-autocomplete.component.html',
   styleUrls: ['./draggable-autocomplete.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    DragulaService
-  ],
   standalone: false,
 })
-export class DraggableAutocompleteComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
+export class DraggableAutocompleteComponent implements OnInit, AfterViewInit {
   readonly I18n = inject(I18nService);
   readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-  readonly dragula = inject(DragulaService);
   readonly alternativeSearchService = inject(AlternativeSearchService);
 
   /** Options to show in the autocompleter */
@@ -66,7 +61,13 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
   /** Label to display drag&drop area */
   @Input() dragAreaLabel = '';
 
-  /** Name of drag&drop area group */
+  /**
+   * Name of drag&drop area group.
+   *
+   * @deprecated Instance isolation no longer relies on a group name; each
+   * sortable list is scoped automatically. Kept only so existing
+   * custom-element embeddings that still pass the attribute keep working.
+   */
   @Input() dragAreaName = 'columns';
 
   /** Indicates that at least one entry must be selected */
@@ -83,56 +84,14 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
   /** List of items still available for selection */
   availableOptions:DraggableOption[] = [];
 
-  private autoscroll:any;
-
-  private columnsGroup:Group;
-
   @ViewChild('ngSelectComponent') public ngSelectComponent:NgSelectComponent;
-  @ViewChild('input') inputElement:ElementRef<HTMLInputElement>;
 
   public appendTo = 'body';
 
   ngOnInit():void {
     populateInputsFromDataset(this);
 
-    this.dragula.destroy(this.dragAreaName);
-
     this.updateAvailableOptions();
-
-    // Setup groups
-    this.columnsGroup = this.dragula.createGroup(
-      this.dragAreaName,
-      { mirrorContainer: this.appendToComponent ? document.getElementById(this.formControlId)! : document.body },
-    );
-
-    // Set cursor when dragging
-    this.dragula.drag(this.dragAreaName)
-      .pipe(this.untilDestroyed())
-      .subscribe(() => setBodyCursor('move', 'important'));
-
-    // Reset cursor when cancel or dropped
-    merge(
-      this.dragula.drop(this.dragAreaName),
-      this.dragula.cancel(this.dragAreaName),
-    )
-      .pipe(this.untilDestroyed())
-      .subscribe(() => setBodyCursor('auto'));
-
-    // Setup autoscroll
-    const that = this;
-    this.autoscroll = new DomAutoscrollService(
-      [
-        document.getElementById('content-body')!,
-      ],
-      {
-        margin: 25,
-        maxSpeed: 10,
-        scrollWhenOutside: true,
-        autoScroll(this:any) {
-          return this.down && that.columnsGroup.drake.dragging;
-        },
-      },
-    );
 
     this.appendTo = this.appendToComponent ? `#${this.formControlId}` : 'body';
   }
@@ -149,10 +108,21 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
     }
   }
 
-  ngOnDestroy():void {
-    super.ngOnDestroy();
+  reorder(event:SortableListsDropEvent):void {
+    const reordered = reorderById({
+      list: this.selectedOptions,
+      getId: (item) => item.id,
+      sourceId: event.sourceId,
+      targetId: event.targetId,
+      closestEdge: event.edge,
+      axis: 'horizontal',
+    });
 
-    this.dragula.destroy(this.dragAreaName);
+    // reorderById returns the original reference for no-op moves, so this
+    // only re-renders and emits when the order actually changed.
+    if (reordered !== this.selectedOptions) {
+      this.selectedOptions = reordered;
+    }
   }
 
   select(item:DraggableOption|undefined) {
@@ -168,6 +138,10 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
 
   remove(item:DraggableOption) {
     this.selectedOptions = this.selectedOptions.filter((selected) => selected.id !== item.id);
+  }
+
+  removeLabel(item:DraggableOption):string {
+    return this.I18n.t('js.autocomplete_select.remove', { name: item.name });
   }
 
   isRemovable(item:DraggableOption) {

--- a/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
+++ b/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
@@ -3,7 +3,6 @@ import { NgSelectModule } from '@ng-select/ng-select';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DynamicModule } from 'ng-dynamic-component';
 import { CommonModule } from '@angular/common';
-import { DragulaModule } from 'ng2-dragula';
 
 import { InviteUserButtonModule } from 'core-app/features/invite-user-modal/button/invite-user-button.module';
 import { OpenprojectPrincipalRenderingModule } from 'core-app/shared/components/principal/principal-rendering.module';
@@ -46,6 +45,10 @@ import {
   OpAutocompleterFooterTemplateDirective,
 } from 'core-app/shared/components/autocompleter/autocompleter-footer-template/op-autocompleter-footer-template.directive';
 import { OpSearchHighlightDirective } from 'core-app/shared/directives/search-highlight.directive';
+import { OpSortableListsDirective } from 'core-app/shared/directives/sortable-lists/sortable-lists.directive';
+import {
+  OpSortableListsItemDirective,
+} from 'core-app/shared/directives/sortable-lists/sortable-lists-item.directive';
 import {
   UserAutocompleterTemplateComponent,
 } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component';
@@ -89,7 +92,6 @@ export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
   imports: [
     CommonModule,
     NgSelectModule,
-    DragulaModule,
     FormsModule,
     ReactiveFormsModule,
 
@@ -97,6 +99,9 @@ export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
     OpenprojectPrincipalRenderingModule,
     InviteUserButtonModule,
     IconModule,
+
+    OpSortableListsDirective,
+    OpSortableListsItemDirective,
   ],
   exports: OPENPROJECT_AUTOCOMPLETE_COMPONENTS,
   declarations: OPENPROJECT_AUTOCOMPLETE_COMPONENTS,

--- a/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
+++ b/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
@@ -65,6 +65,7 @@ import {
   ProjectPhaseAutocompleterComponent,
 } from './project-phase-autocompleter/project-phase-autocompleter.component';
 import { IconModule } from 'core-app/shared/components/icon/icon.module';
+import { DynamicIconDirective } from 'core-app/shared/components/primer/dynamic-icon.directive';
 
 export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
   CreateAutocompleterComponent,
@@ -99,6 +100,7 @@ export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
     OpenprojectPrincipalRenderingModule,
     InviteUserButtonModule,
     IconModule,
+    DynamicIconDirective,
 
     OpSortableListsDirective,
     OpSortableListsItemDirective,

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists-item.directive.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists-item.directive.ts
@@ -1,0 +1,175 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  OnInit,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import {
+  draggable,
+  dropTargetForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
+import {
+  type Edge,
+  attachClosestEdge,
+  extractClosestEdge,
+} from 'core-common/drag-and-drop/reorder';
+import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
+import { OpSortableListsDirective } from './sortable-lists.directive';
+
+type CleanupFn = () => void;
+
+// One sortable item inside an `opSortableLists` list. Mirrors the Stimulus
+// `sortable-lists--item` controller: it registers its host element with
+// Pragmatic exactly once per directive instance, so Angular's view lifecycle
+// (`@for` track) owns creation and destruction of the registration. Drag and
+// drop-position state is exposed through `data-dragging` and
+// `data-drop-position` host attributes for the consumer's stylesheet.
+@Directive({
+  selector: '[opSortableListsItem]',
+  host: {
+    '[attr.data-dragging]': 'dragging() ? "true" : null',
+    '[attr.data-drop-position]': 'dropPosition()',
+  },
+})
+export class OpSortableListsItemDirective implements OnInit {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Fails Angular injection loudly when the item is not placed inside an
+  // `opSortableLists` ancestor, instead of silently becoming inert.
+  private readonly list = inject(OpSortableListsDirective);
+
+  itemId = input.required<string>({ alias: 'opSortableListsItem' });
+
+  readonly dragging = signal(false);
+
+  readonly dropPosition = signal<Edge|null>(null);
+
+  ngOnInit():void {
+    if (!this.itemId()) {
+      console.warn(
+        'opSortableListsItem requires a non-empty item id; this item will not be draggable.',
+        this.elementRef.nativeElement,
+      );
+      return;
+    }
+
+    const cleanup = combine(
+      this.registerDraggable(),
+      this.registerDropTarget(),
+    );
+
+    this.destroyRef.onDestroy(() => {
+      this.dragging.set(false);
+      this.dropPosition.set(null);
+      cleanup();
+    });
+  }
+
+  private registerDraggable():CleanupFn {
+    const element = this.elementRef.nativeElement;
+
+    return draggable({
+      element,
+      canDrag: ({ input: pointer }) => this.canDragFromPoint(pointer.clientX, pointer.clientY),
+      getInitialData: () => this.list.payloadScope.itemData(this.itemId()),
+      onDragStart: () => {
+        preventUnhandled.start();
+        this.dragging.set(true);
+      },
+      onDrop: () => {
+        preventUnhandled.stop();
+        this.dragging.set(false);
+      },
+    });
+  }
+
+  private registerDropTarget():CleanupFn {
+    const element = this.elementRef.nativeElement;
+    const { payloadScope } = this.list;
+
+    return dropTargetForElements({
+      element,
+      canDrop: ({ source }) => payloadScope.isItemData(source.data)
+        && source.data.itemId !== this.itemId(),
+      getData: ({ input: pointer }) => attachClosestEdge(payloadScope.itemData(this.itemId()), {
+        element,
+        input: pointer,
+        allowedEdges: this.list.allowedEdges(),
+      }),
+      getIsSticky: ({ input: pointer }) => this.list.containsPoint(pointer),
+      onDragEnter: ({ self }) => this.dropPosition.set(extractClosestEdge(self.data)),
+      onDrag: ({ self }) => this.dropPosition.set(extractClosestEdge(self.data)),
+      onDragLeave: () => this.dropPosition.set(null),
+      onDrop: ({ source, self }) => {
+        this.dropPosition.set(null);
+        this.emitDropIntent(source.data, self.data);
+      },
+    });
+  }
+
+  // The active item target resolves the drop itself, so no global monitor is
+  // needed: a drop onto self or from a foreign list never passes canDrop, and
+  // a drop outside the list reaches no item target at all.
+  private emitDropIntent(
+    sourceData:Record<string|symbol, unknown>,
+    selfData:Record<string|symbol, unknown>,
+  ):void {
+    if (!this.list.payloadScope.isItemData(sourceData)) {
+      return;
+    }
+
+    this.list.emitDrop({
+      sourceId: sourceData.itemId,
+      targetId: this.itemId(),
+      edge: extractClosestEdge(selfData),
+    });
+  }
+
+  // A drag may not start from an interactive descendant (e.g. the remove
+  // button inside a chip), matching the Stimulus sortable-item behavior.
+  private canDragFromPoint(clientX:number, clientY:number):boolean {
+    const element = this.elementRef.nativeElement;
+    const target = element.ownerDocument.elementFromPoint(clientX, clientY);
+
+    if (!(target instanceof Element) || !element.contains(target)) {
+      return true;
+    }
+
+    return closestInteractiveElement(target, element) == null;
+  }
+}

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists-item.directive.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists-item.directive.ts
@@ -33,36 +33,17 @@ import {
   OnInit,
   inject,
   input,
-  signal,
 } from '@angular/core';
-import {
-  draggable,
-  dropTargetForElements,
-} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
-import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
-import {
-  type Edge,
-  attachClosestEdge,
-  extractClosestEdge,
-} from 'core-common/drag-and-drop/reorder';
-import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 import { OpSortableListsDirective } from './sortable-lists.directive';
+import { OpSortableListsListDirective } from './sortable-lists-list.directive';
 
-type CleanupFn = () => void;
-
-// One sortable item inside an `opSortableLists` list. Mirrors the Stimulus
-// `sortable-lists--item` controller: it registers its host element with
-// Pragmatic exactly once per directive instance, so Angular's view lifecycle
-// (`@for` track) owns creation and destruction of the registration. Drag and
-// drop-position state is exposed through `data-dragging` and
-// `data-drop-position` host attributes for the consumer's stylesheet.
+// One sortable item inside an `opSortableLists` root. Registers its host
+// element with the shared engine once per directive instance in `ngOnInit`
+// and cleans up via `DestroyRef`, so a re-rendered item (`@for` track) is a
+// fresh registration, not a stale one reused out of order. All drag/
+// drop-position visual state is written directly to the host by the engine.
 @Directive({
   selector: '[opSortableListsItem]',
-  host: {
-    '[attr.data-dragging]': 'dragging() ? "true" : null',
-    '[attr.data-drop-position]': 'dropPosition()',
-  },
 })
 export class OpSortableListsItemDirective implements OnInit {
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
@@ -71,13 +52,15 @@ export class OpSortableListsItemDirective implements OnInit {
 
   // Fails Angular injection loudly when the item is not placed inside an
   // `opSortableLists` ancestor, instead of silently becoming inert.
-  private readonly list = inject(OpSortableListsDirective);
+  private readonly root = inject(OpSortableListsDirective);
+
+  // The nearest explicit list, if any; falls back to the root's own
+  // implicit list when the item sits directly under a collapsed root.
+  private readonly list = inject(OpSortableListsListDirective, { optional: true });
 
   itemId = input.required<string>({ alias: 'opSortableListsItem' });
 
-  readonly dragging = signal(false);
-
-  readonly dropPosition = signal<Edge|null>(null);
+  canDrag = input<boolean>(true, { alias: 'opSortableListsItemCanDrag' });
 
   ngOnInit():void {
     if (!this.itemId()) {
@@ -88,88 +71,22 @@ export class OpSortableListsItemDirective implements OnInit {
       return;
     }
 
-    const cleanup = combine(
-      this.registerDraggable(),
-      this.registerDropTarget(),
-    );
+    // DI's nearest-list lookup does not stop at an intervening
+    // `opSortableLists` root: an item under a collapsed root nested inside an
+    // outer root's explicit list would otherwise resolve to the OUTER list,
+    // while `this.root` resolves to the INNER root — pairing the inner engine
+    // with a list id it never registered. Only honor the injected list when
+    // it belongs to this item's own nearest root; else fall back to that
+    // root's implicit list.
+    const ownList = this.list?.root === this.root ? this.list : null;
 
-    this.destroyRef.onDestroy(() => {
-      this.dragging.set(false);
-      this.dropPosition.set(null);
-      cleanup();
+    const cleanup = this.root.registerItem({
+      element: this.elementRef.nativeElement,
+      itemId: this.itemId(),
+      listId: ownList?.listId() ?? this.root.implicitListId,
+      canDrag: () => this.canDrag(),
     });
-  }
 
-  private registerDraggable():CleanupFn {
-    const element = this.elementRef.nativeElement;
-
-    return draggable({
-      element,
-      canDrag: ({ input: pointer }) => this.canDragFromPoint(pointer.clientX, pointer.clientY),
-      getInitialData: () => this.list.payloadScope.itemData(this.itemId()),
-      onDragStart: () => {
-        preventUnhandled.start();
-        this.dragging.set(true);
-      },
-      onDrop: () => {
-        preventUnhandled.stop();
-        this.dragging.set(false);
-      },
-    });
-  }
-
-  private registerDropTarget():CleanupFn {
-    const element = this.elementRef.nativeElement;
-    const { payloadScope } = this.list;
-
-    return dropTargetForElements({
-      element,
-      canDrop: ({ source }) => payloadScope.isItemData(source.data)
-        && source.data.itemId !== this.itemId(),
-      getData: ({ input: pointer }) => attachClosestEdge(payloadScope.itemData(this.itemId()), {
-        element,
-        input: pointer,
-        allowedEdges: this.list.allowedEdges(),
-      }),
-      getIsSticky: ({ input: pointer }) => this.list.containsPoint(pointer),
-      onDragEnter: ({ self }) => this.dropPosition.set(extractClosestEdge(self.data)),
-      onDrag: ({ self }) => this.dropPosition.set(extractClosestEdge(self.data)),
-      onDragLeave: () => this.dropPosition.set(null),
-      onDrop: ({ source, self }) => {
-        this.dropPosition.set(null);
-        this.emitDropIntent(source.data, self.data);
-      },
-    });
-  }
-
-  // The active item target resolves the drop itself, so no global monitor is
-  // needed: a drop onto self or from a foreign list never passes canDrop, and
-  // a drop outside the list reaches no item target at all.
-  private emitDropIntent(
-    sourceData:Record<string|symbol, unknown>,
-    selfData:Record<string|symbol, unknown>,
-  ):void {
-    if (!this.list.payloadScope.isItemData(sourceData)) {
-      return;
-    }
-
-    this.list.emitDrop({
-      sourceId: sourceData.itemId,
-      targetId: this.itemId(),
-      edge: extractClosestEdge(selfData),
-    });
-  }
-
-  // A drag may not start from an interactive descendant (e.g. the remove
-  // button inside a chip), matching the Stimulus sortable-item behavior.
-  private canDragFromPoint(clientX:number, clientY:number):boolean {
-    const element = this.elementRef.nativeElement;
-    const target = element.ownerDocument.elementFromPoint(clientX, clientY);
-
-    if (!(target instanceof Element) || !element.contains(target)) {
-      return true;
-    }
-
-    return closestInteractiveElement(target, element) == null;
+    this.destroyRef.onDestroy(cleanup);
   }
 }

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists-list.directive.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists-list.directive.ts
@@ -1,0 +1,84 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  OnInit,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import {
+  OpSortableListsDirective,
+  type SortableListsDropEvent,
+  type SortableListsRemovedEvent,
+} from './sortable-lists.directive';
+
+let lastGeneratedId = 0;
+
+function generateListId():string {
+  lastGeneratedId += 1;
+  return `op-sortable-list-${lastGeneratedId}`;
+}
+
+// An explicit list inside an `opSortableLists` root, for roots managing more
+// than one drop zone (e.g. a "To do" / "Done" pair). Registering one retires
+// the root's implicit list (see `attachList`) and its own outputs take over
+// from the root's proxy outputs for drops resolving to this list.
+@Directive({
+  selector: '[opSortableListsList]',
+})
+export class OpSortableListsListDirective implements OnInit {
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Public so `OpSortableListsItemDirective` can compare owning roots — DI
+  // itself has no notion of a nested root boundary.
+  readonly root = inject(OpSortableListsDirective);
+
+  // The alias intentionally does not double up "List" (selector + capitalized
+  // property name would read `opSortableListsListListId`).
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  listId = input<string>(generateListId(), { alias: 'opSortableListsListId' });
+
+  accepts = input<(() => boolean)|null>(null, { alias: 'opSortableListsListAccepts' });
+
+  scrollContainer = input<Element|null>(null, { alias: 'opSortableListsListScrollContainer' });
+
+  opSortableListsDrop = output<SortableListsDropEvent>();
+
+  opSortableListsRemoved = output<SortableListsRemovedEvent>();
+
+  ngOnInit():void {
+    const cleanup = this.root.attachList(this);
+    this.destroyRef.onDestroy(cleanup);
+  }
+}

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.behavior.spec.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.behavior.spec.ts
@@ -1,0 +1,746 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Component, signal, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  NativeDragSimulation,
+  towardsEdgeOf,
+} from 'core-common/drag-and-drop/testing/native-drag-simulation';
+import { OpSortableListsItemDirective } from './sortable-lists-item.directive';
+import { OpSortableListsListDirective } from './sortable-lists-list.directive';
+import {
+  OpSortableListsDirective,
+  type SortableListsDropEvent,
+  type SortableListsRemovedEvent,
+} from './sortable-lists.directive';
+
+// Behavioral suite for the directive group: scope resolution (collapsed vs.
+// explicit lists, nested roots), the cross-list removed/drop ordering
+// contract, and the completion/finalize → busy lifecycle. Single-root
+// mechanics live in `sortable-lists.directive.spec.ts`.
+
+describe('sortable-lists directive group behavior', () => {
+  describe('single-list collapse (implicit list)', () => {
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsItemDirective],
+      template: `
+        <div
+          class="root"
+          opSortableLists
+          (opSortableListsDrop)="drops.push($event)"
+          style="padding-bottom: 40px;"
+        >
+          @for (entry of items(); track entry.id) {
+            <div
+              class="item"
+              [opSortableListsItem]="entry.id"
+              [opSortableListsItemCanDrag]="entry.canDrag"
+              style="height: 40px; width: 200px;"
+            >{{ entry.id }}</div>
+          }
+        </div>
+      `,
+    })
+    class CollapseHostComponent {
+      items = signal([
+        { id: 'a', canDrag: true },
+        { id: 'b', canDrag: true },
+        { id: 'c', canDrag: true },
+      ]);
+
+      drops:SortableListsDropEvent[] = [];
+    }
+
+    let fixture:ComponentFixture<CollapseHostComponent>;
+    let host:CollapseHostComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [CollapseHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(CollapseHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function root():HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelector('.root')!;
+    }
+
+    function item(index:number):HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('.item')[index];
+    }
+
+    it('emits one drop event on the root proxy output and releases busy on complete', async () => {
+      const simulation = new NativeDragSimulation(item(0));
+
+      await simulation.start();
+      await simulation.drop(item(2), towardsEdgeOf(item(2), 'bottom'));
+
+      expect(host.drops).toHaveLength(1);
+      expect(host.drops[0]).toMatchObject({ sourceId: 'a', targetId: 'c', edge: 'bottom' });
+      expect(root().hasAttribute('data-sortable-lists-busy')).toBe(true);
+
+      host.drops[0].complete(true);
+      // `complete()` defers its own resolution by one microtask hop; one
+      // `await` is enough for the busy release inside it to have run.
+      await Promise.resolve();
+
+      expect(root().hasAttribute('data-sortable-lists-busy')).toBe(false);
+    });
+
+    it('blocks drag start when opSortableListsItemCanDrag is false', async () => {
+      host.items.set([
+        { id: 'a', canDrag: false },
+        { id: 'b', canDrag: true },
+      ]);
+      fixture.detectChanges();
+
+      const simulation = new NativeDragSimulation(item(0));
+      await simulation.start();
+
+      expect(item(0).hasAttribute('data-dragging')).toBe(false);
+
+      // The unblocked sibling still drags normally — proves the gate is
+      // per-item, not a root-wide side effect.
+      const allowed = new NativeDragSimulation(item(1));
+      await allowed.start();
+      expect(item(1).dataset.dragging).toBe('source');
+      await allowed.cancel();
+    });
+
+    // `@for` tracks by id, so replacing the signal with the SAME ids in a new
+    // order moves the existing DOM nodes rather than recreating them —
+    // `registerItem` never re-runs. The engine's bounded-stickiness span
+    // must therefore stay accurate from CURRENT rects, not registration order.
+    it('keeps items draggable and the append span accurate after a track-by-id reorder', async () => {
+      // Registration order a, b, c; reorder to visual order c, a, b, same ids.
+      host.items.set([
+        { id: 'c', canDrag: true },
+        { id: 'a', canDrag: true },
+        { id: 'b', canDrag: true },
+      ]);
+      fixture.detectChanges();
+
+      const itemLabels = [...(fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('.item')]
+        .map((el) => el.textContent);
+      expect(itemLabels).toEqual(['c', 'a', 'b']);
+
+      // Reorder still works post-churn, resolving via the real hovered
+      // element rather than registration order.
+      const reorder = new NativeDragSimulation(item(2));
+      await reorder.start();
+      await reorder.drop(item(0), towardsEdgeOf(item(0), 'top'));
+
+      expect(host.drops.map(({ sourceId, targetId, edge }) => ({ sourceId, targetId, edge })))
+        .toEqual([{ sourceId: 'b', targetId: 'c', edge: 'top' }]);
+      // Same-list transactions settle on complete() alone — must release
+      // busy before the next drag or later canDrag/canDrop checks short-circuit.
+      host.drops[0].complete(true);
+      await Promise.resolve();
+      host.drops = [];
+
+      // Dwell over the visually middle item ('a') to make it sticky, then
+      // move to the root's native target while still squarely inside 'a'.
+      const span = new NativeDragSimulation(item(2));
+      await span.start();
+
+      const middleItem = item(1); // visually 'a'
+      const middleRect = middleItem.getBoundingClientRect();
+      const midSpanPoint = { x: middleRect.left + middleRect.width / 2, y: middleRect.top + middleRect.height / 2 };
+
+      await span.dragOver(middleItem, midSpanPoint);
+      expect(middleItem.hasAttribute('data-drop-position')).toBe(true);
+
+      await span.dragOver(root(), midSpanPoint);
+
+      // The span is derived from every item's CURRENT rect, not registration
+      // order, so 'a' correctly stays sticky via the root's native target.
+      expect(middleItem.hasAttribute('data-drop-position')).toBe(true);
+      expect(root().hasAttribute('data-drop-container')).toBe(false);
+
+      // Beyond the visually last item ('b'), into the root's trailing padding.
+      const lastVisualRect = item(2).getBoundingClientRect(); // visually 'b'
+      const beyondVisualSpan = { x: midSpanPoint.x, y: lastVisualRect.bottom + 30 };
+      await span.dragOver(root(), beyondVisualSpan);
+
+      expect(middleItem.hasAttribute('data-drop-position')).toBe(false);
+      expect(root().getAttribute('data-drop-container')).toBe('active');
+
+      await span.drop(root(), beyondVisualSpan);
+
+      expect(host.drops.map(({ sourceId, targetId, edge }) => ({ sourceId, targetId, edge })))
+        .toEqual([{ sourceId: 'b', targetId: null, edge: null }]);
+    });
+  });
+
+  describe('explicit root + list on the same element', () => {
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsListDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="root" opSortableLists opSortableListsList>
+          @for (id of ids(); track id) {
+            <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+          }
+        </div>
+      `,
+    })
+    class RootListSameElementHostComponent {
+      ids = signal(['a', 'b', 'c']);
+
+      rootDirective = viewChild.required(OpSortableListsDirective);
+
+      listDirective = viewChild.required(OpSortableListsListDirective);
+    }
+
+    let fixture:ComponentFixture<RootListSameElementHostComponent>;
+    let host:RootListSameElementHostComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [RootListSameElementHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(RootListSameElementHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function item(index:number):HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('.item')[index];
+    }
+
+    it('routes drops to the list output; the root proxy stays silent', async () => {
+      // Both directives share the same output name on the same host element,
+      // so a template binding can't tell them apart; spy the instances directly.
+      const rootSpy = vi.spyOn(host.rootDirective().opSortableListsDrop, 'emit');
+      const listSpy = vi.spyOn(host.listDirective().opSortableListsDrop, 'emit');
+
+      const simulation = new NativeDragSimulation(item(0));
+      await simulation.start();
+      await simulation.drop(item(2), towardsEdgeOf(item(2), 'bottom'));
+
+      expect(rootSpy).not.toHaveBeenCalled();
+      expect(listSpy).toHaveBeenCalledTimes(1);
+      expect(listSpy.mock.calls[0][0]).toMatchObject({ sourceId: 'a', targetId: 'c', edge: 'bottom' });
+    });
+  });
+
+  describe('two explicit lists sharing one root', () => {
+    type LoggedEvent =
+      | { type:'drop'; listId:'a'|'b'; event:SortableListsDropEvent }
+      | { type:'removed'; listId:'a'|'b'; event:SortableListsRemovedEvent };
+
+    // Type-predicate lookup, not an `as Extract<...>` cast: fails loudly if
+    // the event was never recorded, instead of silently typing a miss as present.
+    function findEvent<T extends LoggedEvent['type']>(
+      events:LoggedEvent[],
+      type:T,
+    ):Extract<LoggedEvent, { type:T }> {
+      const found = events.find((e):e is Extract<LoggedEvent, { type:T }> => e.type === type);
+      if (!found) {
+        throw new Error(`Expected a '${type}' event to have been recorded.`);
+      }
+      return found;
+    }
+
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsListDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="root" opSortableLists>
+          <div
+            class="list-a"
+            opSortableListsList
+            opSortableListsListId="list-a"
+            (opSortableListsDrop)="events.push({ type: 'drop', listId: 'a', event: $event })"
+            (opSortableListsRemoved)="events.push({ type: 'removed', listId: 'a', event: $event })"
+          >
+            @for (id of idsA(); track id) {
+              <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+            }
+          </div>
+
+          <div
+            class="list-b"
+            opSortableListsList
+            opSortableListsListId="list-b"
+            (opSortableListsDrop)="events.push({ type: 'drop', listId: 'b', event: $event })"
+            (opSortableListsRemoved)="events.push({ type: 'removed', listId: 'b', event: $event })"
+          >
+            @for (id of idsB(); track id) {
+              <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+            }
+          </div>
+        </div>
+      `,
+    })
+    class TwoListsHostComponent {
+      idsA = signal(['a1', 'a2']);
+
+      idsB = signal(['b1', 'b2']);
+
+      events:LoggedEvent[] = [];
+    }
+
+    let fixture:ComponentFixture<TwoListsHostComponent>;
+    let host:TwoListsHostComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [TwoListsHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(TwoListsHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function rootEl():HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelector('.root')!;
+    }
+
+    function itemIn(list:'list-a'|'list-b', index:number):HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>(`.${list} .item`)[index];
+    }
+
+    it('emits removed on the source list before drop on the target list, cross-list', async () => {
+      const simulation = new NativeDragSimulation(itemIn('list-a', 0));
+
+      await simulation.start();
+      await simulation.drop(itemIn('list-b', 0), towardsEdgeOf(itemIn('list-b', 0), 'top'));
+
+      expect(host.events.map((e) => e.type)).toEqual(['removed', 'drop']);
+
+      const removed = findEvent(host.events, 'removed');
+      const drop = findEvent(host.events, 'drop');
+      expect(removed.listId).toBe('a');
+      expect(drop.listId).toBe('b');
+      expect(removed.event.itemId).toBe('a1');
+      expect(removed.event.transactionId).toBe(drop.event.transactionId);
+
+      // `finalize()` is a working no-arg source-side settlement call.
+      drop.event.complete(true);
+      await removed.event.completion;
+      removed.event.finalize();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rootEl().hasAttribute('data-sortable-lists-busy')).toBe(false);
+    });
+
+    it('same-list drop emits drop only; removed is never called', async () => {
+      const simulation = new NativeDragSimulation(itemIn('list-a', 0));
+
+      await simulation.start();
+      await simulation.drop(itemIn('list-a', 1), towardsEdgeOf(itemIn('list-a', 1), 'bottom'));
+
+      expect(host.events).toHaveLength(1);
+      expect(host.events[0]).toMatchObject({ type: 'drop', listId: 'a' });
+    });
+
+    it('holds busy through a pending cross-list completion and releases after finalize', async () => {
+      const simulation = new NativeDragSimulation(itemIn('list-a', 0));
+
+      await simulation.start();
+      await simulation.drop(itemIn('list-b', 0), towardsEdgeOf(itemIn('list-b', 0), 'top'));
+
+      expect(rootEl().hasAttribute('data-sortable-lists-busy')).toBe(true);
+
+      const removed = findEvent(host.events, 'removed');
+      const drop = findEvent(host.events, 'drop');
+
+      // Target handler rejects the drop.
+      drop.event.complete(false);
+      await expect(removed.event.completion).resolves.toBe(false);
+
+      // Target has settled; source has not finalized yet — still busy.
+      expect(rootEl().hasAttribute('data-sortable-lists-busy')).toBe(true);
+
+      removed.event.finalize();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rootEl().hasAttribute('data-sortable-lists-busy')).toBe(false);
+    });
+  });
+
+  describe('dynamic first-list registration', () => {
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsListDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="root" opSortableLists (opSortableListsDrop)="rootDrops.push($event)">
+          @if (explicit()) {
+            <div
+              class="list"
+              opSortableListsList
+              (opSortableListsDrop)="listDrops.push($event)"
+            >
+              @for (id of ids(); track id) {
+                <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+              }
+            </div>
+          } @else {
+            @for (id of ids(); track id) {
+              <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+            }
+          }
+        </div>
+      `,
+    })
+    class DynamicListHostComponent {
+      explicit = signal(false);
+
+      ids = signal(['a', 'b', 'c']);
+
+      rootDrops:SortableListsDropEvent[] = [];
+
+      listDrops:SortableListsDropEvent[] = [];
+    }
+
+    let fixture:ComponentFixture<DynamicListHostComponent>;
+    let host:DynamicListHostComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [DynamicListHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(DynamicListHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function item(index:number):HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('.item')[index];
+    }
+
+    async function dragFirstOntoLast():Promise<void> {
+      const simulation = new NativeDragSimulation(item(0));
+      await simulation.start();
+      await simulation.drop(item(2), towardsEdgeOf(item(2), 'bottom'));
+    }
+
+    it('hands drops from the root proxy to the list output and back as the child toggles', async () => {
+      // Same-list, so complete() alone releases busy — must be called
+      // between drags or the root stays busy for the next one.
+      async function settle(event:SortableListsDropEvent):Promise<void> {
+        event.complete(true);
+        await Promise.resolve();
+      }
+
+      // OFF: no explicit list yet — root is in implicit collapse mode.
+      await dragFirstOntoLast();
+      expect(host.rootDrops).toHaveLength(1);
+      expect(host.listDrops).toHaveLength(0);
+      await settle(host.rootDrops[0]);
+      host.rootDrops = [];
+
+      // ON: the explicit list registers, retiring the implicit list.
+      host.explicit.set(true);
+      fixture.detectChanges();
+
+      await dragFirstOntoLast();
+      expect(host.rootDrops).toHaveLength(0);
+      expect(host.listDrops).toHaveLength(1);
+      await settle(host.listDrops[0]);
+      host.listDrops = [];
+
+      // OFF again: the explicit list unregisters, and implicit collapse
+      // resumes on the root element itself.
+      host.explicit.set(false);
+      fixture.detectChanges();
+
+      await dragFirstOntoLast();
+      expect(host.rootDrops).toHaveLength(1);
+      expect(host.listDrops).toHaveLength(0);
+    });
+  });
+
+  describe('nested roots', () => {
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="outer-root" opSortableLists (opSortableListsDrop)="outerDrops.push($event)">
+          <div class="outer-item" opSortableListsItem="outer-a" style="height: 40px; width: 200px;">outer-a</div>
+
+          <div class="inner-root" opSortableLists (opSortableListsDrop)="innerDrops.push($event)">
+            @for (id of innerIds(); track id) {
+              <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+            }
+          </div>
+        </div>
+      `,
+    })
+    class NestedRootsHostComponent {
+      innerIds = signal(['b1', 'b2', 'b3']);
+
+      outerDrops:SortableListsDropEvent[] = [];
+
+      innerDrops:SortableListsDropEvent[] = [];
+    }
+
+    let fixture:ComponentFixture<NestedRootsHostComponent>;
+    let host:NestedRootsHostComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [NestedRootsHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(NestedRootsHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function innerItem(index:number):HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('.inner-root .item')[index];
+    }
+
+    it("resolves an inner root's items to the inner root; the outer root stays silent", async () => {
+      const simulation = new NativeDragSimulation(innerItem(0));
+
+      await simulation.start();
+      await simulation.drop(innerItem(2), towardsEdgeOf(innerItem(2), 'bottom'));
+
+      expect(host.innerDrops).toHaveLength(1);
+      expect(host.innerDrops[0]).toMatchObject({ sourceId: 'b1', targetId: 'b3', edge: 'bottom' });
+      expect(host.outerDrops).toHaveLength(0);
+    });
+  });
+
+  describe('an inner root nested inside an outer explicit list', () => {
+    // An item under the inner (collapsed) root must never adopt the outer
+    // list's id — DI's nearest-list lookup does not stop at the inner root,
+    // so without the ownership check it would register against the inner
+    // engine under an id that engine never registered a list for.
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsListDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="outer-root" opSortableLists>
+          <div
+            class="outer-list"
+            opSortableListsList
+            opSortableListsListId="outer-list"
+            (opSortableListsDrop)="outerListDrops.push($event)"
+            (opSortableListsRemoved)="outerListRemoved.push($event)"
+          >
+            <div
+              class="inner-root"
+              opSortableLists
+              (opSortableListsDrop)="innerDrops.push($event)"
+              (opSortableListsRemoved)="innerRemoved.push($event)"
+              style="padding-bottom: 40px;"
+            >
+              @for (id of innerIds(); track id) {
+                <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+              }
+            </div>
+          </div>
+        </div>
+      `,
+    })
+    class NestedRootOwnershipHostComponent {
+      innerIds = signal(['b1', 'b2', 'b3']);
+
+      outerListDrops:SortableListsDropEvent[] = [];
+
+      outerListRemoved:SortableListsRemovedEvent[] = [];
+
+      innerDrops:SortableListsDropEvent[] = [];
+
+      innerRemoved:SortableListsRemovedEvent[] = [];
+    }
+
+    let fixture:ComponentFixture<NestedRootOwnershipHostComponent>;
+    let host:NestedRootOwnershipHostComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [NestedRootOwnershipHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(NestedRootOwnershipHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function innerRootEl():HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelector('.inner-root')!;
+    }
+
+    function innerItem(index:number):HTMLElement {
+      return (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('.inner-root .item')[index];
+    }
+
+    it('resolves a drop into the inner container space as a same-list append on the inner root', async () => {
+      const last = innerItem(2);
+      const simulation = new NativeDragSimulation(innerItem(0));
+
+      await simulation.start();
+      // The inner root's own trailing container space (below the last item,
+      // still inside its padding) — a container-level append, not an item target.
+      const lastRect = last.getBoundingClientRect();
+      const appendPoint = { x: lastRect.left + lastRect.width / 2, y: lastRect.bottom + 20 };
+      await simulation.drop(innerRootEl(), appendPoint);
+
+      // A mismatched list id would misclassify this as a cross-list move and
+      // emit `removed` for an item that never left its list.
+      expect(host.innerDrops).toHaveLength(1);
+      expect(host.innerDrops[0]).toMatchObject({ sourceId: 'b1', targetId: null, edge: null });
+      expect(host.innerRemoved).toHaveLength(0);
+      expect(host.outerListDrops).toHaveLength(0);
+      expect(host.outerListRemoved).toHaveLength(0);
+
+      // Same-list transactions settle on complete() alone; a mismatched list
+      // id would misroute through the cross-list path, needing finalize()
+      // too, and leave the inner root stuck busy since nothing here calls it.
+      host.innerDrops[0].complete(true);
+      await Promise.resolve();
+
+      expect(innerRootEl().hasAttribute('data-sortable-lists-busy')).toBe(false);
+    });
+  });
+
+  describe('root teardown', () => {
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsListDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="root" opSortableLists opSortableListsList>
+          @for (id of ids(); track id) {
+            <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+          }
+        </div>
+      `,
+    })
+    class TeardownHostComponent {
+      ids = signal(['a', 'b', 'c']);
+
+      rootDirective = viewChild.required(OpSortableListsDirective);
+    }
+
+    it('does not resurrect the implicit list once root teardown has begun', async () => {
+      // Root and its one explicit list share a host element, so destroying
+      // this fixture tears both down in the same pass — the explicit list
+      // is last to detach, so `attachList`'s cleanup would otherwise call
+      // `registerImplicitList()` against an already-destroying engine.
+      await TestBed.configureTestingModule({ imports: [TeardownHostComponent] }).compileComponents();
+      const fixture = TestBed.createComponent(TeardownHostComponent);
+      const host = fixture.componentInstance;
+      fixture.detectChanges();
+
+      // Spies the private method directly: the engine already no-ops a
+      // post-destroy `registerList` (defense in depth), so a black-box
+      // assertion would pass regardless of whether the directive still tries.
+      const root = host.rootDirective() as unknown as { registerImplicitList():void };
+      const registerImplicitList = vi.spyOn(root, 'registerImplicitList');
+
+      fixture.destroy();
+
+      expect(registerImplicitList).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('opSortableListsScrollContainer', () => {
+    const NOT_SCROLLABLE_WARNING = 'not to be scrollable';
+
+    function warnedNotScrollable(calls:unknown[][]):boolean {
+      return calls.some((call) => typeof call[0] === 'string' && call[0].includes(NOT_SCROLLABLE_WARNING));
+    }
+
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="root" opSortableLists>
+          @for (id of ids(); track id) {
+            <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+          }
+        </div>
+      `,
+    })
+    class PlainRootHostComponent {
+      ids = signal(['a', 'b', 'c']);
+    }
+
+    // `.scroll-target` is a plain sibling, not an ancestor of `.root`, so
+    // honoring it can only be the explicit input taking effect — never the
+    // closest-scrollable-ancestor fallback.
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="root" opSortableLists [opSortableListsScrollContainer]="scrollTarget">
+          @for (id of ids(); track id) {
+            <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+          }
+        </div>
+        <div class="scroll-target" #scrollTarget style="overflow: auto; height: 100px; width: 100px;"></div>
+      `,
+    })
+    class ScrollContainerInputHostComponent {
+      ids = signal(['a', 'b', 'c']);
+    }
+
+    @Component({
+      imports: [OpSortableListsDirective, OpSortableListsItemDirective],
+      template: `
+        <div class="scroll-wrapper" style="overflow: auto; height: 100px;">
+          <div class="root" opSortableLists>
+            @for (id of ids(); track id) {
+              <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+            }
+          </div>
+        </div>
+      `,
+    })
+    class ScrollableAncestorHostComponent {
+      ids = signal(['a', 'b', 'c']);
+    }
+
+    it('warns when the collapsed root has neither an input nor a scrollable ancestor', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        await TestBed.configureTestingModule({ imports: [PlainRootHostComponent] }).compileComponents();
+        const fixture = TestBed.createComponent(PlainRootHostComponent);
+        fixture.detectChanges();
+
+        expect(warnedNotScrollable(warn.mock.calls)).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('honors an explicit scroll container input, silencing that warning', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        await TestBed.configureTestingModule({ imports: [ScrollContainerInputHostComponent] }).compileComponents();
+        const fixture = TestBed.createComponent(ScrollContainerInputHostComponent);
+        fixture.detectChanges();
+
+        expect(warnedNotScrollable(warn.mock.calls)).toBe(false);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('falls back to the closest scrollable ancestor when no input is given', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        await TestBed.configureTestingModule({ imports: [ScrollableAncestorHostComponent] }).compileComponents();
+        const fixture = TestBed.createComponent(ScrollableAncestorHostComponent);
+        fixture.detectChanges();
+
+        expect(warnedNotScrollable(warn.mock.calls)).toBe(false);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+});

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.spec.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.spec.ts
@@ -1,0 +1,228 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  NativeDragSimulation,
+  centerOf,
+  towardsEdgeOf,
+} from 'core-common/drag-and-drop/testing/native-drag-simulation';
+import { OpSortableListsItemDirective } from './sortable-lists-item.directive';
+import { OpSortableListsDirective, SortableListsDropEvent } from './sortable-lists.directive';
+
+// Two lists with overlapping item ids: the second list proves per-instance
+// isolation, since only the payload scope distinguishes their items.
+@Component({
+  imports: [OpSortableListsDirective, OpSortableListsItemDirective],
+  template: `
+    <div
+      class="list-one"
+      opSortableLists
+      (opSortableListsDrop)="drops.push($event)"
+      style="overflow: auto;"
+    >
+      @for (id of ids(); track id) {
+        <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">
+          <span>{{ id }}</span>
+          <button type="button" class="remove-button" style="width: 30px; height: 20px;">x</button>
+        </div>
+      }
+    </div>
+
+    <div
+      class="list-two"
+      opSortableLists
+      (opSortableListsDrop)="otherDrops.push($event)"
+      style="overflow: auto;"
+    >
+      @for (id of otherIds(); track id) {
+        <div class="item" [opSortableListsItem]="id" style="height: 40px; width: 200px;">{{ id }}</div>
+      }
+    </div>
+  `,
+})
+class TestHostComponent {
+  ids = signal(['a', 'b', 'c']);
+  otherIds = signal(['a', 'b', 'c']);
+  drops:SortableListsDropEvent[] = [];
+  otherDrops:SortableListsDropEvent[] = [];
+}
+
+describe('sortable-lists directives', () => {
+  let fixture:ComponentFixture<TestHostComponent>;
+  let host:TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function item(list:string, index:number):HTMLElement {
+    const items = (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>(`.${list} .item`);
+    return items[index];
+  }
+
+  it('emits the source id, target id and closest edge on drop', async () => {
+    const simulation = new NativeDragSimulation(item('list-one', 0));
+
+    await simulation.start();
+    await simulation.drop(item('list-one', 2), towardsEdgeOf(item('list-one', 2), 'bottom'));
+
+    expect(host.drops).toEqual([{ sourceId: 'a', targetId: 'c', edge: 'bottom' }]);
+  });
+
+  it('reflects drag and drop-position state through host attributes', async () => {
+    const source = item('list-one', 0);
+    const target = item('list-one', 2);
+    const simulation = new NativeDragSimulation(source);
+
+    await simulation.start();
+    await simulation.dragOver(target, towardsEdgeOf(target, 'top'));
+    fixture.detectChanges();
+
+    expect(source.getAttribute('data-dragging')).toBe('true');
+    expect(target.getAttribute('data-drop-position')).toBe('top');
+
+    await simulation.drop(target, towardsEdgeOf(target, 'top'));
+    fixture.detectChanges();
+
+    expect(source.hasAttribute('data-dragging')).toBe(false);
+    expect(target.hasAttribute('data-drop-position')).toBe(false);
+  });
+
+  it('does not emit for a drop onto the dragged item itself', async () => {
+    const source = item('list-one', 1);
+    const simulation = new NativeDragSimulation(source);
+
+    await simulation.start();
+    await simulation.drop(source, towardsEdgeOf(source, 'top'));
+
+    expect(host.drops).toEqual([]);
+  });
+
+  it('rejects items of another list, even with an equal item id', async () => {
+    const foreignTarget = item('list-two', 1);
+    const simulation = new NativeDragSimulation(item('list-one', 0));
+
+    await simulation.start();
+    await simulation.dragOver(foreignTarget, towardsEdgeOf(foreignTarget, 'top'));
+    fixture.detectChanges();
+
+    expect(foreignTarget.hasAttribute('data-drop-position')).toBe(false);
+
+    await simulation.drop(foreignTarget, towardsEdgeOf(foreignTarget, 'top'));
+
+    expect(host.drops).toEqual([]);
+    expect(host.otherDrops).toEqual([]);
+  });
+
+  it('releases the sticky target and emits nothing when the drag leaves the list', async () => {
+    const source = item('list-one', 0);
+    const target = item('list-one', 2);
+    const simulation = new NativeDragSimulation(source);
+
+    await simulation.start();
+    await simulation.dragOver(target, towardsEdgeOf(target, 'top'));
+    // Outside the list bounds: over the document body, far away from both lists.
+    await simulation.dragOver(document.body, { x: 900, y: 600 });
+    fixture.detectChanges();
+
+    expect(target.hasAttribute('data-drop-position')).toBe(false);
+
+    await simulation.cancel();
+
+    expect(host.drops).toEqual([]);
+  });
+
+  it('does not start a drag from an interactive descendant', async () => {
+    const source = item('list-one', 0);
+    const removeButton = source.querySelector<HTMLElement>('.remove-button')!;
+    const simulation = new NativeDragSimulation(source);
+
+    await simulation.start(centerOf(removeButton));
+    fixture.detectChanges();
+
+    expect(source.hasAttribute('data-dragging')).toBe(false);
+
+    await simulation.drop(item('list-one', 2), towardsEdgeOf(item('list-one', 2), 'bottom'));
+
+    expect(host.drops).toEqual([]);
+  });
+
+  it('registers items rendered after the initial view', async () => {
+    host.ids.set(['a', 'b', 'c', 'd']);
+    fixture.detectChanges();
+
+    const added = item('list-one', 3);
+    const simulation = new NativeDragSimulation(added);
+
+    await simulation.start();
+    await simulation.drop(item('list-one', 0), towardsEdgeOf(item('list-one', 0), 'top'));
+
+    expect(host.drops).toEqual([{ sourceId: 'd', targetId: 'a', edge: 'top' }]);
+  });
+
+  it('keeps remaining items functional after items are removed', async () => {
+    host.ids.set(['b', 'c']);
+    fixture.detectChanges();
+
+    const simulation = new NativeDragSimulation(item('list-one', 0));
+
+    await simulation.start();
+    await simulation.drop(item('list-one', 1), towardsEdgeOf(item('list-one', 1), 'bottom'));
+
+    expect(host.drops).toEqual([{ sourceId: 'b', targetId: 'c', edge: 'bottom' }]);
+  });
+
+  it('warns and stays inert for an empty item id', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      host.ids.set(['']);
+      fixture.detectChanges();
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('non-empty item id'), expect.anything());
+
+      const source = item('list-one', 0);
+      const simulation = new NativeDragSimulation(source);
+
+      await simulation.start();
+      fixture.detectChanges();
+
+      expect(source.hasAttribute('data-dragging')).toBe(false);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.spec.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.spec.ts
@@ -37,7 +37,8 @@ import { OpSortableListsItemDirective } from './sortable-lists-item.directive';
 import { OpSortableListsDirective, SortableListsDropEvent } from './sortable-lists.directive';
 
 // Two lists with overlapping item ids: the second list proves per-instance
-// isolation, since only the payload scope distinguishes their items.
+// isolation, since only the payload scope distinguishes their items. Neither
+// declares an `opSortableListsList` child, so both operate in collapse mode.
 @Component({
   imports: [OpSortableListsDirective, OpSortableListsItemDirective],
   template: `
@@ -74,6 +75,11 @@ class TestHostComponent {
   otherDrops:SortableListsDropEvent[] = [];
 }
 
+// Ignores the transaction bookkeeping fields; only the resolved intent matters here.
+function intents(events:SortableListsDropEvent[]) {
+  return events.map(({ sourceId, targetId, edge }) => ({ sourceId, targetId, edge }));
+}
+
 describe('sortable-lists directives', () => {
   let fixture:ComponentFixture<TestHostComponent>;
   let host:TestHostComponent;
@@ -99,7 +105,7 @@ describe('sortable-lists directives', () => {
     await simulation.start();
     await simulation.drop(item('list-one', 2), towardsEdgeOf(item('list-one', 2), 'bottom'));
 
-    expect(host.drops).toEqual([{ sourceId: 'a', targetId: 'c', edge: 'bottom' }]);
+    expect(intents(host.drops)).toEqual([{ sourceId: 'a', targetId: 'c', edge: 'bottom' }]);
   });
 
   it('reflects drag and drop-position state through host attributes', async () => {
@@ -111,7 +117,7 @@ describe('sortable-lists directives', () => {
     await simulation.dragOver(target, towardsEdgeOf(target, 'top'));
     fixture.detectChanges();
 
-    expect(source.getAttribute('data-dragging')).toBe('true');
+    expect(source.getAttribute('data-dragging')).toBe('source');
     expect(target.getAttribute('data-drop-position')).toBe('top');
 
     await simulation.drop(target, towardsEdgeOf(target, 'top'));
@@ -190,7 +196,7 @@ describe('sortable-lists directives', () => {
     await simulation.start();
     await simulation.drop(item('list-one', 0), towardsEdgeOf(item('list-one', 0), 'top'));
 
-    expect(host.drops).toEqual([{ sourceId: 'd', targetId: 'a', edge: 'top' }]);
+    expect(intents(host.drops)).toEqual([{ sourceId: 'd', targetId: 'a', edge: 'top' }]);
   });
 
   it('keeps remaining items functional after items are removed', async () => {
@@ -202,7 +208,7 @@ describe('sortable-lists directives', () => {
     await simulation.start();
     await simulation.drop(item('list-one', 1), towardsEdgeOf(item('list-one', 1), 'bottom'));
 
-    expect(host.drops).toEqual([{ sourceId: 'b', targetId: 'c', edge: 'bottom' }]);
+    expect(intents(host.drops)).toEqual([{ sourceId: 'b', targetId: 'c', edge: 'bottom' }]);
   });
 
   it('warns and stays inert for an empty item id', async () => {

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.ts
@@ -35,27 +35,51 @@ import {
   input,
   output,
 } from '@angular/core';
-import { registerAutoScroll } from 'core-common/drag-and-drop/auto-scroll';
+import { type AutoScrollAllowedAxis } from 'core-common/drag-and-drop/auto-scroll';
 import {
-  createSortableItemPayloadScope,
-} from 'core-common/drag-and-drop/payload';
+  createSortableRoot,
+  type SortableDropTransaction,
+  type SortableRoot,
+} from 'core-common/drag-and-drop/sortable-lists-engine';
 import { type Edge } from 'core-common/drag-and-drop/reorder';
+// Type-only: a value import would create a circular module dependency, since
+// `OpSortableListsListDirective` injects this directive at runtime.
+import type { OpSortableListsListDirective } from './sortable-lists-list.directive';
 
 export type SortableListsAxis = 'vertical'|'horizontal';
 
 export interface SortableListsDropEvent {
+  transactionId:string;
   sourceId:string;
-  targetId:string;
+  sourceListId:string;
+  targetId:string|null;
   edge:Edge|null;
+  complete(success:boolean):void;
 }
 
-// The root of one sortable list whose items are rendered by an Angular
-// template. Mirrors the Stimulus `sortable-lists` root controller: it owns
-// the state shared by its item directives (payload scope, allowed edges,
-// autoscroll, list bounds) and relays their resolved drop intents to the
-// owning component. It does not own the consumer's item array and never
-// moves DOM — reordering the items in response to the drop output is the
-// consumer's job.
+export interface SortableListsRemovedEvent {
+  transactionId:string;
+  itemId:string;
+  targetListId:string;
+  completion:Promise<boolean>;
+  finalize():void;
+}
+
+type CleanupFn = () => void;
+
+let lastGeneratedId = 0;
+
+function generateListId():string {
+  lastGeneratedId += 1;
+  return `op-sortable-list-${lastGeneratedId}`;
+}
+
+// The root of one drag-and-drop scope, thinly binding the shared sortable
+// engine to Angular's view lifecycle; owns nothing about the consumer's data.
+// With no explicit `opSortableListsList` child it behaves as a single
+// implicit list (e.g. the draggable autocompleter) and fires its own proxy
+// outputs; once an explicit list registers, that list's outputs take over —
+// see `attachList`.
 @Directive({
   selector: '[opSortableLists]',
 })
@@ -66,43 +90,136 @@ export class OpSortableListsDirective implements AfterViewInit {
 
   axis = input<SortableListsAxis>('vertical', { alias: 'opSortableListsAxis' });
 
+  // Autoscroll container for the collapsed (implicit-list) case — see
+  // `registerImplicitList`. An explicit `opSortableListsList` child has its
+  // own `opSortableListsListScrollContainer` input instead.
   scrollContainer = input<Element|null>(null, { alias: 'opSortableListsScrollContainer' });
 
+  // Proxy outputs: statically declared so a template can always bind them,
+  // but only emit while this root is acting as the implicit (collapsed)
+  // list — see the class doc comment.
   opSortableListsDrop = output<SortableListsDropEvent>();
 
-  // One payload scope per list instance: item directives create and
-  // recognize drag data through it, so a drag from another list (or any
-  // other Pragmatic consumer) is rejected automatically.
-  readonly payloadScope = createSortableItemPayloadScope();
+  opSortableListsRemoved = output<SortableListsRemovedEvent>();
+
+  readonly implicitListId = generateListId();
+
+  private readonly childLists = new Map<string, OpSortableListsListDirective>();
+
+  private engineRoot:SortableRoot|null = null;
+
+  private implicitListCleanup:CleanupFn|null = null;
+
+  // Set before `engineRoot.destroy()` runs, so a teardown-order callback
+  // still in flight (notably `attachList`'s cleanup below) knows to skip
+  // resurrecting the implicit list rather than relying solely on the
+  // engine's own post-destroy no-op.
+  private destroying = false;
 
   ngAfterViewInit():void {
-    const cleanup = registerAutoScroll({
-      element: this.scrollContainer() ?? this.closestScrollableAncestor() ?? this.elementRef.nativeElement,
-      canScroll: ({ source }) => this.payloadScope.isItemData(source.data),
-      axis: 'all',
+    // Guarantees the engine (and implicit list) exists even for a root that
+    // never receives an item — an empty list must still be a valid drop
+    // target. Idempotent: a nested item/list directive's earlier-running
+    // `ngOnInit` may already have triggered it.
+    this.getEngineRoot();
+  }
+
+  // Called by an explicit `opSortableListsList` child's `ngOnInit`. The first
+  // explicit list retires the implicit list; the last to detach brings it back.
+  attachList(list:OpSortableListsListDirective):CleanupFn {
+    const engineRoot = this.getEngineRoot();
+
+    if (this.childLists.size === 0) {
+      this.unregisterImplicitList();
+    }
+
+    const listId = list.listId();
+    this.childLists.set(listId, list);
+
+    const cleanup = engineRoot.registerList({
+      element: list.elementRef.nativeElement,
+      listId,
+      accepts: this.wrapAccepts(list.accepts()),
+      scrollContainer: list.scrollContainer() ?? undefined,
     });
 
-    this.destroyRef.onDestroy(cleanup);
+    return () => {
+      cleanup();
+      this.childLists.delete(listId);
+      // Skip while mid-teardown: Angular's destroy order does not guarantee
+      // this runs before the root's own `destroyRef.onDestroy` (see `destroying`).
+      if (this.childLists.size === 0 && !this.destroying) {
+        this.registerImplicitList();
+      }
+    };
   }
 
-  allowedEdges():Edge[] {
-    return this.axis() === 'horizontal' ? ['left', 'right'] : ['top', 'bottom'];
+  // Internal API used by `OpSortableListsItemDirective`. Adapts the
+  // consumer-facing no-argument `canDrag` to the engine's pointer-context
+  // signature.
+  registerItem(opts:{
+    element:HTMLElement;
+    itemId:string;
+    listId:string;
+    canDrag?:() => boolean;
+  }):CleanupFn {
+    const engineRoot = this.getEngineRoot();
+
+    return engineRoot.registerItem({
+      element: opts.element,
+      itemId: opts.itemId,
+      listId: opts.listId,
+      canDrag: opts.canDrag ? () => opts.canDrag!() : undefined,
+    });
   }
 
-  // Item targets stay sticky only while the pointer remains over the list,
-  // so a drop outside the list cancels instead of reordering next to the
-  // last hovered item.
-  containsPoint({ clientX, clientY }:{ clientX:number; clientY:number }):boolean {
-    const rect = this.elementRef.nativeElement.getBoundingClientRect();
-
-    return clientX >= rect.left
-      && clientX <= rect.right
-      && clientY >= rect.top
-      && clientY <= rect.bottom;
+  // Public API for a consumer that needs an ADDITIONAL autoscroll container
+  // beyond the collapsed/explicit-list resolution above — e.g. a board whose
+  // scrollable viewport is neither the root nor an ancestor of it.
+  addScrollContainer(element:Element, axis?:AutoScrollAllowedAxis):CleanupFn {
+    return this.getEngineRoot().addScrollContainer(element, axis);
   }
 
-  emitDrop(event:SortableListsDropEvent):void {
-    this.opSortableListsDrop.emit(event);
+  private getEngineRoot():SortableRoot {
+    if (!this.engineRoot) {
+      this.engineRoot = createSortableRoot({
+        element: this.elementRef.nativeElement,
+        axis: this.axis(),
+        onDrop: (transaction) => this.dispatch(transaction),
+      });
+      this.destroyRef.onDestroy(() => {
+        this.destroying = true;
+        this.engineRoot?.destroy();
+      });
+      this.registerImplicitList();
+    }
+
+    return this.engineRoot;
+  }
+
+  private registerImplicitList():void {
+    if (this.implicitListCleanup || !this.engineRoot) {
+      return;
+    }
+
+    this.implicitListCleanup = this.engineRoot.registerList({
+      element: this.elementRef.nativeElement,
+      listId: this.implicitListId,
+      scrollContainer: this.resolveScrollContainer(),
+    });
+  }
+
+  private unregisterImplicitList():void {
+    this.implicitListCleanup?.();
+    this.implicitListCleanup = null;
+  }
+
+  // Collapsed (implicit-list) autoscroll target: explicit input wins, then
+  // the nearest scrollable ancestor — a host with `overflow: visible` (e.g.
+  // the draggable autocompleter) is not itself a valid scroll target and
+  // Pragmatic would warn — else undefined, so the engine's own default applies.
+  private resolveScrollContainer():Element|undefined {
+    return this.scrollContainer() ?? this.closestScrollableAncestor() ?? undefined;
   }
 
   private closestScrollableAncestor():Element|null {
@@ -117,5 +234,56 @@ export class OpSortableListsDirective implements AfterViewInit {
     }
 
     return null;
+  }
+
+  private wrapAccepts(accepts:(() => boolean)|null):(() => boolean)|undefined {
+    return accepts ? () => accepts() : undefined;
+  }
+
+  // Cross-list moves emit `removed` on the source list BEFORE `drop` on the
+  // target, so a `removed` handler never sees the item still in the target's
+  // rendered list. Same-list moves emit `drop` only.
+  private dispatch(transaction:SortableDropTransaction):void {
+    const { intent } = transaction;
+
+    const drop:SortableListsDropEvent = {
+      transactionId: transaction.id,
+      sourceId: intent.sourceId,
+      sourceListId: intent.sourceListId,
+      targetId: intent.targetItemId,
+      edge: intent.edge,
+      complete: (success) => transaction.complete(success),
+    };
+
+    if (intent.sourceListId !== intent.targetListId) {
+      const removed:SortableListsRemovedEvent = {
+        transactionId: transaction.id,
+        itemId: intent.sourceId,
+        targetListId: intent.targetListId,
+        completion: transaction.completion,
+        finalize: () => transaction.finalize(),
+      };
+      this.emitRemoved(intent.sourceListId, removed);
+    }
+
+    this.emitDrop(intent.targetListId, drop);
+  }
+
+  private emitDrop(listId:string, event:SortableListsDropEvent):void {
+    const list = this.childLists.get(listId);
+    if (list) {
+      list.opSortableListsDrop.emit(event);
+    } else {
+      this.opSortableListsDrop.emit(event);
+    }
+  }
+
+  private emitRemoved(listId:string, event:SortableListsRemovedEvent):void {
+    const list = this.childLists.get(listId);
+    if (list) {
+      list.opSortableListsRemoved.emit(event);
+    } else {
+      this.opSortableListsRemoved.emit(event);
+    }
   }
 }

--- a/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.ts
+++ b/frontend/src/app/shared/directives/sortable-lists/sortable-lists.directive.ts
@@ -1,0 +1,121 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  AfterViewInit,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import { registerAutoScroll } from 'core-common/drag-and-drop/auto-scroll';
+import {
+  createSortableItemPayloadScope,
+} from 'core-common/drag-and-drop/payload';
+import { type Edge } from 'core-common/drag-and-drop/reorder';
+
+export type SortableListsAxis = 'vertical'|'horizontal';
+
+export interface SortableListsDropEvent {
+  sourceId:string;
+  targetId:string;
+  edge:Edge|null;
+}
+
+// The root of one sortable list whose items are rendered by an Angular
+// template. Mirrors the Stimulus `sortable-lists` root controller: it owns
+// the state shared by its item directives (payload scope, allowed edges,
+// autoscroll, list bounds) and relays their resolved drop intents to the
+// owning component. It does not own the consumer's item array and never
+// moves DOM — reordering the items in response to the drop output is the
+// consumer's job.
+@Directive({
+  selector: '[opSortableLists]',
+})
+export class OpSortableListsDirective implements AfterViewInit {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  private readonly destroyRef = inject(DestroyRef);
+
+  axis = input<SortableListsAxis>('vertical', { alias: 'opSortableListsAxis' });
+
+  scrollContainer = input<Element|null>(null, { alias: 'opSortableListsScrollContainer' });
+
+  opSortableListsDrop = output<SortableListsDropEvent>();
+
+  // One payload scope per list instance: item directives create and
+  // recognize drag data through it, so a drag from another list (or any
+  // other Pragmatic consumer) is rejected automatically.
+  readonly payloadScope = createSortableItemPayloadScope();
+
+  ngAfterViewInit():void {
+    const cleanup = registerAutoScroll({
+      element: this.scrollContainer() ?? this.closestScrollableAncestor() ?? this.elementRef.nativeElement,
+      canScroll: ({ source }) => this.payloadScope.isItemData(source.data),
+      axis: 'all',
+    });
+
+    this.destroyRef.onDestroy(cleanup);
+  }
+
+  allowedEdges():Edge[] {
+    return this.axis() === 'horizontal' ? ['left', 'right'] : ['top', 'bottom'];
+  }
+
+  // Item targets stay sticky only while the pointer remains over the list,
+  // so a drop outside the list cancels instead of reordering next to the
+  // last hovered item.
+  containsPoint({ clientX, clientY }:{ clientX:number; clientY:number }):boolean {
+    const rect = this.elementRef.nativeElement.getBoundingClientRect();
+
+    return clientX >= rect.left
+      && clientX <= rect.right
+      && clientY >= rect.top
+      && clientY <= rect.bottom;
+  }
+
+  emitDrop(event:SortableListsDropEvent):void {
+    this.opSortableListsDrop.emit(event);
+  }
+
+  private closestScrollableAncestor():Element|null {
+    let element:HTMLElement|null = this.elementRef.nativeElement;
+
+    while (element) {
+      const { overflowX, overflowY } = window.getComputedStyle(element);
+      if (/(auto|scroll|overlay)/.test(overflowY + overflowX)) {
+        return element;
+      }
+      element = element.parentElement;
+    }
+
+    return null;
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -34,7 +34,6 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { NgOptionHighlightDirective } from '@ng-select/ng-option-highlight';
-import { DragulaModule } from 'ng2-dragula';
 import { DynamicModule } from 'ng-dynamic-component';
 import { UIRouterModule } from '@uirouter/angular';
 import { OpSpotModule } from 'core-app/spot/spot.module';
@@ -111,7 +110,6 @@ export function bootstrapModule(injector:Injector):void {
     A11yModule,
     PortalModule,
     DragDropModule,
-    DragulaModule,
     CurrentUserModule,
     FormsModule,
     NgSelectModule,

--- a/frontend/src/common/drag-and-drop/auto-scroll.ts
+++ b/frontend/src/common/drag-and-drop/auto-scroll.ts
@@ -1,0 +1,55 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+
+type CleanupFn = () => void;
+export type AutoScrollAllowedAxis = 'vertical'|'horizontal'|'all';
+
+// Register auto-scrolling on a scroll container for the duration of a drag.
+// The caller supplies `canScroll` (typically a payload-scope check, so only
+// drags belonging to that consumer scroll its container). Returns a cleanup
+// function to detach it.
+export function registerAutoScroll({
+  element,
+  canScroll,
+  axis = 'vertical',
+  maxScrollSpeed = 'standard',
+}:{
+  element:Element;
+  canScroll:(args:{ source:{ data:Record<string|symbol, unknown> } }) => boolean;
+  axis?:AutoScrollAllowedAxis;
+  maxScrollSpeed?:'standard'|'fast';
+}):CleanupFn {
+  return autoScrollForElements({
+    element,
+    canScroll,
+    getAllowedAxis: () => axis,
+    getConfiguration: () => ({ maxScrollSpeed }),
+  });
+}

--- a/frontend/src/common/drag-and-drop/drop-indicator.spec.ts
+++ b/frontend/src/common/drag-and-drop/drop-indicator.spec.ts
@@ -26,39 +26,32 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-// The Pragmatic DnD payload exchanged within one sortable list. Each root
-// creates its own Symbol-keyed scope, so items from one root are never
-// recognized by another root's targets/monitors/autoscrollers, even with
-// equal ids. The scope is shared across sibling lists of the same root, so
-// they interoperate for cross-list drags.
-export interface SortableItemData extends Record<string|symbol, unknown> {
-  itemId:string;
-  listId:string;
-}
+import {
+  clearDropIndicator,
+  dropPositionAttribute,
+  dropPositionOwnerAttribute,
+  renderDropIndicator,
+} from './drop-indicator';
 
-export interface SortableItemPayloadScope {
-  itemData(itemId:string, listId:string):SortableItemData;
-  isItemData(data:Record<string|symbol, unknown>):data is SortableItemData;
-}
+describe('drop indicator owner tracking', () => {
+  it('records the owner when rendering', () => {
+    const el = document.createElement('div');
+    renderDropIndicator(el, 'top', 'item-1');
 
-export function createSortableItemPayloadScope():SortableItemPayloadScope {
-  const scopeKey = Symbol('op-sortable-item');
+    expect(el.getAttribute(dropPositionAttribute)).toBe('top');
+    expect(el.getAttribute(dropPositionOwnerAttribute)).toBe('item-1');
+  });
 
-  return {
-    itemData(itemId:string, listId:string):SortableItemData {
-      return {
-        [scopeKey]: true,
-        itemId,
-        listId,
-      };
-    },
+  it('does not clear an indicator another owner rendered since', () => {
+    const el = document.createElement('div');
+    renderDropIndicator(el, 'top', 'item-1');
+    renderDropIndicator(el, 'bottom', 'item-2');
+    clearDropIndicator(el, 'item-1');
 
-    isItemData(data:Record<string|symbol, unknown>):data is SortableItemData {
-      return data[scopeKey] === true
-        && typeof data.itemId === 'string'
-        && data.itemId.length > 0
-        && typeof data.listId === 'string'
-        && data.listId.length > 0;
-    },
-  };
-}
+    expect(el.getAttribute(dropPositionAttribute)).toBe('bottom');
+
+    clearDropIndicator(el, 'item-2');
+    expect(el.hasAttribute(dropPositionAttribute)).toBe(false);
+    expect(el.hasAttribute(dropPositionOwnerAttribute)).toBe(false);
+  });
+});

--- a/frontend/src/common/drag-and-drop/drop-indicator.ts
+++ b/frontend/src/common/drag-and-drop/drop-indicator.ts
@@ -1,0 +1,49 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+
+// Drop indicator contract shared by the Angular sortable helpers: the closest
+// edge is written to a `data-drop-position` attribute on the hovered element.
+// The visual line is drawn by each consumer's own stylesheet via the
+// `[data-drop-position="top|bottom|left|right"]` selector, since orientation
+// (and therefore the styling) differs per surface.
+export const dropPositionAttribute = 'data-drop-position';
+
+export function renderDropIndicator(element:HTMLElement, edge:Edge|null):void {
+  if (!edge) {
+    clearDropIndicator(element);
+    return;
+  }
+
+  element.setAttribute(dropPositionAttribute, edge);
+}
+
+export function clearDropIndicator(element:HTMLElement):void {
+  element.removeAttribute(dropPositionAttribute);
+}

--- a/frontend/src/common/drag-and-drop/drop-indicator.ts
+++ b/frontend/src/common/drag-and-drop/drop-indicator.ts
@@ -28,22 +28,28 @@
 
 import { type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 
-// Drop indicator contract shared by the Angular sortable helpers: the closest
-// edge is written to a `data-drop-position` attribute on the hovered element.
-// The visual line is drawn by each consumer's own stylesheet via the
-// `[data-drop-position="top|bottom|left|right"]` selector, since orientation
-// (and therefore the styling) differs per surface.
+// Shared drop-indicator contract: the closest edge is written to a
+// `data-drop-position` attribute, with `data-drop-position-owner` tracking
+// who rendered it. Each consumer draws the line itself via
+// `[data-drop-position="top|bottom|left|right"]`.
 export const dropPositionAttribute = 'data-drop-position';
+export const dropPositionOwnerAttribute = 'data-drop-position-owner';
 
-export function renderDropIndicator(element:HTMLElement, edge:Edge|null):void {
+export function renderDropIndicator(element:HTMLElement, edge:Edge|null, ownerId:string):void {
   if (!edge) {
-    clearDropIndicator(element);
+    clearDropIndicator(element, ownerId);
     return;
   }
 
   element.setAttribute(dropPositionAttribute, edge);
+  element.setAttribute(dropPositionOwnerAttribute, ownerId);
 }
 
-export function clearDropIndicator(element:HTMLElement):void {
-  element.removeAttribute(dropPositionAttribute);
+export function clearDropIndicator(element:HTMLElement, ownerId:string):void {
+  // Only clear if the stored owner still matches — another owner may have
+  // rendered since.
+  if (element.getAttribute(dropPositionOwnerAttribute) === ownerId) {
+    element.removeAttribute(dropPositionAttribute);
+    element.removeAttribute(dropPositionOwnerAttribute);
+  }
 }

--- a/frontend/src/common/drag-and-drop/payload.spec.ts
+++ b/frontend/src/common/drag-and-drop/payload.spec.ts
@@ -1,0 +1,60 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { createSortableItemPayloadScope } from './payload';
+
+describe('createSortableItemPayloadScope', () => {
+  it('recognizes data created by the same scope', () => {
+    const scope = createSortableItemPayloadScope();
+    const data = scope.itemData('42');
+
+    expect(scope.isItemData(data)).toBe(true);
+    expect(data.itemId).toBe('42');
+  });
+
+  it('rejects data from another scope, even for an equal item id', () => {
+    const scope = createSortableItemPayloadScope();
+    const otherScope = createSortableItemPayloadScope();
+
+    expect(scope.isItemData(otherScope.itemData('42'))).toBe(false);
+    expect(otherScope.isItemData(scope.itemData('42'))).toBe(false);
+  });
+
+  it('rejects foreign and empty payloads', () => {
+    const scope = createSortableItemPayloadScope();
+
+    expect(scope.isItemData({})).toBe(false);
+    expect(scope.isItemData({ itemId: '42' })).toBe(false);
+  });
+
+  it('rejects data with an empty item id', () => {
+    const scope = createSortableItemPayloadScope();
+
+    expect(scope.isItemData(scope.itemData(''))).toBe(false);
+  });
+});

--- a/frontend/src/common/drag-and-drop/payload.spec.ts
+++ b/frontend/src/common/drag-and-drop/payload.spec.ts
@@ -31,7 +31,7 @@ import { createSortableItemPayloadScope } from './payload';
 describe('createSortableItemPayloadScope', () => {
   it('recognizes data created by the same scope', () => {
     const scope = createSortableItemPayloadScope();
-    const data = scope.itemData('42');
+    const data = scope.itemData('42', 'list');
 
     expect(scope.isItemData(data)).toBe(true);
     expect(data.itemId).toBe('42');
@@ -41,8 +41,8 @@ describe('createSortableItemPayloadScope', () => {
     const scope = createSortableItemPayloadScope();
     const otherScope = createSortableItemPayloadScope();
 
-    expect(scope.isItemData(otherScope.itemData('42'))).toBe(false);
-    expect(otherScope.isItemData(scope.itemData('42'))).toBe(false);
+    expect(scope.isItemData(otherScope.itemData('42', 'list'))).toBe(false);
+    expect(otherScope.isItemData(scope.itemData('42', 'list'))).toBe(false);
   });
 
   it('rejects foreign and empty payloads', () => {
@@ -55,6 +55,21 @@ describe('createSortableItemPayloadScope', () => {
   it('rejects data with an empty item id', () => {
     const scope = createSortableItemPayloadScope();
 
-    expect(scope.isItemData(scope.itemData(''))).toBe(false);
+    expect(scope.isItemData(scope.itemData('', 'list'))).toBe(false);
+  });
+
+  it('carries the list id in the payload', () => {
+    const scope = createSortableItemPayloadScope();
+    const data = scope.itemData('item-1', 'list-a');
+
+    expect(data.itemId).toBe('item-1');
+    expect(data.listId).toBe('list-a');
+    expect(scope.isItemData(data)).toBe(true);
+  });
+
+  it('rejects payloads without a list id', () => {
+    const scope = createSortableItemPayloadScope();
+
+    expect(scope.isItemData({ itemId: 'item-1' })).toBe(false);
   });
 });

--- a/frontend/src/common/drag-and-drop/payload.ts
+++ b/frontend/src/common/drag-and-drop/payload.ts
@@ -1,0 +1,60 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+// The Pragmatic DnD payload exchanged between draggable items and drop
+// targets of one sortable list. Each list instance creates its own scope,
+// keyed with a private Symbol, so items of one list can never be recognized
+// by the targets, monitors or autoscrollers of another — even when both
+// lists contain items with equal ids.
+export interface SortableItemData extends Record<string|symbol, unknown> {
+  itemId:string;
+}
+
+export interface SortableItemPayloadScope {
+  itemData(itemId:string):SortableItemData;
+  isItemData(data:Record<string|symbol, unknown>):data is SortableItemData;
+}
+
+export function createSortableItemPayloadScope():SortableItemPayloadScope {
+  const scopeKey = Symbol('op-sortable-item');
+
+  return {
+    itemData(itemId:string):SortableItemData {
+      return {
+        [scopeKey]: true,
+        itemId,
+      };
+    },
+
+    isItemData(data:Record<string|symbol, unknown>):data is SortableItemData {
+      return data[scopeKey] === true
+        && typeof data.itemId === 'string'
+        && data.itemId.length > 0;
+    },
+  };
+}

--- a/frontend/src/common/drag-and-drop/reorder.spec.ts
+++ b/frontend/src/common/drag-and-drop/reorder.spec.ts
@@ -1,0 +1,86 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { reorderById } from './reorder';
+
+describe('reorderById', () => {
+  interface Item { id:string }
+
+  const a:Item = { id: 'a' };
+  const b:Item = { id: 'b' };
+  const c:Item = { id: 'c' };
+
+  function reorder(list:Item[], sourceId:string, targetId:string, closestEdge:'left'|'right'|null) {
+    return reorderById({
+      list,
+      getId: (item) => item.id,
+      sourceId,
+      targetId,
+      closestEdge,
+      axis: 'horizontal',
+    });
+  }
+
+  it('moves the source before the target on a leading-edge drop', () => {
+    expect(reorder([a, b, c], 'c', 'a', 'left')).toEqual([c, a, b]);
+  });
+
+  it('moves the source after the target on a trailing-edge drop', () => {
+    expect(reorder([a, b, c], 'a', 'c', 'right')).toEqual([b, c, a]);
+  });
+
+  it('returns the original reference when the source id is unknown', () => {
+    const list = [a, b, c];
+
+    expect(reorder(list, 'missing', 'a', 'left')).toBe(list);
+  });
+
+  it('returns the original reference when the target id is unknown', () => {
+    const list = [a, b, c];
+
+    expect(reorder(list, 'a', 'missing', 'left')).toBe(list);
+  });
+
+  it('returns the original reference for a self-drop', () => {
+    const list = [a, b, c];
+
+    expect(reorder(list, 'b', 'b', 'left')).toBe(list);
+  });
+
+  it('returns the original reference when dropped on the leading edge of the next item', () => {
+    const list = [a, b, c];
+
+    expect(reorder(list, 'a', 'b', 'left')).toBe(list);
+  });
+
+  it('returns the original reference when dropped on the trailing edge of the previous item', () => {
+    const list = [a, b, c];
+
+    expect(reorder(list, 'b', 'a', 'right')).toBe(list);
+  });
+});

--- a/frontend/src/common/drag-and-drop/reorder.spec.ts
+++ b/frontend/src/common/drag-and-drop/reorder.spec.ts
@@ -83,4 +83,22 @@ describe('reorderById', () => {
 
     expect(reorder(list, 'b', 'a', 'right')).toBe(list);
   });
+
+  it('appends the source on a null target', () => {
+    const list = ['a', 'b', 'c'];
+    const result = reorderById({
+      list, getId: (x) => x, sourceId: 'a', targetId: null, closestEdge: null, axis: 'vertical',
+    });
+
+    expect(result).toEqual(['b', 'c', 'a']);
+  });
+
+  it('returns the same reference when appending the already-last item', () => {
+    const list = ['a', 'b', 'c'];
+    const result = reorderById({
+      list, getId: (x) => x, sourceId: 'c', targetId: null, closestEdge: null, axis: 'vertical',
+    });
+
+    expect(result).toBe(list);
+  });
 });

--- a/frontend/src/common/drag-and-drop/reorder.ts
+++ b/frontend/src/common/drag-and-drop/reorder.ts
@@ -1,0 +1,80 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  type Edge,
+  attachClosestEdge,
+  extractClosestEdge,
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { reorderWithEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/reorder-with-edge';
+
+export { attachClosestEdge, extractClosestEdge };
+export type { Edge };
+
+export type SortableAxis = 'vertical'|'horizontal';
+
+// Reorder a list by item identity using the closest edge of the drop target.
+// Indices are resolved from the current list (not carried in the payload) so a
+// stale index can never reorder the wrong element. Returns the original list
+// (same reference) when either id cannot be found or the move is a no-op, so
+// callers can suppress false change events via reference equality.
+export function reorderById<T>({
+  list,
+  getId,
+  sourceId,
+  targetId,
+  closestEdge,
+  axis,
+}:{
+  list:T[];
+  getId:(item:T) => string;
+  sourceId:string;
+  targetId:string;
+  closestEdge:Edge|null;
+  axis:SortableAxis;
+}):T[] {
+  const startIndex = list.findIndex((item) => getId(item) === sourceId);
+  const indexOfTarget = list.findIndex((item) => getId(item) === targetId);
+
+  if (startIndex === -1 || indexOfTarget === -1) {
+    return list;
+  }
+
+  const reordered = reorderWithEdge({
+    list,
+    startIndex,
+    indexOfTarget,
+    closestEdgeOfTarget: closestEdge,
+    axis,
+  });
+
+  const isSameOrder = reordered.length === list.length
+    && reordered.every((item, index) => item === list[index]);
+
+  return isSameOrder ? list : reordered;
+}

--- a/frontend/src/common/drag-and-drop/reorder.ts
+++ b/frontend/src/common/drag-and-drop/reorder.ts
@@ -38,11 +38,10 @@ export type { Edge };
 
 export type SortableAxis = 'vertical'|'horizontal';
 
-// Reorder a list by item identity using the closest edge of the drop target.
-// Indices are resolved from the current list (not carried in the payload) so a
-// stale index can never reorder the wrong element. Returns the original list
-// (same reference) when either id cannot be found or the move is a no-op, so
-// callers can suppress false change events via reference equality.
+// Reorders by item identity and the target's closest edge; indices are
+// resolved fresh from `list`, never carried in the payload. Returns the
+// original reference for an unknown id or a no-op, so callers can detect
+// no-change via `===`.
 export function reorderById<T>({
   list,
   getId,
@@ -54,10 +53,21 @@ export function reorderById<T>({
   list:T[];
   getId:(item:T) => string;
   sourceId:string;
-  targetId:string;
+  targetId:string|null;
   closestEdge:Edge|null;
   axis:SortableAxis;
 }):T[] {
+  if (targetId === null) {
+    const startIndex = list.findIndex((item) => getId(item) === sourceId);
+    if (startIndex === -1 || startIndex === list.length - 1) {
+      return list;
+    }
+    const appended = [...list];
+    const [moved] = appended.splice(startIndex, 1);
+    appended.push(moved);
+    return appended;
+  }
+
   const startIndex = list.findIndex((item) => getId(item) === sourceId);
   const indexOfTarget = list.findIndex((item) => getId(item) === targetId);
 

--- a/frontend/src/common/drag-and-drop/sortable-lists-engine.spec.ts
+++ b/frontend/src/common/drag-and-drop/sortable-lists-engine.spec.ts
@@ -1,0 +1,904 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  NativeDragSimulation,
+  centerOf,
+  towardsEdgeOf,
+} from 'core-common/drag-and-drop/testing/native-drag-simulation';
+import {
+  createSortableRoot,
+  type SortableDropIntent,
+  type SortableDropTransaction,
+  type SortableSource,
+} from './sortable-lists-engine';
+
+function buildList(items:string[]):{ root:HTMLElement; rows:HTMLElement[] } {
+  const root = document.createElement('div');
+  const rows = items.map((id) => {
+    const row = document.createElement('div');
+    row.style.cssText = 'height:20px;';
+    row.textContent = id;
+    root.appendChild(row);
+    return row;
+  });
+  document.body.appendChild(root);
+  return { root, rows };
+}
+
+// A list rendered as its own element inside a wrapping root, for cross-list
+// scenarios where the root spans multiple `registerList` instances.
+function buildListIn(root:HTMLElement, items:string[]):{ element:HTMLElement; rows:HTMLElement[] } {
+  const element = document.createElement('div');
+  const rows = items.map((id) => {
+    const row = document.createElement('div');
+    row.style.cssText = 'height:20px;';
+    row.textContent = id;
+    element.appendChild(row);
+    return row;
+  });
+  root.appendChild(element);
+  return { element, rows };
+}
+
+// A horizontal list of fixed-width chips, for axis:'horizontal' scenarios.
+function buildHorizontalList(items:string[]):{ root:HTMLElement; chips:HTMLElement[] } {
+  const root = document.createElement('div');
+  root.style.cssText = 'white-space:nowrap;';
+  const chips = items.map((id) => {
+    const chip = document.createElement('div');
+    chip.style.cssText = 'display:inline-block; width:40px; height:20px;';
+    chip.textContent = id;
+    root.appendChild(chip);
+    return chip;
+  });
+  document.body.appendChild(root);
+  return { root, chips };
+}
+
+// A horizontal list of fixed-width chips inside a fixed-width flex-wrap
+// container, wrapping onto multiple rows — like the autocompleter's chips.
+function buildWrappingHorizontalList(items:string[], containerWidth:number):{ root:HTMLElement; chips:HTMLElement[] } {
+  const root = document.createElement('div');
+  root.style.cssText = `display:flex; flex-wrap:wrap; width:${containerWidth}px; padding-bottom:60px;`;
+  const chips = items.map((id) => {
+    const chip = document.createElement('div');
+    chip.style.cssText = 'width:40px; height:20px; margin:2px;';
+    chip.textContent = id;
+    root.appendChild(chip);
+    return chip;
+  });
+  document.body.appendChild(root);
+  return { root, chips };
+}
+
+describe('createSortableRoot', () => {
+  let cleanupFns:(() => void)[] = [];
+
+  afterEach(() => {
+    cleanupFns.forEach((fn) => fn());
+    cleanupFns = [];
+    document.body.replaceChildren();
+  });
+
+  function setup(items:string[] = ['a', 'b', 'c'], opts:{ accepts?:(args:{ source:SortableSource }) => boolean } = {}) {
+    const { root, rows } = buildList(items);
+    const intents:SortableDropIntent[] = [];
+    const cancels:SortableSource[] = [];
+    const transactions:SortableDropTransaction[] = [];
+
+    const sortableRoot = createSortableRoot({
+      element: root,
+      onDrop: (transaction) => {
+        intents.push(transaction.intent);
+        transactions.push(transaction);
+      },
+      onCancel: (source) => cancels.push(source),
+    });
+
+    const listCleanup = sortableRoot.registerList({ element: root, listId: 'l1', accepts: opts.accepts });
+    const itemCleanups = rows.map((row, index) => sortableRoot.registerItem({
+      element: row,
+      itemId: items[index],
+      listId: 'l1',
+    }));
+
+    cleanupFns.push(listCleanup, ...itemCleanups, () => sortableRoot.destroy());
+
+    return {
+      root, rows, intents, cancels, transactions, sortableRoot,
+    };
+  }
+
+  // Two lists ('l1', 'l2') sharing one root, for cross-list transaction
+  // scenarios (busy gating, `accepts`, settlement across list boundaries).
+  function setupTwoLists(opts:{
+    itemsA?:string[];
+    itemsB?:string[];
+    acceptsB?:(args:{ source:SortableSource }) => boolean;
+  } = {}) {
+    const itemsA = opts.itemsA ?? ['a1', 'a2'];
+    const itemsB = opts.itemsB ?? ['b1', 'b2'];
+
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const listA = buildListIn(root, itemsA);
+    const listB = buildListIn(root, itemsB);
+
+    const intents:SortableDropIntent[] = [];
+    const transactions:SortableDropTransaction[] = [];
+
+    const sortableRoot = createSortableRoot({
+      element: root,
+      onDrop: (transaction) => {
+        intents.push(transaction.intent);
+        transactions.push(transaction);
+      },
+    });
+
+    const cleanupA = sortableRoot.registerList({ element: listA.element, listId: 'l1' });
+    const cleanupB = sortableRoot.registerList({ element: listB.element, listId: 'l2', accepts: opts.acceptsB });
+    const itemCleanupsA = listA.rows.map((row, index) => sortableRoot.registerItem({
+      element: row,
+      itemId: itemsA[index],
+      listId: 'l1',
+    }));
+    const itemCleanupsB = listB.rows.map((row, index) => sortableRoot.registerItem({
+      element: row,
+      itemId: itemsB[index],
+      listId: 'l2',
+    }));
+
+    cleanupFns.push(cleanupA, cleanupB, ...itemCleanupsA, ...itemCleanupsB, () => sortableRoot.destroy());
+
+    return {
+      root, listA, listB, intents, transactions, sortableRoot,
+    };
+  }
+
+  it('resolves a bottom-edge item drop to exactly one intent', async () => {
+    const { rows, intents } = setup();
+    const simulation = new NativeDragSimulation(rows[0]);
+
+    await simulation.start();
+    await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+    expect(intents).toEqual([{
+      sourceId: 'a',
+      sourceListId: 'l1',
+      targetListId: 'l1',
+      targetItemId: 'c',
+      edge: 'bottom',
+    }]);
+  });
+
+  it('resolves a drop on container space to an append intent', async () => {
+    const { root, rows, intents } = setup();
+    root.style.cssText = 'padding-bottom:40px;';
+    const simulation = new NativeDragSimulation(rows[0]);
+    const rootRect = root.getBoundingClientRect();
+    const belowRows = { x: rootRect.left + rootRect.width / 2, y: rootRect.bottom - 5 };
+
+    await simulation.start();
+    await simulation.drop(root, belowRows);
+
+    expect(intents).toEqual([{
+      sourceId: 'a',
+      sourceListId: 'l1',
+      targetListId: 'l1',
+      targetItemId: null,
+      edge: null,
+    }]);
+  });
+
+  it('self-drop produces no intent', async () => {
+    const { rows, intents } = setup();
+    const simulation = new NativeDragSimulation(rows[1]);
+
+    await simulation.start();
+    await simulation.drop(rows[1], centerOf(rows[1]));
+
+    expect(intents).toEqual([]);
+  });
+
+  it('drop outside every registered list cancels', async () => {
+    const { rows, intents, cancels } = setup();
+    const outside = document.createElement('div');
+    outside.style.cssText = 'position:fixed; top:500px; left:500px; width:50px; height:50px;';
+    document.body.appendChild(outside);
+    const simulation = new NativeDragSimulation(rows[0]);
+
+    await simulation.start();
+    await simulation.drop(outside, centerOf(outside));
+
+    expect(cancels).toEqual([{ itemId: 'a', listId: 'l1', element: rows[0] }]);
+    expect(intents).toEqual([]);
+  });
+
+  it('writes the dragging and indicator attributes', async () => {
+    const { rows } = setup();
+    const simulation = new NativeDragSimulation(rows[0]);
+
+    await simulation.start();
+    expect(rows[0].dataset.dragging).toBe('source');
+
+    await simulation.dragOver(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+    expect(rows[2].getAttribute('data-drop-position')).toBe('bottom');
+    expect(rows[2].getAttribute('data-drop-position-owner')).toBe('c');
+
+    await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+    expect(rows[0].hasAttribute('data-dragging')).toBe(false);
+    expect(rows[2].hasAttribute('data-drop-position')).toBe(false);
+  });
+
+  it('data-drop-container is active only for a list-only target', async () => {
+    const { root, rows } = setup();
+    root.style.cssText = 'padding-bottom:40px;';
+    const simulation = new NativeDragSimulation(rows[0]);
+
+    await simulation.start();
+
+    await simulation.dragOver(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+    expect(root.hasAttribute('data-drop-container')).toBe(false);
+
+    const rootRect = root.getBoundingClientRect();
+    const belowRows = { x: rootRect.left + rootRect.width / 2, y: rootRect.bottom - 5 };
+    await simulation.dragOver(root, belowRows);
+    expect(root.getAttribute('data-drop-container')).toBe('active');
+    expect(rows[2].hasAttribute('data-drop-position')).toBe(false);
+
+    await simulation.cancel();
+  });
+
+  it('suppresses the drop indicator while hovering the drag source itself', async () => {
+    const { rows } = setup();
+    const simulation = new NativeDragSimulation(rows[0]);
+
+    await simulation.start();
+    expect(rows[0].dataset.dragging).toBe('source');
+
+    // The row is still a valid drop target (canDrop must accept self), but
+    // must not render a drop-position line on itself.
+    await simulation.dragOver(rows[0], centerOf(rows[0]));
+
+    expect(rows[0].dataset.dragging).toBe('source');
+    expect(rows[0].hasAttribute('data-drop-position')).toBe(false);
+    expect(rows[0].hasAttribute('data-drop-position-owner')).toBe(false);
+
+    await simulation.cancel();
+  });
+
+  it('destroy is idempotent and unregisters every registration', async () => {
+    const { rows, intents, sortableRoot } = setup();
+
+    expect(() => {
+      sortableRoot.destroy();
+      sortableRoot.destroy();
+    }).not.toThrow();
+
+    const simulation = new NativeDragSimulation(rows[0]);
+    await simulation.start();
+    await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+    expect(intents).toEqual([]);
+  });
+
+  describe('teardown', () => {
+    it('destroying with a pending transaction clears busy and allows a fresh root to drag', async () => {
+      const { root, rows, transactions, sortableRoot } = setup();
+      const simulation = new NativeDragSimulation(rows[0]);
+
+      await simulation.start();
+      await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+      expect(root.getAttribute('data-sortable-lists-busy')).toBe('true');
+      // Deliberately never completed nor finalized — a real teardown race
+      // (e.g. Angular tearing down mid-drop) can leave a transaction pending.
+      expect(transactions).toHaveLength(1);
+
+      sortableRoot.destroy();
+      expect(root.hasAttribute('data-sortable-lists-busy')).toBe(false);
+
+      // A fresh engine bound to the same element must not read the busy
+      // attribute (which lives on the shared DOM node) as stranded.
+      const freshIntents:SortableDropIntent[] = [];
+      const freshRoot = createSortableRoot({
+        element: root,
+        onDrop: (transaction) => freshIntents.push(transaction.intent),
+      });
+      const freshListCleanup = freshRoot.registerList({ element: root, listId: 'l1' });
+      const freshItemCleanups = rows.map((row, index) => freshRoot.registerItem({
+        element: row,
+        itemId: ['a', 'b', 'c'][index],
+        listId: 'l1',
+      }));
+      cleanupFns.push(freshListCleanup, ...freshItemCleanups, () => freshRoot.destroy());
+
+      const freshSimulation = new NativeDragSimulation(rows[0]);
+      await freshSimulation.start();
+      await freshSimulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+      expect(freshIntents).toEqual([{
+        sourceId: 'a', sourceListId: 'l1', targetListId: 'l1', targetItemId: 'c', edge: 'bottom',
+      }]);
+    });
+
+    it('registerList and registerItem are inert no-ops after destroy', async () => {
+      const { root, rows, sortableRoot } = setup();
+
+      sortableRoot.destroy();
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const lateListCleanup = sortableRoot.registerList({ element: root, listId: 'late' });
+        const lateItemCleanup = sortableRoot.registerItem({ element: rows[0], itemId: 'late-a', listId: 'late' });
+
+        expect(() => {
+          lateListCleanup();
+          lateItemCleanup();
+        }).not.toThrow();
+
+        // A real registration would attach a Pragmatic autoscroll adapter,
+        // which warns on this non-scrollable root — its absence proves
+        // nothing was registered.
+        expect(warn).not.toHaveBeenCalled();
+
+        const simulation = new NativeDragSimulation(rows[0]);
+        await simulation.start();
+        await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+        expect(rows[0].hasAttribute('data-dragging')).toBe(false);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe('transaction lifecycle', () => {
+    it('defers completion resolution past a synchronous complete() call', async () => {
+      const { root, rows } = buildList(['a', 'b', 'c']);
+      const order:string[] = [];
+
+      const sortableRoot = createSortableRoot({
+        element: root,
+        onDrop: (transaction) => {
+          // Attach before completing, so the reaction is scheduled the
+          // moment the transaction actually resolves.
+          void transaction.completion.then(() => order.push('completion'));
+          transaction.complete(true);
+          // Queued after complete() in the same synchronous callback — only
+          // proves the deferral if complete() doesn't resolve eagerly.
+          queueMicrotask(() => order.push('queued-after-complete'));
+        },
+      });
+      const listCleanup = sortableRoot.registerList({ element: root, listId: 'l1' });
+      const itemCleanups = rows.map((row, index) => sortableRoot.registerItem({
+        element: row,
+        itemId: ['a', 'b', 'c'][index],
+        listId: 'l1',
+      }));
+      cleanupFns.push(listCleanup, ...itemCleanups, () => sortableRoot.destroy());
+
+      const simulation = new NativeDragSimulation(rows[0]);
+      await simulation.start();
+      await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+      // complete() defers its own resolution by one microtask hop, so the
+      // microtask queued right after it in onDrop still runs first.
+      expect(order).toEqual(['queued-after-complete', 'completion']);
+    });
+
+    it('complete is idempotent; the first call wins', async () => {
+      const { rows, transactions } = setup();
+      const simulation = new NativeDragSimulation(rows[0]);
+
+      await simulation.start();
+      await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+      const transaction = transactions[0];
+      transaction.complete(true);
+      transaction.complete(false);
+
+      await expect(transaction.completion).resolves.toBe(true);
+    });
+
+    it('finalize is idempotent', async () => {
+      const { root, rows, transactions } = setup();
+      const simulation = new NativeDragSimulation(rows[0]);
+
+      await simulation.start();
+      await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+      const transaction = transactions[0];
+
+      expect(() => {
+        transaction.finalize();
+        transaction.finalize();
+      }).not.toThrow();
+
+      transaction.complete(true);
+      await transaction.completion;
+
+      expect(root.hasAttribute('data-sortable-lists-busy')).toBe(false);
+    });
+
+    it('busy gates a second drag until both sides settle', async () => {
+      const { listA, listB, root, transactions } = setupTwoLists();
+
+      const simulation = new NativeDragSimulation(listA.rows[0]);
+      await simulation.start();
+      await simulation.drop(listB.rows[0], towardsEdgeOf(listB.rows[0], 'top'));
+
+      expect(root.getAttribute('data-sortable-lists-busy')).toBe('true');
+      expect(transactions).toHaveLength(1);
+      const transaction = transactions[0];
+
+      // A second drag attempt while busy resolves no intent.
+      const second = new NativeDragSimulation(listA.rows[1]);
+      await second.start();
+      await second.drop(listB.rows[1], towardsEdgeOf(listB.rows[1], 'top'));
+      expect(transactions).toHaveLength(1);
+
+      // Target side settles, source side does not: still busy, still gated.
+      transaction.complete(true);
+      await transaction.completion;
+      expect(root.getAttribute('data-sortable-lists-busy')).toBe('true');
+
+      const third = new NativeDragSimulation(listA.rows[1]);
+      await third.start();
+      await third.drop(listB.rows[1], towardsEdgeOf(listB.rows[1], 'top'));
+      expect(transactions).toHaveLength(1);
+
+      // Source side finalizes: busy releases and dragging works again.
+      transaction.finalize();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(root.hasAttribute('data-sortable-lists-busy')).toBe(false);
+
+      const fourth = new NativeDragSimulation(listA.rows[1]);
+      await fourth.start();
+      await fourth.drop(listB.rows[1], towardsEdgeOf(listB.rows[1], 'top'));
+      expect(transactions).toHaveLength(2);
+    });
+
+    it('same-list transactions settle on complete alone', async () => {
+      const { root, rows, transactions } = setup();
+      const simulation = new NativeDragSimulation(rows[0]);
+
+      await simulation.start();
+      await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+      expect(root.getAttribute('data-sortable-lists-busy')).toBe('true');
+
+      const transaction = transactions[0];
+      transaction.complete(true);
+      await transaction.completion;
+
+      expect(root.hasAttribute('data-sortable-lists-busy')).toBe(false);
+    });
+
+    it('resolves a cross-list drop intent', async () => {
+      const { listA, listB, transactions } = setupTwoLists();
+
+      const simulation = new NativeDragSimulation(listA.rows[0]);
+      await simulation.start();
+      await simulation.drop(listB.rows[0], towardsEdgeOf(listB.rows[0], 'top'));
+
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0].intent).toMatchObject({
+        sourceListId: 'l1',
+        targetListId: 'l2',
+      });
+
+      // Settle explicitly so the 10s diagnostic timer doesn't leak past this test.
+      const transaction = transactions[0];
+      transaction.complete(true);
+      transaction.finalize();
+      await transaction.completion;
+    });
+
+    it('accepts gates both the item and container drop targets of the list', async () => {
+      const { listA, listB, transactions } = setupTwoLists({ acceptsB: () => false });
+
+      const simulation = new NativeDragSimulation(listA.rows[0]);
+      await simulation.start();
+
+      // Mid-drag: no indicator on the rejected list's item target.
+      await simulation.dragOver(listB.rows[0], towardsEdgeOf(listB.rows[0], 'top'));
+      expect(listB.rows[0].hasAttribute('data-drop-position')).toBe(false);
+
+      await simulation.drop(listB.rows[0], towardsEdgeOf(listB.rows[0], 'top'));
+      expect(transactions).toEqual([]);
+
+      // Container space of the same list is gated too.
+      const second = new NativeDragSimulation(listA.rows[1]);
+      await second.start();
+      listB.element.style.cssText = 'height:20px; padding-bottom:40px;';
+      const listBRect = listB.element.getBoundingClientRect();
+      const belowRows = { x: listBRect.left + listBRect.width / 2, y: listBRect.bottom - 5 };
+      await second.drop(listB.element, belowRows);
+
+      expect(transactions).toEqual([]);
+    });
+
+    it('accepts also gates same-list reorders (no same-list carve-out)', async () => {
+      const { rows, intents } = setup(['a', 'b', 'c'], { accepts: () => false });
+      const simulation = new NativeDragSimulation(rows[0]);
+
+      await simulation.start();
+
+      // Mid-drag: no indicator on the rejected list's own item target, even
+      // though the drag originates from the very same list.
+      await simulation.dragOver(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+      expect(rows[2].hasAttribute('data-drop-position')).toBe(false);
+
+      await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+      expect(intents).toEqual([]);
+    });
+
+    it('accepts gates a drop into an empty list', async () => {
+      const { listA, listB, transactions } = setupTwoLists({ itemsB: [], acceptsB: () => false });
+      const simulation = new NativeDragSimulation(listA.rows[0]);
+
+      await simulation.start();
+
+      listB.element.style.cssText = 'height:40px;';
+      const listBRect = listB.element.getBoundingClientRect();
+      const center = { x: listBRect.left + listBRect.width / 2, y: listBRect.top + listBRect.height / 2 };
+      await simulation.drop(listB.element, center);
+
+      expect(transactions).toEqual([]);
+    });
+
+    it('resolves a cross-list append into a populated list', async () => {
+      const { listA, listB, transactions } = setupTwoLists();
+      listB.element.style.cssText = 'height:20px; padding-bottom:40px;';
+      const simulation = new NativeDragSimulation(listA.rows[0]);
+      const listBRect = listB.element.getBoundingClientRect();
+      const belowRows = { x: listBRect.left + listBRect.width / 2, y: listBRect.bottom - 5 };
+
+      await simulation.start();
+      await simulation.drop(listB.element, belowRows);
+
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0].intent).toEqual({
+        sourceId: 'a1',
+        sourceListId: 'l1',
+        targetListId: 'l2',
+        targetItemId: null,
+        edge: null,
+      });
+
+      const transaction = transactions[0];
+      transaction.complete(true);
+      transaction.finalize();
+      await transaction.completion;
+    });
+
+    it('resolves a cross-list append into an empty list', async () => {
+      const { listA, listB, transactions } = setupTwoLists({ itemsB: [] });
+      listB.element.style.cssText = 'height:40px;';
+      const simulation = new NativeDragSimulation(listA.rows[0]);
+      const listBRect = listB.element.getBoundingClientRect();
+      const center = { x: listBRect.left + listBRect.width / 2, y: listBRect.top + listBRect.height / 2 };
+
+      await simulation.start();
+      await simulation.drop(listB.element, center);
+
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0].intent).toEqual({
+        sourceId: 'a1',
+        sourceListId: 'l1',
+        targetListId: 'l2',
+        targetItemId: null,
+        edge: null,
+      });
+
+      const transaction = transactions[0];
+      transaction.complete(true);
+      transaction.finalize();
+      await transaction.completion;
+    });
+
+    it('logs a diagnostic for an unsettled transaction after 10s', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      try {
+        // Fake only the timer the diagnostic relies on: the drag simulation
+        // still needs real animation frames to progress.
+        vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+        const { root, rows, transactions } = setup();
+        const simulation = new NativeDragSimulation(rows[0]);
+        await simulation.start();
+        await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+        const transaction = transactions[0];
+        vi.advanceTimersByTime(10_000);
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining(transaction.id));
+        expect(root.getAttribute('data-sortable-lists-busy')).toBe('true');
+      } finally {
+        vi.useRealTimers();
+        warn.mockRestore();
+      }
+    });
+
+    it('destroy cancels a pending unsettled-transaction diagnostic', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      try {
+        // Fake only the timer the diagnostic relies on: the drag simulation
+        // still needs real animation frames to progress.
+        vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+        const { rows, transactions, sortableRoot } = setup();
+        const simulation = new NativeDragSimulation(rows[0]);
+        await simulation.start();
+        await simulation.drop(rows[2], towardsEdgeOf(rows[2], 'bottom'));
+
+        const transaction = transactions[0];
+        warn.mockClear(); // drop the unrelated "Auto scrolling..." registration noise
+
+        // Never settled: destroy() must cancel its diagnostic timer instead
+        // of leaving it to warn after the root is already torn down.
+        sortableRoot.destroy();
+        vi.advanceTimersByTime(10_000);
+
+        expect(warn).not.toHaveBeenCalledWith(expect.stringContaining(transaction.id));
+      } finally {
+        vi.useRealTimers();
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe('bounded stickiness (item→list handoff)', () => {
+    it('sticky item target releases beyond the items span (vertical)', async () => {
+      const { root, rows } = setup();
+      root.style.cssText = 'padding-bottom:40px;';
+      const simulation = new NativeDragSimulation(rows[0]);
+      const lastRect = rows[2].getBoundingClientRect();
+      const midSpanPoint = centerOf(rows[2]);
+
+      await simulation.start();
+      await simulation.dragOver(rows[2], midSpanPoint);
+      expect(rows[2].hasAttribute('data-drop-position')).toBe(true);
+
+      // Dispatched on the list element itself (a gap between rows), but the
+      // coordinate is still within the items span: the item stays sticky.
+      await simulation.dragOver(root, midSpanPoint);
+      expect(rows[2].hasAttribute('data-drop-position')).toBe(true);
+      expect(root.hasAttribute('data-drop-container')).toBe(false);
+
+      // 30px past the last row, still inside the root's own padding: beyond
+      // the span, so the list's container target takes over.
+      const beyondSpan = { x: midSpanPoint.x, y: lastRect.bottom + 30 };
+      await simulation.dragOver(root, beyondSpan);
+      expect(rows[2].hasAttribute('data-drop-position')).toBe(false);
+      expect(root.getAttribute('data-drop-container')).toBe('active');
+
+      await simulation.cancel();
+    });
+
+    it('sticky handoff works horizontally', async () => {
+      const { root, chips } = buildHorizontalList(['a', 'b', 'c']);
+      root.style.cssText = 'white-space:nowrap; padding-right:40px;';
+      const intents:SortableDropIntent[] = [];
+
+      const sortableRoot = createSortableRoot({
+        element: root,
+        axis: 'horizontal',
+        onDrop: (transaction) => intents.push(transaction.intent),
+      });
+      const listCleanup = sortableRoot.registerList({ element: root, listId: 'l1' });
+      const itemCleanups = chips.map((chip, index) => sortableRoot.registerItem({
+        element: chip,
+        itemId: ['a', 'b', 'c'][index],
+        listId: 'l1',
+      }));
+      cleanupFns.push(listCleanup, ...itemCleanups, () => sortableRoot.destroy());
+
+      const simulation = new NativeDragSimulation(chips[0]);
+      const lastRect = chips[2].getBoundingClientRect();
+      const midSpanPoint = centerOf(chips[2]);
+
+      await simulation.start();
+      await simulation.dragOver(chips[2], midSpanPoint);
+      expect(chips[2].hasAttribute('data-drop-position')).toBe(true);
+
+      // Same handoff as the vertical case, along the horizontal axis.
+      await simulation.dragOver(root, midSpanPoint);
+      expect(chips[2].hasAttribute('data-drop-position')).toBe(true);
+      expect(root.hasAttribute('data-drop-container')).toBe(false);
+
+      const beyondSpan = { x: lastRect.right + 30, y: midSpanPoint.y };
+      await simulation.dragOver(root, beyondSpan);
+      expect(chips[2].hasAttribute('data-drop-position')).toBe(false);
+      expect(root.getAttribute('data-drop-container')).toBe('active');
+
+      await simulation.drop(root, beyondSpan);
+      expect(intents).toEqual([{
+        sourceId: 'a',
+        sourceListId: 'l1',
+        targetListId: 'l1',
+        targetItemId: null,
+        edge: null,
+      }]);
+    });
+
+    it('handoff releases before the first item (leading edge)', async () => {
+      const { root, rows } = setup();
+      root.style.cssText = 'padding-top:40px;';
+      const simulation = new NativeDragSimulation(rows[2]);
+      const firstRect = rows[0].getBoundingClientRect();
+
+      await simulation.start();
+
+      // Above the first item, but still inside the root's own padding-top —
+      // the leading edge of the items span.
+      const aboveFirst = { x: centerOf(rows[0]).x, y: firstRect.top - 20 };
+      await simulation.dragOver(root, aboveFirst);
+
+      expect(rows[0].hasAttribute('data-drop-position')).toBe(false);
+      expect(root.getAttribute('data-drop-container')).toBe('active');
+
+      await simulation.cancel();
+    });
+
+    it('wrap-aware: releases stickiness for blank space beyond the union rect of wrapped rows', async () => {
+      // Container fits exactly two 40px chips per row (44px with margin), so
+      // 'a'/'b' occupy row one and 'c' wraps onto row two.
+      const { root, chips } = buildWrappingHorizontalList(['a', 'b', 'c'], 92);
+      const intents:SortableDropIntent[] = [];
+
+      const sortableRoot = createSortableRoot({
+        element: root,
+        axis: 'horizontal',
+        onDrop: (transaction) => intents.push(transaction.intent),
+      });
+      const listCleanup = sortableRoot.registerList({ element: root, listId: 'l1' });
+      const itemCleanups = chips.map((chip, index) => sortableRoot.registerItem({
+        element: chip,
+        itemId: ['a', 'b', 'c'][index],
+        listId: 'l1',
+      }));
+      cleanupFns.push(listCleanup, ...itemCleanups, () => sortableRoot.destroy());
+
+      const firstRowRect = chips[0].getBoundingClientRect();
+      const secondRowRect = chips[2].getBoundingClientRect();
+      expect(secondRowRect.top).toBeGreaterThan(firstRowRect.top); // sanity: actually wrapped
+
+      const simulation = new NativeDragSimulation(chips[0]);
+      await simulation.start();
+
+      await simulation.dragOver(chips[2], centerOf(chips[2]));
+      expect(chips[2].hasAttribute('data-drop-position')).toBe(true);
+
+      // Below the wrapped rows, in the container's trailing blank space. The
+      // X coordinate still falls in the first row's extent, so a root-axis-
+      // only bound would falsely keep the second row's chip sticky here.
+      const beyondUnion = { x: centerOf(chips[0]).x, y: secondRowRect.bottom + 30 };
+      await simulation.dragOver(root, beyondUnion);
+      expect(chips[2].hasAttribute('data-drop-position')).toBe(false);
+      expect(root.getAttribute('data-drop-container')).toBe('active');
+
+      await simulation.drop(root, beyondUnion);
+      expect(intents).toEqual([{
+        sourceId: 'a',
+        sourceListId: 'l1',
+        targetListId: 'l1',
+        targetItemId: null,
+        edge: null,
+      }]);
+    });
+  });
+
+  describe('drag-start gating', () => {
+    it('drag does not start from an interactive descendant', async () => {
+      const { rows } = setup(['a']);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = 'Actions';
+      button.style.cssText = 'display:block; width:16px; height:16px;';
+      rows[0].appendChild(button);
+
+      const simulation = new NativeDragSimulation(rows[0]);
+      await simulation.start(centerOf(button));
+
+      expect(rows[0].hasAttribute('data-dragging')).toBe(false);
+    });
+
+    it('consumer canDrag gate composes', async () => {
+      const { root, rows } = buildList(['a', 'b']);
+      const sortableRoot = createSortableRoot({ element: root, onDrop: () => undefined });
+      const listCleanup = sortableRoot.registerList({ element: root, listId: 'l1' });
+      const itemCleanupA = sortableRoot.registerItem({
+        element: rows[0], itemId: 'a', listId: 'l1', canDrag: () => false,
+      });
+      const itemCleanupB = sortableRoot.registerItem({ element: rows[1], itemId: 'b', listId: 'l1' });
+      cleanupFns.push(listCleanup, itemCleanupA, itemCleanupB, () => sortableRoot.destroy());
+
+      const blocked = new NativeDragSimulation(rows[0]);
+      await blocked.start();
+      expect(rows[0].hasAttribute('data-dragging')).toBe(false);
+
+      const allowed = new NativeDragSimulation(rows[1]);
+      await allowed.start();
+      expect(rows[1].dataset.dragging).toBe('source');
+
+      await allowed.cancel();
+    });
+  });
+
+  describe('custom preview factory', () => {
+    it('custom preview factory renders and cleans up', async () => {
+      const cleanup = vi.fn();
+      const calls:{ source:SortableSource; container:HTMLElement }[] = [];
+      let previewPresentAtDragStart = false;
+
+      const { root, rows } = buildList(['a', 'b']);
+      const sortableRoot = createSortableRoot({
+        element: root,
+        preview: ({ source, container }) => {
+          calls.push({ source, container });
+          container.append(Object.assign(document.createElement('div'), {
+            className: 'test-preview',
+            textContent: source.itemId,
+          }));
+          return cleanup;
+        },
+        onDragStarted: () => {
+          // The preview is still mounted at this exact synchronous point —
+          // the only observable window before Pragmatic tears it down.
+          previewPresentAtDragStart = document.querySelector('.test-preview') !== null;
+        },
+        onDrop: () => undefined,
+      });
+      const listCleanup = sortableRoot.registerList({ element: root, listId: 'l1' });
+      const itemCleanups = rows.map((row, index) => sortableRoot.registerItem({
+        element: row,
+        itemId: ['a', 'b'][index],
+        listId: 'l1',
+      }));
+      cleanupFns.push(listCleanup, ...itemCleanups, () => sortableRoot.destroy());
+
+      const simulation = new NativeDragSimulation(rows[0]);
+      await simulation.start();
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].source).toMatchObject({ itemId: 'a', listId: 'l1' });
+      expect(calls[0].container).toBeInstanceOf(HTMLElement);
+      expect(previewPresentAtDragStart).toBe(true);
+
+      await simulation.drop(rows[1], towardsEdgeOf(rows[1], 'bottom'));
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/common/drag-and-drop/sortable-lists-engine.ts
+++ b/frontend/src/common/drag-and-drop/sortable-lists-engine.ts
@@ -1,0 +1,506 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
+import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
+import { registerAutoScroll, type AutoScrollAllowedAxis } from 'core-common/drag-and-drop/auto-scroll';
+import { clearDropIndicator, renderDropIndicator } from 'core-common/drag-and-drop/drop-indicator';
+import { createSortableItemPayloadScope, type SortableItemData } from 'core-common/drag-and-drop/payload';
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+  type Edge,
+  type SortableAxis,
+} from 'core-common/drag-and-drop/reorder';
+import { closestInteractiveElement } from 'core-common/interactive-element-helper';
+
+export type CleanupFn = () => void;
+
+export interface SortableSource {
+  itemId:string;
+  listId:string;
+  element:HTMLElement;
+}
+
+export interface SortableDropIntent {
+  sourceId:string;
+  sourceListId:string;
+  targetListId:string;
+  targetItemId:string|null;   // null = container drop → append
+  edge:Edge|null;
+}
+
+export interface SortableDropTransaction {
+  id:string;
+  intent:SortableDropIntent;
+  complete(success:boolean):void;   // idempotent; resolves after onDrop returns
+  completion:Promise<boolean>;
+  finalize():void;                  // idempotent; source-side settlement
+}
+
+export type PreviewFactory = (args:{
+  source:SortableSource;
+  container:HTMLElement;
+}) => CleanupFn|void;
+
+export interface SortableRootOptions {
+  element:HTMLElement;
+  axis?:SortableAxis;               // default 'vertical'
+  preview?:'native'|PreviewFactory; // default 'native'
+  onDragStarted?:(source:SortableSource) => void;
+  onCancel?:(source:SortableSource) => void;
+  onDrop:(transaction:SortableDropTransaction) => void;
+}
+
+export interface SortableRoot {
+  registerList(opts:{
+    element:HTMLElement;
+    listId:string;
+    accepts?:(args:{ source:SortableSource }) => boolean;
+    scrollContainer?:Element;
+  }):CleanupFn;
+  registerItem(opts:{
+    element:HTMLElement;
+    itemId:string;
+    listId:string;
+    canDrag?:(args:{ element:HTMLElement; pointer:{ clientX:number; clientY:number } }) => boolean;
+  }):CleanupFn;
+  addScrollContainer(element:Element, axis?:AutoScrollAllowedAxis):CleanupFn;
+  destroy():void;
+}
+
+function allowedEdgesForAxis(axis:SortableAxis):Edge[] {
+  return axis === 'horizontal' ? ['left', 'right'] : ['top', 'bottom'];
+}
+
+interface UnionRect {
+  left:number;
+  right:number;
+  top:number;
+  bottom:number;
+}
+
+export function createSortableRoot(options:SortableRootOptions):SortableRoot {
+  const axis = options.axis ?? 'vertical';
+  const allowedEdges = allowedEdgesForAxis(axis);
+  const scope = createSortableItemPayloadScope();
+  const listDataKey = Symbol('op-sortable-list');
+  const lists = new Map<string, { element:HTMLElement; accepts?:(args:{ source:SortableSource }) => boolean }>();
+  // Registered item elements per list, for the bounded-stickiness union rect
+  // below. Insertion order is irrelevant — it's a geometric min/max.
+  const listItems = new Map<string, Set<HTMLElement>>();
+  let transactionCounter = 0;
+  let destroyed = false;
+  const cleanups:CleanupFn[] = [];
+
+  // Registers `fn` for `destroy()`; the returned handle deregisters itself
+  // too, so a caller-invoked cleanup never double-runs.
+  const track = (fn:CleanupFn):CleanupFn => {
+    let done = false;
+    const wrapped = ():void => {
+      if (done) {
+        return;
+      }
+      done = true;
+      const index = cleanups.indexOf(wrapped);
+      if (index !== -1) {
+        cleanups.splice(index, 1);
+      }
+      fn();
+    };
+    cleanups.push(wrapped);
+    return wrapped;
+  };
+
+  const isListData = (data:Record<string|symbol, unknown>):data is { listId:string } =>
+    data[listDataKey] === true && typeof data.listId === 'string';
+
+  const sourceOf = (data:SortableItemData, element:Element):SortableSource => ({
+    itemId: data.itemId, listId: data.listId, element: element as HTMLElement,
+  });
+
+  // Busy = a transaction is in flight and not yet settled; blocks any
+  // further drag so a second drop can never race the first (spec §A).
+  const isBusy = ():boolean => options.element.hasAttribute('data-sortable-lists-busy');
+  const setBusy = (busy:boolean):void => {
+    if (busy) {
+      options.element.setAttribute('data-sortable-lists-busy', 'true');
+    } else {
+      options.element.removeAttribute('data-sortable-lists-busy');
+    }
+  };
+
+  // `accepts` gates EVERY drop into this list, including same-list reorders —
+  // a list may allow dragging its own items OUT while still rejecting drops
+  // back into itself (e.g. a filtered/read-only view). No same-list carve-out.
+  const admits = (
+    accepts:((args:{ source:SortableSource }) => boolean)|undefined,
+    data:SortableItemData,
+    element:Element,
+  ):boolean => !accepts || accepts({ source: sourceOf(data, element) });
+
+  // Bounded stickiness (spec §item→list handoff): an item target holds
+  // selection via `getIsSticky` while the pointer is within the CURRENT union
+  // rect of its list's items, over BOTH axes — a root-axis-only bound would
+  // misread cross-axis blank space on a wrapped row (flex-wrap chips) as
+  // "within span". Recomputed geometrically, not by registration order (a
+  // stable `@for` track reorders DOM without re-running `ngOnInit`), and
+  // cached per animation frame.
+  let frameCacheToken:number|null = null;
+  const unionRectCache = new Map<string, UnionRect|null>();
+
+  const clearFrameCache = ():void => {
+    frameCacheToken = null;
+    unionRectCache.clear();
+  };
+
+  const unionRectOfListItems = (listId:string):UnionRect|null => {
+    frameCacheToken ??= requestAnimationFrame(clearFrameCache);
+    if (unionRectCache.has(listId)) {
+      return unionRectCache.get(listId) ?? null;
+    }
+
+    const items = listItems.get(listId);
+    if (!items || items.size === 0) {
+      unionRectCache.set(listId, null);
+      return null;
+    }
+
+    let left = Infinity;
+    let right = -Infinity;
+    let top = Infinity;
+    let bottom = -Infinity;
+    items.forEach((element) => {
+      const rect = element.getBoundingClientRect();
+      left = Math.min(left, rect.left);
+      right = Math.max(right, rect.right);
+      top = Math.min(top, rect.top);
+      bottom = Math.max(bottom, rect.bottom);
+    });
+
+    const unionRect:UnionRect = {
+      left, right, top, bottom,
+    };
+    unionRectCache.set(listId, unionRect);
+    return unionRect;
+  };
+
+  const withinItemsSpan = (input:{ clientX:number; clientY:number }, listId:string):boolean => {
+    const rect = unionRectOfListItems(listId);
+    if (!rect) {
+      return false;
+    }
+
+    return input.clientX >= rect.left && input.clientX <= rect.right
+      && input.clientY >= rect.top && input.clientY <= rect.bottom;
+  };
+
+  const createTransaction = (intent:SortableDropIntent):SortableDropTransaction => {
+    transactionCounter += 1;
+    const id = `op-sortable-txn-${transactionCounter}`;
+    // Same-list moves have no separate source to settle, so completing the
+    // target side is enough — a caller that never calls `finalize()` here
+    // must not leave the root stuck busy.
+    const sameList = intent.sourceListId === intent.targetListId;
+    let completed = false;
+    let finalized = false;
+    let resolveCompletion!:(success:boolean) => void;
+    const completion = new Promise<boolean>((resolve) => {
+      resolveCompletion = resolve;
+    });
+
+    setBusy(true);
+    const diagnostic = window.setTimeout(() => {
+      console.warn(`Sortable transaction ${id} neither completed nor finalized after 10s.`);
+    }, 10_000);
+    // Tracked so `destroy()` cancels a still-pending diagnostic (e.g. the
+    // consumer navigates away mid-drop) instead of leaking a timer that
+    // outlives the root.
+    const clearDiagnostic = track(() => window.clearTimeout(diagnostic));
+
+    const trySettle = ():void => {
+      if (completed && (finalized || sameList)) {
+        clearDiagnostic();
+        setBusy(false);
+      }
+    };
+
+    return {
+      id,
+      intent,
+      completion,
+      complete(success:boolean):void {
+        if (completed) {
+          return;
+        }
+        completed = true;
+        // Deferred so a synchronous `complete()` call inside the consumer's
+        // `onDrop` cannot outrun that same callback's own emissions.
+        queueMicrotask(() => {
+          resolveCompletion(success);
+          trySettle();
+        });
+      },
+      finalize():void {
+        if (finalized) {
+          return;
+        }
+        finalized = true;
+        queueMicrotask(trySettle);
+      },
+    };
+  };
+
+  // Root monitor: THE single drop-resolution point (spec §A). Tracked so
+  // `destroy()` stays uniform and never re-invokes it.
+  track(monitorForElements({
+    canMonitor: ({ source }) => !isBusy() && scope.isItemData(source.data),
+    onDrop: ({ source, location }) => {
+      preventUnhandled.stop();
+      delete source.element.dataset.dragging;
+
+      const data = source.data as SortableItemData;
+      const src = sourceOf(data, source.element);
+      const targets = location.current.dropTargets;
+      const itemTarget = targets.find((t) => scope.isItemData(t.data));
+      const listTarget = targets.find((t) => isListData(t.data));
+
+      if (!itemTarget && !listTarget) {
+        options.onCancel?.(src);          // outside every registered list
+        return;
+      }
+
+      const targetItemData = itemTarget?.data as SortableItemData|undefined;
+      if (targetItemData?.itemId === data.itemId
+          && targetItemData?.listId === data.listId) {
+        return;                           // self-drop: no intent
+      }
+
+      const intent:SortableDropIntent = {
+        sourceId: data.itemId,
+        sourceListId: data.listId,
+        targetListId: targetItemData?.listId
+          ?? (listTarget!.data as unknown as { listId:string }).listId,
+        targetItemId: targetItemData?.itemId ?? null,
+        edge: itemTarget ? extractClosestEdge(itemTarget.data) : null,
+      };
+      options.onDrop(createTransaction(intent));
+    },
+  }));
+
+  return {
+    registerList({
+      element, listId, accepts, scrollContainer,
+    }):CleanupFn {
+      // Angular's teardown order can call this after the root is already
+      // destroyed; a no-op is safer than throwing (matches `registerItem`/
+      // `addScrollContainer` below).
+      if (destroyed) {
+        return () => undefined;
+      }
+
+      lists.set(listId, { element, accepts });
+
+      const clearContainerIndicator = ():void => {
+        delete element.dataset.dropContainer;
+      };
+
+      const syncContainerIndicator = ({ location }:{ location:{ current:{ dropTargets:{ element:Element }[] } } }):void => {
+        if (location.current.dropTargets[0]?.element === element) {
+          element.dataset.dropContainer = 'active';
+        } else {
+          clearContainerIndicator();
+        }
+      };
+
+      const dropTargetCleanup = dropTargetForElements({
+        element,
+        getData: () => ({ [listDataKey]: true, listId }),
+        canDrop: ({ source }) => !isBusy()
+          && scope.isItemData(source.data)
+          && admits(accepts, source.data, source.element),
+        getIsSticky: () => false,
+        onDragEnter: syncContainerIndicator,
+        onDrag: syncContainerIndicator,
+        onDragLeave: clearContainerIndicator,
+        onDrop: clearContainerIndicator,
+      });
+
+      const autoScrollCleanup = registerAutoScroll({
+        element: scrollContainer ?? element,
+        canScroll: ({ source }) => scope.isItemData(source.data),
+        axis,
+      });
+
+      return track(combine(dropTargetCleanup, autoScrollCleanup, () => {
+        lists.delete(listId);
+        clearContainerIndicator();
+      }));
+    },
+
+    registerItem({
+      element, itemId, listId, canDrag,
+    }):CleanupFn {
+      // See the matching guard in `registerList` above.
+      if (destroyed) {
+        return () => undefined;
+      }
+
+      const clearIndicator = ():void => clearDropIndicator(element, itemId);
+
+      // The item accepts itself as a drop target (see canDrop below) so the
+      // root monitor can resolve "self-drop, no intent" vs. "no item target,
+      // fall through to container append" — but the indicator must still
+      // never draw on the row being dragged, so suppression lives here, not
+      // in canDrop.
+      const isSelfSource = (data:Record<string|symbol, unknown>):boolean =>
+        scope.isItemData(data) && data.itemId === itemId && data.listId === listId;
+
+      const itemsForList = listItems.get(listId) ?? new Set<HTMLElement>();
+      itemsForList.add(element);
+      listItems.set(listId, itemsForList);
+
+      const draggableCleanup = draggable({
+        element,
+        // Interactive-descendant suppression composes before the consumer's
+        // own `canDrag`: a pointer over a button/input/link inside the row
+        // must never start a drag, so that descendant keeps native behavior.
+        canDrag: ({ input }) => {
+          if (isBusy()) {
+            return false;
+          }
+          const target = element.ownerDocument.elementFromPoint(input.clientX, input.clientY);
+          if (target instanceof Element && element.contains(target)
+              && closestInteractiveElement(target, element) !== null) {
+            return false;
+          }
+          return canDrag ? canDrag({ element, pointer: { clientX: input.clientX, clientY: input.clientY } }) : true;
+        },
+        getInitialData: () => scope.itemData(itemId, listId),
+        onDragStart: () => {
+          preventUnhandled.start();
+          element.dataset.dragging = 'source';
+          options.onDragStarted?.({ itemId, listId, element });
+        },
+        // Only wired when the consumer supplies a factory; 'native' (or the
+        // unset default) leaves Pragmatic's own browser-native preview alone.
+        ...(typeof options.preview === 'function' ? {
+          onGenerateDragPreview: ({ nativeSetDragImage, source }:{
+            nativeSetDragImage:DataTransfer['setDragImage']|null;
+            source:{ element:Element; data:Record<string|symbol, unknown> };
+          }) => {
+            const factory = options.preview as PreviewFactory;
+            setCustomNativeDragPreview({
+              nativeSetDragImage,
+              render: ({ container }) => factory({
+                source: sourceOf(source.data as SortableItemData, source.element),
+                container,
+              }) ?? undefined,
+            });
+          },
+        } : {}),
+      });
+
+      // No same-item exclusion here: registering as its own drop target lets
+      // the root monitor's self-drop check (not this canDrop) resolve it as
+      // the item target and no-op, rather than falling through to the
+      // list's container-append target.
+      const dropTargetCleanup = dropTargetForElements({
+        element,
+        canDrop: ({ source }) => {
+          if (isBusy() || !scope.isItemData(source.data)) {
+            return false;
+          }
+          const list = lists.get(listId);
+          return admits(list?.accepts, source.data, source.element);
+        },
+        getData: ({ input }) => attachClosestEdge(scope.itemData(itemId, listId), {
+          element,
+          input,
+          allowedEdges,
+        }),
+        // Bounded stickiness — see `withinItemsSpan` above.
+        getIsSticky: ({ input }) => withinItemsSpan({ clientX: input.clientX, clientY: input.clientY }, listId),
+        onDragEnter: ({ source, self }) => (
+          isSelfSource(source.data) ? clearIndicator() : renderDropIndicator(element, extractClosestEdge(self.data), itemId)
+        ),
+        onDrag: ({ source, self }) => (
+          isSelfSource(source.data) ? clearIndicator() : renderDropIndicator(element, extractClosestEdge(self.data), itemId)
+        ),
+        onDragLeave: clearIndicator,
+        onDrop: clearIndicator,
+      });
+
+      return track(combine(draggableCleanup, dropTargetCleanup, () => {
+        delete element.dataset.dragging;
+        clearIndicator();
+        itemsForList.delete(element);
+      }));
+    },
+
+    addScrollContainer(element:Element, scrollAxis:AutoScrollAllowedAxis = 'all'):CleanupFn {
+      // See the matching guard in `registerList` above.
+      if (destroyed) {
+        return () => undefined;
+      }
+
+      return track(registerAutoScroll({
+        element,
+        canScroll: ({ source }) => scope.isItemData(source.data),
+        axis: scrollAxis,
+      }));
+    },
+
+    destroy():void {
+      if (destroyed) {
+        return;
+      }
+      destroyed = true;
+      [...cleanups].forEach((fn) => fn());
+      lists.clear();
+      listItems.clear();
+      if (frameCacheToken !== null) {
+        cancelAnimationFrame(frameCacheToken);
+        clearFrameCache();
+      }
+      // Balances an in-flight drag's `preventUnhandled.start()`, whose
+      // matching `stop()` can never run once the monitor is torn down mid-drag.
+      preventUnhandled.stop();
+      // The busy flag lives on the DOM element, not this closure, so it must
+      // be cleared explicitly or a fresh engine reusing the same element
+      // (e.g. Angular recreating the directive) would start out stuck busy.
+      options.element.removeAttribute('data-sortable-lists-busy');
+    },
+  };
+}

--- a/frontend/src/common/drag-and-drop/testing/native-drag-simulation.ts
+++ b/frontend/src/common/drag-and-drop/testing/native-drag-simulation.ts
@@ -1,0 +1,121 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+// Test helper: drives Pragmatic Drag and Drop with real native DragEvents,
+// so specs exercise the actual adapters (draggable/dropTarget registration,
+// hitbox data, stickiness) instead of mocked callbacks.
+//
+// Pragmatic postpones the drag start and throttles drag updates by one
+// animation frame, so every step awaits a frame before returning.
+
+export interface Point {
+  x:number;
+  y:number;
+}
+
+export function centerOf(element:Element):Point {
+  const rect = element.getBoundingClientRect();
+
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+// A point inside the element, close to the given edge (25% from it), so the
+// closest-edge hitbox resolves deterministically to that edge.
+export function towardsEdgeOf(element:Element, edge:'top'|'bottom'|'left'|'right'):Point {
+  const rect = element.getBoundingClientRect();
+  const center = centerOf(element);
+
+  switch (edge) {
+    case 'top':
+      return { x: center.x, y: rect.top + rect.height / 4 };
+    case 'bottom':
+      return { x: center.x, y: rect.bottom - rect.height / 4 };
+    case 'left':
+      return { x: rect.left + rect.width / 4, y: center.y };
+    case 'right':
+      return { x: rect.right - rect.width / 4, y: center.y };
+    default:
+      return center;
+  }
+}
+
+function nextFrame():Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+export class NativeDragSimulation {
+  private dataTransfer = new DataTransfer();
+
+  constructor(private source:Element) {}
+
+  async start(point:Point = centerOf(this.source)):Promise<void> {
+    this.dispatch('dragstart', this.source, point);
+    await nextFrame();
+  }
+
+  async dragOver(target:Element, point:Point = centerOf(target)):Promise<void> {
+    this.dispatch('dragenter', target, point);
+    this.dispatch('dragover', target, point);
+    await nextFrame();
+  }
+
+  async drop(target:Element, point:Point = centerOf(target)):Promise<void> {
+    await this.dragOver(target, point);
+    this.dispatch('drop', target, point);
+    await this.finish();
+  }
+
+  // A drag abandoned without a drop (e.g. released outside every target,
+  // or cancelled with Escape): the browser only fires dragend on the source.
+  async cancel():Promise<void> {
+    this.dispatch('dragend', this.source, centerOf(this.source));
+    await this.finish();
+  }
+
+  private async finish():Promise<void> {
+    await nextFrame();
+    // Pragmatic mounts a "honey pot" element over the last pointer position
+    // after a drag to swallow phantom pointer events; a pointer move removes
+    // it so it cannot shadow elementFromPoint checks of a later drag.
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 0, clientY: 0, bubbles: true }));
+    await nextFrame();
+  }
+
+  private dispatch(type:string, target:Element, point:Point):void {
+    target.dispatchEvent(new DragEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: point.x,
+      clientY: point.y,
+      dataTransfer: this.dataTransfer,
+    }));
+  }
+}

--- a/frontend/src/common/interactive-element-helper.ts
+++ b/frontend/src/common/interactive-element-helper.ts
@@ -1,0 +1,87 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+const ariaInteractiveRoles = new Set([
+  'button',
+  'checkbox',
+  'combobox',
+  'link',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'textbox',
+  'treeitem',
+]);
+
+export function isInteractiveElement(el:Element|null):el is HTMLElement {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.hasAttribute('disabled')) return false;
+  if (el.getAttribute('aria-disabled') === 'true') return false;
+  if (el.hidden) return false;
+
+  const tag = el.tagName.toLowerCase();
+  const role = el.getAttribute('role');
+  const tabIndex = el.tabIndex;
+
+  const nativeInteractive = tag === 'button'
+    || tag === 'select'
+    || tag === 'textarea'
+    || tag === 'summary'
+    || (tag === 'input' && (el as HTMLInputElement).type !== 'hidden')
+    || (tag === 'a' && el.hasAttribute('href'))
+    || (tag === 'audio' && el.hasAttribute('controls'))
+    || (tag === 'video' && el.hasAttribute('controls'));
+
+  return nativeInteractive
+    || (role != null && ariaInteractiveRoles.has(role))
+    || el.isContentEditable
+    || tabIndex >= 0;
+}
+
+export function closestInteractiveElement(el:Element|null, stopAt:Element|null = null):HTMLElement|null {
+  let current = el;
+
+  while (current && current !== stopAt) {
+    if (isInteractiveElement(current)) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}

--- a/frontend/src/stimulus/helpers/interactive-element-helper.ts
+++ b/frontend/src/stimulus/helpers/interactive-element-helper.ts
@@ -28,60 +28,6 @@
  * ++
  */
 
-const ariaInteractiveRoles = new Set([
-  'button',
-  'checkbox',
-  'combobox',
-  'link',
-  'listbox',
-  'menuitem',
-  'menuitemcheckbox',
-  'menuitemradio',
-  'option',
-  'radio',
-  'slider',
-  'spinbutton',
-  'switch',
-  'tab',
-  'textbox',
-  'treeitem',
-]);
-
-export function isInteractiveElement(el:Element|null):el is HTMLElement {
-  if (!(el instanceof HTMLElement)) return false;
-  if (el.hasAttribute('disabled')) return false;
-  if (el.getAttribute('aria-disabled') === 'true') return false;
-  if (el.hidden) return false;
-
-  const tag = el.tagName.toLowerCase();
-  const role = el.getAttribute('role');
-  const tabIndex = el.tabIndex;
-
-  const nativeInteractive = tag === 'button'
-    || tag === 'select'
-    || tag === 'textarea'
-    || tag === 'summary'
-    || (tag === 'input' && (el as HTMLInputElement).type !== 'hidden')
-    || (tag === 'a' && el.hasAttribute('href'))
-    || (tag === 'audio' && el.hasAttribute('controls'))
-    || (tag === 'video' && el.hasAttribute('controls'));
-
-  return nativeInteractive
-    || (role != null && ariaInteractiveRoles.has(role))
-    || el.isContentEditable
-    || tabIndex >= 0;
-}
-
-export function closestInteractiveElement(el:Element|null, stopAt:Element|null = null):HTMLElement|null {
-  let current = el;
-
-  while (current && current !== stopAt) {
-    if (isInteractiveElement(current)) {
-      return current;
-    }
-
-    current = current.parentElement;
-  }
-
-  return null;
-}
+// Relocated to core-common so the framework-neutral drag-and-drop engine
+// can use it; this shim keeps existing core-stimulus import paths working.
+export * from 'core-common/interactive-element-helper';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,6 +21,7 @@
     "paths": {
       "@ng-select/ng-select/*": ["./node_modules/@ng-select/ng-select/*"],
       "core-app/*": ["./src/app/*"],
+      "core-common/*": ["./src/common/*"],
       "core-components/*": ["./src/app/components/*"],
       "core-elements/*": ["./src/elements/*"],
       "core-stimulus/*": ["./src/stimulus/*"],

--- a/frontend/vitest-base.config.ts
+++ b/frontend/vitest-base.config.ts
@@ -6,6 +6,13 @@ import { defineConfig } from 'vitest/config';
 // runner-level options that the builder does not manage belong here.
 export default defineConfig({
   test: {
+    // The builder defaults this to `false` to mimic Karma/Jasmine, which makes
+    // every spec file share one module registry. Specs driving the real
+    // Pragmatic adapters and specs mocking those same `@atlaskit` module ids
+    // then poison each other: whichever file imports first wins the cache, so
+    // the loser sees a real function where it expects a spy.
+    isolate: true,
+
     // jquery-migrate prints this banner to stdout at import time. It is
     // expected, carries no signal, and would otherwise appear once per worker.
     // Filtering here (reporter level) keeps it out of the output without

--- a/spec/features/work_packages/table/configuration_modal/column_spec.rb
+++ b/spec/features/work_packages/table/configuration_modal/column_spec.rb
@@ -48,7 +48,11 @@ RSpec.describe "Work Package table configuration modal columns spec", :js do
   context "When seeing the table" do
     it_behaves_like "add and remove columns"
 
-    context "with three columns", driver: :firefox_de do
+    # Chrome, because reordering the columns is a native HTML5 drag: geckodriver
+    # starts one (dragstart and dragover fire) but never finishes it, so no drop
+    # ever reaches the page and the columns stay put. The German locale this
+    # example has always carried is preserved; nothing here depends on it.
+    context "with three columns", driver: :chrome_de do
       let!(:query) do
         query = build(:query, user:, project:)
         query.column_names = %w[id project subject]


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-755
https://community.openproject.org/wp/DREAM-756 (engine commit; the consumer migrations stack on this PR in #24243)

# What are you trying to accomplish?

Migrates the Angular draggable autocompleter — the chip list used for column selection in the work package table configuration modal, and its other embeddings — from Dragula to Pragmatic drag and drop, and introduces the foundation the remaining Angular DnD surfaces migrate onto: a framework-neutral sortable-lists engine plus thin Angular directives. This is one step in retiring Dragula, not the last one: `ng2-dragula` stays in the tree for now, since the team planner and the shared `DragAndDropService` still depend on it.

Two bugs surfaced while migrating and are fixed here:

- Two draggable autocompleters on the same page reacted to each other's drags, because the drag payload was keyed by a module-level `Symbol` shared across every instance. The payload scope is now created per root instance.
- Dropping a chip outside the list still reordered it next to the last chip hovered, because item drop targets were unconditionally sticky. Stickiness is now bounded to the items' geometric span, so a drop outside cancels instead.

The remove affordance is now a real `<button>` with an `aria-label`, replacing a `<div>` with `tabindex` and hand-rolled enter/space key handlers.

## Drag-and-drop screens touched

The draggable autocompleter is the only user-facing surface this PR changes. Its embeddings (breadcrumbs per the drag-and-drop inventory in https://community.openproject.org/wp/DREAM-777):

- Project › Work packages › Configure view › Columns (modal tab)
- Project › Work packages › Export dialog — column selection, including the PDF report export settings
- Project lists › Configure view (modal)
- Administration › Users and permissions › Users › Configure view (modal)
- Administration › Work packages — default columns for work package lists
- Administration › Projects — default columns for project lists
- Resource planner › Configure view — column selection (Enterprise resource management module)

The engine and directives ship no other consumer in this PR; the remaining Angular surfaces (work package table, card view, boards, BIM BCF) follow in #24243.

## Screenshots

Not yet captured — manual browser verification is still outstanding (see the checklist below), so I would rather not publish stills that imply it is done.

For review, the visible change is the drag affordance itself: Dragula's mirror element and placeholder gap are replaced by a 2px accent line (`--fgColor-accent`) on the edge where the chip would be inserted, and the dragged chip dims to `0.4` opacity while in flight.

# What approach did you choose and why?

Three layers, one commit each:

1. **A framework-neutral engine** (`core-common/drag-and-drop/sortable-lists-engine.ts`). `createSortableRoot` owns the Pragmatic wiring for one drag scope: item/list drop-target registration, a single root monitor that resolves every drop from the target stack into an intent (the pattern both the Stimulus root controller and Atlassian's React examples use), an optimistic two-phase transaction (`complete` from the target side, `finalize` from the source side; busy state serializes drags until both settle), axis-aware bounded stickiness with item→list handoff, drag-start suppression on interactive descendants, and a custom-preview hook. The engine also owns the DOM state attributes, deliberately the same contract the Stimulus `sortable-lists` controllers established — `data-dragging="source"`, `data-drop-position` (+ owner), `data-drop-container`, `data-sortable-lists-busy` — so the two frontends share one styling vocabulary.
2. **Directives as a thin binding.** `opSortableLists` (root) / `opSortableListsList` / `opSortableListsItem`, mirroring the Stimulus root/list/item topology. A root without explicit child lists collapses to a single implicit list, so a simple consumer like the autocompleter binds one attribute and one `(opSortableListsDrop)` handler. Registration follows the Angular view lifecycle (`@for` churn is free); cross-list moves emit `removed` on the source list before `drop` on the target list, carrying the transaction — that contract is what #24243's boards migration consumes.
3. **The autocompleter on that API**, completing its drop transactions synchronously since chips persist on form submit.

An earlier iteration wired the Pragmatic adapters directly in the component; a second one put all behavior in the directives. Both were discarded: the first had to re-pair rendered chips with items after every view change, the second would have duplicated the engine per framework once the `DragAndDropService` rewrite (#24243, stacked on this branch) needed the same core for the work-package fast-table, whose builder-rendered rows can't host directives.

`dragAreaName` is kept as a deprecated input. Instance isolation no longer needs a group name, but custom-element embeddings still pass the attribute, so removing it now would break them silently.

Two changes worth a conscious decision from a reviewer, since neither is strictly about this component:

- **`test.isolate: true`** (its own commit). Specs that drive the real Pragmatic adapters and the Stimulus `sortable-lists` specs that mock the same `@atlaskit` module ids share one module registry, because the Angular builder defaults `isolate` to `false` to mimic Karma. Whichever file imports first wins the cache and the other sees a real function where it expects a spy — which shows up as a flaky, import-order-dependent failure count rather than a clean one. Isolating fixes it, and costs roughly 22s → 99s of frontend suite wall clock.
- **`column_spec.rb` moved from `firefox_de` to `chrome_de`.** Reordering columns is a native HTML5 drag now, and geckodriver starts one — `dragstart` and `dragover` both fire — but never completes it, so no `drop` ever reaches the page and the columns silently stay put. This is a limitation of the driver, not of the feature; real Firefox users drag fine. The German locale the example has always carried is preserved.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a, this is an Angular component with no Lookbook presence
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — **outstanding**: reorder, drop-outside-cancels, chip removal, append beyond the last chip, and two coexisting autocompleters on one page still need a manual pass

