### PR TITLE
[COMMS-914] Can't set OPENPROJECT_EMAILS__SALUTATION env variable

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -473,7 +473,7 @@ module Settings
         env_alias: "EMAIL_DELIVERY_METHOD"
       },
       emails_salutation: {
-        allowed: %w[firstname name],
+        allowed: %i[firstname name],
         default: :firstname
       },
       emails_footer: {

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe Settings::Definition, :settings_reset do
         expect(all[:rails_cache_store].value).to eq :memcache
       end
 
+      it "overriding emails_salutation from ENV will cast the value before validation check",
+         with_env: { "OPENPROJECT_EMAILS__SALUTATION" => "name" } do
+        reset(:emails_salutation)
+        expect(all[:emails_salutation].value).to eq :name
+      end
+
       it "overriding datetime configuration from ENV will cast the value",
          with_env: { "OPENPROJECT_CONSENT__TIME" => "2222-01-01" } do
         reset(:consent_time)


### PR DESCRIPTION
🤖 AI-generated PR. Chat with @op-chomper for any further adjustments.
🔁 Maintainers: [Run](https://github.com/opf/openproject-chomper#taking-over-a-chomper-pr) `gh overtake 24337` to re-publish this PR under your own account.

📋 **Implementation plan:** https://gist.github.com/op-chomper/603801ae8d93ccb6d27ceb676121b36f

# Ticket

https://community.openproject.org/work_packages/COMMS-914

# What are you trying to accomplish?

Setting `OPENPROJECT_EMAILS__SALUTATION=name` (or `firstname`) crashed startup with `Value for emails_salutation must be one of firstname, name but is name (ArgumentError)`. The setting's format is `:symbol` (its default is `:firstname`), so env values are cast to symbols before validation, but its `allowed` list held strings — so the symbol value never matched. This makes the env variable usable again.

# What approach did you choose and why?

Changed the `emails_salutation` `allowed` list from strings (`%w[firstname name]`) to symbols (`%i[firstname name]`) so it matches the cast value. This mirrors the existing `rails_cache_store` symbol setting and keeps the rest of the codebase (which already treats this setting as a symbol) unchanged. Added a regression spec covering the env override.

## Screenshots

N/A — no visual changes.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)