### PR TITLE
[COMMS-885] Support `target_versions` in the MCP server

### DIFF
--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -50,6 +50,17 @@ module WorkPackage::Versions
       where(version_id: nil)
     }
 
+    scope :with_target_version, ->(version_id) {
+      where(id: WorkPackageVersion.where(kind: "target", version_id:).select(:work_package_id))
+    }
+
+    # Work packages with no target version.
+    # Filtering on the `target` rows directly (rather than the `target_versions` join) means an `observed_in`
+    # row on the same work package can never be mistaken for a missing target.
+    scope :without_target_version, -> {
+      where.not(id: WorkPackageVersion.where(kind: "target").select(:work_package_id))
+    }
+
     # Must be registered before `save_journals` (WorkPackage::Journalized) so
     # that the journal snapshot sees the current version sets in the database.
     after_save :persist_version_associations

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -68,32 +68,22 @@ module McpTools
       end
 
       def input_schema(schema = nil)
-        # Used as a setter during class definition: only store the raw
-        # definition. Assembling the effective schema is deferred to the getter
-        # so that runtime conditions (e.g. feature flags) are evaluated per
-        # request rather than frozen at load time.
-        return @input_schema_definition = schema if schema.present?
+        if schema.present?
+          if pagination_enabled?
+            page = {
+              type: "number",
+              default: 1,
+              description: "Page number for pagination. If no page is defined, the first result set is returned. " \
+                           "To get the rest of the results, use a page number of 2 or higher."
+            }
 
-        decorate_input_schema(resolve_input_schema)
-      end
+            @input_schema = schema.deep_merge({ properties: { page: } })
+          else
+            @input_schema = schema
+          end
+        end
 
-      # The raw schema definition before pagination is applied. Overridable by
-      # subclasses that need to adjust the schema at request time.
-      def resolve_input_schema
-        @input_schema_definition
-      end
-
-      def decorate_input_schema(schema)
-        return schema if schema.nil? || !pagination_enabled?
-
-        page = {
-          type: "number",
-          default: 1,
-          description: "Page number for pagination. If no page is defined, the first result set is returned. " \
-                       "To get the rest of the results, use a page number of 2 or higher."
-        }
-
-        schema.deep_merge({ properties: { page: } })
+        @input_schema
       end
 
       def output_schema(schema = nil)

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -68,22 +68,32 @@ module McpTools
       end
 
       def input_schema(schema = nil)
-        if schema.present?
-          if pagination_enabled?
-            page = {
-              type: "number",
-              default: 1,
-              description: "Page number for pagination. If no page is defined, the first result set is returned. " \
-                           "To get the rest of the results, use a page number of 2 or higher."
-            }
+        # Used as a setter during class definition: only store the raw
+        # definition. Assembling the effective schema is deferred to the getter
+        # so that runtime conditions (e.g. feature flags) are evaluated per
+        # request rather than frozen at load time.
+        return @input_schema_definition = schema if schema.present?
 
-            @input_schema = schema.deep_merge({ properties: { page: } })
-          else
-            @input_schema = schema
-          end
-        end
+        decorate_input_schema(resolve_input_schema)
+      end
 
-        @input_schema
+      # The raw schema definition before pagination is applied. Overridable by
+      # subclasses that need to adjust the schema at request time.
+      def resolve_input_schema
+        @input_schema_definition
+      end
+
+      def decorate_input_schema(schema)
+        return schema if schema.nil? || !pagination_enabled?
+
+        page = {
+          type: "number",
+          default: 1,
+          description: "Page number for pagination. If no page is defined, the first result set is returned. " \
+                       "To get the rest of the results, use a page number of 2 or higher."
+        }
+
+        schema.deep_merge({ properties: { page: } })
       end
 
       def output_schema(schema = nil)

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -80,27 +80,14 @@ module McpTools
           type: %w[number null],
           description: "Deprecated: use target_version_id instead. Matches work packages whose target versions " \
                        "include this version. Pass null to search for work packages without a version."
+        },
+        target_version_id: {
+          type: %w[number null],
+          description: "The ID of a version the work package targets. Matches work packages whose target " \
+                       "versions include this version. Pass null to search for work packages without any target version."
         }
       }
     )
