### PR TITLE
[OP-19667] Impossible to create team planner as it redirects to work packages page

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
@@ -155,13 +155,21 @@ export class WorkPackagesListChecksumService {
     );
   }
 
+  private isOnNonRouterPage():boolean {
+    if (!this.$state.current.name) return true;
+    const { pathname } = window.location;
+    return pathname.includes('/team_planners')
+      || pathname.includes('/calendars')
+      || pathname.includes('/ifc_models');
+  }
+
   private maintainUrlQueryState(id:string|null, checksum:string|null):TransitionPromise {
     this.visibleChecksum = checksum;
     this.visibleChecksum$.next(checksum);
 
-    // When uiRouter is not managing the current page (e.g. calendar after Turbo migration),
-    // $state.current.name is empty and state.go('.') does nothing. Fall back to pushState.
-    if (!this.$state.current.name) {
+    // When uiRouter is not managing the current page (e.g. calendar, team planner, BIM after Turbo migration),
+    // $state.current.name may be stale from a previous router page. Detect by URL to avoid incorrect $state.go() navigation.
+    if (this.isOnNonRouterPage()) {
       const url = new URL(window.location.href);
 
       if (checksum) {

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -309,7 +309,7 @@ export class WorkPackagesListService {
         this.toastService.addSuccess(this.I18n.t('js.notice_successful_update'));
         const queryAccessibleByUser = query.public || query.user.id === this.currentUser.userId;
         if (queryAccessibleByUser) {
-          if (!this.$state.current.name) {
+          if (this.isOnNonRouterPage()) {
             this.navigateToQueryOnNonRouterPage(query.id);
           } else {
             void this.$state.go('.', { query_id: query.id, query_props: null }, { reload: true });
@@ -465,8 +465,12 @@ export class WorkPackagesListService {
     }
   }
 
+  private isOnNonRouterPage():boolean {
+    return !this.$state.current.name || !!this.getNonRouterSidemenuId();
+  }
+
   private navigateToQueryOnNonRouterPage(queryId:string|null):void {
-    if (this.$state.current.name) { return; }
+    if (!this.isOnNonRouterPage()) { return; }
 
     // update the URL path to reflect the saved query ID so subsequent refetches use the correct query_id.
     const url = new URL(window.location.href);
@@ -477,7 +481,7 @@ export class WorkPackagesListService {
   }
 
   private reloadSidemenu(selectedQueryId:string|null):void {
-    const sidemenuId = !this.$state.current.name ? this.getNonRouterSidemenuId() : undefined;
+    const sidemenuId = this.isOnNonRouterPage() ? this.getNonRouterSidemenuId() : undefined;
     this.submenuService.reloadSubmenu(selectedQueryId, sidemenuId);
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
@@ -4,7 +4,6 @@ import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { Observable } from 'rxjs';
 import { IView } from 'core-app/core/state/views/view.model';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Injectable()
 export class WorkPackagesQueryViewService {
@@ -33,21 +32,22 @@ export class WorkPackagesQueryViewService {
   }
 
   private get viewType() {
-    if (this.$state.current.name) {
-      if (this.$state.includes('work-packages')) { return 'work_packages_table'; }
-      if (this.$state.includes('team_planner')) { return 'team_planner'; }
-      if (this.$state.includes('bim')) { return 'bim'; }
-      if (this.$state.includes('calendar')) { return 'work_packages_calendar'; }
-      if (this.$state.includes('gantt')) { return 'gantt'; }
-    } else {
-      // Non-uiRouter page — derive view type from URL path
-      const { pathname } = window.location;
-      if (pathname.includes('/calendars')) { return 'work_packages_calendar'; }
-      if (pathname.includes('/team_planners')) { return 'team_planner'; }
-      if (pathname.includes('/ifc_models')) { return 'bim'; }
-      if (pathname.includes('/gantt')) { return 'gantt'; }
-      if (pathname.includes('/work_packages')) { return 'work_packages_table'; }
-    }
+    // Check URL first for non-uiRouter pages (team_planners, calendars, boards).
+    // $state.current.name may be stale from a previous router page after Turbo navigation.
+    const { pathname } = window.location;
+    if (pathname.includes('/team_planners')) { return 'team_planner'; }
+    if (pathname.includes('/calendars')) { return 'work_packages_calendar'; }
+    if (pathname.includes('/boards')) { return 'boards'; }
+
+    // For uiRouter-managed pages, derive from state
+    if (this.$state.includes('work-packages')) { return 'work_packages_table'; }
+    if (this.$state.includes('bim')) { return 'bim'; }
+    if (this.$state.includes('gantt')) { return 'gantt'; }
+
+    // URL fallback for in case $state is stale after Turbo navigation
+    if (pathname.includes('/work_packages')) { return 'work_packages_table'; }
+    if (pathname.includes('/gantt')) { return 'gantt'; }
+    if (pathname.includes('/bcf')) { return 'bim'; }
 
     throw new Error('Not on a path defined for query views');
   }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19667

# What are you trying to accomplish?
Correctly check for non-angular pages and don't rely on `state.current` as stale state objects can be flying around which lead to incorrect saves or redirects.
