### PR TITLE
[COMMS-833] Fix asset paths for documents on a relative url

### DIFF
--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -85,6 +85,23 @@ module FrontendAssetHelper
     end
   end
 
+  ##
+  # Like variable_asset_path, but for callers that use the resulting URL directly
+  # (e.g. as a raw <link href> inside a shadow DOM, as BlockNote does) instead of
+  # passing it through stylesheet_link_tag/javascript_include_tag. Those tag helpers
+  # add relative_url_root automatically; direct consumers don't go through them, so
+  # it must be prepended here instead. Do NOT use variable_asset_path itself for this:
+  # it's shared with the tag-helper call sites, and prepending relative_url_root there
+  # too would cause it to be applied twice for those (Rails' own idempotency guard in
+  # compute_asset_path only catches an exact-prefix match, not one where relative_url_root
+  # has a trailing slash).
+  def raw_variable_asset_path(path)
+    base_path = variable_asset_path(path)
+    return base_path if FrontendAssetHelper.assets_proxied?
+
+    File.join(Rails.application.config.relative_url_root.to_s, base_path)
+  end
+
   private
 
   def lookup_frontend_asset(unhashed_file_name)

--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -60,8 +60,8 @@ module Primer
           }
           @attachments_upload_url = attachments_upload_url
           @attachments_collection_key = attachments_collection_key
-          @blocknote_stylesheet_url = variable_asset_path("blocknote.css")
-          @shadow_dom_stylesheet_url = variable_asset_path("styles.css")
+          @blocknote_stylesheet_url = raw_variable_asset_path("blocknote.css")
+          @shadow_dom_stylesheet_url = raw_variable_asset_path("styles.css")
 
           @collaboration_enabled = Setting.real_time_text_collaboration_enabled?
         end

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -78,6 +78,24 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
     end
   end
 
+  context "when running with a relative_url_root and non-proxied frontend assets",
+          js: false,
+          with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => "1" } do
+    before do
+      allow(Rails.application.config).to receive(:relative_url_root).and_return("/openproject")
+    end
+
+    it "renders the BlockNote shadow-DOM stylesheet urls prefixed with the relative url root" do
+      visit document_path(document)
+
+      block_note_element = find("op-block-note", visible: false)
+      expect(block_note_element["blocknote-stylesheet-url"])
+        .to match(%r{\A/openproject/assets/frontend/blocknote(.*)\.css\z})
+      expect(block_note_element["shadow-dom-stylesheet-url"])
+        .to match(%r{\A/openproject/assets/frontend/styles(.*)\.css\z})
+    end
+  end
+
   describe "with op-blocknote-extensions" do
     it "renders the BlockNote editor with custom menu entries for work package linking" do
       visit document_path(document)

--- a/spec/helpers/frontend_asset_helper_spec.rb
+++ b/spec/helpers/frontend_asset_helper_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe FrontendAssetHelper do
             with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => "" } do
       before do
         allow(Rails.env).to receive(:production?).and_return(false)
+        allow(Rails.application.config).to receive(:relative_url_root).and_return("")
       end
 
       it "returns the proxied frontend server" do
@@ -53,9 +54,25 @@ RSpec.describe FrontendAssetHelper do
       end
     end
 
+    # controller.config is an ActiveSupport::InheritableOptions singleton that persists across the
+    # whole spec run and falls back to Rails.application.config.relative_url_root when unset
+    # (RSpec's `allow(...).to receive(...)` stubs don't affect it here — stylesheet_link_tag reads
+    # relative_url_root through a config that resolves the value via its own internal/parent
+    # storage, not a Ruby method dispatch a stub could intercept). So it must be saved and restored
+    # explicitly via real assignment, and even the "no override" baseline must be pinned to a known
+    # value, or these examples become sensitive to whatever RAILS_RELATIVE_URL_ROOT happens to be
+    # set to in the shell/CI environment running the suite.
     context "when in production" do
+      let(:original_relative_url_root) { controller.config.relative_url_root }
+
       before do
         allow(Rails.env).to receive(:production?).and_return(true)
+        original_relative_url_root # memoize the pre-mutation value before overwriting it below
+        controller.config.relative_url_root = ""
+      end
+
+      after do
+        controller.config.relative_url_root = original_relative_url_root
       end
 
       it "returns the path to the asset" do
@@ -63,9 +80,7 @@ RSpec.describe FrontendAssetHelper do
       end
 
       context "when using relative_url_root" do
