### PR TITLE
[DREAM-753] Cancelling inplace edit fields results in an error

### DIFF
--- a/app/components/open_project/common/inplace_edit_fields/base_field_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/base_field_component.rb
@@ -63,6 +63,15 @@ module OpenProject
                          rows: 5)
         end
 
+        def reset_url
+          inplace_edit_field_reset_path(
+            model: model.class.name,
+            id: model.id,
+            attribute:,
+            system_arguments_json: @system_arguments.to_json
+          )
+        end
+
         def show_comment_field?
           custom_field? && custom_field&.has_comment?
         end

--- a/app/components/open_project/common/inplace_edit_fields/base_field_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/base_field_component.rb
@@ -63,6 +63,27 @@ module OpenProject
                          rows: 5)
         end
 
+        def render_action_buttons(form)
+          form.group(layout: :horizontal, justify_content: :flex_end) do |button_group|
+            button_group.button(name: :cancel,
+                                label: I18n.t(:button_cancel),
+                                tag: :a,
+                                href: reset_url,
+                                scheme: :default,
+                                **cancel_button_options)
+            button_group.submit(name: :submit,
+                                label: I18n.t(:button_save),
+                                scheme: :primary,
+                                **submit_button_options)
+          end
+        end
+
+        def cancel_button_options
+          { data: { turbo_stream: true } }
+        end
+
+        def submit_button_options = {}
+
         def reset_url
           inplace_edit_field_reset_path(
             model: model.class.name,

--- a/app/components/open_project/common/inplace_edit_fields/boolean_input_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/boolean_input_component.rb
@@ -46,15 +46,6 @@ module OpenProject
 
         private
 
-        def reset_url
-          inplace_edit_field_reset_path(
-            model: model.class.name,
-            id: model.id,
-            attribute:,
-            system_arguments_json: @system_arguments.to_json
-          )
-        end
-
         def additional_arguments
           if show_action_buttons
             {

--- a/app/components/open_project/common/inplace_edit_fields/rich_text_area_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/rich_text_area_component.rb
@@ -58,7 +58,7 @@ module OpenProject
                               **@system_arguments)
 
           comment_field_if_enabled(form)
-          render_action_buttons if show_action_buttons
+          render_action_buttons(form) if show_action_buttons
         end
 
         def test_selector
@@ -79,20 +79,12 @@ module OpenProject
           }
         end
 
-        def render_action_buttons
-          form.group(layout: :horizontal, justify_content: :flex_end) do |button_group|
-            button_group.button(name: :reset,
-                                label: I18n.t(:button_cancel),
-                                tag: :a,
-                                href: reset_url,
-                                scheme: :default,
-                                data: { turbo_stream: true },
-                                test_selector: "op-inplace-edit-field--textarea-cancel")
-            button_group.submit(name: :submit,
-                                label: I18n.t(:button_save),
-                                scheme: :primary,
-                                test_selector: "op-inplace-edit-field--textarea-save")
-          end
+        def cancel_button_options
+          super.merge(test_selector: "op-inplace-edit-field--textarea-cancel")
+        end
+
+        def submit_button_options
+          { test_selector: "op-inplace-edit-field--textarea-save" }
         end
       end
     end

--- a/app/components/open_project/common/inplace_edit_fields/rich_text_area_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/rich_text_area_component.rb
@@ -81,12 +81,12 @@ module OpenProject
 
         def render_action_buttons
           form.group(layout: :horizontal, justify_content: :flex_end) do |button_group|
