### PR TITLE
[AGILE-347] Support drag and drop to external applications

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -104,7 +104,17 @@ describe('Sortable lists item controller', () => {
 
   function connectedControllerFor(
     element:HTMLElement,
-    { handle = null, root = fakeRoot() }:{ handle?:HTMLElement|null; root?:SortableListsRoot|null } = {},
+    {
+      handle = null,
+      root = fakeRoot(),
+      externalUrl = null,
+      label = null,
+    }:{
+      handle?:HTMLElement|null;
+      root?:SortableListsRoot|null;
+      externalUrl?:string|null;
+      label?:string|null;
+    } = {},
   ) {
     const controller = Object.create(ItemController.prototype) as InstanceType<typeof ItemControllerType>;
 
@@ -113,6 +123,10 @@ describe('Sortable lists item controller', () => {
     Object.defineProperty(controller, 'hasIdValue', { value: true });
     Object.defineProperty(controller, 'typeValue', { value: 'item' });
     Object.defineProperty(controller, 'hasTypeValue', { value: true });
+    Object.defineProperty(controller, 'externalUrlValue', { value: externalUrl ?? '' });
+    Object.defineProperty(controller, 'hasExternalUrlValue', { value: externalUrl !== null });
+    Object.defineProperty(controller, 'labelValue', { value: label ?? '' });
+    Object.defineProperty(controller, 'hasLabelValue', { value: label !== null });
     Object.defineProperty(controller, 'hasHandleTarget', { value: handle !== null });
     if (handle) {
       Object.defineProperty(controller, 'handleTarget', { value: handle });
@@ -440,10 +454,66 @@ describe('Sortable lists item controller', () => {
     })).toBe(false);
   });
 
-  it('does not expose native external drag data', () => {
+  it('exposes the external URL as native drag data for external consumers', () => {
+    const element = document.createElement('article');
+
+    connectedControllerFor(element, { externalUrl: 'http://example.org/work_packages/123' });
+
+    const externalData = vi.mocked(draggable).mock.lastCall?.[0]
+      .getInitialDataForExternal?.(draggableArgs(element));
+
+    expect(externalData).toEqual({
+      'text/uri-list': 'http://example.org/work_packages/123',
+      'text/plain': 'http://example.org/work_packages/123',
+    });
+  });
+
+  it('adds a text/html link flavour when the item has a label', () => {
+    const element = document.createElement('article');
+
+    connectedControllerFor(element, {
+      externalUrl: 'http://example.org/work_packages/123',
+      label: 'Feature #123: Card subject',
+    });
+
+    const externalData = vi.mocked(draggable).mock.lastCall?.[0]
+      .getInitialDataForExternal?.(draggableArgs(element));
+
+    expect(externalData).toEqual({
+      'text/uri-list': 'http://example.org/work_packages/123',
+      'text/plain': 'http://example.org/work_packages/123',
+      'text/html': '<a href="http://example.org/work_packages/123">Feature #123: Card subject</a>',
+    });
+  });
+
+  it('escapes HTML-sensitive characters in the external link label', () => {
+    const element = document.createElement('article');
+
+    connectedControllerFor(element, {
+      externalUrl: 'http://example.org/work_packages/123',
+      label: '<script>alert("x")</script> & more',
+    });
+
+    const externalData = vi.mocked(draggable).mock.lastCall?.[0]
+      .getInitialDataForExternal?.(draggableArgs(element));
+
+    expect(externalData?.['text/html']).toBe(
+      '<a href="http://example.org/work_packages/123">&lt;script&gt;alert("x")&lt;/script&gt; &amp; more</a>',
+    );
+  });
+
+  it('does not expose native external drag data without an external URL', () => {
     const element = document.createElement('article');
 
     connectedControllerFor(element);
+
+    expect(vi.mocked(draggable).mock.lastCall?.[0].getInitialDataForExternal).toBeUndefined();
+  });
+
+  it('does not expose native external drag data for a blank external URL', () => {
+    const element = document.createElement('article');
+
+    connectedControllerFor(element, { externalUrl: '' });
 
     expect(vi.mocked(draggable).mock.lastCall?.[0].getInitialDataForExternal).toBeUndefined();
   });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -59,6 +59,7 @@ export default class ItemController extends Controller<HTMLElement> implements R
   static values = {
     id: String,
     type: String,
+    externalUrl: String,
     hideUnavailable: { type: Boolean, default: true },
     label: String,
   };
@@ -67,6 +68,8 @@ export default class ItemController extends Controller<HTMLElement> implements R
   declare readonly hasIdValue:boolean;
   declare readonly typeValue:string;
   declare readonly hasTypeValue:boolean;
+  declare readonly externalUrlValue:string;
+  declare readonly hasExternalUrlValue:boolean;
   declare readonly hideUnavailableValue:boolean;
   declare readonly labelValue:string;
   declare readonly hasLabelValue:boolean;
@@ -193,6 +196,12 @@ export default class ItemController extends Controller<HTMLElement> implements R
     return draggable({
       element: this.element,
       ...(this.hasHandleTarget ? { dragHandle: this.handleTarget } : {}),
+      // Native drag data for consumers outside this window (other browser
+      // windows, editors, chat apps). Optional: items without an external
+      // URL expose nothing, exactly as before.
+      ...(this.hasExternalUrlValue && this.externalUrlValue !== '' ? {
+        getInitialDataForExternal: () => this.externalDragData(),
+      } : {}),
       canDrag: ({ input }) => {
         const { root } = this;
         if (root == null || root.busy) {
@@ -202,6 +211,9 @@ export default class ItemController extends Controller<HTMLElement> implements R
       },
       getInitialData: () => this.getItemData(),
       onDragStart: () => {
+        // Cancels drops landing outside registered drop targets. This also
+        // guards the external data channel: a misdropped card carrying
+        // text/uri-list would otherwise navigate the current tab to that URL.
         preventUnhandled.start();
         this.element.setAttribute('data-dragging', 'source');
       },
@@ -304,6 +316,27 @@ export default class ItemController extends Controller<HTMLElement> implements R
 
     return input.clientY >= firstRow.getBoundingClientRect().top
       && input.clientY <= lastRow.getBoundingClientRect().bottom;
+  }
+
+  // The URL flavours carry the bare URL; text/html joins in only when the item
+  // has a label (the same one announcements use), as a link for rich-text
+  // targets (notes apps, editors). The anchor is built through a detached DOM
+  // element so the browser escapes the label and URL canonically.
+  private externalDragData():Record<string, string> {
+    const url = this.externalUrlValue;
+    const data:Record<string, string> = {
+      'text/uri-list': url,
+      'text/plain': url,
+    };
+
+    if (this.hasLabelValue && this.labelValue !== '') {
+      const anchor = this.element.ownerDocument.createElement('a');
+      anchor.href = url;
+      anchor.textContent = this.labelValue;
+      data['text/html'] = anchor.outerHTML;
+    }
+
+    return data;
   }
 
   private getItemData():SortableItemData {

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
@@ -102,7 +102,11 @@ module Backlogs
         controller: "sortable-lists--item",
         sortable_lists__item_id_value: work_package.id,
         sortable_lists__item_label_value: work_package.to_fs(:caption),
-        sortable_lists__item_type_value: "work_package"
+        sortable_lists__item_type_value: "work_package",
+        # Native drag payload for external consumers; the same absolute URL
+        # as the card menu's "Copy URL to clipboard" item. The label above
+        # doubles as the link text of the text/html flavour.
+        sortable_lists__item_external_url_value: url_helpers.work_package_url(work_package)
       }
     end
 

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
@@ -69,10 +69,38 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
       expect(item.row_args[:data]).to include(
         controller: "sortable-lists--item",
         sortable_lists__item_id_value: work_package.id,
-        sortable_lists__item_type_value: "work_package"
+        sortable_lists__item_type_value: "work_package",
+        sortable_lists__item_label_value: work_package.to_fs(:caption)
       )
       expect(item.row_args[:draggable]).to be(true)
       expect(item.row_args).not_to include(:tabindex)
+    end
+
+    context "with classic mode",
+            with_settings: { work_packages_identifier: "classic" } do
+      it "exposes the absolute ID-based work package URL for external drag consumers" do
+        external_url = item.row_args[:data][:sortable_lists__item_external_url_value]
+
+        expect(external_url).to match(%r{\Ahttps?://})
+        expect(external_url).to end_with("/work_packages/#{work_package.id}")
+      end
+    end
+
+    context "with semantic mode",
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:project) { create(:project, types: [type_feature], identifier: "STORY") }
+      let(:sprint) do
+        create(:sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: Date.tomorrow)
+      end
+
+      it "exposes the absolute semantic work package URL for external drag consumers" do
+        external_url = item.row_args[:data][:sortable_lists__item_external_url_value]
+        semantic_id = work_package.reload.identifier
+
+        expect(semantic_id).to start_with("STORY-")
+        expect(external_url).to match(%r{\Ahttps?://})
+        expect(external_url).to end_with("/work_packages/#{semantic_id}")
+      end
     end
 
     context "when the user cannot manage sprint items" do
@@ -86,6 +114,7 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
         expect(item.row_args[:data]).not_to include(:sortable_lists_prev_item_id)
         expect(item.row_args).not_to include(:draggable)
         expect(item.row_args).not_to include(:tabindex)
+        expect(item.row_args[:data]).not_to include(:sortable_lists__item_external_url_value)
       end
 
       it "keeps the card focusable so keyboard users can interact with it" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-347

# What are you trying to accomplish?

Dragging a backlogs card out of the browser window now carries the work package URL as native drag data (`text/uri-list` + `text/plain`), so dropping a card into a chat app, an editor, or another browser window yields a usable link — the same absolute URL as the card menu's "Copy URL to clipboard" item. Rich-text targets (e.g. Apple Mail's composer) additionally receive a `text/html` anchor whose link text is the card's caption.

## Screen Recording

https://github.com/user-attachments/assets/cd0e2555-c455-49c2-8339-b3404ec7a7fc

# What approach did you choose and why?

The generic `sortable-lists--item` controller gains an optional `external-url` Stimulus value and only registers Pragmatic's `getInitialDataForExternal` when the URL is present and non-empty; items without the value behave exactly as before, keeping the controller domain-blind. The `text/html` flavour joins the payload only when the item has a label — the same `label` value the live-region announcements use — and the anchor is built through a detached DOM element so the browser escapes label and URL canonically. The backlogs card component supplies the URL for sprint and bucket lists. `preventUnhandled` stays on and now also prevents a misdropped card from navigating the current tab to the dragged URL.

Out of scope: no caption text in `text/plain` (bare URL), and no accepting inbound external drags (`dropTargetForExternal`).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)


