### PR TITLE
Add MCP tool to obtain custom field items

### DIFF
--- a/app/services/custom_fields/hierarchy/hierarchical_item_aggregator.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_aggregator.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomFields
+  module Hierarchy
+    class HierarchicalItemAggregator
+      class << self
+        def flatten_tree_hash(hash)
+          flat_list = []
+          queue = [hash.merge({ depth: -1 })]
+
+          # From the service we get a hashed tree like this:
+          # {:a => {:b => {:c1 => {:d1 => {}}, :c2 => {:d2 => {}}}, :b2 => {}}}
+          #
+          # We flatten it depth first to this result list:
+          # [:a, :b, :c1, :d1, :c2, :d2, :b2]
+
+          while queue.any?
+            current = queue.shift
+            depth = current[:depth]
+            item, children = current.shift
+
+            flat_list << API::V3::CustomFields::Hierarchy::HierarchicalItemAggregate.new(item:, depth:)
+
+            queue.unshift(current) unless current.keys == [:depth]
+            queue.unshift(children.merge({ depth: depth + 1 })) unless children.empty?
+          end
+
+          flat_list
+        end
+      end
+    end
+  end
+end

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -168,7 +168,7 @@ module CustomFields
       # @param item [CustomField::Hierarchy::Item] the start node
       # @param depth [Integer] limits the max depth of the hash. see {ClosureTree#hash_tree}
       # @return [Success({CustomField::Hierarchy::Item => Array, Hash})]
-      def hashed_subtree(item:, depth:)
+      def hashed_subtree(item:, depth: -1)
         if depth >= 0
           Success(item.hash_tree(limit_depth: depth + 1))
         else

--- a/app/services/mcp_tools/search_custom_field_items.rb
+++ b/app/services/mcp_tools/search_custom_field_items.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class SearchCustomFieldItems < Base
+    default_title "Custom Field Items"
+    default_description "Access items available as values for the given custom field. Usable for hierarchy and " \
+                        "weighted item list custom fields."
+
+    name "search_custom_field_items"
+    annotations read_only: true, idempotent: true, destructive: false
+
+    input_schema(
+      required: %i[custom_field_id],
+      properties: {
+        custom_field_id: {
+          type: "number",
+          description: "The custom field for which items shall be listed."
+        },
+        label: {
+          type: "string",
+          description: "The label of the item. Matches partially and case-insensitive."
+        }
+      }
+    )
+
+    def call(custom_field_id:, label: nil)
+      custom_field = ::CustomField.visible(current_user).find_by(id: custom_field_id)
+      return format_items([]) if custom_field&.hierarchy_root.nil?
+
+      items = flatten_hierarchy(custom_field)
+
+      if label.present?
+        items = items.select { |item| item.label.to_s.downcase.include?(label.downcase) }
+      end
+
+      format_items(items)
+    end
+
+    private
+
+    def format_items(items)
+      {
+        items: items.map { |item| API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter.new(item, current_user:) },
+        total: items.size
+      }
+    end
+
+    def flatten_hierarchy(custom_field)
+      ::CustomFields::Hierarchy::HierarchicalItemService
+        .new
+        .hashed_subtree(item: custom_field.hierarchy_root)
+        .fmap { |tree| ::CustomFields::Hierarchy::HierarchicalItemAggregator.flatten_tree_hash(tree) }
+        .value_or([])
+    end
+  end
+end

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -50,6 +50,7 @@ Rails.application.config.after_initialize do
                     McpTools::ListStatuses,
                     McpTools::ListTypes,
                     McpTools::SearchCustomFields,
+                    McpTools::SearchCustomFieldItems,
                     McpTools::SearchPortfolios,
                     McpTools::SearchPrograms,
                     McpTools::SearchProjects,

--- a/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
+++ b/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
@@ -48,8 +48,10 @@ properties:
       very big numbers.
       If this attribute is set, the `short` is null.
   depth:
