### PR TITLE
[FND-133] Cycle detection for linked form configurations

### DIFF
--- a/app/components/work_package_types/configuration_link_component.html.erb
+++ b/app/components/work_package_types/configuration_link_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% if feature_active? %>
-  <div data-controller="show-when-value-selected">
+  <%= component_wrapper(data: { controller: "show-when-value-selected" }) do %>
     <%= settings_primer_form_with(**form_options) do |f| %>
       <%= render(WorkPackageTypes::ConfigurationLinkForm.new(f)) %>
 
@@ -39,6 +39,12 @@ See COPYRIGHT and LICENSE files for more details.
           <%= render(editor_form.new(f)) %>
         <% end %>
       <% end %>
+
+      <% if standalone? %>
+        <%# Aspect tab: one _method field per mode; only the selected mode's verb submits. %>
+        <%= method_field("patch", "linked") %>
+        <%= method_field("delete", "independent") %>
+      <% end %>
     <% end %>
 
     <% if editor_form.nil? && !linked? %>
@@ -48,7 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
         <%= content %>
       <% end %>
     <% end %>
-  </div>
+  <% end %>
 <% else %>
   <%# Reuse feature off: the tab manages its own configuration directly. %>
   <%= content %>

--- a/app/components/work_package_types/configuration_link_component.rb
+++ b/app/components/work_package_types/configuration_link_component.rb
@@ -36,19 +36,18 @@ module WorkPackageTypes
   class ConfigurationLinkComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
     include OpPrimer::FormHelpers
+    include OpTurbo::Streamable
 
-    # +url+/+method+/+form_id+ let a host (the creation wizard) point the mode form at
-    # its own endpoint instead of the aspect's update endpoint.
-    #
-    # +editor_form+ is an ApplicationForm whose fields belong to that same form, so the
-    # host's submit persists mode and editor together. Editors that self-persist through
-    # their own turbo endpoints are passed as the block content instead.
-    # +form_model+ binds the form to the type, nesting its fields under +type[...]+ and
-    # giving an +editor_form+ a model to work with. The aspect tabs post the mode on its
-    # own, unscoped, so they leave it unbound.
-    def initialize(type:, aspect:, url: nil, method: :put, form_id: nil, form_model: nil,
-                   with_submit: true, editor_form: nil, heading: nil)
+    # +url+/+method+/+form_id+/+form_model+ let a host (the creation wizard) point the mode
+    # form at its own endpoint, binding its fields under that model. +editor_form+ is an
+    # ApplicationForm rendered inside the same form so the host's submit persists mode and
+    # editor together; editors that self-persist via their own turbo endpoint come as the
+    # block content instead. +link+ carries a rejected link so a failed aspect save can
+    # re-render the picker inline with its errors.
+    def initialize(type:, aspect:, link: nil, url: nil, method: nil, form_id: nil,
+                   form_model: nil, with_submit: true, editor_form: nil, heading: nil)
       @aspect = aspect
+      @link = link || type.configuration_links.find_or_initialize_by(aspect:)
       @url = url
       @method = method
       @form_id = form_id
@@ -63,25 +62,41 @@ module WorkPackageTypes
 
     def feature_active? = OpenProject::FeatureDecisions.subtypes_active?
 
-    def linked? = type.linked?(@aspect)
+    def linked? = @link.source_id.present?
 
-    # Not linked yet (any Independent aspect, and every aspect of a fresh sub-type in
-    # the wizard): preselect the parent, the source a sub-type would normally reuse.
-    def current_source = type.source_for(@aspect) || type.parent
+    # The attempted/persisted source, or — when none yet (a fresh sub-type in the wizard,
+    # any Independent aspect) — the parent a sub-type would normally reuse.
+    def current_source = @link.source || type.parent
 
