### PR TITLE
Wrap gems in a source block to apply the cooldown inside the block only.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,404 +28,404 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-source "https://rubygems.org", cooldown: 7
+source "https://rubygems.org", cooldown: 7 do
+  # TODO: Once packager.io and heroku buildpacks support bundler 2.4.22,
+  # then we can use the new bundler syntax `ruby file: '.ruby-version'`.
+  # https://github.com/heroku/heroku-buildpack-ruby/issues/1408#issuecomment-1841596215
 
-# TODO: Once packager.io and heroku buildpacks support bundler 2.4.22,
-# then we can use the new bundler syntax `ruby file: '.ruby-version'`.
-# https://github.com/heroku/heroku-buildpack-ruby/issues/1408#issuecomment-1841596215
+  ruby File.read(File.expand_path(".ruby-version", __dir__)).strip
 
-ruby File.read(File.expand_path(".ruby-version", __dir__)).strip
+  gem "actionpack-xml_parser", "~> 2.0.0"
+  gem "activemodel-serializers-xml", "~> 1.0.1"
+  gem "activerecord-import", "~> 2.2.0"
+  gem "activerecord-session_store", "~> 2.3.0"
+  gem "ox"
+  gem "rails", "~> 8.1.3"
+  gem "responders", "~> 3.2"
 
-gem "actionpack-xml_parser", "~> 2.0.0"
-gem "activemodel-serializers-xml", "~> 1.0.1"
-gem "activerecord-import", "~> 2.2.0"
-gem "activerecord-session_store", "~> 2.3.0"
-gem "ox"
-gem "rails", "~> 8.1.3"
-gem "responders", "~> 3.2"
+  gem "ffi", "~> 1.17"
 
-gem "ffi", "~> 1.17"
+  gem "connection_pool", "~> 3.0.2"
 
-gem "connection_pool", "~> 3.0.2"
+  gem "rdoc", ">= 2.4.2"
 
-gem "rdoc", ">= 2.4.2"
+  gem "doorkeeper", "~> 5.9.3"
+  # Maintain our own omniauth due to relative URL root issues
+  # see upstream PR: https://github.com/omniauth/omniauth/pull/903
+  gem "omniauth", git: "https://github.com/opf/omniauth", ref: "7eb21563ba047ef86d71f099975587b5ec88f9c9"
+  gem "request_store", "~> 1.7.0"
 
-gem "doorkeeper", "~> 5.9.3"
-# Maintain our own omniauth due to relative URL root issues
-# see upstream PR: https://github.com/omniauth/omniauth/pull/903
-gem "omniauth", git: "https://github.com/opf/omniauth", ref: "7eb21563ba047ef86d71f099975587b5ec88f9c9"
-gem "request_store", "~> 1.7.0"
+  gem "warden", "~> 1.2"
+  gem "warden-basic_auth", "~> 0.2.1"
 
-gem "warden", "~> 1.2"
-gem "warden-basic_auth", "~> 0.2.1"
+  gem "pagy"
+  gem "will_paginate", "~> 4.0.0"
 
-gem "pagy"
-gem "will_paginate", "~> 4.0.0"
+  gem "friendly_id", "~> 5.7.0"
 
-gem "friendly_id", "~> 5.7.0"
+  gem "scimitar", "~> 2.13"
 
-gem "scimitar", "~> 2.13"
+  gem "acts_as_list", "~> 1.2.6"
+  gem "acts_as_tree", "~> 2.9.0"
+  gem "awesome_nested_set", "~> 3.9.0"
+  gem "closure_tree", "~> 9.7.0"
+  gem "rubytree", "~> 2.2.0"
 
-gem "acts_as_list", "~> 1.2.6"
-gem "acts_as_tree", "~> 2.9.0"
-gem "awesome_nested_set", "~> 3.9.0"
-gem "closure_tree", "~> 9.7.0"
-gem "rubytree", "~> 2.2.0"
+  gem "addressable", "~> 2.9.0"
 
-gem "addressable", "~> 2.9.0"
+  # Remove whitespace from model input
+  gem "auto_strip_attributes", "~> 2.5"
 
-# Remove whitespace from model input
-gem "auto_strip_attributes", "~> 2.5"
+  # Provide timezone info for TZInfo used by AR
+  gem "tzinfo-data", "~> 1.2026.1"
 
-# Provide timezone info for TZInfo used by AR
-gem "tzinfo-data", "~> 1.2026.1"
+  # to generate html-diffs (e.g. for wiki comparison)
+  gem "htmldiff"
 
-# to generate html-diffs (e.g. for wiki comparison)
-gem "htmldiff"
+  # Generate url slugs with #to_url and other string niceties
+  gem "stringex", "~> 2.8.5"
 
-# Generate url slugs with #to_url and other string niceties
-gem "stringex", "~> 2.8.5"
+  # CommonMark markdown parser with GFM extension
+  gem "commonmarker", "~> 2.8.3"
 
-# CommonMark markdown parser with GFM extension
-gem "commonmarker", "~> 2.8.3"
+  # HTML pipeline for transformations on text formatter output
+  # such as sanitization or additional features
+  gem "html-pipeline", "~> 2.14.0"
+  # Tasklist parsing and renderer
+  gem "deckar01-task_list", "~> 2.3.1"
+  # Requires escape-utils for faster escaping
+  gem "escape_utils", "~> 1.3"
+  # Syntax highlighting used in html-pipeline with rouge
+  gem "rouge", "~> 4.7.0"
+  # HTML sanitization used for html-pipeline
+  gem "sanitize", "~> 7.0.0"
+  # HTML autolinking for mails and urls (replaces autolink)
+  gem "rinku", "~> 2.0.4", require: %w[rinku rails_rinku]
+  # Version parsing with semver
+  gem "semantic", "~> 1.6.1"
 
