### PR TITLE
Bug/agile 349 address remaining open points

### DIFF
--- a/modules/backlogs/app/components/projects/settings/backlogs/multiple_active_sprints_component.html.erb
+++ b/modules/backlogs/app/components/projects/settings/backlogs/multiple_active_sprints_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% if available? %>
+<% if setting_available? %>
   <% if too_many_active_sprints? %>
     <%=
       flex_layout(mb: 3, color: :attention) do |flex|

--- a/modules/backlogs/app/components/projects/settings/backlogs/multiple_active_sprints_component.rb
+++ b/modules/backlogs/app/components/projects/settings/backlogs/multiple_active_sprints_component.rb
@@ -44,16 +44,14 @@ module Projects
 
         attr_reader :project
 
-        def available?
-          return @available if defined?(@available)
+        def setting_available?
+          return @setting_available if defined?(@setting_available)
 
-          @available = project.not_sharing_sprints?
+          @setting_available = project.not_sharing_sprints?
         end
 
         def enabled?
-          return @enabled if defined?(@enabled)
-
-          @enabled = !too_many_active_sprints?
+          !too_many_active_sprints?
         end
 
         def checked?
@@ -65,7 +63,7 @@ module Projects
         def too_many_active_sprints?
           return @too_many_active_sprints if defined?(@too_many_active_sprints)
 
-          @too_many_active_sprints = checked? && project.sprints.active.many?
+          @too_many_active_sprints = checked? && project.many_active_sprints?
         end
       end
     end

--- a/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.html.erb
+++ b/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.html.erb
@@ -37,30 +37,14 @@ See COPYRIGHT and LICENSE files for more details.
     )
 
     header.with_tab_nav(label: nil) do |tab_nav|
-      tab_nav.with_tab(
-        selected: selected_tab?(:types_and_statuses),
-        href: project_settings_backlogs_path(project),
-        data: { turbo_action: "advance" }
-      ) do |t|
-        t.with_text { t("backlogs.types_and_statuses") }
-      end
-
-      if User.current.allowed_in_project?(:share_sprint, project)
+      tabs.each do |tab|
         tab_nav.with_tab(
-          selected: selected_tab?(:sharing),
-          href: project_settings_backlog_sharing_path(project),
+          selected: selected_tab?(tab[:key]),
+          href: tab[:href],
           data: { turbo_action: "advance" }
-        ) do |t|
-          t.with_text { t("backlogs.sharing") }
+        ) do |tab_item|
+          tab_item.with_text { tab[:label] }
         end
-      end
-
-      tab_nav.with_tab(
-        selected: selected_tab?(:multiple_active_sprints),
-        href: project_settings_backlog_multiple_active_sprints_path(project),
-        data: { turbo_action: "advance" }
-      ) do |t|
-        t.with_text { t("backlogs.multiple_active_sprints") }
       end
     end
 

--- a/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.rb
+++ b/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.rb
@@ -45,6 +45,28 @@ module Projects
           selected_tab == tab_name
         end
 
+        def tabs
+          [
+            {
+              key: :types_and_statuses,
+              href: project_settings_backlogs_path(project),
+              label: t("backlogs.types_and_statuses")
+            },
+            (if User.current.allowed_in_project?(:share_sprint, project)
+               {
+                 key: :sharing,
+                 href: project_settings_backlog_sharing_path(project),
+                 label: t("backlogs.sharing")
+               }
+             end),
+            {
+              key: :multiple_active_sprints,
+              href: project_settings_backlog_multiple_active_sprints_path(project),
+              label: t("backlogs.multiple_active_sprints")
+            }
+          ].compact
+        end
+
         private
 
         attr_reader :project, :selected_tab

--- a/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.rb
+++ b/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.rb
@@ -59,11 +59,13 @@ module Projects
                  label: t("backlogs.sharing")
                }
              end),
-            {
-              key: :multiple_active_sprints,
-              href: project_settings_backlog_multiple_active_sprints_path(project),
-              label: t("backlogs.multiple_active_sprints")
-            }
+            (if User.current.allowed_in_project?(:share_sprint, project)
+               {
+                 key: :multiple_active_sprints,
+                 href: project_settings_backlog_multiple_active_sprints_path(project),
+                 label: t("backlogs.multiple_active_sprints")
+               }
+             end)
           ].compact
         end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
@@ -44,4 +44,8 @@ module OpenProject::Backlogs::Patches::ProjectPatch
   def backlogs_enabled?
     module_enabled? "backlogs"
   end
+
+  def many_active_sprints?
+    sprints.active.many?
+  end
 end

--- a/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
       it_behaves_like "contract is invalid", allow_multiple_active_sprints: :requires_no_sharing
     end
 
-    context "when sprint_sharing is changed while allow_multiple_active_sprints is enabled" do
+    context "when sprint_sharing is changed to 'share_subprojects' while allow_multiple_active_sprints is enabled" do
       let(:project) { create(:project, allow_multiple_active_sprints: true) }
 
       before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
