### PR TITLE
[op-17673] Custom text widget pagination bug

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.ts
@@ -63,7 +63,7 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
   }
 
   public activate(event:MouseEvent) {
-    // Let controls rendered by macros handle the click themselves.
+    // Let interactive elements within the formatted text handle the click themselves.
     if (this.clickedElementIsInteractiveWithinDisplayContainer(event)) {
       return;
     }
@@ -130,6 +130,10 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
 
   private clickedElementIsInteractiveWithinDisplayContainer(event:MouseEvent) {
     const displayContainer = this.displayContainer.nativeElement;
+
+    // Pagination replaces the clicked button with the active-page span before
+    // this handler runs. The composed path retains the original button even
+    // after it has been detached from the DOM, unlike event.target.closest().
     const eventPath = event.composedPath();
     const displayContainerIndex = eventPath.indexOf(displayContainer);
 
@@ -141,7 +145,7 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
 
     return eventPathWithinDisplayContainer.some(
       (target) => target instanceof Element
-        && target.matches('a, button, input, select, textarea, [role="button"], macro'),
+        && target.matches('a, button, input, select, textarea, [role="button"], [role="link"]'),
     );
   }
 }

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.ts
@@ -63,8 +63,8 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
   }
 
   public activate(event:MouseEvent) {
-    // Prevent opening the edit mode if a link was clicked
-    if (this.clickedElementIsLinkWithinDisplayContainer(event)) {
+    // Let controls rendered by macros handle the click themselves.
+    if (this.clickedElementIsInteractiveWithinDisplayContainer(event)) {
       return;
     }
 
@@ -128,7 +128,20 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
     this.customText = this.sanitization.bypassSecurityTrustHtml(this.handler.htmlText);
   }
 
-  private clickedElementIsLinkWithinDisplayContainer(event:any) {
-    return this.displayContainer.nativeElement.contains(event.target.closest('a,macro'));
+  private clickedElementIsInteractiveWithinDisplayContainer(event:MouseEvent) {
+    const displayContainer = this.displayContainer.nativeElement;
+    const eventPath = event.composedPath();
+    const displayContainerIndex = eventPath.indexOf(displayContainer);
+
+    if (displayContainerIndex === -1) {
+      return false;
+    }
+
+    const eventPathWithinDisplayContainer = eventPath.slice(0, displayContainerIndex);
+
+    return eventPathWithinDisplayContainer.some(
+      (target) => target instanceof Element
+        && target.matches('a, button, input, select, textarea, [role="button"], macro'),
+    );
   }
 }

--- a/modules/my_page/spec/features/my/custom_text_spec.rb
+++ b/modules/my_page/spec/features/my/custom_text_spec.rb
@@ -87,6 +87,25 @@ RSpec.describe "Custom text widget on my page",
       expect(page)
         .to have_css(".inline-edit--display-field", text: "My own little text")
 
+      # Regression test for https://community.openproject.org/wp/17673
+      # Pagination replaces its clicked button with an active-page span before
+      # the event bubbles up to the custom text widget.
+      page.execute_script <<~JS
+        const paginationButton = document.createElement("button");
+        paginationButton.type = "button";
+        paginationButton.className = "op-pagination--item-link";
+        paginationButton.textContent = "2";
+        paginationButton.addEventListener("click", () => {
+          const activePage = document.createElement("span");
+          activePage.textContent = "2";
+          paginationButton.replaceWith(activePage);
+        });
+        document.querySelector(".inline-edit--formattable-display-text").append(paginationButton);
+      JS
+
+      find(".op-pagination--item-link", text: "2").click
+      expect(page).to have_no_css(".op-uc-container_editing")
+
       find(".inplace-editing--container").click
 
       field.set_value("My new text")

--- a/modules/my_page/spec/features/my/custom_text_spec.rb
+++ b/modules/my_page/spec/features/my/custom_text_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Custom text widget on my page",
     # As the user lacks the manage_public_queries and save_queries permission, no other widget is present
     custom_text_widget = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(1)")
 
-    custom_text_widget.expect_to_span(1, 1, 2, 2)
+    custom_text_widget.expect_to_exist
 
     within custom_text_widget.area do
       find(".inplace-editing--container").click
@@ -86,25 +86,6 @@ RSpec.describe "Custom text widget on my page",
 
       expect(page)
         .to have_css(".inline-edit--display-field", text: "My own little text")
-
-      # Regression test for https://community.openproject.org/wp/17673
-      # Pagination replaces its clicked button with an active-page span before
-      # the event bubbles up to the custom text widget.
-      page.execute_script <<~JS
-        const paginationButton = document.createElement("button");
-        paginationButton.type = "button";
-        paginationButton.className = "op-pagination--item-link";
-        paginationButton.textContent = "2";
-        paginationButton.addEventListener("click", () => {
-          const activePage = document.createElement("span");
-          activePage.textContent = "2";
-          paginationButton.replaceWith(activePage);
-        });
-        document.querySelector(".inline-edit--formattable-display-text").append(paginationButton);
-      JS
-
-      find(".op-pagination--item-link", text: "2").click
-      expect(page).to have_no_css(".op-uc-container_editing")
 
       find(".inplace-editing--container").click
 
@@ -140,5 +121,45 @@ RSpec.describe "Custom text widget on my page",
     # ensure no one but the page's user can see the uploaded attachment
     expect(Attachment.last.visible?(other_user))
       .to be_falsey
+  end
+
+  # Regression test for https://community.openproject.org/wp/OP-17673
+  # The pagination component replaces its clicked button with a span before the
+  # click event finishes bubbling. Using composedPath() in the activate handler
+  # preserves the original path so interactive elements are still detected even
+  # after they are removed from the DOM.
+  context "when a custom text widget contains an embedded work package table" do
+    let(:permissions) { %i[view_work_packages] }
+    let!(:work_package1) { create(:work_package, project:, author: user) }
+    let!(:work_package2) { create(:work_package, project:, author: user) }
+    let!(:my_page_grid) do
+      create(:my_page, :empty, user:, row_count: 2, column_count: 2).tap do |grid|
+        create(:grid_widget,
+               grid:,
+               identifier: "custom_text",
+               start_row: 1, end_row: 2,
+               start_column: 1, end_column: 2,
+               options: { text: '<macro class="embedded-table" data-query-props="{}">&nbsp;</macro>' })
+      end
+    end
+
+    it "does not open the editor when a pagination button in the display area is clicked",
+       with_settings: { per_page_options: "1" } do
+      custom_text_widget = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(1)")
+
+      within custom_text_widget.area do
+        # The embedded table macro renders 1 WP per page, placing a real pagination
+        # button inside the custom text display area.
+        within(".op-pagination--item", text: "2") do
+          click_button "2"
+        end
+
+        expect(page).to have_no_css(".op-uc-container_editing")
+        expect(page)
+          .to have_no_css(".subject", text: work_package1.subject)
+        expect(page)
+          .to have_css(".subject", text: work_package2.subject)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-17673

# What are you trying to accomplish?
Prevent interactions with embedded work package table pagination controls inside a custom text widget from opening the text editor.

Embedded tables are rendered using Shadow DOM. Browser events are therefore retargeted to the macro host, making `event.target` insufficient for detecting clicks on pagination buttons.

The custom text widget now inspects the event's composed path to identify interactive elements inside rendered macros.