### PR TITLE
[FND-132] Read-only form configuration reference for linked types

### DIFF
--- a/app/components/work_package_types/configuration_link_component.html.erb
+++ b/app/components/work_package_types/configuration_link_component.html.erb
@@ -47,11 +47,22 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     <% end %>
 
-    <% if editor_form.nil? && !linked? %>
-      <%# Independent: the tab's own editor, shown while "Independent" is selected. %>
-      <%= content_tag(:div, data: independent_data) do %>
-        <%= render(Primer::Beta::Heading.new(tag: :h2, mb: 3)) { heading } if heading %>
-        <%= content %>
+    <% if editor_form.nil? %>
+      <% if linked? %>
+        <% if readonly_preview? %>
+          <%# Linked: the inherited configuration, shown read-only while "Linked" is selected. %>
+          <%= content_tag(:div, data: linked_data) do %>
+            <%= render(WorkPackageTypes::LinkedSourceReferenceComponent.new(source: effective_source, link_path: source_edit_path)) %>
+            <%= render(Primer::Beta::Heading.new(tag: :h2, mb: 3)) { heading } if heading %>
+            <%= readonly_preview %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%# Independent: the tab's own editor, shown while "Independent" is selected. %>
+        <%= content_tag(:div, data: independent_data) do %>
+          <%= render(Primer::Beta::Heading.new(tag: :h2, mb: 3)) { heading } if heading %>
+          <%= content %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/work_package_types/configuration_link_component.rb
+++ b/app/components/work_package_types/configuration_link_component.rb
@@ -38,6 +38,8 @@ module WorkPackageTypes
     include OpPrimer::FormHelpers
     include OpTurbo::Streamable
 
+    renders_one :readonly_preview
+
     # +url+/+method+/+form_id+/+form_model+ let a host (the creation wizard) point the mode
     # form at its own endpoint, binding its fields under that model. +editor_form+ is an
     # ApplicationForm rendered inside the same form so the host's submit persists mode and
@@ -103,6 +105,21 @@ module WorkPackageTypes
     def heading = @heading
 
     def independent_data = WorkPackageTypes::ConfigurationLinkForm.effect_data("independent")
+
+    def linked_data = WorkPackageTypes::ConfigurationLinkForm.effect_data("linked")
+
+    def effective_source = type.effective_source_for(@aspect)
+
+    # Aspect → the source type's own configuration tab. Only the two implemented aspects
+    # resolve; anything else has no destination yet.
+    def source_edit_path
+      case @aspect
+      when Type::ConfigurationLink::PATTERNS
+        edit_type_subject_configuration_path(effective_source)
+      when Type::ConfigurationLink::PDF_EXPORT
+        edit_type_pdf_export_template_index_path(type_id: effective_source.id)
+      end
+    end
 
     private
 

--- a/app/components/work_package_types/export_configuration_component.html.erb
+++ b/app/components/work_package_types/export_configuration_component.html.erb
@@ -33,14 +33,12 @@ See COPYRIGHT and LICENSE files for more details.
 <p><%= I18n.t("types.edit.export_configuration.intro") %></p>
 <%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model, readonly: readonly?)) %>
 
-<% unless readonly? %>
-  <%= render(Primer::Beta::Subhead.new) do |subhead| %>
-    <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
-  <% end %>
-  <p><%= I18n.t("types.edit.export_configuration.artefact_export.intro") %></p>
-  <%=
-    settings_primer_form_with(**artefact_export_form_options) do |f|
-      render(WorkPackageTypes::ArtefactExportForm.new(f))
-    end
-  %>
+<%= render(Primer::Beta::Subhead.new) do |subhead| %>
+  <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
 <% end %>
+<p><%= I18n.t("types.edit.export_configuration.artefact_export.intro") %></p>
+<%=
+  settings_primer_form_with(**artefact_export_form_options) do |f|
+    render(WorkPackageTypes::ArtefactExportForm.new(f))
+  end
+%>

--- a/app/components/work_package_types/export_configuration_component.html.erb
+++ b/app/components/work_package_types/export_configuration_component.html.erb
@@ -31,14 +31,16 @@ See COPYRIGHT and LICENSE files for more details.
   <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.templates.section_title") } %>
 <% end %>
 <p><%= I18n.t("types.edit.export_configuration.intro") %></p>