+    # Aspect tab: a plain POST whose Independent/Linked toggle enables one of two `_method`
+    # fields (patch/delete), so one model-bound form targets both verbs on the link's URL.
+    # A host (wizard) supplies its own url/method and binds the fields to its own model.
     def form_options
       {
-        url: @url || type_configuration_link_path(type_id: type.id, aspect: @aspect),
-        method: @method,
+        url: @url || type_aspect_configuration_link_path(type, @aspect),
+        method: @method || :post,
         linked: linked?,
         current_source_id: current_source&.id,
         source_options:,
         with_submit: @with_submit
       }.tap do |options|
         options[:html] = { id: @form_id } if @form_id
-        options[:model] = @form_model if @form_model
+        options[:model] = @form_model || @link
       end
     end
+
+    # A `_method` field per mode; show-when-value-selected disables the one whose mode
+    # isn't selected, leaving only the active verb (PATCH link / DELETE independent).
+    def method_field(verb, mode)
+      helpers.tag.input(
+        type: "hidden", name: "_method", value: verb,
+        disabled: mode != current_mode,
+        data: ConfigurationLinkForm.effect_data(mode)
+      )
+    end
+
+    # The `_method` toggle only applies when we own the form; a host drives its own verb.
+    def standalone? = @url.nil?
 
     def editor_form = @editor_form
 
@@ -90,6 +105,10 @@ module WorkPackageTypes
     def independent_data = WorkPackageTypes::ConfigurationLinkForm.effect_data("independent")
 
     private
+
+    def current_mode = linked? ? "linked" : "independent"
+
+    def wrapper_uniq_by = @aspect
 
     def source_options
       Type.global.where.not(id: type.id).order(:name)

--- a/app/controllers/work_package_types/configuration_links_controller.rb
+++ b/app/controllers/work_package_types/configuration_links_controller.rb
@@ -31,6 +31,7 @@
 module WorkPackageTypes
   class ConfigurationLinksController < BaseTabController
     include SubtypesFeature
+    include OpTurbo::ComponentStream
 
     before_action :require_subtypes_feature
 
@@ -38,16 +39,39 @@ module WorkPackageTypes
       :types
     end
 
+    # Linked: create/update the link to the chosen source.
     def update
-      result = SetConfigurationLinkService
-                 .new(type: @type, aspect: params[:aspect])
-                 .call(mode: params[:mode], source_id: params[:source_id])
+      result = service.link(source_id: source_id_param)
 
-      message = result.success? ? { notice: I18n.t(:notice_successful_update) } : { alert: result.message }
-      redirect_to tab_path_for(params[:aspect]), **message
+      if result.success?
+        redirect_to tab_path_for(params[:aspect_id]), notice: I18n.t(:notice_successful_update)
+      else
+        render_rejected_link(result.result)
+      end
+    end
+
+    # Independent: remove the link, adopting the picked source's config first.
+    def destroy
+      service.make_independent(source_id: source_id_param)
+      redirect_to tab_path_for(params[:aspect_id]), notice: I18n.t(:notice_successful_update)
     end
 
     private
+
+    def service
+      SetConfigurationLinkService.new(type: @type, aspect: params[:aspect_id])
+    end
+
+    def source_id_param
+      params.dig(:type_configuration_link, :source_id)
+    end
+
+    def render_rejected_link(link)
+      replace_via_turbo_stream(
+        component: ConfigurationLinkComponent.new(type: @type, aspect: params[:aspect_id], link:)
+      )
+      respond_with_turbo_streams(status: :unprocessable_entity)
+    end
 
     def tab_path_for(aspect)
       case aspect

--- a/app/controllers/work_package_types/creation_wizard_controller.rb
+++ b/app/controllers/work_package_types/creation_wizard_controller.rb
@@ -98,9 +98,13 @@ module WorkPackageTypes
       mode = params.dig(:type, :mode)
       return if aspect.nil? || mode.blank?
 
-      SetConfigurationLinkService
-        .new(type: @type, aspect:)
-        .call(mode:, source_id: params.dig(:type, :source_id))
+      service = SetConfigurationLinkService.new(type: @type, aspect:)
+      source_id = params.dig(:type, :source_id)
+
+      case mode
+      when "linked" then service.link(source_id:)
+      when "independent" then service.make_independent(source_id:)
+      end
     end
 
     def render_step_errors