-
-    # `target_version_id` is only advertised while the multiple versions feature
-    # is active. The equivalent, deprecated `version_id` filter stays available
-    # in all cases.
-    def self.resolve_input_schema
-      schema = super
-      return schema unless Setting::WorkPackageMultipleVersions.active?
-
-      schema.deep_merge(
-        properties: {
-          target_version_id: {
-            type: %w[number null],
-            description: "The ID of a version the work package targets. Matches work packages whose target " \
-                         "versions include this version. Pass null to search for work packages without any target version."
-          }
-        }
-      )
-    end
 
     output_schema(
       type: :object,

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -45,14 +45,7 @@ module McpTools
     # column. `version_id` is kept as a deprecated alias so we no longer query
     # the deprecated column.
     FILTER_ON_TARGET_VERSIONS = ->(wps, version_id) {
-      target_associations = WorkPackageVersion.where(kind: "target")
-
-      if version_id.nil?
-        # "without a target version": work packages that have no target row at all.
-        wps.where.not(id: target_associations.select(:work_package_id))
-      else
-        wps.where(id: target_associations.where(version_id:).select(:work_package_id))
-      end
+      version_id.nil? ? wps.without_target_version : wps.with_target_version(version_id)
     }
 
     # We can't use subclasses of WorkPackageFilter as filter_class, because they overwrite apply_to badly and rely on using

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -36,10 +36,24 @@ module McpTools
                         "of #{page_size} work packages. To get the rest of the results, call the tool again with a" \
                         "page number of 2 or higher."
 
-
     name "search_work_packages"
     annotations read_only: true, idempotent: true, destructive: false
     enable_pagination
+
+    # Both `version_id` and `target_version_id` filter on the `target_versions`
+    # association, which is replacing the legacy `work_packages.version_id`
+    # column. `version_id` is kept as a deprecated alias so we no longer query
+    # the deprecated column.
+    FILTER_ON_TARGET_VERSIONS = ->(wps, version_id) {
+      target_associations = WorkPackageVersion.where(kind: "target")
+
+      if version_id.nil?
+        # "without a target version": work packages that have no target row at all.
+        wps.where.not(id: target_associations.select(:work_package_id))
+      else
+        wps.where(id: target_associations.where(version_id:).select(:work_package_id))
+      end
+    }
 
     # We can't use subclasses of WorkPackageFilter as filter_class, because they overwrite apply_to badly and rely on using
     # an instantiated Query to be used.
@@ -49,7 +63,8 @@ module McpTools
     filter :project_id
     filter :status_id
     filter :type_id
-    filter :version_id
+    filter :version_id, filter_proc: FILTER_ON_TARGET_VERSIONS
+    filter :target_version_id, filter_proc: FILTER_ON_TARGET_VERSIONS
     filter :subject, filter_proc: ->(wps, v) { wps.where("subject ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(v)}%'") }
 
     input_schema(
@@ -70,10 +85,29 @@ module McpTools
         type_id: { type: "number", description: "The ID of the work package's type." },
         version_id: {
           type: %w[number null],
-          description: "The ID of the work package's version. Pass null to search for work packages without a version."
+          description: "Deprecated: use target_version_id instead. Matches work packages whose target versions " \
+                       "include this version. Pass null to search for work packages without a version."
         }
       }
     )
