### PR TITLE
[OP-20017] Fix and cover the dialog stream action

### DIFF
--- a/app/controllers/admin/import/jira/import_runs/select_projects_controller.rb
+++ b/app/controllers/admin/import/jira/import_runs/select_projects_controller.rb
@@ -52,7 +52,7 @@ module Admin::Import::Jira::ImportRuns
 
       @jira_import.update!(projects:)
       stream_wizard do
-        close_dialog_via_turbo_stream("##{Admin::Import::Jira::ImportRuns::SelectProjects::ModalComponent::MODAL_ID}")
+        close_dialog_via_turbo_stream(Admin::Import::Jira::ImportRuns::SelectProjects::ModalComponent::MODAL_ID)
       end
     end
 

--- a/app/controllers/admin/settings/project_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/project_custom_field_sections_controller.rb
@@ -42,7 +42,7 @@ module Admin::Settings
       )
 
       if call.success?
-        close_dialog_via_turbo_stream("##{Settings::ProjectCustomFieldSections::NewSectionDialogComponent::MODAL_ID}")
+        close_dialog_via_turbo_stream(Settings::ProjectCustomFieldSections::NewSectionDialogComponent::MODAL_ID)
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
@@ -58,7 +58,7 @@ module Admin::Settings
       )
 
       if call.success?
-        close_dialog_via_turbo_stream("#project-custom-field-section-dialog#{@project_custom_field_section.id}")
+        close_dialog_via_turbo_stream("project-custom-field-section-dialog#{@project_custom_field_section.id}")
         update_section_via_turbo_stream(project_custom_field_section: call.result)
       else
         update_section_dialog_body_form_via_turbo_stream(project_custom_field_section: call.result)

--- a/app/controllers/admin/settings/user_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/user_custom_field_sections_controller.rb
@@ -41,7 +41,7 @@ module Admin::Settings
       )
 
       if call.success?
-        close_dialog_via_turbo_stream("##{Settings::UserCustomFieldSections::NewSectionDialogComponent::MODAL_ID}")
+        close_dialog_via_turbo_stream(Settings::UserCustomFieldSections::NewSectionDialogComponent::MODAL_ID)
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(user_custom_field_sections: UserCustomFieldSection.all)
       else
@@ -57,7 +57,7 @@ module Admin::Settings
       )
 
       if call.success?
-        close_dialog_via_turbo_stream("#user-custom-field-section-dialog#{@user_custom_field_section.id}")
+        close_dialog_via_turbo_stream("user-custom-field-section-dialog#{@user_custom_field_section.id}")
         update_section_via_turbo_stream(user_custom_field_section: call.result)
       else
         update_section_dialog_body_form_via_turbo_stream(user_custom_field_section: call.result)

--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -140,9 +140,9 @@ module OpTurbo
         .render_in(view_context)
     end
 
-    def close_dialog_via_turbo_stream(target, additional: {})
+    def close_dialog_via_turbo_stream(dialog_id, additional: {})
       turbo_streams << OpTurbo::StreamComponent
-        .new(action: :closeDialog, target:, additional: additional.to_json)
+        .new(action: :closeDialog, target: dialog_id, additional: additional.to_json)
         .render_in(view_context)
     end
 

--- a/app/controllers/projects/settings/work_packages/types/switches_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/switches_controller.rb
@@ -78,7 +78,7 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
 
   # Reload so the repainted list no longer sees the association's cached types.
   def on_switched(target)
-    close_dialog_via_turbo_stream("##{Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}")
+    close_dialog_via_turbo_stream(Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID)
     replace_via_turbo_stream(
       component: Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project.reload)
     )

--- a/app/controllers/projects/settings/work_packages/types_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types_controller.rb
@@ -54,7 +54,7 @@ class Projects::Settings::WorkPackages::TypesController < Projects::SettingsCont
     result = ::Projects::Types::AddService.new(user: current_user, model: @project).call(variant:)
 
     result.on_success do
-      close_dialog_via_turbo_stream("##{Projects::Settings::WorkPackages::Types::AddDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(Projects::Settings::WorkPackages::Types::AddDialogComponent::DIALOG_ID)
       replace_types_list
     end
 

--- a/app/controllers/users/invite_controller.rb
+++ b/app/controllers/users/invite_controller.rb
@@ -91,7 +91,7 @@ class Users::InviteController < ApplicationController
         message: I18n.t("users.invite_user_modal.success_message.#{form_model.principal_type.underscore}",
                         project: form_model.project.name)
       )
