### PR TITLE
[COMMS-902] Cleanup direct access of work package from Version - work package graph widget

### DIFF
--- a/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
+++ b/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
@@ -39,9 +39,9 @@ module Projects
         end
 
         def call
-          # The graph queries work packages by the single-version filter, so it
-          # is only rendered when that filter finds any.
-          return unless version.work_packages.any?
+          # The graph queries work packages by the version filter, which matches
+          # on target versions, so it is only rendered when that finds any.
+          return unless version.targeted_work_packages.any?
 
           widget_wrapper do |widget|
             widget.with_body do

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -97,9 +97,9 @@ See COPYRIGHT and LICENSE files for more details.
   <% if @issues.present? %>
     <% grid.with_widget(Projects::Settings::Versions::RelatedIssuesWidgetComponent, version: @version, issues: @issues) %>
   <% end %>
-  <%# The graph queries work packages by the single-version filter, so it is
-      only shown when that filter finds any. %>
-  <% if @version.work_packages.any? %>
+  <%# The graph queries work packages by the version filter, which matches on
+      target versions, so it is only shown when that finds any. %>
+  <% if @version.targeted_work_packages.any? %>
     <% grid.with_widget(Projects::Settings::Versions::WorkPackagesGraphWidgetComponent, version: @version) %>
   <% end %>
 <% end %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -97,8 +97,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if @issues.present? %>
     <% grid.with_widget(Projects::Settings::Versions::RelatedIssuesWidgetComponent, version: @version, issues: @issues) %>
   <% end %>
-  <%# The graph queries work packages by the version filter, which matches on
-      target versions, so it is only shown when that finds any. %>
+  <%# The graph queries work packages by the version filter, which matches on target versions, so it is only shown when that finds any. %>
   <% if @version.targeted_work_packages.any? %>
     <% grid.with_widget(Projects::Settings::Versions::WorkPackagesGraphWidgetComponent, version: @version) %>
   <% end %>

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -274,8 +274,8 @@ RSpec.describe VersionsController do
         expect(assigns(:issues)).to include work_package
       end
 
-      it "does not render the work packages graph, which still queries by the single-version filter" do
-        expect(response.body).not_to include("opce-wp-overview-graph")
+      it "renders the work packages graph" do
+        expect(response.body).to include("opce-wp-overview-graph")
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/MEET/work_packages/COMMS-902/activity

# What are you trying to accomplish?
Cleaning up some checks that still relied on the version.work_packages direct relation
