### PR TITLE
[dream-668] A missing full stop at the end of confirmation message of danger dialog 

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5897,8 +5897,8 @@ en:
     For more information on what the check provides, what data is needed to provide available updates, and how to disable this check, please visit <a href="%{more_info_url}">the configuration documentation</a>.
   text_notice_too_many_values_are_inperformant: "Note: Displaying more than 100 items per page can increase the page load time."
   text_own_membership_delete_confirmation: "You are about to remove some or all of your permissions and may no longer be able to edit this project after that.\nAre you sure you want to continue?"
-  text_permanent_delete_confirmation_checkbox_label: "I understand that this deletion cannot be reversed"
-  text_permanent_remove_confirmation_checkbox_label: "I understand that this removal cannot be reversed"
+  text_permanent_delete_confirmation_checkbox_label: "I understand that this deletion cannot be reversed."
+  text_permanent_remove_confirmation_checkbox_label: "I understand that this removal cannot be reversed."
   text_plugin_assets_writable: "Plugin assets directory writable"
   text_powered_by: "Powered by %{link}"
   text_project_custom_field_html: >

--- a/lookbook/docs/components/danger-dialog.md.erb
+++ b/lookbook/docs/components/danger-dialog.md.erb
@@ -26,7 +26,7 @@ The DangerDialog is a variation of FeedbackDialog. It consists of:
     - "Cancel this meeting occurrence?"
 - A message explaining the consequences
 - An additional content slot