-# HTML pipeline for transformations on text formatter output
-# such as sanitization or additional features
-gem "html-pipeline", "~> 2.14.0"
-# Tasklist parsing and renderer
-gem "deckar01-task_list", "~> 2.3.1"
-# Requires escape-utils for faster escaping
-gem "escape_utils", "~> 1.3"
-# Syntax highlighting used in html-pipeline with rouge
-gem "rouge", "~> 4.7.0"
-# HTML sanitization used for html-pipeline
-gem "sanitize", "~> 7.0.0"
-# HTML autolinking for mails and urls (replaces autolink)
-gem "rinku", "~> 2.0.4", require: %w[rinku rails_rinku]
-# Version parsing with semver
-gem "semantic", "~> 1.6.1"
+  # generates SVG Graphs
+  # used for statistics on svn repositories
+  gem "svg-graph", "~> 2.2.0"
 
-# generates SVG Graphs
-# used for statistics on svn repositories
-gem "svg-graph", "~> 2.2.0"
+  gem "date_validator", "~> 0.12.0"
+  gem "email_validator", "~> 2.2.3"
+  gem "json_schemer", "~> 2.5.0"
+  gem "msgpack", "~> 1.8.3"
+  gem "ruby-duration", "~> 3.2.0"
 
-gem "date_validator", "~> 0.12.0"
-gem "email_validator", "~> 2.2.3"
-gem "json_schemer", "~> 2.5.0"
-gem "msgpack", "~> 1.8.3"
-gem "ruby-duration", "~> 3.2.0"
+  gem "mail", "2.9.1"
 
-gem "mail", "2.9.1"
+  gem "csv", "~> 3.3"
 
-gem "csv", "~> 3.3"
+  # provide compatible filesystem information for available storage
+  gem "sys-filesystem", "~> 1.6.0", require: false
 
-# provide compatible filesystem information for available storage
-gem "sys-filesystem", "~> 1.6.0", require: false
+  gem "bcrypt", "~> 3.1.22"
 
-gem "bcrypt", "~> 3.1.22"
+  gem "multi_json", "~> 1.21.0"
 
-gem "multi_json", "~> 1.21.0"
+  gem "daemons"
+  gem "good_job", "~> 4.19.2" # update should be done manually in sync with saas-openproject version.
 
-gem "daemons"
-gem "good_job", "~> 4.19.2" # update should be done manually in sync with saas-openproject version.
+  gem "rack-protection", "~> 3.2.0"
 
-gem "rack-protection", "~> 3.2.0"
+  # Rack::Attack is a rack middleware to protect your web app from bad clients.
+  # It allows whitelisting, blacklisting, throttling, and tracking based
+  # on arbitrary properties of the request.
+  # https://github.com/kickstarter/rack-attack
+  gem "rack-attack", "~> 6.8.0"
 
-# Rack::Attack is a rack middleware to protect your web app from bad clients.
-# It allows whitelisting, blacklisting, throttling, and tracking based
-# on arbitrary properties of the request.
-# https://github.com/kickstarter/rack-attack
-gem "rack-attack", "~> 6.8.0"
+  # Browser detection for incompatibility checks
+  gem "browser", "~> 6.2.0"
 
-# Browser detection for incompatibility checks
-gem "browser", "~> 6.2.0"
+  # Providing health checks
+  gem "okcomputer", "~> 1.19.1"
 
-# Providing health checks
-gem "okcomputer", "~> 1.19.1"
+  # Lograge to provide sane and non-verbose logging
+  gem "lograge", "~> 0.15.0"
 
-# Lograge to provide sane and non-verbose logging
-gem "lograge", "~> 0.15.0"
+  # Structured warnings to selectively disable them in production
+  gem "structured_warnings", "~> 0.5.0"
 
-# Structured warnings to selectively disable them in production
-gem "structured_warnings", "~> 0.5.0"
+  # catch exceptions and send them to any airbrake compatible backend
+  # don't require by default, instead load on-demand when actually configured
+  gem "airbrake", "~> 13.0.0", require: false
 
-# catch exceptions and send them to any airbrake compatible backend
-# don't require by default, instead load on-demand when actually configured
-gem "airbrake", "~> 13.0.0", require: false
+  gem "markly", "~> 0.15" # another markdown parser like commonmarker, but with AST support used in PDF export
+  gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "0cb4597becd2243b810e7ce53bbbbf28b5f05844"
+  gem "prawn", "~> 2.4"
+  gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 
-gem "markly", "~> 0.15" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "0cb4597becd2243b810e7ce53bbbbf28b5f05844"
-gem "prawn", "~> 2.4"
-gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
+  # prawn implicitly depends on matrix gem no longer in ruby core with 3.1
+  gem "matrix", "~> 0.4.3"
 
-# prawn implicitly depends on matrix gem no longer in ruby core with 3.1
-gem "matrix", "~> 0.4.3"
+  gem "mcp", "~> 0.24.0"
 
-gem "mcp", "~> 0.24.0"
+  gem "meta-tags", "~> 2.23.0"
 
-gem "meta-tags", "~> 2.23.0"
+  gem "paper_trail", "~> 17.0.0"
 
-gem "paper_trail", "~> 17.0.0"
+  # State machine with audit trail
+  gem "statesman", "~> 13.1.0"
 
-# State machine with audit trail
-gem "statesman", "~> 13.1.0"
+  gem "job-iteration"
 
-gem "job-iteration"
+  gem "op-clamav-client", "~> 3.4", require: "clamav"
 
-gem "op-clamav-client", "~> 3.4", require: "clamav"
+  # Global ID for polymorphic associations
+  gem "globalid", "~> 1.4"
 
