### PR TITLE
[DREAM-771] Project attribute comments are empty in PMflex artefact export  

### DIFF
--- a/config/initializers/export_formats.rb
+++ b/config/initializers/export_formats.rb
@@ -38,6 +38,7 @@ Rails.application.configure do |application|
 
       formatter WorkPackage, Exports::Formatters::CustomField
       formatter WorkPackage, Exports::Formatters::CustomFieldPdf
+      formatter WorkPackage, Exports::Formatters::CustomComment
       formatter WorkPackage, WorkPackage::Exports::Formatters::PDF::CompoundDoneRatio
       formatter WorkPackage, WorkPackage::Exports::Formatters::PDF::CompoundHours
       formatter WorkPackage, WorkPackage::Exports::Formatters::XLS::Costs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1169,7 +1169,6 @@ en:
         contribution_callout: >
           Please, help us improve the Jira Migrator with your feedback and private data donations. You can [join the development community](link) of the Jira Migrator.
         description: "This Jira Migrator is currently in beta. We currently only support Jira Server/Data Center versions 10.x and 11.x. Cloud instances are not supported at this time."
-        supported_versions: ""
         title: "Beta - Try it out!"
       blank:
         description: "Configure a Jira host to start importing items from Jira to this OpenProject instance."


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-771

# What are you trying to achieve?

`custom fields comment` appear empty in the PMflex artefact export

# What approach did you choose and why?

Add the `custom fields comment` formatter to the register for the work package,
