### PR TITLE
[OP-19740] Handle a template error for `/search.json`

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -49,7 +49,9 @@ class SearchController < ApplicationController
       end
     end
 
-    render "index", locals: { menu_name: project_or_global_menu }
+    respond_to do |format|
+      format.html { render "index", locals: { menu_name: project_or_global_menu } }
+    end
   end
 
   private

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -224,6 +224,16 @@ RSpec.describe SearchController do
     end
   end
 
+  describe "unsupported request format" do
+    context "when requesting JSON format" do
+      it "raises UnknownFormat (rendered as 406 Not Acceptable)" do
+        expect do
+          get :index, format: :json
+        end.to raise_error(ActionController::UnknownFormat)
+      end
+    end
+  end
+
   describe "helper methods" do
     describe "#scan_query_tokens" do
       subject { @controller.send(:scan_query_tokens, query) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-19740/files

# What approach did you choose and why?
Make sure we generate a proper 406 to silence the relevant AppSignal error.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
