### PR TITLE
[COMMS-879] Fix error message after failed work package move

### DIFF
--- a/app/models/work_package/semantic_identifier.rb
+++ b/app/models/work_package/semantic_identifier.rb
@@ -186,6 +186,16 @@ module WorkPackage::SemanticIdentifier
     WorkPackage::SemanticIdentifier.format_display_id(display_id)
   end
 
+  # Identifier attributes are cleared for the project move. If validation
+  # fails and moving is not possible, they need to be restored to show
+  # correct error messages.
+  def restore_identifier_after_failed_move
+    return unless cleared_for_project_move?
+
+    self.identifier = identifier_was
+    self.sequence_number = sequence_number_was
+  end
+
   # Override ActiveRecord's default `to_param` so Rails URL helpers
   # (work_package_path, polymorphic_path, form_for, etc.) automatically
   # produce semantic-id URLs in semantic mode. In classic mode display_id

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -33,6 +33,13 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
   private
 
+  def validate_and_result
+    result = super
+    # restore identifier for error messages
+    work_package.restore_identifier_after_failed_move unless result.success?
+    result
+  end
+
   def set_attributes(attributes)
     validate_custom_fields = attributes.delete(:validate_custom_fields)
 

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -225,6 +225,40 @@ RSpec.describe WorkPackages::MovesController, with_settings: { journal_aggregati
           expect(subject).to redirect_to(work_package_path(work_package))
         end
       end
+
+      context "when the move fails validation, with semantic identifiers",
+              with_settings: { work_packages_identifier: "semantic" } do
+        let(:outsider) { create(:user) }
+        let(:unmovable_work_package) do
+          create(:work_package,
+                 project_id: project.id,
+                 type:,
+                 author: user,
+                 priority:,
+                 responsible: outsider)
+        end
+
+        before do
+          # outsider is not a member of target_project, so the move fails
+          # contract validation before anything is persisted.
+          unmovable_work_package.update_columns(identifier: "SRC-1", sequence_number: 1)
+
+          post :create,
+               params: {
+                 work_package_id: unmovable_work_package.id,
+                 new_project_id: target_project.id
+               }
+        end
+
+        it "shows the semantic identifier in the error flash, not the bare numeric id" do
+          expect(flash[:error]).to include("SRC-1")
+          expect(flash[:error]).not_to include("##{unmovable_work_package.id}")
+        end
+
+        it "does not persist the move" do
+          expect(unmovable_work_package.reload.project_id).to eq(project.id)
+        end
+      end
     end
 
     describe "bulk move" do

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -520,6 +520,34 @@ RSpec.describe WorkPackages::SetAttributesService,
         expect(subject.errors).to be_empty
       end
     end
+
+    context "when moving to another project fails validation, with semantic identifiers",
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:user) { build_stubbed(:admin) }
+      let(:source_project) { create(:project) }
+      let(:target_project) { create(:project) }
+      let(:outsider) { create(:user) }
+      let(:invalid_wp) do
+        create(:work_package, project: source_project, responsible: outsider).tap do |wp|
+          wp.update_columns(identifier: "SRC-1", sequence_number: 1)
+        end
+      end
+      let(:call_attributes) { { project_id: target_project.id } }
+
+      subject(:service_result) { instance.call(call_attributes) }
+
+      it "is unsuccessful and restores the semantic identifier on the returned work package", :aggregate_failures do
+        expect(service_result).not_to be_success
+        expect(invalid_wp.identifier).to eq("SRC-1")
+        expect(invalid_wp.sequence_number).to eq(1)
+        expect(invalid_wp.formatted_id).to eq("SRC-1")
+      end
+
+      it "does not persist the move" do
+        service_result
+        expect(invalid_wp.reload.project_id).to eq(source_project.id)
+      end
+    end
   end
 
   context "for start_date & due_date & duration" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-879

# What are you trying to accomplish?
Fix a wrong error message - this was already fixed in dev, but merged only after the feature freeze and should go into 17.7 as well. See https://github.com/opf/openproject/pull/24203 

## Screenshots

# What approach did you choose and why?
WorkPackages::SetAttributesService#clear_semantic_identifier nils out identifier/sequence_number in memory before contract validation runs, so a fresh one can be allocated after a successful move without violating the (project_id, sequence_number) unique index. If the move then fails contract validation, nothing is ever saved -- the DB row's real identifier is untouched -- but the work package object returned to the caller kept the cleared identifier, so anything reading formatted_id/display_id off it (error messages, to_s, ...) showed a bare numeric id instead.

Restore identifier/sequence_number from their pre-clear values via dirty tracking once SetAttributesService knows the contract rejected the change, so every consumer of the returned work package sees accurate data instead of only patching the one view that renders it.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
