### PR TITLE
[COMMS-897] Read and write target versions in the incoming e-mail handler

### DIFF
--- a/app/services/incoming_emails/dispatch_service.rb
+++ b/app/services/incoming_emails/dispatch_service.rb
@@ -286,6 +286,8 @@ module IncomingEmails
       options[:allow_override] << :status unless options[:issue].has_key?(:status)
       # Version overridable by default
       options[:allow_override] << :version unless options[:issue].has_key?(:version)
+      # Target versions follow the same rule as the deprecated single version
+      options[:allow_override] << :target_versions unless options[:issue].has_key?(:target_versions)
       # Type overridable by default
       options[:allow_override] << :type unless options[:issue].has_key?(:type)
       # Priority overridable by default

--- a/app/services/incoming_emails/handlers/base.rb
+++ b/app/services/incoming_emails/handlers/base.rb
@@ -178,7 +178,7 @@ module IncomingEmails::Handlers
         # Work package attribute translations
         I18n.with_locale(lang) do
           %i[assigned_to category due_date estimated_hours parent priority
-             remaining_hours responsible start_date status type version project].each do |attr|
+             remaining_hours responsible start_date status type version target_versions project].each do |attr|
             translations[attr] = ::WorkPackage.human_attribute_name(attr)
           end
         end

--- a/app/services/incoming_emails/handlers/work_package.rb
+++ b/app/services/incoming_emails/handlers/work_package.rb
@@ -164,7 +164,7 @@ module IncomingEmails::Handlers
         "start_date" => wp_start_date_from_keywords,
         "status_id" => wp_status_from_keywords,
         "type_id" => wp_type_from_keywords(work_package),
-        "version_id" => wp_version_from_keywords(work_package)
+        "target_version_ids" => wp_target_version_ids_from_keywords(work_package)
       }.compact_blank!
     end
 
@@ -205,8 +205,24 @@ module IncomingEmails::Handlers
       Principal.possible_assignee(work_package.project).where(id: Principal.like(keyword)).first.try(:id)
     end
 
-    def wp_version_from_keywords(work_package)
-      lookup_case_insensitive_key(work_package.project.shared_versions, :version, Arel.sql("#{Version.table_name}.name"))
+    # Both keywords are always read so neither leaks into the description or
+    # journal note; the target versions keyword takes precedence over the
+    # deprecated single-version one when both are supplied.
+    def wp_target_version_ids_from_keywords(work_package)
+      target = get_keyword(:target_versions)
+      legacy = get_keyword(:version)
+      keyword = target.presence || legacy
+      return if keyword.blank?
+
+      matching_version_ids(work_package, keyword)
+    end
+
+    # The single-value limit is enforced by the contract, so the full
+    # comma-separated list is parsed here regardless of the feature flag.
+    def matching_version_ids(work_package, keyword)
+      names = keyword.split(",").map(&:strip).compact_blank
+      versions_by_name = work_package.project.shared_versions.index_by { |version| version.name.downcase }
+      names.filter_map { |name| versions_by_name[name.downcase]&.id }
     end
 
     def wp_start_date_from_keywords

--- a/docker/prod/cron
+++ b/docker/prod/cron
@@ -24,6 +24,7 @@ while true; do
 			priority="${IMAP_ATTR_PRIORITY}" \
 			status="${IMAP_ATTR_STATUS}" \
 			version="${IMAP_ATTR_VERSION}" \
+			target_versions="${IMAP_ATTR_TARGET_VERSIONS}" \
 			type="${IMAP_ATTR_TYPE}" \
 			assigned_to="${IMAP_ATTR_ASSIGNED_TO}" \
 			unknown_user="${IMAP_UNKNOWN_USER}" \

--- a/docs/installation-and-operations/configuration/incoming-emails/README.md
+++ b/docs/installation-and-operations/configuration/incoming-emails/README.md
@@ -66,7 +66,8 @@ Available arguments that change how the work packages are handled:
 | `category` | `IMAP_ATTR_CATEGORY` | name of the target category |
 | `priority` | `IMAP_ATTR_PRIORITY` | name of the target priority |
 | `status` | `IMAP_ATTR_STATUS` | name of the target status |
-| `version` | `IMAP_ATTR_VERSION` | name of the target version |
+| `version` | `IMAP_ATTR_VERSION` | name of the target version (deprecated, use `target_versions`) |
+| `target_versions` | `IMAP_ATTR_TARGET_VERSIONS` | name of the target version; separate several with commas (more than one requires the multiple versions feature) |
 | `type` | `IMAP_ATTR_TYPE` | name of the target type |
 | `assigned_to` | `IMAP_ATTR_ASSIGNED_TO` | name of the assigned user |
 | `unknown_user` | `IMAP_UNKNOWN_USER` | ignore: email is ignored (default), accept: accept as anonymous user, create: create a user account <br />Hint: You must also set `IMAP_NO_PERMISSION_CHECK=1` for sending mail by anonymous users to work as expected.|
