### PR TITLE
Docs/COMMS-895: Document single-line/multi-line layout argument for attribute value macros

### DIFF
--- a/docs/user-guide/wysiwyg/README.md
+++ b/docs/user-guide/wysiwyg/README.md
@@ -213,19 +213,23 @@ Example:
 
 **Linking to the current project's status**: `projectValue:status`
 
-### Controlling the layout of multi-value attributes
+### Control how multiple values are displayed
 
-Attributes that hold multiple values (for example target versions or multi-select custom fields) render one value per line in the application and comma-separated in PDF exports. Append a layout argument to the macro to choose a layout explicitly:
+Some attributes can contain multiple values, such as **Target versions** or **multi-select custom fields**. These values are displayed one value per line in the application and are separated by a comma PDF exports. 
 
-- `workPackageValue:1234:targetVersions:multiline` renders one value per line
-- `workPackageValue:1234:targetVersions:singleline` renders all values on a single line, comma-separated
+You can choose whether these values are displayed on separate lines or on a single line within the CKEditor.
 
-The layout argument also works with custom fields (`workPackageValue:1234:"My custom field":singleline`), with project attributes (`projectValue:...`) and with relative references (`workPackageValue:targetVersions:singleline`).
+Add one of the following layout options to the macro:
 
-Only attributes that hold multiple values are affected. On single-value attributes such as `subject`, the layout argument is accepted but does not change the rendering.
+- `workPackageValue:1234:targetVersions:multiline` displays each value on a separate line.
+- `workPackageValue:1234:targetVersions:singleline` displays all values on a single line, separated by commas.
+
+The layout option also works with custom fields (for example, `workPackageValue:1234:"My custom field":singleline`), project attributes (`projectValue:...`), and relative references (`workPackageValue:targetVersions:singleline`).
+
+The layout option only affects attributes that can contain multiple values. For single-value attributes, such as `subject`, it has no effect.
 
 > [!NOTE]
-> The deprecated `version` attribute renders the work package's target versions on a single line by default.
+> The deprecated `version` attribute displays the work package's target versions on a single line by default.
 
 ### Embedding attribute help texts
 

--- a/docs/user-guide/wysiwyg/README.md
+++ b/docs/user-guide/wysiwyg/README.md
@@ -215,7 +215,7 @@ Example:
 
 ### Control how multiple values are displayed
 
-Some attributes can contain multiple values, such as **Target versions** or **multi-select custom fields**. These values are displayed one value per line in the application and are separated by a comma PDF exports. 
+Some attributes can contain multiple values, such as **Target versions** or **multi-select custom fields**. These values are displayed one value per line in the application and are separated by a comma in PDF exports. 
 
 You can choose whether these values are displayed on separate lines or on a single line within the CKEditor.
 

--- a/docs/user-guide/wysiwyg/README.md
+++ b/docs/user-guide/wysiwyg/README.md
@@ -213,6 +213,20 @@ Example:
 
 **Linking to the current project's status**: `projectValue:status`
 
+### Controlling the layout of multi-value attributes
+
+Attributes that hold multiple values (for example target versions or multi-select custom fields) render one value per line in the application and comma-separated in PDF exports. Append a layout argument to the macro to choose a layout explicitly:
+
+- `workPackageValue:1234:targetVersions:multiline` renders one value per line
+- `workPackageValue:1234:targetVersions:singleline` renders all values on a single line, comma-separated
+
+The layout argument also works with custom fields (`workPackageValue:1234:"My custom field":singleline`), with project attributes (`projectValue:...`) and with relative references (`workPackageValue:targetVersions:singleline`).
+
+Only attributes that hold multiple values are affected. On single-value attributes such as `subject`, the layout argument is accepted but does not change the rendering.
+
+> [!NOTE]
+> The deprecated `version` attribute renders the work package's target versions on a single line by default.
+
 ### Embedding attribute help texts
 
 You can also embed attribute values and [their help texts](../../system-admin-guide/attribute-help-texts/) by using `workPackageLabel` or `projectLabel`.
@@ -255,7 +269,8 @@ where `1234` stands for the [work package ID](../work-packages).
 | Start date          | `workPackageValue:1234:startDate`                               |
 | Status              | `workPackageValue:1234:status`                                  |
 | Subject / Title     | `workPackageValue:1234:subject`                                 |
-| Version             | `workPackageValue:1234:version`                                 |
+| Target versions     | `workPackageValue:1234:targetVersions`                          |
+| Version _(deprecated)_ | `workPackageValue:1234:version`                              |
 | Work                | `workPackageValue:8415:estimatedTime`                           |
 | Work package type   | `workPackageValue:1234:type`                                    |
 


### PR DESCRIPTION
Ticket: https://community.openproject.org/wp/COMMS-895

Updates the user guide WYSIWYG page for the macro layout argument introduced in #24257: a section explaining `:singleline` / `:multiline` and the one-per-line default, a `targetVersions` row in the work package attributes table, and a deprecation marker on the `version` attribute (which now renders all target versions on a single line).

Follows #24257 