### PR TITLE
[PIR-109] PIR PDF and PMflex artefacts are only shown after 2nd WP status change

### DIFF
--- a/app/services/projects/creation_wizard/reupload_artifact_on_status_changes_service.rb
+++ b/app/services/projects/creation_wizard/reupload_artifact_on_status_changes_service.rb
@@ -41,17 +41,18 @@ module Projects::CreationWizard
       @artifact_work_package = work_package
     end
 
+    def self.applicable?(work_package:, changes:)
+      return false if changes["status_id"].blank?
+
+      work_package.project.project_creation_wizard_artifact_work_package_id.to_s == work_package.id.to_s
+    end
+
     def call!(changes:)
-      return if changes["status_id"].blank?
-      return unless update_is_artifact_work_package?
+      return unless self.class.applicable?(work_package: artifact_work_package, changes:)
 
       User.execute_as_admin(current_user) do
         update_artifact
       end
-    end
-
-    def update_is_artifact_work_package?
-      project.project_creation_wizard_artifact_work_package_id.to_s == artifact_work_package.id.to_s
     end
 
     private

--- a/app/services/projects/creation_wizard/upload_artifact_service.rb
+++ b/app/services/projects/creation_wizard/upload_artifact_service.rb
@@ -69,9 +69,20 @@ module Projects::CreationWizard
       )
 
       if attachment.persisted?
+        journalize_attachment(attachment.author)
         ServiceResult.success(result: attachment)
       else
         ServiceResult.failure(result: attachment, errors: attachment.errors)
+      end
+    end
+
+    # Creating the attachment does not create a work package
+    # journal on its own, so the artefact would only surface in the Activity tab after
+    # the next unrelated change. Create the journal explicitly so it shows up right away.
+    def journalize_attachment(author)
+      OpenProject::Mutex.with_advisory_lock_transaction(artifact_work_package) do
+        artifact_work_package.add_journal(user: author)
+        artifact_work_package.touch_and_save_journals
       end
     end
   end

--- a/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
+++ b/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
@@ -56,9 +56,7 @@ module WorkPackages
       def call!(changes:)
         return unless self.class.applicable?(work_package:, changes:)
 
-        User.execute_as_admin(current_user) do
-          export_and_store!
-        end
+        export_and_store!
       rescue ::Exports::ExportError => e
         Rails.logger.error("Artefact export failed for work package ##{work_package.id}: #{e.message}")
       end
@@ -72,7 +70,9 @@ module WorkPackages
         when Type::ArtefactExport::ATTACHMENT
           store_as_attachment(export)
         when Type::ArtefactExport::FILE_LINK
-          upload_to_storage(export)
+          User.execute_as_admin(current_user) do
+            upload_to_storage(export)
+          end
         end
       end
 
@@ -83,7 +83,7 @@ module WorkPackages
         else
           Rails.logger.error(
             "Failed to attach artefact to work package ##{work_package.id}: " \
-            "#{attachment.errors.full_messages.join(', ')}"
+              "#{attachment.errors.full_messages.join(', ')}"
           )
         end
       end
@@ -133,7 +133,7 @@ module WorkPackages
       def log_missing_storage
         Rails.logger.info(
           "No automatically-managed Nextcloud storage for project ##{project.id}; " \
-          "skipping artefact upload for work package ##{work_package.id}"
+            "skipping artefact upload for work package ##{work_package.id}"
         )
       end
 

--- a/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
+++ b/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
@@ -40,12 +40,21 @@ module WorkPackages
         @work_package = work_package
       end
 
-      def call!(changes:)
-        return if changes["status_id"].blank?
-        return unless type.artefact_export_enabled?
+      def self.applicable?(work_package:, changes:)
+        return false if changes["status_id"].blank?
+        return false unless work_package.type.artefact_export_enabled?
+
         # The creation wizard runs its own export for its artifact work package;
         # skip it here to avoid generating the PDF twice.
-        return if creation_wizard_artifact_work_package?
+        !creation_wizard_artifact_work_package?(work_package)
+      end
+
+      def self.creation_wizard_artifact_work_package?(work_package)
+        work_package.project.project_creation_wizard_artifact_work_package_id.to_s == work_package.id.to_s
+      end
+
+      def call!(changes:)
+        return unless self.class.applicable?(work_package:, changes:)
 
         User.execute_as_admin(current_user) do
           export_and_store!
@@ -55,10 +64,6 @@ module WorkPackages
       end
 
       private
-
-      def creation_wizard_artifact_work_package?
-        project.project_creation_wizard_artifact_work_package_id.to_s == work_package.id.to_s
-      end
 
       def export_and_store!
         export = WorkPackage::PDFExport::Artefact.new(work_package).export!

--- a/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
+++ b/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
@@ -83,7 +83,7 @@ module WorkPackages
         else
           Rails.logger.error(
             "Failed to attach artefact to work package ##{work_package.id}: " \
-              "#{attachment.errors.full_messages.join(', ')}"
+            "#{attachment.errors.full_messages.join(', ')}"
           )
         end
       end
