### PR TITLE
[DREAM-763] Automatically upload PDF artefacts to project folder

### DIFF
--- a/app/components/work_package_types/export_configuration_component.html.erb
+++ b/app/components/work_package_types/export_configuration_component.html.erb
@@ -27,5 +27,18 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<%= render(Primer::Beta::Subhead.new) do |subhead| %>
+  <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.templates.section_title") } %>
+<% end %>
 <p><%= I18n.t("types.edit.export_configuration.intro") %></p>
 <%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model)) %>
+
+<%= render(Primer::Beta::Subhead.new) do |subhead| %>
+  <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
+<% end %>
+<p><%= I18n.t("types.edit.export_configuration.artefact_export.intro") %></p>
+<%=
+  settings_primer_form_with(**artefact_export_form_options) do |f|
+    render(WorkPackageTypes::ArtefactExportForm.new(f))
+  end
+%>

--- a/app/controllers/work_package_types/pdf_export_template_controller.rb
+++ b/app/controllers/work_package_types/pdf_export_template_controller.rb
@@ -34,7 +34,7 @@ module WorkPackageTypes
     layout "admin"
 
     before_action :require_admin
-    before_action :find_type, only: %i[edit toggle drop enable_all disable_all]
+    before_action :find_type, only: %i[edit toggle drop enable_all disable_all update_artefact_export]
     before_action :find_template, only: %i[toggle drop]
 
     current_menu_item do
@@ -42,6 +42,21 @@ module WorkPackageTypes
     end
 
     def edit; end
+
+    def update_artefact_export
+      mode = params.dig(:type, :artefact_export_mode)
+      unless Type::ArtefactExport::MODES.include?(mode)
+        render_error_flash_message_via_turbo_stream(
+          message: I18n.t("types.edit.export_configuration.artefact_export.invalid_mode")
+        )
+        return respond_with_turbo_streams(status: :unprocessable_entity)
+      end
+
+      @type.artefact_export_mode = mode
+      @type.save!
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
+      respond_with_turbo_streams
+    end
 
     def enable_all
       return render_404_turbo_stream if @type.nil?

--- a/app/forms/work_package_types/artefact_export_form.rb
+++ b/app/forms/work_package_types/artefact_export_form.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  class ArtefactExportForm < ApplicationForm
+    form do |f|
+      f.radio_button_group(
+        name: :artefact_export_mode,
+        label: I18n.t("types.edit.export_configuration.artefact_export.label")
+      ) do |group|
+        group.radio_button(
+          value: Type::ArtefactExport::OFF,
+          checked: checked?(Type::ArtefactExport::OFF),
+          label: I18n.t("types.edit.export_configuration.artefact_export.off_mode.label"),
+          caption: I18n.t("types.edit.export_configuration.artefact_export.off_mode.caption")
+        )
+        group.radio_button(
+          value: Type::ArtefactExport::ATTACHMENT,
+          checked: checked?(Type::ArtefactExport::ATTACHMENT),
+          label: I18n.t("types.edit.export_configuration.artefact_export.attachment.label"),
+          caption: I18n.t("types.edit.export_configuration.artefact_export.attachment.caption")
+        )
+        group.radio_button(
+          value: Type::ArtefactExport::FILE_LINK,
+          checked: checked?(Type::ArtefactExport::FILE_LINK),
+          label: file_link_label,
+          caption: I18n.t("types.edit.export_configuration.artefact_export.file_link.caption"),
+          disabled: !file_link_available?
+        )
+      end
+    end
+
+    private
+
+    def checked?(value)
+      value == (model.artefact_export_mode.presence || Type::ArtefactExport::DEFAULT)
+    end
+
+    def file_link_label
+      label = I18n.t("types.edit.export_configuration.artefact_export.file_link.label")
+      return label if file_link_available?
+
+      "#{label} (#{I18n.t('types.edit.export_configuration.artefact_export.unavailable')})"
+    end
+
+    def file_link_available?
+      return @file_link_available if defined?(@file_link_available)
+
+      @file_link_available = Storages::NextcloudStorage.automatic_management_enabled.exists?
+    end
+  end
+end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -41,6 +41,7 @@ class Type < ApplicationRecord
 
   store_attribute :pdf_export_templates_config, :export_templates_disabled, :json
   store_attribute :pdf_export_templates_config, :export_templates_order, :json