@@ -241,8 +241,32 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
       it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
     end
 
+    context "when sprint_sharing is changed to 'share_all_projects' while allow_multiple_active_sprints is enabled" do
+      let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+      before { project.sprint_sharing = Project::SHARE_ALL_PROJECTS }
+
+      it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+    end
+
+    context "when sprint_sharing is changed to 'receive_shared' while allow_multiple_active_sprints is enabled" do
+      let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+      before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+      it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+    end
+
     context "when sprint_sharing is unchanged while allow_multiple_active_sprints is enabled" do
       let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when sprint_sharing is explicitly set to its current value while allow_multiple_active_sprints is enabled" do
+      let(:project) { create(:project, allow_multiple_active_sprints: true, sprint_sharing: Project::NO_SHARING) }
+
+      before { project.sprint_sharing = Project::NO_SHARING }
 
       it_behaves_like "contract is valid"
     end

--- a/modules/backlogs/spec/contracts/backlogs/sprints/start_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/sprints/start_contract_spec.rb
@@ -29,8 +29,11 @@
 #++
 
 require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
 
 RSpec.describe Backlogs::Sprints::StartContract do
+  include_context "ModelContract shared context"
+
   let(:project) { create(:project) }
   let(:user) { create(:user) }
   let(:sprint) do
@@ -51,87 +54,59 @@ RSpec.describe Backlogs::Sprints::StartContract do
 
   describe "validation" do
     context "with valid sprint and permissions" do
-      it "is valid" do
-        expect(contract.validate).to be(true)
-      end
+      it_behaves_like "contract is valid"
     end
 
     context "without start_complete_sprint permission" do
       let(:permissions) { [:view_work_packages] }
 
-      it "is invalid" do
-        expect(contract.validate).to be(false)
-        expect(contract.errors.symbols_for(:base)).to include(:error_unauthorized)
-      end
+      it_behaves_like "contract user is unauthorized"
     end
 
     context "when sprint is active" do
       let(:sprint_status) { "active" }
 
-      it "is invalid" do
-        expect(contract.validate).to be(false)
-        expect(contract.errors.symbols_for(:status)).to include(:must_be_in_planning)
-      end
+      it_behaves_like "contract is invalid", status: :must_be_in_planning
     end
 
     context "when sprint is completed" do
       let(:sprint_status) { "completed" }
 
-      it "is invalid" do
-        expect(contract.validate).to be(false)
-        expect(contract.errors.symbols_for(:status)).to include(:must_be_in_planning)
-      end
+      it_behaves_like "contract is invalid", status: :must_be_in_planning
     end
 
     context "when the sprint has no start date" do
       let(:sprint) { create(:sprint, project:, status: sprint_status, start_date: nil) }
 
-      it "is invalid" do
-        expect(contract.validate).to be(false)
-        expect(contract.errors.symbols_for(:base)).to include(:dates_required)
-      end
+      it_behaves_like "contract is invalid", base: :dates_required
     end
 
     context "when the sprint has no finish date" do
       let(:sprint) { create(:sprint, project:, status: sprint_status, finish_date: nil) }
 
-      it "is invalid" do
-        expect(contract.validate).to be(false)
-        expect(contract.errors.symbols_for(:base)).to include(:dates_required)
-      end
+      it_behaves_like "contract is invalid", base: :dates_required
     end
 
     context "when another active sprint exists in the project" do
       before do
-        create(:sprint,
-               project:,
-               status: "active")
+        create(:sprint, project:, status: "active")
       end
 
-      it "is invalid" do
-        expect(contract.validate).to be(false)
-        expect(contract.errors.symbols_for(:status)).to include(:only_one_active_sprint_allowed)
-      end
+      it_behaves_like "contract is invalid", status: :only_one_active_sprint_allowed
 
       context "when the project allows multiple active sprints" do
         before { project.update!(allow_multiple_active_sprints: true) }
 
-        it "is valid" do
-          expect(contract.validate).to be(true)
-        end
+        it_behaves_like "contract is valid"
       end
     end
 
     context "when an active sprint exists in a different project" do
       before do
-        create(:sprint,
-               project: create(:project),
-               status: "active")
+        create(:sprint, project: create(:project), status: "active")
       end
 
-      it "is valid" do
-        expect(contract.validate).to be(true)
-      end
+      it_behaves_like "contract is valid"
     end
   end
 end

--- a/modules/backlogs/spec/features/projects/settings/backlog_multiple_active_sprints_settings_spec.rb
+++ b/modules/backlogs/spec/features/projects/settings/backlog_multiple_active_sprints_settings_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Backlogs project settings multiple active sprints", :js do
     visit project_settings_backlog_multiple_active_sprints_path(project)
 
     expect(page).to have_link(
-      I18n.t("backlogs.multiple_active_sprints"),
+      "Multiple active sprints",
       href: project_settings_backlog_multiple_active_sprints_path(project)
     )
   end
@@ -64,20 +64,47 @@ RSpec.describe "Backlogs project settings multiple active sprints", :js do
         expect(page).to have_no_text("not available")
       end
 
