### PR TITLE
Implementation/COMMS-878: Read and write target versions in the type form configuration

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -153,7 +153,20 @@ module Type::AttributeGroups
   end
 
   def custom_attribute_groups
-    self[:attribute_groups].presence
+    groups = self[:attribute_groups].presence
+    return if groups.nil?
+
+    # Only one version attribute is offered at a time, so render whichever one a
+    # saved configuration holds as the one the current feature state exposes.
+    stored, offered = if Setting::WorkPackageMultipleVersions.active?
+                        %w[version target_versions]
+                      else
+                        %w[target_versions version]
+                      end
+
+    groups.map do |key, attributes, *rest|
+      [key, attributes.map { |attribute| attribute == stored ? offered : attribute }.uniq, *rest]
+    end
   end
 
   def default_group_key(key)

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -46,8 +46,7 @@ module Type::Attributes
                 parent_id
                 parent
                 readonly
-                schedule_manually
-                target_versions].freeze
+                schedule_manually].freeze
 
   included do
     # Allow plugins to define constraints
@@ -86,6 +85,7 @@ module Type::Attributes
       OpenProject::Cache.fetch_request_cached("all_work_package_form_attributes",
                                               *wp_cf_cache_parts,
                                               EXCLUDED.length,
+                                              Setting::WorkPackageMultipleVersions.active?,
                                               merge_date) do
         calculate_all_work_package_form_attributes(merge_date)
       end
@@ -139,7 +139,14 @@ module Type::Attributes
       # We always want to include the priority even if its required
       return false if key == "priority"
 
-      EXCLUDED.include?(key) || definition[:required]
+      excluded_version_attribute?(key) || EXCLUDED.include?(key) || definition[:required]
+    end
+
+    # Only one of the two version attributes is offered at a time, matching the
+    # query columns: target_versions with the multiple versions feature enabled,
+    # the deprecated single version without it.
+    def excluded_version_attribute?(key)
+      key == (Setting::WorkPackageMultipleVersions.active? ? "version" : "target_versions")
     end
 
     def merge_date_for_form_attributes(attributes)

--- a/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
+++ b/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
@@ -237,6 +237,42 @@ module WorkPackageTypes
           end
         end
 
+        context "when the multiple versions feature is inactive" do
+          it "accepts the deprecated version" do
+            model.attribute_groups = [["foo", ["version"]]]
+
+            expect(contract).to be_valid
+          end
+
+          it "rejects target_versions as an unknown attribute" do
+            model.attribute_groups = [["foo", ["target_versions"]]]
+
+            expect(contract).not_to be_valid
+            expect(contract.errors.details[:attribute_groups]).to include(
+              error: "Invalid work package attribute used: target_versions"
+            )
+          end
+        end
+
+        context "when the multiple versions feature is active",
+                with_flag: { work_package_multiple_versions: true },
+                with_settings: { work_package_multiple_versions: true } do
+          it "accepts target_versions" do
+            model.attribute_groups = [["foo", ["target_versions"]]]
+
+            expect(contract).to be_valid
+          end
+
+          it "rejects the deprecated version as an unknown attribute" do
+            model.attribute_groups = [["foo", ["version"]]]
+
+            expect(contract).not_to be_valid
+            expect(contract.errors.details[:attribute_groups]).to include(
+              error: "Invalid work package attribute used: version"
+            )
+          end
+        end
+
         context "with invalid query group" do
           let(:query) { Query.new(name: "Invalid Query", user:) }
           let(:invalid_query_group) { ["query_group", [query]] }

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -157,6 +157,65 @@ RSpec.describe Type do
     end
   end
 