+  store_attribute :pdf_export_templates_config, :artefact_export_mode, :string
 
   before_destroy :check_integrity
 
@@ -214,6 +215,23 @@ class Type < ApplicationRecord
 
   def pdf_export_templates
     @pdf_export_templates ||= ::Type::PdfExportTemplates.new(self)
+  end
+
+  # The store_attribute :default is not returned when the JSON key is present
+  # but nil, so mirror the getter-override pattern used elsewhere (see
+  # Projects::CreationWizard) to guarantee a value.
+  def artefact_export_mode
+    super.presence || Type::ArtefactExport::DEFAULT
+  end
+
+  def artefact_export_enabled?
+    effective_artefact_export_mode != Type::ArtefactExport::OFF
+  end
+
+  # Sub-types inherit the artefact export configuration from their linked source
+  # for the PDF_EXPORT aspect, consistent with the export templates.
+  def effective_artefact_export_mode
+    effective_source_for(Type::ConfigurationLink::PDF_EXPORT).artefact_export_mode
   end
 
   private

--- a/app/models/type/artefact_export.rb
+++ b/app/models/type/artefact_export.rb
@@ -23,23 +23,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackageTypes
-  class ExportConfigurationComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
+module Type::ArtefactExport
+  # No automatic export (default; existing types are unaffected).
+  OFF = "off"
+  # Save the generated PDF as a work package file attachment.
+  ATTACHMENT = "attachment"
+  # Upload the generated PDF to the project's Nextcloud storage and add a file link.
+  FILE_LINK = "file_link"
 
-    def artefact_export_form_options
-      {
-        model:,
-        url: update_artefact_export_type_pdf_export_template_index_path(type_id: model.id),
-        method: :put,
-        data: { controller: "auto-submit", action: "change->auto-submit#submit" }
-      }
-    end
-  end
+  MODES = [OFF, ATTACHMENT, FILE_LINK].freeze
+  DEFAULT = OFF
 end

