### PR TITLE
[DREAM-769] User labels have different colors

### DIFF
--- a/app/components/users/edit_page_header_component.html.erb
+++ b/app/components/users/edit_page_header_component.html.erb
@@ -28,7 +28,19 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { @user.name }
+    header.with_title do
+      flex_layout(align_items: :center) do |flex|
+        flex.with_column do
+          @user.name
+        end
+        if @user.persisted?
+          flex.with_column(ml: 2) do
+            render(Users::StatusLabelComponent.new(user: @user, display: :block))
+          end
+        end
+      end
+    end
+
     header.with_breadcrumbs(breadcrumb_items)
 
     header.with_action_button(

--- a/app/components/users/status_label_component.rb
+++ b/app/components/users/status_label_component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Users
+  class StatusLabelComponent < ApplicationComponent
+    def initialize(user:, **system_arguments)
+      super
+
+      @user = user
+      @system_arguments = system_arguments
+    end
+
+    def call
+      render(Primer::Beta::Label.new(scheme:, **@system_arguments)) { label }
+    end
+
+    private
+
+    def label
+      helpers.full_user_status(@user)
+    end
+
+    def scheme
+      case @user.status.to_sym
+      when :active then :success
+      when :registered, :invited then :attention
+      else :secondary
+      end
+    end
+  end
+end

--- a/app/forms/users/form/attributes_form.rb
+++ b/app/forms/users/form/attributes_form.rb
@@ -60,31 +60,12 @@ module Users
         return unless show_account_section?
 
         form.fieldset_group(title: I18n.t(:label_account)) do |group|
-          account_status(group) if @user.persisted?
           admin_flag(group) if User.current.admin?
         end
       end
 
       def show_account_section?
         @user.persisted? || User.current.admin?
-      end
-
-      # The current status (e.g. active, locked) as a read-only line rather than
-      # folded into the section title.
-      def account_status(group)
-        status = helpers.full_user_status(@user, true)
-        scheme = if @user.active?
-                   :success
-                 elsif @user.invited?
-                   :accent
-                 elsif @user.locked? || @user.deleted?
-                   :attention
-                 else
-                   :secondary
-                 end
-        group.html_content do
-          render(Primer::Beta::Label.new(scheme:, align_self: :start)) { status }
-        end
       end
 
       def admin_flag(group)

--- a/lookbook/previews/open_project/users/status_label_component_preview.rb
+++ b/lookbook/previews/open_project/users/status_label_component_preview.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Users
+  # @logical_path OpenProject/Users
+  class StatusLabelComponentPreview < Lookbook::Preview
+    # @!group Statuses
+
+    def active
+      render(Users::StatusLabelComponent.new(user: build_user(:active)))
+    end
+
+    def locked
+      render(Users::StatusLabelComponent.new(user: build_user(:locked)))
+    end
+
+    def registered
+      render(Users::StatusLabelComponent.new(user: build_user(:registered)))
+    end
+
+    def invited
+      render(Users::StatusLabelComponent.new(user: build_user(:invited)))
+    end
+
+    # @!endgroup
+
+    private
+
+    def build_user(status)
+      FactoryBot.build_stubbed(:user, status: User.statuses[status])
+    end
+  end
+end

--- a/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.html.erb
@@ -50,7 +50,7 @@ See COPYRIGHT and LICENSE files for more details.
         end
 
         header.with_column do
-          render(Primer::Beta::Label.new(scheme: status_scheme)) { status_label }
+          render(Users::StatusLabelComponent.new(user: @user))
         end
 
         if @remove_path

--- a/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/user_card_list/card_component.rb
@@ -53,14 +53,6 @@ module ResourcePlannerViews::UserCardList
       @user&.visible?(User.current)
     end
 
-    def status_label
-      helpers.full_user_status(@user)
-    end
-
-    def status_scheme
-      @user.active? ? :success : :attention
-    end
-
     def job_title
       return unless (custom_field = UserCustomField.for_semantic_key(:job_title))
 

--- a/modules/resource_management/spec/components/resource_planner_views/user_card_list/card_component_spec.rb
+++ b/modules/resource_management/spec/components/resource_planner_views/user_card_list/card_component_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe ResourcePlannerViews::UserCardList::CardComponent, type: :compone
     context "for an inactive user" do
       before { card_user.update_column(:status, Principal.statuses[:locked]) }
 
-      it "renders the status as an attention label" do
-        expect(rendered).to have_css("span.Label--attention", text: I18n.t("user.locked"))
+      it "renders the status as an secondary label" do
+        expect(rendered).to have_css("span.Label--secondary", text: I18n.t("user.locked"))
         expect(rendered).to have_no_css("span.Label--success")
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-769

# What are you trying to accomplish?
Create Users::StatusLabel component for a harmonized look and feel. On the administration page the label was moved to the PageHeader.

## Screenshots
<img width="170" height="343" alt="Bildschirmfoto 2026-07-20 um 11 39 11" src="https://github.com/user-attachments/assets/359ccb60-6a7d-4a85-ba66-237a00be3430" />


<img width="469" height="145" alt="Bildschirmfoto 2026-07-20 um 11 38 57" src="https://github.com/user-attachments/assets/f34c36c4-af1d-431e-832a-fd213127d85e" />
