### PR TITLE
[SPPM-318] Missing enterprise check on portfolio and program filter

### DIFF
--- a/app/models/queries/projects/filters/ancestor_workspace_type_filter.rb
+++ b/app/models/queries/projects/filters/ancestor_workspace_type_filter.rb
@@ -44,6 +44,7 @@ module Queries::Projects::Filters::AncestorWorkspaceTypeFilter
   def where = nil
 
   def available?
+    (self.class.key == :project || EnterpriseToken.allows_to?(:portfolio_management)) &&
     Project.workspace_type(self.class.key.to_s).visible.exists?
   end
 

--- a/app/models/queries/projects/filters/ancestor_workspace_type_filter.rb
+++ b/app/models/queries/projects/filters/ancestor_workspace_type_filter.rb
@@ -44,7 +44,7 @@ module Queries::Projects::Filters::AncestorWorkspaceTypeFilter
   def where = nil
 
   def available?
-    (self.class.key == :project || EnterpriseToken.allows_to?(:portfolio_management)) &&
+    EnterpriseToken.allows_to?(:portfolio_management) &&
     Project.workspace_type(self.class.key.to_s).visible.exists?
   end
 

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -670,41 +670,53 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
   end
 
   describe "portfolio filter" do
-    context "when a portfolio is visible to the user" do
-      shared_let(:portfolio) { create(:portfolio, name: "Corporate Portfolio") }
-      shared_let(:other_portfolio) { create(:portfolio, name: "Consumer Portfolio") }
-      shared_let(:program) { create(:program, name: "Growth Program", parent: portfolio) }
-      shared_let(:portfolio_child) { create(:project, name: "Growth Initiative", parent: program) }
+    context "with EE", with_ee: %i[portfolio_management] do
+      context "when a portfolio is visible to the user" do
+        shared_let(:portfolio) { create(:portfolio, name: "Corporate Portfolio") }
+        shared_let(:other_portfolio) { create(:portfolio, name: "Consumer Portfolio") }
+        shared_let(:program) { create(:program, name: "Growth Program", parent: portfolio) }
+        shared_let(:portfolio_child) { create(:project, name: "Growth Initiative", parent: program) }
 
-      it "offers only portfolios in the autocomplete and filters for their descendants" do
-        load_and_open_filters admin
+        it "offers only portfolios in the autocomplete and filters for their descendants" do
+          load_and_open_filters admin
 
-        projects_page.expect_filter_available("Portfolio")
+          projects_page.expect_filter_available("Portfolio")
 
-        selected_filter = projects_page.select_filter("portfolio", "Portfolio")
-        within(selected_filter) { find('[data-filter-autocomplete="true"]').click }
+          selected_filter = projects_page.select_filter("portfolio", "Portfolio")
+          within(selected_filter) { find('[data-filter-autocomplete="true"]').click }
 
-        projects_page.expect_ng_option(selected_filter, portfolio.name)
-        projects_page.expect_ng_option(selected_filter, other_portfolio.name)
-        projects_page.expect_no_ng_option(selected_filter, program.name)
-        projects_page.expect_no_ng_option(selected_filter, project.name)
+          projects_page.expect_ng_option(selected_filter, portfolio.name)
+          projects_page.expect_ng_option(selected_filter, other_portfolio.name)
+          projects_page.expect_no_ng_option(selected_filter, program.name)
+          projects_page.expect_no_ng_option(selected_filter, project.name)
 
-        projects_page.set_filter("portfolio", "Portfolio", "is (OR)", [portfolio.name])
+          projects_page.set_filter("portfolio", "Portfolio", "is (OR)", [portfolio.name])
 
-        wait_for_network_idle
+          wait_for_network_idle
 
-        projects_page.expect_projects_listed(program, portfolio_child)
-        projects_page.expect_projects_not_listed(portfolio, other_portfolio,
-                                                 project, public_project,
-                                                 development_project)
+          projects_page.expect_projects_listed(program, portfolio_child)
+          projects_page.expect_projects_not_listed(portfolio, other_portfolio,
+                                                   project, public_project,
+                                                   development_project)
+        end
+      end
+
+      context "when no portfolio is visible to the user" do
+        shared_let(:invisible_portfolio) { create(:portfolio) }
+
+        it "does not offer the filter" do
+          load_and_open_filters manager
+
+          projects_page.expect_filter_not_available("Portfolio")
+        end
       end
     end
 