--- a/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
+++ b/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module TypeArtefactExport
+    class ExportOnStatusChangeService
+      attr_reader :current_user, :work_package
+
+      delegate :project, :type, to: :work_package
+
+      def initialize(current_user:, work_package:)
+        @current_user = current_user
+        @work_package = work_package
+      end
+
+      def call!(changes:)
+        return if changes["status_id"].blank?
+        return unless type.artefact_export_enabled?
+        # The creation wizard runs its own export for its artifact work package;
+        # skip it here to avoid generating the PDF twice.
+        return if creation_wizard_artifact_work_package?
+
+        User.execute_as_admin(current_user) do
+          export_and_store!
+        end
+      rescue ::Exports::ExportError => e
+        Rails.logger.error("Artefact export failed for work package ##{work_package.id}: #{e.message}")
+      end
+
+      private
+
+      def creation_wizard_artifact_work_package?
+        project.project_creation_wizard_artifact_work_package_id.to_s == work_package.id.to_s
+      end
+
+      def export_and_store!
+        export = WorkPackage::PDFExport::Artefact.new(work_package).export!
+
+        case type.effective_artefact_export_mode
+        when Type::ArtefactExport::ATTACHMENT
+          store_as_attachment(export)
+        when Type::ArtefactExport::FILE_LINK
+          upload_to_storage(export)
+        end
+      end
+
+      def store_as_attachment(export)
+        file = OpenProject::Files.create_uploaded_file(
+          name: export.title,
+          content_type: export.mime_type,
+          content: export.content,
+          binary: true
+        )
+
+        attachment = work_package.attachments.create(author: current_user, file:)
+        unless attachment.persisted?
+          Rails.logger.error(
+            "Failed to attach artefact to work package ##{work_package.id}: " \
+            "#{attachment.errors.full_messages.join(', ')}"
+          )
+        end
+      end
+
+      def upload_to_storage(export)
+        project_storage = target_project_storage
+        if project_storage.nil?
+          log_missing_storage
+          return
+        end
+
+        result = upload(export, project_storage)
+        return if result.success?
+
+        Rails.logger.error("Artefact upload failed for work package ##{work_package.id}: #{result.message}")
+      end
+
+      def upload(export, project_storage)
+        Storages::UploadFileService.call(
+          container: work_package,
+          project_storage:,
+          file_path: artefact_folder_name(project_storage.storage),
+          filename: export.title,
+          file_data: StringIO.new(export.content)
+        )
+      end
+
+      def log_missing_storage
+        Rails.logger.info(
+          "No automatically-managed Nextcloud storage for project ##{project.id}; " \
+          "skipping artefact upload for work package ##{work_package.id}"
+        )
+      end
+
+      # A Type is global, so it cannot store a project-scoped storage id.
+      # Use the first automatically-managed Nextcloud project
+      # storage of the work package's project
+      def target_project_storage
+        project.project_storages
+               .automatic
+               .includes(:storage)
+               .find { |project_storage| project_storage.storage.provider_type_nextcloud? }
+      end
+
+      # sanitize managed project folders (according to
+      # Storages::Adapters::Providers::Nextcloud::ManagedFolderIdentifier):
+      def artefact_folder_name(storage)
+        type.name
+            .tr("/\\", "|")
+            .tr(storage.forbidden_file_name_characters, "_")
+      end
+    end
+  end
+end

--- a/app/workers/work_packages/workflow_job.rb
+++ b/app/workers/work_packages/workflow_job.rb
@@ -32,13 +32,22 @@ module WorkPackages
   class WorkflowJob < ApplicationJob
     def perform(journal, changes)
       work_package = journal.journable
-      process_artifact_changes(work_package, changes) unless journal.initial?
+      return if journal.initial?
+
+      process_artifact_changes(work_package, changes)
+      process_type_artefact_export(work_package, changes)
     end
 
     private
 
     def process_artifact_changes(work_package, changes)
       Projects::CreationWizard::ReuploadArtifactOnStatusChangesService
+        .new(current_user: User.current, work_package:)
+        .call!(changes:)
+    end
+
+    def process_type_artefact_export(work_package, changes)
+      WorkPackages::TypeArtefactExport::ExportOnStatusChangeService
         .new(current_user: User.current, work_package:)
         .call!(changes:)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6042,6 +6042,21 @@ en:
         source:
           label: "Source type"
       export_configuration:
+        artefact_export:
+          attachment:
+            caption: "The generated PDF is saved as a file attachment on the work package."
+            label: "Save as work package file attachment"
+          file_link:
+            caption: "The generated PDF is uploaded to the project's automatically-managed Nextcloud storage and linked from the work package. Work packages in projects without such a storage are skipped."
+            label: "Upload file to external file storage and add file link to work package"
+          intro: "Automatically generate a PDF artefact of a work package of this type whenever its status changes."
+          invalid_mode: "Invalid artefact export mode."
+          label: "Automatic artefact export"
+          off_mode:
+            caption: "No PDF is generated automatically."
+            label: "Off"
+          section_title: "Automatic artefact export"
+          unavailable: "unavailable, no automatically-managed Nextcloud storage is configured"
         intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."
         pdf_export_templates:
           actions:
@@ -6049,6 +6064,8 @@ en:
             label_enable_all: "Enable all"
           label: "PDF Export templates"
         tab: "Generate PDF"