-# Global ID for polymorphic associations
-gem "globalid", "~> 1.4"
+  # Recurring meeting events definition
+  gem "ice_cube", "~> 0.17.0"
 
-# Recurring meeting events definition
-gem "ice_cube", "~> 0.17.0"
+  group :production do
+    # we use dalli as standard memcache client
+    # requires memcached 1.6+
+    gem "dalli", "~> 5.0.0"
+    gem "redis", "~> 5.4.0"
+  end
 
-group :production do
-  # we use dalli as standard memcache client
-  # requires memcached 1.6+
-  gem "dalli", "~> 5.0.0"
-  gem "redis", "~> 5.4.0"
-end
+  gem "i18n-js", "~> 4.2.4"
+  gem "rails-i18n", "~> 8.1.0"
 
-gem "i18n-js", "~> 4.2.4"
-gem "rails-i18n", "~> 8.1.0"
+  gem "sprockets", "~> 3.7.2" # lock sprockets below 4.0
+  gem "sprockets-rails", "~> 3.5.1"
 
-gem "sprockets", "~> 3.7.2" # lock sprockets below 4.0
-gem "sprockets-rails", "~> 3.5.1"
+  gem "puma", "~> 8.0"
+  gem "puma-plugin-statsd", "~> 2.7"
+  gem "rack-timeout", "~> 0.7.0", require: "rack/timeout/base"
 
-gem "puma", "~> 8.0"
-gem "puma-plugin-statsd", "~> 2.7"
-gem "rack-timeout", "~> 0.7.0", require: "rack/timeout/base"
+  gem "nokogiri", "~> 1.19.4"
 
-gem "nokogiri", "~> 1.19.4"
+  gem "carrierwave", "~> 2.2.7"
+  gem "carrierwave_direct", "~> 3.0.0"
+  gem "fog-aws"
+  gem "ssrf_filter", "~> 1.3"
 
-gem "carrierwave", "~> 2.2.7"
-gem "carrierwave_direct", "~> 3.0.0"
-gem "fog-aws"
-gem "ssrf_filter", "~> 1.3"
+  gem "aws-sdk-core", "~> 3.251"
+  # File upload via fog + screenshots on travis
+  gem "aws-sdk-s3", "~> 1.227"
 
-gem "aws-sdk-core", "~> 3.251"
-# File upload via fog + screenshots on travis
-gem "aws-sdk-s3", "~> 1.227"
+  gem "openproject-token", "~> 8.12.0"
 
-gem "openproject-token", "~> 8.12.0"
+  gem "plaintext", "~> 0.3.7"
 
-gem "plaintext", "~> 0.3.7"
+  gem "ruby-progressbar", "~> 1.13.0", require: false
 
-gem "ruby-progressbar", "~> 1.13.0", require: false
+  gem "mini_magick", "~> 5.3.2", require: false
 
-gem "mini_magick", "~> 5.3.2", require: false
+  gem "validate_url"
 
-gem "validate_url"
+  # Storages support code
+  gem "dry-core"
+  gem "dry-monads"
+  gem "dry-validation"
 
-# Storages support code
-gem "dry-core"
-gem "dry-monads"
-gem "dry-validation"
+  # ActiveRecord extension which adds typecasting to store accessors
+  gem "store_attribute", "~> 2.0"
 
-# ActiveRecord extension which adds typecasting to store accessors
-gem "store_attribute", "~> 2.0"
+  # Appsignal integration
+  gem "appsignal", "~> 4.8", require: false
 
-# Appsignal integration
-gem "appsignal", "~> 4.8", require: false
+  # Yabeda integration
+  gem "yabeda-activerecord"
+  gem "yabeda-prometheus-mmap", require: false
+  gem "yabeda-puma-plugin"
+  gem "yabeda-rails"
 
-# Yabeda integration
-gem "yabeda-activerecord"
-gem "yabeda-prometheus-mmap", require: false
-gem "yabeda-puma-plugin"
-gem "yabeda-rails"
+  # opentelemetry
+  gem "opentelemetry-exporter-otlp", "~> 0.34.0", require: false
+  gem "opentelemetry-instrumentation-all", "~> 0.94.0", require: false
+  gem "opentelemetry-sdk", "~> 1.10", require: false
 
-# opentelemetry
-gem "opentelemetry-exporter-otlp", "~> 0.34.0", require: false
-gem "opentelemetry-instrumentation-all", "~> 0.94.0", require: false
-gem "opentelemetry-sdk", "~> 1.10", require: false
+  gem "view_component", "~> 4.12.0"
+  # Lookbook
+  gem "lookbook", "2.3.14"
 
-gem "view_component", "~> 4.12.0"
-# Lookbook
-gem "lookbook", "2.3.14"
+  gem "inline_svg", "~> 1.10.0"
 
-gem "inline_svg", "~> 1.10.0"
+  # Require factory_bot for usage with openproject plugins testing
+  gem "factory_bot", "~> 6.6.0", require: false
+  # require factory_bot_rails for convenience in core development
+  gem "factory_bot_rails", "~> 6.5.0", require: false
 
-# Require factory_bot for usage with openproject plugins testing
-gem "factory_bot", "~> 6.6.0", require: false
-# require factory_bot_rails for convenience in core development
-gem "factory_bot_rails", "~> 6.5.0", require: false
+  gem "turbo_power", "~> 0.8.0"
+  gem "turbo-rails", "~> 2.0.20"
 
-gem "turbo_power", "~> 0.8.0"
-gem "turbo-rails", "~> 2.0.20"
+  gem "httpx", "~> 1.8.0"
 
-gem "httpx", "~> 1.8.0"
+  # Brings actual deep-freezing to most ruby objects
+  gem "ice_nine"
 