+
+    # `target_version_id` is only advertised while the multiple versions feature
+    # is active. The equivalent, deprecated `version_id` filter stays available
+    # in all cases.
+    def self.resolve_input_schema
+      schema = super
+      return schema unless Setting::WorkPackageMultipleVersions.active?
+
+      schema.deep_merge(
+        properties: {
+          target_version_id: {
+            type: %w[number null],
+            description: "The ID of a version the work package targets. Matches work packages whose target " \
+                         "versions include this version. Pass null to search for work packages without any target version."
+          }
+        }
+      )
+    end
 
     output_schema(
       type: :object,

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -600,6 +600,41 @@ RSpec.describe WorkPackage do
     end
   end
 
+  describe "target version scopes" do
+    shared_let(:project) { create(:project) }
+    shared_let(:version) { create(:version, project:) }
+    shared_let(:other_version) { create(:version, project:) }
+
+    # Targets `version` and, additionally, is observed in `other_version`. The
+    # observed_in row must not confuse either scope.
+    shared_let(:wp_targeting) do
+      create(:work_package, project:, version:).tap do |wp|
+        WorkPackageVersion.create!(work_package: wp, version: other_version, kind: "observed_in")
+      end
+    end
+    shared_let(:wp_without_target) { create(:work_package, project:, version: nil) }
+
+    describe ".with_target_version" do
+      it "returns only work packages targeting the given version" do
+        expect(described_class.with_target_version(version.id)).to contain_exactly(wp_targeting)
+      end
+
+      it "does not match on an observed_in version" do
+        expect(described_class.with_target_version(other_version.id)).to be_empty
+      end
+    end
+
+    describe ".without_target_version" do
+      it "returns only work packages without any target version" do
+        expect(described_class.without_target_version).to contain_exactly(wp_without_target)
+      end
+
+      it "excludes a work package that targets a version but is observed in another" do
+        expect(described_class.without_target_version).not_to include(wp_targeting)
+      end
+    end
+  end
+
   describe "#on_active_project" do
     shared_let(:work_package) { create(:work_package, project:) }
 

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -181,58 +181,28 @@ RSpec.describe McpTools::SearchWorkPackages do
       end
     end
 
-    # Both filters query the `target_versions` association. `version_id` is the
-    # deprecated alias that stays available regardless of the feature flag,
-    # `target_version_id` is only advertised while the flag is active.
+    # Both params dispatch to the `with_target_version` / `without_target_version`
+    # scopes; the query semantics (incl. observed_in divergence) are covered in
+    # spec/models/work_package_spec.rb. Here we only assert the wiring: each param
+    # reaches the right scope. `version_id` is the deprecated alias for the new
+    # `target_version_id`, so both behave identically.
     %i[version_id target_version_id].each do |filter_name|
       describe "filtering by #{filter_name}" do
-        context "when searching for work packages with a specific version" do
+        context "with a version id" do
           let(:call_args) { { filter_name => version.id } }
 
-          it "finds only work packages targeting the specified version" do
+          it "returns work packages targeting that version" do
             subject
-            expect(result_items.size).to eq(1)
-            expect(result_items.first["id"]).to eq(work_package_a.id)
+            expect(result_items.pluck("id")).to contain_exactly(work_package_a.id)
           end
         end
 
-        context "when searching for work packages without a version" do
+        context "with null" do
           let(:call_args) { { filter_name => nil } }
 
-          it "finds only work packages without a target version" do
+          it "returns work packages without a target version" do
             subject
-            expect(result_items.size).to eq(1)
-            expect(result_items.first["id"]).to eq(work_package_b.id)
-          end
-        end
-
-        context "when the target association diverges from the legacy version_id column" do
-          let(:other_version) { create(:version, project:) }
-
-          before do
-            # Filtering must follow `target_versions`, not the deprecated
-            # `work_packages.version_id` column. Force them apart so a query
-            # against the legacy column would return the wrong result.
-            WorkPackageVersion.where(work_package: work_package_a, kind: "target").delete_all
-            WorkPackageVersion.create!(work_package: work_package_a, version: other_version, kind: "target")
-          end
-
-          context "when filtering by the target version" do
-            let(:call_args) { { filter_name => other_version.id } }
-
-            it "matches on the target version" do
-              subject
-              expect(result_items.pluck("id")).to contain_exactly(work_package_a.id)
-            end
-          end
-
-          context "when filtering by the stale legacy version" do
-            let(:call_args) { { filter_name => version.id } }
-
-            it "does not match" do
-              subject
-              expect(result_items).to be_empty
-            end
+            expect(result_items.pluck("id")).to contain_exactly(work_package_b.id)
           end
         end
       end

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -181,24 +181,82 @@ RSpec.describe McpTools::SearchWorkPackages do
       end
     end
 
-    describe "filtering by version_id" do
-      context "when searching for work packages with a specific version" do
-        let(:call_args) { { version_id: version.id } }
+    # Both filters query the `target_versions` association. `version_id` is the
+    # deprecated alias that stays available regardless of the feature flag,
+    # `target_version_id` is only advertised while the flag is active.
+    %i[version_id target_version_id].each do |filter_name|
+      describe "filtering by #{filter_name}" do
+        context "when searching for work packages with a specific version" do
+          let(:call_args) { { filter_name => version.id } }
 
-        it "finds only work packages with the specified version" do
-          subject
-          expect(result_items.size).to eq(1)
-          expect(result_items.first["id"]).to eq(work_package_a.id)
+          it "finds only work packages targeting the specified version" do
+            subject
+            expect(result_items.size).to eq(1)
+            expect(result_items.first["id"]).to eq(work_package_a.id)
+          end
+        end
+
+        context "when searching for work packages without a version" do
+          let(:call_args) { { filter_name => nil } }
+
+          it "finds only work packages without a target version" do
+            subject
+            expect(result_items.size).to eq(1)
+            expect(result_items.first["id"]).to eq(work_package_b.id)
+          end
+        end
+
+        context "when the target association diverges from the legacy version_id column" do
+          let(:other_version) { create(:version, project:) }
+
+          before do
+            # Filtering must follow `target_versions`, not the deprecated
+            # `work_packages.version_id` column. Force them apart so a query
+            # against the legacy column would return the wrong result.
+            WorkPackageVersion.where(work_package: work_package_a, kind: "target").delete_all
+            WorkPackageVersion.create!(work_package: work_package_a, version: other_version, kind: "target")
+          end
+
+          context "when filtering by the target version" do
+            let(:call_args) { { filter_name => other_version.id } }
+
+            it "matches on the target version" do
+              subject
+              expect(result_items.pluck("id")).to contain_exactly(work_package_a.id)
+            end
+          end
+
+          context "when filtering by the stale legacy version" do
+            let(:call_args) { { filter_name => version.id } }
+
+            it "does not match" do
+              subject
+              expect(result_items).to be_empty
+            end
+          end
+        end
+      end
+    end
+
+    describe "the target_version_id input schema" do
+      subject { described_class.input_schema[:properties].keys }
+
+      context "when the multiple versions feature is active",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        it "advertises target_version_id" do
+          expect(subject).to include(:target_version_id)
         end
       end
 
-      context "when searching for work packages without a version" do
-        let(:call_args) { { version_id: nil } }
+      context "when the multiple versions feature is inactive",
+              with_flag: { work_package_multiple_versions: false } do
+        it "does not advertise target_version_id" do
+          expect(subject).not_to include(:target_version_id)
+        end
 
-        it "finds only work packages without a version" do
-          subject
-          expect(result_items.size).to eq(1)
-          expect(result_items.first["id"]).to eq(work_package_b.id)
+        it "still advertises the deprecated version_id" do
+          expect(subject).to include(:version_id)
         end
       end
     end

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -208,29 +208,6 @@ RSpec.describe McpTools::SearchWorkPackages do
       end
     end
 
-    describe "the target_version_id input schema" do
-      subject { described_class.input_schema[:properties].keys }
-
-      context "when the multiple versions feature is active",
-              with_flag: { work_package_multiple_versions: true },
-              with_settings: { work_package_multiple_versions: true } do
-        it "advertises target_version_id" do
-          expect(subject).to include(:target_version_id)
-        end
-      end
-
-      context "when the multiple versions feature is inactive",
-              with_flag: { work_package_multiple_versions: false } do
-        it "does not advertise target_version_id" do
-          expect(subject).not_to include(:target_version_id)
-        end
-
-        it "still advertises the deprecated version_id" do
-          expect(subject).to include(:version_id)
-        end
-      end
-    end
-
     describe "filtering by subject" do
       context "with exact subject" do
         let(:call_args) { { subject: "First Work Package" } }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-885/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
We are currently replacing singular `WorkPackage` `version` field with multi-valued `target_versions`.

The API implementation plan is outlined [here](https://community.openproject.org/projects/COMMS/work_packages/COMMS-857/activity) -- we deprecate the old field while introducing the new multi-valued field, currently capped to a single item. 

Let's follow the same approach in the MCP server.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
