### PR TITLE
[AGILE-115] Offer sprint and backlog bucket in WP bulk edit

### DIFF
--- a/modules/backlogs/app/views/work_packages/bulk/_sprint_and_backlog_bucket_fields.html.erb
+++ b/modules/backlogs/app/views/work_packages/bulk/_sprint_and_backlog_bucket_fields.html.erb
@@ -1,0 +1,51 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<div class="form--field">
+  <%= styled_label_tag :work_package_sprint_id, WorkPackage.human_attribute_name(:sprint) %>
+  <div class="form--field-container">
+    <%= styled_select_tag(
+          "work_package[sprint_id]",
+          content_tag("option", t(:label_none), value: "none") +
+            options_from_collection_for_select(assignable_sprints, :id, :name),
+          include_blank: t(:label_no_change_option)
+        ) %>
+  </div>
+</div>
+<div class="form--field">
+  <%= styled_label_tag :work_package_backlog_bucket_id, WorkPackage.human_attribute_name(:backlog_bucket) %>
+  <div class="form--field-container">
+    <%= styled_select_tag(
+          "work_package[backlog_bucket_id]",
+          content_tag("option", t(:label_none), value: "none") +
+            options_from_collection_for_select(backlog_buckets, :id, :name),
+          include_blank: t(:label_no_change_option)
+        ) %>
+  </div>
+</div>

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -242,6 +242,8 @@ module OpenProject::Backlogs
     end
 
     config.to_prepare do
+      require "open_project/backlogs/hooks/work_package_hook"
+
       %i[position story_points sprint backlog_bucket].each do |attribute|
         ::Type.add_constraint attribute, ->(_type, project: nil) { project.nil? || project.backlogs_enabled? }
       end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -238,6 +238,8 @@ module OpenProject::Backlogs
     end
 
     config.to_prepare do
+      require "open_project/backlogs/hooks/work_package_hook"
+
       %i[position story_points sprint backlog_bucket].each do |attribute|
         ::Type.add_constraint attribute, ->(_type, project: nil) { project.nil? || project.backlogs_enabled? }
       end

--- a/modules/backlogs/lib/open_project/backlogs/hooks/work_package_hook.rb
+++ b/modules/backlogs/lib/open_project/backlogs/hooks/work_package_hook.rb
@@ -44,7 +44,7 @@ module OpenProject::Backlogs
         context[:hook_caller].render(
           partial: "work_packages/bulk/sprint_and_backlog_bucket_fields",
           locals: {
-            assignable_sprints: Sprint.assignable(project:, user: User.current),
+            assignable_sprints: Sprint.assignable(project:, user: User.current).order_by_date,
             backlog_buckets: BacklogBucket.visible(User.current).for_project(project)
           }
         )

--- a/modules/backlogs/lib/open_project/backlogs/hooks/work_package_hook.rb
+++ b/modules/backlogs/lib/open_project/backlogs/hooks/work_package_hook.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Backlogs
+  module Hooks
+    class WorkPackageHook < ::OpenProject::Hook::ViewListener
+      # Adds the Sprint and Backlog bucket fields to the work package bulk-edit form.
+      #
+      # Only shown when all selected work packages share a single project (context[:project]
+      # is only set in that case, see WorkPackages::BulkController#find_work_packages), that
+      # project has backlogs enabled, and the current user is allowed to manage sprint items.
+      def view_work_packages_bulk_edit_details_bottom(context = {})
+        project = context[:project]
+        return "" unless project&.backlogs_enabled? &&
+                          User.current.allowed_in_project?(:manage_sprint_items, project)
+
+        context[:hook_caller].render(
+          partial: "work_packages/bulk/sprint_and_backlog_bucket_fields",
+          locals: {
+            assignable_sprints: Sprint.assignable(project:, user: User.current),
+            backlog_buckets: BacklogBucket.visible(User.current).for_project(project)
+          }
+        )
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -31,13 +31,14 @@
 require "spec_helper"
 
 RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
-  shared_let(:project) { create(:project, enabled_module_names: %i[backlogs work_package_tracking]) }
-  shared_let(:sprint) { create(:sprint, project:) }
-  shared_let(:bucket) { create(:backlog_bucket, project:) }
+  let!(:sprint) { create(:sprint, project:) }
+  let!(:bucket) { create(:backlog_bucket, project:) }
 
-  shared_let(:work_package1) { create(:work_package, project:) }
-  shared_let(:work_package2) { create(:work_package, project:) }
+  let(:work_package1) { create(:work_package, project:) }
+  let(:work_package2) { create(:work_package, project:) }
 