-        before do
-          controller.config.relative_url_root = "/openproject"
-        end
+        before { controller.config.relative_url_root = "/openproject" }
 
         it "prepends it to the asset path" do
           expect(helper.include_frontend_assets).to match(%r{script src="/openproject/assets/frontend/main(.*).js"})
@@ -73,12 +88,70 @@ RSpec.describe FrontendAssetHelper do
       end
 
       context "when using relative_url_root ending with a slash" do
-        before do
-          controller.config.relative_url_root = "/openproject/"
-        end
+        before { controller.config.relative_url_root = "/openproject/" }
 
         it "prepends it to the asset path only once (bug #41428)" do
           expect(helper.include_frontend_assets).to match(%r{script src="/openproject/assets/frontend/main(.*).js"})
+        end
+      end
+    end
+  end
+
+  describe "#raw_variable_asset_path" do
+    context "when in development or test",
+            with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => "" } do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+        allow(Rails.application.config).to receive(:relative_url_root).and_return("")
+      end
+
+      it "returns the proxied frontend server path" do
+        expect(helper.raw_variable_asset_path("blocknote.css"))
+          .to match(%r{\Ahttp://(frontend-test|localhost):4200/assets/frontend/blocknote(.*)\.css\z})
+      end
+
+      context "when using relative_url_root" do
+        before do
+          allow(Rails.application.config).to receive(:relative_url_root).and_return("/openproject")
+        end
+
+        it "prepends it to the proxied path" do
+          expect(helper.raw_variable_asset_path("blocknote.css"))
+            .to match(%r{\Ahttp://(frontend-test|localhost):4200/openproject/assets/frontend/blocknote(.*)\.css\z})
+        end
+      end
+    end
+
+    context "when in production" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Rails.application.config).to receive(:relative_url_root).and_return("")
+      end
+
+      it "returns a bare root-relative path" do
+        expect(helper.raw_variable_asset_path("blocknote.css"))
+          .to match(%r{\A/assets/frontend/blocknote(.*)\.css\z})
+      end
+
+      context "when using relative_url_root" do
+        before do
+          allow(Rails.application.config).to receive(:relative_url_root).and_return("/openproject")
+        end
+
+        it "prepends it to the raw asset path (regression: BlockNote shadow-DOM stylesheet hrefs)" do
+          expect(helper.raw_variable_asset_path("blocknote.css"))
+            .to match(%r{\A/openproject/assets/frontend/blocknote(.*)\.css\z})
+        end
+      end
+
+      context "when using relative_url_root ending with a slash" do
+        before do
+          allow(Rails.application.config).to receive(:relative_url_root).and_return("/openproject/")
+        end
+
+        it "prepends it exactly once (bug #41428-style double-slash)" do
+          expect(helper.raw_variable_asset_path("blocknote.css"))
+            .to match(%r{\A/openproject/assets/frontend/blocknote(.*)\.css\z})
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-833

# What are you trying to accomplish?
Make assets for documents work when `RAILS_RELATIVE_URL_ROOT` is set.

# What approach did you choose and why?
The documents assets in the shadow root did not respect he relative url, so they were trying to load `<base-url>/assets/...` instead of loading `<base-url>/<relative-url>/assets/...`

Add a new method `raw_variable_asset_path` which has to be used when the rails link helpers (`stylesheet_link_tag`, `javascript_include_tag`, etc) are not used.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

# How to test (if you want to)

1. Build prod docker image locally:

```sh
docker build -f docker/prod/Dockerfile \
--target all-in-one \
--build-arg BIM_SUPPORT=false \
-t openproject-local:test-fix \
.
```

2. Run the image (with additional hocuspocus settings, because locally the URLs under which openproject is reachable for Hocuspocus differ in comparison to openproject running on the web):

```sh
docker run --rm \
-e OPENPROJECT_HOST__NAME=localhost:9090 \
-e SECRET_KEY_BASE=42 \
-e OPENPROJECT_HTTPS=false \
-e OPENPROJECT_URL=http://127.0.0.1 \
-e OPENPROJECT_RAILS__RELATIVE__URL__ROOT=/openproject \
-e OPENPROJECT_ADDITIONAL__HOST__NAMES=127.0.0.1 \
-p 9090:80 \
-it openproject-local:test-fix
```

3. visit `http://localhost:9090/openproject`