### PR TITLE
add children query to seeded agile types

### DIFF
--- a/app/seeders/basic_data/type_configuration_seeder.rb
+++ b/app/seeders/basic_data/type_configuration_seeder.rb
@@ -33,15 +33,8 @@ module BasicData
       BasicData::TypeSeeder
     ]
 
-    def seed!
+    def seed_data!
       seed_data.each("type_configuration") do |type_configuration_data|
-        # The referenced queries are seeded by the GlobalQuerySeeder within the same run. When
-        # re-seeding an installation whose global queries still exist (but whose projects were
-        # deleted), that seeder is skipped and the references are not registered again. We then
-        # cannot re-apply the form configuration, but that is acceptable: the types created in
-        # the initial seeding already carry it.
-        next unless queries_registered?(type_configuration_data)
-
         type = seed_data.find_reference(type_configuration_data["type"])
         groups = query_groups(type_configuration_data)
         groups += type.default_attribute_groups if merge_form_configuration?(type_configuration_data)
@@ -49,12 +42,22 @@ module BasicData
       end
     end
 
-    private
-
-    def queries_registered?(type_configuration_data)
-      type_configuration_data["form_configuration"]
-        .all? { |form_config_attr| seed_data.reference_exists?(form_config_attr["query"]) }
+    # The queries embedded into the form configuration are seeded by the GlobalQuerySeeder within
+    # the same run. When re-seeding an installation whose global queries still exist (but whose
+    # projects were deleted), that seeder is skipped and the references are not registered again.
+    # The seeder is then not applicable: we cannot re-apply the form configuration, but that is
+    # acceptable as the types created in the initial seeding already carry it.
+    def all_required_references
+      references = []
+      seed_data.each("type_configuration") do |type_configuration_data|
+        Array(type_configuration_data["form_configuration"]).each do |form_config_attr|
+          references << form_config_attr["query"]
+        end
+      end
+      references
     end
+
+    private
 
     # Whether the form configuration defined in the seed data should be merged with the type's
     # default form configuration as defined in the Ruby code. Defaults to false, in which case

--- a/app/seeders/basic_data/type_configuration_seeder.rb
+++ b/app/seeders/basic_data/type_configuration_seeder.rb
@@ -35,15 +35,33 @@ module BasicData
 
     def seed!
       seed_data.each("type_configuration") do |type_configuration_data|
+        # The referenced queries are seeded by the GlobalQuerySeeder within the same run. When
+        # re-seeding an installation whose global queries still exist (but whose projects were
+        # deleted), that seeder is skipped and the references are not registered again. We then
+        # cannot re-apply the form configuration, but that is acceptable: the types created in
+        # the initial seeding already carry it.
+        next unless queries_registered?(type_configuration_data)
+
         type = seed_data.find_reference(type_configuration_data["type"])
-        query_groups = query_groups(type_configuration_data)
-        type.update(
-          attribute_groups: query_groups + type.default_attribute_groups
-        )
+        groups = query_groups(type_configuration_data)
+        groups += type.default_attribute_groups if merge_form_configuration?(type_configuration_data)
+        type.update(attribute_groups: groups)
       end
     end
 
     private
+
+    def queries_registered?(type_configuration_data)
+      type_configuration_data["form_configuration"]
+        .all? { |form_config_attr| seed_data.reference_exists?(form_config_attr["query"]) }
+    end
+
+    # Whether the form configuration defined in the seed data should be merged with the type's
+    # default form configuration as defined in the Ruby code. Defaults to false, in which case
+    # only the query groups from the seed data make up the form configuration.
+    def merge_form_configuration?(type_configuration_data)
+      ActiveModel::Type::Boolean.new.cast(type_configuration_data["merge_form_configuration"])
+    end
 
     def query_groups(type_configuration_data)
       type_configuration_data["form_configuration"].map do |form_config_attr|

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -68,10 +68,7 @@ module DemoData
       set_display_representation! attr
 
       query = Query.new attr
