### PR TITLE
Add MCP tool to create work packages

### DIFF
--- a/app/services/mcp_tools/create_work_package.rb
+++ b/app/services/mcp_tools/create_work_package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -21,38 +23,41 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module WorkPackages
-      class ParseParamsService < API::V3::ParseResourceParamsService
-        # Be compatible to super
-        def initialize(user, **_args)
-          super(user, model: WorkPackage, representer: ::API::V3::WorkPackages::WorkPackagePayloadRepresenter)
-        end
+module McpTools
+  class CreateWorkPackage < Base
+    default_title "Create work package"
+    default_description "Create a new work package."
 
-        private
+    name "create_work_package"
+    annotations read_only: false, idempotent: false, destructive: false
 
-        def parse_attributes(request_body)
-          attributes = ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
-            .create(struct, current_user:)
-            .from_hash(Hash(request_body))
-            .to_h
-            .reverse_merge(lock_version: nil)
+    input_schema(
+      properties: {
+        data: {
+          type: %w[object],
+          description: "JSON Representation of the work package to be created. The format is the same as accepted by APIv3."
+        }
+      }
+    )
 
-          meta = attributes.delete(:meta) || {}
-          attributes[:validate_custom_fields] = meta[:validate_custom_fields] if meta[:validate_custom_fields]
+    def call(data:)
+      attributes = ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
+        .create(::API::V3::WorkPackages::ParsingStruct.new, current_user:)
+        .from_hash(data.deep_stringify_keys)
+        .to_h
+        .reverse_merge(lock_version: nil)
 
-          attributes
-        end
+      result = WorkPackages::CreateService.new(user: current_user).call(**attributes)
 
-        def struct
-          ParsingStruct.new
-        end
+      if result.success?
+        API::V3::WorkPackages::WorkPackageRepresenter.create(result.result, current_user:)
+      else
+        { error: result.message }
       end
     end
   end

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -32,9 +32,11 @@ MCP.configure do |config|
   config.exception_reporter = lambda do |exception, server_context|
     cause = exception.cause
     message = "Unhandled exception occured during MCP request: #{exception}"
-    if cause
-      message += ", caused by #{cause} at #{cause.backtrace.first}"
-    end
+    message += if cause
+                 ", caused by #{cause} at #{cause.backtrace.first}"
+               else
+                 " at #{exception.backtrace.first}"
+               end
 
     Rails.logger.error message
     OpenProject::Appsignal.trace_exception(exception, server_context) if OpenProject::Appsignal.enabled?
@@ -43,7 +45,8 @@ MCP.configure do |config|
 end
 
 Rails.application.config.after_initialize do
-  McpTools.register McpTools::CurrentUser,
+  McpTools.register McpTools::CreateWorkPackage,
+                    McpTools::CurrentUser,
                     McpTools::ListStatuses,
                     McpTools::ListTypes,
                     McpTools::SearchPortfolios,

--- a/lib/api/v3/work_packages/parsing_struct.rb
+++ b/lib/api/v3/work_packages/parsing_struct.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -21,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -29,29 +31,9 @@
 module API
   module V3
     module WorkPackages
-      class ParseParamsService < API::V3::ParseResourceParamsService
-        # Be compatible to super
-        def initialize(user, **_args)
-          super(user, model: WorkPackage, representer: ::API::V3::WorkPackages::WorkPackagePayloadRepresenter)
-        end
-
-        private
-
-        def parse_attributes(request_body)
-          attributes = ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
-            .create(struct, current_user:)
-            .from_hash(Hash(request_body))
-            .to_h
-            .reverse_merge(lock_version: nil)
-
-          meta = attributes.delete(:meta) || {}
-          attributes[:validate_custom_fields] = meta[:validate_custom_fields] if meta[:validate_custom_fields]
-
-          attributes
-        end
-
-        def struct
-          ParsingStruct.new
+      class ParsingStruct < OpenStruct # rubocop:disable Style/OpenStructUse
+        def available_custom_fields
+          @available_custom_fields ||= WorkPackageCustomField.all.to_a
         end
       end
     end

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_parsing_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackagePayloadRepresenter, "parsing" d
   let(:hash) { {} }
   let(:current_user) { member }
   let(:representer) do
-    described_class.create(API::V3::WorkPackages::ParseParamsService::ParsingStruct.new, current_user:)
+    described_class.create(API::V3::WorkPackages::ParsingStruct.new, current_user:)
   end
   let(:duration) { nil }
 