-    type: integer
-    description: The hierarchy depth. The root item has a depth of 0.
+    type:
+      - "integer"
+      - "null"
+    description: The hierarchy depth. The root item has a depth of nil, the children of the root item have a depth of 0.
   _links:
     type: object
     required:

--- a/docs/api/apiv3/paths/custom_field_items.yml
+++ b/docs/api/apiv3/paths/custom_field_items.yml
@@ -1,4 +1,4 @@
-# /api/v3/custom_field/{id}/items
+# /api/v3/custom_fields/{id}/items
 ---
 get:
   summary: Get the custom field hierarchy items
@@ -9,11 +9,11 @@ get:
     The hierarchy is a tree structure of hierarchy items. It is represented as a flat list of items, where each item
     has a reference to its parent and children. The list is ordered in a depth-first manner. The first item is the
     requested parent. If parent was unset, the root item is returned as first element.
-    
+
     Passing the `depth` query parameter allows to limit the depth of the hierarchy. If the depth is unset, the full
     hierarchy tree is returned. If the depth is set to `0`, only the requested parent is returned. Any other positive
     integer will return the number of children levels specified by this value.
-    
+
     This endpoint only returns, if the custom field is of type `hierarchy`.
   parameters:
     - name: id

--- a/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
@@ -61,7 +61,7 @@ module API
             {
               href: api_v3_paths.custom_field_item(parent.id),
               title: parent.label
-            }
+            }.compact
           end
 
           links :children do

--- a/lib/api/v3/custom_fields/hierarchy/items_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/items_api.rb
@@ -34,30 +34,6 @@ module API
           include Dry::Monads[:result]
 
           helpers do
-            def flatten_tree_hash(hash)
-              flat_list = []
-              queue = [hash.merge({ depth: -1 })]
-
-              # From the service we get a hashed tree like this:
-              # {:a => {:b => {:c1 => {:d1 => {}}, :c2 => {:d2 => {}}}, :b2 => {}}}
-              #
-              # We flatten it depth first to this result list:
-              # [:a, :b, :c1, :d1, :c2, :d2, :b2]
-
-              while queue.any?
-                current = queue.shift
-                depth = current[:depth]
-                item, children = current.shift
-
-                flat_list << HierarchicalItemAggregate.new(item:, depth:)
-
-                queue.unshift(current) unless current.keys == [:depth]
-                queue.unshift(children.merge({ depth: depth + 1 })) unless children.empty?
-              end
-
-              flat_list
-            end
-
             def item_list(query)
               hierarchy_root = get_hierarchy_root(query)
 
@@ -71,18 +47,16 @@ module API
             end
 
             def flat_tree(item, depth)
-              sub_tree = ::CustomFields::Hierarchy::HierarchicalItemService
-                           .new
-                           .hashed_subtree(item:, depth:)
-                           .either(
-                             ->(value) { value },
-                             ->(error) do
-                               msg = "#{I18n.t('api_v3.errors.code_500')} #{error}"
-                               raise ::API::Errors::SafeInternalError.new(msg)
-                             end
-                           )
-
-              flatten_tree_hash(sub_tree)
+              ::CustomFields::Hierarchy::HierarchicalItemService
+                .new
+                .hashed_subtree(item:, depth:)
+                .either(
+                  ->(value) { ::CustomFields::Hierarchy::HierarchicalItemAggregator.flatten_tree_hash(value) },
+                  ->(error) do
+                    msg = "#{I18n.t('api_v3.errors.code_500')} #{error}"
+                    raise ::API::Errors::SafeInternalError.new(msg)
+                  end
+                )
             end
 
             def get_hierarchy_root(query)