-<%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model)) %>
+<%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model, readonly: readonly?)) %>
 
-<%= render(Primer::Beta::Subhead.new) do |subhead| %>
-  <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
+<% unless readonly? %>
+  <%= render(Primer::Beta::Subhead.new) do |subhead| %>
+    <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
+  <% end %>
+  <p><%= I18n.t("types.edit.export_configuration.artefact_export.intro") %></p>
+  <%=
+    settings_primer_form_with(**artefact_export_form_options) do |f|
+      render(WorkPackageTypes::ArtefactExportForm.new(f))
+    end
+  %>
 <% end %>
-<p><%= I18n.t("types.edit.export_configuration.artefact_export.intro") %></p>
-<%=
-  settings_primer_form_with(**artefact_export_form_options) do |f|
-    render(WorkPackageTypes::ArtefactExportForm.new(f))
-  end
-%>

--- a/app/components/work_package_types/export_configuration_component.rb
+++ b/app/components/work_package_types/export_configuration_component.rb
@@ -33,6 +33,13 @@ module WorkPackageTypes
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
+    def initialize(model, readonly: false, **)
+      @readonly = readonly
+      super(model, **)
+    end
+
+    def readonly? = @readonly
+
     def artefact_export_form_options
       {
         model:,

--- a/app/components/work_package_types/export_configuration_component.rb
+++ b/app/components/work_package_types/export_configuration_component.rb
@@ -45,8 +45,18 @@ module WorkPackageTypes
         model:,
         url: update_artefact_export_type_pdf_export_template_index_path(type_id: model.id),
         method: :put,
-        data: { controller: "auto-submit", action: "change->auto-submit#submit" }
+        readonly: @readonly,
+        data: artefact_export_form_data
       }
+    end
+
+    private
+
+    # A read-only form has disabled inputs, so it never auto-submits; drop the controller.
+    def artefact_export_form_data
+      return {} if @readonly
+
+      { controller: "auto-submit", action: "change->auto-submit#submit" }
     end
   end
 end

--- a/app/components/work_package_types/export_template_list_component.html.erb
+++ b/app/components/work_package_types/export_template_list_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper(data: wrapper_data_attributes) do
-    render(border_box_container(mb: 3, data: drag_and_drop_target_config)) do |component|
+    render(border_box_container(mb: 3, data: (readonly? ? {} : drag_and_drop_target_config))) do |component|
       component.with_header(font_weight: :bold, py: 2) do
         flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
           section_header_container.with_column(py: 2) do
@@ -37,48 +37,51 @@ See COPYRIGHT and LICENSE files for more details.
               I18n.t("types.edit.export_configuration.pdf_export_templates.label")
             end
           end
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: enable_all_type_pdf_export_template_index_path(type_id: @type.id),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_enable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-pdf-export-templates" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_enable_all")
+          unless readonly?
+            section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
+              actions_container.with_column do
+                render(
+                  Primer::Beta::Button.new(
+                    tag: :a,
+                    href: enable_all_type_pdf_export_template_index_path(type_id: @type.id),
+                    scheme: :invisible,
+                    font_weight: :bold,
+                    color: :subtle,
+                    "aria-label": t("projects.settings.actions.label_enable_all"),
+                    data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-pdf-export-templates" }
+                  )
+                ) do |button|
+                  button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+                  I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_enable_all")
+                end
               end
-            end
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: disable_all_type_pdf_export_template_index_path(type_id: @type.id),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_disable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-pdf-export-templates" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_disable_all")
+              actions_container.with_column do
+                render(
+                  Primer::Beta::Button.new(
+                    tag: :a,
+                    href: disable_all_type_pdf_export_template_index_path(type_id: @type.id),
+                    scheme: :invisible,
+                    font_weight: :bold,
+                    color: :subtle,
+                    "aria-label": t("projects.settings.actions.label_disable_all"),
+                    data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-pdf-export-templates" }
+                  )
+                ) do |button|
+                  button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+                  I18n.t("types.edit.export_configuration.pdf_export_templates.actions.label_disable_all")
+                end
               end
             end
           end
         end
       end
       @type.pdf_export_templates.list.each do |template|
-        component.with_row(data: draggable_item_config(template)) do
+        component.with_row(data: (readonly? ? {} : draggable_item_config(template))) do
           render(
             WorkPackageTypes::ExportTemplateRowComponent.new(
               type: @type,
-              template:
+              template:,
+              readonly: readonly?
             )
           )
         end