--- a/spec/requests/mcp/mcp_resources/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_resources/current_user_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::CurrentUser do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -64,14 +64,14 @@ RSpec.describe McpResources::CurrentUser do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted user" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       user_resource = text_content.fetch("text")
       expect(user_resource).to match_json_schema.from_docs("user_model")
     end
 
     it "responds with the current user" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       user_resource = text_content.fetch("text")
       expect(JSON.parse(user_resource).fetch("id")).to eq(user.id)
@@ -86,7 +86,7 @@ RSpec.describe McpResources::CurrentUser do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/project_spec.rb
+++ b/spec/requests/mcp/mcp_resources/project_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::Project do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -65,7 +65,7 @@ RSpec.describe McpResources::Project do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted project" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       wp = text_content.fetch("text")
       expect(wp).to match_json_schema.from_docs("project_model")
@@ -92,7 +92,7 @@ RSpec.describe McpResources::Project do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/status_list_spec.rb
+++ b/spec/requests/mcp/mcp_resources/status_list_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::StatusList do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -68,7 +68,7 @@ RSpec.describe McpResources::StatusList do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted status list" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       statuses = text_content.fetch("text")
       expect(statuses).to match_json_schema.from_docs("status_collection_model")
@@ -86,7 +86,7 @@ RSpec.describe McpResources::StatusList do
       it_behaves_like "MCP text resource response"
 
       it "responds with an empty list" do
-        subject
+        mcp_request
         text_content = parsed_results.fetch("contents").first
         types_collection = JSON.parse(text_content.fetch("text"))
         expect(types_collection.dig("_embedded", "elements")).to be_empty
@@ -96,7 +96,7 @@ RSpec.describe McpResources::StatusList do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/status_spec.rb
+++ b/spec/requests/mcp/mcp_resources/status_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::Status do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -67,7 +67,7 @@ RSpec.describe McpResources::Status do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted status" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       status = text_content.fetch("text")
       expect(status).to match_json_schema.from_docs("status_model")
@@ -94,7 +94,7 @@ RSpec.describe McpResources::Status do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/type_list_spec.rb
+++ b/spec/requests/mcp/mcp_resources/type_list_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::TypeList do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -68,7 +68,7 @@ RSpec.describe McpResources::TypeList do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted type list" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       types = text_content.fetch("text")
       expect(types).to match_json_schema.from_docs("types_model")
@@ -86,7 +86,7 @@ RSpec.describe McpResources::TypeList do
       it_behaves_like "MCP text resource response"
 
       it "responds with an empty list" do
-        subject
+        mcp_request
         text_content = parsed_results.fetch("contents").first
         types_collection = JSON.parse(text_content.fetch("text"))
         expect(types_collection.dig("_embedded", "elements")).to be_empty
@@ -96,7 +96,7 @@ RSpec.describe McpResources::TypeList do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/type_spec.rb
+++ b/spec/requests/mcp/mcp_resources/type_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::Type do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -67,7 +67,7 @@ RSpec.describe McpResources::Type do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted type" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       type = text_content.fetch("text")
       expect(type).to match_json_schema.from_docs("type_model")
@@ -94,7 +94,7 @@ RSpec.describe McpResources::Type do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/user_spec.rb
+++ b/spec/requests/mcp/mcp_resources/user_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::User do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -65,7 +65,7 @@ RSpec.describe McpResources::User do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted user" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       user_json = text_content.fetch("text")
       expect(user_json).to match_json_schema.from_docs("user_model")
@@ -92,7 +92,7 @@ RSpec.describe McpResources::User do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/version_spec.rb
+++ b/spec/requests/mcp/mcp_resources/version_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::Version do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -65,7 +65,7 @@ RSpec.describe McpResources::Version do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted version" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       version = text_content.fetch("text")
       expect(version).to match_json_schema.from_docs("version_read_model")
@@ -92,7 +92,7 @@ RSpec.describe McpResources::Version do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_resources/work_package_spec.rb
+++ b/spec/requests/mcp/mcp_resources/work_package_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpResources::WorkPackage do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -65,7 +65,7 @@ RSpec.describe McpResources::WorkPackage do
     it_behaves_like "MCP text resource response"
 
     it "responds with a properly formatted work package" do
