### PR TITLE
[COMMS-851] Adjust version boards to work with target versions

### DIFF
--- a/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
@@ -14,6 +14,7 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import {
   Observable,
   of,
@@ -24,11 +25,14 @@ import { map } from 'rxjs/operators';
 export class BoardVersionActionService extends CachedBoardActionService {
   readonly halNotification = inject(HalResourceNotificationService);
 
-  // API identifier used to query versions
-  filterName = 'targetVersion';
+  // API identifier used when creating a column: `targetVersion` when multiple
+  // versions are enabled, the always-available `version` otherwise
+  filterName = inject(ConfigurationService).activeFeatureFlags.includes('workPackageMultipleVersions')
+    ? 'targetVersion'
+    : 'version';
 
-  // Filter ids that identify a version column (`version` is the deprecated one)
-  filterNames = [this.filterName, 'version'];
+  // Filter ids matched when reading a column, whichever mode created it
+  filterNames = ['targetVersion', 'version'];
 
   // Work package attributes that move a card between columns when they change
   get watchedAttributes():string[] {

--- a/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, inject } from '@angular/core';
-import { Board } from 'core-app/features/boards/board/board';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { VersionResource } from 'core-app/features/hal/resources/version-resource';
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
@@ -11,8 +10,11 @@ import { CachedBoardActionService } from 'core-app/features/boards/board/board-a
 import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 import { VersionAutocompleterComponent } from 'core-app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
+import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import {
-  firstValueFrom,
   Observable,
   of,
 } from 'rxjs';
@@ -22,18 +24,24 @@ import { map } from 'rxjs/operators';
 export class BoardVersionActionService extends CachedBoardActionService {
   readonly halNotification = inject(HalResourceNotificationService);
 
-  filterName = 'version';
+  // API identifier used to query versions
+  filterName = 'targetVersion';
+
+  // Filter ids that identify a version column (`version` is the deprecated one)
+  filterNames = [this.filterName, 'version'];
+
+  // Work package attributes that move a card between columns when they change
+  get watchedAttributes():string[] {
+    return ['targetVersions', 'version'];
+  }
 
   /**
-   * The work package show view writes the version via the targetVersions
-   * attribute, while dragging a card between lists still writes the
-   * deprecated version attribute. Watch both so either change moves the card.
-   *
-   * TODO: Reduce to targetVersions once boards write it as well
-   * (BoardActionService#assignToWorkPackage in the boards follow-up of COMMS-877).
+   * Match the column's version filter by any of its known ids: the current
+   * `targetVersion` filter or the deprecated `version` filter used by columns
+   * created before COMMS-877.
    */
-  get watchedAttributes():string[] {
-    return [this.filterName, 'targetVersions'];
+  getActionFilter(query:QueryResource, _getHref = false):QueryFilterInstanceResource|undefined {
+    return query.filters.find((filter) => this.filterNames.includes(filter.id));
   }
 
   resourceName = 'version';
@@ -60,8 +68,9 @@ export class BoardVersionActionService extends CachedBoardActionService {
     }
 
     if (!this.writable$) {
-      this.writable$ = query.results.createWorkPackage()
-        .then((form:FormResource) => form.schema.version.writable);
+      const createForm = query.results.createWorkPackage as () => Promise<FormResource>;
+      this.writable$ = createForm()
+        .then((form:FormResource) => (form.schema.targetVersions as { writable:boolean }).writable);
     }
 
     return this.writable$;
@@ -103,6 +112,29 @@ export class BoardVersionActionService extends CachedBoardActionService {
 
   public dragIntoAllowed(query:QueryResource, value:HalResource|undefined) {
     return value instanceof VersionResource && value.isOpen();
+  }
+
+  // A card can be moved when its `targetVersions` attribute is writable
+  public canMove(workPackage:WorkPackageResource):boolean {
+    const schema = this.schemaCache.of(workPackage);
+    return !!(schema.targetVersions as IFieldSchema)?.writable;
+  }
+
+  // Writes the column's version to the card's `targetVersions` attribute
+  public assignToWorkPackage(changeset:WorkPackageChangeset, query:QueryResource):void {
+    if (!changeset.isWritable('targetVersions')) {
+      throw new Error(this.I18n.t(
+        'js.boards.error_attribute_not_writable',
+        { attribute: changeset.humanName('targetVersions') },
+      ));
+    }
+
+    const id = this.getActionValueId(query);
+    const value = id
+      ? [this.halResourceService.fromSelfLink(this.apiV3Service.versions.id(id).toString())]
+      : [];
+
+    changeset.setValue('targetVersions', value);
   }
 
   protected loadUncached():Observable<HalResource[]> {

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -233,19 +233,24 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
    * @param board
    */
   private getActionFiltersFromWidget(board:Board):(string|null)[] {
+    const service = this.boardActionRegistry.get(board.actionAttribute!);
+    const filterNames = (service as { filterNames?:string[] }).filterNames ?? [service.filterName];
+    const filterKeys = filterNames.flatMap((name) => [
+      name,
+      `${name.replace(/([A-Z])/g, '_$1').toLowerCase()}_id`,
+    ]);
+
     return board.grid.widgets
       .map((widget) => {
-        const service = this.boardActionRegistry.get(board.actionAttribute!);
-        const { filterName } = service;
-        const idFilterName = `${filterName}_id`;
         const options = widget.options as unknown as BoardWidgetOption;
-        const instance = options.filters.find((f) => !!f[filterName] || !!f[idFilterName]);
+        const instance = options.filters?.find((f) => filterKeys.some((key) => !!f[key]));
 
-        if (instance) {
-          return ((instance[filterName] || instance[idFilterName])?.values[0] || null) as unknown as string|null;
+        if (!instance) {
+          return null;
         }
 
-        return null;
+        const key = filterKeys.find((name) => !!instance[name])!;
+        return (instance[key]?.values[0] || null) as unknown as string|null;
       })
       .filter((value) => value !== undefined);
   }

--- a/modules/boards/app/services/boards/version_board_create_service.rb
+++ b/modules/boards/app/services/boards/version_board_create_service.rb
@@ -43,7 +43,7 @@ module Boards
     end
 
     def query_filters(version)
-      [{ version_id: { operator: "=", values: [version.id.to_s] } }]
+      [{ target_version_id: { operator: "=", values: [version.id.to_s] } }]
     end
 
     def options_for_widgets(params)

--- a/modules/boards/app/services/boards/version_board_create_service.rb
+++ b/modules/boards/app/services/boards/version_board_create_service.rb
@@ -43,7 +43,8 @@ module Boards
     end
 
     def query_filters(version)
-      [{ target_version_id: { operator: "=", values: [version.id.to_s] } }]
+      key = Setting::WorkPackageMultipleVersions.active? ? :target_version_id : :version_id
+      [{ key => { operator: "=", values: [version.id.to_s] } }]
     end
 
     def options_for_widgets(params)

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -105,6 +105,10 @@ RSpec.describe "Version action board",
       board_page.expect_list_option "Shared version"
       board_page.expect_list_option "Closed version"
 
+      # Versions already represented as a column are not offered again
+      board_page.expect_list_option "Open version", present: false
+      board_page.expect_list_option "A second version", present: false
+
       board_page.board(reload: true) do |board|
         expect(board.name).to eq "My Version Board"
         queries = board.contained_queries

--- a/modules/boards/spec/services/version_board_create_service_spec.rb
+++ b/modules/boards/spec/services/version_board_create_service_spec.rb
@@ -115,5 +115,28 @@ RSpec.describe Boards::VersionBoardCreateService do
 
       it_behaves_like "sets the appropriate sort_criteria on each query"
     end
+
+    describe "version filter" do
+      let(:queries) { Query.all }
+      let(:filter_names) { queries.flat_map(&:filters).map(&:name).uniq }
+
+      context "with multiple versions disabled (default)" do
+        it "filters the columns by the version attribute" do
+          subject
+
+          expect(filter_names).to eq([:version_id])
+        end
+      end
+
+      context "with multiple versions enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        it "filters the columns by the target_versions attribute" do
+          subject
+
+          expect(filter_names).to eq([:target_version_id])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-851/activity

# What are you trying to accomplish?
- Read from version & target_versions
- Write to target_versions when the feature is enabled (setting + feature flag)

When the feature flag is disabled we still have to use version_id
We do not handle *multiple* versions here and will need a follow up to handle that

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