-            button_group.submit(name: :reset,
-                                type: :submit,
+            button_group.button(name: :reset,
                                 label: I18n.t(:button_cancel),
+                                tag: :a,
+                                href: reset_url,
                                 scheme: :default,
-                                formaction: inplace_edit_field_reset_path(model: model.class.name, id: model.id, attribute:),
-                                formmethod: :get,
+                                data: { turbo_stream: true },
                                 test_selector: "op-inplace-edit-field--textarea-cancel")
             button_group.submit(name: :submit,
                                 label: I18n.t(:button_save),

--- a/app/components/open_project/common/inplace_edit_fields/select_list_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/select_list_component.rb
@@ -51,7 +51,7 @@ module OpenProject
           end
 
           comment_field_if_enabled(form)
-          render_action_buttons if show_action_buttons
+          render_action_buttons(form) if show_action_buttons
         end
 
         private
@@ -63,20 +63,6 @@ module OpenProject
           opts[:wrapper_id] ||= @system_arguments[:wrapper_id]
           opts[:focusDirectly] = true if opts[:focusDirectly].nil?
           opts[:closeOnSelect] = false if opts[:closeOnSelect].nil?
-        end
-
-        def render_action_buttons
-          form.group(layout: :horizontal, justify_content: :flex_end) do |button_group|
-            button_group.button(name: :reset,
-                                label: I18n.t(:button_cancel),
-                                tag: :a,
-                                href: reset_url,
-                                scheme: :default,
-                                data: { turbo_stream: true })
-            button_group.submit(name: :submit,
-                                label: I18n.t(:button_save),
-                                scheme: :primary)
-          end
         end
 
         def render_custom_field_input

--- a/app/components/open_project/common/inplace_edit_fields/select_list_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/select_list_component.rb
@@ -67,12 +67,12 @@ module OpenProject
 
         def render_action_buttons
           form.group(layout: :horizontal, justify_content: :flex_end) do |button_group|
-            button_group.submit(name: :reset,
-                                type: :submit,
+            button_group.button(name: :reset,
                                 label: I18n.t(:button_cancel),
+                                tag: :a,
+                                href: reset_url,
                                 scheme: :default,
-                                formaction: inplace_edit_field_reset_path(model: model.class.name, id: model.id, attribute:),
-                                formmethod: :get)
+                                data: { turbo_stream: true })
             button_group.submit(name: :submit,
                                 label: I18n.t(:button_save),
                                 scheme: :primary)

--- a/app/components/open_project/common/inplace_edit_fields/text_input_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/text_input_component.rb
@@ -47,15 +47,6 @@ module OpenProject
 
         private
 
-        def reset_url
-          inplace_edit_field_reset_path(
-            model: model.class.name,
-            id: model.id,
-            attribute:,
-            system_arguments_json: @system_arguments.to_json
-          )
-        end
-
         def additional_arguments
           if show_action_buttons
             {

--- a/lookbook/docs/patterns/06-inplace-edit-fields.md.erb
+++ b/lookbook/docs/patterns/06-inplace-edit-fields.md.erb
@@ -107,7 +107,7 @@ Custom fields are registered automatically. The format-to-component mappings (e.
 
 `BaseFieldComponent` is the **base class for all edit field components**. It provides shared functionality that concrete field components can use, and should be inherited from when building new field components.
 
-It handles the optional rendering of a comment field for custom fields with comments enabled.
+It handles the optional rendering of a comment field for custom fields with comments enabled, and provides a shared `render_action_buttons` implementation with overridable hooks.
 
 **Class-level API:**
 
@@ -145,6 +145,28 @@ Call this helper from any field component's `call` method to conditionally rende
 
 The generated form field name follows the pattern `model[custom_comments][custom_field_id]` (e.g. `project[custom_comments][18]`), so that multiple custom field comments can coexist in the same form submission.
 
+**`render_action_buttons(form)`**
+
+Renders a horizontal button group with a Cancel link and a Save submit button. Call this from `call` when the field should display its own action buttons (controlled via `show_action_buttons`).
+
+The Cancel button always includes `data: { turbo_stream: true }` to ensure the reset request is handled via Turbo. Subclasses can customize the buttons by overriding the hook methods:
+
+| Method | Default | Description |
+|---|---|---|
+| `cancel_button_options` | `{ data: { turbo_stream: true } }` | Extra options merged into the Cancel button. Always call `super.merge(...)` to preserve `turbo_stream`. |
+| `submit_button_options` | `{}` | Extra options merged into the Save button. |
+
+```ruby
+# Override in a subclass to add test selectors:
+def cancel_button_options
+  super.merge(test_selector: "my-field-cancel")
+end
+
+def submit_button_options
+  { test_selector: "my-field-save" }
+end
+```
+
 #### EditFieldComponents
 
 `EditFieldComponents` are responsible for rendering the actual form field. They receive a form builder, the model, the attribute, and the forwarded system arguments.
@@ -168,18 +190,17 @@ module OpenProject
         def call
           form.rich_text_area(name: attribute, **@system_arguments)
           comment_field_if_enabled(form)
+          render_action_buttons(form) if show_action_buttons
+        end
 
-          form.group(layout: :horizontal) do |button_group|
-            button_group.button(name: :reset,
-                                label: I18n.t(:button_cancel),
-                                tag: :a,
-                                href: reset_url,
-                                scheme: :default,
-                                data: { turbo_stream: true })
-            button_group.submit(name: :submit,
-                                label: I18n.t(:button_save),
-                                scheme: :primary)
-          end
+        private
+
+        def cancel_button_options
+          super.merge(test_selector: "op-inplace-edit-field--textarea-cancel")
+        end
+
+        def submit_button_options
+          { test_selector: "op-inplace-edit-field--textarea-save" }
         end
       end
     end
@@ -387,7 +408,8 @@ To add a new editable attribute:
 
 1. Create an `EditFieldComponent` that inherits from `BaseFieldComponent`.
 2. Call `comment_field_if_enabled(form)` in `call` if the field should support custom field comments.
-3. Register it in the `FieldRegistry`. Optionally provide a display component.
+3. Call `render_action_buttons(form) if show_action_buttons` in `call` to render Save/Cancel buttons. Override `cancel_button_options` or `submit_button_options` to customize (e.g. add `test_selector`). Always call `super.merge(...)` in `cancel_button_options` to preserve the required `data: { turbo_stream: true }`.
+4. Register it in the `FieldRegistry`. Optionally provide a display component.
 
 No changes to the core component or controller should be required.
 

--- a/lookbook/docs/patterns/06-inplace-edit-fields.md.erb
+++ b/lookbook/docs/patterns/06-inplace-edit-fields.md.erb
@@ -170,11 +170,12 @@ module OpenProject
           comment_field_if_enabled(form)
 
           form.group(layout: :horizontal) do |button_group|
-            button_group.submit(name: :reset,
-                                type: :submit,
+            button_group.button(name: :reset,
                                 label: I18n.t(:button_cancel),
-                                formaction: inplace_edit_field_reset_path(model:, id:, attribute:),
-                                formmethod: :get)
+                                tag: :a,
+                                href: reset_url,
+                                scheme: :default,
+                                data: { turbo_stream: true })
             button_group.submit(name: :submit,
                                 label: I18n.t(:button_save),
                                 scheme: :primary)

--- a/spec/components/open_project/common/inplace_edit_fields/rich_text_area_component_spec.rb
+++ b/spec/components/open_project/common/inplace_edit_fields/rich_text_area_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe OpenProject::Common::InplaceEditFields::RichTextAreaComponent,
     expect(rendered_content).to have_css("textarea[name='project[name]']", visible: :hidden)
     expect(rendered_content).to have_css("opce-ckeditor-augmented-textarea")
     expect(rendered_content).to have_button(I18n.t(:button_save))
-    expect(rendered_content).to have_button(I18n.t(:button_cancel))
+    expect(rendered_content).to have_link(I18n.t(:button_cancel))
   end
 
   it "omits action buttons when show_action_buttons is false" do
@@ -67,6 +67,6 @@ RSpec.describe OpenProject::Common::InplaceEditFields::RichTextAreaComponent,
     end
 
     expect(rendered_content).to have_no_button(I18n.t(:button_save))
-    expect(rendered_content).to have_no_button(I18n.t(:button_cancel))
+    expect(rendered_content).to have_no_link(I18n.t(:button_cancel))
   end
 end

--- a/spec/components/open_project/common/inplace_edit_fields/select_list_component_spec.rb
+++ b/spec/components/open_project/common/inplace_edit_fields/select_list_component_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe OpenProject::Common::InplaceEditFields::SelectListComponent,
 
     expect(rendered_content).to have_css("opce-autocompleter")
     expect(rendered_content).to have_button(I18n.t(:button_save))
-    expect(rendered_content).to have_button(I18n.t(:button_cancel))
+    expect(rendered_content).to have_link(I18n.t(:button_cancel))
   end
 
   it "omits action buttons when show_action_buttons is false" do
@@ -62,6 +62,6 @@ RSpec.describe OpenProject::Common::InplaceEditFields::SelectListComponent,
 
     expect(rendered_content).to have_css("opce-autocompleter")
     expect(rendered_content).to have_no_button(I18n.t(:button_save))
-    expect(rendered_content).to have_no_button(I18n.t(:button_cancel))
+    expect(rendered_content).to have_no_link(I18n.t(:button_cancel))
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-753

# What are you trying to accomplish?
Switch to normal links for cancelling to avoid that the form content is passed as parameter causing a 414 URI too large