--- a/app/components/work_package_types/export_template_row_component.html.erb
+++ b/app/components/work_package_types/export_template_row_component.html.erb
@@ -29,8 +29,10 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   component_wrapper do
     flex_layout(align_items: :center) do |item_information|
-      item_information.with_column(mr: 2) do
-        render(Primer::OpenProject::DragHandle.new)
+      unless readonly?
+        item_information.with_column(mr: 2) do
+          render(Primer::OpenProject::DragHandle.new)
+        end
       end
       item_information.with_column(flex: 1, flex_layout: true) do |title_container|
         title_container.with_column(pt: 1, mr: 2) do
@@ -45,18 +47,23 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
       item_information.with_column(py: 1, mr: 2) do
-        render(
-          Primer::Alpha::ToggleSwitch.new(
+        toggle_options = {
+          checked: @template.enabled,
+          enabled: !readonly?,
+          size: :small,
+          status_label_position: :start,
+          test_selector: "toggle-pdf-export-template-row-#{@template.id}"
+        }
+        # A read-only toggle is disabled, so it never posts; omit the mutation wiring entirely.
+        unless readonly?
+          toggle_options.merge!(
             src: toggle_type_pdf_export_template_path(type_id: @type.id, id: @template.id),
             csrf_token: form_authenticity_token,
             data: { "turbo-method": :post, "turbo-stream": true },
-            checked: @template.enabled,
-            size: :small,
-            status_label_position: :start,
-            test_selector: "toggle-pdf-export-template-row-#{@template.id}",
             classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"
           )
-        )
+        end
+        render(Primer::Alpha::ToggleSwitch.new(**toggle_options))
       end
     end
   end

--- a/app/components/work_package_types/export_template_row_component.rb
+++ b/app/components/work_package_types/export_template_row_component.rb
@@ -34,11 +34,14 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(type:, template:)
+    def initialize(type:, template:, readonly: false)
       super
 
       @template = template
       @type = type
+      @readonly = readonly
     end
+
+    def readonly? = @readonly
   end
 end

--- a/app/components/work_package_types/linked_source_reference_component.html.erb
+++ b/app/components/work_package_types/linked_source_reference_component.html.erb
@@ -27,30 +27,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% if readonly? %>
-  <%= settings_primer_form_with(**form_options) do |f| %>
-    <%= render(WorkPackageTypes::SubjectConfigurationForm.new(f)) %>
+<%= render(Primer::Beta::Flash.new(scheme: :default, mt: 3, mb: 3)) do %>
+  <%= t("types.edit.configuration_link.reference.reusing", source: source.name) %>
+  <% if show_link? %>
+    <%= render(Primer::Beta::Link.new(href: link_path)) { t("types.edit.configuration_link.reference.edit_at_source") } %>
   <% end %>
-<% elsif show_upsale_page? %>
-  <%= render(
-        EnterpriseEdition::BannerComponent.new(
-          :work_package_subject_generation,
-          variant: :large,
-          video: "enterprise/automatically_generated_subjects.mp4"
-        )
-      ) %>
-<% else %>
-  <%= render(
-        EnterpriseEdition::BannerComponent.new(
-          :work_package_subject_generation,
-          variant: :medium,
-          image: "enterprise/automatically-generated-subjects.png"
-        )
-      ) %>
-
-  <%=
-    settings_primer_form_with(**form_options) do |f|
-      render(WorkPackageTypes::SubjectConfigurationForm.new(f))
-    end
-  %>
 <% end %>

--- a/app/components/work_package_types/linked_source_reference_component.rb
+++ b/app/components/work_package_types/linked_source_reference_component.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # The "reused from <source>" note shown for a Linked aspect, with an optional link
+  # to the source's own configuration tab. The link is guarded: type configuration is
+  # admin-only today, and a project admin must not be pointed at a type they cannot open.
+  class LinkedSourceReferenceComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    def initialize(source:, link_path: nil)
+      super(source)
+
+      @source = source
+      @link_path = link_path
+    end
+
+    def source = @source
+
+    def link_path = @link_path
+
+    def show_link? = @link_path.present? && User.current.admin?
+  end
+end

--- a/app/components/work_package_types/subject_configuration_component.rb
+++ b/app/components/work_package_types/subject_configuration_component.rb
@@ -34,22 +34,21 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(model, subject_configuration_form_data: nil, **)
+    def initialize(model, subject_configuration_form_data: nil, readonly: false, **)
       @subject_configuration_form_data = subject_configuration_form_data
+      @readonly = readonly
       super(model, **)
     end
 
-    def form_options
-      form_model = subject_form_object
+    def readonly? = @readonly
 
+    def form_options
       {
         url: type_subject_configuration_path(type_id: model.id),
         method: :put,
-        model: form_model,
-        data: {
-          controller: "admin--subject-configuration",
-          admin__subject_configuration_hide_pattern_input_value: form_model.subject_configuration == :manual
-        }
+        model: subject_form_object,
+        readonly: @readonly,
+        data: form_data
       }
     end
 
@@ -58,6 +57,15 @@ module WorkPackageTypes
     end
 
     private
+
+    def form_data
+      return {} if @readonly
+
+      {
+        controller: "admin--subject-configuration",
+        admin__subject_configuration_hide_pattern_input_value: subject_form_object.subject_configuration == :manual
+      }
+    end
 
     def enterprise?
       EnterpriseToken.allows_to?(:work_package_subject_generation)

--- a/app/components/work_package_types/wizard/page_component.html.erb
+++ b/app/components/work_package_types/wizard/page_component.html.erb
@@ -34,7 +34,8 @@
                   editor_form: step_editor_form,
                   heading: step_title
                 )
