### PR TITLE
Add MCP update_work_package tool

### DIFF
--- a/app/services/mcp_tools/update_work_package.rb
+++ b/app/services/mcp_tools/update_work_package.rb
@@ -29,26 +29,43 @@
 #++
 
 module McpTools
-  class CreateWorkPackage < Base
-    default_title "Create work package"
-    default_description "Create a new work package."
+  class UpdateWorkPackage < Base
+    default_title "Update work package"
+    default_description "Updates a work package in-place."
 
-    name "create_work_package"
+    name "update_work_package"
     annotations read_only: false, idempotent: false, destructive: false
 
     input_schema(
+      required: %w[id data],
       properties: {
+        id: {
+          type: :number,
+          description: "The ID of the work package that shall be updated."
+        },
         data: {
           type: %w[object],
-          description: "JSON Representation of the work package to be created. The format is the same as accepted by APIv3."
+          description: "JSON Representation of the work package to be updated. Only attributes that shall be changed need " \
+                       "to be included. The format is the same as accepted by APIv3.",
+          required: %w[lockVersion],
+          properties: {
+            lockVersion: {
+              type: :number,
+              description: "The lock version as indicated by the work package when reading it. This value is used for " \
+                           "optimistic locking, if a change is rejected because of a conflict, " \
+                           "re-read the work package and apply changes based on its new state."
+            }
+          }
         }
       }
     )
 
-    def call(data:)
-      attributes = parse_work_package(data)
+    def call(id:, data:)
+      work_package = WorkPackage.visible(current_user).find_by(id:)
+      return { error: "The given work package could not be found." } if work_package.nil?
 
-      result = WorkPackages::CreateService.new(user: current_user).call(**attributes)
+      attributes = parse_work_package(data)
+      result = WorkPackages::UpdateService.new(user: current_user, model: work_package).call(**attributes)
 
       if result.success?
         API::V3::WorkPackages::WorkPackageRepresenter.create(result.result, current_user:)

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -54,7 +54,8 @@ Rails.application.config.after_initialize do
                     McpTools::SearchProjects,
                     McpTools::SearchUsers,
                     McpTools::SearchVersions,
-                    McpTools::SearchWorkPackages
+                    McpTools::SearchWorkPackages,
+                    McpTools::UpdateWorkPackage
 
   McpResources.register McpResources::CurrentUser,
                         McpResources::Project,

--- a/spec/requests/mcp/mcp_tools/update_work_package_spec.rb
+++ b/spec/requests/mcp/mcp_tools/update_work_package_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpTools::UpdateWorkPackage do
+  subject(:mcp_request) do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) { create(:oauth_access_token, scopes: "mcp", resource_owner: user) }
+  let(:user) { create(:admin) }
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "update_work_package",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) do
+    {
+      id: work_package.id,
+      data: {
+        lockVersion: work_package.lock_version,
+        subject: "The new subject"
+      }
+    }
+  end
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+  let(:result_item) { parsed_results.fetch("structuredContent") }
+
+  let(:work_package) { create(:work_package).reload }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  before do
+    server_config.save!
+    tool_config.save!
+    work_package.save!
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
+    it_behaves_like "MCP text tool"
+
+    it "updates the work package" do
+      expect { mcp_request }.not_to change(WorkPackage, :count)
+
+      expect(work_package.reload.subject).to eq("The new subject")
+    end
+
+    it "responds with a properly formatted work package" do
+      mcp_request
+
+      expect(result_item.to_json).to match_json_schema.from_docs("work_package_model")
+    end
+
+    context "when using a wrong lock version" do
+      let(:call_args) do
+        {
+          id: work_package.id,
+          data: {
+            subject: "My new subject",
+            lockVersion: work_package.lock_version + 42
+          }
+        }
+      end
+
+      it "responds with an error" do
+        mcp_request
+        expect(result_item.fetch("error")).to eq("Information has been updated by at least one other user in the meantime.")
+      end
+
+      it "does not update the work package" do
+        expect { mcp_request }.not_to change { work_package.reload.subject }
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds with a 404" do
+      mcp_request
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
It works similar to the create_work_package tool,
but requires that a lockVersion is being passed from the MCP client.

The ID is being passed outside the data block, because it's not commonly part of the JSON request body in other requests too.

# Ticket
https://community.openproject.org/wp/AI-73