@@ -133,7 +133,7 @@ module WorkPackages
       def log_missing_storage
         Rails.logger.info(
           "No automatically-managed Nextcloud storage for project ##{project.id}; " \
-            "skipping artefact upload for work package ##{work_package.id}"
+          "skipping artefact upload for work package ##{work_package.id}"
         )
       end
 

--- a/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
+++ b/app/services/work_packages/type_artefact_export/export_on_status_change_service.rb
@@ -72,19 +72,33 @@ module WorkPackages
       end
 
       def store_as_attachment(export)
-        file = OpenProject::Files.create_uploaded_file(
+        attachment = work_package.attachments.create(author: current_user, file: uploaded_file(export))
+        if attachment.persisted?
+          journalize_attachment(attachment.author)
+        else
+          Rails.logger.error(
+            "Failed to attach artefact to work package ##{work_package.id}: " \
+            "#{attachment.errors.full_messages.join(', ')}"
+          )
+        end
+      end
+
+      def uploaded_file(export)
+        OpenProject::Files.create_uploaded_file(
           name: export.title,
           content_type: export.mime_type,
           content: export.content,
           binary: true
         )
+      end
 
-        attachment = work_package.attachments.create(author: current_user, file:)
-        unless attachment.persisted?
-          Rails.logger.error(
-            "Failed to attach artefact to work package ##{work_package.id}: " \
-            "#{attachment.errors.full_messages.join(', ')}"
-          )
+      # Creating the attachment through the association does not create a work package
+      # journal on its own, so the artefact would only surface in the Activity tab after
+      # the next unrelated change. Create the journal explicitly so it shows up right away.
+      def journalize_attachment(author)
+        OpenProject::Mutex.with_advisory_lock_transaction(work_package) do
+          work_package.add_journal(user: author)
+          work_package.touch_and_save_journals
         end
       end
 

--- a/app/workers/work_packages/workflow_job.rb
+++ b/app/workers/work_packages/workflow_job.rb
@@ -34,27 +34,26 @@ module WorkPackages
       work_package = journal.journable
       return if journal.initial?
 
+      services = applicable_services(work_package, changes)
+      return if services.empty?
+
       # The job runs with a clean request store, so User.current would be
       # Anonymous here. Act as the user who caused the journalized change so the
       # generated artefacts (attachment and its journal entry) are attributed to them.
       User.execute_as(journal.user) do
-        process_artifact_changes(work_package, changes)
-        process_type_artefact_export(work_package, changes)
+        services.each do |service|
+          service.new(current_user: journal.user, work_package:).call!(changes:)
+        end
       end
     end
 
     private
 
-    def process_artifact_changes(work_package, changes)
-      Projects::CreationWizard::ReuploadArtifactOnStatusChangesService
-        .new(current_user: User.current, work_package:)
-        .call!(changes:)
-    end
-
-    def process_type_artefact_export(work_package, changes)
-      WorkPackages::TypeArtefactExport::ExportOnStatusChangeService
-        .new(current_user: User.current, work_package:)
-        .call!(changes:)
+    def applicable_services(work_package, changes)
+      [
+        Projects::CreationWizard::ReuploadArtifactOnStatusChangesService,
+        WorkPackages::TypeArtefactExport::ExportOnStatusChangeService
+      ].select { |service| service.applicable?(work_package:, changes:) }
     end
   end
 end

--- a/app/workers/work_packages/workflow_job.rb
+++ b/app/workers/work_packages/workflow_job.rb
@@ -34,8 +34,13 @@ module WorkPackages
       work_package = journal.journable
       return if journal.initial?
 
-      process_artifact_changes(work_package, changes)
-      process_type_artefact_export(work_package, changes)
+      # The job runs with a clean request store, so User.current would be
+      # Anonymous here. Act as the user who caused the journalized change so the
+      # generated artefacts (attachment and its journal entry) are attributed to them.
+      User.execute_as(journal.user) do
+        process_artifact_changes(work_package, changes)
+        process_type_artefact_export(work_package, changes)
+      end
     end
 
     private

--- a/spec/services/projects/creation_wizard/reupload_artifact_on_status_changes_service_spec.rb
+++ b/spec/services/projects/creation_wizard/reupload_artifact_on_status_changes_service_spec.rb
@@ -150,6 +150,17 @@ RSpec.describe Projects::CreationWizard::ReuploadArtifactOnStatusChangesService 
         expect(attachment.author).to eq(current_user)
       end
 
+      it "journalizes the work package so the attachment shows up in the Activity tab" do
+        initial_journal_count = work_package.journals.count
+
+        instance.call!(changes:)
+
+        work_package.reload
+        expect(work_package.journals.count).to eq(initial_journal_count + 1)
+        expect(work_package.last_journal.attachable_journals.map(&:attachment))
+          .to include(work_package.attachments.last)
+      end
+
       context "when work package already has an attachment" do
         before do
           work_package.attachments.create(

--- a/spec/services/projects/creation_wizard/upload_artifact_service_spec.rb
+++ b/spec/services/projects/creation_wizard/upload_artifact_service_spec.rb
@@ -94,6 +94,18 @@ RSpec.describe Projects::CreationWizard::UploadArtifactService do
       expect(attachment.author).to eq(current_user)
     end
 
+    it "journalizes the work package so the attachment shows up in the Activity tab" do
+      initial_journal_count = work_package.journals.count
+
+      result = instance.call
+
+      expect(result).to be_success
+      work_package.reload
+      expect(work_package.journals.count).to eq(initial_journal_count + 1)
+      expect(work_package.last_journal.attachable_journals.map(&:attachment))
+        .to include(work_package.attachments.last)
+    end
+
     context "when work package already has an attachment" do
       before do
         work_package.attachments.create(

--- a/spec/services/work_packages/type_artefact_export/export_on_status_change_service_spec.rb
+++ b/spec/services/work_packages/type_artefact_export/export_on_status_change_service_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe WorkPackages::TypeArtefactExport::ExportOnStatusChangeService do
         expect(attachment.filename).to end_with(".pdf")
         expect(attachment.author).to eq(current_user)
       end
+
+      it "journalizes the work package so the attachment shows up in the Activity tab" do
+        expect { instance.call!(changes:) }
+          .to change { work_package.reload.journals.count }.by(1)
+
+        expect(work_package.last_journal.attachable_journals.map(&:attachment))
+          .to include(work_package.attachments.last)
+      end
     end
 
     context "when the mode is 'file_link'" do

--- a/spec/workers/work_packages/workflow_job_spec.rb
+++ b/spec/workers/work_packages/workflow_job_spec.rb
@@ -33,7 +33,8 @@ require "spec_helper"
 RSpec.describe WorkPackages::WorkflowJob do
   let(:work_package) { build_stubbed(:work_package) }
   let(:changes) { { "status_id" => [1, 2] } }
-  let(:journal) { instance_double(Journal, journable: work_package, initial?: initial) }
+  let(:journal_user) { build_stubbed(:user) }
+  let(:journal) { instance_double(Journal, journable: work_package, initial?: initial, user: journal_user) }
   let(:initial) { false }
 
   let(:reupload_service) do
@@ -58,6 +59,15 @@ RSpec.describe WorkPackages::WorkflowJob do
 
       expect(reupload_service).to have_received(:call!).with(changes:)
       expect(type_export_service).to have_received(:call!).with(changes:)
+    end
+
+    it "acts as the journal's user so generated artefacts are attributed to them" do
+      current_user_during_call = nil
+      allow(type_export_service).to receive(:call!) { current_user_during_call = User.current }
+
+      perform
+
+      expect(current_user_during_call).to eq(journal_user)
     end
   end
 

--- a/spec/workers/work_packages/workflow_job_spec.rb
+++ b/spec/workers/work_packages/workflow_job_spec.rb
@@ -44,11 +44,14 @@ RSpec.describe WorkPackages::WorkflowJob do
     instance_double(WorkPackages::TypeArtefactExport::ExportOnStatusChangeService, call!: nil)
   end
 
+  let(:reupload_applicable) { true }
+  let(:type_export_applicable) { true }
+
   before do
     allow(Projects::CreationWizard::ReuploadArtifactOnStatusChangesService)
-      .to receive(:new).and_return(reupload_service)
+      .to receive_messages(new: reupload_service, applicable?: reupload_applicable)
     allow(WorkPackages::TypeArtefactExport::ExportOnStatusChangeService)
-      .to receive(:new).and_return(type_export_service)
+      .to receive_messages(new: type_export_service, applicable?: type_export_applicable)
   end
 
   subject(:perform) { described_class.new.perform(journal, changes) }
@@ -68,6 +71,32 @@ RSpec.describe WorkPackages::WorkflowJob do
       perform
 
       expect(current_user_during_call).to eq(journal_user)
+    end
+
+    context "when only one service is applicable" do
+      let(:reupload_applicable) { false }
+
+      it "only instantiates and invokes the applicable service" do
+        perform
+
+        expect(Projects::CreationWizard::ReuploadArtifactOnStatusChangesService).not_to have_received(:new)
+        expect(type_export_service).to have_received(:call!).with(changes:)
+      end
+    end
+
+    context "when no service is applicable" do
+      let(:reupload_applicable) { false }
+      let(:type_export_applicable) { false }
+
+      it "does not set up a user context or instantiate any service" do
+        allow(User).to receive(:execute_as)
+
+        perform
+
+        expect(User).not_to have_received(:execute_as)
+        expect(Projects::CreationWizard::ReuploadArtifactOnStatusChangesService).not_to have_received(:new)
+        expect(WorkPackages::TypeArtefactExport::ExportOnStatusChangeService).not_to have_received(:new)
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/PIR-109

# What are you trying to achieve?

a) Upload to attachment did not create a journal save, so the files showed up late on unrelated wp changes
b) The upload & generation services where always created for any journal change
c) The uploading user for PDF attachment was the last user who changed something on the wp, not the user changing the state
d) PMflex artifacts should not be generated with admin rights, uploading to Nextcloud should


# What approach did you choose and why?

a) notifying the journal after attachment upload
b) now a quicker check is done beforehand before creating the services
c) triggering user is set, so the journal entry will show the correct uploader
d) moved the admin escalation block

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
