### PR TITLE
few float simplifications

### DIFF
--- a/app/models/custom_actions/actions/strategies/float.rb
+++ b/app/models/custom_actions/actions/strategies/float.rb
@@ -42,8 +42,6 @@ module CustomActions::Actions::Strategies::Float
   def to_float_or_nil(value)
     return nil if value.nil?
 
-    Float(value)
-  rescue TypeError, ArgumentError
-    nil
+    Float(value, exception: false)
   end
 end

--- a/app/models/custom_value/calculated_value_strategy.rb
+++ b/app/models/custom_value/calculated_value_strategy.rb
@@ -61,10 +61,7 @@ class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
   end
 
   def validate_type_of_value
-    Kernel.Float(value)
-    nil
-  rescue StandardError
-    :not_a_number
+    :not_a_number unless Kernel.Float(value, exception: false)
   end
 
   private

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -44,9 +44,6 @@ class CustomValue::FloatStrategy < CustomValue::FormatStrategy
   end
 
   def validate_type_of_value
-    Kernel.Float(value)
-    nil
-  rescue StandardError
-    :not_a_number
+    :not_a_number unless Kernel.Float(value, exception: false)
   end
 end

--- a/lib/open_project/patches/string.rb
+++ b/lib/open_project/patches/string.rb
@@ -43,7 +43,7 @@ module OpenProject
         end
         # 2,5 => 2.5
         s.tr!(",", ".")
-        begin; Kernel.Float(s); rescue StandardError; nil; end
+        Kernel.Float(s, exception: false)
       end
 
       def with_leading_slash

--- a/modules/xls_export/lib/open_project/xls_export/spreadsheet_builder.rb
+++ b/modules/xls_export/lib/open_project/xls_export/spreadsheet_builder.rb
@@ -57,7 +57,7 @@ module OpenProject::XlsExport
         return 18
       end
 
-      tot_w = [Float(0)]
+      tot_w = [0.0]
       idx = 0
       value.to_s.each_char do |c|
         case c
@@ -69,7 +69,7 @@ module OpenProject::XlsExport
           tot_w[idx] += 1.2
         when "\n"
           idx = idx + 1
-          tot_w << Float(0)
+          tot_w << 0.0
         else
           tot_w[idx] += 1.05
         end


### PR DESCRIPTION
While working on https://community.openproject.org/wp/OP-19665

Use `Float(x, exception: false)` instead of relying on `ArgumentError`
Use `0.0` instead of `Float(0)`
