### PR TITLE
Prevent possibility of infinite loop when checking formula references

### DIFF
--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -147,15 +147,13 @@ module CustomField::CalculatedValue
     end
 
     def usable_custom_field_references_for_formula
-      visible_cfs = ProjectCustomField
-                      .where(field_format: FIELD_FORMATS_FOR_FORMULA)
-                      .where.not(id:)
-                      .visible
-
       cache = {}
-      visible_cfs.reject do |custom_field|
-        custom_field.formula_references_id?(id, cache)
-      end
+
+      ProjectCustomField
+        .where(field_format: FIELD_FORMATS_FOR_FORMULA)
+        .where.not(id:)
+        .visible
+        .reject { it.formula_references_id?(id, cache) }
     end
 
     def validate_referenced_custom_fields

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -153,7 +153,7 @@ module CustomField::CalculatedValue
         .where(field_format: FIELD_FORMATS_FOR_FORMULA)
         .where.not(id:)
         .visible
-        .reject { it.formula_references_id?(id, cache) }
+        .select { it.can_be_referenced_by?(id, cache) }
     end
 
     def validate_referenced_custom_fields
@@ -171,16 +171,16 @@ module CustomField::CalculatedValue
       end
     end
 
-    def formula_references_id?(original_id, cache = {})
-      return false unless field_format_calculated_value?
+    def can_be_referenced_by?(target_id, cache = {})
+      return true unless field_format_calculated_value?
 
       cache.fetch(id) do
-        cache[id] = true # break infinite loop while recursing
+        cache[id] = false # assume it cannot be referenced until proven otherwise during recursion
 
         referenced_ids = formula_referenced_custom_field_ids
 
-        cache[id] = referenced_ids.intersect?([original_id, id]) ||
-          ProjectCustomField.where(id: referenced_ids).any? { it.formula_references_id?(original_id, cache) }
+        cache[id] = !referenced_ids.intersect?([target_id, id]) &&
+          ProjectCustomField.where(id: referenced_ids).all? { it.can_be_referenced_by?(target_id, cache) }
       end
     end
 

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -172,20 +172,15 @@ module CustomField::CalculatedValue
     end
 
     def formula_references_id?(original_id, cache = {})
-      cache.fetch(id) do
-        cache[id] = if field_format_calculated_value?
-                      referenced_custom_fields = formula_referenced_custom_field_ids
+      return false unless field_format_calculated_value?
 
-                      if referenced_custom_fields.include?(original_id) || referenced_custom_fields.include?(id)
-                        true
-                      else
-                        ProjectCustomField.where(id: referenced_custom_fields).any? do |referenced_field|
-                          referenced_field.formula_references_id?(original_id, cache)
-                        end
-                      end
-                    else
-                      false
-                    end
+      cache.fetch(id) do
+        cache[id] = true # break infinite loop while recursing
+
+        referenced_ids = formula_referenced_custom_field_ids
+
+        cache[id] = referenced_ids.intersect?([original_id, id]) ||
+          ProjectCustomField.where(id: referenced_ids).any? { it.formula_references_id?(original_id, cache) }
       end
     end
 

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
     end
   end
 
-  describe "#formula_references_id?" do
+  describe "#can_be_referenced_by?" do
     let!(:int_field) { create(:project_custom_field, :integer, default_value: 10, is_for_all: true) }
     let!(:float_field) { create(:project_custom_field, :float, default_value: 5.5, is_for_all: true) }
     let!(:text_field) { create(:project_custom_field, :text, default_value: "text", is_for_all: true) }
@@ -414,16 +414,16 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
     current_user { create(:admin) }
 
     context "when checking a non-calculated value custom field" do
-      it "returns false for integer custom field" do
-        expect(int_field.formula_references_id?(subject.id)).to be false
+      it "returns true for integer custom field" do
+        expect(int_field.can_be_referenced_by?(subject.id)).to be true
       end
 
-      it "returns false for float custom field" do
-        expect(float_field.formula_references_id?(subject.id)).to be false
+      it "returns true for float custom field" do
+        expect(float_field.can_be_referenced_by?(subject.id)).to be true
       end
 
-      it "returns false for text custom field" do
-        expect(text_field.formula_references_id?(subject.id)).to be false
+      it "returns true for text custom field" do
+        expect(text_field.can_be_referenced_by?(subject.id)).to be true
       end
     end
 
@@ -432,8 +432,8 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
         create(:calculated_value_project_custom_field, formula: "1 + 2", is_for_all: true)
       end
 
-      it "returns false" do
-        expect(simple_calculated_field.formula_references_id?(subject.id)).to be false
+      it "returns true" do
+        expect(simple_calculated_field.can_be_referenced_by?(subject.id)).to be true
       end
     end
 
@@ -450,9 +450,9 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
         self_referencing_field.save(validate: false)
       end
 
-      it "returns true when field references itself" do
-        circular = self_referencing_field.formula_references_id?(self_referencing_field.id)
-        expect(circular).to be true
+      it "returns false when field references itself" do
+        referenceable = self_referencing_field.can_be_referenced_by?(self_referencing_field.id)
+        expect(referenceable).to be false
       end
     end
 
@@ -486,17 +486,17 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
         field_c.save(validate: false)
       end
 
