### PR TITLE
MCP endpoint for custom fields

### DIFF
--- a/app/services/mcp_resources/custom_field.rb
+++ b/app/services/mcp_resources/custom_field.rb
@@ -23,42 +23,24 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
-require "rack/test"
+module McpResources
+  class CustomField < Base
+    name "custom_field"
+    uri_template "/api/v3/custom_fields/{id}"
 
-RSpec.describe "API v3 Custom field resource" do
-  include Rack::Test::Methods
-  include API::V3::Utilities::PathHelper
+    default_title "Custom Field"
+    default_description "Access custom fields of this OpenProject instance."
 
-  current_user { create(:user) }
+    def read(id:)
+      custom_field = ::CustomField.visible(current_user).find_by(id:)
+      return nil if custom_field.nil?
 
-  describe "custom_fields/:id" do
-    describe "#get" do
-      let!(:custom_field) { create(:user_custom_field) }
-      let(:get_path) { api_v3_paths.custom_field custom_field.id }
-
-      subject(:response) { last_response }
-
-      before do
-        allow(User).to receive(:current).and_return(current_user)
-
-        get get_path
-      end
-
-      context "with valid custom field id" do
-        it { expect(response).to have_http_status(:ok) }
-      end
-
-      context "with invalid custom field id" do
-        let(:get_path) { api_v3_paths.custom_field "bogus" }
-
-        it_behaves_like "not found"
-      end
+      API::V3::CustomFields::CustomFieldRepresenter.new(custom_field, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_custom_fields.rb
+++ b/app/services/mcp_tools/search_custom_fields.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class SearchCustomFields < Base
+    default_title "Search custom fields"
+    default_description "Show details of the custom fields matching given criteria."
+
+    name "search_custom_fields"
+    annotations read_only: true, idempotent: true, destructive: false
+    enable_pagination
+
+    filter :id
+    filter :name, filter_proc: ->(cfs, v) { cfs.where("name ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(v)}%'") }
+
+    input_schema(
+      properties: {
+        id: {
+          type: %i[number array],
+          description: "The ID of the custom field that shall be fetched. Can also be an array of IDs to fetch " \
+                       "multiple custom fields at once."
+        },
+        name: {
+          type: :string,
+          description: "The name of the custom field that shall be fetched. Matches partially and case-insensitive."
+        }
+      }
+    )
+
+    def call(page: nil, **filters)
+      custom_fields = apply_filters(CustomField.visible, filters)
+      custom_fields = apply_pagination(custom_fields, page)
+
+      {
+        items: custom_fields.map do |custom_field|
+          ::API::V3::CustomFields::CustomFieldRepresenter.create(custom_field, current_user:)
+        end
+      }
+    end
+  end
+end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -33,8 +33,9 @@ module McpTools
     default_title "Search work packages"
     default_description "Search work packages matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
-                        "of #{page_size} work packages. To get the rest of the results, call the tool again with a" \
-                        "page number of 2 or higher."
+                        "of #{page_size} work packages. To get the rest of the results, call the tool again with a " \
+                        "page number of 2 or higher. Names of custom fields should be resolved through the corresponding tool " \
+                        "before showing them to the user. They should not be rendered as 'customFieldN'."
 
     name "search_work_packages"
     annotations read_only: true, idempotent: true, destructive: false

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -49,6 +49,7 @@ Rails.application.config.after_initialize do
                     McpTools::CurrentUser,
                     McpTools::ListStatuses,
                     McpTools::ListTypes,
+                    McpTools::SearchCustomFields,
                     McpTools::SearchPortfolios,
                     McpTools::SearchPrograms,
                     McpTools::SearchProjects,
@@ -58,6 +59,7 @@ Rails.application.config.after_initialize do
                     McpTools::UpdateWorkPackage
 
   McpResources.register McpResources::CurrentUser,
+                        McpResources::CustomField,
                         McpResources::Project,
                         McpResources::Status,
                         McpResources::StatusList,

--- a/docs/api/apiv3/components/schemas/custom_field_model.yml
+++ b/docs/api/apiv3/components/schemas/custom_field_model.yml
@@ -66,5 +66,9 @@ example:
   fieldFormat: hierarchy
   isRequired: false
   isMultiValue: false
-  createdAt: "2026-07-20T13:37:00"
-  updatedAt: "2026-07-20T20:13:37"
+  createdAt: "2026-07-20T13:37:00Z"
+  updatedAt: "2026-07-20T20:13:37Z"
+  _links:
+    self:
+      href: "/api/v3/custom_fields/42"
+      title: "Celestial Body"

--- a/docs/api/apiv3/components/schemas/custom_field_model.yml
+++ b/docs/api/apiv3/components/schemas/custom_field_model.yml
@@ -1,0 +1,70 @@
+# Schema: CustomFieldModel
+---
+type: object
+required:
+- id
+- name
+- fieldFormat
+- isRequired
+- isMultiValue
+- createdAt
+- updatedAt
+- _links
+properties:
+  id:
+    type: integer
+    description: The custom field ID.
+    readOnly: true
+  name:
+    type: string
+    description: The human-readable name of the custom field.
+  fieldFormat:
+    type: string
+    description: Defines which kind of values are allowed in the custom field.
+    enum:
+    - bool
+    - date
+    - float
+    - hierarchy
+    - int
+    - link
+    - list
+    - string
+    - text
+    - user
+    - version
+    - weighted_item_list
+  isRequired:
+    type: boolean
+    description: Whether the custom field must be filled out to save an object using it.
+  isMultiValue:
+    type: boolean
+    description: Whether the custom field accepts more than one value.
+  createdAt:
+    type: string
+    format: date-time
+    description: Time of creation.
+    readOnly: true
+  updatedAt:
+    type: string
+    format: date-time
+    description: Time of the most recent change to the custom field.
+    readOnly: true
+  _links:
+    type: object
+    required:
+    - self
+    properties:
+      self:
+        allOf:
+        - $ref: "./link.yml"
+        - description: APIv3 self-reference of the custom field.
+
+example:
+  id: 42
+  name: Celestial Body
+  fieldFormat: hierarchy
+  isRequired: false
+  isMultiValue: false
+  createdAt: "2026-07-20T13:37:00"
+  updatedAt: "2026-07-20T20:13:37"

--- a/docs/api/apiv3/paths/custom_field.yml
+++ b/docs/api/apiv3/paths/custom_field.yml
@@ -1,0 +1,46 @@
+# /api/v3/custom_field/{id}
+---
+get:
+  summary: Get custom field
+  operationId: get_custom_field
+  description: |-
+    Retrieves the custom field with the given ID.
+  parameters:
+    - name: id
+      description: The custom field's unique identifier
+      in: path
+      example: '42'
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/custom_field_model.yml'
+    '403':
+      description: Returned if the user is not logged in.
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+    '404':
+      description: Returned if the custom field does not exist or the user lacks the permission to view it.
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.

--- a/lib/api/v3/custom_fields/custom_field_representer.rb
+++ b/lib/api/v3/custom_fields/custom_field_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,20 +31,25 @@
 module API
   module V3
     module CustomFields
-      class CustomFieldsAPI < ::API::OpenProjectAPI
-        resource :custom_fields do
-          route_param :id, type: Integer, desc: "Custom Field ID" do
-            after_validation do
-              authorize_logged_in
+      class CustomFieldRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+        include API::Decorators::DateProperty
 
-              @custom_field = CustomField.visible.find(params[:id])
-            end
-
-            get &API::V3::Utilities::Endpoints::Show.new(model: CustomField).mount
-
-            mount Hierarchy::ItemsAPI
-          end
+        def self_v3_path(*)
+          api_v3_paths.custom_field(represented.id)
         end
+
+        self_link title_getter: ->(*) { represented.name }
+
+        property :id
+        property :name
+        property :field_format
+
+        property :is_required
+        property :is_multi_value, getter: ->(*) { multi_value }
+
+        date_time_property :created_at
+        date_time_property :updated_at
       end
     end
   end

--- a/spec/lib/api/v3/custom_fields/custom_field_representer_spec.rb
+++ b/spec/lib/api/v3/custom_fields/custom_field_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -21,29 +23,24 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module CustomFields
-      class CustomFieldsAPI < ::API::OpenProjectAPI
-        resource :custom_fields do
-          route_param :id, type: Integer, desc: "Custom Field ID" do
-            after_validation do
-              authorize_logged_in
+require "spec_helper"
 
-              @custom_field = CustomField.visible.find(params[:id])
-            end
+RSpec.describe API::V3::CustomFields::CustomFieldRepresenter do
+  subject(:generated) { representer.to_json }
 
-            get &API::V3::Utilities::Endpoints::Show.new(model: CustomField).mount
+  let(:representer) do
+    described_class.create(custom_field, current_user: user)
+  end
 
-            mount Hierarchy::ItemsAPI
-          end
-        end
-      end
-    end
+  let(:custom_field) { create(:custom_field) }
+  let(:user) { create(:user) }
+
+  it "fulfills the documented schema" do
+    expect(generated).to match_json_schema.from_docs("custom_field_model")
   end
 end

--- a/spec/requests/api/v3/custom_field_resource_spec.rb
+++ b/spec/requests/api/v3/custom_field_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,23 +28,36 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module CustomFields
-      class CustomFieldsAPI < ::API::OpenProjectAPI
-        resource :custom_fields do
-          route_param :id, type: Integer, desc: "Custom Field ID" do
-            after_validation do
-              authorize_logged_in
+require "spec_helper"
+require "rack/test"
 
-              @custom_field = CustomField.visible.find(params[:id])
-            end
+RSpec.describe "API v3 Custom field resource" do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
 
-            get &API::V3::Utilities::Endpoints::Show.new(model: CustomField).mount
+  current_user { create(:user) }
 
-            mount Hierarchy::ItemsAPI
-          end
-        end
+  describe "custom_fields/:id" do
+    describe "#get" do
+      let!(:custom_field) { create(:user_custom_field) }
+      let(:get_path) { api_v3_paths.custom_field custom_field.id }
+
+      subject(:response) { last_response }
+
+      before do
+        allow(User).to receive(:current).and_return(current_user)
+
+        get get_path
+      end
+
+      context "valid custom field id" do
+        it { expect(response).to have_http_status(:ok) }
+      end
+
+      context "invalid custom field id" do
+        let(:get_path) { api_v3_paths.custom_field "bogus" }
+
+        it_behaves_like "not found"
       end
     end
   end

--- a/spec/requests/mcp/mcp_resources/custom_field_spec.rb
+++ b/spec/requests/mcp/mcp_resources/custom_field_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpResources::CustomField do
+  subject(:mcp_request) do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) { create(:oauth_access_token, scopes: "mcp", resource_owner: user) }
+  let(:user) { create(:admin) }
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "resources/read",
+      params: { uri: resource_uri }
+    }
+  end
+  let(:resource_uri) { "http://test.host/api/v3/custom_fields/#{custom_field.id}" }
+
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+
+  let(:custom_field) { create(:wp_custom_field) }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:resource_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  before do
+    server_config.save!
+    resource_config.save!
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
+    it_behaves_like "MCP text resource response"
+
+    it "responds with a properly formatted custom field" do
+      mcp_request
+      text_content = parsed_results.fetch("contents").first
+      custom_field = text_content.fetch("text")
+      expect(custom_field).to match_json_schema.from_docs("custom_field_model")
+    end
+
+    context "when the resource is disabled via configuration" do
+      let(:resource_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
+
+      it_behaves_like "MCP empty resource response"
+    end
+
+    context "when requesting a non-existing custom field" do
+      let(:resource_uri) { "http://test.host/api/v3/custom_fields/#{custom_field.id + 1}" }
+
+      it_behaves_like "MCP empty resource response"
+    end
+
+    context "when requesting a custom field not visible to the user" do
+      let(:user) { create(:user) }
+
+      it_behaves_like "MCP empty resource response"
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds in a 404" do
+      mcp_request
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end

--- a/spec/requests/mcp/mcp_tools/search_custom_fields_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_custom_fields_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpTools::SearchCustomFields do
+  subject(:mcp_request) do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) do
+    # avoid owner for application, so that we don't have additional users created
+    create(:oauth_access_token, scopes: "mcp", resource_owner: user, application: create(:oauth_application, owner: nil))
+  end
+  let(:user) { create(:admin) }
+
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "search_custom_fields",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) { {} }
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+
+  let!(:custom_field_one) { create(:wp_custom_field, name: "One custom field") }
+  let!(:custom_field_two) { create(:wp_custom_field, name: "Another field") }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  before do
+    server_config.save!
+    tool_config.save!
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
+    it_behaves_like "MCP text tool"
+
+    it "finds all custom fields without filters" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "items").size).to eq(2)
+    end
+
+    it "responds with properly formatted custom fields" do
+      mcp_request
+      parsed_results.dig("structuredContent", "items").each do |cf|
+        expect(cf.to_json).to match_json_schema.from_docs("custom_field_model")
+      end
+    end
+
+    context "when filtering by the full custom field name" do
+      let(:call_args) { { name: "One custom field" } }
+
+      it "finds the custom field" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+        expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(custom_field_one.id)
+      end
+    end
+
+    context "when filtering on a partial, wrongly-cased term" do
+      let(:call_args) { { name: "cUstom" } }
+
+      it "finds the custom field" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+        expect(parsed_results.dig("structuredContent", "items").first.fetch("id")).to eq(custom_field_one.id)
+      end
+    end
+
+    context "when not allowed to see the custom field" do
+      let(:user) { create(:user) }
+
+      it "does not find the custom field" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(0)
+      end
+    end
+
+    describe "pagination" do
+      let(:page_size) { 10 }
+      let(:overspilling_fields) { 5 }
+      let(:field_count) { page_size + overspilling_fields }
+      let(:call_args) { { name: "user custom" } }
+
+      before do
+        allow(described_class).to receive(:page_size).and_return(page_size)
+
+        create_list(:user_custom_field, field_count)
+      end
+
+      it "returns only results up to the page size" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(page_size)
+      end
+
+      context "if another page is requested" do
+        let(:call_args) { { name: "user custom", page: 2 } }
+
+        it "returns the requested page" do
+          mcp_request
+          expect(parsed_results.dig("structuredContent", "items").size).to eq(overspilling_fields)
+        end
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds in a 404" do
+      mcp_request
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds MCP (and APIv3) endpoints to fetch custom field information. This should allow MCP clients to fetch additional metadata about work packages (but also other resources), where they'd have to guess what a custom field meant before.

# Ticket
https://community.openproject.org/wp/AI-74

# Limitations

Most reading use cases should be covered by this PR, since it's possible to fetch custom fields after reading a work package by their ID. It's also possible to instead ask for a specific custom field and search that by name, so that not all of them need to be fetched at once.

However, the current state is probably not enough for all writing use cases covering custom fields. Most notably:

* It's not easy to find out which custom fields are **required** to create a certain kind of work package
* There are no endpoints to fetch allowed custom values for list or hierarchy custom fields