-# Brings actual deep-freezing to most ruby objects
-gem "ice_nine"
+  group :test do
+    gem "launchy", "~> 3.1.0"
+    gem "rack-test", "~> 2.2.0"
+    gem "shoulda-context", "~> 2.0"
 
-group :test do
-  gem "launchy", "~> 3.1.0"
-  gem "rack-test", "~> 2.2.0"
-  gem "shoulda-context", "~> 2.0"
+    # Test prof provides factories from code
+    # and other niceties
+    gem "test-prof", "~> 1.6.2"
+    gem "turbo_tests", github: "opf/turbo_tests", ref: "with-patches"
 
-  # Test prof provides factories from code
-  # and other niceties
-  gem "test-prof", "~> 1.6.2"
-  gem "turbo_tests", github: "opf/turbo_tests", ref: "with-patches"
+    gem "rack_session_access"
+    gem "rspec", "~> 3.13.2"
+    # also add to development group, so 'spec' rake task gets loaded
+    gem "rspec-rails", "~> 8.0.4", group: :development
 
-  gem "rack_session_access"
-  gem "rspec", "~> 3.13.2"
-  # also add to development group, so 'spec' rake task gets loaded
-  gem "rspec-rails", "~> 8.0.4", group: :development
+    # Retry failures within the same environment
+    gem "retriable", "~> 4.2.0"
+    gem "rspec-retry", "~> 0.6.1"
 
-  # Retry failures within the same environment
-  gem "retriable", "~> 4.2.0"
-  gem "rspec-retry", "~> 0.6.1"
+    # Accessibility tests
+    gem "axe-core-rspec"
 
-  # Accessibility tests
-  gem "axe-core-rspec"
+    # Modify ENV
+    gem "climate_control"
 
-  # Modify ENV
-  gem "climate_control"
+    # XML comparison tests
+    gem "compare-xml", "~> 0.66", require: false
 
-  # XML comparison tests
-  gem "compare-xml", "~> 0.66", require: false
+    # PDF Export tests
+    gem "pdf-inspector", "~> 1.2"
 
-  # PDF Export tests
-  gem "pdf-inspector", "~> 1.2"
+    # brings back testing for 'assigns' and 'assert_template' extracted in rails 5
+    gem "rails-controller-testing", "~> 1.0.2"
 
-  # brings back testing for 'assigns' and 'assert_template' extracted in rails 5
-  gem "rails-controller-testing", "~> 1.0.2"
+    gem "capybara", "~> 3.40.0"
+    gem "capybara_accessible_selectors", git: "https://github.com/citizensadvice/capybara_accessible_selectors", tag: "v0.16.0"
+    gem "capybara-screenshot", "~> 1.0.17"
+    gem "cuprite", "~> 0.17.0"
+    gem "rspec-wait"
+    gem "selenium-devtools"
+    gem "selenium-webdriver", "~> 4.38"
 
-  gem "capybara", "~> 3.40.0"
-  gem "capybara_accessible_selectors", git: "https://github.com/citizensadvice/capybara_accessible_selectors", tag: "v0.16.0"
-  gem "capybara-screenshot", "~> 1.0.17"
-  gem "cuprite", "~> 0.17.0"
-  gem "rspec-wait"
-  gem "selenium-devtools"
-  gem "selenium-webdriver", "~> 4.38"
+    gem "fuubar", "~> 2.5.0", require: false
+    gem "timecop", "~> 0.9.0"
 
-  gem "fuubar", "~> 2.5.0", require: false
-  gem "timecop", "~> 0.9.0"
+    # Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.
+    gem "vcr"
+    # Mock backend requests (for ruby tests)
+    gem "webmock", "~> 3.26", require: false
 
-  # Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.
-  gem "vcr"
-  # Mock backend requests (for ruby tests)
-  gem "webmock", "~> 3.26", require: false
+    # Mock selenium requests through proxy (for feature tests)
+    gem "puffing-billy", "~> 4.0.0"
+    gem "table_print", "~> 1.5.6"
 
-  # Mock selenium requests through proxy (for feature tests)
-  gem "puffing-billy", "~> 4.0.0"
-  gem "table_print", "~> 1.5.6"
+    gem "equivalent-xml", "~> 0.6"
+    gem "json_spec", "~> 1.1.4"
+    gem "shoulda-matchers", "~> 8.0", require: nil
 
-  gem "equivalent-xml", "~> 0.6"
-  gem "json_spec", "~> 1.1.4"
-  gem "shoulda-matchers", "~> 8.0", require: nil
+    gem "parallel_tests", "~> 4.0"
+  end
 
-  gem "parallel_tests", "~> 4.0"
-end
+  group :ldap do
+    gem "net-ldap", "~> 0.20.0"
+  end
 
-group :ldap do
-  gem "net-ldap", "~> 0.20.0"
-end
+  group :development do
+    gem "listen", "~> 3.10.0" # Use for event-based reloaders
 
-group :development do
-  gem "listen", "~> 3.10.0" # Use for event-based reloaders
+    gem "letter_opener_web"
 
-  gem "letter_opener_web"
+    gem "spring"
+    gem "spring-commands-rspec"
+    gem "spring-commands-rubocop"
 
-  gem "spring"
-  gem "spring-commands-rspec"
-  gem "spring-commands-rubocop"
+    gem "colored2"
+  end
 
-  gem "colored2"
-end
+  group :development, :test do
+    gem "dotenv-rails"
 
-group :development, :test do
-  gem "dotenv-rails"
+    # Tracing and profiling gems
+    gem "flamegraph", require: false
+    gem "rack-mini-profiler", require: false
+    gem "ruby-prof", require: false
+    gem "stackprof", require: false
+    gem "vernier", require: false
 
