### PR TITLE
[DREAM-770] Misaligned text on LDAP group sync filter deletion danger dialog

### DIFF
--- a/modules/ldap_groups/app/components/ldap_groups/synchronized_filters/destroy_dialog_component.html.erb
+++ b/modules/ldap_groups/app/components/ldap_groups/synchronized_filters/destroy_dialog_component.html.erb
@@ -46,17 +46,21 @@ See COPYRIGHT and LICENSE files for more details.
       )
     end
     if @filter.groups.any?
-      dialog.with_additional_details do
-        concat content_tag(:p, I18n.t("ldap_groups.synchronized_filters.destroy.removed_groups"))
-        concat(
-          content_tag(:ul) do
-            safe_join(
-              @filter.groups.map do |synced_group|
-                content_tag(:li, link_to(synced_group.group.name, edit_group_path(synced_group.group), target: "_blank", rel: "noopener"))
-              end
-            )
+      dialog.with_additional_details(px: 4) do
+        helpers.flex_layout do |layout|
+          layout.with_row do
+            content_tag(:p, I18n.t("ldap_groups.synchronized_filters.destroy.removed_groups"))
           end
-        )
+          layout.with_row do
+            content_tag(:ul) do
+              safe_join(
+                @filter.groups.map do |synced_group|
+                  content_tag(:li, link_to(synced_group.group.name, edit_group_path(synced_group.group), target: "_blank", rel: "noopener"))
+                end
+              )
+            end
+          end
+        end
       end
     end
     dialog.with_confirmation_check_box_content(I18n.t(:text_permanent_delete_confirmation_checkbox_label))


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-770

# What are you trying to accomplish?
Correctly align the additional details of the DangerDialog

## Screenshots

<img width="709" height="482" alt="Bildschirmfoto 2026-07-20 um 11 47 54" src="https://github.com/user-attachments/assets/17358853-b9fc-40ad-bdbc-2cf0ee256015" />
