### PR TITLE
[AGILE-324] Live-region announcements for backlog card moves

### DIFF
--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -94,17 +94,6 @@
     outline-offset: calc(var(--borderWidth-thick) * -1)
     border-radius: var(--borderRadius-medium)
 
-  // While a move persists the list is aria-busy: show progress and dim the
-  // rows until the server render reconciles them.
-  &[aria-busy="true"]
-    cursor: progress
-
-    .Box-list
-      opacity: 0.7
-
-      @media (prefers-reduced-motion: no-preference)
-        transition: opacity 0.1s ease-in-out
-
   // The empty-state row only makes sense while it is alone in the list. Hiding
   // it as soon as a sibling row appears (e.g. dropped by drag and drop) avoids
   // a flicker between the drop and the server render removing it.

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -858,6 +858,15 @@ en:
       sorted_no: "No sort applied, "
       sorting_disabled: "sorting is disabled"
 
+    sortable_lists:
+      announcements:
+        fallback_item_label: "Item"
+        fallback_list_name: "another list"
+        move_failed_check_position: "Move failed. Check the item's current position."
+        move_failed_rolled_back: "Move failed. %{label} returned to its previous position."
+        moved: "%{label} moved to position %{position} of %{total}"
+        moved_to_list: "%{label} moved to %{list}, position %{position} of %{total}"
+
     spot:
       drop_modal:
         close: "Close modal"

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -56,7 +56,8 @@ vi.mock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-previe
 
 import type { monitorForElements as monitorForElementsFn } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { waitFor } from '@testing-library/dom';