+  describe "target versions in the form configuration" do
+    context "when the multiple versions feature is inactive" do
+      it "offers the deprecated version in the default configuration" do
+        members = type.default_attribute_groups.to_h
+
+        expect(members[:details]).to include("version")
+        expect(members[:details]).not_to include("target_versions")
+      end
+
+      it "renders a persisted target_versions key as the deprecated version" do
+        type[:attribute_groups] = [["details", %w[category target_versions]]]
+        type.unset_attribute_groups_objects
+
+        details = type.attribute_groups.detect { |group| group.key == "details" }
+
+        expect(details.attributes).to include("version")
+        expect(details.attributes).not_to include("target_versions")
+      end
+    end
+
+    context "when the multiple versions feature is active",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      it "offers target_versions in the default configuration" do
+        members = type.default_attribute_groups.to_h
+
+        expect(members[:details]).to include("target_versions")
+        expect(members[:details]).not_to include("version")
+      end
+
+      it "renders a persisted legacy version key as target_versions" do
+        type[:attribute_groups] = [["details", %w[category version]]]
+        type.unset_attribute_groups_objects
+
+        details = type.attribute_groups.detect { |group| group.key == "details" }
+
+        expect(details.attributes).to include("target_versions")
+        expect(details.attributes).not_to include("version")
+      end
+
+      it "keeps the display name of a renamed group while normalizing it" do
+        type[:attribute_groups] = [["details", %w[category version], "Custom Details"]]
+        type.unset_attribute_groups_objects
+
+        details = type.attribute_groups.detect { |group| group.key == "details" }
+
+        expect(details.attributes).to include("target_versions")
+        expect(details.display_name).to eq("Custom Details")
+      end
+    end
+
+    it "leaves query group members untouched" do
+      query_member = :"#{Type::QueryGroup::MEMBER_PREFIX}1"
+      type[:attribute_groups] = [["Related", [query_member]]]
+
+      expect(type.send(:custom_attribute_groups)).to eq([["Related", [query_member]]])
+    end
+  end
+
   describe "custom fields" do
     let!(:custom_field) do
       create(

--- a/spec/models/type/attributes_spec.rb
+++ b/spec/models/type/attributes_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Type::Attributes do
+  before { RequestStore.clear! }
+
+  describe ".all_work_package_form_attributes" do
+    subject(:attributes) { Type.all_work_package_form_attributes }
+
+    context "when the multiple versions feature is inactive" do
+      it "offers the deprecated version and hides target_versions" do
+        expect(attributes).to have_key("version")
+        expect(attributes).not_to have_key("target_versions")
+      end
+    end
+
+    context "when the multiple versions feature is active",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      it "offers target_versions and hides the deprecated version" do
+        expect(attributes).to have_key("target_versions")
+        expect(attributes).not_to have_key("version")
+      end
+    end
+  end
+
+  describe ".translated_work_package_form_attributes" do
+    context "when the multiple versions feature is inactive" do
+      it "labels the deprecated version field" do
+        expect(Type.translated_work_package_form_attributes["version"])
+          .to eq(I18n.t("activerecord.attributes.work_package.version"))
+      end
+    end
+
+    context "when the multiple versions feature is active",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      it "labels the target versions field" do
+        expect(Type.translated_work_package_form_attributes["target_versions"])
+          .to eq(I18n.t("activerecord.attributes.work_package.target_versions"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
[COMMS-878](https://community.openproject.org/wp/COMMS-878)

The work package form configuration (the admin form builder on a type) still worked only in terms of the deprecated single `version` attribute. It now follows the multiple versions feature the same way the query columns already do: the form builder offers `target_versions` when the feature is enabled and the deprecated `version` when it is not.

A configuration that holds the other version attribute (for instance after the feature is toggled) is normalized to the exposed one when read, so it keeps rendering the field and rewrites itself on the next save. Single-version installations see no change.

https://openproject.local/types/1/form_configuration/edit

_Multiple versions feature OFF_

<img width="1013" height="375" alt="Screenshot 2026-07-22 at 10 06 02 AM" src="https://github.com/user-attachments/assets/c3bdb293-6d32-4f67-ab22-393a269e7e2b" />

_Multiple versions feature ON_

<img width="1006" height="369" alt="Screenshot 2026-07-22 at 10 08 51 AM" src="https://github.com/user-attachments/assets/d0a9765a-f0d2-4ac8-9ec0-6012c23861a3" />