-    context "when no portfolio is visible to the user" do
-      shared_let(:invisible_portfolio) { create(:portfolio) }
+    context "without EE", without_ee: %i[portfolio_management] do
+      shared_let(:portfolio) { create(:portfolio, name: "Corporate Portfolio") }
 
       it "does not offer the filter" do
-        load_and_open_filters manager
+        load_and_open_filters admin
 
         projects_page.expect_filter_not_available("Portfolio")
       end
@@ -712,43 +724,55 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
   end
 
   describe "program filter" do
-    context "when a program is visible to the user" do
-      # portfolio is intentionally unrelated to program: were it its parent, the autocompleter
-      # would legitimately display it as a disabled ancestor entry for tree context.
-      shared_let(:portfolio) { create(:portfolio, name: "Corporate Portfolio") }
-      shared_let(:program) { create(:program, name: "Growth Program") }
-      shared_let(:other_program) { create(:program, name: "Retention Program") }
-      shared_let(:program_child) { create(:project, name: "Growth Initiative", parent: program) }
+    context "with EE", with_ee: %i[portfolio_management] do
+      context "when a program is visible to the user" do
+        # portfolio is intentionally unrelated to program: were it its parent, the autocompleter
+        # would legitimately display it as a disabled ancestor entry for tree context.
+        shared_let(:portfolio) { create(:portfolio, name: "Corporate Portfolio") }
+        shared_let(:program) { create(:program, name: "Growth Program") }
+        shared_let(:other_program) { create(:program, name: "Retention Program") }
+        shared_let(:program_child) { create(:project, name: "Growth Initiative", parent: program) }
 
-      it "offers only programs in the autocomplete and filters for their descendants" do
-        load_and_open_filters admin
+        it "offers only programs in the autocomplete and filters for their descendants" do
+          load_and_open_filters admin
 
-        projects_page.expect_filter_available("Program")
+          projects_page.expect_filter_available("Program")
 
-        selected_filter = projects_page.select_filter("program", "Program")
-        within(selected_filter) { find('[data-filter-autocomplete="true"]').click }
+          selected_filter = projects_page.select_filter("program", "Program")
+          within(selected_filter) { find('[data-filter-autocomplete="true"]').click }
 
-        projects_page.expect_ng_option(selected_filter, program.name)
-        projects_page.expect_ng_option(selected_filter, other_program.name)
-        projects_page.expect_no_ng_option(selected_filter, portfolio.name)
-        projects_page.expect_no_ng_option(selected_filter, project.name)
+          projects_page.expect_ng_option(selected_filter, program.name)
+          projects_page.expect_ng_option(selected_filter, other_program.name)
+          projects_page.expect_no_ng_option(selected_filter, portfolio.name)
+          projects_page.expect_no_ng_option(selected_filter, project.name)
 
-        projects_page.set_filter("program", "Program", "is (OR)", [program.name])
+          projects_page.set_filter("program", "Program", "is (OR)", [program.name])
 
-        wait_for_network_idle
+          wait_for_network_idle
 
-        projects_page.expect_projects_listed(program_child)
-        projects_page.expect_projects_not_listed(portfolio, program,
-                                                 other_program, project,
-                                                 public_project, development_project)
+          projects_page.expect_projects_listed(program_child)
+          projects_page.expect_projects_not_listed(portfolio, program,
+                                                   other_program, project,
+                                                   public_project, development_project)
+        end
+      end
+
+      context "when no program is visible to the user" do
+        shared_let(:invisible_program) { create(:program) }
+
+        it "does not offer the filter" do
+          load_and_open_filters manager
+
+          projects_page.expect_filter_not_available("Program")
+        end
       end
     end
 
-    context "when no program is visible to the user" do
-      shared_let(:invisible_program) { create(:program) }
+    context "without EE", without_ee: %i[portfolio_management] do
+      shared_let(:program) { create(:program, name: "Growth Program") }
 
       it "does not offer the filter" do
