### PR TITLE
[DREAM-768] Spacings and font size for new PDF settings are a little bit off

### DIFF
--- a/app/components/work_package_types/export_configuration_component.html.erb
+++ b/app/components/work_package_types/export_configuration_component.html.erb
@@ -28,13 +28,13 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= render(Primer::Beta::Subhead.new) do |subhead| %>
-  <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.templates.section_title") } %>
+  <% subhead.with_heading(tag: :h3, size: :medium, mt: 3) { I18n.t("types.edit.export_configuration.templates.section_title") } %>
 <% end %>
 <p><%= I18n.t("types.edit.export_configuration.intro") %></p>
 <%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model)) %>
 
 <%= render(Primer::Beta::Subhead.new) do |subhead| %>
-  <% subhead.with_heading(tag: :h3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
+  <% subhead.with_heading(tag: :h3, size: :medium, mt: 3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>
 <% end %>
 <p><%= I18n.t("types.edit.export_configuration.artefact_export.intro") %></p>
 <%=


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-768

# What are you trying to accomplish?
Correct size and spacing of headings

## Screenshots

<img width="2208" height="1094" alt="Bildschirmfoto 2026-07-17 um 11 18 07" src="https://github.com/user-attachments/assets/cfc8426d-aead-492f-90d2-3b3a000d5cfd" />
