### PR TITLE
[DREAM-342] "Subproject of" dropdown border missing at bottom / dropdown cut off

### DIFF
--- a/app/forms/projects/settings/relations_form.rb
+++ b/app/forms/projects/settings/relations_form.rb
@@ -42,7 +42,7 @@ module Projects
             autocomplete_options: {
               model: project_autocompleter_model,
               focusDirectly: false,
-              dropdownPosition: "bottom",
+              dropdownPosition: dropdown_position,
               url: project_autocompleter_url,
               filters: [],
               data: { test_selector: "parent" }
@@ -53,15 +53,16 @@ module Projects
         end
       end
 
-      def initialize(invisible: false)
+      def initialize(invisible: false, dropdown_position: "top")
         super()
 
         @invisible = invisible
+        @dropdown_position = dropdown_position
       end
 
       private
 
-      attr_reader :invisible
+      attr_reader :invisible, :dropdown_position
 
       def visible?
         model.parent_allowed? && !invisible


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-342

# What are you trying to accomplish?
Default the dropdown position to top for the parent project selector. Currently all places where the form is used, fallback to that as the form us always rendered at the very bottom. If this changes in the future, we can override that on a per need basis.

