### PR TITLE
[COMMS-838] Documents: Drag and drop of blocks only works when dragging over editor content

### DIFF
--- a/frontend/src/react/components/DocumentLoadingSkeleton.tsx
+++ b/frontend/src/react/components/DocumentLoadingSkeleton.tsx
@@ -33,7 +33,7 @@ const SKELETON_CONTENT_STYLE = { width: '100%', height: '150px' };
 
 export function DocumentLoadingSkeleton() {
   return (
-    <div>
+    <div className={'document-loading-skeleton'}>
       <div className={'mb-3'}>
         <div style={SKELETON_TITLE_STYLE} className={'SkeletonBox'} />
       </div>

--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -1,4 +1,5 @@
 $blocknote-max-width: 800px
+$blocknote-side-menu-gutter: 48px // Left lane for BlockNote's side menu (drag handle + "+"); BlockNote doesn't expose this, its own default is 54px
 
 .document-form--long-description
   .ck-content
@@ -28,7 +29,8 @@ $blocknote-max-width: 800px
     width: 100%
     background-color: transparent
     padding-top: 10px // Small padding to display cursor label when at the very top
-    padding-inline: 0 // No inline padding necessary given transparent background
+    padding-inline: 0 // Drop BlockNote's default 54px inline padding
+    padding-left: $blocknote-side-menu-gutter
     font-size: var(--body-font-size)
   > .bn-default-styles
     font-family: var(--body-font-family)

--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -37,3 +37,11 @@ $blocknote-side-menu-gutter: 48px // Left lane for BlockNote's side menu (drag h
 
   :focus-visible
     outline: none !important // Remove default focus outline to use custom styles
+
+// The loading skeleton replaces the editor container in the same (shadow-DOM) mount, so give
+// it the editor's box - max-width, centering and gutter - instead of a full-width flush block.
+.document-loading-skeleton
+  max-width: $blocknote-max-width
+  width: 100%
+  margin: 0 auto
+  padding-left: $blocknote-side-menu-gutter

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -66,6 +66,7 @@
             tag.div(
               render(Documents::ShowEditView::ConnectionErrorNoticeComponent.new(document)),
               hidden: true,
+              class: "op-document-view--editor-notice",
               data: { "documents--editor-connection-target": "error" }
             ),
             tag.div(data: { "documents--editor-connection-target": "editor" }) do

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
@@ -5,10 +5,10 @@
   @media screen and (min-width: $breakpoint-lg)
     @include extended-content--left
 
-  @media screen and (min-width: $breakpoint-lg)
-    // Do not offset the breadcrumbs within documents as page header is nested within main layout
-    #wrapper .hidden-navigation .PageHeader-contextBar
-      margin-left: 0
+  // Desktop layout: drop the breadcrumb offset (page header is nested in the main layout).
+  // Mobile keeps the default 30px so the back-arrow clears the main-menu toggler.
+  #wrapper .hidden-navigation .document-page-layout_desktop-device .PageHeader-contextBar
+    margin-left: 0
 
 .op-document-view
   .PageHeader
@@ -29,6 +29,29 @@
       margin: 0 auto
       padding-left: var(--base-size-16, 1rem)
       padding-right: var(--base-size-16, 1rem)
+
+  // Desktop: align the title with the editor body (column base-size-16 + gutter).
+  &--header
+    @media screen and (min-width: $breakpoint-lg)
+      padding-left: calc(var(--base-size-16, 1rem) + #{$blocknote-side-menu-gutter})
+
+  // Narrow desktop: --editor's column padding is min-width-gated, so the body sits on the gutter alone.
+  &.document-page-layout_desktop-device
+    @media screen and (max-width: $breakpoint-lg)
+      .op-document-view--header
+        padding-left: $blocknote-side-menu-gutter
+
+  // Mobile: strip the panel's px:3 inset (!important beats the utility) so the body isn't double-indented on top of the gutter.
+  &:not(.document-page-layout_desktop-device) .document-page-layout--right-content
+    padding-left: 0 !important
+
+  // Notices sit beside the editor, not in it — add the gutter so they line up with the body.
+  &--editor-notice
+    padding-left: $blocknote-side-menu-gutter
+
+  // Mobile: the notice has no drag handle, so no gutter — a plain base-size-16 margin.
+  &:not(.document-page-layout_desktop-device) .op-document-view--editor-notice
+    padding-left: var(--base-size-16, 1rem)
 
   .UnderlineNav
     padding-left: var(--base-size-16, 1rem)

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
@@ -5,8 +5,11 @@
   @media screen and (min-width: $breakpoint-lg)
     @include extended-content--left
 
-  // Desktop layout: drop the breadcrumb offset (page header is nested in the main layout).
-  // Mobile keeps the default 30px so the back-arrow clears the main-menu toggler.
+  // Mobile tab layout: full-bleed left too (squished desktop keeps its padding above).
+  #content-body:has(.op-document-view:not(.document-page-layout_desktop-device))
+    padding-left: 0
+
+  // Desktop only: drop the breadcrumb offset (nested header); mobile keeps the default 30px to clear the toggler.
   #wrapper .hidden-navigation .document-page-layout_desktop-device .PageHeader-contextBar
     margin-left: 0
 
@@ -41,17 +44,31 @@
       .op-document-view--header
         padding-left: $blocknote-side-menu-gutter
 
-  // Mobile: strip the panel's px:3 inset (!important beats the utility) so the body isn't double-indented on top of the gutter.
+  // Mobile: margin for the title/breadcrumb (the editor body stays full-bleed for a tight "+").
+  &:not(.document-page-layout_desktop-device) .op-document-view--header
+    padding-left: var(--base-size-16, 1rem)
+
+  .document-page-layout--right-content
+    padding-inline: var(--base-size-16, 1rem)
+
   &:not(.document-page-layout_desktop-device) .document-page-layout--right-content
-    padding-left: 0 !important
+    padding-inline: var(--base-size-16, 1rem) 0
+
+  &:not(.document-page-layout_desktop-device) .document-page-layout--right-content:has(op-block-note)
+    padding-inline: 0
 
   // Notices sit beside the editor, not in it — add the gutter so they line up with the body.
   &--editor-notice
     padding-left: $blocknote-side-menu-gutter
 
-  // Mobile: the notice has no drag handle, so no gutter — a plain base-size-16 margin.
+  // Mobile: align the notice with the title and tabs' margin, not the editor gutter.
   &:not(.document-page-layout_desktop-device) .op-document-view--editor-notice
     padding-left: var(--base-size-16, 1rem)
 
   .UnderlineNav
     padding-left: var(--base-size-16, 1rem)
+
+  // Mobile: tabs flush to the grey baseline (padding 0), bar margin so it's off the screen edge.
+  &:not(.document-page-layout_desktop-device) .UnderlineNav
+    padding-left: 0
+    margin-left: var(--base-size-16, 1rem)

--- a/modules/documents/app/components/documents/show_edit_view/page_layout_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_layout_component.rb
@@ -107,7 +107,7 @@ module Documents
 
       def add_tab_to_underline_panels(name, active, counter, **system_arguments, &)
         @underline_panels.with_tab(selected: active, id: name, **system_arguments) do |tab|
-          tab.with_panel(px: 3, classes: "document-page-layout--right-content", &)
+          tab.with_panel(classes: "document-page-layout--right-content", &)
           tab.with_text { name }
           tab.with_counter(count: counter, hide_if_zero: true)
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-838

# What are you trying to accomplish?
In Documents, drag-and-drop of blocks only worked when the cursor was over the editor content itself. There was no space in the left "lane" for BlockNote's side menu (drag handle + "+"), so dragging up/down along the handle's column did nothing, and the "+" (add block) affordance was cut off.

The left lane is essential for working with BlockNote (reordering blocks, list items, etc.), so this reserves it on **all** screen sizes - matching the behaviour on BlockNote's own demo editor and in the mobile app. The document title and breadcrumbs are aligned to the editor body on both mobile and desktop.

# Screenshots
PC:
<img width="912" height="539" alt="image" src="https://github.com/user-attachments/assets/2e056b16-24bb-42c4-8f5f-172c1067bb4f" />
<img width="935" height="557" alt="image" src="https://github.com/user-attachments/assets/4d5549ed-9010-4d99-93c1-2a6c4c548286" />

Mobile:
<img width="935" height="557" alt="image" src="https://github.com/user-attachments/assets/5dcdeef6-d859-41fc-b3ac-bb709300dfa2" />
<img width="935" height="557" alt="image" src="https://github.com/user-attachments/assets/b86c9d1a-3a5f-4484-8bde-ea8fb7dbe66b" />
<img width="517" height="172" alt="image" src="https://github.com/user-attachments/assets/74e236ed-0846-4299-8df6-b87ea3bb0c4e" />




# What approach did you choose and why?
The root cause was a `padding-inline: 0` override on `.bn-editor`. BlockNote ships a default `padding-inline: 54px` precisely to reserve the gutter for the side menu; zeroing it removed that space and broke dragging.

- **Editor gutter (all sizes)**: reserve a left lane on `.bn-editor` via a new `$blocknote-side-menu-gutter` variable (48px), no longer gated behind `min-width: $breakpoint-lg`.
- **Title alignment**: the header `padding-left` matches the editor body's offset - `$blocknote-side-menu-gutter` on mobile (editor column has no side padding there) and `calc(base-size-16 + $blocknote-side-menu-gutter)` on desktop (column adds `base-size-16`).
- **Breadcrumbs**: the `.PageHeader-contextBar` `margin-left: 0` reset now applies on all sizes (the "nested within main layout" rationale is breakpoint-independent), keeping breadcrumbs aligned with the title.
- **Named variable**: BlockNote does not expose the gutter as a CSS variable, so its size lives in `$blocknote-side-menu-gutter`, replacing the previous hard-coded `40px`/`56px` offsets.
- **Notice alignment**: the connection-error banner sits *beside* the editor, not inside `.bn-editor`, so it misses the gutter. A new `op-document-view--editor-notice` class re-applies `$blocknote-side-menu-gutter` so the banner lines up with the editor body and title (otherwise it stuck out ~48px to the left in the offline/error state).

### Alternatives considered

- **Just removing the `padding-inline: 0` override** (letting BlockNote's native 54px apply everywhere): rejected - BlockNote pads *both* inline sides, whereas we only want a left lane, and a named variable gives us a single controlled value.
- **A JS/positioning fix on the handle**: rejected - the problem is purely a lack of horizontal space, so a CSS gutter is the correct and minimal layer.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