-      subject
+      mcp_request
       text_content = parsed_results.fetch("contents").first
       wp = text_content.fetch("text")
       expect(wp).to match_json_schema.from_docs("work_package_model")
@@ -92,7 +92,7 @@ RSpec.describe McpResources::WorkPackage do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/create_work_package_spec.rb
+++ b/spec/requests/mcp/mcp_tools/create_work_package_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpTools::CreateWorkPackage do
+  subject do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) { create(:oauth_access_token, scopes: "mcp", resource_owner: user) }
+  let(:user) { create(:admin) }
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "create_work_package",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) do
+    {
+      data: {
+        subject: "My subject",
+        _links: {
+          status: { href: "/api/v3/statuses/#{status.id}" },
+          type: { href: "/api/v3/types/#{type.id}" },
+          project: { href: "/api/v3/projects/#{project.id}" }
+        }
+      }
+    }
+  end
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+  let(:result_item) { parsed_results.fetch("structuredContent") }
+
+  let(:project) { create(:project).tap { |p| p.types << type } }
+  let(:type) { create(:type) }
+  let(:status) { create(:status) }
+  let!(:priority) { create(:default_priority) }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  before do
+    server_config.save!
+    tool_config.save!
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
+    it_behaves_like "MCP text tool"
+
+    it "creates a new work package" do
+      expect { subject }.to change(WorkPackage, :count).from(0).to(1)
+
+      wp = WorkPackage.first
+      expect(wp.subject).to eq("My subject")
+      expect(wp.status).to eq(status)
+      expect(wp.type).to eq(type)
+      expect(wp.project).to eq(project)
+    end
+
+    it "responds with a properly formatted work package" do
+      subject
+
+      expect(result_item.to_json).to match_json_schema.from_docs("work_package_model")
+    end
+
+    context "when setting an unexpected type" do
+      let(:wrong_type) { create(:type) }
+
+      let(:call_args) do
+        {
+          data: {
+            subject: "My subject",
+            _links: {
+              status: { href: "/api/v3/statuses/#{status.id}" },
+              type: { href: "/api/v3/types/#{wrong_type.id}" },
+              project: { href: "/api/v3/projects/#{project.id}" }
+            }
+          }
+        }
+      end
+
+      it "responds with an error" do
+        subject
+        expect(result_item.fetch("error")).to eq("Type is not set to one of the allowed values.")
+      end
+
+      it "does not create a work package" do
+        expect { subject }.not_to change(WorkPackage, :count)
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds with a 404" do
+      subject
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end

--- a/spec/requests/mcp/mcp_tools/create_work_package_spec.rb
+++ b/spec/requests/mcp/mcp_tools/create_work_package_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::CreateWorkPackage do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -82,7 +82,7 @@ RSpec.describe McpTools::CreateWorkPackage do
     it_behaves_like "MCP text tool"
 
     it "creates a new work package" do
-      expect { subject }.to change(WorkPackage, :count).from(0).to(1)
+      expect { mcp_request }.to change(WorkPackage, :count).from(0).to(1)
 
       wp = WorkPackage.first
       expect(wp.subject).to eq("My subject")
@@ -92,7 +92,7 @@ RSpec.describe McpTools::CreateWorkPackage do
     end
 
     it "responds with a properly formatted work package" do
-      subject
+      mcp_request
 
       expect(result_item.to_json).to match_json_schema.from_docs("work_package_model")
     end
@@ -114,19 +114,19 @@ RSpec.describe McpTools::CreateWorkPackage do
       end
 
       it "responds with an error" do
-        subject
+        mcp_request
         expect(result_item.fetch("error")).to eq("Type is not set to one of the allowed values.")
       end
 
       it "does not create a work package" do
-        expect { subject }.not_to change(WorkPackage, :count)
+        expect { mcp_request }.not_to change(WorkPackage, :count)
       end
     end
   end
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds with a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_tools/current_user_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::CurrentUser do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -65,19 +65,19 @@ RSpec.describe McpTools::CurrentUser do
     it_behaves_like "MCP embedded resource tool"
 
     it "responds with a properly formatted user" do
-      subject
+      mcp_request
       expect(parsed_results.fetch("structuredContent").to_json).to match_json_schema.from_docs("user_model")
     end
 
     it "responds with the current user" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "id")).to eq(user.id)
     end
   end
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::ListStatuses do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -70,12 +70,12 @@ RSpec.describe McpTools::ListStatuses do
     it_behaves_like "MCP embedded resource tool"
 
     it "finds all statuses" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "count")).to eq(2)
     end
 
     it "responds with properly formatted statuses" do
