### PR TITLE
[OP-18140] Keep notifications planner statistics fresh

### DIFF
--- a/db/migrate/20260807193029_keep_notifications_planner_statistics_fresh.rb
+++ b/db/migrate/20260807193029_keep_notifications_planner_statistics_fresh.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Increase how often autovacuum runs ANALYZE on the high-churn notifications
+# table so the query planner keeps accurate row estimates for it. When those
+# estimates go stale, the unread-notification bell falls back to a slow
+# nested-loop plan instead of a hash semi-join.
+class KeepNotificationsPlannerStatisticsFresh < ActiveRecord::Migration[8.0]
+  def up
+    execute(<<~SQL.squish)
+      ALTER TABLE notifications SET (
+        autovacuum_analyze_scale_factor = 0.02,
+        autovacuum_analyze_threshold = 200
+      )
+    SQL
+  end
+
+  def down
+    execute(<<~SQL.squish)
+      ALTER TABLE notifications RESET (
+        autovacuum_analyze_scale_factor,
+        autovacuum_analyze_threshold
+      )
+    SQL
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/OP-18140
(Part of the performance initiative https://community.openproject.org/work_packages/OP-18047.)

# What are you trying to accomplish?
The unread-notification bell renders on every page load and, on large instances, can take on the order of ~10 s for users with many visible work packages.

`Notification.visible(user)` filters `resource_id IN (<visible work packages>)`. When PostgreSQL's row estimate for a recipient's notifications is stale and too low, the planner chooses a nested-loop semi-join that re-derives the entire visible work-package set once per notification. On a production instance we observed this as ~39 × ~66k ≈ 2.6M index probes → ~10 s, versus a ~150 ms hash semi-join whenever the statistics are current.

`notifications` is a high-churn table (rows are created and marked read constantly), so with the default analyze cadence
(`autovacuum_analyze_scale_factor = 0.1`, i.e. after ~10% of rows change) its statistics can lag well behind reality between autovacuum runs. This migration lowers that table's `autovacuum_analyze_scale_factor` (and threshold) so autovacuum `ANALYZE`s it far more often, keeping the planner's estimate accurate and the plan a hash semi-join.

No SQL or permission semantics change; this is purely a planner-statistics fix.

# Testing & performance

**Reproduction.** On a seeded instance (a recipient who can see ~5k work packages) I simulated the stale-statistics condition the way it arises in production, statistics captured while the recipient had no notifications, then notifications inserted without a re-analyze (the estimate then drifts until the next autovacuum). `EXPLAIN (ANALYZE, BUFFERS)`
on the unread `Notification.visible(user)` query:

| `notifications` statistics | Plan | Execution time |
| -------------------------- | ---- | -------------- |
| Stale (recipient estimate too low) | Nested-loop semi-join — visible set re-derived per notification (~102k inner-loop iterations) | ~47 ms |
| After `ANALYZE`                     | Hash semi-join — visible set built once (~5k)                                                   | ~4.6 ms |

The plan flips exactly as it does in production; the absolute numbers are smaller because the seed is smaller. A larger 55k-work-package seed showed the same flip (~610 ms → ~55 ms).

**Production numbers (measured on a live instance).** The same query was a **~10.6 s** nested loop (recipient estimate **1** vs **39** actual → ~2.6M index probes) versus **~150 ms** whenever statistics were current and the planner chose the hash plan.

**Ruled out.** A composite `(recipient_id, resource_type, resource_id)` index and a raised
per-column statistics target did **not** change the plan — only fresh statistics do. That is why
the fix tunes the analyze cadence rather than adding an index.

**Migration.** Verified reversible: `up` sets the reloptions
(`autovacuum_analyze_scale_factor = 0.02`, `autovacuum_analyze_threshold = 200`) and `down` reverts
them. It changes only table storage parameters — no schema or data change.

# What approach did you choose and why?

The root cause is stale planner statistics, not the query itself. I reproduced the pathology on a seeded instance: with stale `notifications` statistics the bell is a nested-loop that re-derives the visible set per row; a plain `ANALYZE` restores a hash semi-join (~10× faster at the seed's scale, consistent with the ~10 s → ~150 ms seen in production). I also confirmed that a composite `(recipient_id, resource_type, resource_id)` index and a raised per-column statistics target do _not_ change the plan, only fresh statistics do. So the durable fix is to keep statistics fresh, and the in-database way to do that for a high-churn table is to tune its autovacuum analyze cadence.

Alternatives considered:

- One-off / scheduled `ANALYZE`: fixes it, but is operational and easy to miss; this migration makes it automatic and durable. On instances that manage autovacuum at the infrastructure layer, that remains a valid equivalent.
- Composite index / higher statistics target: measured; no effect on the plan.

This change is intentionally narrow and independent of the separate structural work under OP-18140 (consolidating the repeated permission subqueries). It targets the acute bell latency on its own and can be adopted or reverted independently.

# Merge checklist

- [x] Added/updated tests — n/a: this migration only sets PostgreSQL table storage parameters (`autovacuum_analyze_scale_factor` / `_threshold`); there is no application behaviour to unit-test. Validated by reproducing the query-plan change (nested-loop → hash) with stale vs fresh statistics.
- [x] Added/updated documentation in Lookbook — n/a (no UI/pattern changes).
- [x] Tested major browsers — n/a (backend / database-only change).