@@ -192,7 +193,8 @@ Other available keys for the email are as follows. You can always use the intern
 | responsible     | Accountable     | sets the accountable, via user email or login         | responsible:user@example.org     |
 | assigned_to     | Assignee        | sets the assignee. Use the email or login of the user | assignee:test.nutzer@example.org |
 | type            | Type            | sets the type                                         | type:Milestone                   |
-| version         | Version         | sets the version                                      | version:v4.1.0                   |
+| version         | Version         | sets the version (deprecated, use target_versions)    | version:v4.1.0                   |
+| target_versions | Target versions | sets the target versions; separate several with commas (more than one requires the multiple versions feature) | target_versions:v4.1.0, v4.2.0 |
 | start_date      | Start date      | sets the start date                                   | start_date:2015-02-28            |
 | due_date        | Due date        | sets the finish date                                  | due:_date:2015-02-28             |
 | estimated_hours | Estimated hours | sets the estimated hours. Use a number                | estimated_hours:10.5             |

--- a/docs/installation-and-operations/configuration/incoming-emails/README.md
+++ b/docs/installation-and-operations/configuration/incoming-emails/README.md
@@ -66,8 +66,7 @@ Available arguments that change how the work packages are handled:
 | `category` | `IMAP_ATTR_CATEGORY` | name of the target category |
 | `priority` | `IMAP_ATTR_PRIORITY` | name of the target priority |
 | `status` | `IMAP_ATTR_STATUS` | name of the target status |
-| `version` | `IMAP_ATTR_VERSION` | name of the target version (deprecated, use `target_versions`) |
-| `target_versions` | `IMAP_ATTR_TARGET_VERSIONS` | name of the target version; separate several with commas (more than one requires the multiple versions feature) |
+| `version` | `IMAP_ATTR_VERSION` | name of the target version |
 | `type` | `IMAP_ATTR_TYPE` | name of the target type |
 | `assigned_to` | `IMAP_ATTR_ASSIGNED_TO` | name of the assigned user |
 | `unknown_user` | `IMAP_UNKNOWN_USER` | ignore: email is ignored (default), accept: accept as anonymous user, create: create a user account <br />Hint: You must also set `IMAP_NO_PERMISSION_CHECK=1` for sending mail by anonymous users to work as expected.|
@@ -193,8 +192,7 @@ Other available keys for the email are as follows. You can always use the intern
 | responsible     | Accountable     | sets the accountable, via user email or login         | responsible:user@example.org     |
 | assigned_to     | Assignee        | sets the assignee. Use the email or login of the user | assignee:test.nutzer@example.org |
 | type            | Type            | sets the type                                         | type:Milestone                   |
-| version         | Version         | sets the version (deprecated, use target_versions)    | version:v4.1.0                   |
-| target_versions | Target versions | sets the target versions; separate several with commas (more than one requires the multiple versions feature) | target_versions:v4.1.0, v4.2.0 |
+| version         | Version         | sets the version                                      | version:v4.1.0                   |
 | start_date      | Start date      | sets the start date                                   | start_date:2015-02-28            |
 | due_date        | Due date        | sets the finish date                                  | due:_date:2015-02-28             |
 | estimated_hours | Estimated hours | sets the estimated hours. Use a number                | estimated_hours:10.5             |

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -230,14 +230,18 @@ namespace :redmine do
     private
 
     def options_from_env
-      { issue: {} }.tap do |options|
-        default_fields = ENV.fetch("default_fields", "").split
-        default_fields |= %w[project status type category priority assigned_to version]
-        default_fields.each { |field| options[:issue][field.to_sym] = ENV[field] if ENV[field].present? }
+      { issue: issue_defaults_from_env }.tap do |options|
+        %w[allow_override unknown_user no_permission_check].each do |key|
+          options[key.to_sym] = ENV[key] if ENV[key]
+        end
+      end
+    end
 
-        options[:allow_override] = ENV["allow_override"] if ENV["allow_override"]
-        options[:unknown_user] = ENV["unknown_user"] if ENV["unknown_user"]
-        options[:no_permission_check] = ENV["no_permission_check"] if ENV["no_permission_check"]
+    def issue_defaults_from_env
+      fields = ENV.fetch("default_fields", "").split
+      fields |= %w[project status type category priority assigned_to version target_versions]
+      fields.each_with_object({}) do |field, issue|
+        issue[field.to_sym] = ENV[field] if ENV[field].present?
       end
     end
   end

--- a/spec/fixtures/mail_handler/wp_reply_setting_version.eml
+++ b/spec/fixtures/mail_handler/wp_reply_setting_version.eml
@@ -1,0 +1,14 @@
+Date: Tue, 16 Mar 2021 15:17:04 +0100
+To: notifications@openproject.com
+From: JSmith@somenet.foo
+Message-ID: <op.journal-9001@example.net>
+References: <op.work_package-555@example.net>
+Subject: Re: [onlinestore] Some work package
+Mime-Version: 1.0
+Content-Type: text/plain;
+	charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+This is the text of the reply.
+
+Version: alpha

--- a/spec/fixtures/mail_handler/wp_with_multiple_target_versions.eml
+++ b/spec/fixtures/mail_handler/wp_with_multiple_target_versions.eml
@@ -1,0 +1,20 @@
+Return-Path: <JSmith@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "John Smith" <JSmith@somenet.foo>
+To: <openproject@somenet.foo>
+Subject: New ticket with several target versions
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+Some description here
+
+Project: onlinestore
+Target versions: alpha, beta

