### PR TITLE
[SPPM-312] Tooltip for clustered gates shows wrong informtion

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -305,5 +305,62 @@ describe('ProjectTimelineGraphComponent', () => {
         expect(result.querySelector('.__hl_inline_project_phase_definition_5')).toBeTruthy();
       });
     });
+
+    describe('for a clustered gate item', () => {
+      const octoberGate:ProjectTimelineItem = {
+        id: 'gate-oct',
+        group: 'gates',
+        type: 'point',
+        start: new Date('2024-10-01'),
+        content: document.createElement('i'),
+        title: 'October Gate',
+        className: 'op-timeline-gate',
+      };
+      const novemberGate:ProjectTimelineItem = {
+        id: 'gate-nov',
+        group: 'gates',
+        type: 'point',
+        start: new Date('2024-11-01'),
+        content: document.createElement('i'),
+        title: 'November Gate',
+        className: 'op-timeline-gate',
+      };
+
+      const makeCluster = (items:ProjectTimelineItem[]):HTMLElement => tooltipTemplate({
+        id: 'cluster-1',
+        group: 'gates',
+        type: 'point',
+        start: new Date('2024-10-01'),
+        content: document.createElement('i'),
+        title: '',
+        className: 'op-timeline-gate',
+        isCluster: true,
+        items,
+      }) as HTMLElement;
+
+      it('shows "Gate" as the type label', () => {
+        const meta = makeCluster([octoberGate, novemberGate]).querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('Gate');
+      });
+
+      it('lists all gate names', () => {
+        const name = makeCluster([octoberGate, novemberGate]).querySelector('.op-timeline-tooltip--name');
+        expect(name?.textContent).toBe('October Gate, November Gate');
+      });
+
+      it('sorts dates chronologically even when items arrive in reverse order', () => {
+        const formattedDates:Date[] = [];
+        vi.spyOn(timezoneStub, 'formattedDate').mockImplementation((d:unknown) => {
+          formattedDates.push(d as Date);
+          return String(d);
+        });
+
+        // Items intentionally in reverse order (November before October)
+        makeCluster([novemberGate, octoberGate]);
+
+        expect(formattedDates.length).toBe(2);
+        expect(formattedDates[0].getTime()).toBeLessThan(formattedDates[1].getTime());
+      });
+    });
   });
 });

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -69,6 +69,8 @@ export interface ProjectTimelineItem {
   type:'range'|'point'|'background';
   className:string;
   definitionId?:number;
+  isCluster?:boolean;
+  items?:ProjectTimelineItem[];
 }
 
 const GROUP_GATES = 'gates';
@@ -208,18 +210,18 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
   private tooltipTemplate(item:ProjectTimelineItem):HTMLElement | string {
     if (item.type === 'background') return '';
 
-    const isGate = item.type === 'point';
-    const formatDate = (d:Date | string) => this.timezone.formattedDate(d as string);
-    const dateStr = isGate
-      ? formatDate(item.start)
-      : item.originalEnd
-        ? formatDate(item.originalEnd)
-        : `${formatDate(item.start)} – ${formatDate(item.end!)}`;
+    const isCluster = item.isCluster === true;
+    const isGate = item.type === 'point' || isCluster; // Currently only gates are clustered
+
+    const { dateStr, titleText, definitionId } = isCluster && item.items?.length
+      ? { ...this.tooltipClusterData(item.items), definitionId: undefined }
+      : this.tooltipItemData(item, isGate);
+
     const typeLabel = isGate
       ? this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_gate')
       : this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_phase');
 
-    const hlInlineClass = `__hl_inline_project_phase_definition_${item.definitionId!}`;
+    const hlInlineClass = definitionId != undefined ? `__hl_inline_project_phase_definition_${definitionId}` : '';
 
     const icon = octiconElement(isGate ? opGateIconData : opPhaseIconData, 'small', `octicon ${hlInlineClass}`);
     const typeSpan = document.createElement('span');
@@ -232,7 +234,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
     const name = document.createElement('div');
     name.className = 'op-timeline-tooltip--name';
-    name.textContent = item.title;
+    name.textContent = titleText;
 
     const wrapper = document.createElement('div');
     wrapper.className = 'op-timeline-tooltip';
@@ -251,5 +253,32 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
   private updateTimeline(phases:ProjectPhaseData[]):void {
     const { items, groups } = this.buildData(phases);
     this.timeline!.setData({ items: new DataSet(items as unknown as DataItem[]), groups: new DataSet(groups) });
+  }
+
+  private tooltipClusterData(items:ProjectTimelineItem[]):{dateStr:string; titleText:string} {
+    const sorted = items.slice().sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+    const minDate = sorted[0].start;
+    const maxDate = sorted[sorted.length - 1].start;
+    const dateStr = minDate === maxDate
+      ? this.timezone.formattedDate(minDate as string)
+      : `${this.timezone.formattedDate(minDate as string)} – ${this.timezone.formattedDate(maxDate as string)}`;
+
+    return { dateStr, titleText: items.map((i) => i.title).join(', ') };
+  }
+
+  private tooltipItemData(item:ProjectTimelineItem, isGate:boolean):{dateStr:string; titleText:string; definitionId:number | undefined} {
+    const formatDate = (d:Date | string) => this.timezone.formattedDate(d as string);
+
+    let dateStr:string;
+    if (isGate) {
+      dateStr = formatDate(item.start);
+    } else if (item.originalEnd) {
+      // One-day phase: visual start/end were adjusted, show the real date
+      dateStr = formatDate(item.originalEnd);
+    } else {
+      dateStr = `${formatDate(item.start)} – ${formatDate(item.end!)}`;
+    }
+
+    return { dateStr, titleText: item.title, definitionId: item.definitionId };
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-312

# What are you trying to accomplish?
Extend tooltip template function to also handle clusters

## Screenshots

<img width="303" height="130" alt="Bildschirmfoto 2026-07-15 um 15 05 50" src="https://github.com/user-attachments/assets/118fef12-b4e7-4d50-8cbd-6aca55cb0bfa" />