--- a/spec/requests/mcp/mcp_tools/search_custom_field_items_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_custom_field_items_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpTools::SearchCustomFieldItems do
+  subject(:mcp_request) do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) do
+    # avoid owner for application, so that we don't have additional users created
+    create(:oauth_access_token, scopes: "mcp", resource_owner: user, application: create(:oauth_application, owner: nil))
+  end
+  let(:user) { create(:admin) }
+  let(:global_permissions) { %i[view_all_principals view_user_email] }
+
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "search_custom_field_items",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) { { custom_field_id: custom_field.id } }
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+
+  let!(:custom_field) do
+    create(:wp_custom_field, :hierarchy).tap do |cf|
+      service = CustomFields::Hierarchy::HierarchicalItemService.new
+      root = cf.hierarchy_root
+      hierarchy_items.each do |label|
+        service.insert_item(contract_class: CustomFields::Hierarchy::InsertListItemContract, parent: root, label:)
+      end
+    end
+  end
+  let(:hierarchy_items) { ["the green item", "the red item", "the yellow item"] }
+
+  let!(:other_custom_field) do
+    create(:wp_custom_field, :hierarchy).tap do |cf|
+      service = CustomFields::Hierarchy::HierarchicalItemService.new
+      root = cf.hierarchy_root
+      unrelated_items.each do |label|
+        service.insert_item(contract_class: CustomFields::Hierarchy::InsertListItemContract, parent: root, label:)
+      end
+    end
+  end
+  let(:unrelated_items) { %w[unrelated_1 unrelated_2] }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  before do
+    create(:global_member, user:, roles: [create(:global_role, permissions: global_permissions)])
+
+    server_config.save!
+    tool_config.save!
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server custom_field_hierarchies] do
+    it_behaves_like "MCP text tool"
+
+    it "finds all items of the custom field" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "items").size).to eq(hierarchy_items.size + 1) # items plus root
+    end
+
+    it "finds no items from unrelated custom fields" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "items").map { |i| i.fetch("label") }).not_to include(*unrelated_items)
+    end
+
+    it "responds with properly formatted items" do
+      mcp_request
+      parsed_results.dig("structuredContent", "items").each do |item|
+        expect(item.to_json).to match_json_schema.from_docs("hierarchy_item_read_model")
+      end
+    end
+
+    it "indicates the total number of results" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "total")).to eq(hierarchy_items.size + 1) # items plus root
+    end
+
+    context "when not passing a custom_field_id" do
+      let(:call_args) { {} }
+
+      it_behaves_like "MCP tool execution error response"
+    end
+
+    context "when filtering by label" do
+      let(:call_args) { { custom_field_id: custom_field.id, label: "the green item" } }
+
+      it "finds the item" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+        expect(parsed_results.dig("structuredContent", "items").first.fetch("label")).to eq("the green item")
+      end
+    end
+
+    context "when filtering on a partial, wrongly-cased label" do
+      let(:call_args) { { custom_field_id: custom_field.id, label: "Green" } }
+
+      it "finds the item" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+        expect(parsed_results.dig("structuredContent", "items").first.fetch("label")).to eq("the green item")
+      end
+    end
+
+    context "when not allowed to see the custom field" do
+      let(:user) { create(:user) }
+
+      it "finds no items" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(0)
+      end
+    end
+
+    context "when querying a custom field without a hierarchy" do
+      let!(:custom_field) { create(:wp_custom_field, :text) }
+
+      it "finds no items" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(0)
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled", with_ee: %i[custom_field_hierarchies] do
+    it "responds in a 404" do
+      mcp_request
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
Those can be used for custom fields of type hierarchy or weighted item list.

# Ticket
https://community.openproject.org/wp/AI-93

# "Screenshot"

```
❯ Please set the celestial body of work package 8 to Toril.                                   

● I'll look up the work package and the custom field to find the right value to set.

  Called openproject (ctrl+o to expand)

● Custom field 13 is "Celestial Body" (hierarchy type). Now let me find the "Toril" item and
  the work package's current lock version.

  Called openproject 2 times (ctrl+o to expand)

● Found it: WP 8 currently has Celestial Body ("customField13") set to "Deimos", lockVersion
  151. Now updating it to "Toril" (item ID 46).

  Called openproject (ctrl+o to expand)

● Done — work package 8's Celestial Body field is now set to "Toril" (previously "Deimos").

✻ Churned for 20s
```