-  # Tracing and profiling gems
-  gem "flamegraph", require: false
-  gem "rack-mini-profiler", require: false
-  gem "ruby-prof", require: false
-  gem "stackprof", require: false
-  gem "vernier", require: false
+    # Output a stack trace anytime, useful when a process is stuck
+    gem "rbtrace"
 
-  # Output a stack trace anytime, useful when a process is stuck
-  gem "rbtrace"
+    # REPL with debug commands, Debug changed to byebug due to the issue below
+    # https://github.com/puma/puma/issues/2835#issuecomment-2302133927
+    gem "byebug"
 
-  # REPL with debug commands, Debug changed to byebug due to the issue below
-  # https://github.com/puma/puma/issues/2835#issuecomment-2302133927
-  gem "byebug"
+    # Unreleased fix of readline dependency of pry: https://github.com/pry/pry/pull/2366
+    # Once this gets released, the specific dev dependency on pry can be removed
+    gem "pry", github: "pry/pry", ref: "135640262879544c6bfecbf3e78511289bfe956c"
+    gem "pry-byebug", "~> 3.12.0", platforms: [:mri]
+    gem "pry-rails", "~> 0.3.6"
+    gem "pry-rescue", "~> 1.6.0"
 
-  # Unreleased fix of readline dependency of pry: https://github.com/pry/pry/pull/2366
-  # Once this gets released, the specific dev dependency on pry can be removed
-  gem "pry", github: "pry/pry", ref: "135640262879544c6bfecbf3e78511289bfe956c"
-  gem "pry-byebug", "~> 3.12.0", platforms: [:mri]
-  gem "pry-rails", "~> 0.3.6"
-  gem "pry-rescue", "~> 1.6.0"
+    # ruby linting
+    gem "rubocop", require: false
+    gem "rubocop-capybara", require: false
+    gem "rubocop-factory_bot", require: false
+    gem "rubocop-openproject", require: false
+    gem "rubocop-performance", require: false
+    gem "rubocop-rails", "~> 2.36.0"
+    gem "rubocop-rspec", require: false
+    gem "rubocop-rspec_rails", require: false
 
-  # ruby linting
-  gem "rubocop", require: false
-  gem "rubocop-capybara", require: false
-  gem "rubocop-factory_bot", require: false
-  gem "rubocop-openproject", require: false
-  gem "rubocop-performance", require: false
-  gem "rubocop-rails", "~> 2.36.0"
-  gem "rubocop-rspec", require: false
-  gem "rubocop-rspec_rails", require: false
+    # erb linting
+    gem "erb_lint", require: false
+    gem "erblint-github", require: false
 
-  # erb linting
-  gem "erb_lint", require: false
-  gem "erblint-github", require: false
+    # Brakeman scanner
+    gem "brakeman", "~> 8.0.5"
 
-  # Brakeman scanner
-  gem "brakeman", "~> 8.0.5"
+    # i18n-tasks helps find and manage missing and unused translations.
+    gem "i18n-tasks", "~> 1.1.0", require: false
 
-  # i18n-tasks helps find and manage missing and unused translations.
-  gem "i18n-tasks", "~> 1.1.0", require: false
+    # Active Record Doctor helps to keep the database in good shape.
+    gem "active_record_doctor", "~> 2.0.1"
+  end
 
-  # Active Record Doctor helps to keep the database in good shape.
-  gem "active_record_doctor", "~> 2.0.1"
-end
+  # API gems
+  gem "grape", "~> 3.3.3"
+  gem "grape_logging", "~> 3.0.0"
+  gem "roar", "~> 1.2.0"
 
-# API gems
-gem "grape", "~> 3.3.3"
-gem "grape_logging", "~> 3.0.0"
-gem "roar", "~> 1.2.0"
+  # CORS for API
+  gem "rack-cors", "~> 2.0.2"
 
-# CORS for API
-gem "rack-cors", "~> 2.0.2"
+  # Gmail API
+  gem "google-apis-gmail_v1", require: false
+  gem "googleauth", require: false
 
-# Gmail API
-gem "google-apis-gmail_v1", require: false
-gem "googleauth", require: false
+  # Required for contracts
+  gem "disposable", "~> 0.6.2"
 
-# Required for contracts
-gem "disposable", "~> 0.6.2"
+  # Used for formula evaluation of calculated values
+  gem "dentaku", "~> 3.5", git: "https://github.com/opf/dentaku", ref: "78eece45bf3f4ed021c05dd2f5411d1c3f9b168a"
 
-# Used for formula evaluation of calculated values
-gem "dentaku", "~> 3.5", git: "https://github.com/opf/dentaku", ref: "78eece45bf3f4ed021c05dd2f5411d1c3f9b168a"
+  # Used for more powerful counter caches
+  gem "counter_culture", "~> 3.14"
 
-# Used for more powerful counter caches
-gem "counter_culture", "~> 3.14"
+  group :postgres do
+    gem "pg", "~> 1.6.2"
+  end
 
-group :postgres do
-  gem "pg", "~> 1.6.2"
-end
+  # Support application loading when no database exists yet.
+  gem "activerecord-nulldb-adapter", "~> 1.2.2"
 
-# Support application loading when no database exists yet.
-gem "activerecord-nulldb-adapter", "~> 1.2.2"
+  # Have application level locks on the database to have a mutex shared between workers/hosts.
+  # We e.g. employ this to safeguard the creation of journals.
+  gem "with_advisory_lock", "~> 7.5.0"
 
-# Have application level locks on the database to have a mutex shared between workers/hosts.
-# We e.g. employ this to safeguard the creation of journals.
-gem "with_advisory_lock", "~> 7.5.0"
+  # Load Gemfile.modules explicitly to allow dependabot to work
+  eval_gemfile "./Gemfile.modules"
 