-- (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
+- (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed."
 - Footer actions: "Cancel" and "Delete" (danger red)
 
 For the Danger Confirmation, the primary button text is "Delete permanently" and it is disabled until the user checks the confirmation checkbox.

--- a/lookbook/previews/patterns/danger_dialog_preview/default.html.erb
+++ b/lookbook/previews/patterns/danger_dialog_preview/default.html.erb
@@ -8,6 +8,6 @@
       message.with_heading(tag: :h2) { "Are you sure?" }
       message.with_description_content("You are going to delete the whole project and all its WorkPackages!")
     end
-    dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed")
+    dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed.")
   end
 %>

--- a/modules/auth_saml/spec/features/administration/saml_crud_spec.rb
+++ b/modules/auth_saml/spec/features/administration/saml_crud_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "SAML administration CRUD",
 
       click_link_or_button "Delete"
 
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       expect(page).to have_text "No SAML providers configured yet."

--- a/modules/documents/spec/features/documents/project/delete_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/delete_document_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Delete Document",
           expect(page).to have_text "This will permanently delete this document and all file attachments. " \
                                     "Are you sure you want to do this?"
 
-          check "I understand that this deletion cannot be reversed"
+          check "I understand that this deletion cannot be reversed."
           click_on "Delete permanently"
         end
 
@@ -134,7 +134,7 @@ RSpec.describe "Delete Document",
             expect(page).to have_text "This will permanently delete this document and all file attachments. " \
                                       "Are you sure you want to do this?"
 
-            check "I understand that this deletion cannot be reversed"
+            check "I understand that this deletion cannot be reversed."
             click_on "Delete permanently"
           end
 

--- a/modules/ldap_groups/spec/features/administration_spec.rb
+++ b/modules/ldap_groups/spec/features/administration_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "LDAP group sync administration spec", :js do
       find(".buttons a", text: "Delete").click
 
       SeleniumHubWaiter.wait
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       SeleniumHubWaiter.wait

--- a/modules/meeting/spec/features/meeting_notifications_spec.rb
+++ b/modules/meeting/spec/features/meeting_notifications_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe "Meeting notifications", :js do
       show_page.delete_meeting_series
       retry_block do
         show_page.within_modal "Delete meeting series" do
-          check "I understand that this deletion cannot be reversed", allow_label_click: true
+          check "I understand that this deletion cannot be reversed.", allow_label_click: true
           click_on "Delete permanently"
         end
       end

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Recurring meetings CRUD",
     show_page.delete_meeting_series
     retry_block do
       show_page.within_modal "Delete meeting series" do
-        check "I understand that this deletion cannot be reversed", allow_label_click: true
+        check "I understand that this deletion cannot be reversed.", allow_label_click: true
         click_on "Delete permanently"
       end
     end

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "Recurring meetings end series", :js do
       expect(page).to have_text("Ending the series will delete any future open or scheduled meeting occurrences")
 
       retry_block do
-        check "I understand that this deletion cannot be reversed", allow_label_click: true
-        expect(page).to have_checked_field("I understand that this deletion cannot be reversed")
+        check "I understand that this deletion cannot be reversed.", allow_label_click: true
+        expect(page).to have_checked_field("I understand that this deletion cannot be reversed.")
       end
 
       click_on "End series now"
@@ -106,7 +106,7 @@ RSpec.describe "Recurring meetings end series", :js do
       show_page.end_meeting_series
       show_page.within_modal "End meeting series" do
         retry_block do
-          check "I understand that this deletion cannot be reversed", allow_label_click: true
+          check "I understand that this deletion cannot be reversed.", allow_label_click: true
           click_on "End series now"
         end
       end

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Recurring meetings global CRUD", :js do
 
     retry_block do
       show_page.within_modal "Delete meeting series" do
-        check "I understand that this deletion cannot be reversed", allow_label_click: true
+        check "I understand that this deletion cannot be reversed.", allow_label_click: true
         click_on "Delete permanently"
       end
     end

--- a/modules/openid_connect/spec/features/administration/oidc_custom_crud_spec.rb
+++ b/modules/openid_connect/spec/features/administration/oidc_custom_crud_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "OIDC administration CRUD",
 
       click_link_or_button "Delete"
 
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       expect(page).to have_text "No OpenID providers configured yet."

--- a/modules/storages/spec/features/delete_project_storage_and_file_links_spec.rb
+++ b/modules/storages/spec/features/delete_project_storage_and_file_links_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Delete ProjectStorage with FileLinks", :js, :webmock do
     # Danger dialog confirmation flow
     within_test_selector("op-project-storages--delete-dialog") do
       expect(page).to have_text("Delete file storage")
-      expect(page).to have_unchecked_field("I understand that this removal cannot be reversed")
+      expect(page).to have_unchecked_field("I understand that this removal cannot be reversed.")
       expect(page).to have_button("Remove permanently", disabled: true)
 
       # Cancel Confirmation
@@ -93,7 +93,7 @@ RSpec.describe "Delete ProjectStorage with FileLinks", :js, :webmock do
 
     within_test_selector("op-project-storages--delete-dialog") do
       # Approve Confirmation
-      page.check "I understand that this removal cannot be reversed"
+      page.check "I understand that this removal cannot be reversed."
       page.click_button("Remove permanently")
     end
 

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe("Activation of storages in projects",
 
     within_test_selector("op-project-storages--delete-dialog") do
       expect(page).to have_text("Delete file storage")
-      expect(page).to have_unchecked_field("I understand that this removal cannot be reversed")
+      expect(page).to have_unchecked_field("I understand that this removal cannot be reversed.")
       expect(page).to have_button("Remove permanently", disabled: true)
 
       # Cancel Confirmation
@@ -192,7 +192,7 @@ RSpec.describe("Activation of storages in projects",
 
     within_test_selector("op-project-storages--delete-dialog") do
       # Approve Confirmation
-      page.check "I understand that this removal cannot be reversed"
+      page.check "I understand that this removal cannot be reversed."
       page.click_button("Remove permanently")
     end
 

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe "Admin Edit File storage",
 
     within_test_selector("op-storages--destroy-confirm-dialog") do
       expect(page).to have_text("Delete file storage")
-      expect(page).to have_unchecked_field("I understand that this deletion cannot be reversed")
+      expect(page).to have_unchecked_field("I understand that this deletion cannot be reversed.")
       expect(page).to have_button("Delete permanently", disabled: true)
 
-      page.check("I understand that this deletion cannot be reversed")
+      page.check("I understand that this deletion cannot be reversed.")
       page.click_button("Delete permanently")
     end
 

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe "Admin lists project mappings for a storage",
 
       within_test_selector("op-storages--destroy-confirm-dialog") do
         expect(page).to have_text("Delete file storage")
-        expect(page).to have_unchecked_field("I understand that this deletion cannot be reversed")
+        expect(page).to have_unchecked_field("I understand that this deletion cannot be reversed.")
         expect(page).to have_button("Delete permanently", disabled: true)
       end
     end
@@ -399,7 +399,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         page.within("dialog") do
           expect(page).to have_button("Remove", disabled: true)
           Retryable.repeat_until_success do
-            check "I understand that this removal cannot be reversed", allow_label_click: true
+            check "I understand that this removal cannot be reversed.", allow_label_click: true
             expect(page).to have_button("Remove", disabled: false) # ensure button is clickable
             click_on "Remove permanently"
           end

--- a/spec/features/admin/custom_fields/work_packages/hierarchy_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/hierarchy_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "work package custom fields of type hierarchy", :js do
     hierarchy_page.open_action_menu_for("Phoenix Squad")
     click_on "Delete"
     expect(page).to have_test_selector("op-custom-fields--delete-item-dialog")
-    check "I understand that this deletion cannot be reversed", allow_label_click: true
+    check "I understand that this deletion cannot be reversed.", allow_label_click: true
     click_on "Delete permanently"
     expect(page).not_to have_test_selector("op-custom-fields--delete-item-dialog")
     expect(page).to have_test_selector("op-custom-fields--hierarchy-item", count: 1)

--- a/spec/features/placeholder_users/delete_spec.rb
+++ b/spec/features/placeholder_users/delete_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "delete placeholder user", :js do
       click_on "Delete"
 
       # Expect to be on delete confirmation
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       expect_flash(type: :info, message: I18n.t(:notice_deletion_scheduled))

--- a/spec/features/projects/destroy_spec.rb
+++ b/spec/features/projects/destroy_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe "Projects#destroy", :js do
     within_modal "Delete project" do
       expect(page).to have_heading "Permanently delete this project?"
 
-      expect(page).to have_unchecked_field "I understand that this deletion cannot be reversed"
+      expect(page).to have_unchecked_field "I understand that this deletion cannot be reversed."
 
       # Without confirmation, the button is disabled
       expect(page).to have_button "Delete permanently", disabled: true
 
       # Confirm the deletion
-      check "I understand that this deletion cannot be reversed", allow_label_click: true
+      check "I understand that this deletion cannot be reversed.", allow_label_click: true
       expect(page).to have_button "Delete permanently", disabled: false
 
       click_on "Delete permanently"

--- a/spec/features/repositories/repository_settings_spec.rb
+++ b/spec/features/repositories/repository_settings_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Repository Settings", :js do
         find("a.icon-delete", text: I18n.t(:button_delete)).click
 
         SeleniumHubWaiter.wait
-        check "I understand that this deletion cannot be reversed"
+        check "I understand that this deletion cannot be reversed."
         click_on I18n.t(:button_delete_permanently)
       else
         find("a.icon-remove", text: I18n.t(:button_remove)).click

--- a/spec/features/users/delete_spec.rb
+++ b/spec/features/users/delete_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "user deletion:", :js, :selenium, driver: :firefox_en do
       visit my_account_path
       page.find_test_selector("delete-my-account-button").click
 
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       dialog.confirm_flow_with user_password
@@ -101,14 +101,14 @@ RSpec.describe "user deletion:", :js, :selenium, driver: :firefox_en do
       click_on "Delete"
 
       SeleniumHubWaiter.wait
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       dialog.confirm_flow_with "wrong", should_fail: true
 
       click_on "Delete"
       SeleniumHubWaiter.wait
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       dialog.confirm_flow_with user_password, should_fail: false
@@ -127,7 +127,7 @@ RSpec.describe "user deletion:", :js, :selenium, driver: :firefox_en do
       click_on "Delete"
 
       SeleniumHubWaiter.wait
-      check "I understand that this deletion cannot be reversed"
+      check "I understand that this deletion cannot be reversed."
       click_on "Delete permanently"
 
       dialog.confirm_flow_with user_password, with_keyboard: true, should_fail: false

--- a/spec/support/components/work_packages/destroy_modal.rb
+++ b/spec/support/components/work_packages/destroy_modal.rb
@@ -57,7 +57,7 @@ module Components
 
       def confirm_deletion
         within_dialog do
-          check "I understand that this deletion cannot be reversed"
+          check "I understand that this deletion cannot be reversed."
           expect(page).to have_button "Delete permanently", disabled: false
           click_button "Delete permanently"
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-668