-      subject
+      mcp_request
       expect(parsed_results.fetch("structuredContent").to_json).to match_json_schema.from_docs("status_collection_model")
     end
 
@@ -83,7 +83,7 @@ RSpec.describe McpTools::ListStatuses do
       let(:permissions) { [] }
 
       it "finds no statuses" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "count")).to eq(0)
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe McpTools::ListStatuses do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/list_types_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_types_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::ListTypes do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -70,12 +70,12 @@ RSpec.describe McpTools::ListTypes do
     it_behaves_like "MCP embedded resource tool"
 
     it "finds all types" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "count")).to eq(2)
     end
 
     it "responds with properly formatted types" do
-      subject
+      mcp_request
       expect(parsed_results.fetch("structuredContent").to_json).to match_json_schema.from_docs("types_model")
     end
 
@@ -83,7 +83,7 @@ RSpec.describe McpTools::ListTypes do
       let(:permissions) { [] }
 
       it "finds no types" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "count")).to eq(0)
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe McpTools::ListTypes do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::SearchPortfolios do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
@@ -70,12 +70,12 @@ RSpec.describe McpTools::SearchPortfolios do
     it_behaves_like "MCP text tool"
 
     it "finds all portfolios without filters" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "items").size).to eq(2)
     end
 
     it "responds with properly formatted portfolios" do
-      subject
+      mcp_request
       parsed_results.dig("structuredContent", "items").each do |portfolio|
         expect(portfolio.to_json).to match_json_schema.from_docs("portfolio_model")
       end
@@ -85,7 +85,7 @@ RSpec.describe McpTools::SearchPortfolios do
       let(:call_args) { { identifier: "abc" } }
 
       it "finds the portfolio" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe McpTools::SearchPortfolios do
       let(:call_args) { { identifier: "Abc" } }
 
       it "does not find the portfolio" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe McpTools::SearchPortfolios do
       let(:call_args) { { name: "The ABC Portfolio" } }
 
       it "finds the portfolio" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe McpTools::SearchPortfolios do
       end
 
       it "returns only results up to the page size" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
@@ -134,7 +134,7 @@ RSpec.describe McpTools::SearchPortfolios do
         let(:call_args) { { name: "Death Star", page: 2 } }
 
         it "returns the requested page" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_portfolios)
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe McpTools::SearchPortfolios do
       let(:call_args) { { name: "The abc" } }
 
       it "finds the portfolio" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe McpTools::SearchPortfolios do
       let(:call_args) { { status_code: "on_track" } }
 
       it "finds the portfolio" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
 
@@ -161,7 +161,7 @@ RSpec.describe McpTools::SearchPortfolios do
         let(:call_args) { { status_code: "on_track", identifier: "abc" } }
 
         it "finds the portfolio" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_present
         end
       end
@@ -170,7 +170,7 @@ RSpec.describe McpTools::SearchPortfolios do
         let(:call_args) { { status_code: "on_track", identifier: "def" } }
 
         it "does not find the portfolio" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_empty
         end
       end
@@ -186,7 +186,7 @@ RSpec.describe McpTools::SearchPortfolios do
       let(:user) { create(:user) }
 
       it "does not find the portfolio" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
     end
@@ -194,7 +194,7 @@ RSpec.describe McpTools::SearchPortfolios do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_programs_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_programs_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::SearchPrograms do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
@@ -70,12 +70,12 @@ RSpec.describe McpTools::SearchPrograms do
     it_behaves_like "MCP text tool"
 
     it "finds all programs without filters" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "items").size).to eq(2)
     end
 
     it "responds with properly formatted programs" do
-      subject
+      mcp_request
       parsed_results.dig("structuredContent", "items").each do |program|
         expect(program.to_json).to match_json_schema.from_docs("program_model")
       end
@@ -85,7 +85,7 @@ RSpec.describe McpTools::SearchPrograms do
       let(:call_args) { { identifier: "abc" } }
 
       it "finds the program" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe McpTools::SearchPrograms do
       let(:call_args) { { identifier: "Abc" } }
 
       it "does not find the program" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe McpTools::SearchPrograms do
       let(:call_args) { { name: "The ABC Program" } }
 
       it "finds the program" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe McpTools::SearchPrograms do
       end
 
       it "returns only results up to the page size" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