+  let(:project) { create(:project, enabled_module_names: enabled_modules) }
+  let(:enabled_modules) { %i[backlogs work_package_tracking] }
   let(:permissions) do
     %i[view_work_packages edit_work_packages view_sprints manage_sprint_items]
   end
@@ -51,25 +52,25 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
     before { get :edit, params: { ids: [work_package1.id, work_package2.id] } }
 
     it "displays the sprint and backlog bucket selects" do
-      assert_select "select", attributes: { name: "work_package[sprint_id]" }
-      assert_select "select", attributes: { name: "work_package[backlog_bucket_id]" }
+      expect(response.body).to have_select("Sprint", with_options: [sprint.name])
+      expect(response.body).to have_select("Backlog bucket", with_options: [bucket.name])
     end
 
     context "without the manage_sprint_items permission" do
       let(:permissions) { %i[view_work_packages edit_work_packages view_sprints] }
 
       it "does not display the fields" do
-        assert_select "select", { attributes: { name: "work_package[sprint_id]" } }, false
-        assert_select "select", { attributes: { name: "work_package[backlog_bucket_id]" } }, false
+        expect(response.body).to have_no_select("Sprint")
+        expect(response.body).to have_no_select("Backlog bucket")
       end
     end
 
     context "when the project does not have backlogs enabled" do
-      before { project.enabled_module_names -= ["backlogs"] }
+      let(:enabled_modules) { %i[work_package_tracking] }
 
       it "does not display the fields" do
-        assert_select "select", { attributes: { name: "work_package[sprint_id]" } }, false
-        assert_select "select", { attributes: { name: "work_package[backlog_bucket_id]" } }, false
+        expect(response.body).to have_no_select("Sprint")
+        expect(response.body).to have_no_select("Backlog bucket")
       end
     end
 
@@ -85,8 +86,8 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
       end
 
       it "does not display the fields" do
-        assert_select "select", { attributes: { name: "work_package[sprint_id]" } }, false
-        assert_select "select", { attributes: { name: "work_package[backlog_bucket_id]" } }, false
+        expect(response.body).to have_no_select("Sprint")
+        expect(response.body).to have_no_select("Backlog bucket")
       end
     end
   end