-              ) do %>
+              ) do |c| %>
+            <% c.with_readonly_preview { render(step_readonly_preview) } if step_readonly_preview %>
             <%= render(step_body) %>
           <% end %>
         <% else %>

--- a/app/components/work_package_types/wizard/page_component.rb
+++ b/app/components/work_package_types/wizard/page_component.rb
@@ -68,6 +68,16 @@ module WorkPackageTypes
         WorkflowsForm if current_step == :workflows
       end
 
+      # Only PDF has linked-to-parent behaviour among the wizard steps today; the others
+      # start Independent, so no other step has a source to preview.
+      def step_readonly_preview
+        return unless current_step == :pdf
+        return unless type.linked?(Type::ConfigurationLink::PDF_EXPORT)
+
+        source = type.effective_source_for(Type::ConfigurationLink::PDF_EXPORT)
+        WorkPackageTypes::ExportConfigurationComponent.new(source, readonly: true)
+      end
+
       # Editors that self-persist through their own turbo endpoints.
       def step_body
         case current_step

--- a/app/forms/work_package_types/artefact_export_form.rb
+++ b/app/forms/work_package_types/artefact_export_form.rb
@@ -38,12 +38,14 @@ module WorkPackageTypes
         group.radio_button(
           value: Type::ArtefactExport::OFF,
           checked: checked?(Type::ArtefactExport::OFF),
+          disabled: readonly?,
           label: I18n.t("types.edit.export_configuration.artefact_export.off_mode.label"),
           caption: I18n.t("types.edit.export_configuration.artefact_export.off_mode.caption")
         )
         group.radio_button(
           value: Type::ArtefactExport::ATTACHMENT,
           checked: checked?(Type::ArtefactExport::ATTACHMENT),
+          disabled: readonly?,
           label: I18n.t("types.edit.export_configuration.artefact_export.attachment.label"),
           caption: I18n.t("types.edit.export_configuration.artefact_export.attachment.caption")
         )
@@ -52,12 +54,14 @@ module WorkPackageTypes
           checked: checked?(Type::ArtefactExport::FILE_LINK),
           label: file_link_label,
           caption: I18n.t("types.edit.export_configuration.artefact_export.file_link.caption"),
-          disabled: !file_link_available?
+          disabled: readonly? || !file_link_available?
         )
       end
     end
 
     private
+
+    def readonly? = @builder.options[:readonly] == true
 
     def checked?(value)
       value == (model.artefact_export_mode.presence || Type::ArtefactExport::DEFAULT)

