### PR TITLE
[FND-126] Read-only form configuration reference for Linked types

### DIFF
--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
@@ -1,14 +1,16 @@
 <%=
   flex_layout(justify_content: :space_between, align_items: :center) do |row|
     row.with_column(flex_layout: true, align_items: :center, flex: 1) do |left|
-      left.with_column(mr: 2, classes: "hide-when-print type-form-configuration-page--drag-handle") do
-        render(
-          Primer::OpenProject::DragHandle.new(
-            classes: "attribute-handle",
-            "aria-label": t("types.edit.form_configuration.drag_to_reorder"),
-            test_selector: "type-form-configuration-attribute-handle-#{@attribute[:key]}"
+      unless readonly?
+        left.with_column(mr: 2, classes: "hide-when-print type-form-configuration-page--drag-handle") do
+          render(
+            Primer::OpenProject::DragHandle.new(
+              classes: "attribute-handle",
+              "aria-label": t("types.edit.form_configuration.drag_to_reorder"),
+              test_selector: "type-form-configuration-attribute-handle-#{@attribute[:key]}"
+            )
           )
-        )
+        end
       end
       left.with_column do
         render(Primer::Beta::Text.new) { @attribute[:translation] }
@@ -20,58 +22,60 @@
       end
     end
 
-    row.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
-      render(Primer::Alpha::ActionMenu.new) do |menu|
-        menu.with_show_button(
-          icon: "kebab-horizontal",
-          scheme: :invisible,
-          size: :small,
-          classes: "type-form-configuration-page--actions-button",
-          test_selector: "type-form-configuration-attribute-actions-#{@attribute[:key]}",
-          "aria-label": t("types.edit.form_configuration.row_actions")
-        )
-
-        if attribute_can_move_up?
-          move_action(
-            menu:,
-            href: row_move_path(:highest),
-            label: t("label_agenda_item_move_to_top"),
-            icon: "move-to-top"
+    unless readonly?
+      row.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
+        render(Primer::Alpha::ActionMenu.new) do |menu|
+          menu.with_show_button(
+            icon: "kebab-horizontal",
+            scheme: :invisible,
+            size: :small,
+            classes: "type-form-configuration-page--actions-button",
+            test_selector: "type-form-configuration-attribute-actions-#{@attribute[:key]}",
+            "aria-label": t("types.edit.form_configuration.row_actions")
           )
-          move_action(
-            menu:,
-            href: row_move_path(:higher),
-            label: t("label_agenda_item_move_up"),
-            icon: "chevron-up"
-          )
-        end
 
-        if attribute_can_move_down?
-          move_action(
-            menu:,
-            href: row_move_path(:lower),
-            label: t("label_agenda_item_move_down"),
-            icon: "chevron-down"
-          )
-          move_action(
-            menu:,
-            href: row_move_path(:lowest),
-            label: t("label_agenda_item_move_to_bottom"),
-            icon: "move-to-bottom"
-          )
-        end
+          if attribute_can_move_up?
+            move_action(
+              menu:,
+              href: row_move_path(:highest),
+              label: t("label_agenda_item_move_to_top"),
+              icon: "move-to-top"
+            )
+            move_action(
+              menu:,
+              href: row_move_path(:higher),
+              label: t("label_agenda_item_move_up"),
+              icon: "chevron-up"
+            )
+          end
 
-        menu.with_divider if show_delete_divider?
+          if attribute_can_move_down?
+            move_action(
+              menu:,
+              href: row_move_path(:lower),
+              label: t("label_agenda_item_move_down"),
+              icon: "chevron-down"
+            )
+            move_action(
+              menu:,
+              href: row_move_path(:lowest),
+              label: t("label_agenda_item_move_to_bottom"),
+              icon: "move-to-bottom"
+            )
+          end
 
-        menu.with_item(
-          label: t("button_delete"),
-          test_selector: "type-form-configuration-delete-attribute-#{@attribute[:key]}",
-          scheme: :danger,
-          tag: :a,
-          href: row_destroy_path,
-          content_arguments: { data: { turbo_method: :delete, turbo_stream: true } }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :trash)
+          menu.with_divider if show_delete_divider?
+
+          menu.with_item(
+            label: t("button_delete"),
+            test_selector: "type-form-configuration-delete-attribute-#{@attribute[:key]}",
+            scheme: :danger,
+            tag: :a,
+            href: row_destroy_path,
+            content_arguments: { data: { turbo_method: :delete, turbo_stream: true } }
+          ) do |item|
+            item.with_leading_visual_icon(icon: :trash)
+          end
         end
       end
     end

--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.rb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.rb
@@ -33,12 +33,17 @@ module WorkPackageTypes
     class GroupAttributeRowComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      def initialize(attribute:, type:, index:, total_count:)
+      def initialize(attribute:, type:, index:, total_count:, readonly: false)
         super
         @attribute = attribute
         @type = type
         @index = index
         @total_count = total_count
+        @readonly = readonly
+      end
+
+      def readonly?
+        @readonly
       end
 
       private

--- a/app/components/work_package_types/form_configuration/group_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_component.html.erb
@@ -41,7 +41,8 @@ See COPYRIGHT and LICENSE files for more details.
             first: first?,
             last: last?,
             edit_mode: edit_mode?,
-            form_model: @form_model
+            form_model: @form_model,
+            readonly: readonly?
           )
         )
       end