+      context "when toggling on" do
+        it "enables the setting" do
+          visit project_settings_backlog_multiple_active_sprints_path(project)
+
+          expect(page).to have_css(".ToggleSwitch")
+          expect(page).to have_no_css(".ToggleSwitch--checked")
+          find(".ToggleSwitch").click
+          expect(page).to have_css(".ToggleSwitch--checked")
+
+          expect(project.reload.allow_multiple_active_sprints).to be(true)
+        end
+      end
+
+      context "when toggling off" do
+        before { project.update!(allow_multiple_active_sprints: true) }
+
+        it "disables the setting" do
+          visit project_settings_backlog_multiple_active_sprints_path(project)
+
+          expect(page).to have_css(".ToggleSwitch--checked")
+          find(".ToggleSwitch").click
+          expect(page).to have_no_css(".ToggleSwitch--checked")
+
+          expect(project.reload.allow_multiple_active_sprints).to be(false)
+        end
+      end
+
       context "when multiple active sprints is already enabled and multiple sprints are active" do
         before do
           project.update!(allow_multiple_active_sprints: true)
-          create(:sprint, project:, status: "active", start_date: Date.yesterday, finish_date: Date.tomorrow)
-          create(:sprint, project:, status: "active", start_date: Date.yesterday, finish_date: Date.tomorrow)
+          create(:sprint, project:, status: "active",
+                          start_date: Time.zone.today - 1, finish_date: Time.zone.today + 1)
+          create(:sprint, project:, status: "active",
+                          start_date: Time.zone.today - 1, finish_date: Time.zone.today + 1)
         end
 
         it "renders the toggle disabled with a warning" do
           visit project_settings_backlog_multiple_active_sprints_path(project)
 
           expect(page).to have_css(".ToggleSwitch--disabled")
-          expect(page).to have_text(
-            I18n.t("projects.settings.backlogs.multiple_active_sprints_component.cannot_turn_off")
-          )
+          expect(page).to have_text("Multiple sprints are currently active")
         end
       end
     end

--- a/modules/backlogs/spec/features/projects/settings/backlog_multiple_active_sprints_settings_spec.rb
+++ b/modules/backlogs/spec/features/projects/settings/backlog_multiple_active_sprints_settings_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe "Backlogs project settings multiple active sprints", :js do
     )
   end
 
+  context "without share_sprint permission" do
+    let(:permissions) { %i[create_sprints select_backlog_types_and_statuses] }
+
+    it "does not show the multiple active sprints tab in the navigation" do
+      visit project_settings_backlogs_path(project)
+
+      expect(page).to have_link("Types and statuses")
+      expect(page).to have_no_link("Multiple active sprints")
+    end
+  end
+
   context "without an enterprise token for multiple_active_sprints" do
     it "renders an enterprise banner instead of the toggle" do
       visit project_settings_backlog_multiple_active_sprints_path(project)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-349

Follow up PR to #24191 , which contained some remarks we would like to fix.

# What are you trying to accomplish?

The following points are addressed in this PR

* a1ae5cd213fd5bc3f45fc19fa09b868a82da4803
  * Removal of [unnecessary memoization](https://github.com/opf/openproject/pull/24191#discussion_r3579535443)
  * The [backlog settings contract spec](https://github.com/opf/openproject/pull/24191#discussion_r3580995861) now includes a test case for every sharing option. The previous test setup only tested an example. The updated one ensures that each sharing option prohibits the use of multiple active sprints.
  * The MAS settings component will now delegate the definition of too many active projects to the project object. This should bring [the level of abstraction](https://github.com/opf/openproject/pull/24191#discussion_r3579740759) of this and other methods within the component closer.
* c7c0b492ca693728f44f5da7a061042d23f975a4
  * [Improve the specs for the sprint start contract](https://github.com/opf/openproject/pull/24191#discussion_r3581026156)
* 1152e2f03af37f25afe66a5af7168240b8d7f6a5
  * Improve [feature specs](https://github.com/opf/openproject/pull/24191#discussion_r3581067314) for the MAS settings
* 5f58267adf55fcdfdafadd3667545eb1376ca229
  * Refactor [project backlog settings tab management](https://github.com/opf/openproject/pull/24191#discussion_r3579567715)
* ff33f85da77c16a27cd33c8cea7a80a775d9c677
  * This is a drive-by **bugfix** that was not mentioned in the previous PR: the MAS tab within the project backlog settings should only be visible to users who have the `share_sprint` permission. This was not explicitly stated in the requirements, but it is how the "Share sprints" tab works. It makes sense to have both tabs behave the same.

There's an [open point about renaming](https://github.com/opf/openproject/pull/24191#discussion_r3580042161) the `SprintSharing` mixin since it now also deals with multiple active sprints. The name is no longer accurate. But renaming this will require changes in 16 files 🫪 I'd like to do that separately in [AGILE-353](https://community.openproject.org/wp/AGILE-353).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
