### PR TITLE
[op-18860] User sees a success banner if they save a letter/word as integer

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.component.ts
@@ -32,11 +32,13 @@ import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-
   template: `
     <input type="number"
            class="inline-edit--field op-input"
+           #input
            [attr.aria-required]="required"
            [attr.required]="required"
            [disabled]="inFlight"
            [attr.lang]="locale"
-           [(ngModel)]="value"
+           [ngModel]="value"
+           (ngModelChange)="value = parseIntegerInput($event, input)"
            (keydown)="handler.handleUserKeydown($event)"
            [id]="handler.htmlId" />
   `,
@@ -48,4 +50,15 @@ import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-
 })
 export class IntegerEditFieldComponent extends EditFieldComponent {
   public locale = I18n.locale;
+
+  public parseIntegerInput(this:void, value:number|null, input:HTMLInputElement):number|string|null {
+    if (!input.validity.badInput) {
+      return value;
+    }
+
+    // Number inputs report invalid text as `null` (and Chromium also hides the
+    // text from `input.value`). Keep the change invalid so that it reaches the
+    // custom value validation instead of being mistaken for clearing the field.
+    return input.value || 'invalid';
+  }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-18860

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Preserve invalid number input values so backend validation can reject them instead of treating them as empty values and showing success.
