### PR TITLE
Bug/COMMS-905: Activity tab floods page with "not found" banners after session expiry

### DIFF
--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -200,7 +200,13 @@ class WorkPackages::ActivitiesTabController < ApplicationController
     @work_package = WorkPackage.visible.find(params[:work_package_id])
     @project = @work_package.project
   rescue ActiveRecord::RecordNotFound
-    respond_with_error(I18n.t("label_not_found"))
+    # Background polls get a bare 404; a flash stream would add a new error
+    # banner on every polling interval once the session or visibility is gone.
+    if action_name == "update_streams"
+      head :not_found
+    else
+      respond_with_error(I18n.t("label_not_found"))
+    end
   end
 
   def initialize_pagination

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -3,6 +3,7 @@ import { renderStreamMessage } from '@hotwired/turbo';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { TurboHelpers } from 'core-turbo/helpers';
+import { TurboRequestError } from 'core-turbo/turbo-request-error';
 import { getMetaContent } from '../setup/globals/global-helpers';
 
 @Injectable({ providedIn: 'root' })
@@ -56,7 +57,7 @@ export class TurboRequestsService {
         }
 
         if (!result.response.ok) {
-          throw new Error(result.response.statusText);
+          throw new TurboRequestError(result.response.status, result.response.statusText);
         } else {
           // enable further processing of the html and headers in the calling function
           return { html: result.html, headers: result.headers };

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.spec.ts
@@ -29,6 +29,7 @@
 import { vi, type Mock } from 'vitest';
 
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import { TurboRequestError } from 'core-turbo/turbo-request-error';
 import type PollingControllerType from './polling.controller';
 import type IndexController from './index.controller';
 
@@ -133,5 +134,43 @@ describe('Activities tab polling controller', () => {
     await vi.advanceTimersByTimeAsync(30000);
 
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  describe('circuit breaker', () => {
+    it('halts polling after a not-found poll response', async () => {
+      await renderPolling();
+      request.mockRejectedValue(new TurboRequestError(404, ''));
+
+      resolveContext(pluginContext());
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(request).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30000);
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resume polling on visibility change once halted', async () => {
+      await renderPolling();
+      request.mockRejectedValue(new TurboRequestError(404, ''));
+
+      resolveContext(pluginContext());
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(request).toHaveBeenCalledTimes(1);
+
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(30000);
+
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps polling after an error without an HTTP status', async () => {
+      await renderPolling();
+      request.mockRejectedValue(new Error('network hiccup'));
+
+      resolveContext(pluginContext());
+      await vi.advanceTimersByTimeAsync(20000);
+
+      expect(request).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/polling.controller.ts
@@ -31,6 +31,7 @@
 import type { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import type { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
+import { TurboRequestError } from 'core-turbo/turbo-request-error';
 import type AutoScrollingController from './auto-scrolling.controller';
 import BaseController from './base.controller';
 
@@ -61,7 +62,13 @@ export default class PollingController extends BaseController {
   declare apiV3Service:ApiV3Service;
   declare services:Promise<PickedServices<'turboRequests'|'apiV3Service'>>;
 
+  // A poll failing with one of these statuses can only repeat the same failure
+  // (the session or the work package's visibility is gone), so polling halts
+  // until the next page load instead of retrying forever.
+  private static readonly permanentFailureStatuses = [401, 403, 404];
+
   private updateInProgress = false;
+  private pollingHalted = false;
   private intervallId:number;
   private abortController = new AbortController();
 
@@ -89,7 +96,7 @@ export default class PollingController extends BaseController {
   }
 
   async updateActivitiesList() {
-    if (this.updateInProgress) return;
+    if (this.updateInProgress || this.pollingHalted) return;
 
     this.updateInProgress = true;
     const editingJournals = this.captureEditingJournals();
@@ -104,7 +111,11 @@ export default class PollingController extends BaseController {
       .then(({ html, headers }) => {
         this.handleUpdateStreamsResponse(html, headers, journalsContainerAtBottom);
       }).catch((error) => {
-        console.error('Error updating activities list:', error);
+        if (this.isPermanentPollingFailure(error)) {
+          this.haltPolling();
+        } else {
+          console.error('Error updating activities list:', error);
+        }
       }).finally(() => {
         this.updateInProgress = false;
       });
@@ -117,6 +128,8 @@ export default class PollingController extends BaseController {
   }
 
   private startPolling() {
+    if (this.pollingHalted) return;
+
     if (this.intervallId) {
       this.stopPolling();
     }
@@ -126,6 +139,16 @@ export default class PollingController extends BaseController {
 
   private stopPolling() {
     window.clearInterval(this.intervallId);
+  }
+
+  private isPermanentPollingFailure(error:unknown):boolean {
+    return error instanceof TurboRequestError
+      && PollingController.permanentFailureStatuses.includes(error.status);
+  }
+
+  private haltPolling() {
+    this.pollingHalted = true;
+    this.stopPolling();
   }
 
   private setLatestKnownChangesetUpdatedAt() {

--- a/frontend/src/turbo/turbo-request-error.ts
+++ b/frontend/src/turbo/turbo-request-error.ts
@@ -27,14 +27,14 @@
 //++
 
 // Error thrown for non-ok responses of requests issued via TurboRequestsService.
-// Carries the HTTP status so callers can react to it; the message keeps the
-// response's status text, which is empty under HTTP/2.
+// Carries the HTTP status so callers can react to it. The message always names
+// the status, since the response's status text is empty under HTTP/2.
 export class TurboRequestError extends Error {
   constructor(
     public readonly status:number,
     statusText:string,
   ) {
-    super(statusText);
+    super(`${status} ${statusText}`.trimEnd());
     this.name = 'TurboRequestError';
   }
 }

--- a/frontend/src/turbo/turbo-request-error.ts
+++ b/frontend/src/turbo/turbo-request-error.ts
@@ -1,0 +1,40 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+// Error thrown for non-ok responses of requests issued via TurboRequestsService.
+// Carries the HTTP status so callers can react to it; the message keeps the
+// response's status text, which is empty under HTTP/2.
+export class TurboRequestError extends Error {
+  constructor(
+    public readonly status:number,
+    statusText:string,
+  ) {
+    super(statusText);
+    this.name = 'TurboRequestError';
+  }
+}

--- a/spec/requests/work_packages/activities_tab_spec.rb
+++ b/spec/requests/work_packages/activities_tab_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe "Work package activities tab",
       expect(response.media_type).to eq("text/vnd.turbo-stream.html")
       expect(response.body.scan('<turbo-stream action="flash"').size).to eq(1)
     end
+
+    it "responds to a background poll with a bare 404 without a flash stream" do
+      get update_streams_work_package_activities_path(work_package_id: 0),
+          params: { last_update_timestamp: 1.hour.ago.iso8601 },
+          headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to be_empty
+    end
   end
 
   describe "GET update_streams" do


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-905

Leaving a work package activity tab open past the end of the session floods the page with "not found" banners: every 10-second poll of `update_streams` answers 404 with a turbo-stream flash, the client renders each one, and polling never stops.

The server now answers background polls it cannot resolve with a bare 404 (user-triggered actions keep their flash), and the client halts polling until the next page load once a poll fails with 401, 403 or 404, statuses a retry can only repeat. To make that detectable, failed turbo requests now throw an error carrying the HTTP status, since the status text they used to rely on is empty under HTTP/2. Transient network errors keep polling as before.

_Before: banner flood after session expiry_

<img width="1448" height="1048" alt="flood-of-not-found-errors" src="https://github.com/user-attachments/assets/c95add15-7fb2-4161-aacb-1578575852b4" />