-      # Skip validations while seeding: some seed queries reference columns that are only
-      # resolvable in the runtime rendering context and not at seed time. For example, the
-      # backlogs `sprint` column requires the :view_sprints permission in a project, which the
-      # seeding user does not necessarily hold for a project-less (global) query.
+      # Skip validations while seeding: some seed queries reference columns requiring permissions.
       query.save!(validate: false)
 
       create_view(query) unless config[:hidden]
@@ -113,10 +110,8 @@ module DemoData
 
       attr[:sort_criteria] =
         if sort_by.is_a?(Array)
-          # A list of [column, direction] pairs, e.g. [[status, desc], [id, asc]].
           sort_by.map { |criterion| Array(criterion).map(&:to_s) }
         else
-          # A single column name, sorted ascending.
           [[sort_by.to_s, "asc"]]
         end
     end

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -67,7 +67,12 @@ module DemoData
       set_filters! attr
       set_display_representation! attr
 
-      query = Query.create! attr
+      query = Query.new attr
+      # Skip validations while seeding: some seed queries reference columns that are only
+      # resolvable in the runtime rendering context and not at seed time. For example, the
+      # backlogs `sprint` column requires the :view_sprints permission in a project, which the
+      # seeding user does not necessarily hold for a project-less (global) query.
+      query.save!(validate: false)
 
       create_view(query) unless config[:hidden]
 
@@ -104,8 +109,16 @@ module DemoData
 
     def set_sort_by!(attr)
       sort_by = config[:sort_by]
+      return if sort_by.blank?
 
-      attr[:sort_criteria] = [[sort_by, "asc"]] if sort_by
+      attr[:sort_criteria] =
+        if sort_by.is_a?(Array)
+          # A list of [column, direction] pairs, e.g. [[status, desc], [id, asc]].
+          sort_by.map { |criterion| Array(criterion).map(&:to_s) }
+        else
+          # A single column name, sorted ascending.
+          [[sort_by.to_s, "asc"]]
+        end
     end
 
     def set_group_by!(attr)

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -1143,6 +1143,58 @@ types:
     is_in_roadmap: true
     position: 7
 
+# Hidden global queries embedded into the form configuration of the Epic and User story
+# types (see type_configuration below). The `parent: '{id}'` filter is a templated value that
+# is resolved to the currently displayed work package, so each query lists that work package's
+# children.
+global_queries:
+  - t_name: "Epic children: User stories and bugs"
+    reference: :default_type_epic__children_query
+    parent: '{id}'
+    hidden: true
+    public: false
+    type:
+      - :default_type_user_story
+      - :default_type_bug
+    sort_by:
+      - [status, desc] # work in progress first
+      - [sprint, asc] # current sprint first, no sprint last
+      - [position, asc] # keep the order defined within the sprint
+    columns:
+      - id
+      - subject
+      - status
+      - assigned_to
+      - story_points
+      - sprint
+  - t_name: "User story children: Tasks"
+    reference: :default_type_user_story__children_query
+    parent: '{id}'
+    hidden: true
+    public: false
+    sort_by:
+      - [status, desc] # work in progress first
+      - [id, asc] # older first
+    columns:
+      - id
+      - subject
+      - type
+      - status
+      - assigned_to
+      - sprint
+
+type_configuration:
+  - type: :default_type_epic
+    merge_form_configuration: true
+    form_configuration:
+      - t_group_name: "User stories and bugs"
+        query: :default_type_epic__children_query
+  - type: :default_type_user_story
+    merge_form_configuration: true
+    form_configuration:
+      - t_group_name: "Tasks"
+        query: :default_type_user_story__children_query
+
 workflows:
   - type: :default_type_task
     statuses:

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -1143,10 +1143,6 @@ types:
     is_in_roadmap: true
     position: 7
 