-# Load Gemfile.modules explicitly to allow dependabot to work
-eval_gemfile "./Gemfile.modules"
-
-# Load Gemfile.local, Gemfile.plugins and custom Gemfiles
-gemfiles = Dir.glob File.expand_path("{Gemfile.plugins,Gemfile.local}", __dir__)
-gemfiles << ENV["CUSTOM_PLUGIN_GEMFILE"] unless ENV["CUSTOM_PLUGIN_GEMFILE"].nil?
-gemfiles.each do |file|
-  # We use send to allow dependabot to function
-  # don't use eval_gemfile(file) here as it will break dependabot!
-  send(:eval_gemfile, file) if File.readable?(file)
+  # Load Gemfile.local, Gemfile.plugins and custom Gemfiles
+  gemfiles = Dir.glob File.expand_path("{Gemfile.plugins,Gemfile.local}", __dir__)
+  gemfiles << ENV["CUSTOM_PLUGIN_GEMFILE"] unless ENV["CUSTOM_PLUGIN_GEMFILE"].nil?
+  gemfiles.each do |file|
+    # We use send to allow dependabot to function
+    # don't use eval_gemfile(file) here as it will break dependabot!
+    send(:eval_gemfile, file) if File.readable?(file)
+  end
 end
 
 # Set cooldown 0 for our own gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,9 @@ PATH
       spreadsheet (~> 1.3.0)
 
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -1563,106 +1566,106 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  actionpack-xml_parser (~> 2.0.0)
-  active_record_doctor (~> 2.0.1)
-  activemodel-serializers-xml (~> 1.0.1)
-  activerecord-import (~> 2.2.0)
-  activerecord-nulldb-adapter (~> 1.2.2)
-  activerecord-session_store (~> 2.3.0)
-  acts_as_list (~> 1.2.6)
-  acts_as_tree (~> 2.9.0)
-  addressable (~> 2.9.0)
-  airbrake (~> 13.0.0)
-  appsignal (~> 4.8)
-  auto_strip_attributes (~> 2.5)
-  awesome_nested_set (~> 3.9.0)
-  aws-sdk-core (~> 3.251)
-  aws-sdk-s3 (~> 1.227)
-  axe-core-rspec
-  bcrypt (~> 3.1.22)
-  brakeman (~> 8.0.5)
-  browser (~> 6.2.0)
+  actionpack-xml_parser (~> 2.0.0)!
+  active_record_doctor (~> 2.0.1)!
+  activemodel-serializers-xml (~> 1.0.1)!
+  activerecord-import (~> 2.2.0)!
+  activerecord-nulldb-adapter (~> 1.2.2)!
+  activerecord-session_store (~> 2.3.0)!
+  acts_as_list (~> 1.2.6)!
+  acts_as_tree (~> 2.9.0)!
+  addressable (~> 2.9.0)!
+  airbrake (~> 13.0.0)!
+  appsignal (~> 4.8)!
+  auto_strip_attributes (~> 2.5)!
+  awesome_nested_set (~> 3.9.0)!
+  aws-sdk-core (~> 3.251)!
+  aws-sdk-s3 (~> 1.227)!
+  axe-core-rspec!
+  bcrypt (~> 3.1.22)!
+  brakeman (~> 8.0.5)!
+  browser (~> 6.2.0)!
   budgets!
-  byebug
-  capybara (~> 3.40.0)
-  capybara-screenshot (~> 1.0.17)
+  byebug!
+  capybara (~> 3.40.0)!
+  capybara-screenshot (~> 1.0.17)!
   capybara_accessible_selectors!
-  carrierwave (~> 2.2.7)
-  carrierwave_direct (~> 3.0.0)
-  climate_control
-  closure_tree (~> 9.7.0)
-  colored2
-  commonmarker (~> 2.8.3)
-  compare-xml (~> 0.66)
-  connection_pool (~> 3.0.2)
+  carrierwave (~> 2.2.7)!
+  carrierwave_direct (~> 3.0.0)!
+  climate_control!
+  closure_tree (~> 9.7.0)!
+  colored2!
+  commonmarker (~> 2.8.3)!
+  compare-xml (~> 0.66)!
+  connection_pool (~> 3.0.2)!
   costs!
-  counter_culture (~> 3.14)
-  csv (~> 3.3)
-  cuprite (~> 0.17.0)
-  daemons
-  dalli (~> 5.0.0)
-  date_validator (~> 0.12.0)
-  deckar01-task_list (~> 2.3.1)
+  counter_culture (~> 3.14)!
+  csv (~> 3.3)!
+  cuprite (~> 0.17.0)!
+  daemons!
+  dalli (~> 5.0.0)!
+  date_validator (~> 0.12.0)!
+  deckar01-task_list (~> 2.3.1)!
   dentaku (~> 3.5)!
-  disposable (~> 0.6.2)
-  doorkeeper (~> 5.9.3)
-  dotenv-rails
-  dry-core
-  dry-monads
-  dry-validation
-  email_validator (~> 2.2.3)
-  equivalent-xml (~> 0.6)
-  erb_lint
-  erblint-github
-  escape_utils (~> 1.3)
-  factory_bot (~> 6.6.0)
-  factory_bot_rails (~> 6.5.0)
-  ffi (~> 1.17)
-  flamegraph
-  fog-aws
-  friendly_id (~> 5.7.0)
-  fuubar (~> 2.5.0)
-  globalid (~> 1.4)
-  good_job (~> 4.19.2)
-  google-apis-gmail_v1
-  googleauth
-  grape (~> 3.3.3)
-  grape_logging (~> 3.0.0)
+  disposable (~> 0.6.2)!
+  doorkeeper (~> 5.9.3)!
+  dotenv-rails!
+  dry-core!
+  dry-monads!
+  dry-validation!
+  email_validator (~> 2.2.3)!
+  equivalent-xml (~> 0.6)!
+  erb_lint!
+  erblint-github!
+  escape_utils (~> 1.3)!
+  factory_bot (~> 6.6.0)!
+  factory_bot_rails (~> 6.5.0)!
+  ffi (~> 1.17)!
+  flamegraph!
+  fog-aws!
+  friendly_id (~> 5.7.0)!
+  fuubar (~> 2.5.0)!
+  globalid (~> 1.4)!
+  good_job (~> 4.19.2)!
+  google-apis-gmail_v1!
+  googleauth!
+  grape (~> 3.3.3)!
+  grape_logging (~> 3.0.0)!
   grids!
