### PR TITLE
[COMMS-911] Modify target_versions instead of version when changing project parent

### DIFF
--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -73,16 +73,16 @@ module WorkPackage::Versions
     # Unassigns work packages from +version+ if it's no longer shared with
     # the work package's project
     def update_versions_from_sharing_change(version)
-      # Update work packages assigned to the version
-      update_versions(["#{WorkPackage.table_name}.version_id = ?", version.id])
+      # Update work packages referencing the version
+      update_versions(["#{WorkPackageVersion.table_name}.version_id = ?", version.id])
     end
 
     # Unassigns work packages from versions that are no longer shared
     # after +project+ was moved
     def update_versions_from_hierarchy_change(project)
       moved_project_ids = project.self_and_descendants.reload.map(&:id)
-      # Update work packages of the moved projects and work packages assigned
-      # to a version of a moved project
+      # Update work packages of the moved projects and work packages referencing
+      # a version of a moved project
       update_versions(
         ["#{Version.table_name}.project_id IN (?) OR #{WorkPackage.table_name}.project_id IN (?)",
          moved_project_ids,
@@ -92,35 +92,52 @@ module WorkPackage::Versions
 
     private
 
+    # Work packages referencing (through any work_package_versions kind) a
+    # non-systemwide version of another project
     def having_version_from_other_project
-      where(
-        "#{WorkPackage.table_name}.version_id IS NOT NULL" +
-        " AND #{WorkPackage.table_name}.project_id <> #{Version.table_name}.project_id" +
-        " AND #{Version.table_name}.sharing <> 'system'"
-      )
+      joins(work_package_versions: :version)
+        .where.not(versions: { sharing: "system" })
+        .where("#{Version.table_name}.project_id <> #{WorkPackage.table_name}.project_id")
+        .distinct
     end
 
-    # Update work packages so their versions are not pointing to a
-    # version that is not shared with the work package's project
-    def update_versions(conditions = nil) # rubocop:disable Metrics/AbcSize
-      # Only need to update work packages with a version from
-      # a different project and that is not systemwide shared
+    # Update work packages so they do not reference versions that are not
+    # shared with their project
+    def update_versions(conditions = nil)
       having_version_from_other_project
         .where(conditions)
-        .includes(:project, :version)
-        .references(:versions).find_each do |work_package|
-        next if work_package.project.nil? || work_package.version.nil?
+        .includes(:project)
+        .find_each do |work_package|
+        next if work_package.project.nil?
 
-        unless work_package.project.shared_versions.include?(work_package.version)
-          # this path clears version_id without going through the services,
-          # so we need to manually drop the matching target association here too.
-          work_package.target_versions.delete(work_package.version)
-          work_package.version = nil
-          unless work_package.save
-            Rails.logger.error "Failed to clear version on work package ##{work_package.id}: " \
-                               "#{work_package.errors.full_messages.to_sentence}"
-          end
-        end
+        remove_unshared_version_references(work_package)
+      end
+    end
+
+    def remove_unshared_version_references(work_package)
+      # Pruning goes through the *_version_ids_replacements accessors, so the
+      # save-time mirror (persist_version_associations) keeps the deprecated
+      # version_id column and the journals consistent, as for any other change.
+      return if prune_unshared_version_kinds(work_package).empty?
+
+      unless work_package.save
+        Rails.logger.error "Failed to clear versions on work package ##{work_package.id}: " \
+                           "#{work_package.errors.full_messages.to_sentence}"
+      end
+    end
+
+    # Sets the replacements for every kind that references versions not shared
+    # with the work package's project, returning the kinds that changed.
+    def prune_unshared_version_kinds(work_package)
+      shared_ids = work_package.project.shared_versions.pluck(:id)
+
+      %w[target observed_in].filter_map do |kind|
+        current_ids = work_package.work_package_versions.where(kind:).pluck(:version_id)
+        kept_ids = current_ids & shared_ids
+        next if kept_ids.sort == current_ids.sort
+
+        work_package.public_send(:"#{kind}_version_ids_replacements=", kept_ids)
+        kind
       end
     end
   end

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -96,7 +96,7 @@ module WorkPackage::Versions
     # non-systemwide version of another project
     def having_version_from_other_project
       joins(work_package_versions: :version)
-        .where.not(versions: { sharing: "system" })
+        .merge(Version.systemwide.invert_where)
         .where("#{Version.table_name}.project_id <> #{WorkPackage.table_name}.project_id")
         .distinct
     end

--- a/spec/models/work_package/work_package_update_versions_spec.rb
+++ b/spec/models/work_package/work_package_update_versions_spec.rb
@@ -61,4 +61,36 @@ RSpec.describe WorkPackage, ".update_versions keeping target_versions consistent
     expect(work_package.version_id).to be_nil
     expect(target_version_ids(work_package)).to be_empty
   end
+
+  it "drops an unshared target version beyond the first, keeping the others" do
+    own_version = create(:version, project: child_project)
+    work_package.work_package_versions.create!(version: own_version, kind: "target")
+
+    shared_version.update!(sharing: "none")
+    described_class.update_versions_from_sharing_change(shared_version)
+
+    work_package.reload
+    expect(target_version_ids(work_package)).to contain_exactly(own_version.id)
+    expect(work_package.version_id).to eq(own_version.id)
+  end
+
+  it "drops an unshared observed_in version" do
+    work_package.work_package_versions.create!(version: shared_version, kind: "observed_in")
+
+    shared_version.update!(sharing: "none")
+    described_class.update_versions_from_sharing_change(shared_version)
+
+    work_package.reload
+    expect(work_package.work_package_versions.where(kind: "observed_in")).to be_empty
+    expect(target_version_ids(work_package)).to be_empty
+  end
+
+  it "leaves systemwide-shared versions alone" do
+    shared_version.update!(sharing: "system")
+    described_class.update_versions_from_sharing_change(shared_version)
+
+    work_package.reload
+    expect(target_version_ids(work_package)).to contain_exactly(shared_version.id)
+    expect(work_package.version_id).to eq(shared_version.id)
+  end
 end

--- a/spec/models/work_package/work_package_update_versions_spec.rb
+++ b/spec/models/work_package/work_package_update_versions_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe WorkPackage, ".update_versions keeping target_versions consistent
     expect(target_version_ids(work_package)).to be_empty
   end
 
-  it "leaves systemwide-shared versions alone" do
+  it "excludes systemwide-shared versions" do
     shared_version.update!(sharing: "system")
     described_class.update_versions_from_sharing_change(shared_version)
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-911/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Yet another change needed to migrate from `WorkPackage.version` to `target_versions`.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