--- a/app/models/type/configuration_link.rb
+++ b/app/models/type/configuration_link.rb
@@ -51,12 +51,24 @@ class Type
     enum :aspect, ASPECTS.index_with(&:itself), validate: true
 
     validates :type_id, uniqueness: { scope: :aspect }
-    validate :source_differs_from_type
+    validate :source_would_not_create_cycle
 
     private
 
-    def source_differs_from_type
-      errors.add(:source, :must_differ_from_type) if source_id.present? && source_id == type_id
+    # Rejects a link whose source chain already reaches this type, so the per-aspect
+    # source graph stays acyclic. A self-link is the degenerate 1-cycle and is caught here.
+    def source_would_not_create_cycle
+      return if source_id.blank?
+
+      # `seen` tolerates cyclic rows created before this validation existed (legacy
+      # FND-129 data): it lets the walk terminate instead of hanging on such data.
+      node = source
+      seen = Set.new
+      while node && seen.add?(node.id)
+        return errors.add(:source, :would_create_cycle) if node.id == type_id
+
+        node = node.source_for(aspect)
+      end
     end
   end
 end

--- a/app/models/type/configuration_link.rb
+++ b/app/models/type/configuration_link.rb
@@ -65,7 +65,7 @@ class Type
       node = source
       seen = Set.new
       while node && seen.add?(node.id)
-        return errors.add(:source, :would_create_cycle) if node.id == type_id
+        return errors.add(:source_id, :would_create_cycle) if node.id == type_id
 
         node = node.source_for(aspect)
       end

--- a/app/models/type/configuration_linkable.rb
+++ b/app/models/type/configuration_linkable.rb
@@ -71,8 +71,8 @@ class Type
     end
 
     # Walks the link chain to the type that actually owns the aspect (Independent).
-    # The visited-set guard keeps it terminating even before transitive cycle
-    # prevention lands.
+    # The visited-set guard tolerates cyclic rows created before write-time cycle
+    # prevention (FND-133) existed, keeping resolution terminating.
     #
     # Guarded by the subtypes feature flag: with the flag off, links are ignored
     # and every type resolves to its own stored configuration.

--- a/app/services/work_package_types/set_configuration_link_service.rb
+++ b/app/services/work_package_types/set_configuration_link_service.rb
@@ -31,38 +31,29 @@
 module WorkPackageTypes
   # Sets one configuration aspect of a type to Linked (a chosen global source) or
   # Independent. The source-graph invariants (present, global, not-self) are the
-  # link record's own validations; this service maps the UI mode onto them.
+  # link record's own validations; the two intents map onto the link resource's
+  # PATCH (link) and DELETE (make independent).
   class SetConfigurationLinkService
     def initialize(type:, aspect:)
       @type = type
       @aspect = aspect
     end
 
-    def call(mode:, source_id: nil)
-      source = Type.global.find_by(id: source_id)
-
-      case mode.to_s
-      when "independent"
-        @type.make_independent!(@aspect, source:)
-        ServiceResult.success(result: @type)
-      when "linked"
-        link_to(source)
-      else
-        ServiceResult.failure(result: @type)
-      end
-    end
-
-    private
-
-    def link_to(source)
+    def link(source_id:)
       link = @type.configuration_links.find_or_initialize_by(aspect: @aspect)
-      link.source = source
+      link.source = Type.global.find_by(id: source_id)
 
       if link.save
         ServiceResult.success(result: @type)
       else
-        ServiceResult.failure(result: @type, errors: link.errors)
+        # Return the rejected link so the controller can re-render the picker with its errors.
+        ServiceResult.failure(result: link, errors: link.errors)
       end
+    end
+
+    def make_independent(source_id: nil)
+      @type.make_independent!(@aspect, source: Type.global.find_by(id: source_id))
+      ServiceResult.success(result: @type)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -830,7 +830,7 @@ en:
               invalid_tokens: "One or more attributes inside the field are not valid. Please, fix the attributes before saving."
         type/configuration_link:
           attributes:
-            source:
+            source_id:
               would_create_cycle: "would link these configurations in a loop."
         user:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -831,7 +831,7 @@ en:
         type/configuration_link:
           attributes:
             source:
-              must_differ_from_type: "can't be the type itself."
+              would_create_cycle: "would link these configurations in a loop."
         user:
           attributes:
             base:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,7 +187,12 @@ Rails.application.routes.draw do
     resource :settings, controller: "settings_tab", only: %i[update edit]
     resource :subject_configuration, controller: "subject_configuration_tab", only: %i[update edit]
 
-    resources :configuration_links, only: %i[update], param: :aspect
+    # One configuration link per (type, aspect): a singular resource nested under its aspect.
+    resources :aspects,
+              only: [],
+              constraints: { aspect_id: Regexp.union(Type::ConfigurationLink::ASPECTS) } do
+      resource :configuration_link, only: %i[update destroy]
+    end
 
     resource :creation_wizard, controller: "creation_wizard", only: %i[show update]
 

--- a/spec/models/type/configuration_link_spec.rb
+++ b/spec/models/type/configuration_link_spec.rb
@@ -83,11 +83,46 @@ RSpec.describe Type::ConfigurationLink do
 
       expect(link).not_to be_valid
     end
+  end
 
-    it "rejects a link whose source is the type itself" do
-      link = build(:type_configuration_link, type:, source: type, aspect: described_class::PATTERNS)
+  describe "cycle detection" do
+    let(:aspect) { described_class::PATTERNS }
+    let(:a) { create(:type) }
+    let(:b) { create(:type) }
+    let(:c) { create(:type) }
 
-      expect(link).not_to be_valid
+    def link(type, source, on_aspect: aspect)
+      create(:type_configuration_link, type:, source:, aspect: on_aspect)
+    end
+
+    it "rejects a self-link (the degenerate 1-cycle)" do
+      expect(build(:type_configuration_link, type: a, source: a, aspect:)).not_to be_valid
+    end
+
+    it "rejects a direct 2-cycle (A->B then B->A)" do
+      link(a, b)
+
+      expect(build(:type_configuration_link, type: b, source: a, aspect:)).not_to be_valid
+    end
+
+    it "rejects a longer cycle (A->B->C then C->A)" do
+      link(a, b)
+      link(b, c)
+
+      expect(build(:type_configuration_link, type: c, source: a, aspect:)).not_to be_valid
+    end
+
+    it "allows a diamond (A->C and B->C share a source without looping)" do
+      link(a, c)
+
+      expect(build(:type_configuration_link, type: b, source: c, aspect:)).to be_valid
+    end
+
+    it "keeps aspects isolated (A->B on patterns, B->A on pdf_export)" do
+      link(a, b, on_aspect: described_class::PATTERNS)
+
+      expect(build(:type_configuration_link, type: b, source: a, aspect: described_class::PDF_EXPORT))
+        .to be_valid
     end
   end
 

--- a/spec/models/type/configuration_linkable_spec.rb
+++ b/spec/models/type/configuration_linkable_spec.rb
@@ -148,9 +148,11 @@ RSpec.describe Type::ConfigurationLinkable do
     end
 
     it "terminates on a cycle instead of looping forever" do
+      # A cycle can no longer be created through validated writes, so bypass validation
+      # to reproduce a cyclic row that predates write-time prevention (FND-133).
       other = create(:type)
       type.link!(aspect, source: other)
-      other.link!(aspect, source: type)
+      build(:type_configuration_link, type: other, source: type, aspect:).save!(validate: false)
 
       expect { type.effective_source_for(aspect) }.not_to raise_error
     end

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe "Work package type configuration source",
     end
 
     it "blocks the update endpoint" do
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "linked", source_id: source.id }
+      patch type_aspect_configuration_link_path(type, aspect),
+            params: { type_configuration_link: { source_id: source.id } }
 
       expect(response).to have_http_status(:not_found)
       expect(type).not_to be_linked(aspect)
@@ -104,63 +104,70 @@ RSpec.describe "Work package type configuration source",
     end
   end
 