--- a/modules/backlogs/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
+  shared_let(:project) { create(:project, enabled_module_names: %i[backlogs work_package_tracking]) }
+  shared_let(:sprint) { create(:sprint, project:) }
+  shared_let(:bucket) { create(:backlog_bucket, project:) }
+
+  shared_let(:work_package1) { create(:work_package, project:) }
+  shared_let(:work_package2) { create(:work_package, project:) }
+
+  let(:permissions) do
+    %i[view_work_packages edit_work_packages view_sprints manage_sprint_items]
+  end
+  let(:user) { create(:user, member_with_permissions: { project => permissions }) }
+
+  current_user { user }
+
+  describe "#edit" do
+    render_views
+
+    before { get :edit, params: { ids: [work_package1.id, work_package2.id] } }
+
+    it "displays the sprint and backlog bucket selects" do
+      assert_select "select", attributes: { name: "work_package[sprint_id]" }
+      assert_select "select", attributes: { name: "work_package[backlog_bucket_id]" }
+    end
+
+    context "without the manage_sprint_items permission" do
+      let(:permissions) { %i[view_work_packages edit_work_packages view_sprints] }
+
+      it "does not display the fields" do
+        assert_select "select", { attributes: { name: "work_package[sprint_id]" } }, false
+        assert_select "select", { attributes: { name: "work_package[backlog_bucket_id]" } }, false
+      end
+    end
+
+    context "when the project does not have backlogs enabled" do
+      before { project.enabled_module_names -= ["backlogs"] }
+
+      it "does not display the fields" do
+        assert_select "select", { attributes: { name: "work_package[sprint_id]" } }, false
+        assert_select "select", { attributes: { name: "work_package[backlog_bucket_id]" } }, false
+      end
+    end
+
+    context "when the selected work packages span multiple projects" do
+      shared_let(:other_project) { create(:project, enabled_module_names: %i[work_package_tracking]) }
+      shared_let(:work_package3) { create(:work_package, project: other_project) }
+
+      before do
+        create(:member, project: other_project, principal: user,
+                        roles: [create(:project_role, permissions:)])
+
+        get :edit, params: { ids: [work_package1.id, work_package2.id, work_package3.id] }
+      end
+
+      it "does not display the fields" do
+        assert_select "select", { attributes: { name: "work_package[sprint_id]" } }, false
+        assert_select "select", { attributes: { name: "work_package[backlog_bucket_id]" } }, false
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:work_package_ids) { [work_package1.id, work_package2.id] }
+
+    it "assigns the sprint to all selected work packages" do
+      put :update, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
+
+      expect(work_package1.reload.sprint).to eq sprint
+      expect(work_package2.reload.sprint).to eq sprint
+    end
+
+    it "assigns the backlog bucket to all selected work packages" do
+      put :update, params: { ids: work_package_ids, work_package: { backlog_bucket_id: bucket.id } }
+
+      expect(work_package1.reload.backlog_bucket).to eq bucket
+      expect(work_package2.reload.backlog_bucket).to eq bucket
+    end
+
+    it "clears the sprint when 'none' is selected" do
+      work_package1.update!(sprint:)
+
+      put :update, params: { ids: work_package_ids, work_package: { sprint_id: "none" } }
+
+      expect(work_package1.reload.sprint).to be_nil
+    end
+
+    it "clears an existing sprint when a backlog bucket is assigned instead" do
+      work_package1.update!(sprint:)
+
+      put :update, params: { ids: work_package_ids, work_package: { backlog_bucket_id: bucket.id } }
+
+      expect(work_package1.reload).to have_attributes(sprint: nil, backlog_bucket: bucket)
+    end
+
+    it "clears an existing backlog bucket when a sprint is assigned instead" do
+      work_package1.update!(backlog_bucket: bucket)
+
+      put :update, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
+
+      expect(work_package1.reload).to have_attributes(sprint:, backlog_bucket: nil)
+    end
+
+    it "rejects assigning both a sprint and a backlog bucket in the same submission" do
+      put :update,
+          params: { ids: work_package_ids, work_package: { sprint_id: sprint.id, backlog_bucket_id: bucket.id } }
+
+      expect(flash[:error])
+        .to include(I18n.t(:"work_packages.bulk.none_could_be_saved", total: work_package_ids.size))
+      expect(work_package1.reload).to have_attributes(sprint: nil, backlog_bucket: nil)
+      expect(work_package2.reload).to have_attributes(sprint: nil, backlog_bucket: nil)
+    end
+
+    context "without the manage_sprint_items permission" do
+      let(:permissions) { %i[view_work_packages edit_work_packages view_sprints] }
+
+      it "does not assign the sprint" do
+        put :update, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
+
+        expect(work_package1.reload.sprint).to be_nil
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/requests/work_packages/bulk_spec.rb
+++ b/modules/backlogs/spec/requests/work_packages/bulk_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
+RSpec.describe "Work packages bulk edit: sprint and backlog bucket", :skip_csrf, type: :rails_request do
   let!(:sprint) { create(:sprint, project:) }
   let!(:bucket) { create(:backlog_bucket, project:) }
 
@@ -46,10 +46,8 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
 
   current_user { user }
 
-  describe "#edit" do
-    render_views
-
-    before { get :edit, params: { ids: [work_package1.id, work_package2.id] } }
+  describe "GET edit" do
+    before { get edit_work_packages_bulk_path(ids: [work_package1.id, work_package2.id]) }
 
     it "displays the sprint and backlog bucket selects" do
       expect(response.body).to have_select("Sprint", with_options: [sprint.name])
@@ -82,7 +80,7 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
         create(:member, project: other_project, principal: user,
                         roles: [create(:project_role, permissions:)])
 
-        get :edit, params: { ids: [work_package1.id, work_package2.id, work_package3.id] }
+        get edit_work_packages_bulk_path(ids: [work_package1.id, work_package2.id, work_package3.id])
       end
 
       it "does not display the fields" do
@@ -92,18 +90,18 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
     end
   end
 
-  describe "#update" do
+  describe "PUT update" do
     let(:work_package_ids) { [work_package1.id, work_package2.id] }
 
     it "assigns the sprint to all selected work packages" do
-      put :update, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
+      put work_packages_bulk_path, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
 
       expect(work_package1.reload.sprint).to eq sprint
       expect(work_package2.reload.sprint).to eq sprint
     end
 
     it "assigns the backlog bucket to all selected work packages" do
-      put :update, params: { ids: work_package_ids, work_package: { backlog_bucket_id: bucket.id } }
+      put work_packages_bulk_path, params: { ids: work_package_ids, work_package: { backlog_bucket_id: bucket.id } }
 
       expect(work_package1.reload.backlog_bucket).to eq bucket
       expect(work_package2.reload.backlog_bucket).to eq bucket