--- a/app/forms/work_package_types/subject_configuration_form.rb
+++ b/app/forms/work_package_types/subject_configuration_form.rb
@@ -37,6 +37,7 @@ module WorkPackageTypes
         group.radio_button(
           value: :manual,
           checked: subject_configuration_manual?,
+          disabled: readonly?,
           label: I18n.t("types.edit.subject_configuration.manually_editable_subjects.label"),
           caption: I18n.t("types.edit.subject_configuration.manually_editable_subjects.caption"),
           data: { action: "admin--subject-configuration#hidePatternInput" }
@@ -46,7 +47,7 @@ module WorkPackageTypes
           checked: !subject_configuration_manual?,
           label: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.label"),
           caption: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.caption"),
-          disabled: !enterprise?,
+          disabled: readonly? || !enterprise?,
           data: { action: "admin--subject-configuration#showPatternInput" }
         )
       end
@@ -55,7 +56,7 @@ module WorkPackageTypes
         toggleable_group.pattern_input(
           name: :pattern,
           value: model.pattern,
-          disabled: !enterprise?,
+          disabled: readonly? || !enterprise?,
           suggestions: model.suggestions,
           label: I18n.t("types.edit.subject_configuration.pattern.label"),
           caption: pattern_input_caption,
@@ -64,14 +65,18 @@ module WorkPackageTypes
         )
       end
 
-      subject_form.submit(
-        name: :submit,
-        label: I18n.t(:button_save),
-        scheme: :primary
-      )
+      unless readonly?
+        subject_form.submit(
+          name: :submit,
+          label: I18n.t(:button_save),
+          scheme: :primary
+        )
+      end
     end
 
     private
+
+    def readonly? = @builder.options[:readonly] == true
 
     def subject_configuration_manual?
       model.subject_configuration == :manual

--- a/app/views/work_package_types/pdf_export_template/edit.html.erb
+++ b/app/views/work_package_types/pdf_export_template/edit.html.erb
@@ -30,6 +30,12 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
-<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::PDF_EXPORT)) do %>
+<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::PDF_EXPORT)) do |c| %>
+  <% if @type.linked?(Type::ConfigurationLink::PDF_EXPORT) %>
+    <% c.with_readonly_preview do %>
+      <%= render WorkPackageTypes::ExportConfigurationComponent
+                   .new(@type.effective_source_for(Type::ConfigurationLink::PDF_EXPORT), readonly: true) %>
+    <% end %>
+  <% end %>
   <%= render WorkPackageTypes::ExportConfigurationComponent.new(@type) %>
 <% end %>

--- a/app/views/work_package_types/subject_configuration_tab/edit.html.erb
+++ b/app/views/work_package_types/subject_configuration_tab/edit.html.erb
@@ -30,7 +30,13 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
-<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::PATTERNS)) do %>
+<%= render(WorkPackageTypes::ConfigurationLinkComponent.new(type: @type, aspect: Type::ConfigurationLink::PATTERNS)) do |c| %>
+  <% if @type.linked?(Type::ConfigurationLink::PATTERNS) %>
+    <% c.with_readonly_preview do %>
+      <%= render WorkPackageTypes::SubjectConfigurationComponent
+                   .new(@type.effective_source_for(Type::ConfigurationLink::PATTERNS), readonly: true) %>
+    <% end %>
+  <% end %>
   <%= render WorkPackageTypes::SubjectConfigurationComponent
                .new(@type, subject_configuration_form_data: params[:work_package_types_forms_subject_configuration_form_model]) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6045,6 +6045,9 @@ en:
           caption: "These settings are reused from a source type and stay in sync with it. To change them, edit the source type."
           label: "Linked"
           warning: "Linking replaces this type's own settings with the source type's. The current settings are discarded and work packages of this type may be affected. Please proceed with caution."
+        reference:
+          edit_at_source: "Edit at source"
+          reusing: "Configuration reused from %{source}."
         source:
           label: "Source type"
       export_configuration:

