### PR TITLE
add logging for file source in check_links script

### DIFF
--- a/script/docs/check_links
+++ b/script/docs/check_links
@@ -286,6 +286,7 @@ class DocsChecker
       endLine: end_line == line ? nil : line
     }.compact
     attributes_string = attributes.map { |k, v| "#{k}=#{v}" }.join(",")
+    puts "Issue in file #{file}"
     puts "::#{report_level} #{attributes_string}::#{github_escape(message)}"
   end
 end


### PR DESCRIPTION
If a broken link in the docs is not a file changed in a PR, there is no way in the PR to find out where, as the filename is omitted in the GitHub output of its report format.

Fix: include the filename in the output.