### PR TITLE
[XWI-143] use inline message in health checks

### DIFF
--- a/app/components/health_reports/report_component.html.erb
+++ b/app/components/health_reports/report_component.html.erb
@@ -31,8 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
   component_wrapper do
     flex_layout do |report_container|
       report_container.with_row do
-        concat(render(Primer::Beta::Octicon.new(mr: 2, **summary_icon(report.tally))))
-        concat(render(Primer::Beta::Text.new(font_weight: :bold)) { humanize_summary(report.tally) })
+        render(Primer::OpenProject::InlineMessage.new(scheme: summary_scheme(report.tally))) do
+          humanize_summary(report.tally)
+        end
       end
 
       report_container.with_row(mt: 2) do
@@ -57,8 +58,9 @@ See COPYRIGHT and LICENSE files for more details.
                 end
 
                 header.with_column do
-                  concat(render(Primer::Beta::Octicon.new(mr: 2, **summary_icon(result_group.tally))))
-                  concat(render(Primer::Beta::Text.new) { humanize_summary(result_group.tally) })
+                  render(Primer::OpenProject::InlineMessage.new(scheme: summary_scheme(result_group.tally))) do
+                    humanize_summary(result_group.tally)
+                  end
                 end
               end
             end

--- a/app/components/health_reports/report_component.rb
+++ b/app/components/health_reports/report_component.rb
@@ -46,14 +46,14 @@ module HealthReports
 
     attr_reader :i18n_scope
 
-    def summary_icon(check_tally)
+    def summary_scheme(check_tally)
       case check_tally
       in { failure: 1.. }
-        { icon: :alert, color: :danger }
+        :critical
       in { warning: 1.. }
-        { icon: :alert, color: :attention }
+        :warning
       else
-        { icon: :"check-circle", color: :success }
+        :success
       end
     end
 

--- a/modules/storages/app/components/storages/admin/side_panel/validation_result_component.html.erb
+++ b/modules/storages/app/components/storages/admin/side_panel/validation_result_component.html.erb
@@ -34,8 +34,9 @@ See COPYRIGHT and LICENSE files for more details.
         container.with_row do
           header = summary_header
 
-          concat(render(Primer::Beta::Octicon.new(icon: header[:icon], color: header[:icon_color], mr: 2)))
-          concat(render(Primer::Beta::Text.new(font_weight: :bold)) { header[:text] })
+          render(Primer::OpenProject::InlineMessage.new(scheme: header[:scheme])) do
+            header[:text]
+          end
         end
 
         container.with_row(mt: 2) do

--- a/modules/storages/app/components/storages/admin/side_panel/validation_result_component.rb
+++ b/modules/storages/app/components/storages/admin/side_panel/validation_result_component.rb
@@ -46,19 +46,11 @@ module Storages
           tally = @result.tally
           case tally
           in { failure: 1.. }
-            {
-              icon: :alert,
-              icon_color: :danger,
-              text: I18n.t("health_reports.common.checks.failures", count: tally[:failure])
-            }
+            { scheme: :critical, text: I18n.t("health_reports.common.checks.failures", count: tally[:failure]) }
           in { warning: 1.. }
-            {
-              icon: :alert,
-              icon_color: :attention,
-              text: I18n.t("health_reports.common.checks.warnings", count: tally[:warning])
-            }
+            { scheme: :warning, text: I18n.t("health_reports.common.checks.warnings", count: tally[:warning]) }
           else
-            { icon: :"check-circle", icon_color: :success, text: I18n.t("health_reports.common.checks.success") }
+            { scheme: :success, text: I18n.t("health_reports.common.checks.success") }
           end
         end
 

--- a/modules/wikis/app/components/wikis/admin/side_panel/health_status_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/side_panel/health_status_component.html.erb
@@ -37,8 +37,9 @@ See COPYRIGHT and LICENSE files for more details.
           container.with_row do
             header = summary_header
 
-            concat(render(Primer::Beta::Octicon.new(icon: header[:icon], color: header[:icon_color], mr: 2)))
-            concat(render(Primer::Beta::Text.new(font_weight: :bold)) { header[:text] })
+            render(Primer::OpenProject::InlineMessage.new(scheme: header[:scheme])) do
+              header[:text]
+            end
           end
 
           container.with_row(mt: 2) do

--- a/modules/wikis/app/components/wikis/admin/side_panel/health_status_component.rb
+++ b/modules/wikis/app/components/wikis/admin/side_panel/health_status_component.rb
@@ -43,22 +43,13 @@ module Wikis
         end
 
         def summary_header
-          tally = report.tally
-          case tally
+          case report.tally
           in { failure: 1.. }
-            {
-              icon: :alert,
-              icon_color: :danger,
-              text: I18n.t("health_reports.common.checks.failures", count: tally[:failure])
-            }
+            { scheme: :critical, text: I18n.t("health_reports.common.checks.failures", count: tally[:failure]) }
           in { warning: 1.. }
-            {
-              icon: :alert,
-              icon_color: :attention,
-              text: I18n.t("health_reports.common.checks.warnings", count: tally[:warning])
-            }
+            { scheme: :warning, text: I18n.t("health_reports.common.checks.warnings", count: tally[:warning]) }
           else
-            { icon: :"check-circle", icon_color: :success, text: I18n.t("health_reports.common.checks.success") }
+            { scheme: :success, text: I18n.t("health_reports.common.checks.success") }
           end
         end
 


### PR DESCRIPTION
# Ticket
[XWI-143](https://community.openproject.org/wp/XWI-143)

# What are you trying to accomplish?
- see nicely aligned validation messages in health checks

# What approach did you choose and why?
- remove custom validation components
- replace with inline message view component
- kept original texts
