### PR TITLE
Filter action-based links from MCP work package responses

### DIFF
--- a/app/services/mcp_output_filters/hash_filter.rb
+++ b/app/services/mcp_output_filters/hash_filter.rb
@@ -29,43 +29,32 @@
 #++
 
 module McpOutputFilters
-  class RemoveWorkPackageActionLinks < HashFilter
-    BLOCKED_LINKS = %w[
-      update
-      updateImmediately
-      delete
-      logTime
-      move
-      copy
-      generate_pdf
-      configureForm
-      availableWatchers
-      watch
-      unwatch
-      addWatcher
-      removeWatcher
-      addRelation
-      addChild
-      changeParent
-      addComment
-      addAttachment
-      previewMarkup
-      timeEntries
-      showCosts
-      addFileLink
-    ].to_set
-
+  # Base class for output filters that want to filter on the content of hashes in a result.
+  # It will descend into the values of arrays and hashes and call #on_hash for each hash found
+  # along the way, allowing for the implementation to modify the given hash along the way.
+  class HashFilter
     class << self
+      def filter(hash_or_array)
+        case hash_or_array
+        when Hash
+          filter_hash(hash_or_array)
+        when Array
+          hash_or_array.each { |value| filter(value) }
+        end
+      end
+
       private
 
-      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
-        links = hash["_links"]
-        if links
-          links.delete_if { |key| BLOCKED_LINKS.include?(key) }
-          return false
+      def filter_hash(hash)
+        if on_hash(hash)
+          hash.each_value { |value| filter(value) }
         end
+      end
 
-        true
+      # Expected to be overwritten by subclasses. Should return a truthy value to descend further into
+      # values of the given hash or false to stop descending here.
+      def on_hash(_hash)
+        raise SubclassResponsibilityError
       end
     end
   end

--- a/app/services/mcp_output_filters/remove_formattable_html.rb
+++ b/app/services/mcp_output_filters/remove_formattable_html.rb
@@ -29,25 +29,17 @@
 #++
 
 module McpOutputFilters
-  class RemoveFormattableHtml
+  class RemoveFormattableHtml < HashFilter
     class << self
-      def filter(hash_or_array)
-        case hash_or_array
-        when Hash
-          filter_hash(hash_or_array)
-        when Array
-          hash_or_array.each { |value| filter(value) }
-        end
-      end
-
       private
 
-      def filter_hash(hash)
+      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
         if formattable?(hash)
           hash.delete("html")
-        else
-          hash.each_value { |value| filter(value) }
+          return false
         end
+
+        true
       end
 
       def formattable?(hash)

--- a/app/services/mcp_output_filters/remove_work_package_action_links.rb
+++ b/app/services/mcp_output_filters/remove_work_package_action_links.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpOutputFilters
+  class RemoveWorkPackageActionLinks
+    BLOCKED_LINKS = %w[
+      update
+      updateImmediately
+      delete
+      logTime
+      move
+      copy
+      generate_pdf
+      configureForm
+      availableWatchers
+      watch
+      unwatch
+      addWatcher
+      removeWatcher
+      addRelation
+      addChild
+      changeParent
+      addComment
+      addAttachment
+      previewMarkup
+      timeEntries
+      showCosts
+      addFileLink
+    ].to_set
+
+    class << self
+      def filter(hash_or_array)
+        case hash_or_array
+        when Hash
+          filter_hash(hash_or_array)
+        when Array
+          hash_or_array.each { |value| filter(value) }
+        end
+      end
+
+      private
+
+      def filter_hash(hash)
+        hash.each do |key, value|
+          if key == "_links"
+            filter_links(value)
+          else
+            filter(value)
+          end
+        end
+      end
+
+      def filter_links(links)
+        links.delete_if { |key| BLOCKED_LINKS.include?(key) }
+      end
+    end
+  end
+end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -91,6 +91,7 @@ module McpTools
     )
 
     output_filter McpOutputFilters::RemoveFormattableHtml
+    output_filter McpOutputFilters::RemoveWorkPackageActionLinks
 
     def call(page: nil, **filters)
       filtered = apply_filters(WorkPackage.visible, filters)

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -110,6 +110,15 @@ RSpec.describe McpTools::SearchWorkPackages do
       end
     end
 
+    it "removes unnecessary links from work packages, such as purely action-based links" do
+      subject
+      result_items.each do |work_package|
+        # Spec is based on the assumption that we might have to increase this number over time, but rather not reduce it.
+        # When you are here to increase it, maybe reflect on whether we should've filtered more links by now.
+        expect(work_package.fetch("_links").size).to be < 40
+      end
+    end
+
     describe "filtering by id" do
       let(:call_args) { { id: work_package_a.id } }
 

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -116,6 +116,12 @@ RSpec.describe McpTools::SearchWorkPackages do
         # Spec is based on the assumption that we might have to increase this number over time, but rather not reduce it.
         # When you are here to increase it, maybe reflect on whether we should've filtered more links by now.
         expect(work_package.fetch("_links").size).to be < 40
+
+        # it keeps non-action links, because they are still useful (non-exhaustive examples) ...
+        expect(work_package.fetch("_links").keys).to include("status", "type", "assignee")
+
+        # ... but rejects links that merely tell the client "what's possible to do" (non-exhaustive examples)
+        expect(work_package.fetch("_links").keys).not_to include("logTime", "generate_pdf", "copy")
       end
     end
 


### PR DESCRIPTION
These links don't offer any helpful context for understanding the work package better, but they increase the size of the response significantly.

In our HAL/Hateoas-based APIv3 they are used to communicate what can happen to a resource. However, MCP clients will usually try to do what users ask them to do and then see if that succeeds, rather than assuming that a certain action is not possible because a corresponding link is missing. Thus those "action links" are mostly dead weight in the response.

# Ticket
https://community.openproject.org/wp/AI-45

# Impact

I am trying to gauge the impact of this change (including the upstream change of filtering HTML).

In our `search_work_package` test case that returns two work packages, the response size on `dev` is ~22kB, while the size on this PR is just shy of 12kB. This means a reduction in response size of about 45%.

I also did another test with one of my local test work packages. It might over-use wiki page links a bit, so also take that with a grain of salt, but here the reduction is more impactful, shrinking the response from 28.48 kiB to 4.22 kiB, so a reduction by 85%.

For reference, this is the work package:

<img width="830" height="816" alt="image" src="https://github.com/user-attachments/assets/40955ed3-3e9d-4fd0-9820-32e839226fa9" />