### PR TITLE
[AGILE-353] Rename SprintSharing mixin to SprintSettings

### DIFF
--- a/modules/backlogs/app/models/projects/scopes/not_sharing_sprints.rb
+++ b/modules/backlogs/app/models/projects/scopes/not_sharing_sprints.rb
@@ -33,7 +33,7 @@ module Projects::Scopes::NotSharingSprints
 
   class_methods do
     def not_sharing_sprints
-      with_settings(sprint_sharing: Projects::SprintSharing::NO_SHARING)
+      with_settings(sprint_sharing: Projects::SprintSettings::NO_SHARING)
         .or(with_settings(sprint_sharing: ""))
         .or(with_settings(sprint_sharing: nil))
     end

--- a/modules/backlogs/app/models/projects/scopes/receive_shared_sprints.rb
+++ b/modules/backlogs/app/models/projects/scopes/receive_shared_sprints.rb
@@ -33,7 +33,7 @@ module Projects::Scopes::ReceiveSharedSprints
 
   class_methods do
     def receive_shared_sprints
-      with_settings(sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED)
+      with_settings(sprint_sharing: Projects::SprintSettings::RECEIVE_SHARED)
     end
   end
 end

--- a/modules/backlogs/app/models/projects/scopes/share_sprints_with_all_projects.rb
+++ b/modules/backlogs/app/models/projects/scopes/share_sprints_with_all_projects.rb
@@ -33,7 +33,7 @@ module Projects::Scopes::ShareSprintsWithAllProjects
 
   class_methods do
     def share_sprints_with_all_projects
-      with_settings(sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
+      with_settings(sprint_sharing: Projects::SprintSettings::SHARE_ALL_PROJECTS)
     end
   end
 end

--- a/modules/backlogs/app/models/projects/scopes/share_sprints_with_subprojects.rb
+++ b/modules/backlogs/app/models/projects/scopes/share_sprints_with_subprojects.rb
@@ -33,7 +33,7 @@ module Projects::Scopes::ShareSprintsWithSubprojects
 
   class_methods do
     def share_sprints_with_subprojects
-      with_settings(sprint_sharing: Projects::SprintSharing::SHARE_SUBPROJECTS)
+      with_settings(sprint_sharing: Projects::SprintSettings::SHARE_SUBPROJECTS)
     end
   end
 end

--- a/modules/backlogs/app/models/projects/sprint_settings.rb
+++ b/modules/backlogs/app/models/projects/sprint_settings.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects::SprintSharing
+module Projects::SprintSettings
   extend ActiveSupport::Concern
 
   NO_SHARING         = "no_sharing"
@@ -64,7 +64,7 @@ module Projects::SprintSharing
     # 2. The closest share_subprojects ancestor of each receiving allowed project
     # 3. The global sharer for receiving projects that have no share_subprojects ancestor
     def sprint_source_for(projects) # rubocop:disable Metrics/AbcSize
-      share_subprojects = Projects::SprintSharing::SHARE_SUBPROJECTS
+      share_subprojects = Projects::SprintSettings::SHARE_SUBPROJECTS
 
       receiving_in_allowed = projects.receive_shared_sprints
       receiving_ids_sql = receiving_in_allowed.select(:id).to_sql
@@ -72,7 +72,7 @@ module Projects::SprintSharing
       # Case 1: Non-receiving allowed projects (sprint_source = self)
       direct = projects
                  .where("settings->>'sprint_sharing' IS DISTINCT FROM ?",
-                        Projects::SprintSharing::RECEIVE_SHARED)
+                        Projects::SprintSettings::RECEIVE_SHARED)
                  .select(:id)
 
       # Case 2: Closest share_subprojects ancestor for each receiving project.

--- a/modules/backlogs/lib/open_project/backlogs/patches/copy_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/copy_service_patch.rb
@@ -38,7 +38,7 @@ module OpenProject::Backlogs::Patches::CopyServicePatch
   module InstanceMethods
     def clean_settings_attributes!(settings)
       # There can be only one project sharing with all projects.
-      if settings["sprint_sharing"] == Projects::SprintSharing::SHARE_ALL_PROJECTS ||
+      if settings["sprint_sharing"] == Projects::SprintSettings::SHARE_ALL_PROJECTS ||
          !EnterpriseToken.allows_to?(:sprint_sharing)
         settings.delete("sprint_sharing")
       end

--- a/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
@@ -30,7 +30,7 @@
 
 module OpenProject::Backlogs::Patches::ProjectPatch
   extend ActiveSupport::Concern