-        load_and_open_filters manager
+        load_and_open_filters admin
 
         projects_page.expect_filter_not_available("Program")
       end

--- a/spec/models/queries/projects/filters/portfolio_filter_spec.rb
+++ b/spec/models/queries/projects/filters/portfolio_filter_spec.rb
@@ -67,30 +67,41 @@ RSpec.describe Queries::Projects::Filters::PortfolioFilter do
   end
 
   describe "#available?" do
-    it "is true if any portfolio is visible to the current user" do
+    let(:portfolio_exists) { true }
+
+    before do
       allow(Project)
         .to receive_message_chain(:workspace_type, :visible, :exists?) # rubocop:disable RSpec/MessageChain
         .with("portfolio")
         .with(no_args)
         .with(no_args)
-        .and_return(true)
-
-      instance = described_class.create!(name: :portfolio, operator: "=", values: [])
-
-      expect(instance).to be_available
+        .and_return(portfolio_exists)
     end
 
-    it "is false if no portfolio is visible to the current user" do
-      allow(Project)
-        .to receive_message_chain(:workspace_type, :visible, :exists?) # rubocop:disable RSpec/MessageChain
-        .with("portfolio")
-        .with(no_args)
-        .with(no_args)
-        .and_return(false)
+    context "with EE", with_ee: %i[portfolio_management] do
+      it "is true if any portfolio is visible to the current user" do
+        instance = described_class.create!(name: :portfolio, operator: "=", values: [])
 
-      instance = described_class.create!(name: :portfolio, operator: "=", values: [])
+        expect(instance).to be_available
+      end
 
-      expect(instance).not_to be_available
+      context "when no portfolio is visible to the current user" do
+        let(:portfolio_exists) { false }
+
+        it "is false" do
+          instance = described_class.create!(name: :portfolio, operator: "=", values: [])
+
+          expect(instance).not_to be_available
+        end
+      end
+    end
+
+    context "without EE", without_ee: %i[portfolio_management] do
+      it "is false" do
+        instance = described_class.create!(name: :portfolio, operator: "=", values: [])
+
+        expect(instance).not_to be_available
+      end
     end
   end
 

--- a/spec/models/queries/projects/filters/program_filter_spec.rb
+++ b/spec/models/queries/projects/filters/program_filter_spec.rb
@@ -67,30 +67,41 @@ RSpec.describe Queries::Projects::Filters::ProgramFilter do
   end
 
   describe "#available?" do
-    it "is true if any program is visible to the current user" do
+    let(:program_exists) { true }
+
+    before do
       allow(Project)
         .to receive_message_chain(:workspace_type, :visible, :exists?) # rubocop:disable RSpec/MessageChain
         .with("program")
         .with(no_args)
         .with(no_args)
-        .and_return(true)
-
-      instance = described_class.create!(name: :program, operator: "=", values: [])
-
-      expect(instance).to be_available
+        .and_return(program_exists)
     end
 
-    it "is false if no program is visible to the current user" do
-      allow(Project)
-        .to receive_message_chain(:workspace_type, :visible, :exists?) # rubocop:disable RSpec/MessageChain
-        .with("program")
-        .with(no_args)
-        .with(no_args)
-        .and_return(false)
+    context "with EE", with_ee: %i[portfolio_management] do
+      it "is true if any program is visible to the current user" do
+        instance = described_class.create!(name: :program, operator: "=", values: [])
 
-      instance = described_class.create!(name: :program, operator: "=", values: [])
+        expect(instance).to be_available
+      end
 
-      expect(instance).not_to be_available
+      context "when no program is visible to the current user" do
+        let(:program_exists) { false }
+
+        it "is false" do
+          instance = described_class.create!(name: :program, operator: "=", values: [])
+
+          expect(instance).not_to be_available
+        end
+      end
+    end
+
+    context "without EE", without_ee: %i[portfolio_management] do
+      it "is false" do
+        instance = described_class.create!(name: :program, operator: "=", values: [])
+
+        expect(instance).not_to be_available
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-318

# What are you trying to accomplish?
Add missing enterprise check for program and portfolio filters.

# What approach did you choose and why?

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
