### PR TITLE
[COMMS-913] Adjust WP eager loader checksum to use `target_versions`

### DIFF
--- a/lib/api/v3/work_packages/eager_loading/checksum.rb
+++ b/lib/api/v3/work_packages/eager_loading/checksum.rb
@@ -54,16 +54,19 @@ module API
 
             protected
 
-            # The versions associated via work_package_versions are a has_many,
-            # which the left_joins/pluck design above cannot express (it would
-            # multiply rows), so they enter the checksum as an aggregated
-            # correlated subquery. This also covers versions beyond the first,
-            # which the deprecated version association could not see.
+            # The target versions associated via work_package_versions are a
+            # has_many, which the left_joins/pluck design above cannot express
+            # (it would multiply rows), so they enter the checksum as an
+            # aggregated correlated subquery. This also covers versions beyond
+            # the first, which the deprecated version association could not see.
+            # Only "target" rows are folded in: they are what the representer
+            # renders (as `version` and `targetVersions`); observed_in versions
+            # do not appear in the representation and must not bust its cache.
             VERSIONS_CHECKSUM_SQL = <<~SQL.squish
               (SELECT COALESCE(STRING_AGG(CONCAT(v.id, v.updated_at), ',' ORDER BY v.id), '')
                  FROM work_package_versions wpv
                  INNER JOIN versions v ON v.id = wpv.version_id
-                WHERE wpv.work_package_id = work_packages.id)
+                WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target')
             SQL
 
             def md5_concat