@@ -51,11 +52,12 @@ See COPYRIGHT and LICENSE files for more details.
           render(
             WorkPackageTypes::FormConfiguration::GroupQueryRowComponent.new(
               group: @group,
-              ee_available: ee_available?
+              ee_available: ee_available?,
+              readonly: readonly?
             )
           )
         end
-      elsif attributes.empty?
+      elsif attributes.empty? && !readonly?
         box.with_row(data: { "empty-list-item": true }) do
           flex_layout(align_items: :center) do |empty_row|
             empty_row.with_column(mr: 2, classes: "type-form-configuration-page--row-alignment-spacer")
@@ -66,24 +68,28 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
         end
-      else
+      elsif !attributes.empty?
         attributes.each_with_index do |attribute, index|
-          box.with_row(
-            data: {
-              attr_key: attribute[:key],
-              attr_translation: attribute[:translation],
-              attr_is_cf: attribute[:is_cf],
-              "draggable-id": attribute[:key],
-              "draggable-type": "attribute",
-              "drop-url": row_drop_path(attribute)
-            }
-          ) do
+          row_data = if readonly?
+                       {}
+                     else
+                       {
+                         attr_key: attribute[:key],
+                         attr_translation: attribute[:translation],
+                         attr_is_cf: attribute[:is_cf],
+                         "draggable-id": attribute[:key],
+                         "draggable-type": "attribute",
+                         "drop-url": row_drop_path(attribute)
+                       }
+                     end
+          box.with_row(data: row_data) do
             render(
               WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent.new(
                 attribute:,
                 type: @type,
                 index:,
-                total_count: attributes.length
+                total_count: attributes.length,
+                readonly: readonly?
               )
             )
           end

--- a/app/components/work_package_types/form_configuration/group_component.rb
+++ b/app/components/work_package_types/form_configuration/group_component.rb
@@ -35,7 +35,7 @@ module WorkPackageTypes
       include OpPrimer::ComponentHelpers
 
       def initialize(group:, type: nil, ee_available: false, first: false, last: false, edit_mode: false,
-                     form_model: nil)
+                     form_model: nil, readonly: false)
         super(group)
         @group = group
         @type = type
@@ -44,6 +44,7 @@ module WorkPackageTypes
         @last = last
         @edit_mode = edit_mode
         @form_model = form_model
+        @readonly = readonly
         @instance_uid = SecureRandom.hex(4)
       end
 
@@ -53,6 +54,10 @@ module WorkPackageTypes
 
       def edit_mode?
         @edit_mode
+      end
+
+      def readonly?
+        @readonly
       end
 
       def query_group?
@@ -95,7 +100,7 @@ module WorkPackageTypes
       end
 
       def draggable_item_config
