### PR TITLE
[OP-19778] Boolean calculated value is not properly formatted in input

### DIFF
--- a/app/components/open_project/common/inplace_edit_fields/calculated_value_input_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/calculated_value_input_component.rb
@@ -37,10 +37,9 @@ module OpenProject
         end
 
         def initialize(form:, attribute:, model:, **system_arguments)
-          system_arguments ||= {}
-          system_arguments[:readonly] = true
+          super(form:, attribute:, model:, show_action_buttons: false, readonly: true, **system_arguments)
 
-          super(form:, attribute:, model:, show_action_buttons: false, **system_arguments)
+          @system_arguments[:value] = model.formatted_custom_value_for(custom_field) if custom_field?
         end
       end
     end

--- a/spec/components/open_project/common/inplace_edit_fields/calculated_value_input_component_spec.rb
+++ b/spec/components/open_project/common/inplace_edit_fields/calculated_value_input_component_spec.rb
@@ -29,11 +29,10 @@
 #++
 require "rails_helper"
 
-RSpec.describe OpenProject::Common::InplaceEditFields::CalculatedValueInputComponent,
-               type: :component do
+RSpec.describe OpenProject::Common::InplaceEditFields::CalculatedValueInputComponent, type: :component do
   include ViewComponent::TestHelpers
 
-  let(:project) { build_stubbed(:project) }
+  shared_let(:project) { create(:project) }
 
   it "renders a readonly text input without buttons" do
     component_class = described_class
@@ -49,5 +48,67 @@ RSpec.describe OpenProject::Common::InplaceEditFields::CalculatedValueInputCompo
 
     expect(rendered_content).to have_no_button(I18n.t(:button_save))
     expect(rendered_content).to have_no_button(I18n.t(:button_cancel))
+  end
+
+  describe "rendering value", with_ee: %i[calculated_values] do
+    let(:custom_field) { create(:calculated_value_project_custom_field, projects: [project]) }
+
+    current_user { build_stubbed(:admin) }
+
+    before do
+      create(:custom_value, customized: project, custom_field:, value:)
+    end
+
+    shared_examples "formats the value" do
+      it "renders the formatted custom value" do
+        attribute = custom_field.attribute_getter
+
+        component_class = described_class
+        render_in_view_context(project) do |model|
+          primer_form_with(url: "/foo", model:) do |f|
+            render_inline_form(f) do |form|
+              render component_class.new(form:, model:, attribute:, label: "Calc")
+            end
+          end
+        end
+
+        expect(rendered_content).to have_field("project[#{attribute}]", type: "text", readonly: true, with: formatted)
+      end
+    end
+
+    context "for integer value" do
+      let(:value) { 42 }
+      let(:formatted) { "42" }
+
+      include_examples "formats the value"
+    end
+
+    context "for float value" do
+      let(:value) { 3.14159 }
+      let(:formatted) { "3.142" }
+
+      include_examples "formats the value"
+    end
+
+    context "for true value" do
+      let(:value) { true }
+      let(:formatted) { I18n.t(:general_text_Yes) }
+
+      include_examples "formats the value"
+    end
+
+    context "for false value" do
+      let(:value) { false }
+      let(:formatted) { I18n.t(:general_text_No) }
+
+      include_examples "formats the value"
+    end
+
+    context "for no value" do
+      let(:value) { nil }
+      let(:formatted) { "" }
+
+      include_examples "formats the value"
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19778

# What are you trying to accomplish?
Use formatted instead of raw value in the readonly edit field in a dialog displayed when the calculated value custom field has comment.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