-# Hidden global queries embedded into the form configuration of the Epic and User story
-# types (see type_configuration below). The `parent: '{id}'` filter is a templated value that
-# is resolved to the currently displayed work package, so each query lists that work package's
-# children.
 global_queries:
   - t_name: "Epic children: User stories and bugs"
     reference: :default_type_epic__children_query
@@ -1157,9 +1153,9 @@ global_queries:
       - :default_type_user_story
       - :default_type_bug
     sort_by:
-      - [status, desc] # work in progress first
-      - [sprint, asc] # current sprint first, no sprint last
-      - [position, asc] # keep the order defined within the sprint
+      - [status, desc]
+      - [sprint, asc]
+      - [position, asc]
     columns:
       - id
       - subject
@@ -1173,8 +1169,8 @@ global_queries:
     hidden: true
     public: false
     sort_by:
-      - [status, desc] # work in progress first
-      - [id, asc] # older first
+      - [status, desc]
+      - [id, asc]
     columns:
       - id
       - subject

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -200,6 +200,7 @@ global_queries:
       - project
 type_configuration:
   - type: :default_type_summary_task
+    merge_form_configuration: true
     form_configuration:
       - t_group_name: "Children"
         query: :global_query__children

--- a/spec/seeders/basic_data/type_configuration_seeder_spec.rb
+++ b/spec/seeders/basic_data/type_configuration_seeder_spec.rb
@@ -48,6 +48,26 @@ RSpec.describe BasicData::TypeConfigurationSeeder do
     end
   end
 
+  context "with a form_configuration referencing a query that is not registered" do
+    # Happens when re-seeding an installation whose global queries still exist: the
+    # GlobalQuerySeeder is then skipped and their references are not registered again.
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        type_configuration:
+        - type: :default_type_summary_task
+          form_configuration:
+            - group_name: "Children"
+              query: :query__not_registered
+      SEEDING_DATA_YAML
+    end
+
+    it "skips the entry without raising and leaves the form configuration untouched" do
+      attribute_groups_before = phase_type.attribute_groups.dup
+      expect { seeder.seed! }.not_to raise_error
+      expect(phase_type.attribute_groups).to eq(attribute_groups_before)
+    end
+  end
+
   context "with a form_configuration entry in type_configuration in seed data" do
     let(:data_hash) do
       YAML.load <<~SEEDING_DATA_YAML
@@ -77,6 +97,35 @@ RSpec.describe BasicData::TypeConfigurationSeeder do
         .to include(an_instance_of(Type::QueryGroup).and(having_attributes(attributes: query)))
       expect(attribute_groups_now)
         .to include(an_instance_of(Type::QueryGroup).and(having_attributes(attributes: bugs_of_the_week_query)))
+    end
+
+    it "does not merge the default form configuration by default" do
+      seeder.seed!
+      expect(phase_type.attribute_groups).to all(be_a(Type::QueryGroup))
+      expect(phase_type.default_attribute_groups).to be_present # sanity check: there is something to merge
+    end
+
+    context "with merge_form_configuration enabled" do
+      let(:data_hash) do
+        YAML.load <<~SEEDING_DATA_YAML
+          type_configuration:
+          - type: :default_type_summary_task
+            merge_form_configuration: true
+            form_configuration:
+              - group_name: "Children"
+                query: :query__children
+        SEEDING_DATA_YAML
+      end
+
+      it "appends the type's default form configuration to the seeded query groups" do
+        default_group_keys = phase_type.default_attribute_groups.map(&:first)
+        seeder.seed!
+        attribute_groups_now = phase_type.attribute_groups
+
+        expect(attribute_groups_now.first)
+          .to be_a(Type::QueryGroup).and(having_attributes(attributes: query))
+        expect(attribute_groups_now.map(&:key)).to include("Children", *default_group_keys)
+      end
     end
   end
 end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -260,34 +260,51 @@ RSpec.describe RootSeeder,
       )
     end
 
-    it "seeds the epic type with an embedded children query in its form configuration" do
+    it "seeds the epic type with embedded query in its form configuration while keeping the default attribute groups" do
       epic = root_seeder.seed_data.find_reference(:default_type_epic)
