### PR TITLE
Filter HTML format from work package responses

### DIFF
--- a/app/services/mcp_output_filters/remove_formattable_html.rb
+++ b/app/services/mcp_output_filters/remove_formattable_html.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpOutputFilters
+  class RemoveFormattableHtml
+    class << self
+      def filter(hash_or_array)
+        case hash_or_array
+        when Hash
+          filter_hash(hash_or_array)
+        when Array
+          hash_or_array.each { |value| filter(value) }
+        end
+      end
+
+      private
+
+      def filter_hash(hash)
+        if formattable?(hash)
+          hash.delete("html")
+        else
+          hash.each_value { |value| filter(value) }
+        end
+      end
+
+      def formattable?(hash)
+        hash.key?("format") && hash.key?("raw") && hash.key?("html")
+      end
+    end
+  end
+end

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -124,6 +124,14 @@ module McpTools
         @filters ||= {}
       end
 
+      def output_filter(filter_class)
+        output_filters << filter_class
+      end
+
+      def output_filters
+        @output_filters ||= []
+      end
+
       def annotations(read_only:, idempotent:, destructive:)
         @annotations = {
           read_only_hint: read_only,
@@ -176,6 +184,7 @@ module McpTools
     end
 
     def format_response(result)
+      result = self.class.output_filters.inject(JSON.parse(result.to_json)) { |r, f| f.filter(r) }
       plain = render_plain_content? ? format_content(result) : []
       structured_content = render_structured_content? ? format_structured_content(result) : nil
       MCP::Tool::Response.new(plain, **{ structured_content: }.compact)

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -75,6 +75,8 @@ module McpTools
       }
     )
 
+    output_filter McpOutputFilters::RemoveFormattableHtml
+
     def call(page: nil, **filters)
       filtered = apply_filters(WorkPackage.visible, filters)
       work_packages = apply_pagination(filtered, page)

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -103,6 +103,13 @@ RSpec.describe McpTools::SearchWorkPackages do
       end
     end
 
+    it "removes html from the description" do
+      subject
+      result_items.each do |work_package|
+        expect(work_package.fetch("description")).not_to have_key("html")
+      end
+    end
+
     describe "filtering by id" do
       let(:call_args) { { id: work_package_a.id } }
 


### PR DESCRIPTION
The HTML format is essentially a less useful duplication of the raw (markdown) format. However, it's pretty verbose so it increases the output volume quite a lot.

# Ticket
https://community.openproject.org/wp/AI-44