### PR TITLE
FND-128: resolve custom field visibility through effective form type

### DIFF
--- a/app/models/work_package_custom_fields/scopes/on_visible_type_and_project.rb
+++ b/app/models/work_package_custom_fields/scopes/on_visible_type_and_project.rb
@@ -40,11 +40,17 @@ module WorkPackageCustomFields::Scopes
       # * on a project the user has access to
       # Both conditions need to be met on the same project.
       #
+      # A type whose form configuration is linked resolves to the type that
+      # actually owns that configuration, so its work packages surface the
+      # source type's fields.
+      #
       # Pass +project:+ to restrict the check to a single known project instead of
       # scanning all projects visible to the user.
       def on_visible_type_and_project(user = User.current, project: nil)
         visible_projects = Project.visible(user)
         visible_projects = visible_projects.where(id: project.id) if project&.persisted?
+
+        source_join, source_type_id = effective_form_source_sql
 
         where(<<~SQL.squish)
           EXISTS (
@@ -52,8 +58,9 @@ module WorkPackageCustomFields::Scopes
             FROM (#{visible_projects.select(:id).to_sql}) vp
             JOIN projects_types pt
               ON pt.project_id = vp.id
+            #{source_join}
             JOIN custom_fields_types cft
-              ON cft.type_id = pt.type_id
+              ON cft.type_id = #{source_type_id}
              AND cft.custom_field_id = custom_fields.id
             LEFT JOIN custom_fields_projects cfp
               ON cfp.project_id = vp.id
@@ -62,6 +69,35 @@ module WorkPackageCustomFields::Scopes
                OR cfp.custom_field_id IS NOT NULL
           )
         SQL
+      end
+
+      private
+
+      # Returns [join_sql, type_id_expression] used to key the custom_fields_types
+      # join. When some type links its form configuration elsewhere, the join is
+      # redirected through the link's terminal source; otherwise the physical
+      # type is used unchanged.
+      def effective_form_source_sql
+        map = form_source_map
+        return ["", "pt.type_id"] if map.empty?
+
+        values = map.map { |type_id, source_id| "(#{type_id}, #{source_id})" }.join(", ")
+        join = "LEFT JOIN (VALUES #{values}) AS effective(type_id, source_id) " \
+               "ON effective.type_id = pt.type_id"
+        [join, "COALESCE(effective.source_id, pt.type_id)"]
+      end
+
+      # Maps each type linking its form configuration to the id of the type that
+      # owns it. Reuses Type#effective_source_for so the feature-flag gate and
+      # cycle tolerance stay in one place; the map is empty (identity everywhere)
+      # when the subtypes feature is off.
+      def form_source_map
+        aspect = Type::ConfigurationLink::FORM_CONFIGURATION
+        linked_type_ids = Type::ConfigurationLink.where(aspect:).distinct.pluck(:type_id)
+
+        Type.where(id: linked_type_ids)
+            .to_h { |type| [type.id, type.effective_source_for(aspect).id] }
+            .reject { |type_id, source_id| type_id == source_id }
       end
     end
   end

--- a/spec/models/work_package_custom_fields/scopes/on_visible_type_and_project_spec.rb
+++ b/spec/models/work_package_custom_fields/scopes/on_visible_type_and_project_spec.rb
@@ -57,4 +57,87 @@ RSpec.describe WorkPackageCustomFields::Scopes::OnVisibleTypeAndProject do
       end
     end
   end
+
+  describe ".on_visible_type_and_project with a linked form configuration" do
+    shared_let(:source_type) { create(:type) }
+    shared_let(:linked_type) { create(:type) }
+    shared_let(:linked_project) { create(:project, types: [linked_type]) }
+    shared_let(:linked_user) do
+      create(:user, member_with_permissions: { linked_project => [] })
+    end
+
+    # Activated on the SOURCE type and enabled in the linked type's project.
+    shared_let(:source_cf) do
+      create(:integer_wp_custom_field, projects: [linked_project], types: [source_type])
+    end
+    # Activated on the linked type itself (a leftover from before it was linked).
+    shared_let(:linked_own_cf) do
+      create(:integer_wp_custom_field, projects: [linked_project], types: [linked_type])
+    end
+
+    subject { WorkPackageCustomField.on_visible_type_and_project(linked_user) }
+
+    context "when the subtypes feature is enabled", with_flag: { subtypes: true } do
+      before do
+        create(:type_configuration_link,
+               type: linked_type,
+               source: source_type,
+               aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+      end
+
+      it "surfaces the source type's custom fields for the linked type's project" do
+        expect(subject).to include(source_cf)
+      end
+
+      it "replaces the linked type's own fields with the source's (not a union)" do
+        expect(subject).not_to include(linked_own_cf)
+      end
+    end
+
+    context "when the subtypes feature is disabled", with_flag: { subtypes: false } do
+      before do
+        create(:type_configuration_link,
+               type: linked_type,
+               source: source_type,
+               aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+      end
+
+      it "ignores the link and does not surface the source type's fields" do
+        expect(subject).not_to include(source_cf)
+      end
+    end
+
+    context "with a multi-hop link chain", with_flag: { subtypes: true } do
+      shared_let(:mid_type) { create(:type) }
+
+      before do
+        create(:type_configuration_link,
+               type: linked_type, source: mid_type,
+               aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+        create(:type_configuration_link,
+               type: mid_type, source: source_type,
+               aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+      end
+
+      it "resolves to the terminal source type's fields" do
+        expect(subject).to include(source_cf)
+      end
+    end
+
+    context "with cyclic link rows", with_flag: { subtypes: true } do
+      before do
+        create(:type_configuration_link,
+               type: linked_type, source: source_type,
+               aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+        reversed = build(:type_configuration_link,
+                         type: source_type, source: linked_type,
+                         aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+        reversed.save!(validate: false)
+      end
+
+      it "terminates without raising" do
+        expect { subject.to_a }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/models/work_package_custom_fields/scopes/visible_spec.rb
+++ b/spec/models/work_package_custom_fields/scopes/visible_spec.rb
@@ -57,4 +57,40 @@ RSpec.describe WorkPackageCustomFields::Scopes::Visible do
       end
     end
   end
+
+  describe ".visible with a linked form configuration", with_flag: { subtypes: true } do
+    shared_let(:source_type) { create(:type) }
+    shared_let(:linked_type) { create(:type) }
+    shared_let(:linked_project) { create(:project, types: [linked_type]) }
+    shared_let(:source_cf) do
+      create(:integer_wp_custom_field, projects: [linked_project], types: [source_type])
+    end
+
+    before do
+      create(:type_configuration_link,
+             type: linked_type, source: source_type,
+             aspect: Type::ConfigurationLink::FORM_CONFIGURATION)
+    end
+
+    context "for a non-privileged user" do
+      shared_let(:member_user) do
+        create(:user, member_with_permissions: { linked_project => [] })
+      end
+
+      it "surfaces the source type's fields through the visibility scope" do
+        expect(WorkPackageCustomField.visible(member_user)).to include(source_cf)
+      end
+    end
+
+    context "for a user allowed to select custom fields anywhere" do
+      shared_let(:privileged_user) do
+        create(:user,
+               member_with_permissions: { linked_project => %i[select_custom_fields] })
+      end
+
+      it "returns all custom fields (short-circuit unaffected)" do
+        expect(WorkPackageCustomField.visible(privileged_user)).to include(source_cf)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/FND-128

# What are you trying to accomplish?

A type whose form configuration is **linked** borrows the source type's fields, which live under the *source's* `type_id`. This makes `WorkPackageCustomField.on_visible_type_and_project` resolve through the **effective form source**, so linked types surface the fields they actually display.

# What approach did you choose and why?

- Reuse `Type#effective_source_for(:form_configuration)` to build a `{ linked_type_id => owner_type_id }` map — keeps the feature-flag gate and cycle tolerance in one place instead of re-encoding them in SQL.
- Inject the map into the scope as an inline `VALUES` table and key the join via `COALESCE(effective.source_id, pt.type_id)`.
- Empty map (no links, or `subtypes` feature off) ⇒ original SQL emitted verbatim — zero behavioural change on production today.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a (no UI change)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — n/a (backend-only)
