### PR TITLE
[AGILE-184] Morph "complete sprint" state before redirect

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -82,7 +82,7 @@ module Backlogs
       else
         base_arguments.merge(
           tag: :a,
-          href: start_project_backlogs_sprint_path(project, sprint),
+          href: start_project_backlogs_sprint_path(project, sprint, backlog_filter_params),
           data: { turbo_method: :post }
         )
       end

--- a/modules/backlogs/app/controllers/backlogs/sprints_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/sprints_controller.rb
@@ -120,11 +120,7 @@ module Backlogs
       result = start_sprint
 
       if result.success?
-        @sprint = result.result
-        flash[:notice] = I18n.t(:notice_successful_start)
-        render turbo_stream: turbo_stream.redirect_to(
-          project_work_package_board_path(@project, @sprint.task_board_for(@project))
-        )
+        respond_with_start_success(sprint: result.result)
       else
         respond_with_start_finish_failure(message: start_finish_failure_message(:start, result.message))
       end
@@ -144,6 +140,19 @@ module Backlogs
     end
 
     private
+
+    def respond_with_start_success(sprint:)
+      flash[:notice] = I18n.t(:notice_successful_start)
+
+      # Update sprint component so that it shows the correct state for users
+      # that navigate back via the browser's back button:
+      update_sprint_component_via_turbo_stream(sprint:)
+
+      turbo_streams << turbo_stream.redirect_to(
+        project_work_package_board_path(@project, sprint.task_board_for(@project))
+      )
+      respond_with_turbo_streams
+    end
 
     def update_sprint_component_via_turbo_stream(sprint:)
       update_via_turbo_stream(

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -297,6 +297,19 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         it "renders the start-sprint link enabled" do
           expect(rendered_component).to have_link("Start sprint")
         end
+
+        context "when params[:all] is true" do
+          before do
+            vc_test_controller.params[:all] = "1"
+          end
+
+          it "preserves ?all=true on the start-sprint link" do
+            expect(rendered_component).to have_link(
+              "Start sprint",
+              href: start_project_backlogs_sprint_path(project, sprint, all: true)
+            )
+          end
+        end
       end
 
       context "when the sprint is in planning without start date" do

--- a/modules/backlogs/spec/controllers/backlogs/sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/sprints_controller_spec.rb
@@ -242,8 +242,9 @@ RSpec.describe Backlogs::SprintsController do
         expect(response).to be_successful
         expect(response).to have_http_status :ok
         expect(response.body).to have_turbo_stream action: "flash"
-        expect(response.body).to have_turbo_stream action: "update", target: "backlogs-sprint-component-#{sprint.id}"
-        assert_select %(turbo-stream[action="update"][target="backlogs-sprint-component-#{sprint.id}"][method="morph"])
+        expect(response.body).to have_turbo_stream(
+          action: "update", target: "backlogs-sprint-component-#{sprint.id}", method: "morph"
+        )
         expect(response.body).to include("Successful update.")
         expect(controller.controller_path).to eq("backlogs/sprints")
         expect(controller.action_name).to eq("update")
@@ -446,6 +447,9 @@ RSpec.describe Backlogs::SprintsController do
 
           expect(response).to be_successful
           expect(response).to have_turbo_stream(action: "redirect_to")
+          expect(response.body).to have_turbo_stream(
+            action: "update", target: "backlogs-sprint-component-#{sprint.id}", method: "morph"
+          )
           expect(flash[:notice]).to eq(I18n.t(:notice_successful_start))
           expect(service).to have_received(:call)
         end
@@ -550,7 +554,7 @@ RSpec.describe Backlogs::SprintsController do
         end
 
         it "finishes the sprint and redirects to the backlog", :aggregate_failures do
-          post :finish, params: request_params
+          post :finish, format: :turbo_stream, params: request_params
 
           expect(response).to be_successful
           expect(response.body).to have_turbo_stream(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-184

# What are you trying to accomplish?
When the user starts a sprint, they get redirected to the board. When they navigate back via the browser back button, they should not see the invalid "start sprint" button. Instead, they should see the correct "complete sprint" button which reflects the sprints current state.

## Demo

https://github.com/user-attachments/assets/15a5d570-7dd8-4aab-a955-ca298788c2e1

# What approach did you choose and why?

There are multiple options to fix this:

* Disable the cache (I think our Angular pages often do this). This works, but it requires a full page reload when users navigate back. Usually, Turbo is smart and reinstantiates the previous state without reloading. Disregarded because I would like to keep the speed-advantage if it makes sense.
* Subscribe to the `turbo:before-cache` event and handle the navigation details in the frontend. Disregarded because the Rails backend already knows exactly how to update the sprint component when a sprint is started. No need to introduce duplicate logic.
* Lastly, and this is what I went with, use a turbo stream to update the sprint component of the started sprint right before redirecting to boards. That way, when navigating back, the old state that is restored by Turbo is the correct one. This required only a little code change. There is a caveat: users might notice that the button changes its text and icon right before the redirect happens. Additionally, if users double click the start sprint button, they might start and _directly_ close a sprint again. I'm interested in the reviewers opinion on this matter. Personally, I don't think this has to be fixed or prevented on the client-side. Double clicking buttons on a web page is a valid source for an error, I just hope our users won't actually do this.

There might be more options that I didn't think about 🤔 Please let me know if you have another idea.

## Out of scope

This PR does _not_ solve the issue that other users could also change the state in the meantime. As an example: Alice starts a sprint and visits the board. Meanwhile, Bob completes the sprint. Alice navigates back and still sees the state where the sprint looks like it is currently active. This issue is separate and does not require fixing IMO. We have validations in place to avoid actual state errors, only the visual state is untrue. Additionally, this will only happen rarely.

This PR does _not_ apply the same morphing logic to the finish action. If navigating back after finishing a sprint, you might see an outdated state. With the same fix for the finish action in place, the page looked restless and jumpy when completing a sprint. The dialog would close, the sprint component would update and _then_ you'd get redirected. The classic experience feels much smoother. I chose to keep the UI pleasant for this case and only apply the fix to the start action. My reasoning is that users might regularly navigate back to the backlog and sprints page after starting a sprint (because they are guided to the board against their will and might want to come back). But they _won't_ navigate back after completing as they are still on the _same_ page. At least this is what works for me personally. Let me know if you agree.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