-  include Projects::SprintSharing
+  include Projects::SprintSettings
 
   included do
     has_and_belongs_to_many :done_statuses, join_table: "done_statuses_for_project", class_name: "::Status"

--- a/modules/backlogs/spec/contracts/backlogs/sprints/create_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/sprints/create_contract_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Backlogs::Sprints::CreateContract do
 
   describe "validation" do
     context "when the project is configured to receive sprints" do
-      let(:sprint_project) { build_stubbed(:project, sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
+      let(:sprint_project) { build_stubbed(:project, sprint_sharing: Projects::SprintSettings::RECEIVE_SHARED) }
 
       it_behaves_like "contract is invalid", project: :receiving_sprints
     end

--- a/modules/backlogs/spec/features/backlogs/create_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "Create", :js do
   end
 
   context "with the project receiving sprints from another project" do
-    let(:project) { create(:project, sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
+    let(:project) { create(:project, sprint_sharing: Projects::SprintSettings::RECEIVE_SHARED) }
 
     it "is missing the 'new sprint' button" do
       planning_page.visit!

--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -181,8 +181,8 @@ RSpec.describe "Edit", :js do
   end
 
   context "with a shared sprint" do
-    let(:project) { create(:project, sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
-    let(:source_project) { create(:project, sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS) }
+    let(:project) { create(:project, sprint_sharing: Projects::SprintSettings::RECEIVE_SHARED) }
+    let(:source_project) { create(:project, sprint_sharing: Projects::SprintSettings::SHARE_ALL_PROJECTS) }
     let!(:first_sprint) do
       create(:sprint,
              name: "Shared Sprint",

--- a/modules/backlogs/spec/features/backlogs/sprints/index_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/sprints/index_spec.rb
@@ -155,10 +155,10 @@ RSpec.describe "Sprint index", :js do
 
   context "when a sprint is shared from another project" do
     let(:source_project) do
-      create(:project, sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
+      create(:project, sprint_sharing: Projects::SprintSettings::SHARE_ALL_PROJECTS)
     end
     let(:receiving_project) do
-      create(:project, sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED)
+      create(:project, sprint_sharing: Projects::SprintSettings::RECEIVE_SHARED)
     end
     let(:sprints_page) { Pages::Sprints.new(receiving_project) }
     let!(:shared_sprint) do

--- a/modules/backlogs/spec/lib/open_project/backlogs/event_subscriptions_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/event_subscriptions_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe OpenProject::Notifications, "backlogs event subscriptions" do # r
       )
     end
 
-    Projects::SprintSharing::SPRINT_SHARING_MODES.each do |sharing_mode|
+    Projects::SprintSettings::SPRINT_SHARING_MODES.each do |sharing_mode|
       context "when the backlogs module is disabled on a project with #{sharing_mode}" do
         let(:project) { create(:project, sprint_sharing: sharing_mode) }
         let(:disabled_module) { instance_double(EnabledModule, name: "backlogs", project:) }
@@ -47,21 +47,21 @@ RSpec.describe OpenProject::Notifications, "backlogs event subscriptions" do # r
         it "sets sprint sharing to no_sharing" do
           subject
 
-          expect(project.reload.sprint_sharing).to eq(Projects::SprintSharing::NO_SHARING)
+          expect(project.reload.sprint_sharing).to eq(Projects::SprintSettings::NO_SHARING)
         end
       end
     end
 
     context "when a different module is disabled" do
       let(:project) do
-        create(:project, sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
+        create(:project, sprint_sharing: Projects::SprintSettings::SHARE_ALL_PROJECTS)
       end
       let(:disabled_module) { instance_double(EnabledModule, name: "wiki", project:) }
 
       it "does not reset sprint sharing" do
         subject
 
-        expect(project.reload.sprint_sharing).to eq(Projects::SprintSharing::SHARE_ALL_PROJECTS)
+        expect(project.reload.sprint_sharing).to eq(Projects::SprintSettings::SHARE_ALL_PROJECTS)
       end
     end
   end
@@ -74,14 +74,14 @@ RSpec.describe OpenProject::Notifications, "backlogs event subscriptions" do # r
       )
     end
 
-    Projects::SprintSharing::SPRINT_SHARING_MODES.each do |sharing_mode|
+    Projects::SprintSettings::SPRINT_SHARING_MODES.each do |sharing_mode|
       context "when a project with #{sharing_mode} is archived" do
         let(:project) { create(:project, sprint_sharing: sharing_mode) }
 
         it "sets sprint sharing to no_sharing" do
           subject
 
-          expect(project.reload.sprint_sharing).to eq(Projects::SprintSharing::NO_SHARING)
+          expect(project.reload.sprint_sharing).to eq(Projects::SprintSettings::NO_SHARING)
         end
       end
     end

--- a/modules/backlogs/spec/models/projects/sprint_settings_spec.rb
+++ b/modules/backlogs/spec/models/projects/sprint_settings_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Projects::SprintSharing do
+RSpec.describe Projects::SprintSettings do
   let(:sprint_sharing) { "no_sharing" }
   let(:active) { true }
   let!(:project) { create(:project, sprint_sharing:, active:) }

--- a/modules/backlogs/spec/services/backlogs/sprints/update_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/sprints/update_service_spec.rb
@@ -31,8 +31,8 @@
 require "spec_helper"
 
 RSpec.describe Backlogs::Sprints::UpdateService, type: :model do
-  let(:project) { create(:project, sprint_sharing: Projects::SprintSharing::RECEIVE_SHARED) }
-  let(:source_project) { create(:project, sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS) }
+  let(:project) { create(:project, sprint_sharing: Projects::SprintSettings::RECEIVE_SHARED) }
+  let(:source_project) { create(:project, sprint_sharing: Projects::SprintSettings::SHARE_ALL_PROJECTS) }
   let(:sprint) { create(:sprint, project: source_project, name: "Sprint 1") }
   let(:user) do
     create(:user, member_with_permissions: { project => project_permissions, source_project => source_project_permissions })

--- a/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/projects/copy_service_integration_spec.rb
@@ -61,55 +61,55 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
       context "with an ee license for sprint sharing", with_ee: %i[sprint_sharing] do
         context "when the source project is set to receive" do
           before do
-            source.sprint_sharing = Projects::SprintSharing::RECEIVE_SHARED
+            source.sprint_sharing = Projects::SprintSettings::RECEIVE_SHARED
             source.save!
           end
 
           it "copies the backlog sharing setting" do
             expect(subject).to be_success
-            expect(project_copy.sprint_sharing).to eq Projects::SprintSharing::RECEIVE_SHARED
+            expect(project_copy.sprint_sharing).to eq Projects::SprintSettings::RECEIVE_SHARED
           end
         end
 
         context "when the source project is set to share with subprojects" do
           before do
-            source.sprint_sharing = Projects::SprintSharing::SHARE_SUBPROJECTS
+            source.sprint_sharing = Projects::SprintSettings::SHARE_SUBPROJECTS
             source.save!
           end
 
           it "copies the backlog sharing setting" do
             expect(subject).to be_success
-            expect(project_copy.sprint_sharing).to eq Projects::SprintSharing::SHARE_SUBPROJECTS
+            expect(project_copy.sprint_sharing).to eq Projects::SprintSettings::SHARE_SUBPROJECTS
           end
         end
 
         context "when the source project is set to not share" do
           before do
-            source.sprint_sharing = Projects::SprintSharing::NO_SHARING
+            source.sprint_sharing = Projects::SprintSettings::NO_SHARING
             source.save!
           end
 
           it "copies the backlog sharing setting" do
             expect(subject).to be_success
-            expect(project_copy.sprint_sharing).to eq Projects::SprintSharing::NO_SHARING
+            expect(project_copy.sprint_sharing).to eq Projects::SprintSettings::NO_SHARING
           end
         end
 
         context "when the source project is set to share with all" do
           before do
-            source.sprint_sharing = Projects::SprintSharing::SHARE_ALL_PROJECTS
+            source.sprint_sharing = Projects::SprintSettings::SHARE_ALL_PROJECTS
             source.save!
           end
 
           it "does not copy the setting as that would result in two projects sharing with all" do
             expect(subject).to be_success
-            expect(project_copy.sprint_sharing).to eq Projects::SprintSharing::NO_SHARING
+            expect(project_copy.sprint_sharing).to eq Projects::SprintSettings::NO_SHARING
           end
         end
       end
 
       context "without an ee license for sprint sharing", with_ee: %i[] do
-        Projects::SprintSharing::SPRINT_SHARING_MODES.each do |mode|
+        Projects::SprintSettings::SPRINT_SHARING_MODES.each do |mode|
           context "when the source project is set to #{mode}" do
             before do
               source.sprint_sharing = mode
@@ -118,7 +118,7 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
 
             it "copies the backlog sharing setting" do
               expect(subject).to be_success
-              expect(project_copy.sprint_sharing).to eq Projects::SprintSharing::NO_SHARING
+              expect(project_copy.sprint_sharing).to eq Projects::SprintSettings::NO_SHARING
             end
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-353

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
It used to only hold information about sprint sharing. This is no longer the case so let's rename it to properly reflect it's broader responsibility.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