-  html-pipeline (~> 2.14.0)
-  htmldiff
-  httpx (~> 1.8.0)
-  i18n-js (~> 4.2.4)
-  i18n-tasks (~> 1.1.0)
-  ice_cube (~> 0.17.0)
-  ice_nine
-  inline_svg (~> 1.10.0)
-  job-iteration
-  json_schemer (~> 2.5.0)
-  json_spec (~> 1.1.4)
-  ladle
-  launchy (~> 3.1.0)
-  letter_opener_web
-  listen (~> 3.10.0)
-  lograge (~> 0.15.0)
-  lookbook (= 2.3.14)
-  mail (= 2.9.1)
-  markly (~> 0.15)
-  matrix (~> 0.4.3)
-  mcp (~> 0.24.0)
+  html-pipeline (~> 2.14.0)!
+  htmldiff!
+  httpx (~> 1.8.0)!
+  i18n-js (~> 4.2.4)!
+  i18n-tasks (~> 1.1.0)!
+  ice_cube (~> 0.17.0)!
+  ice_nine!
+  inline_svg (~> 1.10.0)!
+  job-iteration!
+  json_schemer (~> 2.5.0)!
+  json_spec (~> 1.1.4)!
+  ladle!
+  launchy (~> 3.1.0)!
+  letter_opener_web!
+  listen (~> 3.10.0)!
+  lograge (~> 0.15.0)!
+  lookbook (= 2.3.14)!
+  mail (= 2.9.1)!
+  markly (~> 0.15)!
+  matrix (~> 0.4.3)!
+  mcp (~> 0.24.0)!
   md_to_pdf!
-  meta-tags (~> 2.23.0)
-  mini_magick (~> 5.3.2)
-  msgpack (~> 1.8.3)
-  multi_json (~> 1.21.0)
+  meta-tags (~> 2.23.0)!
+  mini_magick (~> 5.3.2)!
+  msgpack (~> 1.8.3)!
+  multi_json (~> 1.21.0)!
   my_page!
-  net-ldap (~> 0.20.0)
-  nokogiri (~> 1.19.4)
-  okcomputer (~> 1.19.1)
+  net-ldap (~> 0.20.0)!
+  nokogiri (~> 1.19.4)!
+  okcomputer (~> 1.19.1)!
   omniauth!
   omniauth-openid-connect!
   omniauth-openid_connect-providers!
-  op-clamav-client (~> 3.4)
+  op-clamav-client (~> 3.4)!
   openproject-auth_plugins!
   openproject-auth_saml!
   openproject-avatars!
@@ -1687,106 +1690,106 @@ DEPENDENCIES
   openproject-resource_management!
   openproject-storages!
   openproject-team_planner!
-  openproject-token (~> 8.12.0)
+  openproject-token (~> 8.12.0)!
   openproject-two_factor_authentication!
   openproject-webhooks!
   openproject-wikis!
   openproject-xls_export!
-  opentelemetry-exporter-otlp (~> 0.34.0)
-  opentelemetry-instrumentation-all (~> 0.94.0)
-  opentelemetry-sdk (~> 1.10)
+  opentelemetry-exporter-otlp (~> 0.34.0)!
+  opentelemetry-instrumentation-all (~> 0.94.0)!
+  opentelemetry-sdk (~> 1.10)!
   overviews!
-  ox
-  pagy
-  paper_trail (~> 17.0.0)
-  parallel_tests (~> 4.0)
-  pdf-inspector (~> 1.2)
-  pg (~> 1.6.2)
-  plaintext (~> 0.3.7)
-  prawn (~> 2.4)
+  ox!
+  pagy!
+  paper_trail (~> 17.0.0)!
+  parallel_tests (~> 4.0)!
+  pdf-inspector (~> 1.2)!
+  pg (~> 1.6.2)!
+  plaintext (~> 0.3.7)!
+  prawn (~> 2.4)!
   pry!
