### PR TITLE
Bump op-blocknote-extensions from 0.2.0 to 0.2.1

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.3.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
         "tsx": "^4.22.5"
       },
       "devDependencies": {
@@ -4127,9 +4127,9 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.0",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
-      "integrity": "sha512-qbRABOjnuKx8RTuheFhg4BPY9AFMaeQsxkrRo1orXgzWOJUDAjvqv7wFQtYx/x1mmDdKfhuxqD7cNuOvmUtTBw==",
+      "version": "0.2.1",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
+      "integrity": "sha512-6o5CKneDMX1WGomdW1waKPzYqTwtisKtJOp8+YMWfuz+oJJxn60x+bd4UiBrdUbPCn+ODiLR/R3CY72Wa6RaWg==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.3.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
     "tsx": "^4.22.5"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.3.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
         "openapi-explorer": "^2.4.801",
         "pako": "^2.2.0",
         "qr-creator": "^1.0.0",
@@ -13819,9 +13819,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.0",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
-      "integrity": "sha512-qbRABOjnuKx8RTuheFhg4BPY9AFMaeQsxkrRo1orXgzWOJUDAjvqv7wFQtYx/x1mmDdKfhuxqD7cNuOvmUtTBw==",
+      "version": "0.2.1",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
+      "integrity": "sha512-6o5CKneDMX1WGomdW1waKPzYqTwtisKtJOp8+YMWfuz+oJJxn60x+bd4UiBrdUbPCn+ODiLR/R3CY72Wa6RaWg==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -152,7 +152,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.3.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.0/op-blocknote-extensions-0.2.0.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
     "openapi-explorer": "^2.4.801",
     "pako": "^2.2.0",
     "qr-creator": "^1.0.0",


### PR DESCRIPTION
This includes:
[BNE-47] Create a work package link when pasting a work package URL into BlockNote editor (Paste from clipboard)
[BNE-111] Preview for tiny work package links in documents
[BNE-112] Work package link with missing permissions is not resizable
[BNE-120] Reduce likelihood for npm toolchain attacks 

# Tickets
https://community.openproject.org/wp/BNE-47
https://community.openproject.org/wp/BNE-111
https://community.openproject.org/wp/BNE-112
https://community.openproject.org/wp/BNE-120

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
