### PR TITLE
[FND-121] Read-only workflow reference for Linked types  

### DIFF
--- a/app/components/workflows/blankslate_component.html.erb
+++ b/app/components/workflows/blankslate_component.html.erb
@@ -30,14 +30,16 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
     blankslate.with_heading(tag: :h2).with_content(t("admin.workflows.blankslate.title"))
-    blankslate.with_description_content(t("admin.workflows.blankslate.description"))
-    blankslate.with_primary_action(
-      href: helpers.status_dialog_type_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id)),
-      scheme: :secondary,
-      data: { controller: "async-dialog" }
-    ) do |button|
-      button.with_leading_visual_icon(icon: :plus)
-      t("admin.workflows.status_button")
+    blankslate.with_description_content(t(description_key))
+    unless read_only?
+      blankslate.with_primary_action(
+        href: helpers.status_dialog_type_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id)),
+        scheme: :secondary,
+        data: { controller: "async-dialog" }
+      ) do |button|
+        button.with_leading_visual_icon(icon: :plus)
+        t("admin.workflows.status_button")
+      end
     end
   end
 %>

--- a/app/components/workflows/blankslate_component.rb
+++ b/app/components/workflows/blankslate_component.rb
@@ -38,5 +38,13 @@ module Workflows
       @type = type
       @tab = tab
     end
+
+    private
+
+    def read_only? = helpers.workflow_linked?(@type)
+
+    def description_key
+      read_only? ? "admin.workflows.blankslate.linked_description" : "admin.workflows.blankslate.description"
+    end
   end
 end

--- a/app/components/workflows/status_matrix_form_component.html.erb
+++ b/app/components/workflows/status_matrix_form_component.html.erb
@@ -99,28 +99,30 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
 
-      subheader.with_action_button(
-        tag: :a,
-        scheme: :secondary,
-        leading_icon: :plus,
-        label: t("admin.workflows.status_button"),
-        href: helpers.status_dialog_type_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id), status_ids: @statuses.pluck(:id).presence),
-        data: { controller: "async-dialog" }
-      ) do
-        t("admin.workflows.status_button")
-      end
+      unless read_only?
+        subheader.with_action_button(
+          tag: :a,
+          scheme: :secondary,
+          leading_icon: :plus,
+          label: t("admin.workflows.status_button"),
+          href: helpers.status_dialog_type_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id), status_ids: @statuses.pluck(:id).presence),
+          data: { controller: "async-dialog" }
+        ) do
+          t("admin.workflows.status_button")
+        end
 
-      subheader.with_action_button(
-        tag: :a,
-        scheme: :secondary,
-        leading_icon: :copy,
-        label: t(:button_copy),
-        href: helpers.new_type_workflow_copy_path(@type, source_role_id: @roles.first&.id),
-        aria: { label: t(:button_copy) },
-        title: t(:button_copy),
-        data: { controller: "async-dialog", "admin--workflow-checkbox-state-confirmation-trigger": "click" }
-      ) do
-        t(:button_copy)
+        subheader.with_action_button(
+          tag: :a,
+          scheme: :secondary,
+          leading_icon: :copy,
+          label: t(:button_copy),
+          href: helpers.new_type_workflow_copy_path(@type, source_role_id: @roles.first&.id),
+          aria: { label: t(:button_copy) },
+          title: t(:button_copy),
+          data: { controller: "async-dialog", "admin--workflow-checkbox-state-confirmation-trigger": "click" }
+        ) do
+          t(:button_copy)
+        end
       end
     end
   %>
@@ -144,41 +146,43 @@ See COPYRIGHT and LICENSE files for more details.
 
         <%= helpers.render_tabs helpers.workflow_tabs(@type) %>
 
-        <div class="workflow-save-bar">
+        <% unless read_only? %>
+          <div class="workflow-save-bar">
+            <%=
+              render Primer::Beta::Button.new(scheme: :primary, type: :submit, mt: 3, ml: 3, mb: 4) do
+                t(:button_save)
+              end
+            %>
+          </div>
+
           <%=
-            render Primer::Beta::Button.new(scheme: :primary, type: :submit, mt: 3, ml: 3, mb: 4) do
-              t(:button_save)
-            end
-          %>
-        </div>
+            render(
+              Primer::OpenProject::FeedbackDialog.new(
+                title: t("admin.workflows.leave_confirmation.title"),
+                data: {
+                  "admin--workflow-checkbox-state-target": "confirmationDialog"
+                }
+              )
+            ) do |dialog|
+              dialog.with_feedback_message(icon_arguments: { icon: :none }) do |message|
+                message.with_heading(tag: :h2) { t("admin.workflows.leave_confirmation.title") }
+                message.with_description_content(t("admin.workflows.leave_confirmation.description"))
+              end
 