-      it "returns true when there is an indirect circular reference" do
-        expect(field_a.formula_references_id?(field_a.id)).to be true
+      it "returns false when there is an indirect circular reference" do
+        expect(field_a.can_be_referenced_by?(field_a.id)).to be false
       end
 
-      it "returns true when checking from any field in the circular chain" do
-        expect(field_b.formula_references_id?(field_b.id)).to be true
-        expect(field_c.formula_references_id?(field_c.id)).to be true
+      it "returns false when checking from any field in the circular chain" do
+        expect(field_b.can_be_referenced_by?(field_b.id)).to be false
+        expect(field_c.can_be_referenced_by?(field_c.id)).to be false
       end
 
-      it "returns true for an id outside of the circular chain instead of raising an error" do
-        expect(field_a.formula_references_id?(int_field.id)).to be true
+      it "returns false for an id outside of the circular chain instead of raising an error" do
+        expect(field_a.can_be_referenced_by?(int_field.id)).to be false
       end
     end
 
@@ -520,12 +520,12 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
                is_for_all: true)
       end
 
-      it "returns false when there is no circular reference" do
-        expect(field_x.formula_references_id?(field_x.id)).to be false
-        expect(field_x.formula_references_id?(field_y.id)).to be false
-        expect(field_x.formula_references_id?(field_z.id)).to be false
-        expect(field_y.formula_references_id?(field_y.id)).to be false
-        expect(field_z.formula_references_id?(field_z.id)).to be false
+      it "returns true when there is no circular reference" do
+        expect(field_x.can_be_referenced_by?(field_x.id)).to be true
+        expect(field_x.can_be_referenced_by?(field_y.id)).to be true
+        expect(field_x.can_be_referenced_by?(field_z.id)).to be true
+        expect(field_y.can_be_referenced_by?(field_y.id)).to be true
+        expect(field_z.can_be_referenced_by?(field_z.id)).to be true
       end
     end
 
@@ -542,14 +542,14 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
                is_for_all: true)
       end
 
-      it "returns true when a node has already been visited" do
-        visited = { field1.id => true }
-        expect(field1.formula_references_id?(field2.id, visited)).to be true
+      it "returns false when a node has already been visited" do
+        visited = { field1.id => false }
+        expect(field1.can_be_referenced_by?(field2.id, visited)).to be false
       end
 
-      it "returns false when checking a new node with empty visited set" do
+      it "returns true when checking a new node with empty visited set" do
         visited = {}
-        expect(field1.formula_references_id?(field2.id, visited)).to be false
+        expect(field1.can_be_referenced_by?(field2.id, visited)).to be true
       end
     end
 
@@ -565,9 +565,9 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
         field_with_invalid_ref.save(validate: false)
       end
 
-      it "returns false when referenced custom field does not exist" do
-        circular = field_with_invalid_ref.formula_references_id?(field_with_invalid_ref.id)
-        expect(circular).to be false
+      it "returns true when referenced custom field does not exist" do
+        referenceable = field_with_invalid_ref.can_be_referenced_by?(field_with_invalid_ref.id)
+        expect(referenceable).to be true
       end
     end
   end

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -286,6 +286,12 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
         expect(field_b.usable_custom_field_references_for_formula).to include(int, float)
         expect(field_c.usable_custom_field_references_for_formula).to include(int, float)
       end
+
+      it "does not enter infinite recursion when called on a field outside of the cycle" do
+        # subject is not part of the field_a -> field_b -> field_c -> field_a cycle,
+        # so traversing the cycle never hits the original id and must terminate on its own
+        expect { subject.usable_custom_field_references_for_formula }.not_to raise_error
+      end
     end
 
     context "when two calculated values reference the same custom field" do
@@ -487,6 +493,10 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
       it "returns true when checking from any field in the circular chain" do
         expect(field_b.formula_references_id?(field_b.id)).to be true
         expect(field_c.formula_references_id?(field_c.id)).to be true
+      end
+
+      it "returns true for an id outside of the circular chain instead of raising an error" do
+        expect(field_a.formula_references_id?(int_field.id)).to be true
       end
     end
 
@@ -736,6 +746,26 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
       it_behaves_like "invalid formula",
                       "The attribute int, float cannot be used because it leads to a circular reference; " \
                       "one attribute depends on the other."
+    end
+
+    context "when unrelated fields contain a circular reference" do
+      let!(:int) { create(:project_custom_field, :integer, default_value: 4, is_for_all: true) }
+      let!(:field_a) { create(:calculated_value_project_custom_field, formula: "2 + 2", is_for_all: true) }
+      let!(:field_b) { create(:calculated_value_project_custom_field, formula: "2 + 2", is_for_all: true) }
+
+      let(:formula) { "1 + #{int}" }
+
+      current_user { create(:admin) }
+
+      before do
+        field_a.formula = "#{field_b} + 1"
+        field_b.formula = "#{field_a} + 2"
+
+        field_a.save(validate: false)
+        field_b.save(validate: false)
+      end
+
+      it_behaves_like "valid formula"
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/OP-19808 extracted from PR for https://community.openproject.org/wp/OP-19665

# What are you trying to accomplish?
Remove the possibility of an infinite loop.
`cache` was written after recursion, but if recursion would go over a loop in formulas, it is never written and will cause a stack overflow

# What approach did you choose and why?
As problem with `cache` can be caused only if there is a loop (or a self reference), se cache for the id to `true` before recursion

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
