### PR TITLE
[COMMS-894] Fix `TimeEntriesCleaner` crashing on semantic ID lookup

### DIFF
--- a/app/models/work_package/time_entries_cleaner.rb
+++ b/app/models/work_package/time_entries_cleaner.rb
@@ -61,16 +61,16 @@ module WorkPackage::TimeEntriesCleaner
       TimeEntry.where(["entity_type = ? AND entity_id IN (?)", "WorkPackage", work_packages.map(&:id)]).update_all(action)
     end
 
-    def reassign_time_entries_before_destruction_of(work_packages, user, ids)
+    def reassign_time_entries_before_destruction_of(work_packages, user, reassign_to_id)
       work_packages = Array(work_packages)
       reassign_to = WorkPackage
                     .joins(:project)
                     .merge(Project.allowed_to(user, :edit_time_entries))
-                    .find_by(id: ids)
+                    .find_by_display_id(reassign_to_id)
 
       if reassign_to.nil?
         work_packages.each do |wp|
-          wp.errors.add(:base, :is_not_a_valid_target_for_time_entries, id: ids)
+          wp.errors.add(:base, :is_not_a_valid_target_for_time_entries, id: reassign_to_id)
         end
 
         false


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-894

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
* Fix a stray usage of `find_by` with semantic IDs, observed in [this AppSignal entry](https://appsignal.com/openproject-gmbh/sites/673c529383eb67b55471dda2/exceptions/incidents/1737).
* While at it, rename a misleading variable name

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