@@ -134,7 +134,7 @@ RSpec.describe McpTools::SearchPrograms do
         let(:call_args) { { name: "Death Star", page: 2 } }
 
         it "returns the requested page" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_programs)
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe McpTools::SearchPrograms do
       let(:call_args) { { name: "The abc" } }
 
       it "finds the program" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe McpTools::SearchPrograms do
       let(:call_args) { { status_code: "on_track" } }
 
       it "finds the program" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
 
@@ -161,7 +161,7 @@ RSpec.describe McpTools::SearchPrograms do
         let(:call_args) { { status_code: "on_track", identifier: "abc" } }
 
         it "finds the program" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_present
         end
       end
@@ -170,7 +170,7 @@ RSpec.describe McpTools::SearchPrograms do
         let(:call_args) { { status_code: "on_track", identifier: "def" } }
 
         it "does not find the program" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_empty
         end
       end
@@ -186,7 +186,7 @@ RSpec.describe McpTools::SearchPrograms do
       let(:user) { create(:user) }
 
       it "does not find the program" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
     end
@@ -194,7 +194,7 @@ RSpec.describe McpTools::SearchPrograms do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::SearchProjects do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -69,12 +69,12 @@ RSpec.describe McpTools::SearchProjects do
     it_behaves_like "MCP text tool"
 
     it "finds all projects without filters" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "items").size).to eq(2)
     end
 
     it "responds with properly formatted projects" do
-      subject
+      mcp_request
       parsed_results.dig("structuredContent", "items").each do |project|
         expect(project.to_json).to match_json_schema.from_docs("project_model")
       end
@@ -84,7 +84,7 @@ RSpec.describe McpTools::SearchProjects do
       let(:call_args) { { identifier: "abc" } }
 
       it "finds the project" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe McpTools::SearchProjects do
       let(:call_args) { { identifier: "Abc" } }
 
       it "does not find the project" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe McpTools::SearchProjects do
       let(:call_args) { { name: "The ABC Project" } }
 
       it "finds the project" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe McpTools::SearchProjects do
       end
 
       it "returns only results up to the page size" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
@@ -133,7 +133,7 @@ RSpec.describe McpTools::SearchProjects do
         let(:call_args) { { name: "Death Star", page: 2 } }
 
         it "returns the requested page" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_projects)
         end
       end
@@ -143,7 +143,7 @@ RSpec.describe McpTools::SearchProjects do
       let(:call_args) { { name: "The abc" } }
 
       it "finds the project" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
     end
@@ -152,7 +152,7 @@ RSpec.describe McpTools::SearchProjects do
       let(:call_args) { { status_code: "on_track" } }
 
       it "finds the project" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_present
       end
 
@@ -160,7 +160,7 @@ RSpec.describe McpTools::SearchProjects do
         let(:call_args) { { status_code: "on_track", identifier: "abc" } }
 
         it "finds the project" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_present
         end
       end
@@ -169,7 +169,7 @@ RSpec.describe McpTools::SearchProjects do
         let(:call_args) { { status_code: "on_track", identifier: "def" } }
 
         it "does not find the project" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_empty
         end
       end
@@ -185,7 +185,7 @@ RSpec.describe McpTools::SearchProjects do
       let(:user) { create(:user) }
 
       it "does not find the project" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
     end
@@ -193,7 +193,7 @@ RSpec.describe McpTools::SearchProjects do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_users_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_users_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::SearchUsers do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -75,12 +75,12 @@ RSpec.describe McpTools::SearchUsers do
     it_behaves_like "MCP text tool"
 
     it "finds all users without filters" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "items").size).to eq(3)
     end
 
     it "responds with properly formatted users" do
-      subject
+      mcp_request
       parsed_results.dig("structuredContent", "items").each do |u|
         expect(u.to_json).to match_json_schema.from_docs("user_model")
       end
@@ -90,7 +90,7 @@ RSpec.describe McpTools::SearchUsers do
       let(:call_args) { { search_term: "Karl Kabauter" } }
 
       it "finds the user" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
         expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(other_user_karl.id)
       end
@@ -100,7 +100,7 @@ RSpec.describe McpTools::SearchUsers do
       let(:call_args) { { search_term: "Kabauter Karl" } }
 
       it "finds the user" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
         expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(other_user_karl.id)
       end
