### PR TITLE
[OP-19788] If user name is long, it overlaps with user status on resource management user card

### DIFF
--- a/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
 
         header.with_column(flex: 1, mr: 2, classes: "op-user-card--identity") do
           flex_layout do |identity|
-            identity.with_row do
+            identity.with_row(overflow: :hidden) do
               render(Primer::Beta::Text.new(font_weight: :semibold, classes: "op-user-card--name")) { @user.name }
             end
 

--- a/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.sass
+++ b/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.sass
@@ -5,6 +5,7 @@
     min-width: 0
 
   &--name
+    display: block
     @include text-shortener()
 
   &--attribute-value


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19788

# What are you trying to accomplish?
Avoid long overflowing user names

## Screenshots

<img width="671" height="145" alt="Bildschirmfoto 2026-07-20 um 08 50 04" src="https://github.com/user-attachments/assets/2669790a-adbb-419f-beee-09f71d5a6123" />