+      query_group = epic.attribute_groups[0]
+      default_groups = epic.attribute_groups[1..]
 
-      # The default (Ruby-defined) attribute groups are merged in, so the type keeps its regular
-      # fields in addition to the embedded query group.
-      expect(epic.attribute_groups.map(&:class)).to include(Type::AttributeGroup, Type::QueryGroup)
+      expect(query_group).to be_a Type::QueryGroup
+      expect(default_groups).to all(be_a Type::AttributeGroup)
 
-      query_group = epic.attribute_groups.find { |group| group.is_a?(Type::QueryGroup) }
+      # Filters on children (templated parent) that are user stories or bugs.
       query = query_group.query
       expect(query.column_names).to eq(%i[id subject status assigned_to story_points sprint])
       expect(query.sort_criteria).to eq([["status", "desc"], ["sprint", "asc"], ["position", "asc"]])
       expect(query.hidden).to be(true)
-      # Filters on children (templated parent) that are user stories or bugs.
-      expect(query.filters.map(&:name)).to contain_exactly(:parent, :type_id)
+      expect(query.find_active_filter(:parent)).to be_present
+      expect(query.find_active_filter(:parent).operator).to eql "="
+      expect(query.find_active_filter(:parent).values).to eql ["{id}"]
+      expect(query.find_active_filter(:type_id)).to be_present
+      expect(query.find_active_filter(:type_id).operator).to eql "="
+      expect(query.find_active_filter(:type_id).values)
+        .to eql [root_seeder.seed_data.find_reference(:default_type_user_story).id.to_s,
+                 root_seeder.seed_data.find_reference(:default_type_bug).id.to_s]
+
+      # The other attribute groups are kept
+      expect(default_groups.map { [it.key, it.attributes] }).to eql epic.default_attribute_groups
     end
 
-    it "seeds the user story type with an embedded children query in its form configuration" do
+    it "seeds the user story type with embedded query in its form configuration while keeping the default attribute groups" do
       user_story = root_seeder.seed_data.find_reference(:default_type_user_story)
+      query_group = user_story.attribute_groups[0]
+      default_groups = user_story.attribute_groups[1..]
 
-      expect(user_story.attribute_groups.map(&:class)).to include(Type::AttributeGroup, Type::QueryGroup)
+      expect(query_group).to be_a Type::QueryGroup
+      expect(default_groups).to all(be_a Type::AttributeGroup)
 
-      query_group = user_story.attribute_groups.find { |group| group.is_a?(Type::QueryGroup) }
+      # Filters on children (templated parent) that are user stories or bugs.
       query = query_group.query
       expect(query.column_names).to eq(%i[id subject type status assigned_to sprint])
       expect(query.sort_criteria).to eq([["status", "desc"], ["id", "asc"]])
       expect(query.hidden).to be(true)
-      # Filters on children (templated parent) only, no type restriction.
-      expect(query.filters.map(&:name)).to contain_exactly(:parent)
+      expect(query.find_active_filter(:parent)).to be_present
+      expect(query.find_active_filter(:parent).operator).to eql "="
+      expect(query.find_active_filter(:parent).values).to eql ["{id}"]
+
+      # The other attribute groups are kept
+      expect(default_groups.map { [it.key, it.attributes] }).to eql user_story.default_attribute_groups
     end
 
     include_examples "it creates records", model: Color, expected_count: 148

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe RootSeeder,
       expect(View.where(type: "work_packages_table").count).to eq 5
       expect(View.where(type: "team_planner").count).to eq 1
       expect(View.where(type: "gantt").count).to eq 2
-      expect(Query.count).to eq 26
+      # 26 project/global queries with views + 2 hidden global queries embedded into the
+      # Epic and User story form configuration.
+      expect(Query.count).to eq 28
       expect(ProjectRole.count).to eq 5
       expect(WorkPackageRole.count).to eq 3
       expect(GlobalRole.count).to eq 2