--- a/spec/components/work_package_types/configuration_link_component_spec.rb
+++ b/spec/components/work_package_types/configuration_link_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::ConfigurationLinkComponent, type: :component do
+  let(:source) { create(:type, name: "Phase") }
+  let(:type) { create(:type) }
+
+  before do
+    allow(OpenProject::FeatureDecisions).to receive(:subtypes_active?).and_return(true)
+    login_as(create(:admin))
+  end
+
+  context "when the aspect is linked" do
+    before { type.link!(Type::ConfigurationLink::PATTERNS, source:) }
+
+    it "renders the source reference and the readonly preview slot", :aggregate_failures do
+      render_inline(described_class.new(type:, aspect: Type::ConfigurationLink::PATTERNS)) do |c|
+        c.with_readonly_preview { "PREVIEW_MARKER" }
+      end
+
+      expect(page).to have_text("Configuration reused from Phase")
+      expect(page).to have_text("PREVIEW_MARKER")
+    end
+  end
+
+  context "when the aspect is independent" do
+    it "does not render the readonly preview" do
+      render_inline(described_class.new(type:, aspect: Type::ConfigurationLink::PATTERNS)) do |c|
+        c.with_readonly_preview { "PREVIEW_MARKER" }
+      end
+
+      expect(page).to have_no_text("PREVIEW_MARKER")
+    end
+  end
+end

--- a/spec/components/work_package_types/export_configuration_component_spec.rb
+++ b/spec/components/work_package_types/export_configuration_component_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe WorkPackageTypes::ExportConfigurationComponent, type: :component 
       expect(page).to have_no_css("[data-test-selector='enable-all-pdf-export-templates']")
       expect(page).to have_no_css("[data-test-selector='disable-all-pdf-export-templates']")
     end
+
+    it "renders the inherited artefact export mode as disabled radios" do
+      render_inline(described_class.new(type, readonly: true))
+
+      expect(page.find("input[type=radio][value='#{Type::ArtefactExport::OFF}']")).to be_disabled
+    end
   end
 
   context "when editable (default)" do
@@ -47,6 +53,12 @@ RSpec.describe WorkPackageTypes::ExportConfigurationComponent, type: :component 
       render_inline(described_class.new(type))
 
       expect(page).to have_css("[data-test-selector='enable-all-pdf-export-templates']")
+    end
+
+    it "renders the artefact export mode as editable radios" do
+      render_inline(described_class.new(type))
+
+      expect(page.find("input[type=radio][value='#{Type::ArtefactExport::OFF}']")).not_to be_disabled
     end
   end
 end

--- a/spec/components/work_package_types/export_configuration_component_spec.rb
+++ b/spec/components/work_package_types/export_configuration_component_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,47 +26,27 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module WorkPackageTypes
-  class ExportTemplateListComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
-    include OpTurbo::Streamable
+require "rails_helper"
 
-    def initialize(type:, readonly: false)
-      super
+RSpec.describe WorkPackageTypes::ExportConfigurationComponent, type: :component do
+  let(:type) { create(:type) }
 
-      @type = type
-      @readonly = readonly
+  context "when readonly" do
+    it "hides the enable-all / disable-all actions", :aggregate_failures do
+      render_inline(described_class.new(type, readonly: true))
+
+      expect(page).to have_no_css("[data-test-selector='enable-all-pdf-export-templates']")
+      expect(page).to have_no_css("[data-test-selector='disable-all-pdf-export-templates']")
     end
+  end
 
-    def readonly? = @readonly
+  context "when editable (default)" do
+    it "shows the enable-all action" do
+      render_inline(described_class.new(type))
 
-    def wrapper_data_attributes
-      return {} if @readonly
-
-      {
-        controller: "generic-drag-and-drop"
-      }
-    end
-
-    def drag_and_drop_target_config
-      {
-        generic_drag_and_drop_target: "container",
-        "target-container-accessor": ":scope > ul",
-        "target-allowed-drag-type": "template",
-        test_selector: "pdf-export-template-rows"
-      }
-    end
-
-    def draggable_item_config(template)
-      {
-        "draggable-id": template.id,
-        "draggable-type": "template",
-        "drop-url": drop_type_pdf_export_template_path(type_id: @type.id, id: template.id),
-        test_selector: "pdf-export-template-row-#{template.id}"
-      }
+      expect(page).to have_css("[data-test-selector='enable-all-pdf-export-templates']")
     end
   end
 end

--- a/spec/components/work_package_types/export_template_row_component_spec.rb
+++ b/spec/components/work_package_types/export_template_row_component_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,47 +26,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module WorkPackageTypes
-  class ExportTemplateListComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
-    include OpTurbo::Streamable
+require "rails_helper"
 
-    def initialize(type:, readonly: false)
-      super
+RSpec.describe WorkPackageTypes::ExportTemplateRowComponent, type: :component do
+  let(:type) { create(:type) }
+  let(:template) { Type::PdfExportTemplates::Template.new(id: 1, label: "Full", caption: "A4", enabled: true) }
 
