### PR TITLE
[SPPM-314] Gates are shown even if the phase is not fully configured

### DIFF
--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -72,9 +72,9 @@ module Grids
           name: phase.definition.name,
           startDate: phase.start_date&.iso8601,
           endDate: phase.finish_date&.iso8601,
-          startGate: phase.definition.start_gate,
+          startGate: phase.definition.start_gate && phase.date_range_set?,
           startGateName: phase.definition.start_gate_name,
-          finishGate: phase.definition.finish_gate,
+          finishGate: phase.definition.finish_gate && phase.date_range_set?,
           finishGateName: phase.definition.finish_gate_name
         }
       end

--- a/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
       )
     end
 
+    context "when the phase has only a start_date but no finish_date" do
+      let!(:phase) { create(:project_phase, project:, definition:, finish_date: nil) }
+
+      it "does not include start or finish gates" do
+        expect(data.first).to include("startGate" => false, "finishGate" => false)
+      end
+    end
+
     context "with an additional inactive phase" do
       before { create(:project_phase, :inactive, project:) }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-314

# What are you trying to accomplish?
Do not show gates until the phase is fully defined