@@ -260,6 +262,36 @@ RSpec.describe RootSeeder,
       )
     end
 
+    it "seeds the epic type with an embedded children query in its form configuration" do
+      epic = root_seeder.seed_data.find_reference(:default_type_epic)
+
+      # The default (Ruby-defined) attribute groups are merged in, so the type keeps its regular
+      # fields in addition to the embedded query group.
+      expect(epic.attribute_groups.map(&:class)).to include(Type::AttributeGroup, Type::QueryGroup)
+
+      query_group = epic.attribute_groups.find { |group| group.is_a?(Type::QueryGroup) }
+      query = query_group.query
+      expect(query.column_names).to eq(%i[id subject status assigned_to story_points sprint])
+      expect(query.sort_criteria).to eq([["status", "desc"], ["sprint", "asc"], ["position", "asc"]])
+      expect(query.hidden).to be(true)
+      # Filters on children (templated parent) that are user stories or bugs.
+      expect(query.filters.map(&:name)).to contain_exactly(:parent, :type_id)
+    end
+
+    it "seeds the user story type with an embedded children query in its form configuration" do
+      user_story = root_seeder.seed_data.find_reference(:default_type_user_story)
+
+      expect(user_story.attribute_groups.map(&:class)).to include(Type::AttributeGroup, Type::QueryGroup)
+
+      query_group = user_story.attribute_groups.find { |group| group.is_a?(Type::QueryGroup) }
+      query = query_group.query
+      expect(query.column_names).to eq(%i[id subject type status assigned_to sprint])
+      expect(query.sort_criteria).to eq([["status", "desc"], ["id", "asc"]])
+      expect(query.hidden).to be(true)
+      # Filters on children (templated parent) only, no type restriction.
+      expect(query.filters.map(&:name)).to contain_exactly(:parent)
+    end
+
     include_examples "it creates records", model: Color, expected_count: 148
     include_examples "it creates records", model: DocumentType, expected_count: 6
     include_examples "it creates records", model: GlobalRole, expected_count: 2
@@ -306,7 +338,7 @@ RSpec.describe RootSeeder,
         expect(View.where(type: "work_packages_table").count).to eq 5
         expect(View.where(type: "team_planner").count).to eq 1
         expect(View.where(type: "gantt").count).to eq 2
-        expect(Query.count).to eq 26
+        expect(Query.count).to eq 28
         expect(ProjectRole.count).to eq 5
         expect(WorkPackageRole.count).to eq 3
         expect(GlobalRole.count).to eq 2
@@ -351,6 +383,15 @@ RSpec.describe RootSeeder,
         expect(Project.count).to eq 2
         # but they're mostly empty because of the missing default statuses
         expect(WorkPackage.count).to eq 0
+      end
+
+      it "keeps the epic form configuration from the initial seeding" do
+        # The global queries embedded into the form configuration are not deleted, so the
+        # GlobalQuerySeeder is skipped on this re-seed and their references are not registered
+        # again. The TypeConfigurationSeeder therefore cannot re-apply the form configuration,
+        # but the type created initially still carries it (accepted limitation).
+        expect(Type.find_by(name: "Epic").attribute_groups)
+          .to include(an_instance_of(Type::QueryGroup))
       end
     end
   end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -60,8 +60,6 @@ RSpec.describe RootSeeder,
       expect(View.where(type: "work_packages_table").count).to eq 5
       expect(View.where(type: "team_planner").count).to eq 1
       expect(View.where(type: "gantt").count).to eq 2
-      # 26 project/global queries with views + 2 hidden global queries embedded into the
-      # Epic and User story form configuration.
       expect(Query.count).to eq 28
       expect(ProjectRole.count).to eq 5
       expect(WorkPackageRole.count).to eq 3


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-285

# What are you trying to accomplish?

Add children queries to the seeded type configuration form for both "Epic" and "User story" according to the specification in the linked work package.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