-      close_dialog_via_turbo_stream("##{Users::Invitation::DialogComponent::DIALOG_ID}",
+      close_dialog_via_turbo_stream(Users::Invitation::DialogComponent::DIALOG_ID,
                                     additional: { user_id: call.result.user_id })
     else
       replace_via_turbo_stream(component: Users::Invitation::PrincipalStep::FormComponent.new(form_model))

--- a/app/controllers/work_package_types/configuration_copies_controller.rb
+++ b/app/controllers/work_package_types/configuration_copies_controller.rb
@@ -52,7 +52,7 @@ module WorkPackageTypes
       if source.nil?
         render_error_flash_message_via_turbo_stream(message: t("types.edit.reuse_mode.copy.invalid_source"))
       else
-        close_dialog_via_turbo_stream("##{ConfigurationCopies::DialogComponent::DIALOG_ID}")
+        close_dialog_via_turbo_stream(ConfigurationCopies::DialogComponent::DIALOG_ID)
         dialog_via_turbo_stream(component: ConfigurationCopies::ConfirmDialogComponent.new(variant: @variant, aspect:, source:))
       end
 
@@ -62,7 +62,7 @@ module WorkPackageTypes
     def copy
       result = copy_service.call(source:)
 
-      close_dialog_via_turbo_stream("##{ConfigurationCopies::ConfirmDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ConfigurationCopies::ConfirmDialogComponent::DIALOG_ID)
 
       if result.success?
         respond_to_copy_success

--- a/app/controllers/work_package_types/configuration_independence_controller.rb
+++ b/app/controllers/work_package_types/configuration_independence_controller.rb
@@ -51,7 +51,7 @@ module WorkPackageTypes
     # The mode picker's submit: swaps the picker for the danger confirmation.
     def confirm
       if IndependentMode.available?(aspect, mode)
-        close_dialog_via_turbo_stream("##{ConfigurationIndependence::DialogComponent::DIALOG_ID}")
+        close_dialog_via_turbo_stream(ConfigurationIndependence::DialogComponent::DIALOG_ID)
         dialog_via_turbo_stream(component: ConfigurationIndependence::ConfirmDialogComponent.new(variant: @variant, aspect:,
                                                                                                  mode:))
       else
@@ -64,7 +64,7 @@ module WorkPackageTypes
     def switch
       result = SwitchToIndependentModeService.new(variant: @variant, aspect:, user: current_user).call(mode:)
 
-      close_dialog_via_turbo_stream("##{ConfigurationIndependence::ConfirmDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ConfigurationIndependence::ConfirmDialogComponent::DIALOG_ID)
 
       respond_to_switch(result)
 

--- a/app/controllers/work_package_types/configuration_links_controller.rb
+++ b/app/controllers/work_package_types/configuration_links_controller.rb
@@ -53,7 +53,7 @@ module WorkPackageTypes
       if source.nil?
         render_error_flash_message_via_turbo_stream(message: t("types.edit.reuse_mode.linked.invalid_source"))
       else
-        close_dialog_via_turbo_stream("##{ConfigurationLinks::DialogComponent::DIALOG_ID}")
+        close_dialog_via_turbo_stream(ConfigurationLinks::DialogComponent::DIALOG_ID)
         dialog_via_turbo_stream(component: ConfigurationLinks::ConfirmDialogComponent.new(variant: @variant, aspect:, source:))
       end
 
@@ -63,7 +63,7 @@ module WorkPackageTypes
     def switch
       result = SwitchToLinkedModeService.new(variant: @variant, aspect:).call(source:)
 
-      close_dialog_via_turbo_stream("##{ConfigurationLinks::ConfirmDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ConfigurationLinks::ConfirmDialogComponent::DIALOG_ID)
 
       respond_to_switch(result)
 

--- a/app/controllers/work_package_types/projects_tab_controller.rb
+++ b/app/controllers/work_package_types/projects_tab_controller.rb
@@ -84,7 +84,7 @@ module WorkPackageTypes
 
       result = apply_to(projects)
 
-      close_dialog_via_turbo_stream("##{ProjectsTab::AddFormComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ProjectsTab::AddFormComponent::DIALOG_ID)
       refresh_projects
 
       if result.success?
@@ -243,7 +243,7 @@ module WorkPackageTypes
 
     def on_switched(target)
       close_dialog_via_turbo_stream(
-        "##{::Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}"
+        ::Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID
       )
       refresh_projects
       render_success_flash_message_via_turbo_stream(

--- a/app/controllers/workflows/copies/from_roles_controller.rb
+++ b/app/controllers/workflows/copies/from_roles_controller.rb
@@ -56,7 +56,7 @@ class Workflows::Copies::FromRolesController < ApplicationController
     else
       Workflow.copy(@source_variant, @source_role, [@source_variant], @target_roles)
 
-      close_dialog_via_turbo_stream("#copy_from_type_dialog")
+      close_dialog_via_turbo_stream("copy_from_type_dialog")
       render_success_flash_message_via_turbo_stream(
         message: t(".notice", count: @target_roles.size, role_name: @target_roles.first.name)
       )

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -72,6 +72,7 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { ensureId, generateId } from 'core-app/shared/helpers/dom-helpers';
 import { target } from 'core-app/shared/helpers/event-helpers';
 import { html, render } from 'lit-html';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 interface TimeEntrySchema extends SchemaResource {
   activity:IFieldSchema;
@@ -730,10 +731,8 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
       .filter((value) => value !== null);
   }
 
-  private handleDialogClose(event:CustomEvent):void {
-    const {
-      detail: { dialog, submitted },
-    } = event as { detail:{ dialog:HTMLDialogElement; submitted:boolean } };
+  private handleDialogClose(event:CustomEvent<DialogCloseDetail>):void {
+    const { detail: { dialog, submitted } } = event;
     if (dialog.id === 'time-entry-dialog' && submitted) {
       void this.fetchTimeEntries(
         this.memoizedTimeEntries.start,

--- a/frontend/src/app/features/invite-user-modal/invite-user-dialog.service.ts
+++ b/frontend/src/app/features/invite-user-modal/invite-user-dialog.service.ts
@@ -32,6 +32,7 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 @Injectable({ providedIn: 'root' })
 export class OpInviteUserDialogService implements OnDestroy {
@@ -59,11 +60,9 @@ export class OpInviteUserDialogService implements OnDestroy {
     );
   }
 
-  private handleDialogClose(event:CustomEvent):void {
-    const {
-      detail: { dialog, submitted, additional },
-    } = event as { detail:{ dialog:HTMLDialogElement; submitted:boolean, additional:{ user_id:number } } };
-    if (dialog.id === 'user-invitation-dialog' && submitted) {
+  private handleDialogClose(event:CustomEvent<DialogCloseDetail<{ user_id:number }>>):void {
+    const { detail: { dialog, submitted, additional } } = event;
+    if (dialog.id === 'user-invitation-dialog' && submitted && additional) {
       this
         .apiV3Service
         .principals

--- a/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -35,6 +35,7 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { WorkDisplayField } from 'core-app/shared/components/fields/display/field-types/work-display-field.module';
 import moment from 'moment-timezone';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 export class WorkPackageSpentTimeDisplayField extends WorkDisplayField {
   public text = {
@@ -122,12 +123,10 @@ export class WorkPackageSpentTimeDisplayField extends WorkDisplayField {
     );
   }
 
-  private handleDialogClose(event:CustomEvent):void {
+  private handleDialogClose(event:CustomEvent<DialogCloseDetail>):void {
     document.removeEventListener('dialog:close', this.closeDialogHandler);
 
-    const {
-      detail: { dialog, submitted },
-    } = event as { detail:{ dialog:HTMLDialogElement; submitted:boolean } };
+    const { detail: { dialog, submitted } } = event;
     if (dialog.id === 'time-entry-dialog' && submitted) {
       void this.apiV3Service.work_packages
         .id(this.workPackageForHandler.id!)

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -44,6 +44,7 @@ import {
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 @Directive()
 export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetComponent implements OnInit, AfterViewInit, OnDestroy {
@@ -241,8 +242,8 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
       .get();
   }
 
-  private handleDialogClose(event:CustomEvent):void {
-    const { detail: { dialog, submitted } } = event as { detail:{ dialog:HTMLDialogElement; submitted:boolean } };
+  private handleDialogClose(event:CustomEvent<DialogCloseDetail>):void {
+    const { detail: { dialog, submitted } } = event;
     if (dialog.id === 'time-entry-dialog' && submitted) {
       this.loadTimeEntries();
     }

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -52,6 +52,7 @@ import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-re
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { isSemanticWorkPackageId } from 'core-app/shared/helpers/work-package-id-pattern';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
@@ -260,8 +261,8 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
     return this.items;
   }
 
-  private handleTimeEntryDialogClose(event:CustomEvent):void {
-    const { detail: { dialog, submitted } } = event as { detail:{ dialog:HTMLDialogElement, submitted:boolean } };
+  private handleTimeEntryDialogClose(event:CustomEvent<DialogCloseDetail>):void {
+    const { detail: { dialog, submitted } } = event;
 
     if (dialog.id === 'time-entry-dialog' && submitted) {
       void this.apiV3Service

--- a/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
+++ b/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
@@ -86,8 +86,8 @@ export class TriggerActionsEntryComponent {
 
   editTimeEntry() {
     void this.loadEntry().subscribe((entry:TimeEntryResource) => {
-      document.addEventListener('dialog:close', (event:CustomEvent) => {
-        const { detail: { dialog, submitted } } = event as { detail:{ dialog:HTMLDialogElement, submitted:boolean } };
+      document.addEventListener('dialog:close', (event) => {
+        const { detail: { dialog, submitted } } = event;
         if (dialog.id === 'time-entry-dialog' && submitted) {
           window.location.reload();
         }

--- a/frontend/src/app/shared/components/time_entries/services/time-entry-timer.service.ts
+++ b/frontend/src/app/shared/components/time_entries/services/time-entry-timer.service.ts
@@ -55,6 +55,7 @@ import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { octiconElement } from 'core-app/shared/helpers/op-icon-builder';
 import { clockIconData } from '@openproject/octicons-angular';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 @Injectable()
 export class TimeEntryTimerService {
@@ -202,8 +203,8 @@ export class TimeEntryTimerService {
   }
 
 
-  private handleTimeEntryDialogClose(event:CustomEvent):void {
-    const { detail: { dialog, submitted } } = event as { detail:{ dialog:HTMLDialogElement, submitted:boolean } };
+  private handleTimeEntryDialogClose(event:CustomEvent<DialogCloseDetail>):void {
+    const { detail: { dialog, submitted } } = event;
     const isOngoing = dialog.dataset.ongoing === 'true';
 
     if (dialog.id === 'time-entry-dialog' && submitted && isOngoing) {

--- a/frontend/src/stimulus/controllers/dynamic/generic-dialog-close.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-dialog-close.controller.ts
@@ -27,6 +27,7 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 export default class GenericDialogCloseController extends Controller<HTMLElement> {
   // TODO: Add something that we can only refresh a certain turbo frame, etc
@@ -39,8 +40,8 @@ export default class GenericDialogCloseController extends Controller<HTMLElement
     document.removeEventListener('dialog:close', this.dialogCloseListener);
   }
 
-  dialogCloseListener(this:void, event:CustomEvent):void {
-    const { detail: { dialog, submitted } } = event as { detail:{ dialog:HTMLDialogElement; submitted:boolean } };
+  dialogCloseListener(this:void, event:CustomEvent<DialogCloseDetail>):void {
+    const { detail: { dialog, submitted } } = event;
 
     if (dialog.id === 'time-entry-dialog' && submitted) {
       window.location.reload();

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -43,6 +43,11 @@ import { useMeta } from 'stimulus-use';
 import { html, render, TemplateResult } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
+
+interface AdditionalDialogCloseData {
+  spent_on?:string;
+}
 
 export default class MyTimeTrackingController extends Controller {
   static services:ServiceKey[] = ['turboRequests', 'pathHelperService'];
@@ -520,14 +525,8 @@ export default class MyTimeTrackingController extends Controller {
     );
   }
 
-  dialogCloseListener(event:CustomEvent):void {
-    interface AdditionalDialogCloseData {
-      spent_on?:string;
-    }
-
-    const { detail: { dialog, additional, submitted } } = event as {
-      detail:{ dialog:HTMLDialogElement; additional:AdditionalDialogCloseData|undefined; submitted:boolean }
-    };
+  dialogCloseListener(event:CustomEvent<DialogCloseDetail<AdditionalDialogCloseData>>):void {
+    const { detail: { dialog, additional, submitted } } = event;
     if (dialog.id !== 'time-entry-dialog' || !submitted) { return; }
 
     // we simply refresh the calendar page

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
@@ -29,6 +29,7 @@
 import { ApplicationController } from 'stimulus-use';
 import { renderStreamMessage } from '@hotwired/turbo';
 import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
+import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
 export default class RequirePasswordConfirmationController extends ApplicationController {
   static services:ServiceKey[] = ['pathHelperService'];
@@ -75,9 +76,9 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
     document.removeEventListener('password-confirmation-dialog:submit', this.dialogSubmitListener);
   }
 
-  private onDialogClose(event:CustomEvent) {
-    const dialog = (event.detail as { dialog?:HTMLElement }|undefined)?.dialog;
-    if (dialog?.id !== 'password-confirmation-dialog') {
+  private onDialogClose(event:CustomEvent<DialogCloseDetail>) {
+    const { detail: { dialog } } = event;
+    if (dialog.id !== 'password-confirmation-dialog') {
       return;
     }
 

--- a/frontend/src/turbo/dialog-stream-action.spec.ts
+++ b/frontend/src/turbo/dialog-stream-action.spec.ts
@@ -1,0 +1,156 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { StreamActions } from '@hotwired/turbo';
+import { waitFor } from '@testing-library/dom';
+import { DialogCloseDetail, registerDialogStreamAction } from './dialog-stream-action';
+
+describe('registerDialogStreamAction', () => {
+  let controller:AbortController;
+  let closeEvents:CustomEvent<DialogCloseDetail>[];
+
+  beforeEach(() => {
+    registerDialogStreamAction();
+    controller = new AbortController();
+    closeEvents = [];
+    document.addEventListener('dialog:close', (event) => {
+      closeEvents.push(event);
+    }, { signal: controller.signal });
+  });
+
+  afterEach(() => {
+    controller.abort();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  function dialog(content:string, id = 'test-dialog'):HTMLDialogElement {
+    const element = document.createElement('turbo-stream');
+    element.innerHTML = `<template><dialog-helper><dialog id="${id}">${content}</dialog></dialog-helper></template>`;
+    StreamActions.dialog.call(element);
+
+    return document.getElementById(id) as HTMLDialogElement;
+  }
+
+  function closeDialog(attributes:Record<string, string>):void {
+    const element = document.createElement('turbo-stream');
+    Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value));
+    StreamActions.closeDialog.call(element);
+  }
+
+  it('appends and shows a new dialog', () => {
+    const dialogElement = dialog('<p>Initial content</p>');
+
+    expect(dialogElement.parentElement?.tagName).toBe('DIALOG-HELPER');
+    expect(dialogElement.open).toBe(true);
+  });
+
+  it('removes a newly streamed dialog and reports an unsuccessful close', async () => {
+    const dialogElement = dialog('<p>Initial content</p>');
+
+    dialogElement.close();
+
+    await waitFor(() => expect(closeEvents).toHaveLength(1));
+    expect(dialogElement).not.toBeInTheDocument();
+    expect(closeEvents[0].detail).toEqual({ dialog: dialogElement, submitted: false });
+  });
+
+  it('reports a submitted close with additional data without dispatching a duplicate event', async () => {
+    const dialogElement = dialog('<p>Initial content</p>');
+
+    closeDialog({ target: 'test-dialog', additional: '{"workPackageId":42}' });
+
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0].detail).toEqual({
+      dialog: dialogElement,
+      submitted: true,
+      additional: { workPackageId: 42 },
+    });
+
+    await waitFor(() => expect(dialogElement).not.toBeInTheDocument());
+    expect(closeEvents).toHaveLength(1);
+  });
+
+  it('closes the dialog matched by a targets selector', async () => {
+    const dialogElement = dialog('<p>Initial content</p>');
+
+    closeDialog({ targets: '#test-dialog' });
+
+    expect(closeEvents).toHaveLength(1);
+    await waitFor(() => expect(dialogElement).not.toBeInTheDocument());
+  });
+
+  it('defaults the additional data to an empty object', () => {
+    dialog('<p>Initial content</p>');
+
+    closeDialog({ target: 'test-dialog' });
+
+    expect(closeEvents[0].detail.additional).toEqual({});
+  });
+
+  it('ignores a close target that matches no element', () => {
+    const dialogElement = dialog('<p>Initial content</p>');
+
+    closeDialog({ target: 'missing-dialog' });
+
+    expect(closeEvents).toHaveLength(0);
+    expect(dialogElement).toBeInTheDocument();
+    expect(dialogElement.open).toBe(true);
+  });
+
+  it('ignores a close target that is not a dialog', () => {
+    document.body.insertAdjacentHTML('beforeend', '<div id="not-a-dialog"></div>');
+
+    closeDialog({ target: 'not-a-dialog' });
+
+    expect(closeEvents).toHaveLength(0);
+  });
+
+  it('morphs and reopens the existing dialog when the same id is streamed again', () => {
+    const dialogElement = dialog('<p>Initial content</p>');
+    dialogElement.removeAttribute('open');
+    expect(dialogElement.open).toBe(false);
+
+    dialog('<h2>Updated content</h2>');
+
+    expect(document.querySelectorAll('#test-dialog')).toHaveLength(1);
+    expect(document.getElementById('test-dialog')).toBe(dialogElement);
+    expect(dialogElement.innerHTML).toBe('<h2>Updated content</h2>');
+    expect(dialogElement.open).toBe(true);
+  });
+
+  it('adjusts the dialog width after it is shown', () => {
+    vi.useFakeTimers();
+    const dialogElement = dialog('<p>Initial content</p>');
+    Object.defineProperty(dialogElement, 'offsetWidth', { configurable: true, value: 320 });
+
+    vi.advanceTimersByTime(250);
+
+    expect(dialogElement.style.width).toBe('321px');
+  });
+});

--- a/frontend/src/turbo/dialog-stream-action.spec.ts
+++ b/frontend/src/turbo/dialog-stream-action.spec.ts
@@ -1,0 +1,132 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { StreamActions } from '@hotwired/turbo';
+import { registerDialogStreamAction } from './dialog-stream-action';
+
+interface DialogCloseDetail {
+  dialog:HTMLDialogElement;
+  submitted:boolean;
+  additional?:unknown;
+}
+
+describe('registerDialogStreamAction', () => {
+  let controller:AbortController;
+  let closeEvents:CustomEvent<DialogCloseDetail>[];
+
+  beforeEach(() => {
+    registerDialogStreamAction();
+    controller = new AbortController();
+    closeEvents = [];
+    document.addEventListener('dialog:close', (event) => {
+      closeEvents.push(event as CustomEvent<DialogCloseDetail>);
+    }, { signal: controller.signal });
+  });
+
+  afterEach(() => {
+    controller.abort();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  function showDialog(content:string, id = 'test-dialog'):HTMLDialogElement {
+    const element = document.createElement('turbo-stream');
+    element.innerHTML = `<template><dialog-helper><dialog id="${id}">${content}</dialog></dialog-helper></template>`;
+    StreamActions.dialog.call(element);
+
+    return document.getElementById(id) as HTMLDialogElement;
+  }
+
+  function closeDialog(attributes:Record<string, string>):void {
+    const element = document.createElement('turbo-stream');
+    Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value));
+    StreamActions.closeDialog.call(element);
+  }
+
+  it('appends and shows a new dialog', () => {
+    const dialog = showDialog('<p>Initial content</p>');
+
+    expect(dialog.parentElement?.tagName).toBe('DIALOG-HELPER');
+    expect(dialog.open).toBe(true);
+  });
+
+  it('removes a newly streamed dialog and reports an unsuccessful close', async () => {
+    const dialog = showDialog('<p>Initial content</p>');
+    const closed = new Promise<void>((resolve) => dialog.addEventListener('close', () => resolve(), { once: true }));
+
+    dialog.close();
+    await closed;
+
+    expect(document.getElementById(dialog.id)).toBeNull();
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0].detail).toEqual({ dialog, submitted: false });
+  });
+
+  it('reports a submitted close with additional data without dispatching a duplicate event', async () => {
+    const dialog = showDialog('<p>Initial content</p>');
+    const closed = new Promise<void>((resolve) => dialog.addEventListener('close', () => resolve(), { once: true }));
+
+    closeDialog({ target: '#test-dialog', additional: '{"workPackageId":42}' });
+    await closed;
+
+    expect(dialog.open).toBe(false);
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0].detail).toEqual({
+      dialog,
+      submitted: true,
+      additional: { workPackageId: 42 },
+    });
+  });
+
+  it('morphs and reopens the existing dialog when the same id is streamed again', () => {
+    const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+    const dialog = showDialog('<p>Initial content</p>');
+
+    showDialog('<h2>Updated content</h2>');
+
+    expect(document.querySelectorAll('#test-dialog')).toHaveLength(1);
+    expect(document.getElementById('test-dialog')).toBe(dialog);
+    expect(dialog.innerHTML).toBe('<h2>Updated content</h2>');
+    expect(showModalSpy).toHaveBeenCalledTimes(2);
+    expect(showModalSpy.mock.contexts[1]).toBe(dialog);
+  });
+
+  it('adjusts the dialog width after it is shown', () => {
+    vi.useFakeTimers();
+    const dialog = showDialog('<p>Initial content</p>');
+    Object.defineProperty(dialog, 'offsetWidth', { configurable: true, value: 320 });
+
+    vi.advanceTimersByTime(250);
+
+    expect(dialog.style.width).toBe('321px');
+  });
+});

--- a/frontend/src/turbo/dialog-stream-action.ts
+++ b/frontend/src/turbo/dialog-stream-action.ts
@@ -29,15 +29,32 @@
 import { StreamActions, StreamElement } from '@hotwired/turbo';
 import { Idiomorph } from 'idiomorph';
 
+export interface DialogCloseDetail<TAdditional = unknown> {
+  dialog:HTMLDialogElement;
+  submitted:boolean;
+  additional?:TAdditional;
+}
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    'dialog:close':CustomEvent<DialogCloseDetail>;
+  }
+}
+
 export function registerDialogStreamAction() {
   StreamActions.closeDialog = function closeDialogStreamAction(this:StreamElement) {
-    const dialog = document.querySelector(this.target)!;
+    const [dialog] = this.targetElements;
+
+    if (!(dialog instanceof HTMLDialogElement)) {
+      return;
+    }
+
     const additionalData = JSON.parse(this.getAttribute('additional') ?? '{}') as unknown;
 
     // dispatching with submitted: true to indicate that the behavior of a successful submission should
     // be triggered (i.e. reloading the ui)
-    document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: true, additional: additionalData } }));
-    (dialog as HTMLDialogElement).close('close-event-already-dispatched');
+    document.dispatchEvent(new CustomEvent<DialogCloseDetail>('dialog:close', { detail: { dialog, submitted: true, additional: additionalData } }));
+    dialog.close('close-event-already-dispatched');
   };
 
   StreamActions.dialog = function dialogStreamAction(this:StreamElement) {
@@ -63,7 +80,7 @@ export function registerDialogStreamAction() {
         }
 
         if (dialog.returnValue !== 'close-event-already-dispatched') {
-          document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: false } }));
+          document.dispatchEvent(new CustomEvent<DialogCloseDetail>('dialog:close', { detail: { dialog, submitted: false } }));
         }
       });
     }

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -27,6 +27,7 @@
 //++
 
 import { readScriptNonce, scrubScriptElements } from './csp-script-nonce';
+import { DialogCloseDetail } from './dialog-stream-action';
 
 export function addTurboEventListeners(doc:Document = document, signal?:AbortSignal) {
   // Close the primer dialog when the form inside has been submitted with a success response.
@@ -47,7 +48,7 @@ export function addTurboEventListeners(doc:Document = document, signal?:AbortSig
       if (dialog) {
         if (dialog.dataset.keepOpenOnSubmit !== 'true') {
           dialog.close('close-event-already-dispatched');
-          doc.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: true } }));
+          doc.dispatchEvent(new CustomEvent<DialogCloseDetail>('dialog:close', { detail: { dialog, submitted: true } }));
         }
       }
     }

--- a/modules/costs/app/controllers/time_entries_controller.rb
+++ b/modules/costs/app/controllers/time_entries_controller.rb
@@ -89,7 +89,7 @@ class TimeEntriesController < ApplicationController
     @time_entry = call.result
 
     if call.success?
-      close_dialog_via_turbo_stream("#time-entry-dialog", additional: { spent_on: @time_entry.spent_on })
+      close_dialog_via_turbo_stream("time-entry-dialog", additional: { spent_on: @time_entry.spent_on })
     else
       form_component = TimeEntries::TimeEntryFormComponent.new(time_entry: @time_entry, **form_config_options)
       update_via_turbo_stream(component: form_component, status: :bad_request)
@@ -107,7 +107,7 @@ class TimeEntriesController < ApplicationController
 
     if call.success?
       if request_from_dialog?
-        close_dialog_via_turbo_stream("#time-entry-dialog", additional: { spent_on: @time_entry.spent_on })
+        close_dialog_via_turbo_stream("time-entry-dialog", additional: { spent_on: @time_entry.spent_on })
       else
         reload_page_via_turbo_stream
       end
@@ -129,7 +129,7 @@ class TimeEntriesController < ApplicationController
 
     if request_from_dialog?
       if call.success?
-        close_dialog_via_turbo_stream("#time-entry-dialog")
+        close_dialog_via_turbo_stream("time-entry-dialog")
       else
         form_component = TimeEntries::TimeEntryFormComponent.new(time_entry: @time_entry, **form_config_options)
         update_via_turbo_stream(component: form_component, status: :bad_request)

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -277,7 +277,7 @@ class MeetingAgendaItemsController < ApplicationController
     duplicate_call = duplicate_agenda_item_in_meeting(next_occurrence)
 
     if duplicate_call.success?
-      close_dialog_via_turbo_stream("#duplicate-in-next-meeting-dialog")
+      close_dialog_via_turbo_stream("duplicate-in-next-meeting-dialog")
       render_next_meeting_flash(:text_agenda_item_duplicated_in_next_meeting, next_occurrence)
       update_header_component_via_turbo_stream
       respond_with_turbo_streams

--- a/modules/resource_management/app/controllers/resource_management/resource_allocations_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/resource_allocations_controller.rb
@@ -41,7 +41,7 @@ module ::ResourceManagement
       # Opened from a user's utilization dialog: replace it rather than stack on
       # top. It is reopened (refreshed) after a successful create.
       if reopen_user_allocations_dialog?
-        close_dialog_via_turbo_stream("##{ResourcePlannerViews::UserCardList::UserAllocationsDialogComponent::DIALOG_ID}")
+        close_dialog_via_turbo_stream(ResourcePlannerViews::UserCardList::UserAllocationsDialogComponent::DIALOG_ID)
       end
 
       respond_with_dialog ResourceAllocations::NewDialogComponent.new(
@@ -75,7 +75,7 @@ module ::ResourceManagement
 
     def edit
       if reopen_user_allocations_dialog?
-        close_dialog_via_turbo_stream("##{ResourcePlannerViews::UserCardList::UserAllocationsDialogComponent::DIALOG_ID}")
+        close_dialog_via_turbo_stream(ResourcePlannerViews::UserCardList::UserAllocationsDialogComponent::DIALOG_ID)
       end
 
       respond_with_dialog ResourceAllocations::EditDialogComponent.new(
@@ -240,7 +240,7 @@ module ::ResourceManagement
       render_success_flash_message_via_turbo_stream(
         message: I18n.t("resource_management.allocate_resource_dialog.success_message")
       )
-      close_dialog_via_turbo_stream("##{ResourceAllocations::NewDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ResourceAllocations::NewDialogComponent::DIALOG_ID)
       refresh_allocations_list(allocation.entity)
       notify_allocation_change(allocation.entity)
       reopen_user_dialog(allocation)
@@ -332,7 +332,7 @@ module ::ResourceManagement
       render_success_flash_message_via_turbo_stream(
         message: I18n.t("resource_management.edit_allocation_dialog.success_message")
       )
-      close_dialog_via_turbo_stream("##{ResourceAllocations::EditDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ResourceAllocations::EditDialogComponent::DIALOG_ID)
       refresh_allocations_list(allocation.entity)
       notify_allocation_change(allocation.entity)
       reopen_user_dialog(allocation)
@@ -345,7 +345,7 @@ module ::ResourceManagement
       )
       # Closes the edit dialog when the delete was triggered from it; a harmless
       # no-op when deleting from a list row, where the dialog is not open.
-      close_dialog_via_turbo_stream("##{ResourceAllocations::EditDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ResourceAllocations::EditDialogComponent::DIALOG_ID)
       refresh_allocations_list(entity)
       notify_allocation_change(entity)
       respond_with_turbo_streams

--- a/modules/resource_management/app/controllers/resource_management/resource_planner_views_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/resource_planner_views_controller.rb
@@ -123,7 +123,7 @@ module ::ResourceManagement
 
       replace_view_content
       close_dialog_via_turbo_stream(
-        "##{ResourcePlannerViews::WorkPackageList::AddWorkPackageDialogComponent::DIALOG_ID}"
+        ResourcePlannerViews::WorkPackageList::AddWorkPackageDialogComponent::DIALOG_ID
       )
       respond_with_turbo_streams
     end
@@ -177,7 +177,7 @@ module ::ResourceManagement
 
       replace_view_content
       close_dialog_via_turbo_stream(
-        "##{ResourcePlannerViews::UserCardList::AddUserDialogComponent::DIALOG_ID}"
+        ResourcePlannerViews::UserCardList::AddUserDialogComponent::DIALOG_ID
       )
       respond_with_turbo_streams
     end
@@ -283,7 +283,7 @@ module ::ResourceManagement
         )
       )
       replace_via_turbo_stream(component: work_package_list_content(view))
-      close_dialog_via_turbo_stream("##{ResourcePlannerViews::EditDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ResourcePlannerViews::EditDialogComponent::DIALOG_ID)
       respond_with_turbo_streams
     end
 

--- a/modules/resource_management/app/controllers/resource_management/staffing_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/staffing_controller.rb
@@ -86,7 +86,7 @@ module ::ResourceManagement
       render_success_flash_message_via_turbo_stream(
         message: I18n.t("resource_management.staffing.success_message")
       )
-      close_dialog_via_turbo_stream("##{ResourceAllocations::AssignmentDialogComponent::DIALOG_ID}")
+      close_dialog_via_turbo_stream(ResourceAllocations::AssignmentDialogComponent::DIALOG_ID)
       replace_via_turbo_stream(component: list_component)
       respond_with_turbo_streams
     end

--- a/modules/resource_management/app/controllers/resource_management/work_package_progress_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/work_package_progress_controller.rb
@@ -80,7 +80,7 @@ module ::ResourceManagement
     def render_update_success
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
       close_dialog_via_turbo_stream(
-        "##{ResourcePlannerViews::WorkPackageList::EditTotalWorkDialogComponent::DIALOG_ID}"
+        ResourcePlannerViews::WorkPackageList::EditTotalWorkDialogComponent::DIALOG_ID
       )
       replace_via_turbo_stream(component: work_package_list_content(@view))
       respond_with_turbo_streams

--- a/modules/resource_management/spec/requests/resource_allocations_spec.rb
+++ b/modules/resource_management/spec/requests/resource_allocations_spec.rb
@@ -684,7 +684,7 @@ RSpec.describe "ResourceAllocations requests",
 
       expect(response.body).to have_turbo_stream(
         action: "closeDialog",
-        target: "##{ResourceAllocations::EditDialogComponent::DIALOG_ID}"
+        target: ResourceAllocations::EditDialogComponent::DIALOG_ID
       )
     end
   end
@@ -759,7 +759,7 @@ RSpec.describe "ResourceAllocations requests",
           as: :turbo_stream
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to have_turbo_stream(action: "closeDialog", target: "##{user_dialog_id}")
+      expect(response.body).to have_turbo_stream(action: "closeDialog", target: user_dialog_id)
       expect(response.body).not_to include('value="filter"')
     end
 

--- a/modules/resource_management/spec/requests/resource_planner_views_spec.rb
+++ b/modules/resource_management/spec/requests/resource_planner_views_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "ResourcePlannerViews requests",
     it "closes the dialog and replaces the tab nav and content in place" do
       perform
 
-      expect(response.body).to have_turbo_stream(action: "closeDialog", target: "#edit-resource-planner-view-dialog")
+      expect(response.body).to have_turbo_stream(action: "closeDialog", target: "edit-resource-planner-view-dialog")
       expect(response.body).to have_turbo_stream(action: "replace", target: "resource-planners-show-page-header-component")
       expect(response.body).to have_turbo_stream(action: "replace", target: "resource-planner-views-content-component")
 

--- a/modules/wikis/app/controllers/wikis/page_link_macro_controller.rb
+++ b/modules/wikis/app/controllers/wikis/page_link_macro_controller.rb
@@ -73,7 +73,7 @@ module Wikis
 
     def close_existing_page_dialog
       params = inline_existing_params
-      close_dialog_via_turbo_stream("##{InlineWikiPageDialog::DIALOG_ID}",
+      close_dialog_via_turbo_stream(InlineWikiPageDialog::DIALOG_ID,
                                     additional: {
                                       action: "close_existing_page_dialog",
                                       providerId: params[:provider_id],
@@ -93,7 +93,7 @@ module Wikis
 
       result.either(
         ->(info) do
-          close_dialog_via_turbo_stream("##{InlineWikiPageDialog::DIALOG_ID}",
+          close_dialog_via_turbo_stream(InlineWikiPageDialog::DIALOG_ID,
                                         additional: {
                                           action: "close_new_page_dialog",
                                           providerId: provider.id,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-20017

# What are you trying to accomplish?

Adds Vitest coverage for the two dialog stream actions, `dialog` and `closeDialog`. Writing the missing-target case turned up a live defect, so the PR now carries the fix as well.

A turbo-stream `target` is an element id and `targets` is a CSS selector, but `closeDialog` resolved `target` with `querySelector`. Most callers passed `"##{DIALOG_ID}"`, which worked. Five callers passed a bare id, so the lookup searched for a tag of that name, found nothing, and the non-null assertion let `null` through. A `dialog:close` event was dispatched with `detail.dialog === null`. This reached all ten listeners, each of which dereferences `dialog.id`, and `close()` then threw.

Nothing appeared broken because `turbo-event-listeners.ts` already closes any dialog whose form submits successfully, on `turbo:submit-end`, before the stream elements render. All five bare-id call sites fire from such a submit, so the stream action was redundant on exactly the paths where it was broken. No spec caught it either: `expect_closed` exists on the inplace-edit dialog helper but nothing calls it.

While in here, the `dialog:close` detail shape was written out by hand at each of the three dispatch sites and again, as a cast, in every listener. Two of those casts disagreed about whether the `additional` payload could be missing.

# What approach did you choose and why?

The close action now resolves the dialog through Turbo's own `targetElements` getter, which is what `turbo_power` uses for every one of its actions. That gives `target`-as-id and `targets`-as-selector for free, returns an empty list rather than throwing when nothing matches, and leaves no bespoke selector handling in our code. The result is checked with `instanceof HTMLDialogElement` - a runtime narrowing, where `querySelector<HTMLDialogElement>()` would only be a compile-time assertion and would still let a matched `<div>` reach `.close()`.

The 33 call sites that carried a leading `#` now pass a bare id, and the helper argument is renamed to `dialog_id` so the contract is legible at the definition. Two alternatives were rejected: stripping the `#` inside the Ruby helper, which just moves the both-forms tolerance from JS to Ruby; and switching the helper to emit `targets:`, which breaks the bare-id callers and uses plural `querySelectorAll` semantics for what is always a single dialog.

The event detail is exported once from `dialog-stream-action.ts` and registered on `GlobalEventHandlersEventMap`, following the `op:dragscroll` precedent in `OpDragScrollDirective`. Listeners are typed without annotating anything at the `addEventListener` call, and the ten hand-rolled casts are gone. It is generic in the `additional` payload so the two listeners that read one can name their own shape.

The commits are split by language, and neither ordering is independently green because the contract change spans both halves. Frontend lands first because between the two commits the `#`-prefixed callers become silent no-ops. The reverse order would leave every caller throwing.

The 250 ms `setTimeout` width hack is untouched. It still leaves a real timer pending after each spec that opens a dialog; the callback writes `style.width` on a node already detached from the document and touches nothing else. Removing it is a separate follow-up.

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) - the unit specs run in chromium, firefox and webkit, but no manual browser QA yet