-        <%=
-          render(
-            Primer::OpenProject::FeedbackDialog.new(
-              title: t("admin.workflows.leave_confirmation.title"),
-              data: {
-                "admin--workflow-checkbox-state-target": "confirmationDialog"
-              }
-            )
-          ) do |dialog|
-            dialog.with_feedback_message(icon_arguments: { icon: :none }) do |message|
-              message.with_heading(tag: :h2) { t("admin.workflows.leave_confirmation.title") }
-              message.with_description_content(t("admin.workflows.leave_confirmation.description"))
-            end
+              dialog.with_footer do
+                component_collection do |footer|
+                  footer.with_component(
+                    Primer::Beta::Button.new(scheme: :danger, data: { "admin--workflow-checkbox-state-target": "ignoreButton" })
+                  ) { t("admin.workflows.leave_confirmation.ignore") }
 
-            dialog.with_footer do
-              component_collection do |footer|
-                footer.with_component(
-                  Primer::Beta::Button.new(scheme: :danger, data: { "admin--workflow-checkbox-state-target": "ignoreButton" })
-                ) { t("admin.workflows.leave_confirmation.ignore") }
-
-                footer.with_component(
-                  Primer::Beta::Button.new(scheme: :primary, data: { "admin--workflow-checkbox-state-target": "saveButton" })
-                ) { t("admin.workflows.leave_confirmation.save") }
+                  footer.with_component(
+                    Primer::Beta::Button.new(scheme: :primary, data: { "admin--workflow-checkbox-state-target": "saveButton" })
+                  ) { t("admin.workflows.leave_confirmation.save") }
+                end
               end
             end
-          end
-        %>
+          %>
+        <% end %>
       <% end %>
   <% else %>
     <%= render Workflows::BlankslateComponent.new(roles: @roles, type: @type, tab: @tab) %>

--- a/app/components/workflows/status_matrix_form_component.rb
+++ b/app/components/workflows/status_matrix_form_component.rb
@@ -49,6 +49,8 @@ module Workflows
 
     def form_id = FORM_ID
 