-  describe "PUT update" do
+  describe "PATCH update (link)" do
     it "links the aspect to the chosen source" do
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "linked", source_id: source.id }
+      patch type_aspect_configuration_link_path(type, aspect),
+            params: { type_configuration_link: { source_id: source.id } }
 
       expect(response).to be_redirect
       expect(type.source_for(aspect)).to eq(source)
     end
 
-    it "switches the aspect back to independent" do
-      type.link!(aspect, source:)
+    it "re-renders the picker with an inline error instead of persisting a cyclic link" do
+      # The source already borrows from the type, so linking back would close a loop.
+      create(:type_configuration_link, type: source, source: type, aspect:)
 
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "independent" }
+      patch type_aspect_configuration_link_path(type, aspect),
+            params: { type_configuration_link: { source_id: source.id } },
+            as: :turbo_stream
 
-      expect(response).to be_redirect
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("would link these configurations in a loop")
       expect(type.reload).not_to be_linked(aspect)
-    end
-
-    it "adopts a source's config when switching to independent with a source" do
-      configured = create(:type)
-      configured.pdf_export_templates.disable_all
-      configured.save!
-
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "independent", source_id: configured.id }
-
-      expect(type.reload).not_to be_linked(aspect)
-      expect(type.export_templates_disabled).to eq(configured.export_templates_disabled)
-    end
-
-    it "does not persist an invalid (self) source and flashes an alert" do
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "linked", source_id: type.id }
-
-      expect(type).not_to be_linked(aspect)
-      expect(flash[:alert]).to be_present
-      expect(flash[:notice]).to be_blank
+      expect(flash[:alert]).to be_blank
     end
 
     it "does not link when no source was picked" do
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "linked", source_id: "" }
+      patch type_aspect_configuration_link_path(type, aspect),
+            params: { type_configuration_link: { source_id: "" } },
+            as: :turbo_stream
 
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(type).not_to be_linked(aspect)
-      expect(flash[:alert]).to be_present
-      expect(flash[:notice]).to be_blank
+      expect(flash[:alert]).to be_blank
     end
 
     it "requires admin" do
       login_as create(:user)
 
-      put type_configuration_link_path(type_id: type.id, aspect:),
-          params: { mode: "linked", source_id: source.id }
+      patch type_aspect_configuration_link_path(type, aspect),
+            params: { type_configuration_link: { source_id: source.id } }
 
       expect(response).not_to be_successful
       expect(type).not_to be_linked(aspect)
+    end
+  end
+
+  describe "DELETE destroy (make independent)" do
+    it "switches the aspect back to independent" do
+      type.link!(aspect, source:)
+
+      delete type_aspect_configuration_link_path(type, aspect)
+
+      expect(response).to be_redirect
+      expect(type.reload).not_to be_linked(aspect)
+    end
+
+    it "adopts a source's config while switching to independent" do
+      configured = create(:type)
+      configured.pdf_export_templates.disable_all
+      configured.save!
+
+      delete type_aspect_configuration_link_path(type, aspect),
+             params: { type_configuration_link: { source_id: configured.id } }
+
+      expect(type.reload).not_to be_linked(aspect)
+      expect(type.export_templates_disabled).to eq(configured.export_templates_disabled)
     end
   end
 end

--- a/spec/services/work_package_types/set_configuration_link_service_spec.rb
+++ b/spec/services/work_package_types/set_configuration_link_service_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
       expect(result).not_to be_success
       expect(type).not_to be_linked(aspect)
     end
+
+    it "fails when linking would create a cycle" do
+      create(:type_configuration_link, type: source, source: type, aspect:)
+
+      result = service.call(mode: "linked", source_id: source.id)
+
+      expect(result).not_to be_success
+      expect(type).not_to be_linked(aspect)
+    end
   end
 
   describe "independent mode" do

--- a/spec/services/work_package_types/set_configuration_link_service_spec.rb
+++ b/spec/services/work_package_types/set_configuration_link_service_spec.rb
@@ -37,33 +37,33 @@ RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
 
   subject(:service) { described_class.new(type:, aspect:) }
 
-  describe "linked mode" do
+  describe "#link" do
     it "links the aspect to the chosen source" do