+        templates:
+          section_title: "PDF export templates"
       form_configuration:
         add_attribute_group: "Section"
         add_query_group: "Related work packages table"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,7 +193,7 @@ Rails.application.routes.draw do
 
     resources :pdf_export_template, only: %i[],
                                     controller: "pdf_export_template",
-                                    path: "pdf_export_template" do
+                                    path: "pdf_export" do
       member do
         post :toggle
         put :drop
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
         get :edit
         put :enable_all
         put :disable_all
+        put :update_artefact_export
       end
     end
 

--- a/spec/controllers/work_package_types/pdf_export_template_controller_spec.rb
+++ b/spec/controllers/work_package_types/pdf_export_template_controller_spec.rb
@@ -101,5 +101,55 @@ RSpec.describe WorkPackageTypes::PdfExportTemplateController do
         expect(wp_type.export_templates_disabled.length).to eq(wp_type.pdf_export_templates.list.length)
       end
     end
+
+    describe "#edit" do
+      render_views
+
+      it "renders the export configuration page including the artefact export form" do
+        get :edit, params: { type_id: wp_type.id }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("types.edit.export_configuration.artefact_export.section_title"))
+      end
+
+      context "when no automatically-managed Nextcloud storage is configured" do
+        it "marks the file link option as unavailable" do
+          get :edit, params: { type_id: wp_type.id }
+
+          expect(response.body).to include(I18n.t("types.edit.export_configuration.artefact_export.unavailable"))
+        end
+      end
+
+      context "when an automatically-managed Nextcloud storage is configured" do
+        before { create(:nextcloud_storage, :as_automatically_managed) }
+
+        it "offers the file link option without the unavailable hint" do
+          get :edit, params: { type_id: wp_type.id }
+
+          expect(response.body).not_to include(I18n.t("types.edit.export_configuration.artefact_export.unavailable"))
+        end
+      end
+    end
+
+    describe "#update_artefact_export" do
+      it "stores a valid artefact export mode and responds with a turbo stream" do
+        put :update_artefact_export,
+            params: { type_id: wp_type.id, type: { artefact_export_mode: Type::ArtefactExport::FILE_LINK } },
+            as: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(wp_type.reload.artefact_export_mode).to eq(Type::ArtefactExport::FILE_LINK)
+      end
+
+      it "rejects an invalid mode" do
+        put :update_artefact_export,
+            params: { type_id: wp_type.id, type: { artefact_export_mode: "bogus" } },
+            as: :turbo_stream
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(wp_type.reload.artefact_export_mode).to eq(Type::ArtefactExport::OFF)
+      end
+    end
   end
 end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -453,4 +453,28 @@ RSpec.describe Type do
       end
     end
   end
+
+  describe "#artefact_export_mode" do
+    it "defaults to 'off'" do
+      expect(build(:type).artefact_export_mode).to eq(Type::ArtefactExport::OFF)
+    end
+
+    it "persists the value into the pdf_export_templates_config jsonb column" do
+      persisted = create(:type)
+      persisted.update!(artefact_export_mode: Type::ArtefactExport::ATTACHMENT)
+
+      expect(persisted.reload.artefact_export_mode).to eq(Type::ArtefactExport::ATTACHMENT)
+      expect(persisted.pdf_export_templates_config).to include("artefact_export_mode" => "attachment")
+    end
+  end
+
+  describe "#artefact_export_enabled?" do
+    it "is false when off" do
+      expect(build(:type, pdf_export_templates_config: { "artefact_export_mode" => "off" })).not_to be_artefact_export_enabled
+    end
+
+    it "is true when a storing mode is set" do
+      expect(build(:type, pdf_export_templates_config: { "artefact_export_mode" => "file_link" })).to be_artefact_export_enabled
+    end
+  end
 end

