### PR TITLE
[DREAM-95] Implement a primerized page for creating a new 2FA device 

### DIFF
--- a/frontend/src/global_styles/content/modules/_2fa.sass
+++ b/frontend/src/global_styles/content/modules/_2fa.sass
@@ -33,32 +33,6 @@
 .qr-code-element
   padding: 5px
 
-.mobile-otp-new-devices
-  display: flex
-  flex-direction: row
-  width: 75%
-
-  @media screen and (max-width: $breakpoint-sm)
-    flex-direction: column
-    gap: 1rem
-    width: 100%
-
-.mobile-otp-new-device
-  border: 1px solid var(--borderColor-default)
-  padding: 20px
-  margin-right: 10px
-  flex: 1 0 25%
-
-  // Flex self for alignment of button
-  display: flex
-  flex-direction: column
-
-  h2
-    border-bottom: none
-
-.mobile-otp-new-device--body
-  flex: 1
-
 #resend_otp_container
   margin-top: 30px
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -46,7 +46,6 @@ module ::TwoFactorAuthentication
       session[:authenticated_user_force_2fa] = service.needs_registration?
 
       if service.needs_registration?
-        flash[:info] = I18n.t("two_factor_authentication.forced_registration.required_to_add_device")
         redirect_to new_forced_2fa_device_path
       elsif !service.requires_token?
         complete_stage_redirect

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/new_type.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/new_type.html.erb
@@ -10,16 +10,30 @@
   end
 %>
 
-<div class="mobile-otp-new-devices">
-  <% @available_devices.each do |key, device_class| %>
-    <div class="mobile-otp-new-device mobile-otp-new-device-<%= key %>">
-      <h2><%= t("two_factor_authentication.devices.#{key}.title") %></h2>
-      <div class="mobile-otp-new-device--body">
-        <p><%= t("two_factor_authentication.devices.#{key}.description") %></p>
-      </div>
-      <div class="mobile-otp-new-device--footer">
-        <%= link_to t("two_factor_authentication.devices.register"), url_for(action: :new, type: key), class: "button button--tiny" %>
-      </div>
-    </div>
-  <% end %>
-</div>
+<%= render(Primer::Alpha::Banner.new(mb: 2, test_selector: "banner--2fa-required")) do
+      I18n.t("two_factor_authentication.forced_registration.required_to_add_device")
+    end %>
+
+<%= primer_form_with(url: url_for(action: :new), method: :get) do |f| %>
+  <% available_devices = @available_devices %>
+  <%= render_inline_form(f) do |form|
+        form.radio_button_group(
+          name: :type,
+          label: helpers.t("two_factor_authentication.devices.add_new"),
+          visually_hide_label: true
+        ) do |group|
+          available_devices.each_with_index do |(key, _), index|
+            group.radio_button(
+              value: key,
+              label: helpers.t("two_factor_authentication.devices.#{key}.title"),
+              caption: helpers.t("two_factor_authentication.devices.#{key}.description"),
+              checked: index == 0
+            )
+          end
+        end
+
+        form.group(layout: :horizontal) do |button_group|
+          button_group.submit(name: :submit, label: helpers.t(:button_next), scheme: :primary)
+        end
+      end %>
+<% end %>

--- a/modules/two_factor_authentication/config/locales/en.yml
+++ b/modules/two_factor_authentication/config/locales/en.yml
@@ -128,7 +128,7 @@ en:
     error_no_device: "No registered 2FA device found for this user, despite being required for this instance."
     error_no_matching_strategy: "No matching 2FA strategy available for this user. Please contact your administratior."
     forced_registration:
-      required_to_add_device: "An active security policy requires you to enable two-factor authentication. Please use the following form to register a device."
+      required_to_add_device: "The administrator has enforced two-factor authentication for this instance. To sign in, please add a two factor authentication method."
 
     label_2fa_disabled: "Two-factor authentication not active"
     label_2fa_enabled: "Two-factor authentication is active"

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_shared_examples.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_shared_examples.rb
@@ -28,10 +28,6 @@ RSpec.shared_examples "2FA forced registry" do
     expect(session[:authenticated_user_id]).to eq user.id
   end
 
-  it "flashes info message" do
-    expect(flash[:info]).not_to be_empty
-  end
-
   it "renders the login_otp" do
     expect(response).to redirect_to new_forced_2fa_device_path
   end

--- a/modules/two_factor_authentication/spec/features/shared_two_factor_examples.rb
+++ b/modules/two_factor_authentication/spec/features/shared_two_factor_examples.rb
@@ -48,12 +48,14 @@ end
 
 RSpec.shared_examples "create enforced sms device" do
   it do
-    expect_flash(type: :info,
-                 message: I18n.t("two_factor_authentication.forced_registration.required_to_add_device"))
+    expect(page)
+      .to have_test_selector "banner--2fa-required",
+                             text: I18n.t("two_factor_authentication.forced_registration.required_to_add_device")
 
     SeleniumHubWaiter.wait
     # Create SMS device
-    find(".mobile-otp-new-device-sms .button--tiny").click
+    choose I18n.t("two_factor_authentication.devices.sms.title")
+    click_button accessible_name: "Next"
     SeleniumHubWaiter.wait
     fill_in "device_phone_number", with: "invalid"
     click_on "Continue"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-95

# What are you trying to accomplish?
Primerize the page to select 2fa device

## Screenshots
<img width="1265" height="471" alt="Bildschirmfoto 2026-07-15 um 08 54 06" src="https://github.com/user-attachments/assets/41c521ac-3bbb-4ddf-b170-71540d7817cf" />