@@ -110,7 +110,7 @@ RSpec.describe McpTools::SearchUsers do
       let(:call_args) { { search_term: "klko@example.com" } }
 
       it "finds the user" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
         expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(other_user_klara.id)
       end
@@ -119,7 +119,7 @@ RSpec.describe McpTools::SearchUsers do
         let(:global_permissions) { %i[view_all_principals] }
 
         it "finds the no one" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").size).to eq(0)
         end
       end
@@ -129,7 +129,7 @@ RSpec.describe McpTools::SearchUsers do
       let(:call_args) { { search_term: "kaba" } }
 
       it "finds the user" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
         expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(other_user_karl.id)
       end
@@ -139,7 +139,7 @@ RSpec.describe McpTools::SearchUsers do
       let(:global_permissions) { %i[] }
 
       it "only finds itself" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
         expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(user.id)
       end
@@ -158,7 +158,7 @@ RSpec.describe McpTools::SearchUsers do
       end
 
       it "returns only results up to the page size" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(page_size)
       end
 
@@ -166,7 +166,7 @@ RSpec.describe McpTools::SearchUsers do
         let(:call_args) { { search_term: "Konrad", page: 2 } }
 
         it "returns the requested page" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").size).to eq(overspilling_users)
         end
       end
@@ -175,7 +175,7 @@ RSpec.describe McpTools::SearchUsers do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_versions_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_versions_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::SearchVersions do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
@@ -71,12 +71,12 @@ RSpec.describe McpTools::SearchVersions do
     it_behaves_like "MCP text tool"
 
     it "finds all versions without filters" do
-      subject
+      mcp_request
       expect(parsed_results.dig("structuredContent", "items").size).to eq(2)
     end
 
     it "responds with properly formatted versions" do
-      subject
+      mcp_request
       parsed_results.dig("structuredContent", "items").each do |version|
         expect(version.to_json).to match_json_schema.from_docs("version_read_model")
       end
@@ -86,7 +86,7 @@ RSpec.describe McpTools::SearchVersions do
       let(:call_args) { { name: "v1.0.1-alpha" } }
 
       it "finds the version" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe McpTools::SearchVersions do
       let(:call_args) { { name: "alpha" } }
 
       it "finds the version" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe McpTools::SearchVersions do
       let(:call_args) { { sharing: "system" } }
 
       it "finds the version" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
       end
 
@@ -112,7 +112,7 @@ RSpec.describe McpTools::SearchVersions do
         let(:call_args) { { sharing: "system", name: "v1" } }
 
         it "finds the version" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
         end
       end
@@ -121,7 +121,7 @@ RSpec.describe McpTools::SearchVersions do
         let(:call_args) { { sharing: "system", name: "alpha" } }
 
         it "does not find the version" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items")).to be_empty
         end
       end
@@ -142,7 +142,7 @@ RSpec.describe McpTools::SearchVersions do
       end
 
       it "returns only results up to the page size" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
@@ -150,7 +150,7 @@ RSpec.describe McpTools::SearchVersions do
         let(:call_args) { { name: "beta", page: 2 } }
 
         it "returns the requested page" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_versions)
         end
       end
@@ -159,7 +159,7 @@ RSpec.describe McpTools::SearchVersions do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds in a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe McpTools::SearchWorkPackages do
-  subject do
+  subject(:mcp_request) do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
@@ -92,12 +92,12 @@ RSpec.describe McpTools::SearchWorkPackages do
     it_behaves_like "MCP text tool"
 
     it "finds all work packages without filters" do
-      subject
+      mcp_request
       expect(result_items.size).to eq(2)
     end
 
     it "responds with properly formatted work packages" do
-      subject
+      mcp_request
       result_items.each do |work_package|
         expect(work_package.to_json).to match_json_schema.from_docs("work_package_model")
       end
@@ -107,7 +107,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:call_args) { { id: work_package_a.id } }
 
       it "finds the work package" do
-        subject
+        mcp_request
         expect(result_items.size).to eq(1)
         expect(result_items.first["id"]).to eq(work_package_a.id)
       end
@@ -119,7 +119,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:call_args) { { project_id: project.id } }
 
       it "finds only work packages in the specified project" do
-        subject
+        mcp_request
         expect(result_items.size).to eq(2)
         expect(result_items.pluck("id")).to contain_exactly(work_package_a.id, work_package_b.id)
       end