@@ -112,7 +110,7 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
     it "clears the sprint when 'none' is selected" do
       work_package1.update!(sprint:)
 
-      put :update, params: { ids: work_package_ids, work_package: { sprint_id: "none" } }
+      put work_packages_bulk_path, params: { ids: work_package_ids, work_package: { sprint_id: "none" } }
 
       expect(work_package1.reload.sprint).to be_nil
     end
@@ -120,7 +118,7 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
     it "clears an existing sprint when a backlog bucket is assigned instead" do
       work_package1.update!(sprint:)
 
-      put :update, params: { ids: work_package_ids, work_package: { backlog_bucket_id: bucket.id } }
+      put work_packages_bulk_path, params: { ids: work_package_ids, work_package: { backlog_bucket_id: bucket.id } }
 
       expect(work_package1.reload).to have_attributes(sprint: nil, backlog_bucket: bucket)
     end
@@ -128,13 +126,13 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
     it "clears an existing backlog bucket when a sprint is assigned instead" do
       work_package1.update!(backlog_bucket: bucket)
 
-      put :update, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
+      put work_packages_bulk_path, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
 
       expect(work_package1.reload).to have_attributes(sprint:, backlog_bucket: nil)
     end
 
     it "rejects assigning both a sprint and a backlog bucket in the same submission" do
-      put :update,
+      put work_packages_bulk_path,
           params: { ids: work_package_ids, work_package: { sprint_id: sprint.id, backlog_bucket_id: bucket.id } }
 
       expect(flash[:error])
@@ -147,7 +145,7 @@ RSpec.describe WorkPackages::BulkController, "sprint and backlog bucket" do
       let(:permissions) { %i[view_work_packages edit_work_packages view_sprints] }
 
       it "does not assign the sprint" do
-        put :update, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
+        put work_packages_bulk_path, params: { ids: work_package_ids, work_package: { sprint_id: sprint.id } }
 
         expect(work_package1.reload.sprint).to be_nil
       end

--- a/modules/backlogs/spec/requests/work_packages/bulk_spec.rb
+++ b/modules/backlogs/spec/requests/work_packages/bulk_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe "Work packages bulk edit: sprint and backlog bucket", :skip_csrf,
       expect(response.body).to have_select("Backlog bucket", with_options: [bucket.name])
     end
 
+    it "orders the assignable sprints chronologically, soonest first" do
+      sprint_later = create(:sprint, project:, name: "Sprint later",
+                                     start_date: Time.zone.today + 30.days, finish_date: Time.zone.today + 44.days)
+      sprint_soon = create(:sprint, project:, name: "Sprint soon",
+                                    start_date: Time.zone.today + 7.days, finish_date: Time.zone.today + 20.days)
+      sprint_latest = create(:sprint, project:, name: "Sprint latest",
+                                      start_date: Time.zone.today + 60.days, finish_date: Time.zone.today + 74.days)
+
+      get edit_work_packages_bulk_path(ids: [work_package1.id, work_package2.id])
+
+      rendered_order = page.all("select[name='work_package[sprint_id]'] option")
+                           .map { |option| option.text.strip }
+                           # Skip blank and "None" options, we are only interested in the sprints to assert the ordering
+                           .intersection([sprint_soon.name, sprint_later.name, sprint_latest.name])
+
+      expect(rendered_order).to eq [sprint_soon.name, sprint_later.name, sprint_latest.name]
+    end
+
     context "without the manage_sprint_items permission" do
       let(:permissions) { %i[view_work_packages edit_work_packages view_sprints] }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-115

# What are you trying to accomplish?
Show backlog bucket and sprint options when bulk editing a work package.

## Screenshots
<img width="1235" height="770" alt="image" src="https://github.com/user-attachments/assets/2705ff3c-2c48-4195-b222-627cb8361b17" />

# What approach did you choose and why?

I took the solution from the 2FA module as inspiration and added a work package hook to extend the bulk edit form for projects that have the backlogs module enabled.

All work packages must be part of the same project context, otherwise, we don't offer sprints/backlog buckets in the form as they might differ from project to project.

No UI changes made to bulk editing -> users can choose to mass assign a work package to a bucket and a sprint at the same time. The contract will catch this and render a comprehensive error. But there's no logic that prevents a user from attempting this in the bulk edit form.

I only added controller specs and covered most (but not all) cases. I didn't want to add slow feature specs for this feature. Happy to discuss this if you disagree.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