-  pry-byebug (~> 3.12.0)
-  pry-rails (~> 0.3.6)
-  pry-rescue (~> 1.6.0)
-  puffing-billy (~> 4.0.0)
-  puma (~> 8.0)
-  puma-plugin-statsd (~> 2.7)
-  rack-attack (~> 6.8.0)
-  rack-cors (~> 2.0.2)
-  rack-mini-profiler
-  rack-protection (~> 3.2.0)
-  rack-test (~> 2.2.0)
-  rack-timeout (~> 0.7.0)
-  rack_session_access
-  rails (~> 8.1.3)
-  rails-controller-testing (~> 1.0.2)
-  rails-i18n (~> 8.1.0)
-  rbtrace
-  rdoc (>= 2.4.2)
-  redis (~> 5.4.0)
-  request_store (~> 1.7.0)
-  responders (~> 3.2)
-  retriable (~> 4.2.0)
-  rinku (~> 2.0.4)
-  roar (~> 1.2.0)
-  rouge (~> 4.7.0)
-  rspec (~> 3.13.2)
-  rspec-rails (~> 8.0.4)
-  rspec-retry (~> 0.6.1)
-  rspec-wait
-  rubocop
-  rubocop-capybara
-  rubocop-factory_bot
-  rubocop-openproject
-  rubocop-performance
-  rubocop-rails (~> 2.36.0)
-  rubocop-rspec
-  rubocop-rspec_rails
-  ruby-duration (~> 3.2.0)
-  ruby-prof
-  ruby-progressbar (~> 1.13.0)
-  rubytree (~> 2.2.0)
-  sanitize (~> 7.0.0)
-  scimitar (~> 2.13)
-  selenium-devtools
-  selenium-webdriver (~> 4.38)
-  semantic (~> 1.6.1)
-  shoulda-context (~> 2.0)
-  shoulda-matchers (~> 8.0)
-  spring
-  spring-commands-rspec
-  spring-commands-rubocop
-  sprockets (~> 3.7.2)
-  sprockets-rails (~> 3.5.1)
-  ssrf_filter (~> 1.3)
-  stackprof
-  statesman (~> 13.1.0)
-  store_attribute (~> 2.0)
-  stringex (~> 2.8.5)
-  structured_warnings (~> 0.5.0)
-  svg-graph (~> 2.2.0)
-  sys-filesystem (~> 1.6.0)
-  table_print (~> 1.5.6)
-  test-prof (~> 1.6.2)
-  timecop (~> 0.9.0)
-  ttfunk (~> 1.7.0)
-  turbo-rails (~> 2.0.20)
-  turbo_power (~> 0.8.0)
+  pry-byebug (~> 3.12.0)!
+  pry-rails (~> 0.3.6)!
+  pry-rescue (~> 1.6.0)!
+  puffing-billy (~> 4.0.0)!
+  puma (~> 8.0)!
+  puma-plugin-statsd (~> 2.7)!
+  rack-attack (~> 6.8.0)!
+  rack-cors (~> 2.0.2)!
+  rack-mini-profiler!
+  rack-protection (~> 3.2.0)!
+  rack-test (~> 2.2.0)!
+  rack-timeout (~> 0.7.0)!
+  rack_session_access!
+  rails (~> 8.1.3)!
+  rails-controller-testing (~> 1.0.2)!
+  rails-i18n (~> 8.1.0)!
+  rbtrace!
+  rdoc (>= 2.4.2)!
+  redis (~> 5.4.0)!
+  request_store (~> 1.7.0)!
+  responders (~> 3.2)!
+  retriable (~> 4.2.0)!
+  rinku (~> 2.0.4)!
+  roar (~> 1.2.0)!
+  rouge (~> 4.7.0)!
+  rspec (~> 3.13.2)!
+  rspec-rails (~> 8.0.4)!
+  rspec-retry (~> 0.6.1)!
+  rspec-wait!
+  rubocop!
+  rubocop-capybara!
+  rubocop-factory_bot!
+  rubocop-openproject!
+  rubocop-performance!
+  rubocop-rails (~> 2.36.0)!
+  rubocop-rspec!
+  rubocop-rspec_rails!
+  ruby-duration (~> 3.2.0)!
+  ruby-prof!
+  ruby-progressbar (~> 1.13.0)!
+  rubytree (~> 2.2.0)!
+  sanitize (~> 7.0.0)!
+  scimitar (~> 2.13)!
+  selenium-devtools!
+  selenium-webdriver (~> 4.38)!
+  semantic (~> 1.6.1)!
+  shoulda-context (~> 2.0)!
+  shoulda-matchers (~> 8.0)!
+  spring!
+  spring-commands-rspec!
+  spring-commands-rubocop!
+  sprockets (~> 3.7.2)!
+  sprockets-rails (~> 3.5.1)!
+  ssrf_filter (~> 1.3)!
+  stackprof!
+  statesman (~> 13.1.0)!
+  store_attribute (~> 2.0)!
+  stringex (~> 2.8.5)!
+  structured_warnings (~> 0.5.0)!
+  svg-graph (~> 2.2.0)!
+  sys-filesystem (~> 1.6.0)!
+  table_print (~> 1.5.6)!
+  test-prof (~> 1.6.2)!
+  timecop (~> 0.9.0)!
+  ttfunk (~> 1.7.0)!
+  turbo-rails (~> 2.0.20)!
+  turbo_power (~> 0.8.0)!
   turbo_tests!
-  tzinfo-data (~> 1.2026.1)
-  validate_url
-  vcr
-  vernier
-  view_component (~> 4.12.0)
-  warden (~> 1.2)
-  warden-basic_auth (~> 0.2.1)
-  webmock (~> 3.26)
-  will_paginate (~> 4.0.0)
-  with_advisory_lock (~> 7.5.0)
-  yabeda-activerecord
-  yabeda-prometheus-mmap
-  yabeda-puma-plugin
-  yabeda-rails
+  tzinfo-data (~> 1.2026.1)!
+  validate_url!
+  vcr!
+  vernier!
+  view_component (~> 4.12.0)!
+  warden (~> 1.2)!
+  warden-basic_auth (~> 0.2.1)!
+  webmock (~> 3.26)!
+  will_paginate (~> 4.0.0)!
+  with_advisory_lock (~> 7.5.0)!
+  yabeda-activerecord!
+  yabeda-prometheus-mmap!
+  yabeda-puma-plugin!
+  yabeda-rails!
 
 CHECKSUMS
   Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
@@ -1841,7 +1844,6 @@ CHECKSUMS
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   budgets (1.0.0)
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-screenshot (1.0.27) sha256=afa1896cc23df77be1774e8d3b3ce3953bf060aeaa04ff87607b5daf689174f2


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Having a global source definition overriders subsequent source cooldown definitions. As a result, gems inside the `source "https://rubygems.org", cooldown: 0 do` block are still treated with a 7 day cooldown.

# What approach did you choose and why?
Wrap all the gems inside the global source block.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
