### PR TITLE
[COMMS-898] Seed work package versions through target_version_ids_replacements

### DIFF
--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -139,8 +139,7 @@ module DemoData
     def set_version_filter!(filters)
       version = seed_data.find_reference(config[:version])
       if version
-        # The stored filter key remains "version_id" (it matches on target_versions via
-        # FilterOnTargetVersionsMixin) until saved query filters are migrated to the new key.
+        # TODO(COMMS-863): use version_id filter until we migrate to target_versions
         filters[:version_id] = {
           operator: "=",
           values: [version.id]

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -139,6 +139,8 @@ module DemoData
     def set_version_filter!(filters)
       version = seed_data.find_reference(config[:version])
       if version
+        # The stored filter key remains "version_id" (it matches on target_versions via
+        # FilterOnTargetVersionsMixin) until saved query filters are migrated to the new key.
         filters[:version_id] = {
           operator: "=",
           values: [version.id]

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -88,14 +88,12 @@ module DemoData
     def create_work_package(attributes)
       wp_attr = base_work_package_attributes attributes
 
-      # TODO(COMMS-863): remove once the version_id column is dropped in favor of target_versions.
-      set_version! wp_attr, attributes
+      set_target_versions! wp_attr, attributes
       set_time_tracking_attributes! wp_attr, attributes
       set_backlogs_attributes! wp_attr, attributes
 
       work_package = WorkPackage.create! wp_attr
 
-      set_target_versions! work_package, attributes
       create_children! work_package, attributes
       create_attachments! work_package, attributes
       update_description! work_package
@@ -172,22 +170,14 @@ module DemoData
       end
     end
 
-    def set_version!(wp_attr, attributes)
-      reference = Array(attributes["target_versions"]).first
-      version = seed_data.find_reference(reference)
-      if version
-        wp_attr[:version] = version
+    # The legacy version_id column is kept in sync from the replacements on
+    # save (WorkPackage::Versions#update_legacy_version_field).
+    def set_target_versions!(wp_attr, attributes)
+      version_ids = Array(attributes["target_versions"]).filter_map do |reference|
+        seed_data.find_reference(reference)&.id
       end
-    end
 
-    def set_target_versions!(work_package, attributes)
-      Array(attributes["target_versions"]).each do |reference|
-        version = seed_data.find_reference(reference)
-        next unless version
-
-        # The first version already has a row, mirrored from version_id on save.
-        work_package.work_package_versions.find_or_create_by!(version_id: version.id, kind: "target")
-      end
+      wp_attr[:target_version_ids_replacements] = version_ids if version_ids.any?
     end
 
     def set_time_tracking_attributes!(wp_attr, attributes)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/COMMS-898/activity

# What are you trying to accomplish?
The demo seeder no longer dual-writes the legacy version attribute; all seeded versions go through the model's target replacements, which mirror the first one into version_id on save (COMMS-863).