--- a/spec/services/work_packages/type_artefact_export/export_on_status_change_service_spec.rb
+++ b/spec/services/work_packages/type_artefact_export/export_on_status_change_service_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::TypeArtefactExport::ExportOnStatusChangeService do
+  shared_let(:status_new) { create(:status, name: "New") }
+  shared_let(:status_approved) { create(:status, name: "Approved") }
+  shared_let(:type) { create(:type, name: "Deliverable") }
+  shared_let(:current_user) { create(:admin, lastname: "current_user") }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:project) { create(:project, name: "Important Project", types: [type]) }
+
+  shared_let(:work_package) do
+    create(:work_package, project:, type:, status: status_new, subject: "A deliverable")
+  end
+
+  let(:instance) { described_class.new(current_user:, work_package:) }
+  let(:changes) { { "status_id" => [status_new.id, status_approved.id] } }
+
+  before do
+    login_as current_user
+  end
+
+  describe "#call!" do
+    context "when the type has artefact export disabled (default off)" do
+      it "does not export" do
+        allow(User).to receive(:execute_as_admin)
+
+        instance.call!(changes:)
+
+        expect(User).not_to have_received(:execute_as_admin)
+      end
+    end
+
+    context "when status_id is not part of the changes" do
+      let(:changes) { { "subject" => %w[a b] } }
+
+      before { type.update!(artefact_export_mode: Type::ArtefactExport::ATTACHMENT) }
+
+      it "does not export" do
+        allow(User).to receive(:execute_as_admin)
+
+        instance.call!(changes:)
+
+        expect(User).not_to have_received(:execute_as_admin)
+      end
+    end
+
+    context "when the work package is the creation wizard artifact work package" do
+      before do
+        type.update!(artefact_export_mode: Type::ArtefactExport::ATTACHMENT)
+        project.update!(project_creation_wizard_artifact_work_package_id: work_package.id)
+      end
+
+      it "does not export (handled by the creation wizard service)" do
+        allow(User).to receive(:execute_as_admin)
+
+        instance.call!(changes:)
+
+        expect(User).not_to have_received(:execute_as_admin)
+      end
+    end
+
+    context "when the mode is 'attachment'" do
+      before { type.update!(artefact_export_mode: Type::ArtefactExport::ATTACHMENT) }
+
+      it "adds the generated PDF as an attachment to the work package" do
+        expect { instance.call!(changes:) }
+          .to change { work_package.reload.attachments.count }.by(1)
+
+        attachment = work_package.attachments.last
+        expect(attachment.content_type).to eq("application/pdf")
+        expect(attachment.filename).to end_with(".pdf")
+        expect(attachment.author).to eq(current_user)
+      end
+    end
+
+    context "when the mode is 'file_link'" do
+      let(:storage) { create(:nextcloud_storage_with_local_connection) }
+      let!(:project_storage) do
+        create(:project_storage, :as_automatically_managed, project:, storage:)
+      end
+      let(:service_result) { ServiceResult.success(result: nil) }
+
+      before do
+        type.update!(artefact_export_mode: Type::ArtefactExport::FILE_LINK)
+        allow(Storages::UploadFileService).to receive(:call).and_return(service_result)
+      end
+
+      it "uploads the generated PDF to the project's Nextcloud storage" do
+        instance.call!(changes:)
+
+        expect(work_package.reload.attachments.count).to eq(0)
+        expect(Storages::UploadFileService)
+          .to have_received(:call)
+          .with(container: work_package,
+                project_storage:,
+                file_path: type.name,
+                filename: /\.pdf\z/,
+                file_data: instance_of(StringIO))
+      end
+
+      context "when the type name contains path/forbidden characters" do
+        before { type.update!(name: "Feature/Bug") }
+
+        it "sanitizes the folder name so it cannot inject nested folders" do
+          instance.call!(changes:)
+
+          expect(Storages::UploadFileService)
+            .to have_received(:call)
+            .with(container: work_package,
+                  project_storage:,
+                  file_path: a_string_matching(%r{\AFeature[^/]Bug\z}),
+                  filename: /\.pdf\z/,
+                  file_data: instance_of(StringIO))
+        end
+      end
+
+      context "and the upload fails" do
+        let(:service_result) do
+          ServiceResult.failure(result: nil).tap { |r| r.errors.add(:base, "boom") }
+        end
+
+        it "logs the failure and does not raise" do
+          allow(Rails.logger).to receive(:error)
+
+          expect { instance.call!(changes:) }.not_to raise_error
+          expect(Rails.logger).to have_received(:error).with(/Artefact upload failed/)
+        end
+      end
+
+      context "without a Nextcloud storage on the project" do
+        let!(:project_storage) { nil }
+
+        it "skips the upload and logs" do
+          allow(Rails.logger).to receive(:info)
+
+          instance.call!(changes:)
+
+          expect(Storages::UploadFileService).not_to have_received(:call)
+          expect(Rails.logger).to have_received(:info).with(/skipping artefact upload/)
+        end
+      end
+    end
+
+    context "when PDF generation raises" do
+      let(:pdf_export) { instance_double(WorkPackage::PDFExport::Artefact) }
+
+      before do
+        type.update!(artefact_export_mode: Type::ArtefactExport::ATTACHMENT)
+        allow(WorkPackage::PDFExport::Artefact).to receive(:new).and_return(pdf_export)
+        allow(pdf_export).to receive(:export!).and_raise(Exports::ExportError, "kaboom")
+      end
+
+      it "rescues and logs the error" do
+        allow(Rails.logger).to receive(:error)
+
+        expect { instance.call!(changes:) }.not_to raise_error
+        expect(Rails.logger).to have_received(:error).with(/Artefact export failed/)
+      end
+    end
+  end
+end