-        return {} if @group[:key].blank? || temporary_group?
+        return {} if readonly? || @group[:key].blank? || temporary_group?
 
         {
           "draggable-id": @group[:key],
@@ -105,7 +110,7 @@ module WorkPackageTypes
       end
 
       def row_drop_target_config
-        return {} if query_group? || @group[:key].blank? || temporary_group?
+        return {} if readonly? || query_group? || @group[:key].blank? || temporary_group?
 
         {
           "admin--type-form-configuration--rows-drag-and-drop-target": "container",

--- a/app/components/work_package_types/form_configuration/group_header_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_header_component.html.erb
@@ -22,73 +22,77 @@
   <%=
     flex_layout(justify_content: :space_between, align_items: :center) do |header|
       header.with_column(flex_layout: true, align_items: :center, flex: 1) do |left|
-        left.with_column(mr: 2, classes: "hide-when-print type-form-configuration-page--drag-handle") do
-          render(
-            Primer::OpenProject::DragHandle.new(
-              classes: "group-handle",
-              "aria-label": t("types.edit.form_configuration.drag_to_reorder"),
-              test_selector: "type-form-configuration-group-handle-#{@group[:key]}"
+        unless readonly?
+          left.with_column(mr: 2, classes: "hide-when-print type-form-configuration-page--drag-handle") do
+            render(
+              Primer::OpenProject::DragHandle.new(
+                classes: "group-handle",
+                "aria-label": t("types.edit.form_configuration.drag_to_reorder"),
+                test_selector: "type-form-configuration-group-handle-#{@group[:key]}"
+              )
             )
-          )
+          end
         end
         left.with_column(flex: 1) do
           render(Primer::Beta::Text.new(font_weight: :bold)) { group_name }
         end
       end
 
-      header.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
-        render(Primer::Alpha::ActionMenu.new) do |menu|
-          menu.with_show_button(
-            icon: "kebab-horizontal",
-            scheme: :invisible,
-            size: :small,
-            classes: "type-form-configuration-page--actions-button",
-            test_selector: "type-form-configuration-group-actions-#{@group[:key]}",
-            "aria-label": t("types.edit.form_configuration.group_actions")
-          )
+      unless readonly?
+        header.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
+          render(Primer::Alpha::ActionMenu.new) do |menu|
+            menu.with_show_button(
+              icon: "kebab-horizontal",
+              scheme: :invisible,
+              size: :small,
+              classes: "type-form-configuration-page--actions-button",
+              test_selector: "type-form-configuration-group-actions-#{@group[:key]}",
+              "aria-label": t("types.edit.form_configuration.group_actions")
+            )
 
-          if ee_available?
-            with_item_group(menu) do
-              menu.with_item(
-                label: t("types.edit.form_configuration.rename_group"),
-                test_selector: "type-form-configuration-group-rename-#{@group[:key]}",
-                tag: :a,
-                href: edit_path,
-                content_arguments: { data: { turbo_stream: true } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :pencil)
+            if ee_available?
+              with_item_group(menu) do
+                menu.with_item(
+                  label: t("types.edit.form_configuration.rename_group"),
+                  test_selector: "type-form-configuration-group-rename-#{@group[:key]}",
+                  tag: :a,
+                  href: edit_path,
+                  content_arguments: { data: { turbo_stream: true } }
+                ) do |item|
+                  item.with_leading_visual_icon(icon: :pencil)
+                end
               end
             end
-          end
 
-          with_item_group(menu) do
-            unless first?
-              move_action(menu:, href: move_path(:highest), label: t("label_agenda_item_move_to_top"), icon: "move-to-top")
-              move_action(menu:, href: move_path(:higher), label: t("label_agenda_item_move_up"), icon: "chevron-up")
-            end
-
-            unless last?
-              move_action(menu:, href: move_path(:lower), label: t("label_agenda_item_move_down"), icon: "chevron-down")
-              move_action(menu:, href: move_path(:lowest), label: t("label_agenda_item_move_to_bottom"), icon: "move-to-bottom")
-            end
-          end
-
-          if ee_available?
             with_item_group(menu) do
-              menu.with_item(
-                label: t("button_delete"),
-                scheme: :danger,
-                tag: :a,
-                href: destroy_path,
-                content_arguments: {
-                  data: {
-                    turbo_method: :delete,
-                    turbo_stream: true,
-                    turbo_confirm: t("types.edit.form_configuration.confirm_delete_group")
+              unless first?
+                move_action(menu:, href: move_path(:highest), label: t("label_agenda_item_move_to_top"), icon: "move-to-top")
+                move_action(menu:, href: move_path(:higher), label: t("label_agenda_item_move_up"), icon: "chevron-up")
+              end
+
+              unless last?
+                move_action(menu:, href: move_path(:lower), label: t("label_agenda_item_move_down"), icon: "chevron-down")
+                move_action(menu:, href: move_path(:lowest), label: t("label_agenda_item_move_to_bottom"), icon: "move-to-bottom")
+              end
+            end
+
+            if ee_available?
+              with_item_group(menu) do
+                menu.with_item(
+                  label: t("button_delete"),
+                  scheme: :danger,
+                  tag: :a,
+                  href: destroy_path,
+                  content_arguments: {
+                    data: {
+                      turbo_method: :delete,
+                      turbo_stream: true,
+                      turbo_confirm: t("types.edit.form_configuration.confirm_delete_group")
+                    }
                   }
-                }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :trash)
+                ) do |item|
+                  item.with_leading_visual_icon(icon: :trash)
+                end
               end
             end
           end

--- a/app/components/work_package_types/form_configuration/group_header_component.rb
+++ b/app/components/work_package_types/form_configuration/group_header_component.rb
@@ -33,7 +33,7 @@ module WorkPackageTypes
     class GroupHeaderComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      def initialize(group:, type:, ee_available:, first:, last:, edit_mode:, form_model: nil)
+      def initialize(group:, type:, ee_available:, first:, last:, edit_mode:, form_model: nil, readonly: false)
         super
         @group = group
         @type = type
@@ -42,10 +42,15 @@ module WorkPackageTypes
         @last = last
         @edit_mode = edit_mode
         @form_model = form_model
+        @readonly = readonly
       end
 
       def edit_mode?
         @edit_mode
+      end
+
+      def readonly?
+        @readonly
       end
 
       private

--- a/app/components/work_package_types/form_configuration/group_query_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_query_row_component.html.erb
@@ -3,7 +3,7 @@
     row.with_column(flex_layout: true, align_items: :center, flex: 1) do |left|
       left.with_column(mr: 2, classes: "type-form-configuration-page--row-alignment-spacer")
       left.with_column(flex: 1) do
-        if ee_available?
+        if ee_available? && !readonly?
           render(
             Primer::Beta::Button.new(
               scheme: :link,
@@ -20,7 +20,7 @@
       end
     end
 
-    if ee_available?
+    if ee_available? && !readonly?
       row.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
         render(Primer::Alpha::ActionMenu.new) do |menu|
           menu.with_show_button(

--- a/app/components/work_package_types/form_configuration/group_query_row_component.rb
+++ b/app/components/work_package_types/form_configuration/group_query_row_component.rb
@@ -33,10 +33,15 @@ module WorkPackageTypes
     class GroupQueryRowComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      def initialize(group:, ee_available:)
+      def initialize(group:, ee_available:, readonly: false)
         super
         @group = group
         @ee_available = ee_available
+        @readonly = readonly
+      end
+
+      def readonly?
+        @readonly
       end
 
       private

--- a/app/components/work_package_types/form_configuration/main_content_component.html.erb
+++ b/app/components/work_package_types/form_configuration/main_content_component.html.erb
@@ -5,50 +5,52 @@
     flex_layout do |main|
       main.with_row do
         render(Primer::OpenProject::SubHeader.new(mb: 0)) do |subheader|
-          subheader.with_action_button(
-            tag: :a,
-            scheme: :secondary,
-            leading_icon: :undo,
-            label: t("types.edit.form_configuration.reset_to_defaults"),
-            href: reset_dialog_type_form_configuration_path(@type),
-            "data-test-selector": "type-form-configuration-reset-button",
-            data: { controller: "async-dialog" }
-          ) do
-            t("types.edit.form_configuration.reset_to_defaults")
-          end
+          unless readonly?
+            subheader.with_action_button(
+              tag: :a,
+              scheme: :secondary,
+              leading_icon: :undo,
+              label: t("types.edit.form_configuration.reset_to_defaults"),
+              href: reset_dialog_type_form_configuration_path(@type),
+              "data-test-selector": "type-form-configuration-reset-button",
+              data: { controller: "async-dialog" }
+            ) do
+              t("types.edit.form_configuration.reset_to_defaults")
+            end
 
-          if ee_available?
-            subheader.with_action_menu(
-              leading_icon: :plus,
-              trailing_icon: :"triangle-down",
-              label: t(:button_add),
-              anchor_align: :end,
-              button_arguments: {
-                scheme: :primary,
-                "aria-label": t(:button_add),
-                "data-test-selector": "type-form-configuration-add-button"
-              }
-            ) do |menu|
-              menu.with_item(
-                label: t("types.edit.form_configuration.add_attribute_group"),
-                tag: :a,
-                href: add_group_type_form_configuration_groups_path(@type, group_type: :attribute),
-                content_arguments: {
-                  data: { turbo_method: :post, turbo_stream: true }
+            if ee_available?
+              subheader.with_action_menu(
+                leading_icon: :plus,
+                trailing_icon: :"triangle-down",
+                label: t(:button_add),
+                anchor_align: :end,
+                button_arguments: {
+                  scheme: :primary,
+                  "aria-label": t(:button_add),
+                  "data-test-selector": "type-form-configuration-add-button"
                 }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :rows)
-              end
+              ) do |menu|
+                menu.with_item(
+                  label: t("types.edit.form_configuration.add_attribute_group"),
+                  tag: :a,
+                  href: add_group_type_form_configuration_groups_path(@type, group_type: :attribute),
+                  content_arguments: {
+                    data: { turbo_method: :post, turbo_stream: true }
+                  }
+                ) do |item|
+                  item.with_leading_visual_icon(icon: :rows)
+                end
 
-              menu.with_item(
-                label: t("types.edit.form_configuration.add_query_group"),
-                tag: :button,
-                content_arguments: {
-                  data: { action: "click->admin--type-form-configuration--main#addQueryGroup",
-                          test_selector: "admin--type-form-configuration--add-query-group" }
-                }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :table)
+                menu.with_item(
+                  label: t("types.edit.form_configuration.add_query_group"),
+                  tag: :button,
+                  content_arguments: {
+                    data: { action: "click->admin--type-form-configuration--main#addQueryGroup",
+                            test_selector: "admin--type-form-configuration--add-query-group" }
+                  }
+                ) do |item|
+                  item.with_leading_visual_icon(icon: :table)
+                end
               end
             end
           end

--- a/app/components/work_package_types/form_configuration/main_content_component.rb
+++ b/app/components/work_package_types/form_configuration/main_content_component.rb
@@ -34,11 +34,16 @@ module WorkPackageTypes
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
-      def initialize(type:, group_components:, ee_available:)
+      def initialize(type:, group_components:, ee_available:, readonly: false)
         super
         @type = type
         @group_components = group_components
         @ee_available = ee_available
+        @readonly = readonly
+      end
+
+      def readonly?
+        @readonly
       end
 
       private
@@ -48,6 +53,8 @@ module WorkPackageTypes
       end
 
       def groups_container_data
+        return { "test-selector": "type-form-configuration-groups-container" } if readonly?
+
         {
           "test-selector": "type-form-configuration-groups-container",
           "admin--type-form-configuration--main-target": "groupsContainer",

--- a/app/components/work_package_types/form_configuration_component.html.erb
+++ b/app/components/work_package_types/form_configuration_component.html.erb
@@ -31,36 +31,36 @@ See COPYRIGHT and LICENSE files for more details.
       class: "type-form-configuration-page--wrapper",
       data: wrapper_data
     ) do %>
-  <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :md, overflow: :hidden, h: :full, classes: "type-form-configuration-page")) do |content| %>
-    <% content.with_sidebar(row_placement: :start, col_placement: :start, border: true, border_bottom: 0, p: 3, overflow: :auto, classes: "type-form-configuration-page--sidebar") do %>
-      <%= render(
-            WorkPackageTypes::FormConfiguration::InactiveAttributesSidebarComponent.new(
-              type: @type,
-              inactive_attributes: @inactive_attributes
-            )
-          ) %>
+  <% if readonly? %>
+    <%= tag.div(class: "type-form-configuration-page--active-list") do %>
+      <%= render(main_content_component) %>
     <% end %>
-
-    <% content.with_main(classes: "type-form-configuration-page--main") do %>
-      <%= tag.div(
-            class: "type-form-configuration-page--active-list",
-            data: active_list_data
-          ) do %>
-        <%= render(EnterpriseEdition::BannerComponent.new(:edit_attribute_groups, mb: 3)) %>
-
-        <% unless ee_available? %>
-          <%= render(Primer::Alpha::Banner.new(scheme: :default, icon: :info, mb: 3)) do %>
-            <%= t("text_form_configuration") %> <%= t("text_custom_field_hint_activate_per_project") %>
-          <% end %>
-        <% end %>
-
+  <% else %>
+    <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :md, overflow: :hidden, h: :full, classes: "type-form-configuration-page")) do |content| %>
+      <% content.with_sidebar(row_placement: :start, col_placement: :start, border: true, border_bottom: 0, p: 3, overflow: :auto, classes: "type-form-configuration-page--sidebar") do %>
         <%= render(
-              WorkPackageTypes::FormConfiguration::MainContentComponent.new(
+              WorkPackageTypes::FormConfiguration::InactiveAttributesSidebarComponent.new(
                 type: @type,
-                group_components: group_components,
-                ee_available: ee_available?
+                inactive_attributes:
               )
             ) %>
+      <% end %>
+
+      <% content.with_main(classes: "type-form-configuration-page--main") do %>
+        <%= tag.div(
+              class: "type-form-configuration-page--active-list",
+              data: active_list_data
+            ) do %>
+          <%= render(EnterpriseEdition::BannerComponent.new(:edit_attribute_groups, mb: 3)) %>
+
+          <% unless ee_available? %>
+            <%= render(Primer::Alpha::Banner.new(scheme: :default, icon: :info, mb: 3)) do %>
+              <%= t("text_form_configuration") %> <%= t("text_custom_field_hint_activate_per_project") %>
+            <% end %>
+          <% end %>
+
+          <%= render(main_content_component) %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -33,19 +33,41 @@ module WorkPackageTypes
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
+    ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
+
     def initialize(type:, form_attributes:, no_filter_query:)
       super(type)
       @type = type
-      @groups = form_attributes[:actives].reject { |g| g[:key].to_s == "__empty" }
-      @inactive_attributes = form_attributes[:inactives]
+      @form_attributes = form_attributes
       @no_filter_query = no_filter_query
+    end
+
+    def readonly?
+      OpenProject::FeatureDecisions.subtypes_active? && @type.linked?(ASPECT)
+    end
+
+    def source
+      @type.effective_source_for(ASPECT)
     end
 
     def ee_available?
       EnterpriseToken.allows_to?(:edit_attribute_groups)
     end
 
+    def inactive_attributes
+      @form_attributes[:inactives]
+    end
+
+    # In read-only mode the visible configuration is the linked source's, resolved at
+    # render time; independent types show their own stored configuration.
+    def active_groups
+      attributes = readonly? ? helpers.form_configuration_groups(source) : @form_attributes
+      attributes[:actives].reject { |g| g[:key].to_s == "__empty" }
+    end
+
     def wrapper_data
+      return {} if readonly?
+
       {
         controller: "admin--type-form-configuration--main admin--type-form-configuration--rows-drag-and-drop",
         "admin--type-form-configuration--main-no-filter-query-value": @no_filter_query,
@@ -56,6 +78,8 @@ module WorkPackageTypes
     end
 
     def active_list_data
+      return {} if readonly?
+
       {
         controller: "admin--type-form-configuration--drag-and-drop",
         "admin--type-form-configuration--drag-and-drop-handle-selector-value": ".group-handle",
@@ -64,16 +88,26 @@ module WorkPackageTypes
       }
     end
 
-    def group_components
-      @groups.map.with_index do |group, i|
+    def main_content_component
+      groups_type = readonly? ? source : @type
+      groups = active_groups
+      group_components = groups.map.with_index do |group, i|
         WorkPackageTypes::FormConfiguration::GroupComponent.new(
           group:,
-          type: @type,
+          type: groups_type,
           ee_available: ee_available?,
           first: i == 0,
-          last: i == @groups.length - 1
+          last: i == groups.length - 1,
+          readonly: readonly?
         )
       end
+
+      WorkPackageTypes::FormConfiguration::MainContentComponent.new(
+        type: @type,
+        group_components:,
+        ee_available: ee_available?,
+        readonly: readonly?
+      )
     end
   end
 end

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, type: :component do
+  let(:type) { create(:type) }
+  let(:attribute) do
+    { key: "assignee", is_cf: false, is_required: false, translation: "Assignee", field_format_label: "Built-in field" }
+  end
+
+  it "renders the drag handle and actions menu in editable mode", :aggregate_failures do
+    render_inline(described_class.new(attribute:, type:, index: 0, total_count: 2))
+
+    expect(page).to have_test_selector("type-form-configuration-attribute-handle-assignee")
+    expect(page).to have_test_selector("type-form-configuration-attribute-actions-assignee")
+    expect(page).to have_text("Assignee")
+  end
+
+  it "omits the handle and actions menu when readonly", :aggregate_failures do
+    render_inline(described_class.new(attribute:, type:, index: 0, total_count: 2, readonly: true))
+
+    expect(page).to have_no_test_selector("type-form-configuration-attribute-handle-assignee")
+    expect(page).to have_no_test_selector("type-form-configuration-attribute-actions-assignee")
+    expect(page).to have_text("Assignee")
+  end
+end

--- a/spec/components/work_package_types/form_configuration/group_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfiguration::GroupComponent, type: :component do
+  let(:type) { create(:type) }
+  let(:group) do
+    {
+      key: "details",
+      name: "Details",
+      type: :attribute,
+      attributes: [
+        { key: "assignee", is_cf: false, is_required: false, translation: "Assignee", field_format_label: "Built-in field" }
+      ],
+      query: nil
+    }
+  end
+
+  it "renders handles and per-row drag data in editable mode", :aggregate_failures do
+    render_inline(described_class.new(group:, type:, ee_available: true, first: true, last: true))
+
+    expect(page).to have_test_selector("type-form-configuration-group-handle-details")
+    expect(page).to have_test_selector("type-form-configuration-attribute-handle-assignee")
+  end
+
+  it "renders no handles, menus, or drag data when readonly", :aggregate_failures do
+    render_inline(described_class.new(group:, type:, ee_available: true, first: true, last: true, readonly: true))
+
+    expect(page).to have_no_test_selector("type-form-configuration-group-handle-details")
+    expect(page).to have_no_test_selector("type-form-configuration-attribute-handle-assignee")
+    expect(page).to have_no_test_selector("type-form-configuration-attribute-actions-assignee")
+    expect(page).to have_no_css("[data-draggable-id]")
+    expect(page).to have_text("Details")
+    expect(page).to have_text("Assignee")
+  end
+
+  context "with an empty group" do
+    let(:group) { { key: "details", name: "Details", type: :attribute, attributes: [], query: nil } }
+
+    it "shows the drag hint in editable mode" do
+      render_inline(described_class.new(group:, type:, ee_available: true, first: true, last: true))
+
+      expect(page).to have_text("Drag attributes here")
+    end
+
+    it "omits the drag hint when readonly", :aggregate_failures do
+      render_inline(described_class.new(group:, type:, ee_available: true, first: true, last: true, readonly: true))
+
+      expect(page).to have_no_text("Drag attributes here")
+      expect(page).to have_text("Details")
+    end
+  end
+end

--- a/spec/components/work_package_types/form_configuration/group_header_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_header_component_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfiguration::GroupHeaderComponent, type: :component do
+  let(:type) { create(:type) }
+  let(:group) { { key: "details", name: "Details", type: :attribute } }
+
+  def render_header(readonly:)
+    render_inline(described_class.new(group:, type:, ee_available: true, first: true, last: true,
+                                      edit_mode: false, readonly:))
+  end
+
+  it "renders the drag handle and actions menu in editable mode", :aggregate_failures do
+    render_header(readonly: false)
+
+    expect(page).to have_test_selector("type-form-configuration-group-handle-details")
+    expect(page).to have_test_selector("type-form-configuration-group-actions-details")
+    expect(page).to have_text("Details")
+  end
+
+  it "omits the handle and actions menu when readonly", :aggregate_failures do
+    render_header(readonly: true)
+
+    expect(page).to have_no_test_selector("type-form-configuration-group-handle-details")
+    expect(page).to have_no_test_selector("type-form-configuration-group-actions-details")
+    expect(page).to have_text("Details")
+  end
+end

--- a/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfiguration::GroupQueryRowComponent, type: :component do
+  let(:group) { { key: "query-1", name: "Related", type: :query } }
+
+  it "renders the edit-query action when EE and editable" do
+    render_inline(described_class.new(group:, ee_available: true))
+
+    expect(page).to have_test_selector("type-form-configuration-query-actions-query-1")
+  end
+
+  it "omits the actions menu when readonly", :aggregate_failures do
+    render_inline(described_class.new(group:, ee_available: true, readonly: true))
+
+    expect(page).to have_no_test_selector("type-form-configuration-query-actions-query-1")
+    expect(page).to have_text("Related work packages table")
+  end
+end

--- a/spec/components/work_package_types/form_configuration/main_content_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/main_content_component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfiguration::MainContentComponent, type: :component do
+  let(:type) { create(:type) }
+
+  it "renders Reset and Add actions in editable EE mode", :aggregate_failures do
+    render_inline(described_class.new(type:, group_components: [], ee_available: true))
+
+    expect(page).to have_test_selector("type-form-configuration-reset-button")
+    expect(page).to have_test_selector("type-form-configuration-add-button")
+  end
+
+  it "omits Reset, Add, and drag targets when readonly", :aggregate_failures do
+    render_inline(described_class.new(type:, group_components: [], ee_available: true, readonly: true))
+
+    expect(page).to have_no_test_selector("type-form-configuration-reset-button")
+    expect(page).to have_no_test_selector("type-form-configuration-add-button")
+    expect(page).to have_no_css("[data-admin--type-form-configuration--drag-and-drop-target]")
+    expect(page).to have_test_selector("type-form-configuration-groups-container")
+  end
+end

--- a/spec/components/work_package_types/form_configuration_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration_component_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfigurationComponent, type: :component do
+  let(:source) { create(:type, name: "Bug") }
+  let(:type) { create(:type, name: "Mobile app bug") }
+  let(:no_filter_query) { "{}" }
+  # The independent path renders whatever it is given; the read-only path ignores this and
+  # resolves the source's groups itself, so a minimal shape is enough for both.
+  let(:form_attributes) { { actives: [], inactives: [] } }
+
+  before do
+    source.attribute_groups = [["Reused From Source", %w[assignee]]]
+    source.save!
+    login_as(create(:admin))
+  end
+
+  def render_component
+    render_inline(described_class.new(type:, form_attributes:, no_filter_query:))
+  end
+
+  context "when the form configuration aspect is linked (feature enabled)" do
+    before do
+      allow(OpenProject::FeatureDecisions).to receive(:subtypes_active?).and_return(true)
+      type.link!(Type::ConfigurationLink::FORM_CONFIGURATION, source:)
+    end
+
+    it "renders the source's groups read-only", :aggregate_failures do
+      render_component
+
+      expect(page).to have_text("Reused From Source")
+      expect(page).to have_no_css(".type-form-configuration-page--sidebar")
+      expect(page).to have_no_test_selector("type-form-configuration-reset-button")
+      expect(page).to have_no_test_selector("type-form-configuration-add-button")
+      expect(page).to have_no_css("[data-draggable-type='group']")
+    end
+  end
+
+  context "when independent" do
+    before { allow(OpenProject::FeatureDecisions).to receive(:subtypes_active?).and_return(true) }
+
+    it "renders the editable page with the inactive sidebar", :aggregate_failures do
+      render_component
+
+      expect(page).to have_css(".type-form-configuration-page--sidebar")
+    end
+  end
+
+  context "when linked but the feature flag is off" do
+    before do
+      allow(OpenProject::FeatureDecisions).to receive(:subtypes_active?).and_return(false)
+      type.link!(Type::ConfigurationLink::FORM_CONFIGURATION, source:)
+    end
+
+    it "renders the editable page (read-only branch not taken)", :aggregate_failures do
+      render_component
+
+      expect(page).to have_css(".type-form-configuration-page--sidebar")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

[FND-126](https://community.openproject.org/wp/FND-126)

# What are you trying to accomplish?

Render the form configuration admin tab **read-only** when a type's form configuration aspect is Linked.

- Shows the **effective source's** attribute groups (resolved at render time), not the type's own
- Strips all editing affordances: inactive-fields sidebar, drag handles, group/row kebab menus, Reset/Add
- Query-group rows render as static text
- Editable (Independent) path is unchanged
- Gated by the `subtypes` feature flag; a stale link with the flag off stays editable

## Screenshots

<img width="1080" height="836" alt="Screenshot for source" src="https://github.com/user-attachments/assets/f39026dd-12bc-40b8-a490-be9fab85d58e" />

<img width="1092" height="403" alt="Screenshot for linked configuration" src="https://github.com/user-attachments/assets/cdfe4246-5334-4edf-bc64-db88c9264d5e" />

# What approach did you choose and why?

- `FormConfigurationComponent` derives `readonly?` and threads a `readonly:` flag down `MainContentComponent` → `GroupComponent` → header / row / query-row
- Reuses the existing components/markup (flag toggles affordances) rather than duplicating a read-only tree
- EE banners and `ee_available?` guards left untouched; read-only only ever adds a restriction on top
- No `:js` feature spec — server-side render divergence, covered by ViewComponent render specs

Easier to diff with [whitespaces disabled](https://github.com/opf/openproject/pull/24318/changes?w=1).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a (component needs persisted type + link + flag; not preview-constructible)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) — n/a (no client-side behavior)