@@ -73,9 +76,6 @@ module API
                 %W[#{table_name}.id #{table_name}.updated_at]
               end
               md5_parts << VERSIONS_CHECKSUM_SQL
-              # The deprecated version link still renders from version_id;
-              # remove together with the column.
-              md5_parts << "work_packages.version_id"
 
               <<-SQL
                 MD5(CONCAT(#{md5_parts.join(', ')}))

--- a/lib/api/v3/work_packages/eager_loading/checksum.rb
+++ b/lib/api/v3/work_packages/eager_loading/checksum.rb
@@ -54,12 +54,28 @@ module API
 
             protected
 
+            # The versions associated via work_package_versions are a has_many,
+            # which the left_joins/pluck design above cannot express (it would
+            # multiply rows), so they enter the checksum as an aggregated
+            # correlated subquery. This also covers versions beyond the first,
+            # which the deprecated version association could not see.
+            VERSIONS_CHECKSUM_SQL = <<~SQL.squish
+              (SELECT COALESCE(STRING_AGG(CONCAT(v.id, v.updated_at), ',' ORDER BY v.id), '')
+                 FROM work_package_versions wpv
+                 INNER JOIN versions v ON v.id = wpv.version_id
+                WHERE wpv.work_package_id = work_packages.id)
+            SQL
+
             def md5_concat
-              md5_parts = checksum_associations.map do |association_name|
+              md5_parts = checksum_associations.flat_map do |association_name|
                 table_name = md5_checksum_table_name(association_name)
 
                 %W[#{table_name}.id #{table_name}.updated_at]
-              end.flatten
+              end
+              md5_parts << VERSIONS_CHECKSUM_SQL
+              # The deprecated version link still renders from version_id;
+              # remove together with the column.
+              md5_parts << "work_packages.version_id"
 
               <<-SQL
                 MD5(CONCAT(#{md5_parts.join(', ')}))
@@ -67,7 +83,7 @@ module API
             end
 
             def checksum_associations
-              %i[status author responsible assigned_to version priority category type budget]
+              %i[status author responsible assigned_to priority category type budget]
             end
 
             def md5_checksum_table_name(association_name)

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -122,14 +122,15 @@ RSpec.describe API::V3::WorkPackages::EagerLoading::Checksum do
         .not_to eql orig_checksum
     end
 
-    it "produces a different checksum on changes to the version id" do
-      WorkPackage.where(id: work_package.id).update_all(version_id: 0)
+    it "produces a different checksum on reassigning the target version" do
+      other_version = create(:version, project:)
+      work_package.work_package_versions.where(kind: "target").update_all(version_id: other_version.id)
 
       expect(new_checksum)
         .not_to eql orig_checksum
     end
 
-    it "produces a different checksum on changes to the version" do
+    it "produces a different checksum on changes to the target version" do
       work_package.version.update_attribute(:updated_at, 10.seconds.from_now)
 
       expect(new_checksum)
@@ -142,6 +143,14 @@ RSpec.describe API::V3::WorkPackages::EagerLoading::Checksum do
 
       expect(new_checksum)
         .not_to eql orig_checksum
+    end
+
+    it "produces the same checksum on changes to an observed_in version" do
+      other_version = create(:version, project:)
+      work_package.work_package_versions.create!(version: other_version, kind: "observed_in")
+
+      expect(new_checksum)
+        .to eql orig_checksum
     end
 
     it "produces a different checksum on changes to the type id" do

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe API::V3::WorkPackages::EagerLoading::Checksum do
         .not_to eql orig_checksum
     end
 
+    it "produces a different checksum on changes to an additional target version" do
+      other_version = create(:version, project:)
+      work_package.work_package_versions.create!(version: other_version, kind: "target")
+
+      expect(new_checksum)
+        .not_to eql orig_checksum
+    end
+
     it "produces a different checksum on changes to the type id" do
       new_type = create(:type)
       WorkPackage.where(id: work_package.id).update_all(type_id: new_type.id)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-913

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The API v3 `WorkPackageRepresenter` caches its JSON output under a key that includes a `cache_checksum` — an MD5 over the `id`/`updated_at` of each associated record, so that changing an associated record invalidates the cached representation.

Its version part was still derived from the legacy singular `belongs_to :version` (`version_id`). As part of the move to `target_versions` (a `has_many` through `work_package_versions`), a work package can now carry versions beyond that single legacy one. Renaming or reassigning any target version other than the first left the checksum unchanged, so cached representations would be served stale.

# What approach did you choose and why?
The version association is now a `has_many`, which the existing `left_joins(...).pluck(...)` design can't express: joining it would multiply rows and corrupt the `id => checksum` hash the batch query builds (and force every other association's columns to be aggregated too). So the target versions enter the checksum as an **aggregated correlated subquery (`STRING_AGG(CONCAT(v.id, v.updated_at))`) in the SELECT list.

## Manual QA
Before:
```
[8] pry(main)> ActiveRecord::Base.logger = nil
[8] pry(main)> wp = WorkPackage.first
[8] pry(main)> wp.update!(version: nil)
[8] pry(main)> wp.target_versions << Version.first # induce a state with target_versions present but legacy version missing
[8] pry(main)> ck = ->(id) { API::V3::WorkPackages::EagerLoading::Checksum.for(WorkPackage.find(id)) }
[8] pry(main)> pre_rename_hash = ck.call(wp.id)
[8] pry(main)> v = wp.target_versions.first
[8] pry(main)> v.update!(name: "#{v.name} (renamed)")
[8] pry(main)> post_rename_hash = ck.call(wp.id)
[8] pry(main)> pre_rename_hash == post_rename_hash
=> true
```

After:
```
[3] pry(main)> ActiveRecord::Base.logger = nil
[3] pry(main)> wp = WorkPackage.first
[3] pry(main)> wp.update!(version: nil)
[3] pry(main)> wp.target_versions << Version.first # induce a state with target_versions present but legacy version missing
[3] pry(main)> ck = ->(id) { API::V3::WorkPackages::EagerLoading::Checksum.for(WorkPackage.find(id)) }
[3] pry(main)> pre_rename_hash = ck.call(wp.id)
[3] pry(main)> v = wp.target_versions.first
[3] pry(main)> v.update!(name: "#{v.name} (renamed)")
[3] pry(main)> post_rename_hash = ck.call(wp.id)
[3] pry(main)> pre_rename_hash == post_rename_hash
=> false
```

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