-      @type = type
-      @readonly = readonly
+  context "when readonly" do
+    it "renders the toggle as a disabled, non-interactive switch", :aggregate_failures do
+      render_inline(described_class.new(type:, template:, readonly: true))
+
+      expect(page).to have_css("[data-test-selector='toggle-pdf-export-template-row-1']")
+      expect(page).to have_css(".ToggleSwitch--disabled")
+      expect(page).to have_no_css("[data-turbo-method]")
     end
+  end
 
-    def readonly? = @readonly
+  context "when editable (default)" do
+    it "renders an interactive toggle switch", :aggregate_failures do
+      render_inline(described_class.new(type:, template:))
 
-    def wrapper_data_attributes
-      return {} if @readonly
-
-      {
-        controller: "generic-drag-and-drop"
-      }
-    end
-
-    def drag_and_drop_target_config
-      {
-        generic_drag_and_drop_target: "container",
-        "target-container-accessor": ":scope > ul",
-        "target-allowed-drag-type": "template",
-        test_selector: "pdf-export-template-rows"
-      }
-    end
-
-    def draggable_item_config(template)
-      {
-        "draggable-id": template.id,
-        "draggable-type": "template",
-        "drop-url": drop_type_pdf_export_template_path(type_id: @type.id, id: template.id),
-        test_selector: "pdf-export-template-row-#{template.id}"
-      }
+      expect(page).to have_css("[data-test-selector='toggle-pdf-export-template-row-1']")
+      expect(page).to have_no_css(".ToggleSwitch--disabled")
     end
   end
 end

--- a/spec/components/work_package_types/linked_source_reference_component_spec.rb
+++ b/spec/components/work_package_types/linked_source_reference_component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::LinkedSourceReferenceComponent, type: :component do
+  let(:source) { build_stubbed(:type, name: "Phase") }
+  let(:link_path) { "/types/1/subject_configuration/edit" }
+
+  it "names the source and links to it for an admin", :aggregate_failures do
+    login_as(build_stubbed(:admin))
+    render_inline(described_class.new(source:, link_path:))
+
+    expect(page).to have_text("Configuration reused from Phase")
+    expect(page).to have_link("Edit at source", href: link_path)
+  end
+
+  it "omits the link when the user is not an admin" do
+    login_as(build_stubbed(:user))
+    render_inline(described_class.new(source:, link_path:))
+
+    expect(page).to have_no_link("Edit at source")
+  end
+
+  it "omits the link when no path is given" do
+    login_as(build_stubbed(:admin))
+    render_inline(described_class.new(source:))
+
+    expect(page).to have_no_link("Edit at source")
+  end
+end

--- a/spec/components/work_package_types/subject_configuration_component_spec.rb
+++ b/spec/components/work_package_types/subject_configuration_component_spec.rb
@@ -128,6 +128,26 @@ RSpec.describe WorkPackageTypes::SubjectConfigurationComponent, type: :component
     end
   end
 
+  context "when readonly", with_ee: %i[work_package_subject_generation] do
+    subject(:render_readonly) { render_inline(described_class.new(type, readonly: true)) }
+
+    let(:type) { create(:type, patterns: { subject: { blueprint: "Created by {{assignee}}", enabled: true } }) }
+
+    it "disables the mode selectors and hides the save button", :aggregate_failures do
+      render_readonly
+
+      expect(page.find("input[type=radio][value=generated]")).to be_disabled
+      expect(page.find("input[type=radio][value=manual]")).to be_disabled
+      expect(page).to have_no_button("Save")
+    end
+
+    it "shows no enterprise banner" do
+      render_readonly
+
+      expect(page).not_to have_enterprise_banner
+    end
+  end
+
   private
 
   def hidden_input_field_selector

--- a/spec/components/work_package_types/wizard/page_component_spec.rb
+++ b/spec/components/work_package_types/wizard/page_component_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,47 +26,22 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module WorkPackageTypes
-  class ExportTemplateListComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
-    include OpTurbo::Streamable
+require "rails_helper"
 
-    def initialize(type:, readonly: false)
-      super
+RSpec.describe WorkPackageTypes::Wizard::PageComponent, type: :component, with_flag: { subtypes: true } do
+  let(:parent) { create(:type, name: "Phase") }
+  let(:type) { create(:type) }
 