--- a/spec/fixtures/mail_handler/wp_with_target_version.eml
+++ b/spec/fixtures/mail_handler/wp_with_target_version.eml
@@ -1,0 +1,20 @@
+Return-Path: <JSmith@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "John Smith" <JSmith@somenet.foo>
+To: <openproject@somenet.foo>
+Subject: New ticket with a single target version
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+Some description here
+
+Project: onlinestore
+Target versions: alpha

--- a/spec/fixtures/mail_handler/wp_with_version_and_target_versions.eml
+++ b/spec/fixtures/mail_handler/wp_with_version_and_target_versions.eml
@@ -1,0 +1,21 @@
+Return-Path: <JSmith@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "John Smith" <JSmith@somenet.foo>
+To: <openproject@somenet.foo>
+Subject: New ticket with both version keywords
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+Some description here
+
+Project: onlinestore
+Version: alpha
+Target versions: beta

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -597,6 +597,13 @@ RSpec.describe IncomingEmails::MailHandler do # rubocop:disable RSpec/SpecFilePa
             .to eql(version)
         end
 
+        it "sets the target version, keeping the legacy version in sync" do
+          expect(subject.target_versions)
+            .to contain_exactly(version)
+          expect(subject.version)
+            .to eql(version)
+        end
+
         it "sets the estimated_hours" do
           expect(subject.estimated_hours)
             .to be(2.5)
@@ -1241,6 +1248,100 @@ RSpec.describe IncomingEmails::MailHandler do # rubocop:disable RSpec/SpecFilePa
             expect(subject.remaining_hours).to eq(10.5)
             expect(subject.category).to eq(stock_category)
           end
+        end
+      end
+    end
+
+    context "when setting target versions from keywords" do
+      let(:permissions) { %i[add_work_packages edit_work_packages view_work_packages assign_versions] }
+      let!(:user) do
+        create(:user,
+               mail: "JSmith@somenet.foo",
+               firstname: "John",
+               lastname: "Smith",
+               member_with_permissions: { project => permissions })
+      end
+      let!(:alpha) { create(:version, name: "alpha", project:) }
+      let!(:beta) { create(:version, name: "beta", project:) }
+
+      context "when the multiple-versions feature is enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        subject { submit_email("wp_with_multiple_target_versions.eml", issue: { project: "onlinestore" }) }
+
+        it "assigns every named target version" do
+          expect(subject.target_versions)
+            .to contain_exactly(alpha, beta)
+        end
+
+        it "keeps the legacy version in sync with the first target version" do
+          expect(subject.version)
+            .to eql(alpha)
+        end
+
+        it "removes the keyword from the description" do
+          expect(subject.description)
+            .not_to match(/^Target versions:/i)
+        end
+      end
+
+      context "when the multiple-versions feature is disabled" do
+        context "with a single named version" do
+          subject { submit_email("wp_with_target_version.eml", issue: { project: "onlinestore" }) }
+
+          it "assigns the target version" do
+            expect(subject.target_versions)
+              .to contain_exactly(alpha)
+          end
+        end
+
+        context "with several named versions" do
+          subject { submit_email("wp_with_multiple_target_versions.eml", issue: { project: "onlinestore" }) }
+
+          it "is refused by the single-value rule rather than silently dropped" do
+            expect(subject)
+              .not_to be_persisted
+            expect(subject.errors.symbols_for(:base))
+              .to include(:target_versions_only_allow_single_value)
+          end
+        end
+      end
+
+      context "when both version and target versions keywords are present",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        subject { submit_email("wp_with_version_and_target_versions.eml", issue: { project: "onlinestore" }) }
+
+        it "lets the target versions keyword win" do
+          expect(subject.target_versions)
+            .to contain_exactly(beta)
+        end
+
+        it "removes both keywords from the description" do
+          expect(subject.description)
+            .not_to match(/^Version:/i)
+          expect(subject.description)
+            .not_to match(/^Target versions:/i)
+        end
+      end
+
+      context "when replying to a work package that already has target versions" do
+        let!(:work_package) do
+          create(:work_package, project:).tap do |wp|
+            wp.work_package_versions.create!(version_id: alpha.id, kind: "target")
+            wp.work_package_versions.create!(version_id: beta.id, kind: "target")
+          end
+        end
+
+        before do
+          allow(WorkPackage).to receive(:find_by).with(id: 555).and_return(work_package)
+        end
+
+        it "replaces the whole target version set with the named version" do
+          submit_email("wp_reply_setting_version.eml", issue: { project: "onlinestore" })
+
+          expect(work_package.reload.target_versions)
+            .to contain_exactly(alpha)
         end
       end
     end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-897

Adapt the work package e-mail handler to set a work package's version via `Target versions:` - the legacy `Version:` keyword is retained as a secondary supported option but it is marked as deprecated in the relevant docs.

> [!NOTE]
> Docs PR separate so it's reviewable by the docs team #24361 