-import { type Mock } from 'vitest';
+import { type Mock, type MockInstance } from 'vitest';
+import { LiveRegionElement } from '@primer/live-region-element';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type SortableListsControllerType from './sortable-lists.controller';
 import type {
@@ -76,6 +77,10 @@ describe('Sortable lists controller', () => {
   let fixture:HTMLElement;
   let fetchMock:Mock;
   let renderStreamMessageMock:Mock;
+  // `ReturnType<typeof vi.spyOn>` collapses to a call signature TypeScript
+  // cannot resolve `.mock.calls`'s element type from; pin the spied method's
+  // own signature instead so calls stay typed.
+  let announceSpy:MockInstance<typeof LiveRegionElement.prototype.announce>;
 
   beforeAll(async () => {
     ({ monitorForElements } = await import('@atlaskit/pragmatic-drag-and-drop/element/adapter'));
@@ -103,7 +108,12 @@ describe('Sortable lists controller', () => {
     row.setAttribute('data-controller', 'sortable-lists--item');
     row.setAttribute('data-sortable-lists--item-id-value', id);
     row.setAttribute('data-sortable-lists--item-type-value', 'work_package');
+    row.setAttribute('data-sortable-lists--item-label-value', `Story ${id}`);
     return row;
+  }
+
+  function announcedMessages():[string, unknown][] {
+    return announceSpy.mock.calls.map((call) => [call[0], call[1]]);
   }
 
   function renderFixture({
@@ -118,8 +128,8 @@ describe('Sortable lists controller', () => {
         data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
         data-sortable-lists-sortable-lists--scrollable-outlet="#sortable-root [data-controller~='sortable-lists--scrollable']"
       >
-        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="backlog_bucket" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="work_package"></ul>
-        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="sprint" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="work_package"></ul>
+        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="backlog_bucket" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="work_package" data-sortable-lists--list-name-value="Product backlog"></ul>
+        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="sprint" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="work_package" data-sortable-lists--list-name-value="Sprint 1"></ul>
         <div data-controller="sortable-lists--scrollable"></div>
       </div>
     `;
@@ -153,6 +163,7 @@ describe('Sortable lists controller', () => {
               sortableListData({
                 type: list.getAttribute('data-sortable-lists--list-type-value')!,
                 listId: list.getAttribute('data-sortable-lists--list-id-value'),
+                name: list.getAttribute('data-sortable-lists--list-name-value'),
               }),
             ),
           ],
@@ -204,6 +215,29 @@ describe('Sortable lists controller', () => {
       renderStreamMessage: renderStreamMessageMock,
     });
 
+    document.body.appendChild(document.createElement('live-region'));
+    announceSpy = vi.spyOn(LiveRegionElement.prototype, 'announce');
+    // I18n.store merges straight into I18n#translations, which the lookup
+    // reads through the active locale ("en" by default); an unlocalized
+    // payload here would resolve to nothing and every message would report
+    // as missing.
+    window.I18n.store({
+      en: {
+        js: {
+          sortable_lists: {
+            announcements: {
+              fallback_item_label: 'Item',
+              fallback_list_name: 'another list',
+              move_failed_check_position: 'Move failed. Check the item\'s current position.',
+              move_failed_rolled_back: 'Move failed. %{label} returned to its previous position.',
+              moved: '%{label} moved to position %{position} of %{total}',
+              moved_to_list: '%{label} moved to %{list}, position %{position} of %{total}',
+            },
+          },
+        },
+      },
+    });
+
     ctx = await setupStimulusTest({
       controllers: {
         'sortable-lists': SortableListsController,
@@ -217,6 +251,7 @@ describe('Sortable lists controller', () => {
 
   afterEach(() => {
     ctx.dispose();
+    document.body.querySelector('live-region')?.remove();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -536,6 +571,121 @@ describe('Sortable lists controller', () => {
 
     expect(itemIds(sourceList)).toEqual(['2', '3', '1']);
     expect(itemIds(targetList)).toEqual(['4', '5']);
+  });
+
+  it('announces a same-list move with its absolute position', async () => {
+    const { sourceList, firstSourceItem } = renderFixture();
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, sourceList);
+
+    expect(announcedMessages()).toEqual([
+      ['Story 1 moved to position 3 of 3', { politeness: 'polite' }],
+    ]);
+  });
+
+  it('announces a cross-list move with the target list name', async () => {
+    const { targetList, firstSourceItem } = renderFixture();
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    expect(announcedMessages()).toEqual([
+      ['Story 1 moved to Sprint 1, position 3 of 3', { politeness: 'polite' }],
+    ]);
+  });
+
+  it('falls back to generic wording without item label and list name', async () => {
+    const { targetList, firstSourceItem } = renderFixture();
+    firstSourceItem.removeAttribute('data-sortable-lists--item-label-value');
+    targetList.removeAttribute('data-sortable-lists--list-name-value');
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    expect(announcedMessages()).toEqual([
+      ['Item moved to another list, position 3 of 3', { politeness: 'polite' }],
+    ]);
+  });
+
+  it('announces absolute positions across a truncation marker', async () => {
+    const { sourceList, firstSourceItem } = renderFixture();
+    const markerRow = document.createElement('li');
+    markerRow.setAttribute('data-sortable-lists-prev-item-id', '90');
+    markerRow.setAttribute('data-sortable-lists-omitted-count', '40');
+    sourceList.insertBefore(markerRow, sourceList.querySelector('[data-sortable-lists--item-id-value="3"]'));
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, sourceList);
+
+    expect(announcedMessages()).toEqual([
+      ['Story 1 moved to position 43 of 43', { politeness: 'polite' }],
+    ]);
+  });
+
+  it('announces nothing for a drop at the current position', async () => {
+    const { sourceList } = renderFixture();
+    const lastSourceItem = sourceList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="3"]')!;
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(lastSourceItem, sourceList);
+
+    expect(announceSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays silent on a 422, whose error flash announces server-side', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 422 }));
+    const { targetList, firstSourceItem } = renderFixture();
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+    await flushPromises();
+
+    // Only the optimistic-placement announcement; no client failure message.
+    expect(announcedMessages()).toEqual([
+      ['Story 1 moved to Sprint 1, position 3 of 3', { politeness: 'polite' }],
+    ]);
+  });
+
+  it('announces a verified rollback assertively on a network failure', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Network failure'));
+    const { targetList, firstSourceItem } = renderFixture();
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+    await flushPromises();
+
+    expect(announcedMessages()).toEqual([
+      ['Story 1 moved to Sprint 1, position 3 of 3', { politeness: 'polite' }],
+      ['Move failed. Story 1 returned to its previous position.', { politeness: 'assertive' }],
+    ]);
+  });
+
+  it('announces the fallback failure wording when the rollback is skipped', async () => {
+    let rejectMove:(error:Error) => void;
+
+    fetchMock.mockImplementationOnce(() => {
+      return new Promise<Response>((_resolve, reject) => {
+        rejectMove = reject;
+      });
+    });
+
+    const { sourceList, targetList, firstSourceItem } = renderFixture();
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    // A concurrent morph (e.g. an unrelated list refresh) relocates the row
+    // before the move request fails, so the fresher-morph guard skips the
+    // rollback (same setup as the rollback-skip test above).
+    sourceList.append(firstSourceItem);
+
+    rejectMove!(new Error('Network failure'));
+    await flushPromises();
+
+    expect(announcedMessages()[1]).toEqual(
+      ['Move failed. Check the item\'s current position.', { politeness: 'assertive' }],
+    );
   });
 
   it('does not dispatch a generic toast when a 422 turbo stream rejects the move', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -383,7 +383,7 @@ describe('Sortable lists controller', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('marks the root and lists busy while moving an item', async () => {
+  it('marks the root busy while moving an item without flagging lists aria-busy', async () => {
     let resolveMove:(response:Response) => void;
 
     fetchMock.mockImplementationOnce(() => {
@@ -398,7 +398,9 @@ describe('Sortable lists controller', () => {
     await dropCurrentItemOnList(firstSourceItem, targetList);
 
     expect(root.dataset.sortableListsBusy).toEqual('true');
-    expect(targetList.getAttribute('aria-busy')).toEqual('true');
+    // The reorder already happened; the await window contains no DOM change,
+    // so lists must not claim to be busy (Turbo marks frames busy itself).
+    expect(targetList.hasAttribute('aria-busy')).toBe(false);
 
     resolveMove!(new Response('', { status: 200 }));
     await flushPromises();

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -32,6 +32,7 @@ import {
 } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { Controller } from '@hotwired/stimulus';
 import { FetchRequest } from '@rails/request.js';
+import { announce } from '@primer/live-region-element';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { OPToastEvent } from 'core-app/shared/components/toaster/toast-event';
 import { flipMove } from 'core-stimulus/helpers/flip-helper';
@@ -49,6 +50,8 @@ import {
   reorderRows,
   resolveDirectionalPreviousItemId,
   resolveItemId,
+  resolveItemLabel,
+  resolveItemPosition,
   resolveMoveAvailability,
   restoreRowPositions,
   rowOf,
@@ -61,6 +64,7 @@ import {
 type CleanupFn = () => void;
 type ElementDropPayload = ElementEventPayloadMap['onDrop'];
 type MoveResult = { ok:true }|{ ok:false; showToast:boolean };
+interface MoveAnnouncementContext { label:string|null; listName:string|null; crossList:boolean }
 
 export default class SortableListsController extends Controller<HTMLElement> implements SortableListsRoot {
   static outlets = ['sortable-lists--list', 'sortable-lists--item', 'sortable-lists--scrollable'];
@@ -283,6 +287,13 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     moveUrl:string;
   }):Promise<void> {
     const rows = [sourceRow];
+    // Captured before the reorder: afterwards the row already belongs to the
+    // target list, so source-relative facts would be lost.
+    const announcementContext:MoveAnnouncementContext = {
+      label: resolveItemLabel(sourceRow),
+      listName: listData.name,
+      crossList: sourceRow.parentElement !== rowsContainer,
+    };
     const rollback = captureRowPositions(rows);
     reorderRows({ rows, rowsContainer, previousItemId });
 
@@ -295,17 +306,24 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
+    this.announceMove(announcementContext, sourceRow, rowsContainer);
+
     const optimisticPlacement = captureRowPositions(rows);
 
     const result = await this.moveItem({ listData, previousItemId, moveUrl });
 
     if (!result.ok) {
+      let rolledBack = false;
       try {
         // A concurrent morph that removed or repositioned the rows carries
         // fresher server state than the pre-move snapshot; roll back only
         // while the rows still sit where the optimistic move put them.
         if (rowsRemainAt(optimisticPlacement)) {
           flipMove(rows, () => restoreRowPositions(rollback));
+          // restoreRowPositions silently skips rows whose captured parent
+          // disconnected, so verify the postcondition instead of trusting
+          // the absence of an exception.
+          rolledBack = rowsRemainAt(rollback);
         }
       } catch (error) {
         debugLog('Failed to roll back sortable list item move', error);
@@ -313,6 +331,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
       if (result.showToast) {
         this.dispatchErrorToast();
+        this.announceMoveFailure(announcementContext, rolledBack);
       }
     }
   }
@@ -391,5 +410,46 @@ export default class SortableListsController extends Controller<HTMLElement> imp
         type: 'error',
       },
     }));
+  }
+
+  // The one meaningful message for the whole optimistic move; spoken from the
+  // global live region, in sync with what sighted users see. Failure paths
+  // append their own message below. A 422 stays silent here: its error flash
+  // is streamed by the server and self-announces (matching the toast rule).
+  private announceMove(context:MoveAnnouncementContext, sourceRow:HTMLElement, rowsContainer:HTMLElement):void {
+    const placement = resolveItemPosition({ row: sourceRow, rowsContainer });
+    if (!placement) {
+      return;
+    }
+
+    // Resolved outside the options object literal below: nested inside it,
+    // the call's generic return type would be inferred from the object's
+    // contextual `TranslateOptions` index signature (`any`) instead of its
+    // own `string` default.
+    const label = context.label ?? I18n.t('js.sortable_lists.announcements.fallback_item_label');
+    const listName = context.listName ?? I18n.t('js.sortable_lists.announcements.fallback_list_name');
+    const message = context.crossList
+      ? I18n.t('js.sortable_lists.announcements.moved_to_list', {
+        label,
+        list: listName,
+        position: placement.position,
+        total: placement.total,
+      })
+      : I18n.t('js.sortable_lists.announcements.moved', {
+        label,
+        position: placement.position,
+        total: placement.total,
+      });
+
+    void announce(message, { politeness: 'polite' });
+  }
+
+  private announceMoveFailure(context:MoveAnnouncementContext, rolledBack:boolean):void {
+    const label = context.label ?? I18n.t('js.sortable_lists.announcements.fallback_item_label');
+    const message = rolledBack
+      ? I18n.t('js.sortable_lists.announcements.move_failed_rolled_back', { label })
+      : I18n.t('js.sortable_lists.announcements.move_failed_check_position');
+
+    void announce(message, { politeness: 'assertive' });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -382,7 +382,6 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     } else {
       this.element.removeAttribute(sortableListsBusyAttribute);
     }
-    this.sortableListsListOutlets.forEach((list) => list.reflectBusy(busy));
   }
 
   private dispatchErrorToast():void {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -59,6 +59,8 @@ export interface SortableListData extends Record<string|symbol, unknown> {
   [sortableListDataKey]:true;
   type:string;
   listId:string|null;
+  // Human-readable list name for announcements; null when the list is unnamed.
+  name:string|null;
   // Where a list-only drop (header or empty space, not over an item) lands.
   dropPosition:SortableListDropPosition;
   // The element whose direct children are the list's rows, resolved by the list
@@ -125,11 +127,13 @@ export function sortableListData({
   listId,
   dropPosition = 'end',
   rowsContainer = null,
+  name = null,
 }:{
   type:string;
   listId:string|null;
   dropPosition?:SortableListDropPosition;
   rowsContainer?:HTMLElement|null;
+  name?:string|null;
 }):SortableListData {
   return {
     [sortableListDataKey]: true,
@@ -137,6 +141,7 @@ export function sortableListData({
     listId,
     dropPosition,
     rowsContainer,
+    name,
   };
 }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -60,6 +60,7 @@ export default class ItemController extends Controller<HTMLElement> implements R
     id: String,
     type: String,
     hideUnavailable: { type: Boolean, default: true },
+    label: String,
   };
 
   declare readonly idValue:string;
@@ -67,6 +68,8 @@ export default class ItemController extends Controller<HTMLElement> implements R
   declare readonly typeValue:string;
   declare readonly hasTypeValue:boolean;
   declare readonly hideUnavailableValue:boolean;
+  declare readonly labelValue:string;
+  declare readonly hasLabelValue:boolean;
 
   declare readonly handleTarget:HTMLElement;
   declare readonly hasHandleTarget:boolean;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -515,6 +515,11 @@ describe('resolveItemPosition', () => {
 
     expect(resolveItemPosition({ row: foreign, rowsContainer: container })).toBeNull();
     expect(resolveItemPosition({ row: marker(3), rowsContainer: container })).toBeNull();
+
+    // Also test an in-container marker row
+    const inContainerMarker = marker(5);
+    container.append(inContainerMarker);
+    expect(resolveItemPosition({ row: inContainerMarker, rowsContainer: container })).toBeNull();
   });
 });
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -32,6 +32,8 @@ import {
   resolveDirectionalPreviousItemId,
   resolveMoveAvailability,
   resolveListAppendPreviousItemId,
+  resolveItemPosition,
+  resolveItemLabel,
   restoreRowPositions,
   rowOf,
   rowsRemainAt,
@@ -455,5 +457,76 @@ describe('directional move helpers', () => {
       expect(resolveDirectionalPreviousItemId({ ...at(ul, 'a'), direction: 'bottom' })).toBe('d');
       expect(resolveDirectionalPreviousItemId({ ...at(ul, 'd'), direction: 'top' })).toBeNull();
     });
+  });
+});
+
+describe('resolveItemPosition', () => {
+  function item(id:string, label?:string):HTMLLIElement {
+    const row = document.createElement('li');
+    row.setAttribute('data-sortable-lists--item-id-value', id);
+    if (label) {
+      row.setAttribute('data-sortable-lists--item-label-value', label);
+    }
+    return row;
+  }
+
+  function marker(omittedCount:number, prevItemId = '99'):HTMLLIElement {
+    const row = document.createElement('li');
+    row.setAttribute('data-sortable-lists-prev-item-id', prevItemId);
+    row.setAttribute('data-sortable-lists-omitted-count', String(omittedCount));
+    return row;
+  }
+
+  it('returns the 1-based position and total of an item row', () => {
+    const container = document.createElement('ul');
+    const rows = [item('1'), item('2'), item('3')];
+    container.append(...rows);
+
+    expect(resolveItemPosition({ row: rows[1], rowsContainer: container }))
+      .toEqual({ position: 2, total: 3 });
+  });
+
+  it('counts the hidden items a truncation marker stands in for', () => {
+    const container = document.createElement('ul');
+    const before = item('1');
+    const after = item('2');
+    container.append(before, marker(40), after);
+
+    expect(resolveItemPosition({ row: before, rowsContainer: container }))
+      .toEqual({ position: 1, total: 42 });
+    expect(resolveItemPosition({ row: after, rowsContainer: container }))
+      .toEqual({ position: 42, total: 42 });
+  });
+
+  it('ignores non-item rows without an omitted count', () => {
+    const container = document.createElement('ul');
+    const divider = document.createElement('li');
+    const row = item('1');
+    container.append(divider, row);
+
+    expect(resolveItemPosition({ row, rowsContainer: container }))
+      .toEqual({ position: 1, total: 1 });
+  });
+
+  it('returns null for a row that is not an item row of the container', () => {
+    const container = document.createElement('ul');
+    container.append(item('1'));
+    const foreign = item('2');
+
+    expect(resolveItemPosition({ row: foreign, rowsContainer: container })).toBeNull();
+    expect(resolveItemPosition({ row: marker(3), rowsContainer: container })).toBeNull();
+  });
+});
+
+describe('resolveItemLabel', () => {
+  it('reads the label from the row item element and returns null without one', () => {
+    const labelled = document.createElement('li');
+    labelled.setAttribute('data-sortable-lists--item-id-value', '1');
+    labelled.setAttribute('data-sortable-lists--item-label-value', 'Story one');
+    const bare = document.createElement('li');
+    bare.setAttribute('data-sortable-lists--item-id-value', '2');
+
+    expect(resolveItemLabel(labelled)).toEqual('Story one');
+    expect(resolveItemLabel(bare)).toBeNull();
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -40,6 +40,7 @@ export const sortableListsRootSelector = '[data-controller~="sortable-lists"]';
 export const sortableItemSelector = '[data-sortable-lists--item-id-value]';
 export const sortableListSelector = '[data-controller~="sortable-lists--list"]';
 export const sortablePreviousItemIdAttribute = 'data-sortable-lists-prev-item-id';
+export const sortableOmittedCountAttribute = 'data-sortable-lists-omitted-count';
 
 // Rows are the direct children of the list's resolved rows container. The
 // rows container itself (a nested <ul>, the list element, ...) is decided by the list
@@ -213,6 +214,51 @@ export function isMoveDirection(value:unknown):value is MoveDirection {
 
 function isItemRow(row:Element|undefined):boolean {
   return !!row && resolveItemElement(row) !== null;
+}
+
+// Hidden items a non-item row stands in for (a truncation marker annotated
+// with the size of its collapsed block). Rows without the attribute, or with
+// a non-numeric or non-positive value, count nothing.
+function rowOmittedCount(row:Element):number {
+  const raw = row.getAttribute(sortableOmittedCountAttribute);
+  const count = raw === null ? NaN : parseInt(raw, 10);
+
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}
+
+// The row's absolute 1-based position among the list's items and the item
+// total. Counting walks the live rows, so it is correct immediately after an
+// optimistic reorder; truncation markers contribute their hidden block to
+// both numbers, keeping positions absolute in sparse lists. Null when `row`
+// is not an item row of this container.
+export function resolveItemPosition({
+  row,
+  rowsContainer,
+}:{
+  row:HTMLElement;
+  rowsContainer:HTMLElement;
+}):{ position:number; total:number }|null {
+  let position = 0;
+  let total = 0;
+  let found = false;
+
+  for (const current of listRows(rowsContainer)) {
+    if (isItemRow(current)) {
+      total += 1;
+      if (current === row) {
+        found = true;
+        position = total;
+      }
+    } else {
+      total += rowOmittedCount(current);
+    }
+  }
+
+  return found ? { position, total } : null;
+}
+
+export function resolveItemLabel(row:Element):string|null {
+  return resolveItemElement(row)?.getAttribute('data-sortable-lists--item-label-value') ?? null;
 }
 
 // A row a predecessor id can be read from: an item row, or a non-item row

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -250,37 +250,6 @@ describe('Sortable lists list controller', () => {
       .toBe(false);
   });
 
-  it('reflects the root busy state as aria-busy on connect', async () => {
-    const { list } = await connectedListFor({ root: fakeRoot(document.createElement('div'), { busy: true }) });
-
-    expect(list.getAttribute('aria-busy')).toEqual('true');
-  });
-
-  it('clears aria-busy when reflectBusy is turned off', async () => {
-    const { list, controller } = await connectedListFor({ root: fakeRoot(document.createElement('div'), { busy: true }) });
-    expect(list.getAttribute('aria-busy')).toEqual('true');
-
-    controller.reflectBusy(false);
-    expect(list.hasAttribute('aria-busy')).toBe(false);
-  });
-
-  it('clears aria-busy when the root outlet disconnects mid-move', async () => {
-    const { list, controller } = await connectedListFor({ root: fakeRoot(document.createElement('div'), { busy: true }) });
-    expect(list.getAttribute('aria-busy')).toEqual('true');
-
-    controller.disconnectRoot();
-    expect(list.hasAttribute('aria-busy')).toBe(false);
-  });
-
-  it('clears aria-busy when the list element disconnects mid-move', async () => {
-    const { list } = await connectedListFor({ root: fakeRoot(document.createElement('div'), { busy: true }) });
-    expect(list.getAttribute('aria-busy')).toEqual('true');
-
-    list.remove();
-    await ctx.nextFrame();
-    expect(list.hasAttribute('aria-busy')).toBe(false);
-  });
-
   it('outlines the container for a list-only drop', async () => {
     const { list } = await connectedListFor();
     const options = dropTargetOptionsFor(list);

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
@@ -127,22 +127,10 @@ export default class ListController extends Controller<HTMLElement> implements R
   // Called by the root controller's outlet-connected callback.
   connectRoot(root:SortableListsRoot):void {
     this.root = root;
-    this.reflectBusy(root.busy);
   }
 
   disconnectRoot():void {
     this.root = undefined;
-    // The root only reaches still-connected list outlets when it ends a move, so
-    // a list that disconnects mid-move would otherwise keep aria-busy forever.
-    this.reflectBusy(false);
-  }
-
-  reflectBusy(busy:boolean):void {
-    if (busy) {
-      this.element.setAttribute('aria-busy', 'true');
-    } else {
-      this.element.removeAttribute('aria-busy');
-    }
   }
 
   private get dropPosition():SortableListDropPosition {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
@@ -49,6 +49,7 @@ export default class ListController extends Controller<HTMLElement> implements R
     id: String,
     dropPosition: { type: String, default: 'end' },
     acceptedType: String,
+    name: String,
   };
 
   static elements = { rowsContainer: ':scope > ul' };
@@ -60,6 +61,8 @@ export default class ListController extends Controller<HTMLElement> implements R
   declare readonly dropPositionValue:string;
   declare readonly acceptedTypeValue:string;
   declare readonly hasAcceptedTypeValue:boolean;
+  declare readonly nameValue:string;
+  declare readonly hasNameValue:boolean;
 
   // Provided by the stimulus-elements blessing, declared manually in the same
   // style as the controller's values/targets.
@@ -150,6 +153,7 @@ export default class ListController extends Controller<HTMLElement> implements R
       listId: this.hasIdValue ? this.idValue : null,
       dropPosition: this.dropPosition,
       rowsContainer: this.rowsContainer,
+      name: this.hasNameValue ? this.nameValue : null,
     });
   }
 

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -37,6 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
         drag_and_drop: {
           list_type:,
           list_id: backlog_bucket.id,
+          name: backlog_bucket.name,
           accepted_type: "work_package",
           drop_position: "start"
         },

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -41,6 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
         data: {
           controller: "sortable-lists--list",
           sortable_lists__list_type_value: list_type,
+          sortable_lists__list_name_value: t(".title"),
           sortable_lists__list_accepted_type_value: "work_package",
           sortable_lists__list_drop_position_value: "start"
         }
@@ -77,7 +78,10 @@ See COPYRIGHT and LICENSE files for more details.
           list.with_item(
             scheme: :neutral,
             classes: "op-work-package-card-list--show-more-row",
-            data: { sortable_lists_prev_item_id: last_omitted_id }
+            data: {
+              sortable_lists_prev_item_id: last_omitted_id,
+              sortable_lists_omitted_count: omitted_count
+            }
           ) do
             render(
               Primer::Beta::Button.new(

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -75,6 +75,10 @@ module Backlogs
       work_packages[-(tail_size + 1)]&.id
     end
 
+    def omitted_count
+      work_packages.size - TRUNCATE_MIDDLE - tail_size
+    end
+
     private
 
     def list_type
@@ -87,10 +91,6 @@ module Backlogs
 
     def truncate_threshold
       TRUNCATE_MIDDLE + (tail_size * 2)
-    end
-
-    def omitted_count
-      work_packages.size - TRUNCATE_MIDDLE - tail_size
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -37,6 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
         drag_and_drop: {
           list_type:,
           list_id: sprint.id,
+          name: sprint.name,
           accepted_type: "work_package",
           drop_position: "start"
         },

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
@@ -116,7 +116,7 @@ module Backlogs
       )
     end
 
-    def drag_and_drop_data
+    def drag_and_drop_data # rubocop:disable Metrics/AbcSize
       data = {
         controller: "sortable-lists--list",
         sortable_lists__list_type_value: drag_and_drop.fetch(:list_type),

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
@@ -128,6 +128,9 @@ module Backlogs
       if drag_and_drop[:drop_position].present?
         data[:sortable_lists__list_drop_position_value] = drag_and_drop[:drop_position]
       end
+      if drag_and_drop[:name].present?
+        data[:sortable_lists__list_name_value] = drag_and_drop[:name]
+      end
       data
     end
 

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
@@ -101,6 +101,7 @@ module Backlogs
       {
         controller: "sortable-lists--item",
         sortable_lists__item_id_value: work_package.id,
+        sortable_lists__item_label_value: work_package.to_fs(:caption),
         sortable_lists__item_type_value: "work_package"
       }
     end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -96,6 +96,7 @@ module Backlogs
 
     def move
       source_target = Backlogs::Target.for_work_package(@work_package)
+      source_position = @work_package.position
 
       call = ::Backlogs::WorkPackages::UpdateService
         .new(user: current_user, work_package: @work_package)
@@ -111,6 +112,10 @@ module Backlogs
           detail: { work_package_id: call.result.id }
         )
         return respond_with_turbo_streams(status: call)
+      end
+
+      if announce_move?(call, source_target, source_position)
+        render_move_announcement(call.result)
       end
 
       render_update_turbo_streams(call)
@@ -143,12 +148,56 @@ module Backlogs
     def render_invisible_after_move_flash(work_package)
       return unless work_package_invisible_after_move?(work_package)
 
-      backlog_name = work_package.sprint&.name ||
+      render_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_work_package_invisible_after_move, backlog: target_list_name(work_package))
+      )
+    end
+
+    # A dialog move (never flagged optimistic) is announced by the server; the
+    # optimistic drag and menu paths announce client-side, and the flash
+    # covers moves whose result is no longer visible. Persisted no-ops
+    # (same target, same position) stay silent.
+    def announce_move?(call, source_target, source_position)
+      return false if optimistic_move? || call.failure?
+      return false if work_package_invisible_after_move?(call.result)
+
+      Backlogs::Target.for_work_package(call.result) != source_target ||
+        call.result.position != source_position
+    end
+
+    def render_move_announcement(work_package)
+      ids = announcement_list_scope(work_package).pluck(:id)
+      index = ids.index(work_package.id)
+      return if index.nil?
+
+      render_live_region_update_message(
+        message: t(
+          ".moved_announcement",
+          label: work_package.to_fs(:caption),
+          list: target_list_name(work_package),
+          position: index + 1,
+          total: ids.size
+        )
+      )
+    end
+
+    # The scopes the page renders, so the announced position matches what a
+    # sighted user sees: sprints are scoped to the project (shared sprints
+    # render only the project's items), buckets and the inbox go through the
+    # backlog scope with its excluded types and done statuses.
+    def announcement_list_scope(work_package)
+      if work_package.sprint
+        work_package.sprint.work_packages_for(@project)
+      else
+        WorkPackage.in_backlog_for(project: @project)
+          .where(backlog_bucket_id: work_package.backlog_bucket_id)
+      end
+    end
+
+    def target_list_name(work_package)
+      work_package.sprint&.name ||
         work_package.backlog_bucket&.name ||
         I18n.t(:label_inbox)
-      render_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_work_package_invisible_after_move, backlog: backlog_name)
-      )
     end
 
     def load_work_package

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -252,6 +252,8 @@ en:
       add_existing_dialog:
         invalid_target: "The target you are trying to add to is invalid."
         target_not_found: "The sprint or backlog you are trying to add to was not found."
+      move:
+        moved_announcement: "%{label} moved to %{list}, position %{position} of %{total}"
       update_service:
         invalid_target_type: "list_type must be one of: backlog_bucket with a list_id, sprint with a list_id, or inbox without a list_id."
         missing_target: "list_type or list_id must be present."

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -591,7 +591,7 @@ RSpec.describe Backlogs::WorkPackagesController do
         # The liveRegion stream carries its message as an attribute on the
         # <turbo-stream> element itself (see render_live_region_update_message),
         # not inside a <template>, so we assert against the raw body.
-        expect(response.body).to include("moved to Sprint 2, position 2 of 2")
+        expect(response.body).to include("#{work_package_in_sprint.to_fs(:caption)} moved to Sprint 2, position 2 of 2")
       end
     end
 
@@ -610,7 +610,7 @@ RSpec.describe Backlogs::WorkPackagesController do
       it "streams a live region announcement with the new position" do
         expect(response).to be_successful
         expect(response).to have_turbo_stream action: "liveRegion"
-        expect(response.body).to include("moved to Agile Sprint 1, position 2 of 2")
+        expect(response.body).to include("#{work_package_in_sprint.to_fs(:caption)} moved to Agile Sprint 1, position 2 of 2")
       end
     end
 

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Backlogs::WorkPackagesController do
       expect(response).to have_http_status :ok
       expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
       expect(turbo_stream_template(action: "flash")).to include(message)
+      expect(response).not_to have_turbo_stream action: "liveRegion"
     end
   end
 
@@ -573,6 +574,87 @@ RSpec.describe Backlogs::WorkPackagesController do
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}"
+        expect(response).not_to have_turbo_stream action: "liveRegion"
+      end
+    end
+
+    context "with a non-optimistic move to another sprint (dialog move)" do
+      let(:other_sprint) { create(:sprint, name: "Sprint 2", project:) }
+      let!(:wp_in_target) { create(:work_package, status:, sprint: other_sprint, project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { other_sprint.id }
+      let(:prev_id) { wp_in_target.id }
+
+      it "streams a live region announcement with the new position" do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "liveRegion"
+        # The liveRegion stream carries its message as an attribute on the
+        # <turbo-stream> element itself (see render_live_region_update_message),
+        # not inside a <template>, so we assert against the raw body.
+        expect(response.body).to include("moved to Sprint 2, position 2 of 2")
+      end
+    end
+
+    context "with a non-optimistic same-list move that changes only the position" do
+      let!(:predecessor) { create(:work_package, status:, sprint:, project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { predecessor.id }
+
+      before do
+        # Start the moved work package at the top so moving it after the
+        # predecessor changes its position without changing its list.
+        work_package_in_sprint.move_after(prev_id: nil)
+      end
+
+      it "streams a live region announcement with the new position" do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "liveRegion"
+        expect(response.body).to include("moved to Agile Sprint 1, position 2 of 2")
+      end
+    end
+
+    context "with an optimistic move (client announces)" do
+      let!(:other_wp_in_sprint) { create(:work_package, status:, sprint:, project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { other_wp_in_sprint.id }
+      let(:optimistic) { "true" }
+
+      it "does not stream a live region announcement" do
+        expect(response).to be_successful
+        expect(response).not_to have_turbo_stream action: "liveRegion"
+      end
+    end
+
+    context "with an optimistic cross-list move (client announces)" do
+      let(:other_sprint) { create(:sprint, name: "Sprint 2", project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { other_sprint.id }
+      let(:prev_id) { "" }
+      let(:optimistic) { "true" }
+
+      it "does not stream a live region announcement" do
+        expect(response).to be_successful
+        expect(response).not_to have_turbo_stream action: "liveRegion"
+      end
+    end
+
+    context "with a non-optimistic same-list move that changes nothing" do
+      let!(:predecessor) { create(:work_package, status:, sprint:, project:) }
+      let(:list_type) { "sprint" }
+      let(:list_id) { sprint.id }
+      let(:prev_id) { predecessor.id }
+
+      before do
+        # Put the moved work package right after its requested predecessor
+        # already, so the move is a persisted no-op.
+        work_package_in_sprint.move_after(prev_id: predecessor.id)
+      end
+
+      it "does not stream a live region announcement" do
+        expect(response).to be_successful
+        expect(response).not_to have_turbo_stream action: "liveRegion"
       end
     end
   end
@@ -1045,6 +1127,7 @@ RSpec.describe Backlogs::WorkPackagesController do
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}"
+        expect(response).not_to have_turbo_stream action: "liveRegion"
       end
     end
 

--- a/modules/backlogs/spec/features/work_packages/move_via_menu_announcement_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_via_menu_announcement_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Live region announcements for backlog card menu moves",
+               :js do
+  include RSpec::Wait
+
+  let!(:project) do
+    create(:project,
+           types: [type],
+           enabled_module_names: %w(work_package_tracking backlogs))
+  end
+  let(:manage_sprint_items_role) do
+    create(:project_role,
+           permissions: %i(view_sprints
+                           manage_sprint_items
+                           view_work_packages
+                           edit_work_packages))
+  end
+
+  let(:type) { create(:type) }
+
+  let!(:sprint) { create(:sprint, name: "Sprint 1", project:) }
+
+  let!(:sprint_wp1) { create(:work_package, subject: "First story", sprint:, type:, project:) }
+  let!(:sprint_wp2) { create(:work_package, subject: "Second story", sprint:, type:, project:) }
+  let!(:sprint_wp3) { create(:work_package, subject: "Third story", sprint:, type:, project:) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user, member_with_roles: { project => manage_sprint_items_role })
+  end
+
+  before do
+    backlogs_page.visit!
+  end
+
+  # Primer's live-region element stores the message inside an open shadow
+  # root, not as host text, so it has to be read through its getMessage API.
+  def polite_announcement
+    page.evaluate_script("document.querySelector('live-region')?.getMessage('polite')")
+  end
+
+  it "announces the move and persists it" do
+    # The announcement fires with the optimistic reorder, before the request
+    # settles, so it is asserted separately from persistence below.
+    backlogs_page.click_in_sprint_story_move_menu(sprint_wp2, "Move up", wait: false)
+
+    wait_for { polite_announcement }
+      .to eq("#{sprint_wp2.to_fs(:caption)} moved to position 1 of 3")
+
+    wait_for do
+      WorkPackage.where(sprint:).order_by_position.pluck(:id)
+    end.to eq([sprint_wp2.id, sprint_wp1.id, sprint_wp3.id])
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-324

# What are you trying to accomplish?

Announce backlog card moves to screen readers via ARIA live regions — covering the card move menu (higher/lower/top/bottom), pointer drag and drop, the move-to-sprint/bucket dialogs, and failed moves that are rolled back. Also removes the mistimed list-level `aria-busy` reflection and the visual pending state built on it.

# What approach did you choose and why?

**One announcement owner per state transition**, split on the existing `optimistic` request flag:

| Transition | Owner |
|---|---|
| Optimistic placement (menu + drag) | Client, `polite`, right after the reorder — in sync with what sighted users see |
| 422 / service failure | Server error flash (self-announces already); client silent, mirroring the no-toast-on-422 rule |
| Network / non-422 failure | Client, `assertive`, wording decided by rollback postcondition (`rowsRemainAt`), never by absence of exceptions |
| Dialog move, visible success, target/position actually changed | Server `liveRegion` turbo-stream — first real caller of `render_live_region_update_message` |
| Invisible-after-move / dialog failure | Existing flashes (self-announce) |

Alternatives considered: fully server-side announcements (rejected — cannot announce network failures and rollback accurately, and would lag the optimistic DOM change by a round-trip) and fully client-side (rejected — dialog moves bypass the sortable-lists controller entirely).

Positions are absolute in the truncated inbox: the truncation marker row now carries `data-sortable-lists-omitted-count`, and the position helper counts the hidden block. The sortable-lists subsystem stays generic — backlogs passes labels (`to_fs(:caption)`) and list names via new optional Stimulus values.

**aria-busy removal:** the reflection covered only the request await — the optimistic reorder mutates the DOM before busy was set, frame reloads finish after it cleared (Turbo natively marks frames `aria-busy`), rollbacks ran after it cleared. The dim/`cursor: progress` Sass pending style is deleted rather than rewired, since dimming already-settled content contradicts the optimistic UX.

New driver-neutral (Cuprite) feature spec asserts the announcement through the live-region shadow-root API and persistence separately via DB order — the announcement fires before the request settles, so it is deliberately not used as a persistence signal.

## Follow-up (out of scope)

`aria-posinset`/`aria-setsize` on truncated-inbox rows for virtual-cursor browsing — needs client renumbering after optimistic reorders.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

## Manual screen-reader QA (merge gate)

- [ ] VoiceOver + Safari/Chrome on the backlogs page: menu move (up/down/top/bottom), pointer drag same-list and cross-list, dialog move to sprint and bucket, a failed move (DevTools offline), a move in a truncated inbox
- [ ] Listen for double-speak from the existing `aria-live` list counters / sprint velocity during cross-list frame morphs; file a follow-up if disruptive
- [ ] If the very first announcement after page load is swallowed, consider the flash controller's registration-delay workaround (`flash.controller.ts`) — only with QA evidence