-      @type = type
-      @readonly = readonly
-    end
+  before do
+    login_as(create(:admin))
+    type.link!(Type::ConfigurationLink::PDF_EXPORT, source: parent)
+  end
 
-    def readonly? = @readonly
+  it "shows the read-only PDF preview on the pdf step" do
+    render_inline(described_class.new(type:, current_step: :pdf))
 
-    def wrapper_data_attributes
-      return {} if @readonly
-
-      {
-        controller: "generic-drag-and-drop"
-      }
-    end
-
-    def drag_and_drop_target_config
-      {
-        generic_drag_and_drop_target: "container",
-        "target-container-accessor": ":scope > ul",
-        "target-allowed-drag-type": "template",
-        test_selector: "pdf-export-template-rows"
-      }
-    end
-
-    def draggable_item_config(template)
-      {
-        "draggable-id": template.id,
-        "draggable-type": "template",
-        "drop-url": drop_type_pdf_export_template_path(type_id: @type.id, id: template.id),
-        test_selector: "pdf-export-template-row-#{template.id}"
-      }
-    end
+    expect(page).to have_text("Configuration reused from Phase")
   end
 end

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -104,6 +104,20 @@ RSpec.describe "Work package type configuration source",
     end
   end
 
+  describe "read-only preview of a Linked aspect" do
+    it "shows the inherited subject pattern and links to the source" do
+      source.update!(patterns: { subject: { blueprint: "PR-{{id}}", enabled: true } })
+      type.link!(Type::ConfigurationLink::PATTERNS, source:)
+
+      get edit_type_subject_configuration_path(type_id: type.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Configuration reused from")
+      expect(response.body).to include("PR-{{id}}")
+      expect(response.body).to include(edit_type_subject_configuration_path(source))
+    end
+  end
+
   describe "PATCH update (link)" do
     it "links the aspect to the chosen source" do
       patch type_aspect_configuration_link_path(type, aspect),

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -86,13 +86,15 @@ RSpec.describe "Work package type configuration source",
       expect(response.body).to include("The current settings are discarded and work packages of this type may be affected.")
     end
 
-    it "hides the editor and shows the source picker when Linked" do
+    it "shows the source picker and a read-only preview instead of the editable editor when Linked" do
       type.link!(Type::ConfigurationLink::PDF_EXPORT, source:)
 
       get edit_type_pdf_export_template_index_path(type_id: type.id)
 
       expect(response.body).to include("Source type")
-      expect(response.body).not_to include("PDF Export templates")
+      expect(response.body).to include("Configuration reused from")
+      # the preview lists the templates but drops the editable enable/disable actions
+      expect(response.body).not_to include("enable-all-pdf-export-templates")
     end
 
     it "explains the copy-on-adopt when a Linked type may switch to Independent" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/FND-132

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

When a work-package type's subject or PDF export configuration is *Linked* to a source type, the tab previously showed nothing about the inherited configuration — only the Independent/Linked toggle and the source picker. This makes the reused configuration visible: the tab now renders the inherited subject pattern / PDF export templates **read-only**, alongside a link to the source type where they can be edited.

Applies to both the subject and PDF tabs, and to the PDF step of the sub-type creation wizard.

Stacked on FND-133 (#24236) — this PR's base is the FND-133 branch, so it should be merged after it.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The read-only view reuses the existing editor components in a new `readonly:` mode rather than duplicating their layout, so the reference stays visually in sync with the editable form. The editors are fed the resolved source type (`Type#effective_source_for(aspect)`) as their model, so they render the inherited values without knowing anything about linking.

The shared mechanism lands in the first commit: a `readonly_preview` slot on `ConfigurationLinkComponent`, rendered in its Linked branch and shown while the "Linked" radio is selected (reusing the existing `show-when-value-selected` behaviour), plus a `LinkedSourceReferenceComponent` for the "reused from …" line and source link. The second commit reuses all of it for the PDF aspect, so the two commits read as "paving the way" (subject) then "following the way" (PDF). The third commit integrates the artefact-export feature that landed on `dev` mid-flight.

The source link is guarded on permission (admin-only today) — forward protection for when project-specific sub-types exist and a project admin may not be able to view the source type. The preview reflects the persisted source and does not live-update as the picker changes; that was deliberately left out of scope.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