@@ -131,7 +131,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:call_args) { { status_id: status.id } }
 
       it "finds only work packages with the specified status" do
-        subject
+        mcp_request
         expect(result_items.size).to eq(2)
         expect(result_items.pluck("id")).to contain_exactly(work_package_a.id, work_package_b.id)
       end
@@ -143,7 +143,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:call_args) { { type_id: type.id } }
 
       it "finds only work packages with the specified type" do
-        subject
+        mcp_request
         expect(result_items.size).to eq(2)
         expect(result_items.pluck("id")).to contain_exactly(work_package_a.id, work_package_b.id)
       end
@@ -154,7 +154,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { assigned_to_id: assignee.id } }
 
         it "finds only work packages assigned to the specified user" do
-          subject
+          mcp_request
           expect(result_items.size).to eq(1)
           expect(result_items.first["id"]).to eq(work_package_a.id)
         end
@@ -164,7 +164,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { assigned_to_id: nil } }
 
         it "finds only unassigned work packages" do
-          subject
+          mcp_request
           expect(result_items.size).to eq(1)
           expect(result_items.first["id"]).to eq(work_package_b.id)
         end
@@ -175,7 +175,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:call_args) { { author_id: author.id } }
 
       it "finds only work packages created by the specified user" do
-        subject
+        mcp_request
         expect(result_items.size).to eq(1)
         expect(result_items.first["id"]).to eq(work_package_a.id)
       end
@@ -192,7 +192,7 @@ RSpec.describe McpTools::SearchWorkPackages do
           let(:call_args) { { filter_name => version.id } }
 
           it "returns work packages targeting that version" do
-            subject
+            mcp_request
             expect(result_items.pluck("id")).to contain_exactly(work_package_a.id)
           end
         end
@@ -201,7 +201,7 @@ RSpec.describe McpTools::SearchWorkPackages do
           let(:call_args) { { filter_name => nil } }
 
           it "returns work packages without a target version" do
-            subject
+            mcp_request
             expect(result_items.pluck("id")).to contain_exactly(work_package_b.id)
           end
         end
@@ -213,7 +213,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { subject: "First Work Package" } }
 
         it "finds the work package" do
-          subject
+          mcp_request
           expect(result_items.size).to eq(1)
           expect(result_items.first["id"]).to eq(work_package_a.id)
         end
@@ -223,7 +223,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { subject: "First" } }
 
         it "finds the work package" do
-          subject
+          mcp_request
           expect(result_items.size).to eq(1)
           expect(result_items.first["id"]).to eq(work_package_a.id)
         end
@@ -233,7 +233,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { subject: "first work" } }
 
         it "finds the work package" do
-          subject
+          mcp_request
           expect(result_items.size).to eq(1)
           expect(result_items.first["id"]).to eq(work_package_a.id)
         end
@@ -243,7 +243,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { subject: "Work Package" } }
 
         it "finds all matching work packages" do
-          subject
+          mcp_request
           expect(result_items.size).to eq(2)
         end
       end
@@ -253,7 +253,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:call_args) { { project_id: project.id, assigned_to_id: assignee.id } }
 
       it "applies all filters" do
-        subject
+        mcp_request
         expect(result_items.size).to eq(1)
         expect(result_items.first["id"]).to eq(work_package_a.id)
       end
@@ -263,7 +263,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       let(:user) { create(:user) }
 
       it "does not find any work packages" do
-        subject
+        mcp_request
         expect(result_items).to be_empty
       end
     end
@@ -287,7 +287,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       end
 
       it "returns only results up to the page size" do
-        subject
+        mcp_request
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
@@ -295,7 +295,7 @@ RSpec.describe McpTools::SearchWorkPackages do
         let(:call_args) { { subject: "Stormtrooper", page: 2 } }
 
         it "returns the requested page" do
-          subject
+          mcp_request
           expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_work_packages)
         end
       end
@@ -304,7 +304,7 @@ RSpec.describe McpTools::SearchWorkPackages do
 
   context "when the mcp_server enterprise feature is disabled" do
     it "responds with a 404" do
-      subject
+      mcp_request
       expect(last_response).to have_http_status(404)
     end
   end


### PR DESCRIPTION
The tool accepts a bare JSON data object that expects a JSON-formatted work package in essentially the same format that the APIv3 would expect or that's returned from a search_work_packages request.

# Ticket
https://community.openproject.org/wp/AI-72