+    def read_only? = helpers.workflow_linked?(@type)
+
     def data_attributes
       {
         controller: "admin--workflow-role-select",

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -152,6 +152,10 @@ class Workflows::TabsController < ApplicationController
     @type = ::Type.find(params.expect(:type_id))
   end
 
+  def workflow_source_type
+    @workflow_source_type ||= @type.effective_source_for(Type::ConfigurationLink::WORKFLOWS)
+  end
+
   def set_tab
     @tab = params[:tab]
   end
@@ -173,7 +177,7 @@ class Workflows::TabsController < ApplicationController
                 elsif @type && @roles.any?
                   statuses_for_roles_and_type
                 elsif @type
-                  @type.statuses
+                  workflow_source_type.statuses
                 else
                   Status.all
                 end
@@ -188,12 +192,12 @@ class Workflows::TabsController < ApplicationController
   end
 
   def statuses_for_roles_and_type
-    status_ids = @roles.map { |role| @type.statuses(role:, tab: @tab).pluck(:id) }.flatten.uniq
+    status_ids = @roles.map { |role| workflow_source_type.statuses(role:, tab: @tab).pluck(:id) }.flatten.uniq
     Status.where(id: status_ids)
   end
 
   def workflows_for_form
-    workflows = Workflow.where(role_id: @roles.map(&:id), type_id: @type.id)
+    workflows = Workflow.where(role_id: @roles.map(&:id), type_id: workflow_source_type.id)
     @workflows = {}
     @workflows["always"] = workflows.select { |w| !w.author && !w.assignee }
     @workflows["author"] = workflows.select(&:author)

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -29,6 +29,10 @@
 #++
 
 module WorkflowHelper
+  def workflow_linked?(type)
+    type&.linked?(Type::ConfigurationLink::WORKFLOWS)
+  end
+
   def workflow_tabs(type)
     [
       { name: "always",

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -29,6 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% name = tab[:name] %>
 <% workflows = @workflows[name] %>
+<% read_only = workflow_linked?(@type) %>
 
 <%=
   if name == "assignee"
@@ -72,19 +73,21 @@ See COPYRIGHT and LICENSE files for more details.
                   <span class="flex-1">
                     <%= t(:label_new_statuses_allowed) %>
                   </span>
-                  <%=
-                    check_all_links "workflow_form_#{name}" do |links|
-                      links.with_check_all_button do |button|
-                        button.with_tooltip(text: t(".matrix_check_all_label"))
-                        t(:button_check_all)
-                      end
+                  <% unless read_only %>
+                    <%=
+                      check_all_links "workflow_form_#{name}" do |links|
+                        links.with_check_all_button do |button|
+                          button.with_tooltip(text: t(".matrix_check_all_label"))
+                          t(:button_check_all)
+                        end
 
-                      links.with_uncheck_all_button do |button|
-                        button.with_tooltip(text: t(".matrix_uncheck_all_label"))
-                        t(:button_uncheck_all)
+                        links.with_uncheck_all_button do |button|
+                          button.with_tooltip(text: t(".matrix_uncheck_all_label"))
+                          t(:button_uncheck_all)
+                        end
                       end
-                    end
-                  %>
+                    %>
+                  <% end %>
                 <% end %>
               </div>
             </div>
@@ -112,6 +115,7 @@ See COPYRIGHT and LICENSE files for more details.
                       scheme: :invisible,
                       size: :small,
                       icon: :check,
+                      disabled: read_only,
                       tooltip_direction: :sw,
                       aria: {
                         label: t(".matrix_check_uncheck_all_in_col_label_html", new_status: new_status.name)
@@ -152,6 +156,7 @@ See COPYRIGHT and LICENSE files for more details.
                       scheme: :invisible,
                       size: :small,
                       icon: :check,
+                      disabled: read_only,
                       tooltip_direction: :sw,
                       aria: {
                         label: t(".matrix_check_uncheck_all_in_row_label_html", old_status: old_status.name)
@@ -183,6 +188,7 @@ See COPYRIGHT and LICENSE files for more details.
                         name: "status[#{old_status.id}][#{new_status.id}]",
                         id: "status_#{old_status.id}_#{new_status.id}", # See BUG https://github.com/primer/view_components/issues/3811
                         value: name,
+                        disabled: read_only,
                         checked: !some_roles && (transition_role_ids.any? || newly_added_status),
                         label: t(".matrix_checkbox_label", old_status: old_status.name, new_status: new_status.name),
                         visually_hide_label: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1532,6 +1532,7 @@ en:
     workflows:
       blankslate:
         description: "Add statuses to start configuring workflows for this role"
+        linked_description: "This type reuses the workflows of its linked source type, which has no status transitions configured"
         title: "No status transitions configured"
       leave_confirmation:
         description: "You are about to leave this page but you have unsaved changes. Would you like to save them before continuing?"

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -211,7 +211,7 @@ ul.SegmentedControl,
         margin: var(--base-size-8) 0 0 var(--base-size-8)
 
 // Bug in @openproject/primer-view-components: .FormControl-checkbox:indeterminate
-// has no background rule, and :indeterminate:before doesn't cancel checkmarkOut.
+// has no background rule, and :indeterminate:before doesn't cancel checkmarkOut
 .FormControl-checkbox:indeterminate
   background: var(--control-checked-bgColor-rest, var(--color-accent-fg))
   border-color: var(--control-checked-borderColor-rest, var(--color-accent-fg))
@@ -219,6 +219,13 @@ ul.SegmentedControl,
   &:before
     animation: none
     clip-path: inset(0)
+
+  // Mirror Primer's :checked:disabled so a disabled indeterminate box reads as
+  // inactive instead of keeping the accent background from the rule above
+  &:disabled
+    background: var(--control-fgColor-disabled)
+    border-color: var(--control-fgColor-disabled)
+    cursor: not-allowed
 
 // At some point in time, this needs to be extracted into a proper component,
 // something like `FilterableTreeViewSelectPanel`

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -723,4 +723,32 @@ RSpec.describe "Workflow edit", :js do
       end
     end
   end
+
+  describe "when the workflow is linked from a source" do
+    let(:source_type) { create(:type) }
+    let!(:source_workflow) do
+      create(:workflow, role_id: role.id,
+                        type_id: source_type.id,
+                        old_status_id: statuses[0].id,
+                        new_status_id: statuses[1].id,
+                        author: false,
+                        assignee: false)
+    end
+
+    before do
+      type.link!(Type::ConfigurationLink::WORKFLOWS, source: source_type)
+      visit_workflow_edit(roles: [role])
+    end
+
+    it "shows the source's transitions read-only without editing actions" do
+      expect(page).to have_field(workflow_checkbox(0, 1), checked: true, disabled: true)
+      expect(page).to have_field(workflow_checkbox(1, 0), disabled: true)
+      expect(page).to have_no_button "Save"
+
+      within "#workflow-table" do
+        expect(page).to have_no_link "Status"
+        expect(page).to have_no_link "Copy"
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/FND-121

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
- Make the workflows tab read only when in linked mode

# What approach did you choose and why?
- Hide action buttons
- Make the matrix checkboxes disabled
   - This also needed custom css to make the indeterminate disabled state greyed out. Without the css, the checkbox is disabled, but appears to be enabled (blue)


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
