### PR TITLE
[COSTS-127] Comment field content overflows tooltip in 'My Spent Time' calendar

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
@@ -1,5 +1,6 @@
 @import '../../app/spot/styles/sass/variables'
 @import '../../global_styles/openproject/variables'
+@import "helpers"
 
 op-time-entries-calendar
   // The two media queries below make sure the "Log time" button does not overlap
@@ -19,6 +20,9 @@ op-time-entries-calendar
     .fc-toolbar-chunk:last-child
       flex-basis: 165px
       flex-shrink: 0
+
+  .te-calendar--popover-entry
+    @include text-shortener(false)
 
   full-calendar
     overflow-x: auto

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -642,26 +642,26 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
 
   private popoverContentHtml(entry:TimeEntryResource, schema:TimeEntrySchema) {
     return html`
-        <div class="Popover">
+        <div class="Popover te-calendar--popover">
           <div class="Box Popover-message Popover-message--left-top ml-2 mx-auto p-2 text-left text-small">
             <ul class="list-style-none ml-0">
-              <li>
+              <li class="te-calendar--popover-entry">
                 <span class="text-bold">${schema.project.name}:</span>
                 <span>${this.sanitizedValue(entry.project.name)}</span>
               </li>
-              <li>
+              <li class="te-calendar--popover-entry">
                 <span class="text-bold">${schema.entity.name}:</span>
                 <span>${entry.entity ? this.sanitizedValue(this.entityName(entry)) : this.i18n.t('js.placeholders.default')}</span>
               </li>
-              <li>
+              <li class="te-calendar--popover-entry">
                 <span class="text-bold">${schema.activity.name}:</span>
                 <span>${this.sanitizedValue(entry.activity?.name ?? '')}</span>
               </li>
-              <li>
+              <li class="te-calendar--popover-entry">
                 <span class="text-bold">${schema.hours.name}:</span>
                 <span>${this.timezone.formattedDuration(entry.hours as string)}</span>
               </li>
-              <li>
+              <li class="te-calendar--popover-entry">
                 <span class="text-bold">${schema.comment.name}:</span>
                 <span>${this.sanitizedValue(entry.comment.raw ?? this.i18n.t('js.placeholders.default'))}</span>
               </li>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COSTS-127

# What are you trying to accomplish?
Avoid long words to overlow the Popover

## Screenshots
<img width="561" height="355" alt="Bildschirmfoto 2026-07-20 um 08 27 50" src="https://github.com/user-attachments/assets/d93d1764-d593-4a79-beac-8db0116b36a4" />