--- a/spec/workers/work_packages/workflow_job_spec.rb
+++ b/spec/workers/work_packages/workflow_job_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::WorkflowJob do
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:changes) { { "status_id" => [1, 2] } }
+  let(:journal) { instance_double(Journal, journable: work_package, initial?: initial) }
+  let(:initial) { false }
+
+  let(:reupload_service) do
+    instance_double(Projects::CreationWizard::ReuploadArtifactOnStatusChangesService, call!: nil)
+  end
+  let(:type_export_service) do
+    instance_double(WorkPackages::TypeArtefactExport::ExportOnStatusChangeService, call!: nil)
+  end
+
+  before do
+    allow(Projects::CreationWizard::ReuploadArtifactOnStatusChangesService)
+      .to receive(:new).and_return(reupload_service)
+    allow(WorkPackages::TypeArtefactExport::ExportOnStatusChangeService)
+      .to receive(:new).and_return(type_export_service)
+  end
+
+  subject(:perform) { described_class.new.perform(journal, changes) }
+
+  context "when the journal is not the initial one" do
+    it "invokes both the creation-wizard reupload and the type artefact export" do
+      perform
+
+      expect(reupload_service).to have_received(:call!).with(changes:)
+      expect(type_export_service).to have_received(:call!).with(changes:)
+    end
+  end
+
+  context "when the journal is the initial one" do
+    let(:initial) { true }
+
+    it "does not invoke either handler" do
+      perform
+
+      expect(reupload_service).not_to have_received(:call!)
+      expect(type_export_service).not_to have_received(:call!)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-763

# What are you trying to achieve?

PMflex PDF artefacts should be generated for all status changes and automatically uploaded into the project folder/attached to the work package

# What approach did you choose and why?

Adapted the strategy for generating & uploading PIAs: In the journal state change callback we check if this work package should generate a PDF and upload it.
The configuration is done in the PDF export configuration for work package types, mirroring the configuration of the PIA generation, but with an "Off" setting which is the default.
As the PIA works in project scope, but work package types are global, the PIA code has not been touched.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
