### PR TITLE
[COMMS-876] Single-line/multi-line layout argument for attribute value macros

### DIFF
--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -175,10 +175,23 @@ module WorkPackage::Exports
         custom_field = find_custom_field(obj, attribute)
 
         attribute_name = convert_to_attribute_name(custom_field, attribute, obj)
+        attribute_name, layout = map_legacy_version(attribute_name, layout, obj)
         return " " unless can_view_attribute?(custom_field, obj, attribute_name)
 
         is_rich_text = custom_field&.formattable? || disabled_rich_text_fields.include?(attribute_name.to_sym)
         [format_attribute_value(attribute_name, obj.class, obj, is_rich_text, layout), is_rich_text]
+      end
+
+      ##
+      # The deprecated version attribute renders the work package's target
+      # versions, on a single line by default so legacy macros keep their
+      # inline shape within existing content.
+      def self.map_legacy_version(attribute_name, layout, obj)
+        if obj.is_a?(WorkPackage) && attribute_name == "version"
+          ["target_versions", layout || "singleline"]
+        else
+          [attribute_name, layout]
+        end
       end
 
       def self.can_view_attribute?(custom_field, obj, attribute_name)

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -63,7 +63,7 @@ module WorkPackage::Exports
           (?<model>\w+)(?<type>Label|Value) # The model type we try to reference
           (?::(?:(?<id>[^":\s]+)|"(?<quoted_id>[^"]+)"))? # Optional: An ID or subject reference
           (?::(?<attribute>[^":\s.]+|"(?<quoted_attribute>[^".]+)")) # The attribute name we're trying to reference
-          (?::(?<layout>#{LAYOUTS.join('|')}))? # Optional: A layout argument
+          (?::(?<layout>#{LAYOUTS.join('|')})\b)? # Optional: A layout argument (whole keyword only)
         }x
       end
 

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -75,8 +75,8 @@ module WorkPackage::Exports
           attribute: match[:quoted_attribute] || match[:attribute],
           layout: match[:layout]
         }
-        OpenProject::TextFormatting::Matchers::AttributeMacros
-          .reinterpret_idless_layout(macro_attributes, quoted_attribute: !match[:quoted_attribute].nil?)
+        macro_attributes = OpenProject::TextFormatting::Matchers::AttributeMacros
+          .reinterpret_as_relative_embed(macro_attributes, quoted_attribute: !match[:quoted_attribute].nil?)
 
         resolve_match(match[:type].downcase, macro_attributes, context)
       end
@@ -180,7 +180,7 @@ module WorkPackage::Exports
         return " " unless can_view_attribute?(custom_field, obj, attribute_name)
 
         is_rich_text = custom_field&.formattable? || disabled_rich_text_fields.include?(attribute_name.to_sym)
-        [format_attribute_value(attribute_name, obj.class, obj, is_rich_text, layout), is_rich_text]
+        [format_attribute_value(attribute_name, obj.class, obj, is_rich_text, layout:), is_rich_text]
       end
 
       ##
@@ -210,7 +210,7 @@ module WorkPackage::Exports
         obj.available_custom_fields.find { |pcf| pcf.name == attribute }
       end
 
-      def self.format_attribute_value(ar_name, model, obj, is_rich_text, layout = nil)
+      def self.format_attribute_value(ar_name, model, obj, is_rich_text, layout: nil)
         formatter = Exports::Register.formatter_for(model, ar_name, :pdf)
         value = formatter.format(obj, array_separator: array_separator(layout))
         # do NOT escape a tag for custom field link

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -48,14 +48,17 @@ module WorkPackage::Exports
     #   projectValue:my-project-identifier:active # Outputs project with identifier my-project-identifier value for "active"
     class Attributes < OpenProject::TextFormatting::Matchers::RegexMatcher
       extend WorkPackage::Exports::Attributes
+
       DISABLED_PROJECT_RICH_TEXT_FIELDS = %i[description status_explanation status_description].freeze
       DISABLED_WORK_PACKAGE_RICH_TEXT_FIELDS = %i[description].freeze
+      LAYOUTS = OpenProject::TextFormatting::Matchers::AttributeMacros::LAYOUTS
 
       def self.regexp
         %r{
-          (\w+)(Label|Value) # The model type we try to reference
-          (?::(?:([^"\s]+)|"([^"]+)"))? # Optional: An ID or subject reference
-          (?::([^"\s.]+|"([^".]+)")) # The attribute name we're trying to reference
+          (?<model>\w+)(?<type>Label|Value) # The model type we try to reference
+          (?::(?:(?<id>[^":\s]+)|"(?<quoted_id>[^"]+)"))? # Optional: An ID or subject reference
+          (?::(?<attribute>[^":\s.]+|"(?<quoted_attribute>[^".]+)")) # The attribute name we're trying to reference
+          (?::(?<layout>#{LAYOUTS.join('|')}))? # Optional: A layout argument
         }x
       end
 
@@ -66,20 +69,28 @@ module WorkPackage::Exports
       end
 
       def self.process_match(match, _matched_string, context)
-        type = match[2].downcase
-        model_s = match[1].downcase
-        id = match[4] || match[3]
-        attribute = match[6] || match[5]
-        resolve_match(type, model_s, id, attribute, context)
+        macro_attributes = {
+          model: match[:model].downcase,
+          id: match[:quoted_id] || match[:id],
+          attribute: match[:quoted_attribute] || match[:attribute],
+          layout: match[:layout]
+        }
+        OpenProject::TextFormatting::Matchers::AttributeMacros
+          .reinterpret_idless_layout(macro_attributes, quoted_attribute: !match[:quoted_attribute].nil?)
+
+        resolve_match(match[:type].downcase, macro_attributes, context)
       end
 
-      def self.resolve_match(type, model_s, id, attribute, context)
-        if model_s == "workpackage"
-          resolve_work_package_match(id || context[:work_package]&.id, type, attribute, context[:user])
-        elsif model_s == "project"
-          resolve_project_match(id || context[:project]&.id, type, attribute, context[:user])
+      def self.resolve_match(type, macro_attributes, context)
+        id, attribute, layout = macro_attributes.values_at(:id, :attribute, :layout)
+
+        case macro_attributes[:model]
+        when "workpackage"
+          resolve_work_package_match(id || context[:work_package]&.id, type, attribute, context[:user], layout:)
+        when "project"
+          resolve_project_match(id || context[:project]&.id, type, attribute, context[:user], layout:)
         else
-          msg_macro_error I18n.t("export.macro.model_not_found", model: model_s)
+          msg_macro_error I18n.t("export.macro.model_not_found", model: macro_attributes[:model])
         end
       end
 
@@ -116,7 +127,7 @@ module WorkPackage::Exports
       # @param attribute [String] The attribute to resolve.
       # @param user [User] The user context for visibility checks.
 
-      def self.resolve_work_package_match(id, type, attribute, user)
+      def self.resolve_work_package_match(id, type, attribute, user, layout: nil)
         return resolve_label_work_package(attribute) if type == "label"
         return msg_macro_error(I18n.t("export.macro.model_not_found", model: type)) unless type == "value"
 
@@ -125,10 +136,10 @@ module WorkPackage::Exports
           return msg_macro_error(I18n.t("export.macro.resource_not_found", resource: "#{WorkPackage.name} #{id}"))
         end
 
-        resolve_value_work_package(work_package, attribute)
+        resolve_value_work_package(work_package, attribute, layout:)
       end
 
-      def self.resolve_project_match(id, type, attribute, user)
+      def self.resolve_project_match(id, type, attribute, user, layout: nil)
         return resolve_label_project(attribute) if type == "label"
         return msg_macro_error(I18n.t("export.macro.model_not_found", model: type)) unless type == "value"
 
@@ -138,7 +149,13 @@ module WorkPackage::Exports
           return msg_macro_error(I18n.t("export.macro.resource_not_found", resource: "#{Project.name} #{id}"))
         end
 
-        resolve_value_project(project, attribute)
+        resolve_value_project(project, attribute, layout:)
+      end
+
+      # The multi-line separator ends in two spaces + newline, the markdown
+      # hard line break, so each value renders on its own line in the export.
+      def self.array_separator(layout)
+        layout == "singleline" ? ", " : "  \n"
       end
 
       def self.escape_tags(value)
@@ -146,22 +163,22 @@ module WorkPackage::Exports
         value.to_s.gsub("<", "&lt;").gsub(">", "&gt;")
       end
 
-      def self.resolve_value_project(project, attribute)
-        resolve_value(project, attribute, DISABLED_PROJECT_RICH_TEXT_FIELDS)
+      def self.resolve_value_project(project, attribute, layout: nil)
+        resolve_value(project, attribute, DISABLED_PROJECT_RICH_TEXT_FIELDS, layout:)
       end
 
-      def self.resolve_value_work_package(work_package, attribute)
-        resolve_value(work_package, attribute, DISABLED_WORK_PACKAGE_RICH_TEXT_FIELDS)
+      def self.resolve_value_work_package(work_package, attribute, layout: nil)
+        resolve_value(work_package, attribute, DISABLED_WORK_PACKAGE_RICH_TEXT_FIELDS, layout:)
       end
 
-      def self.resolve_value(obj, attribute, disabled_rich_text_fields)
+      def self.resolve_value(obj, attribute, disabled_rich_text_fields, layout: nil)
         custom_field = find_custom_field(obj, attribute)
 
         attribute_name = convert_to_attribute_name(custom_field, attribute, obj)
         return " " unless can_view_attribute?(custom_field, obj, attribute_name)
 
         is_rich_text = custom_field&.formattable? || disabled_rich_text_fields.include?(attribute_name.to_sym)
-        [format_attribute_value(attribute_name, obj.class, obj, is_rich_text), is_rich_text]
+        [format_attribute_value(attribute_name, obj.class, obj, is_rich_text, layout), is_rich_text]
       end
 
       def self.can_view_attribute?(custom_field, obj, attribute_name)
@@ -180,9 +197,9 @@ module WorkPackage::Exports
         obj.available_custom_fields.find { |pcf| pcf.name == attribute }
       end
 
-      def self.format_attribute_value(ar_name, model, obj, is_rich_text)
+      def self.format_attribute_value(ar_name, model, obj, is_rich_text, layout = nil)
         formatter = Exports::Register.formatter_for(model, ar_name, :pdf)
-        value = formatter.format(obj)
+        value = formatter.format(obj, array_separator: array_separator(layout))
         # do NOT escape a tag for custom field link
         return value.to_html if value.is_a?(::Exports::Formatters::LinkFormatter)
 

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -36,10 +36,12 @@ module WorkPackage::Exports
 
     #   workPackageValue:subject # Outputs the subject of the current work package
     #   workPackageValue:1234:subject # Outputs the subject of #1234
+    #   workPackageValue:PROJ-10:subject # Outputs the subject of PROJ-10 (semantic identifier mode)
     #   workPackageValue:"custom field name" # Outputs the custom field value of the current work package
     #   workPackageValue:1234:"custom field name" # Outputs the custom field value of #1234
     #
     #   workPackageValue:1234:targetVersions:singleline # Outputs the values of #1234 comma-separated (export default)
+    #   workPackageValue:PROJ-10:targetVersions:singleline # Outputs the values of PROJ-10 comma-separated
     #   workPackageValue:1234:targetVersions:multiline # Outputs the values of #1234 one per line
     #
     #   projectLabel:active # Outputs current project label attribute "active"

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -152,10 +152,11 @@ module WorkPackage::Exports
         resolve_value_project(project, attribute, layout:)
       end
 
-      # The multi-line separator ends in two spaces + newline, the markdown
+      # Values are comma-joined unless the multiline layout is requested
+      # explicitly; its separator ends in two spaces + newline, the markdown
       # hard line break, so each value renders on its own line in the export.
       def self.array_separator(layout)
-        layout == "singleline" ? ", " : "  \n"
+        layout == "multiline" ? "  \n" : ", "
       end
 
       def self.escape_tags(value)
@@ -175,7 +176,7 @@ module WorkPackage::Exports
         custom_field = find_custom_field(obj, attribute)
 
         attribute_name = convert_to_attribute_name(custom_field, attribute, obj)
-        attribute_name, layout = map_legacy_version(attribute_name, layout, obj)
+        attribute_name = map_legacy_version(attribute_name, obj)
         return " " unless can_view_attribute?(custom_field, obj, attribute_name)
 
         is_rich_text = custom_field&.formattable? || disabled_rich_text_fields.include?(attribute_name.to_sym)
@@ -184,13 +185,12 @@ module WorkPackage::Exports
 
       ##
       # The deprecated version attribute renders the work package's target
-      # versions, on a single line by default so legacy macros keep their
-      # inline shape within existing content.
-      def self.map_legacy_version(attribute_name, layout, obj)
+      # versions.
+      def self.map_legacy_version(attribute_name, obj)
         if obj.is_a?(WorkPackage) && attribute_name == "version"
-          ["target_versions", layout || "singleline"]
+          "target_versions"
         else
-          [attribute_name, layout]
+          attribute_name
         end
       end
 

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -39,6 +39,9 @@ module WorkPackage::Exports
     #   workPackageValue:"custom field name" # Outputs the custom field value of the current work package
     #   workPackageValue:1234:"custom field name" # Outputs the custom field value of #1234
     #
+    #   workPackageValue:1234:targetVersions:singleline # Outputs the values of #1234 comma-separated (export default)
+    #   workPackageValue:1234:targetVersions:multiline # Outputs the values of #1234 one per line
+    #
     #   projectLabel:active # Outputs current project label attribute "active"
     #   projectLabel:1234:active # Outputs project label attribute "active"
     #   projectLabel:my-project-identifier:active # Outputs project label attribute "active"

--- a/frontend/src/app/shared/components/fields/display/display-field.service.spec.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.spec.ts
@@ -14,6 +14,9 @@ import {
 import {
   MultipleLinesHierarchyItemDisplayField,
 } from 'core-app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module';
+import {
+  SingleLineUserDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/single-line-user-display-field.module';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 type DisplayFieldClass = new (name:string, context:DisplayFieldContext) => DisplayField;
@@ -41,19 +44,20 @@ describe('DisplayFieldService', () => {
     return service.getField({} as HalResource, 'multiValueAttribute', { type } as IFieldSchema, context);
   }
 
-  // Every type the singleline layout applies to, paired with the multi-line
-  // field it otherwise renders as in the single view
-  const multiValueTypes:[string, DisplayFieldClass][] = [
-    ['[]Version', MultipleLinesCustomOptionsDisplayField],
-    ['[]CustomOption', MultipleLinesCustomOptionsDisplayField],
-    ['[]User', MultipleLinesUserFieldModule],
-    ['[]CustomField::Hierarchy::Item', MultipleLinesHierarchyItemDisplayField],
+  // Every type the singleline layout applies to, paired with the fields it
+  // renders as in the single view for each layout. Users keep their avatar
+  // rendering in the singleline layout via a dedicated field.
+  const multiValueTypes:[string, DisplayFieldClass, DisplayFieldClass][] = [
+    ['[]Version', SingleLineResourcesDisplayField, MultipleLinesCustomOptionsDisplayField],
+    ['[]CustomOption', SingleLineResourcesDisplayField, MultipleLinesCustomOptionsDisplayField],
+    ['[]User', SingleLineUserDisplayField, MultipleLinesUserFieldModule],
+    ['[]CustomField::Hierarchy::Item', SingleLineResourcesDisplayField, MultipleLinesHierarchyItemDisplayField],
   ];
 
-  multiValueTypes.forEach(([type, multilineClass]) => {
+  multiValueTypes.forEach(([type, singlelineClass, multilineClass]) => {
     describe(`for schema type ${type}`, () => {
-      it('routes the singleline layout to SingleLineResourcesDisplayField', () => {
-        expect(fieldFor(type, 'singleline')).toBeInstanceOf(SingleLineResourcesDisplayField);
+      it(`routes the singleline layout to ${singlelineClass.name}`, () => {
+        expect(fieldFor(type, 'singleline')).toBeInstanceOf(singlelineClass);
       });
 
       it(`routes the multiline layout to ${multilineClass.name}`, () => {

--- a/frontend/src/app/shared/components/fields/display/display-field.service.spec.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.spec.ts
@@ -1,0 +1,68 @@
+import { DisplayFieldService, DisplayFieldContext } from 'core-app/shared/components/fields/display/display-field.service';
+import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+import {
+  SingleLineResourcesDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/single-line-resources-display-field.module';
+import {
+  MultipleLinesCustomOptionsDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/multiple-lines-custom-options-display-field.module';
+import {
+  MultipleLinesUserFieldModule,
+} from 'core-app/shared/components/fields/display/field-types/multiple-lines-user-display-field.module';
+import {
+  MultipleLinesHierarchyItemDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+
+type DisplayFieldClass = new (name:string, context:DisplayFieldContext) => DisplayField;
+
+describe('DisplayFieldService', () => {
+  const service = new DisplayFieldService();
+
+  const mockI18n = { t: (key:string) => key };
+
+  const serviceMap = new Map<unknown, unknown>([
+    [I18nService, mockI18n],
+  ]);
+
+  const mockInjector = {
+    get: (token:unknown, notFoundValue?:unknown) => serviceMap.get(token) ?? notFoundValue ?? {},
+  };
+
+  function fieldFor(type:string, layout?:string):DisplayField {
+    const context = {
+      injector: mockInjector,
+      container: 'single-view',
+      options: layout ? { layout } : {},
+    } as unknown as DisplayFieldContext;
+
+    return service.getField({} as HalResource, 'multiValueAttribute', { type } as IFieldSchema, context);
+  }
+
+  // Every type the singleline layout applies to, paired with the multi-line
+  // field it otherwise renders as in the single view
+  const multiValueTypes:[string, DisplayFieldClass][] = [
+    ['[]Version', MultipleLinesCustomOptionsDisplayField],
+    ['[]CustomOption', MultipleLinesCustomOptionsDisplayField],
+    ['[]User', MultipleLinesUserFieldModule],
+    ['[]CustomField::Hierarchy::Item', MultipleLinesHierarchyItemDisplayField],
+  ];
+
+  multiValueTypes.forEach(([type, multilineClass]) => {
+    describe(`for schema type ${type}`, () => {
+      it('routes the singleline layout to SingleLineResourcesDisplayField', () => {
+        expect(fieldFor(type, 'singleline')).toBeInstanceOf(SingleLineResourcesDisplayField);
+      });
+
+      it(`routes the multiline layout to ${multilineClass.name}`, () => {
+        expect(fieldFor(type, 'multiline')).toBeInstanceOf(multilineClass);
+      });
+
+      it(`routes the default layout to ${multilineClass.name}`, () => {
+        expect(fieldFor(type)).toBeInstanceOf(multilineClass);
+      });
+    });
+  });
+});

--- a/frontend/src/app/shared/components/fields/display/display-field.service.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.ts
@@ -48,6 +48,9 @@ import {
 import {
   MultipleLinesHierarchyItemDisplayField,
 } from 'core-app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module';
+import {
+  SingleLineResourcesDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/single-line-resources-display-field.module';
 
 export interface DisplayFieldContext {
   /** The injector to use for the context of this field. Relevant for embedded service injection */
@@ -88,6 +91,13 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
   }
 
   private getFieldForContext(resource:HalResource, fieldName:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField {
+    // The singleline layout (macro argument) renders multi value fields as a
+    // comma-separated list instead of the one-per-line variants below
+    const multiValueTypes = ['[]CustomOption', '[]Version', '[]User', '[]CustomField::Hierarchy::Item'];
+    if (context.options.layout === 'singleline' && multiValueTypes.includes(schema.type)) {
+      return new SingleLineResourcesDisplayField(fieldName, context);
+    }
+
     // We handle multi value fields differently in the single view context
     const isCustomMultiLinesField = ['[]CustomOption'].includes(schema.type);
     if (context.container === 'single-view' && isCustomMultiLinesField) {

--- a/frontend/src/app/shared/components/fields/display/display-field.service.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.ts
@@ -51,6 +51,9 @@ import {
 import {
   SingleLineResourcesDisplayField,
 } from 'core-app/shared/components/fields/display/field-types/single-line-resources-display-field.module';
+import {
+  SingleLineUserDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/single-line-user-display-field.module';
 
 export interface DisplayFieldContext {
   /** The injector to use for the context of this field. Relevant for embedded service injection */
@@ -92,9 +95,14 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
 
   private getFieldForContext(resource:HalResource, fieldName:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField {
     // The singleline layout (macro argument) renders multi value fields as a
-    // comma-separated list instead of the one-per-line variants below
+    // comma-separated list instead of the one-per-line variants below.
+    // Users keep their avatars via a dedicated inline field.
     const multiValueTypes = ['[]CustomOption', '[]Version', '[]User', '[]CustomField::Hierarchy::Item'];
     if (context.container === 'single-view' && context.options.layout === 'singleline' && multiValueTypes.includes(schema.type)) {
+      if (schema.type === '[]User') {
+        return new SingleLineUserDisplayField(fieldName, context);
+      }
+
       return new SingleLineResourcesDisplayField(fieldName, context);
     }
 

--- a/frontend/src/app/shared/components/fields/display/display-field.service.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.ts
@@ -94,7 +94,7 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
     // The singleline layout (macro argument) renders multi value fields as a
     // comma-separated list instead of the one-per-line variants below
     const multiValueTypes = ['[]CustomOption', '[]Version', '[]User', '[]CustomField::Hierarchy::Item'];
-    if (context.options.layout === 'singleline' && multiValueTypes.includes(schema.type)) {
+    if (context.container === 'single-view' && context.options.layout === 'singleline' && multiValueTypes.includes(schema.type)) {
       return new SingleLineResourcesDisplayField(fieldName, context);
     }
 

--- a/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.spec.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.spec.ts
@@ -1,0 +1,62 @@
+import { SingleLineResourcesDisplayField } from './single-line-resources-display-field.module';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DisplayFieldContext } from 'core-app/shared/components/fields/display/display-field.service';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+
+describe('SingleLineResourcesDisplayField', () => {
+  let field:SingleLineResourcesDisplayField;
+  let element:HTMLElement;
+
+  const mockI18n = { t: (key:string) => key };
+
+  const serviceMap = new Map<unknown, unknown>([
+    [I18nService, mockI18n],
+  ]);
+
+  const mockInjector = {
+    get: (token:unknown, notFoundValue?:unknown) => serviceMap.get(token) ?? notFoundValue ?? {},
+  };
+
+  function render(values:string[]) {
+    const resource = {
+      targetVersions: values.map((name) => ({ name })),
+    } as unknown as HalResource;
+
+    field = new SingleLineResourcesDisplayField('targetVersions', {
+      injector: mockInjector,
+      container: 'single-view',
+      options: { layout: 'singleline' },
+    } as unknown as DisplayFieldContext);
+
+    field.apply(resource, { type: '[]Version' } as IFieldSchema);
+
+    element = document.createElement('div');
+    field.render(element, field.valueString);
+  }
+
+  it('renders all values comma-separated on one line', () => {
+    render(['Sprint 1', 'Master backlog', 'backlog']);
+
+    expect(element.textContent).toEqual('Sprint 1, Master backlog, backlog');
+  });
+
+  it('does not abridge to a count badge for more than two values', () => {
+    render(['Sprint 1', 'Master backlog', 'backlog', 'Release 1.0.0']);
+
+    expect(element.querySelector('.badge')).toBeNull();
+    expect(element.textContent).toContain('Release 1.0.0');
+  });
+
+  it('renders a single value plainly', () => {
+    render(['Sprint 1']);
+
+    expect(element.textContent).toEqual('Sprint 1');
+  });
+
+  it('keeps the full value list as the element title', () => {
+    render(['Sprint 1', 'Master backlog']);
+
+    expect(element.getAttribute('title')).toEqual('Sprint 1, Master backlog');
+  });
+});

--- a/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.spec.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.spec.ts
@@ -41,11 +41,10 @@ describe('SingleLineResourcesDisplayField', () => {
     expect(element.textContent).toEqual('Sprint 1, Master backlog, backlog');
   });
 
-  it('does not abridge to a count badge for more than two values', () => {
+  it('renders every value in full for more than two values', () => {
     render(['Sprint 1', 'Master backlog', 'backlog', 'Release 1.0.0']);
 
-    expect(element.querySelector('.badge')).toBeNull();
-    expect(element.textContent).toContain('Release 1.0.0');
+    expect(element.textContent).toEqual('Sprint 1, Master backlog, backlog, Release 1.0.0');
   });
 
   it('renders a single value plainly', () => {
@@ -58,5 +57,11 @@ describe('SingleLineResourcesDisplayField', () => {
     render(['Sprint 1', 'Master backlog']);
 
     expect(element.getAttribute('title')).toEqual('Sprint 1, Master backlog');
+  });
+
+  it('renders the placeholder for an empty value list', () => {
+    render([]);
+
+    expect(element.textContent).toEqual('js.placeholders.default');
   });
 });

--- a/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.ts
@@ -1,0 +1,40 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ResourcesDisplayField } from './resources-display-field.module';
+
+/**
+ * Renders a multi-value resource attribute on a single line for the macro
+ * `singleline` layout argument: the full comma-separated value list, without
+ * the abridged two-values-plus-badge rendering of the base class.
+ */
+export class SingleLineResourcesDisplayField extends ResourcesDisplayField {
+  protected renderValues(values:string[], element:HTMLElement):void {
+    element.textContent = values.join(', ');
+  }
+}

--- a/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/single-line-resources-display-field.module.ts
@@ -34,6 +34,10 @@ import { ResourcesDisplayField } from './resources-display-field.module';
  * the abridged two-values-plus-badge rendering of the base class.
  */
 export class SingleLineResourcesDisplayField extends ResourcesDisplayField {
+  public get valueString():string {
+    return this.stringValue.join(', ');
+  }
+
   protected renderValues(values:string[], element:HTMLElement):void {
     element.textContent = values.join(', ');
   }

--- a/frontend/src/app/shared/components/fields/display/field-types/single-line-user-display-field.module.spec.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/single-line-user-display-field.module.spec.ts
@@ -1,0 +1,64 @@
+import { SingleLineUserDisplayField } from './single-line-user-display-field.module';
+import { PrincipalRendererService } from 'core-app/shared/components/principal/principal-renderer.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DisplayFieldContext } from 'core-app/shared/components/fields/display/display-field.service';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+
+describe('SingleLineUserDisplayField', () => {
+  let field:SingleLineUserDisplayField;
+  let element:HTMLElement;
+  let renderMultipleCalls:unknown[][];
+
+  const mockI18n = { t: (key:string) => key };
+
+  const mockPrincipalRenderer = {
+    renderMultiple: (...args:unknown[]) => renderMultipleCalls.push(args),
+  };
+
+  const serviceMap = new Map<unknown, unknown>([
+    [I18nService, mockI18n],
+    [PrincipalRendererService, mockPrincipalRenderer],
+  ]);
+
+  const mockInjector = {
+    get: (token:unknown, notFoundValue?:unknown) => serviceMap.get(token) ?? notFoundValue ?? {},
+  };
+
+  function render(names:string[]) {
+    renderMultipleCalls = [];
+
+    const resource = {
+      multiUser: names.map((name) => ({ name })),
+    } as unknown as HalResource;
+
+    field = new SingleLineUserDisplayField('multiUser', {
+      injector: mockInjector,
+      container: 'single-view',
+      options: { layout: 'singleline' },
+    } as unknown as DisplayFieldContext);
+
+    field.apply(resource, { type: '[]User' } as IFieldSchema);
+
+    element = document.createElement('div');
+    field.render(element, names.join(', '));
+  }
+
+  it('renders users through the principal renderer in its inline mode', () => {
+    render(['Kabiru User II', 'GitLab User']);
+
+    expect(renderMultipleCalls.length).toEqual(1);
+
+    const [container, users, , , , multiLine] = renderMultipleCalls[0];
+    expect(container).toBe(element);
+    expect((users as { name:string }[]).map((u) => u.name)).toEqual(['Kabiru User II', 'GitLab User']);
+    expect(multiLine).toBe(false);
+  });
+
+  it('renders the placeholder for an empty value list', () => {
+    render([]);
+
+    expect(renderMultipleCalls.length).toEqual(0);
+    expect(element.textContent).toEqual('js.placeholders.default');
+  });
+});

--- a/frontend/src/app/shared/components/fields/display/field-types/single-line-user-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/single-line-user-display-field.module.ts
@@ -1,0 +1,49 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { UserResource } from 'core-app/features/hal/resources/user-resource';
+import {
+  MultipleLinesUserFieldModule,
+} from './multiple-lines-user-display-field.module';
+
+/**
+ * Renders a multi-value user attribute on a single line for the macro
+ * `singleline` layout argument: avatars and names inline, separated by commas.
+ */
+export class SingleLineUserDisplayField extends MultipleLinesUserFieldModule {
+  protected renderValues(values:UserResource[], element:HTMLElement) {
+    this.principalRenderer.renderMultiple(
+      element,
+      values,
+      { hide: false, link: false },
+      { hide: false, size: 'medium' },
+      { isActivated: true },
+      false,
+    );
+  }
+}

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.spec.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.spec.ts
@@ -1,0 +1,74 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { AttributeValueMacroComponent } from 'core-app/shared/components/fields/macros/attribute-value-macro.component';
+import { AttributeModelLoaderService } from 'core-app/shared/components/fields/macros/attribute-model-loader.service';
+import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
+import { DisplayFieldService } from 'core-app/shared/components/fields/display/display-field.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+
+describe('AttributeValueMacroComponent', () => {
+  let fixture:ComponentFixture<AttributeValueMacroComponent>;
+
+  function render(dataset:Record<string, string>, resourceType = 'WorkPackage'):Promise<AttributeValueMacroComponent> {
+    const resource = { _type: resourceType } as HalResource;
+
+    const schema = {
+      attributeFromLocalizedName: (name:string) => name,
+    };
+
+    const schemaProxy = {
+      isMilestone: false,
+      ofProperty: () => ({ type: '[]Version' }),
+    };
+
+    TestBed.configureTestingModule({
+      declarations: [AttributeValueMacroComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        { provide: AttributeModelLoaderService, useValue: { require: () => of(resource) } },
+        { provide: SchemaCacheService, useValue: { ensureLoaded: () => Promise.resolve(schema), proxied: () => schemaProxy } },
+        { provide: DisplayFieldService, useValue: {} },
+        { provide: I18nService, useValue: { t: (key:string) => key } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(AttributeValueMacroComponent);
+    const element = fixture.nativeElement as HTMLElement;
+    Object.entries(dataset).forEach(([key, value]) => {
+      element.dataset[key] = value;
+    });
+
+    fixture.detectChanges();
+    return fixture.whenStable().then(() => fixture.componentInstance);
+  }
+
+  describe('with the deprecated version attribute on a work package', () => {
+    it('maps to targetVersions with the singleline layout', async () => {
+      const component = await render({ model: 'workPackage', id: '42', attribute: 'version' });
+
+      expect(component.fieldName).toEqual('targetVersions');
+      expect(component.layout).toEqual('singleline');
+    });
+
+    it('keeps an explicitly requested multiline layout', async () => {
+      const component = await render({
+        model: 'workPackage', id: '42', attribute: 'version', layout: 'multiline',
+      });
+
+      expect(component.fieldName).toEqual('targetVersions');
+      expect(component.layout).toEqual('multiline');
+    });
+  });
+
+  describe('with a version attribute on another resource type', () => {
+    it('keeps the attribute untouched', async () => {
+      const component = await render({ model: 'project', id: '42', attribute: 'version' }, 'Project');
+
+      expect(component.fieldName).toEqual('version');
+      expect(component.layout).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
@@ -83,11 +83,14 @@ export class AttributeValueMacroComponent implements OnInit {
 
   fieldName:string;
 
+  layout?:string;
+
   ngOnInit():void {
     const element = this.elementRef.nativeElement;
     const model = element.dataset.model as SupportedAttributeModels;
     const id = element.dataset.id!;
     const attributeName = element.dataset.attribute!;
+    this.layout = element.dataset.layout;
     element.classList.add(ATTRIBUTE_MACRO_CLASS);
     this.ariaContext = this.text.aria_label(model);
 

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
@@ -45,6 +45,10 @@ import { ISchemaProxy } from 'core-app/features/hal/schemas/schema-proxy';
 
 export const ATTRIBUTE_MACRO_CLASS = 'op-attribute-value-macro';
 
+// An undefined layout means the author did not choose one; the display field
+// service then falls through to the attribute type's regular rendering.
+export type MacroLayout = 'singleline'|'multiline';
+
 @Component({
   templateUrl: './attribute-value-macro.html',
   styleUrls: ['./attribute-macro.sass'],
@@ -83,14 +87,14 @@ export class AttributeValueMacroComponent implements OnInit {
 
   fieldName:string;
 
-  layout?:string;
+  layout?:MacroLayout;
 
   ngOnInit():void {
     const element = this.elementRef.nativeElement;
     const model = element.dataset.model as SupportedAttributeModels;
     const id = element.dataset.id!;
     const attributeName = element.dataset.attribute!;
-    this.layout = element.dataset.layout;
+    this.layout = element.dataset.layout as MacroLayout|undefined;
     element.classList.add(ATTRIBUTE_MACRO_CLASS);
     this.ariaContext = this.text.aria_label(model);
 

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
@@ -127,7 +127,15 @@ export class AttributeValueMacroComponent implements OnInit {
 
     const schema = await this.schemaCache.ensureLoaded(resource);
     const proxied = this.schemaCache.proxied(resource, schema);
-    const attribute = schema.attributeFromLocalizedName(attributeName) ?? this.dateAttribute(resource, proxied, attributeName);
+    let attribute = schema.attributeFromLocalizedName(attributeName) ?? this.dateAttribute(resource, proxied, attributeName);
+
+    // The deprecated version attribute renders the work package's target
+    // versions, single-line by default so legacy macros keep their inline shape.
+    if (resource._type === 'WorkPackage' && attribute === 'version') {
+      attribute = 'targetVersions';
+      this.layout = this.layout ?? 'singleline';
+    }
+
     const fieldSchema = proxied.ofProperty(attribute) as IFieldSchema|undefined;
 
     if (fieldSchema) {

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.html
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.html
@@ -7,7 +7,7 @@
 @if (!!resource) {
   <display-field [resource]="resource"
     containerType="single-view"
-    [displayFieldOptions]="{ writable: false }"
+    [displayFieldOptions]="{ writable: false, layout: layout }"
     [fieldName]="fieldName" />
   <span class="sr-only" [textContent]="ariaContext"></span>
 }

--- a/lib/open_project/text_formatting/matchers/attribute_macros.rb
+++ b/lib/open_project/text_formatting/matchers/attribute_macros.rb
@@ -105,23 +105,25 @@ module OpenProject::TextFormatting
           layout: match[:layout]
         }
 
-        reinterpret_idless_layout(macro_attributes, quoted_attribute: !match[:quoted_attribute].nil?)
+        macro_attributes = reinterpret_as_relative_embed(macro_attributes, quoted_attribute: !match[:quoted_attribute].nil?)
         macro_attributes[:id] = relative_id(macro_attributes, context) if relative_embed?(macro_attributes)
         macro_attributes
       end
 
       ##
-      # In the id-less form (workPackageValue:targetVersions:singleline), the regex
-      # binds the attribute to the id slot and the layout keyword to the attribute
-      # slot. A bare attribute matching a reserved layout keyword marks that form,
-      # so shift the segments accordingly.
-      def self.reinterpret_idless_layout(macro_attributes, quoted_attribute:)
-        return if macro_attributes[:layout] || quoted_attribute || macro_attributes[:id].nil?
-        return unless LAYOUTS.include?(macro_attributes[:attribute])
+      # In the relative form (workPackageValue:targetVersions:singleline), the
+      # regex binds the attribute to the id slot and the layout keyword to the
+      # attribute slot. A bare attribute matching a reserved layout keyword
+      # marks that form, so shift the segments into a relative embed.
+      def self.reinterpret_as_relative_embed(macro_attributes, quoted_attribute:)
+        return macro_attributes if macro_attributes[:layout] || quoted_attribute || macro_attributes[:id].nil?
+        return macro_attributes unless LAYOUTS.include?(macro_attributes[:attribute])
 
-        macro_attributes[:layout] = macro_attributes[:attribute]
-        macro_attributes[:attribute] = macro_attributes[:id]
-        macro_attributes[:id] = nil
+        macro_attributes.merge(
+          layout: macro_attributes[:attribute],
+          attribute: macro_attributes[:id],
+          id: nil
+        )
       end
     end
   end

--- a/lib/open_project/text_formatting/matchers/attribute_macros.rb
+++ b/lib/open_project/text_formatting/matchers/attribute_macros.rb
@@ -52,7 +52,7 @@ module OpenProject::TextFormatting
           (?<model>\w+)(?<type>Label|Value) # The model type we try to reference
           (?::(?:(?<id>[^":\s]+)|"(?<quoted_id>[^"]+)"))? # Optional: An ID or subject reference
           (?::(?<attribute>[^":\s.]+|"(?<quoted_attribute>[^"]+)")) # The attribute name we're trying to reference
-          (?::(?<layout>#{LAYOUTS.join('|')}))? # Optional: A layout argument
+          (?::(?<layout>#{LAYOUTS.join('|')})\b)? # Optional: A layout argument (whole keyword only)
         }x
       end
 

--- a/lib/open_project/text_formatting/matchers/attribute_macros.rb
+++ b/lib/open_project/text_formatting/matchers/attribute_macros.rb
@@ -37,14 +37,22 @@ module OpenProject::TextFormatting
     #   workPackageValue:subject      # Outputs the actual subject of #1234 of the current work package 1234 if applicable
     #   workPackageValue:1234:subject # Outputs the actual subject of #1234
     #
+    #   workPackageValue:1234:targetVersions:singleline # Outputs the values of #1234 on a single line
+    #   workPackageValue:1234:targetVersions:multiline  # Outputs the values of #1234 on multiple lines (default)
+    #
     #   projectLabel:statusExplanation # Outputs current project label attribute "Status description" + help text
     #   projectValue:statusExplanation # Outputs current project value for "Status description"
     class AttributeMacros < RegexMatcher
+      # Reserved keywords of the optional layout argument. An attribute with
+      # such a name can still be referenced by quoting it.
+      LAYOUTS = %w[multiline singleline].freeze
+
       def self.regexp
         %r{
-          (\w+)(Label|Value) # The model type we try to reference
-          (?::(?:([^"\s]+)|"([^"]+)"))? # Optional: An ID or subject reference
-          (?::([^"\s.]+|"([^"]+)")) # The attribute name we're trying to reference
+          (?<model>\w+)(?<type>Label|Value) # The model type we try to reference
+          (?::(?:(?<id>[^":\s]+)|"(?<quoted_id>[^"]+)"))? # Optional: An ID or subject reference
+          (?::(?<attribute>[^":\s.]+|"(?<quoted_attribute>[^"]+)")) # The attribute name we're trying to reference
+          (?::(?<layout>#{LAYOUTS.join('|')}))? # Optional: A layout argument
         }x
       end
 
@@ -82,19 +90,38 @@ module OpenProject::TextFormatting
       end
 
       def self.process_match(match, _matched_string, context)
-        # Leading string before match
-        macro_attributes = {
-          model: match[1],
-          id: match[4] || match[3],
-          attribute: match[6] || match[5]
-        }
-        type = match[2].downcase
-
-        macro_attributes[:id] = relative_id(macro_attributes, context) if relative_embed?(macro_attributes)
+        type = match[:type].downcase
 
         ApplicationController.helpers.content_tag "opce-macro-attribute-#{type}",
                                                   "",
-                                                  data: macro_attributes
+                                                  data: extract_macro_attributes(match, context).compact
+      end
+
+      def self.extract_macro_attributes(match, context)
+        macro_attributes = {
+          model: match[:model],
+          id: match[:quoted_id] || match[:id],
+          attribute: match[:quoted_attribute] || match[:attribute],
+          layout: match[:layout]
+        }
+
+        reinterpret_idless_layout(macro_attributes, quoted_attribute: !match[:quoted_attribute].nil?)
+        macro_attributes[:id] = relative_id(macro_attributes, context) if relative_embed?(macro_attributes)
+        macro_attributes
+      end
+
+      ##
+      # In the id-less form (workPackageValue:targetVersions:singleline), the regex
+      # binds the attribute to the id slot and the layout keyword to the attribute
+      # slot. A bare attribute matching a reserved layout keyword marks that form,
+      # so shift the segments accordingly.
+      def self.reinterpret_idless_layout(macro_attributes, quoted_attribute:)
+        return if macro_attributes[:layout] || quoted_attribute || macro_attributes[:id].nil?
+        return unless LAYOUTS.include?(macro_attributes[:attribute])
+
+        macro_attributes[:layout] = macro_attributes[:attribute]
+        macro_attributes[:attribute] = macro_attributes[:id]
+        macro_attributes[:id] = nil
       end
     end
   end

--- a/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
@@ -101,6 +101,10 @@ RSpec.shared_examples_for "resolving macros" do
           Relative quoted custom field with layout: workPackageValue:"My list field":singleline
 
           Unknown keyword is not a layout: workPackageValue:1234:targetVersions:block
+
+          Bare layout keyword after an id reads as relative reference plus layout: workPackageValue:1234:singleline
+
+          Quoted layout keyword stays an attribute name: workPackageValue:1234:"singleline"
         RAW
       end
 
@@ -123,6 +127,12 @@ RSpec.shared_examples_for "resolving macros" do
           </p>
           <p class="op-uc-p">
             Unknown keyword is not a layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions"></opce-macro-attribute-value>:block
+          </p>
+          <p class="op-uc-p">
+            Bare layout keyword after an id reads as relative reference plus layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="1234" data-layout="singleline"></opce-macro-attribute-value>
+          </p>
+          <p class="op-uc-p">
+            Quoted layout keyword stays an attribute name: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="singleline"></opce-macro-attribute-value>
           </p>
         EXPECTED
       end

--- a/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
@@ -102,6 +102,8 @@ RSpec.shared_examples_for "resolving macros" do
 
           Unknown keyword is not a layout: workPackageValue:1234:targetVersions:block
 
+          Prefixed keyword is not a layout: workPackageValue:1234:targetVersions:multilinefoo
+
           Bare layout keyword after an id reads as relative reference plus layout: workPackageValue:1234:singleline
 
           Quoted layout keyword stays an attribute name: workPackageValue:1234:"singleline"
@@ -127,6 +129,9 @@ RSpec.shared_examples_for "resolving macros" do
           </p>
           <p class="op-uc-p">
             Unknown keyword is not a layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions"></opce-macro-attribute-value>:block
+          </p>
+          <p class="op-uc-p">
+            Prefixed keyword is not a layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions"></opce-macro-attribute-value>:multilinefoo
           </p>
           <p class="op-uc-p">
             Bare layout keyword after an id reads as relative reference plus layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="1234" data-layout="singleline"></opce-macro-attribute-value>

--- a/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
@@ -86,6 +86,49 @@ RSpec.shared_examples_for "resolving macros" do
     end
   end
 
+  describe "attribute value macros with layout argument" do
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          Explicit multi-line: workPackageValue:1234:targetVersions:multiline
+
+          Explicit single-line: workPackageValue:1234:targetVersions:singleline
+
+          Quoted custom field with layout: workPackageValue:1234:"My list field":singleline
+
+          Relative reference with layout: workPackageValue:targetVersions:singleline
+
+          Relative quoted custom field with layout: workPackageValue:"My list field":singleline
+
+          Unknown keyword is not a layout: workPackageValue:1234:targetVersions:block
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">
+            Explicit multi-line: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions" data-layout="multiline"></opce-macro-attribute-value>
+          </p>
+          <p class="op-uc-p">
+            Explicit single-line: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions" data-layout="singleline"></opce-macro-attribute-value>
+          </p>
+          <p class="op-uc-p">
+            Quoted custom field with layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="My list field" data-layout="singleline"></opce-macro-attribute-value>
+          </p>
+          <p class="op-uc-p">
+            Relative reference with layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions" data-layout="singleline"></opce-macro-attribute-value>
+          </p>
+          <p class="op-uc-p">
+            Relative quoted custom field with layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="My list field" data-layout="singleline"></opce-macro-attribute-value>
+          </p>
+          <p class="op-uc-p">
+            Unknown keyword is not a layout: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="targetVersions"></opce-macro-attribute-value>:block
+          </p>
+        EXPECTED
+      end
+    end
+  end
+
   describe "attribute value macros" do
     it_behaves_like "format_text produces" do
       let(:raw) do

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -304,6 +304,71 @@ RSpec.describe Exports::PDF::Common::Macro do
       end
     end
 
+    describe "with multi select custom field and layout argument" do
+      shared_let(:multi_list_custom_field) do
+        create(
+          :list_wp_custom_field,
+          name: "My List Field",
+          multi_value: true,
+          possible_values: %w[Sprint1 Sprint2 Sprint3],
+          is_for_all: true,
+          types: [type_task]
+        )
+      end
+
+      let(:work_package) do
+        create(
+          :work_package,
+          subject: "Work package 1",
+          type: type_task,
+          project: project,
+          custom_field_values: {
+            multi_list_custom_field.id => multi_list_custom_field.custom_options.first(2).map(&:id)
+          }
+        )
+      end
+
+      describe "without layout argument" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:\"My List Field\"" }
+
+        it "outputs one value per line" do
+          expect(formatted).to eq("Sprint1  \nSprint2")
+        end
+      end
+
+      describe "with multiline layout" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:\"My List Field\":multiline" }
+
+        it "outputs one value per line" do
+          expect(formatted).to eq("Sprint1  \nSprint2")
+        end
+      end
+
+      describe "with singleline layout" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:\"My List Field\":singleline" }
+
+        it "outputs the values comma-separated on one line" do
+          expect(formatted).to eq("Sprint1, Sprint2")
+        end
+      end
+
+      describe "with singleline layout and relative work package reference" do
+        let(:markdown) { "workPackageValue:\"My List Field\":singleline" }
+
+        it "outputs the values comma-separated on one line" do
+          expect(formatted).to eq("Sprint1, Sprint2")
+        end
+      end
+    end
+
+    describe "with singleline layout on a single value attribute" do
+      let(:markdown) { "workPackageValue:subject:singleline" }
+
+      it "outputs the attribute value" do
+        expect(formatted).to eq("Work package 1")
+      end
+    end
+
     describe "with specific work package ID and attribute" do
       let(:markdown) { "workPackageValue:#{work_package.id}:subject" }
 

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -359,6 +359,14 @@ RSpec.describe Exports::PDF::Common::Macro do
           expect(formatted).to eq("Sprint1, Sprint2")
         end
       end
+
+      describe "with a prefixed layout keyword" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:\"My List Field\":multilinefoo" }
+
+        it "does not treat the prefix as a layout and keeps it as trailing text" do
+          expect(formatted).to eq("Sprint1, Sprint2:multilinefoo")
+        end
+      end
     end
 
     describe "with singleline layout on a single value attribute" do

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -369,6 +369,41 @@ RSpec.describe Exports::PDF::Common::Macro do
       end
     end
 
+    describe "with target versions" do
+      shared_let(:version_one) { create(:version, project:, name: "1.0") }
+      shared_let(:version_two) { create(:version, project:, name: "2.0") }
+
+      before do
+        create(:work_package_version, work_package:, version: version_one)
+        create(:work_package_version, work_package:, version: version_two)
+      end
+
+      describe "with targetVersions attribute" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:targetVersions" }
+
+        it "outputs one version per line" do
+          # the association carries no order, so compare the lines as a set
+          expect(formatted.split("  \n")).to match_array(%w[1.0 2.0])
+        end
+      end
+
+      describe "with legacy version attribute" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:version" }
+
+        it "outputs all target versions on a single line" do
+          expect(formatted.split(", ")).to match_array(%w[1.0 2.0])
+        end
+      end
+
+      describe "with legacy version attribute and multiline layout" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:version:multiline" }
+
+        it "outputs one version per line" do
+          expect(formatted.split("  \n")).to match_array(%w[1.0 2.0])
+        end
+      end
+    end
+
     describe "with specific work package ID and attribute" do
       let(:markdown) { "workPackageValue:#{work_package.id}:subject" }
 

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -410,6 +410,30 @@ RSpec.describe Exports::PDF::Common::Macro do
           expect(formatted.split("  \n")).to match_array(%w[1.0 2.0])
         end
       end
+
+      describe "in semantic identifier mode",
+               with_settings: { work_packages_identifier: "semantic" } do
+        let(:semantic_identifier) do
+          work_package.allocate_and_register_semantic_id
+          work_package.reload.identifier
+        end
+
+        describe "with targetVersions attribute and singleline layout" do
+          let(:markdown) { "workPackageValue:#{semantic_identifier}:targetVersions:singleline" }
+
+          it "resolves the semantic reference and outputs the versions on a single line" do
+            expect(formatted.split(", ")).to match_array(%w[1.0 2.0])
+          end
+        end
+
+        describe "with legacy version attribute" do
+          let(:markdown) { "workPackageValue:#{semantic_identifier}:version" }
+
+          it "outputs all target versions on a single line" do
+            expect(formatted.split(", ")).to match_array(%w[1.0 2.0])
+          end
+        end
+      end
     end
 
     describe "with specific work package ID and attribute" do

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -331,8 +331,8 @@ RSpec.describe Exports::PDF::Common::Macro do
       describe "without layout argument" do
         let(:markdown) { "workPackageValue:#{work_package.id}:\"My List Field\"" }
 
-        it "outputs one value per line" do
-          expect(formatted).to eq("Sprint1  \nSprint2")
+        it "outputs the values comma-separated on one line" do
+          expect(formatted).to eq("Sprint1, Sprint2")
         end
       end
 
@@ -381,8 +381,16 @@ RSpec.describe Exports::PDF::Common::Macro do
       describe "with targetVersions attribute" do
         let(:markdown) { "workPackageValue:#{work_package.id}:targetVersions" }
 
+        it "outputs all versions on a single line" do
+          # the association carries no order, so compare the values as a set
+          expect(formatted.split(", ")).to match_array(%w[1.0 2.0])
+        end
+      end
+
+      describe "with targetVersions attribute and multiline layout" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:targetVersions:multiline" }
+
         it "outputs one version per line" do
-          # the association carries no order, so compare the lines as a set
           expect(formatted.split("  \n")).to match_array(%w[1.0 2.0])
         end
       end


### PR DESCRIPTION
Ticket: https://community.openproject.org/wp/COMMS-876

Multi-value attributes such as target versions render one value per line, which does not always fit the text around a macro. Attribute value macros now accept an optional trailing layout argument (`workPackageValue:X:targetVersions:singleline` or `:multiline`, multi-line being the default) so authors can choose.

- [x] Web macro parsing: the text-formatting matcher parses the argument, including the id-less relative form, and hands it to the macro element as `data-layout`
- [x] Frontend rendering of the single-line variant
- [x] Layout argument on the PDF/export macro path
- [x] Legacy `version` attribute mapped to the single-line behaviour

_CkEditor render_

<img width="848" height="470" alt="macro-layout-verification" src="https://github.com/user-attachments/assets/8f345b6e-5c97-4cd1-ac69-2ba78a5ce929" />

_PDF Export_

<img width="940" height="743" alt="Screenshot 2026-07-15 at 8 20 53 PM" src="https://github.com/user-attachments/assets/8342543f-91cb-48d9-b92e-b892ce3661e5" />