-      result = service.call(mode: "linked", source_id: source.id)
+      result = service.link(source_id: source.id)
 
       expect(result).to be_success
       expect(type.source_for(aspect)).to eq(source)
     end
 
     it "re-points an existing link to a new source" do
-      service.call(mode: "linked", source_id: source.id)
+      service.link(source_id: source.id)
       other = create(:type)
 
-      result = service.call(mode: "linked", source_id: other.id)
+      result = service.link(source_id: other.id)
 
       expect(result).to be_success
       expect(type.reload.source_for(aspect)).to eq(other)
     end
 
     it "fails when no source is given" do
-      result = service.call(mode: "linked", source_id: nil)
+      result = service.link(source_id: nil)
 
       expect(result).not_to be_success
       expect(type).not_to be_linked(aspect)
     end
 
     it "fails when the source is the type itself" do
-      result = service.call(mode: "linked", source_id: type.id)
+      result = service.link(source_id: type.id)
 
       expect(result).not_to be_success
       expect(type).not_to be_linked(aspect)
@@ -72,42 +72,42 @@ RSpec.describe WorkPackageTypes::SetConfigurationLinkService do
     it "fails when linking would create a cycle" do
       create(:type_configuration_link, type: source, source: type, aspect:)
 
-      result = service.call(mode: "linked", source_id: source.id)
+      result = service.link(source_id: source.id)
 
       expect(result).not_to be_success
       expect(type).not_to be_linked(aspect)
     end
   end
 
-  describe "independent mode" do
+  describe "#make_independent" do
     it "removes an existing link" do
-      service.call(mode: "linked", source_id: source.id)
+      service.link(source_id: source.id)
 
-      result = service.call(mode: "independent")
+      result = service.make_independent
 
       expect(result).to be_success
       expect(type.reload).not_to be_linked(aspect)
     end
 
     it "is a no-op when already independent" do
-      result = service.call(mode: "independent")
+      result = service.make_independent
 
       expect(result).to be_success
       expect(type).not_to be_linked(aspect)
     end
-  end
 
-  describe "independent mode adopting a source" do
-    subject(:service) { described_class.new(type:, aspect: Type::ConfigurationLink::PATTERNS) }
+    context "when adopting a source" do
+      subject(:service) { described_class.new(type:, aspect: Type::ConfigurationLink::PATTERNS) }
 
-    it "copies the source's config onto the type once and creates no link" do
-      configured = create(:type, patterns: { subject: { blueprint: "Adopt {{id}}", enabled: true } })
+      it "copies the source's config onto the type once and creates no link" do
+        configured = create(:type, patterns: { subject: { blueprint: "Adopt {{id}}", enabled: true } })
 
-      result = service.call(mode: "independent", source_id: configured.id)
+        result = service.make_independent(source_id: configured.id)
 
-      expect(result).to be_success
-      expect(type).not_to be_linked(Type::ConfigurationLink::PATTERNS)
-      expect(type.reload.patterns.subject.blueprint).to eq("Adopt {{id}}")
+        expect(result).to be_success
+        expect(type).not_to be_linked(Type::ConfigurationLink::PATTERNS)
+        expect(type.reload.patterns.subject.blueprint).to eq("Adopt {{id}}")
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/FND-133

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Prevent linked type configurations from forming a cycle. A type reuses a configuration aspect (`pdf_export`, `patterns`) from a source type, and nothing stopped a chain from looping back (`A → B → C → A`), leaving an aspect with no Independent owner.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="898" height="443" alt="Screenshot of the error message" src="https://github.com/user-attachments/assets/f9d6fc7c-914c-470c-8c43-bda090881397" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

A per-aspect validation on `Type::ConfigurationLink` now rejects any link whose source chain already reaches the type; self-links fold in as the degenerate 1-cycle, so `source_differs_from_type` is dropped and the model keeps a single invariant: the source graph stays acyclic.

Opportunistically, the source picker now shows this (and any) link error inline on the field via a Turbo Stream re-render, instead of a flash alert. See the second commit for this.

This last point has an impact on the wizard too, that’s why you’ll see wizard-related changes in this PR.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
