### PR TITLE
[COMMS-863] WorkPackage <-> Version direct relation cleanup

### DIFF
--- a/app/contracts/versions/delete_contract.rb
+++ b/app/contracts/versions/delete_contract.rb
@@ -37,9 +37,13 @@ module Versions
     protected
 
     def validate_no_work_packages_attached
-      return unless model.work_packages.exists?
+      return unless work_packages_attached?
 
       errors.add(:base, :undeletable_work_packages_attached)
+    end
+
+    def work_packages_attached?
+      model.work_package_versions.exists?
     end
   end
 end

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -47,7 +47,8 @@ module WorkPackages
     attribute :priority_id
     attribute :category_id
     attribute :version_id,
-              permission: :assign_versions do
+              permission: :assign_versions,
+              writable: ->(*) { !Setting::WorkPackageMultipleVersions.active? } do
       validate_version_is_assignable
     end
     attribute :target_versions,

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -38,13 +38,6 @@ class Queries::WorkPackages::Filter::VersionFilter <
     WorkPackage.human_attribute_name("version")
   end
 
-  def joins
-    case operator
-    when "o", "c", "l"
-      :version
-    end
-  end
-
   def self.key
     :version_id
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -33,9 +33,6 @@ class Version < ApplicationRecord
   include ::Scopes::Scoped
 
   belongs_to :project
-  # Deprecated direct relation, replaced by the work_package_versions join
-  # table (see #targeted_work_packages / #observed_in_work_packages).
-  # has_many :work_packages, dependent: :nullify
   has_many :work_package_versions, dependent: :delete_all
   has_many :targeted_work_packages,
            -> { where(work_package_versions: { kind: "target" }) },

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -33,7 +33,9 @@ class Version < ApplicationRecord
   include ::Scopes::Scoped
 
   belongs_to :project
-  has_many :work_packages, dependent: :nullify
+  # Deprecated direct relation, replaced by the work_package_versions join
+  # table (see #targeted_work_packages / #observed_in_work_packages).
+  # has_many :work_packages, dependent: :nullify
   has_many :work_package_versions, dependent: :delete_all
   has_many :targeted_work_packages,
            -> { where(work_package_versions: { kind: "target" }) },

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -42,6 +42,9 @@ class Version < ApplicationRecord
            through: :work_package_versions, source: :work_package
   acts_as_customizable
 
+  # manually clear association, since the has_many/belongs_to were removed
+  before_destroy :nullify_work_package_version_mirror
+
   VERSION_STATUSES = %w(open locked closed).freeze
   VERSION_SHARINGS = %w(none descendants hierarchy tree system).freeze
 
@@ -207,6 +210,10 @@ class Version < ApplicationRecord
     if effective_date && start_date && effective_date < start_date
       errors.add :effective_date, :greater_than_start_date
     end
+  end
+
+  def nullify_work_package_version_mirror
+    WorkPackage.where(version_id: id).update_all(version_id: nil)
   end
 
   # Returns the average estimated time of assigned issues

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -153,7 +153,7 @@ module WorkPackage::Versions
             "represented as a single version. Use #target_versions instead."
     end
 
-    target_versions.first
+    target_versions.min
   end
 
   # Versions that the work_package can be assigned to

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -32,9 +32,6 @@ module WorkPackage::Versions
   extend ActiveSupport::Concern
 
   included do
-    # Deprecated single-version column
-    # belongs_to :version, optional: true
-
     has_many :work_package_versions, dependent: :delete_all
     has_many :versions, through: :work_package_versions, source: :version
     has_many :target_versions,

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -190,8 +190,8 @@ module WorkPackage::Versions
   #   * actual written target_versions
   def effective_target_versions
     if target_version_ids_replacements.nil?
-      # TODO(COMMS-863)
-      return version_id_changed? ? Array(version) : target_versions
+      # TODO(COMMS-863): drop this branch once nothing writes version_id directly
+      return version_id_changed? ? Array(Version.find_by(id: version_id)) : target_versions
     end
 
     versions_by_id = Version.where(id: target_version_ids_replacements).index_by(&:id)

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -32,10 +32,8 @@ module WorkPackage::Versions
   extend ActiveSupport::Concern
 
   included do
-    # Deprecated single-version column, kept in sync with the first target
-    # version (see #update_legacy_version_field). Can be dropped once all
-    # subsystems read target_versions instead.
-    belongs_to :version, optional: true
+    # Deprecated single-version column
+    # belongs_to :version, optional: true
 
     has_many :work_package_versions, dependent: :delete_all
     has_many :versions, through: :work_package_versions, source: :version
@@ -143,6 +141,19 @@ module WorkPackage::Versions
         kind
       end
     end
+  end
+
+  # Read-only replacement for the former +belongs_to :version+ association.
+  #
+  # Returns the work package's single target version, or nil when it has none.
+  # Raises an error if target_versions has multiple values
+  def version
+    if target_versions.size > 1
+      raise "WorkPackage##{id} has multiple target versions and cannot be " \
+            "represented as a single version. Use #target_versions instead."
+    end
+
+    target_versions.first
   end
 
   # Versions that the work_package can be assigned to

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -136,16 +136,13 @@ module Projects::Copy
     end
 
     def copy_work_package_attribute_overrides(source_work_package, parent_id, user_cf_ids)
-      target_version_ids = work_package_target_version_ids(source_work_package)
+      target_version_ids = mapped_version_ids(source_work_package.target_versions)
 
       {
         project: target,
         parent_id:,
-        # TODO(COMMS-863): The legacy version_id has to agree with the first target
-        # version (contract validation) until the column is dropped.
-        version_id: target_version_ids&.first,
         target_version_ids:,
-        observed_in_version_ids: work_package_observed_in_version_ids(source_work_package),
+        observed_in_version_ids: mapped_version_ids(source_work_package.observed_in_versions),
         assigned_to_id: work_package_assigned_to_id(source_work_package),
         responsible_id: work_package_responsible_id(source_work_package),
         custom_field_values: custom_value_attributes(source_work_package, user_cf_ids),
@@ -154,20 +151,10 @@ module Projects::Copy
       }
     end
 
-    def work_package_target_version_ids(source_work_package)
-      lookup = state.version_id_lookup
-      return if lookup.nil?
+    def mapped_version_ids(versions)
+      lookup = state.version_id_lookup || {}
 
-      # `.presence` forces return nil instead of an empty array when the source has no target
-      # versions. This skips writing target versions unnecessarily and avoid conflicts with legacy version_id
-      source_work_package.target_versions.filter_map { |v| state.version_id_lookup[v.id] }.presence
-    end
-
-    def work_package_observed_in_version_ids(source_work_package)
-      lookup = state.version_id_lookup
-      return if lookup.nil?
-
-      source_work_package.observed_in_versions.filter_map { |v| state.version_id_lookup[v.id] }.presence
+      versions.filter_map { |version| lookup[version.id] }
     end
 
     def work_package_assigned_to_id(source_work_package)

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -106,11 +106,11 @@ class WorkPackages::CopyService < BaseServices::BaseCallable
     attributes = {}
 
     if writable_attributes.include?("target_versions")
-      attributes["target_version_ids"] = work_package.target_versions.pluck(:version_id).presence
+      attributes["target_version_ids"] = work_package.target_version_ids.presence
     end
 
     if writable_attributes.include?("observed_in_versions")
-      attributes["observed_in_version_ids"] = work_package.observed_in_versions.pluck(:version_id).presence
+      attributes["observed_in_version_ids"] = work_package.observed_in_version_ids.presence
     end
 
     attributes.compact

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -275,7 +275,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     return unless work_package.project_id_changed? && work_package.project_id
 
     model.change_by_system do
-      set_versions_to_nil
+      clear_unassignable_versions
       reassign_category
       set_parent_to_nil
       clear_semantic_identifier
@@ -367,15 +367,6 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     else
       DeriveProgressValuesWorkBased
     end
-  end
-
-  def set_versions_to_nil
-    if work_package.version &&
-       work_package.project&.shared_versions&.exclude?(work_package.version)
-      work_package.version = nil
-    end
-
-    clear_unassignable_versions
   end
 
   def clear_unassignable_versions

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -305,6 +305,8 @@ module API
                                          },
                                          required: false
 
+          # Deprecated in favour of `targetVersions`
+          # Removed from the API if multiple_versions is enabled on the instance
           schema_with_allowed_collection :version,
                                          value_representer: Versions::VersionRepresenter,
                                          link_factory: ->(version) {
@@ -315,6 +317,7 @@ module API
                                          },
                                          required: false,
                                          deprecated: true,
+                                         show_if: ->(*) { !Setting::WorkPackageMultipleVersions.active? },
                                          description: -> { I18n.t("api_v3.attributes.version.deprecated") }
 
           # While multiple versions is not enabled, the field keeps the label of the

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -302,6 +302,8 @@ module API
                                          },
                                          required: false
 
+          # Deprecated in favour of `targetVersions`
+          # Removed from the API if multiple_versions is enabled on the instance
           schema_with_allowed_collection :version,
                                          value_representer: Versions::VersionRepresenter,
                                          link_factory: ->(version) {
@@ -312,6 +314,7 @@ module API
                                          },
                                          required: false,
                                          deprecated: true,
+                                         show_if: ->(*) { !Setting::WorkPackageMultipleVersions.active? },
                                          description: -> { I18n.t("api_v3.attributes.version.deprecated") }
 
           # While multiple versions is not enabled, the field keeps the label of the

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -582,6 +582,14 @@ module API
         associated_resource :version,
                             v3_path: :version,
                             representer: ::API::V3::Versions::VersionRepresenter,
+                            # representable evaluates the getter before `skip_render`, so we manually
+                            # check if we *can* render the result here before actually doing it
+                            getter: ->(*) {
+                              next if Setting::WorkPackageMultipleVersions.active?
+                              next unless embed_link?(:version) && represented.version
+
+                              ::API::V3::Versions::VersionRepresenter.create(represented.version, current_user:)
+                            },
                             skip_render: ->(*) { Setting::WorkPackageMultipleVersions.active? }
 
         associated_resources :target_versions,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -577,9 +577,12 @@ module API
                             link: ::API::V3::Principals::PrincipalRepresenterFactory
                               .create_link_lambda(:assigned_to)
 
+        # Deprecated in favour of `targetVersions`
+        # Removed from the API if multiple_versions is enabled on the instance
         associated_resource :version,
                             v3_path: :version,
-                            representer: ::API::V3::Versions::VersionRepresenter
+                            representer: ::API::V3::Versions::VersionRepresenter,
+                            skip_render: ->(*) { Setting::WorkPackageMultipleVersions.active? }
 
         associated_resources :target_versions,
                              v3_path: :version,

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -104,7 +104,7 @@ module JournalFormatter
     def class_from_field(field)
       association = @journal.journable.class.reflect_on_association(field)
 
-      association&.klass
+      association&.klass || field.to_s.camelize.safe_constantize
     end
   end
 end

--- a/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
+++ b/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
     shared_examples "migrates by the primary version" do
       context "when the sprint version is the primary (version_id) target" do
         let!(:wp_multi) do
-          create(:work_package, project:, version:).tap do |wp|
+          create(:work_package, project:, version_id: version.id).tap do |wp|
             create(:work_package_version, work_package: wp, version: secondary_version, kind: :target)
           end
         end
@@ -271,7 +271,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
 
       context "when the sprint version is only a secondary target" do
         let!(:wp_secondary) do
-          create(:work_package, project:, version: secondary_version).tap do |wp|
+          create(:work_package, project:, version_id: secondary_version.id).tap do |wp|
             create(:work_package_version, work_package: wp, version:, kind: :target)
           end
         end

--- a/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
+++ b/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
   let!(:version) do
     create(:version, project:, name: "Test Sprint", start_date:, effective_date:, status:)
   end
-  let!(:wp1) { create(:work_package, version:, project:) }
+  let!(:wp1) { create(:work_package, version_id: version.id, project:) }
 
   def use_version(as:, version: self.version, project: self.project)
     display = case as
@@ -187,7 +187,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
   end
 
   describe "work package association" do
-    let!(:wp2) { create(:work_package, version:, project:) }
+    let!(:wp2) { create(:work_package, version_id: version.id, project:) }
 
     it "sets sprint_id on all associated work packages" do
       migrate
@@ -206,7 +206,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
 
     context "with multiple versions" do
       let!(:version2) { create(:version, project:, status: "closed") }
-      let!(:wp3) { create(:work_package, version: version2, project:) }
+      let!(:wp3) { create(:work_package, version_id: version2.id, project:) }
 
       before { use_version(as: :sprint, version: version2) }
 
@@ -221,7 +221,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
 
     context "when the version is shared with another project that displays it as backlog" do
       let(:other_project) { create(:project) }
-      let!(:wp_in_other_project) { create(:work_package, version:, project: other_project) }
+      let!(:wp_in_other_project) { create(:work_package, version_id: version.id, project: other_project) }
 
       before { use_version(as: :backlog, project: other_project) }
 
@@ -236,7 +236,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
 
     context "when the version is shared with another project where it is not displayed" do
       let(:other_project) { create(:project) }
-      let!(:wp_in_other_project) { create(:work_package, version:, project: other_project) }
+      let!(:wp_in_other_project) { create(:work_package, version_id: version.id, project: other_project) }
 
       before { use_version(as: :display_none, project: other_project) }
 

--- a/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
+++ b/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Backlogs::MigrateVersionSprintJournalsJob, type: :model do
   shared_let(:version_b) { create(:version, project:, name: "Version B") }
   shared_let(:sprint_a) { create(:sprint, name: "Sprint A", project:) }
   shared_let(:sprint_b) { create(:sprint, name: "Sprint B", project:) }
-  shared_let(:wp1) { create(:work_package, project:, version: version_a, sprint: sprint_a) }
-  shared_let(:wp2) { create(:work_package, project:, version: version_b, sprint: sprint_b) }
+  shared_let(:wp1) { create(:work_package, project:, version_id: version_a.id, sprint: sprint_a) }
+  shared_let(:wp2) { create(:work_package, project:, version_id: version_b.id, sprint: sprint_b) }
   shared_let(:wp_no_version) { create(:work_package, project:, sprint: sprint_a) }
 
   subject(:perform) { job.perform }

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -64,7 +64,11 @@ RSpec.describe "Version action board",
   let!(:shared_version) { create(:version, project: second_project, name: "Shared version", sharing: "system") }
   let!(:closed_version) { create(:version, project:, status: "closed", name: "Closed version") }
 
-  let!(:work_package) { create(:work_package, project:, subject: "Foo", version: open_version) }
+  let!(:work_package) do
+    create(:work_package, project:, subject: "Foo", version_id: open_version.id).tap do |wp|
+      wp.target_versions = [open_version]
+    end
+  end
   let!(:closed_version_wp) { create(:work_package, project:, subject: "Closed", version: closed_version) }
   let(:filters) { Components::WorkPackages::Filters.new }
 

--- a/modules/boards/spec/features/board_reference_work_package_spec.rb
+++ b/modules/boards/spec/features/board_reference_work_package_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Board reference work package spec",
 
     # Reload work package expect version to be applied by filter
     work_package.reload
-    expect(work_package.version_id).to eq version.id
+    expect(work_package.target_versions).to contain_exactly(version)
   end
 
   context "with a subproject and work packages within it (Regression #31613)" do

--- a/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
+++ b/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
@@ -35,7 +35,7 @@ module XlsExport::WorkPackage::Exporter
 
     def records
       work_packages
-        .includes(:assigned_to, :type, :priority, :category, :version, :target_versions)
+        .includes(:assigned_to, :type, :priority, :category, :target_versions)
     end
 
     def spreadsheet_title

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1437,6 +1437,30 @@ RSpec.describe WorkPackages::BaseContract do
       end
     end
 
+    describe "legacy version_id writability" do
+      before do
+        work_package.version = assignable_version
+      end
+
+      context "when the multiple-versions feature is disabled" do
+        before { contract.validate }
+
+        it "allows writing the deprecated version_id" do
+          expect(contract.errors.symbols_for(:version_id)).to be_empty
+        end
+      end
+
+      context "when the multiple-versions feature is enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        before { contract.validate }
+
+        it "rejects writing the deprecated version_id as read-only" do
+          expect(contract.errors.symbols_for(:version_id)).to include(:error_readonly)
+        end
+      end
+    end
+
     describe "target versions length" do
       let(:other_assignable_version) { build_stubbed(:version) }
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -178,7 +178,9 @@ RSpec.describe WorkPackages::BaseContract do
       before do
         version = build_stubbed(:version, status: "closed")
 
-        work_package.version = version
+        allow(work_package)
+          .to receive(:effective_target_versions)
+          .and_return([version])
         allow(work_package.status)
           .to receive(:is_closed?)
           .and_return(true)
@@ -225,9 +227,7 @@ RSpec.describe WorkPackages::BaseContract do
         open_version = build_stubbed(:version)
 
         allow(work_package)
-          .to receive(:target_versions)
-          .and_return([closed_version])
-        work_package.version = open_version
+          .to receive_messages(target_versions: [closed_version], effective_target_versions: [open_version])
         allow(work_package.status)
           .to receive(:is_closed?)
           .and_return(true)
@@ -1170,7 +1170,7 @@ RSpec.describe WorkPackages::BaseContract do
 
     context "for assignable version" do
       before do
-        work_package.version = assignable_version
+        work_package.version_id = assignable_version.id
         subject.validate
       end
 
@@ -1181,7 +1181,7 @@ RSpec.describe WorkPackages::BaseContract do
 
     context "for non assignable version" do
       before do
-        work_package.version = invalid_version
+        work_package.version_id = invalid_version.id
         subject.validate
       end
 
@@ -1192,32 +1192,6 @@ RSpec.describe WorkPackages::BaseContract do
 
     context "for a closed version" do
       let(:assignable_version) { build_stubbed(:version, status: "closed") }
-
-      context "when reopening a work package" do
-        before do
-          allow(work_package)
-            .to receive(:reopened?)
-            .and_return(true)
-
-          work_package.version = assignable_version
-          subject.validate
-        end
-
-        it "is invalid" do
-          expect(subject.errors[:base]).to eql [I18n.t(:error_can_not_reopen_work_package_on_closed_version)]
-        end
-      end
-
-      context "when not reopening the work package" do
-        before do
-          work_package.version = assignable_version
-          subject.validate
-        end
-
-        it "is valid" do
-          expect(subject.errors).to be_empty
-        end
-      end
 
       context "when the closed version is assigned through target_versions" do
         before do
@@ -1319,7 +1293,7 @@ RSpec.describe WorkPackages::BaseContract do
 
       context "when the user changes both version_id and target_version_ids to different versions" do
         before do
-          work_package.version = other_assignable_version
+          work_package.version_id = other_assignable_version.id
           work_package.target_version_ids_replacements = [assignable_version.id]
           contract.validate
         end
@@ -1335,12 +1309,12 @@ RSpec.describe WorkPackages::BaseContract do
         # service extends the model with ChangedBySystem before validation, so mirror
         # that here to distinguish the system-driven change from a user one.
         let(:work_package) do
-          build_stubbed(:work_package, type:, project:, version: other_assignable_version)
+          build_stubbed(:work_package, type:, project:, version_id: other_assignable_version.id)
             .extend(OpenProject::ChangedBySystem)
         end
 
         before do
-          work_package.change_by_system { work_package.version = nil }
+          work_package.change_by_system { work_package.version_id = nil }
           work_package.target_version_ids_replacements = [assignable_version.id]
           contract.validate
         end
@@ -1353,7 +1327,7 @@ RSpec.describe WorkPackages::BaseContract do
 
       context "when both are set to the same version" do
         before do
-          work_package.version = assignable_version
+          work_package.version_id = assignable_version.id
           work_package.target_version_ids_replacements = [assignable_version.id]
           contract.validate
         end
@@ -1366,7 +1340,7 @@ RSpec.describe WorkPackages::BaseContract do
 
       context "when only one type of version changed" do
         it "is valid for version" do
-          work_package.version = assignable_version
+          work_package.version_id = assignable_version.id
           contract.validate
           expect(contract.errors).to be_empty
         end
@@ -1439,7 +1413,7 @@ RSpec.describe WorkPackages::BaseContract do
 
     describe "legacy version_id writability" do
       before do
-        work_package.version = assignable_version
+        work_package.version_id = assignable_version.id
       end
 
       context "when the multiple-versions feature is disabled" do

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1465,6 +1465,30 @@ RSpec.describe WorkPackages::BaseContract do
       end
     end
 
+    describe "legacy version_id writability" do
+      before do
+        work_package.version = assignable_version
+      end
+
+      context "when the multiple-versions feature is disabled" do
+        before { contract.validate }
+
+        it "allows writing the deprecated version_id" do
+          expect(contract.errors.symbols_for(:version_id)).to be_empty
+        end
+      end
+
+      context "when the multiple-versions feature is enabled",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        before { contract.validate }
+
+        it "rejects writing the deprecated version_id as read-only" do
+          expect(contract.errors.symbols_for(:version_id)).to include(:error_readonly)
+        end
+      end
+    end
+
     describe "target versions length" do
       let(:other_assignable_version) { build_stubbed(:version) }
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -178,7 +178,9 @@ RSpec.describe WorkPackages::BaseContract do
       before do
         version = build_stubbed(:version, status: "closed")
 
-        work_package.version = version
+        allow(work_package)
+          .to receive(:effective_target_versions)
+          .and_return([version])
         allow(work_package.status)
           .to receive(:is_closed?)
           .and_return(true)
@@ -225,9 +227,7 @@ RSpec.describe WorkPackages::BaseContract do
         open_version = build_stubbed(:version)
 
         allow(work_package)
-          .to receive(:target_versions)
-          .and_return([closed_version])
-        work_package.version = open_version
+          .to receive_messages(target_versions: [closed_version], effective_target_versions: [open_version])
         allow(work_package.status)
           .to receive(:is_closed?)
           .and_return(true)
@@ -1170,7 +1170,7 @@ RSpec.describe WorkPackages::BaseContract do
 
     context "for assignable version" do
       before do
-        work_package.version = assignable_version
+        work_package.version_id = assignable_version.id
         subject.validate
       end
 
@@ -1181,7 +1181,7 @@ RSpec.describe WorkPackages::BaseContract do
 
     context "for non assignable version" do
       before do
-        work_package.version = invalid_version
+        work_package.version_id = invalid_version.id
         subject.validate
       end
 
@@ -1192,32 +1192,6 @@ RSpec.describe WorkPackages::BaseContract do
 
     context "for a closed version" do
       let(:assignable_version) { build_stubbed(:version, status: "closed") }
-
-      context "when reopening a work package" do
-        before do
-          allow(work_package)
-            .to receive(:reopened?)
-            .and_return(true)
-
-          work_package.version = assignable_version
-          subject.validate
-        end
-
-        it "is invalid" do
-          expect(subject.errors[:base]).to eql [I18n.t(:error_can_not_reopen_work_package_on_closed_version)]
-        end
-      end
-
-      context "when not reopening the work package" do
-        before do
-          work_package.version = assignable_version
-          subject.validate
-        end
-
-        it "is valid" do
-          expect(subject.errors).to be_empty
-        end
-      end
 
       context "when the closed version is assigned through target_versions" do
         before do
@@ -1319,7 +1293,7 @@ RSpec.describe WorkPackages::BaseContract do
 
       context "when the user changes both version_id and target_version_ids to different versions" do
         before do
-          work_package.version = other_assignable_version
+          work_package.version_id = other_assignable_version.id
           work_package.target_version_ids_replacements = [assignable_version.id]
           contract.validate
         end
@@ -1335,12 +1309,12 @@ RSpec.describe WorkPackages::BaseContract do
         # service extends the model with ChangedBySystem before validation, so mirror
         # that here to distinguish the system-driven change from a user one.
         let(:work_package) do
-          build_stubbed(:work_package, type:, project:, version: other_assignable_version)
+          build_stubbed(:work_package, type:, project:, version_id: other_assignable_version.id)
             .extend(OpenProject::ChangedBySystem)
         end
 
         before do
-          work_package.change_by_system { work_package.version = nil }
+          work_package.change_by_system { work_package.version_id = nil }
           work_package.target_version_ids_replacements = [assignable_version.id]
           contract.validate
         end
@@ -1353,7 +1327,7 @@ RSpec.describe WorkPackages::BaseContract do
 
       context "when both are set to the same version" do
         before do
-          work_package.version = assignable_version
+          work_package.version_id = assignable_version.id
           work_package.target_version_ids_replacements = [assignable_version.id]
           contract.validate
         end
@@ -1366,7 +1340,7 @@ RSpec.describe WorkPackages::BaseContract do
 
       context "when only one type of version changed" do
         it "is valid for version" do
-          work_package.version = assignable_version
+          work_package.version_id = assignable_version.id
           contract.validate
           expect(contract.errors).to be_empty
         end
@@ -1467,7 +1441,7 @@ RSpec.describe WorkPackages::BaseContract do
 
     describe "legacy version_id writability" do
       before do
-        work_package.version = assignable_version
+        work_package.version_id = assignable_version.id
       end
 
       context "when the multiple-versions feature is disabled" do

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1362,7 +1362,7 @@ RSpec.describe WorkPackages::BaseContract do
         let(:higher_version) { [assignable_version, other_assignable_version].max_by(&:id) }
 
         it "is valid when version names the lowest target version" do
-          work_package.version = lower_version
+          work_package.version_id = lower_version.id
           work_package.target_version_ids_replacements = [higher_version.id, lower_version.id]
           contract.validate
 
@@ -1371,7 +1371,7 @@ RSpec.describe WorkPackages::BaseContract do
         end
 
         it "is invalid when version names a non-lowest target version" do
-          work_package.version = higher_version
+          work_package.version_id = higher_version.id
           work_package.target_version_ids_replacements = [higher_version.id, lower_version.id]
           contract.validate
 

--- a/spec/contracts/work_packages/shared_contract_examples.rb
+++ b/spec/contracts/work_packages/shared_contract_examples.rb
@@ -230,7 +230,7 @@ RSpec.shared_examples "work package contract" do
       context "having full access" do
         context "with an assignable_version" do
           before do
-            work_package.version = persisted_project_version
+            work_package.target_version_ids_replacements = [persisted_project_version.id]
           end
 
           it_behaves_like "contract is valid"
@@ -238,10 +238,10 @@ RSpec.shared_examples "work package contract" do
 
         context "with an unassignable_version" do
           before do
-            work_package.version = persisted_other_project_version
+            work_package.target_version_ids_replacements = [persisted_other_project_version.id]
           end
 
-          it_behaves_like "contract is invalid", version_id: :inclusion
+          it_behaves_like "contract is invalid", target_versions: :inclusion
         end
       end
 
@@ -249,10 +249,10 @@ RSpec.shared_examples "work package contract" do
         let(:permissions) { super() - %i[assign_versions] }
 
         before do
-          work_package.version = persisted_project_version
+          work_package.target_version_ids_replacements = [persisted_project_version.id]
         end
 
-        it_behaves_like "contract is invalid", version_id: :error_readonly
+        it_behaves_like "contract is invalid", target_versions: :error_readonly
       end
     end
 

--- a/spec/contracts/work_packages/shared_contract_examples.rb
+++ b/spec/contracts/work_packages/shared_contract_examples.rb
@@ -227,6 +227,11 @@ RSpec.shared_examples "work package contract" do
     end
 
     describe "version" do
+      # make sure we reset in memory changes
+      after do
+        work_package.target_version_ids_replacements = nil
+      end
+
       context "having full access" do
         context "with an assignable_version" do
           before do

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe WorkPackages::MovesController, with_settings: { journal_aggregati
         before do
           target_project.types << work_package.type
           target_project.save
-          work_package.update!(version: source_version)
+          work_package.target_versions = [source_version]
 
           post :create,
                params: {

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
       days { WorkPackages::Shared::Days.for(self) }
       journals { nil }
       now { Time.zone.now }
+      version { nil }
     end
 
     priority
@@ -107,9 +108,9 @@ FactoryBot.define do
     # The persistence services mirror version_id into a kind: "target" join row,
     # so every saved work package with a version also has one. Factories skip
     # the services, so the row is created here to match.
-    callback(:after_create) do |work_package|
-      if work_package.version_id
-        work_package.work_package_versions.find_or_create_by!(version_id: work_package.version_id, kind: "target")
+    callback(:after_create) do |work_package, evaluator|
+      if evaluator.version
+        work_package.work_package_versions.find_or_create_by!(version_id: evaluator.version.id, kind: "target")
       end
     end
 

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -113,16 +113,19 @@ RSpec.describe "baseline rendering",
 
   shared_let(:wp_task_changed) do
     wp = Timecop.travel(5.days.ago) do
-      create(:work_package,
-             project:,
-             type: type_task,
-             assigned_to: assignee,
-             responsible: assignee,
-             priority: default_priority,
-             version: version_a,
-             subject: "Old subject",
-             start_date: "2023-05-01",
-             due_date: "2023-05-02")
+      # make sure the join row exists before the creation journal
+      work_package = build(:work_package,
+                           project:,
+                           type: type_task,
+                           assigned_to: assignee,
+                           responsible: assignee,
+                           priority: default_priority,
+                           subject: "Old subject",
+                           start_date: "2023-05-01",
+                           due_date: "2023-05-02")
+      work_package.target_version_ids_replacements = [version_a.id]
+      work_package.save!
+      work_package
     end
 
     Timecop.travel(1.day.ago) do
@@ -135,7 +138,7 @@ RSpec.describe "baseline rendering",
           assigned_to: user,
           responsible: user,
           priority: high_priority,
-          version: version_b
+          target_version_ids: [version_b.id]
         )
         .on_failure { |result| raise result.message }
         .result

--- a/spec/features/work_packages/table/target_versions_column_spec.rb
+++ b/spec/features/work_packages/table/target_versions_column_spec.rb
@@ -45,24 +45,26 @@ RSpec.describe "Work package table target versions column", :js do
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
   let(:columns) { Components::WorkPackages::Columns.new }
 
-  let!(:work_package) do
-    create(:work_package, project:).tap do |wp|
-      wp.target_version_ids_replacements = [version_one.id, version_two.id]
-      wp.save!
-    end
-  end
-
-  let!(:query) do
-    create(:query, user:, project:, column_names: %w[id subject target_versions])
-  end
-
   before do
     login_as(user)
+  end
+
+  def work_package_with_target_versions(*versions)
+    create(:work_package, project:).tap do |wp|
+      wp.target_version_ids_replacements = versions.map(&:id)
+      wp.save!
+    end
   end
 
   context "with multiple versions active",
           with_flag: { work_package_multiple_versions: true },
           with_settings: { work_package_multiple_versions: true } do
+    let!(:work_package) { work_package_with_target_versions(version_one, version_two) }
+
+    let!(:query) do
+      create(:query, user:, project:, column_names: %w[id subject target_versions])
+    end
+
     it "shows all target versions and allows editing them inline" do
       wp_table.visit_query query
       wp_table.expect_work_package_listed work_package
@@ -98,6 +100,8 @@ RSpec.describe "Work package table target versions column", :js do
   end
 
   context "with multiple versions inactive" do
+    let!(:work_package) { work_package_with_target_versions(version_one) }
+
     let!(:query) do
       create(:query, user:, project:, column_names: %w[id subject version])
     end

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -1027,6 +1027,16 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           .to be_json_eql(I18n.t("api_v3.attributes.version.deprecated").to_json)
           .at_path("version/description/raw")
       end
+
+      context "when multiple versions is active",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        let(:permissions) { [:assign_versions] }
+
+        it "drops the deprecated version field from the schema" do
+          expect(subject).not_to have_json_path("version")
+        end
+      end
     end
 
     describe "targetVersions" do

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
                   assigned_to:,
                   type:,
                   priority:,
-                  version:,
                   parent:,
                   responsible:).tap do |wp|
       allow(wp)
@@ -100,7 +99,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       allow(wp)
         .to receive_messages(available_custom_fields:,
                              custom_field_values: [custom_value],
-                             effective_target_versions: target_versions)
+                             effective_target_versions: target_versions,
+                             version:,
+                             version_id: version&.id)
     end
   end
   let(:timestamp) { Timestamp.new(1.day.ago) }
@@ -194,7 +195,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       }.to_json
     end
 
-    it "renders as expected", pending: "Fixing in another PR" do
+    it "renders as expected" do
       expect(subject)
         .to be_json_eql(expected_json)
     end
@@ -231,7 +232,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       }.to_json
     end
 
-    it "renders as expected", pending: "Fixing in another PR" do
+    it "renders as expected" do
       expect(subject)
         .to be_json_eql(expected_json)
     end
@@ -580,7 +581,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       }.to_json
     end
 
-    it "renders as expected", pending: "Fixing in another PR" do
+    it "renders as expected" do
       expect(subject)
         .to be_json_eql(expected_json)
     end

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       }.to_json
     end
 
-    it "renders as expected" do
+    it "renders as expected", pending: "Fixing in another PR" do
       expect(subject)
         .to be_json_eql(expected_json)
     end
@@ -231,7 +231,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       }.to_json
     end
 
-    it "renders as expected" do
+    it "renders as expected", pending: "Fixing in another PR" do
       expect(subject)
         .to be_json_eql(expected_json)
     end
@@ -580,7 +580,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       }.to_json
     end
 
-    it "renders as expected" do
+    it "renders as expected", pending: "Fixing in another PR" do
       expect(subject)
         .to be_json_eql(expected_json)
     end

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackagePayloadRepresenter do
         let(:version) { build_stubbed(:version) }
 
         before do
-          work_package.version = version
+          work_package.version_id = version.id
         end
 
         it_behaves_like "linked property" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -700,10 +700,11 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
       end
 
       context "when version is set" do
-        let!(:version) { create(:version, project: workspace) }
+        let(:version) { build_stubbed(:version, project: workspace) }
 
         before do
-          work_package.version = version
+          work_package.version_id = version.id
+          allow(work_package).to receive(:target_versions).and_return([version])
         end
 
         it_behaves_like "has a titled link" do
@@ -721,10 +722,11 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
       context "when multiple versions is active",
               with_flag: { work_package_multiple_versions: true },
               with_settings: { work_package_multiple_versions: true } do
-        let!(:version) { create(:version, project: workspace) }
+        let(:version) { build_stubbed(:version, project: workspace) }
 
         before do
-          work_package.version = version
+          work_package.version_id = version.id
+          allow(work_package).to receive(:target_versions).and_return([version])
         end
 
         it "renders neither the deprecated version link nor the embedded resource" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -717,6 +717,21 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           expect(subject).to be_json_eql(version.name.to_json).at_path("#{embedded_path}/name")
         end
       end
+
+      context "when multiple versions is active",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        let!(:version) { create(:version, project: workspace) }
+
+        before do
+          work_package.version = version
+        end
+
+        it "renders neither the deprecated version link nor the embedded resource" do
+          expect(subject).not_to have_json_path("_links/version")
+          expect(subject).not_to have_json_path("_embedded/version")
+        end
+      end
     end
 
     describe "targetVersions" do

--- a/spec/migrations/backfill_target_versions_from_work_package_spec.rb
+++ b/spec/migrations/backfill_target_versions_from_work_package_spec.rb
@@ -38,12 +38,11 @@ RSpec.describe BackfillTargetVersionsFromWorkPackage, type: :model do
   let(:version) { create(:version, project:) }
   let(:other_version) { create(:version, project:) }
 
-  let!(:work_package_with_version) { create(:work_package, project:, version:) }
-  let!(:work_package_without_version) { create(:work_package, project:, version: nil) }
+  let!(:work_package_with_version) { create(:work_package, project:) }
+  let!(:work_package_without_version) { create(:work_package, project:) }
 
-  # The migration targets work packages that only carry version_id, so remove
-  # the join rows the factory already created.
-  before { WorkPackageVersion.delete_all }
+  # set the version_id to exercise the actual migration
+  before { work_package_with_version.update_columns(version_id: version.id) }
 
   it "succeeds" do
     expect { migrate }.not_to raise_error

--- a/spec/migrations/create_work_package_version_journals_spec.rb
+++ b/spec/migrations/create_work_package_version_journals_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe CreateWorkPackageVersionJournals, type: :model,
   let(:version) { create(:version, project:) }
   let(:other_version) { create(:version, project:) }
 
-  let!(:work_package_with_version) { create(:work_package, project:, version:) }
-  let!(:work_package_without_version) { create(:work_package, project:, version: nil) }
+  let!(:work_package_with_version) { create(:work_package, project:, version_id: version.id) }
+  let!(:work_package_without_version) { create(:work_package, project:, version_id: nil) }
 
   before do
     # A second journal with a different version, so the backfill has to
     # reconstruct a distinct target set per journal, not per work package.
-    work_package_with_version.update!(version: other_version)
+    work_package_with_version.update!(version_id: other_version.id)
 
     # Journals exist but the snapshot table does not yet.
     ActiveRecord::Base.connection.drop_table(:work_package_version_journals)

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -1274,9 +1274,8 @@ RSpec.describe IncomingEmails::MailHandler do # rubocop:disable RSpec/SpecFilePa
             .to contain_exactly(alpha, beta)
         end
 
-        it "keeps the legacy version in sync with the first target version" do
-          expect(subject.version)
-            .to eql(alpha)
+        it "keeps the breaks the legacy version if target version has many entries" do
+          expect { subject.version }.to raise_error(/multiple target versions and cannot be represented/)
         end
 
         it "removes the keyword from the description" do

--- a/spec/models/queries/work_packages/filter/version_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/version_filter_spec.rb
@@ -162,23 +162,13 @@ RSpec.describe Queries::WorkPackages::Filter::VersionFilter do
     end
 
     describe "#joins" do
-      context "for status operators" do
-        %w[o c l].each do |op|
-          context "with operator '#{op}'" do
-            let(:operator) { op }
+      %w[= ! * !* o c l].each do |op|
+        context "with operator '#{op}'" do
+          let(:operator) { op }
 
-            it "returns :version" do
-              expect(instance.joins).to eq(:version)
-            end
+          it "returns nil, as the conditions are self-contained subqueries" do
+            expect(instance.joins).to be_nil
           end
-        end
-      end
-
-      context "for other operators" do
-        let(:operator) { "=" }
-
-        it "returns nil" do
-          expect(instance.joins).to be_nil
         end
       end
     end

--- a/spec/models/query/results_version_filter_integration_spec.rb
+++ b/spec/models/query/results_version_filter_integration_spec.rb
@@ -90,4 +90,38 @@ RSpec.describe Query::Results, "Filtering by version" do
       expect(results).to contain_exactly(wp_with_searched_as_only_target)
     end
   end
+
+  context "with a version status operator" do
+    let(:values) { [] }
+    let(:closed_version) { create(:version, project:, name: "Closed version", status: "closed") }
+    let(:locked_version) { create(:version, project:, name: "Locked version", status: "locked") }
+
+    let!(:wp_with_closed_target) { create(:work_package, project:, version: closed_version) }
+    let!(:wp_with_locked_target) { create(:work_package, project:, version: locked_version) }
+    let!(:wp_without_target_version) { create(:work_package, project:) }
+
+    context 'with the "o" operator' do
+      let(:operator) { "o" }
+
+      it "returns work packages targeting an open version" do
+        expect(results).to contain_exactly(wp_with_searched_as_only_target, wp_with_other_target)
+      end
+    end
+
+    context 'with the "c" operator' do
+      let(:operator) { "c" }
+
+      it "returns work packages targeting a closed version" do
+        expect(results).to contain_exactly(wp_with_closed_target)
+      end
+    end
+
+    context 'with the "l" operator' do
+      let(:operator) { "l" }
+
+      it "returns work packages targeting a locked version" do
+        expect(results).to contain_exactly(wp_with_locked_target)
+      end
+    end
+  end
 end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -704,4 +704,49 @@ RSpec.describe Version do
       expect(described_class.order(name: :desc).pluck(:name)).to eql ordered_names.reverse
     end
   end
+
+  describe "destroying a version referenced by work packages" do
+    shared_let(:owning_project) { create(:project) }
+    shared_let(:other_project) { create(:project) }
+    shared_let(:shared_version) { create(:version, project: owning_project, sharing: "system") }
+    shared_let(:admin) { create(:admin) }
+
+    let!(:work_package) do
+      create(:work_package, project: other_project).tap do |wp|
+        wp.target_version_ids_replacements = [shared_version.id]
+        wp.save!
+      end
+    end
+
+    def update_subject
+      WorkPackages::UpdateService
+        .new(user: admin, model: work_package.reload)
+        .call(subject: "A new subject unrelated to versions")
+    end
+
+    it "starts out mirroring the target version into version_id" do
+      expect(work_package.reload.version_id).to eq(shared_version.id)
+    end
+
+    it "is editable while the version's project still exists" do
+      expect(update_subject).to be_success
+    end
+
+    it "clears version_id when the version itself is destroyed" do
+      expect { shared_version.destroy }
+        .to change { work_package.reload.version_id }.from(shared_version.id).to(nil)
+    end
+
+    it "clears version_id when the version's project is destroyed" do
+      expect { owning_project.destroy }
+        .to change { work_package.reload.version_id }.from(shared_version.id).to(nil)
+    end
+
+    it "leaves the work package editable after its version's project is destroyed" do
+      owning_project.destroy
+
+      result = update_subject
+      expect(result).to be_success, -> { result.errors.full_messages.to_sentence }
+    end
+  end
 end

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -566,20 +566,6 @@ RSpec.describe WorkPackage do
         end
       end
 
-      # While the deprecated version_id column mirrors the target versions,
-      # every version change produces both a version_id and a target_versions
-      # diff. Only the target_versions representation is exposed.
-      context "when changing the version via the legacy version field" do
-        it "journals the change as target versions only" do
-          journable.update!(version:)
-
-          expect(journable.last_journal.details["target_versions"])
-            .to eq([nil, version.id.to_s])
-          expect(journable.last_journal.details)
-            .not_to have_key("version_id")
-        end
-      end
-
       context "when setting target versions via the replacements" do
         it "does not additionally journal the mirrored version_id" do
           set_target_versions([version])

--- a/spec/models/work_package/work_package_update_versions_spec.rb
+++ b/spec/models/work_package/work_package_update_versions_spec.rb
@@ -91,6 +91,6 @@ RSpec.describe WorkPackage, ".update_versions keeping target_versions consistent
 
     work_package.reload
     expect(target_version_ids(work_package)).to contain_exactly(shared_version.id)
-    expect(work_package.version_id).to eq(shared_version.id)
+    expect(work_package.version).to eq(shared_version)
   end
 end

--- a/spec/models/work_package/work_package_versions_spec.rb
+++ b/spec/models/work_package/work_package_versions_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe WorkPackage, "legacy version_id mirror" do
     expect(preloaded.target_versions.map(&:id)).to eq([lower_version.id, higher_version.id])
   end
 
+  it "raises on #version when there is more than one target version" do
+    work_package.target_version_ids_replacements = [lower_version.id, higher_version.id]
+    work_package.save!
+
+    expect { work_package.version }.to raise_error(/multiple target versions/)
+  end
+
   it "clears the mirror when all target versions are removed" do
     work_package.target_version_ids_replacements = [lower_version.id]
     work_package.save!

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe WorkPackage do
     it { is_expected.to belong_to(:author) }
     it { is_expected.to belong_to(:assigned_to).class_name("Principal").optional }
     it { is_expected.to belong_to(:responsible).class_name("Principal").optional }
-    it { is_expected.to belong_to(:version).optional }
     it { is_expected.to belong_to(:project_phase_definition).class_name("Project::PhaseDefinition").optional }
     it { is_expected.to belong_to(:priority).class_name("IssuePriority") }
     it { is_expected.to belong_to(:category).optional }

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -431,12 +431,16 @@ RSpec.describe DemoData::WorkPackageSeeder do
         [work_package_data(subject: "multi", target_versions: %i[version_alpha version_beta])]
       end
 
-      it "creates one kind: 'target' row per resolved version and mirrors the first into the legacy version" do
+      it "creates one kind: 'target' row per resolved version" do
         wp = WorkPackage.find_by(subject: "multi")
         expect(wp.work_package_versions.pluck(:kind, :version_id))
           .to contain_exactly(["target", version_alpha.id], ["target", version_beta.id])
         expect(wp.target_versions).to contain_exactly(version_alpha, version_beta)
-        expect(wp.version).to eq(version_alpha)
+      end
+
+      it "raises an error when trying to access version and there are multiple versions" do
+        wp = WorkPackage.find_by(subject: "multi")
+        expect { wp.version }.to raise_error(/has multiple target versions and cannot be represented/)
       end
     end
   end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -697,7 +697,7 @@ RSpec.describe(
           let!(:assigned_version) { create(:version, name: "Assigned Issues", project: source, status: "open") }
 
           before do
-            source_wp.update!(version: assigned_version)
+            source_wp.target_versions = [assigned_version]
             assigned_version.update!(status: "closed")
           end
 
@@ -705,9 +705,9 @@ RSpec.describe(
             expect(subject).to be_success
 
             wp = copy_of(source_wp)
-            expect(wp.version.name).to eq "Assigned Issues"
-            expect(wp.version).to be_closed
-            expect(wp.version.id).not_to eq assigned_version.id
+            expect(wp.target_versions.first.name).to eq "Assigned Issues"
+            expect(wp.target_versions.first).to be_closed
+            expect(wp.target_versions.first.id).not_to eq assigned_version.id
           end
         end
 
@@ -717,12 +717,7 @@ RSpec.describe(
           let(:version_two) { create(:version, name: "Target Two", project: source, status: "open") }
 
           before do
-            source_wp.work_package_versions.where(kind: "target").delete_all
-            # Contract validation rejects more than one target version, so we bypass it
-            # here to exercise the copy remapping of multiple target versions
-            [version_one, version_two].each do |v|
-              source_wp.work_package_versions.create!(version_id: v.id, kind: "target")
-            end
+            source_wp.target_versions = [version_one, version_two]
           end
 
           it "copies the target_versions remapped to the copied project's versions" do
@@ -744,10 +739,7 @@ RSpec.describe(
           let(:observed_two) { create(:version, name: "Observed Two", project: source, status: "open") }
 
           before do
-            source_wp.work_package_versions.where(kind: "observed_in").delete_all
-            [observed_one, observed_two].each do |v|
-              source_wp.work_package_versions.create!(version_id: v.id, kind: "observed_in")
-            end
+            source_wp.observed_in_versions = [observed_one, observed_two]
           end
 
           it "copies the observed_in_versions remapped to the copied project's versions" do
@@ -790,9 +782,8 @@ RSpec.describe(
 
           before do
             source_wp.work_package_versions.delete_all
-            # Saving the version also creates the target association
-            source_wp.update!(version: assigned_version)
-            source_wp.work_package_versions.create!(version_id: observed_version.id, kind: "observed_in")
+            source_wp.target_versions = [assigned_version]
+            source_wp.observed_in_versions = [observed_version]
           end
 
           it "copies the work package without any version assignments" do
@@ -800,7 +791,6 @@ RSpec.describe(
 
             wp = copy_of(source_wp)
             expect(wp).not_to be_nil
-            expect(wp.version).to be_nil
             expect(wp.target_versions).to be_empty
             expect(wp.observed_in_versions).to be_empty
           end
@@ -1042,26 +1032,6 @@ RSpec.describe(
             end
 
             it_behaves_like "does not sends share notification"
-          end
-        end
-
-        context "with versions" do
-          let(:version) { create(:version, project: source) }
-          let(:version2) { create(:version, project: source) }
-
-          let(:only_args) { %w[versions work_packages] }
-
-          before do
-            work_package.update!(version:)
-            work_package2.update!(version: version2)
-            work_package3
-          end
-
-          it "assigns the work packages to copies of the versions" do
-            expect(subject).to be_success
-            expect(copy_of(work_package).target_versions.map(&:name)).to eq [version.name]
-            expect(copy_of(work_package2).target_versions.map(&:name)).to eq [version2.name]
-            expect(copy_of(work_package3).target_versions).to be_empty
           end
         end
 

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -733,7 +733,7 @@ RSpec.describe(
           let!(:assigned_version) { create(:version, name: "Assigned Issues", project: source, status: "open") }
 
           before do
-            source_wp.update!(version: assigned_version)
+            source_wp.target_versions = [assigned_version]
             assigned_version.update!(status: "closed")
           end
 
@@ -741,9 +741,9 @@ RSpec.describe(
             expect(subject).to be_success
 
             wp = copy_of(source_wp)
-            expect(wp.version.name).to eq "Assigned Issues"
-            expect(wp.version).to be_closed
-            expect(wp.version.id).not_to eq assigned_version.id
+            expect(wp.target_versions.first.name).to eq "Assigned Issues"
+            expect(wp.target_versions.first).to be_closed
+            expect(wp.target_versions.first.id).not_to eq assigned_version.id
           end
         end
 
@@ -753,12 +753,7 @@ RSpec.describe(
           let(:version_two) { create(:version, name: "Target Two", project: source, status: "open") }
 
           before do
-            source_wp.work_package_versions.where(kind: "target").delete_all
-            # Contract validation rejects more than one target version, so we bypass it
-            # here to exercise the copy remapping of multiple target versions
-            [version_one, version_two].each do |v|
-              source_wp.work_package_versions.create!(version_id: v.id, kind: "target")
-            end
+            source_wp.target_versions = [version_one, version_two]
           end
 
           it "copies the target_versions remapped to the copied project's versions" do
@@ -780,10 +775,7 @@ RSpec.describe(
           let(:observed_two) { create(:version, name: "Observed Two", project: source, status: "open") }
 
           before do
-            source_wp.work_package_versions.where(kind: "observed_in").delete_all
-            [observed_one, observed_two].each do |v|
-              source_wp.work_package_versions.create!(version_id: v.id, kind: "observed_in")
-            end
+            source_wp.observed_in_versions = [observed_one, observed_two]
           end
 
           it "copies the observed_in_versions remapped to the copied project's versions" do
@@ -826,9 +818,8 @@ RSpec.describe(
 
           before do
             source_wp.work_package_versions.delete_all
-            # Saving the version also creates the target association
-            source_wp.update!(version: assigned_version)
-            source_wp.work_package_versions.create!(version_id: observed_version.id, kind: "observed_in")
+            source_wp.target_versions = [assigned_version]
+            source_wp.observed_in_versions = [observed_version]
           end
 
           it "copies the work package without any version assignments" do
@@ -836,7 +827,6 @@ RSpec.describe(
 
             wp = copy_of(source_wp)
             expect(wp).not_to be_nil
-            expect(wp.version).to be_nil
             expect(wp.target_versions).to be_empty
             expect(wp.observed_in_versions).to be_empty
           end
@@ -1078,26 +1068,6 @@ RSpec.describe(
             end
 
             it_behaves_like "does not sends share notification"
-          end
-        end
-
-        context "with versions" do
-          let(:version) { create(:version, project: source) }
-          let(:version2) { create(:version, project: source) }
-
-          let(:only_args) { %w[versions work_packages] }
-
-          before do
-            work_package.update!(version:)
-            work_package2.update!(version: version2)
-            work_package3
-          end
-
-          it "assigns the work packages to copies of the versions" do
-            expect(subject).to be_success
-            expect(copy_of(work_package).target_versions.map(&:name)).to eq [version.name]
-            expect(copy_of(work_package2).target_versions.map(&:name)).to eq [version2.name]
-            expect(copy_of(work_package3).target_versions).to be_empty
           end
         end
 

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -125,26 +125,20 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
         end
 
         let(:instance) { described_class.new(work_package:, user: assign_versions_user) }
-        let(:version_one) { create(:version, project:, name: "Copy target 1") }
-        let(:version_two) { create(:version, project:, name: "Copy target 2") }
-        let(:observed_version) { create(:version, project:, name: "Copy observed") }
+        let(:version_one) { create(:version, project:, name: "Target 1") }
+        let(:version_two) { create(:version, project:, name: "Target 2") }
+        let(:observed_version) { create(:version, project:, name: "Observed") }
 
         current_user { assign_versions_user }
 
         before do
-          # bypassing the single-value contract validation to exercise copying
-          # of multiple target versions
-          [version_one, version_two].each do |version|
-            work_package.work_package_versions.create!(version:, kind: "target")
-          end
-          work_package.work_package_versions.create!(version: observed_version, kind: "observed_in")
-          work_package.update_columns(version_id: version_one.id)
+          work_package.target_versions = [version_one, version_two]
+          work_package.observed_in_versions = [observed_version]
         end
 
-        it "copies all target and observed_in versions, not only the mirrored first one" do
+        it "copies all target and observed_in versions" do
           expect(copy.target_versions).to contain_exactly(version_one, version_two)
           expect(copy.observed_in_versions).to contain_exactly(observed_version)
-          expect(copy.version_id).to eq(version_one.id)
         end
 
         context "when the copying user lacks the assign_versions permission" do
@@ -156,7 +150,6 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
             expect(service_result).to be_success
             expect(copy.target_versions).to be_empty
             expect(copy.observed_in_versions).to be_empty
-            expect(copy.version_id).to be_nil
           end
         end
       end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1839,32 +1839,6 @@ RSpec.describe WorkPackages::SetAttributesService,
     end
 
     shared_examples_for "updating the project" do
-      context "for version" do
-        before do
-          work_package.version = version
-        end
-
-        context "when not shared in new project" do
-          it "sets to nil" do
-            subject
-
-            expect(work_package.version)
-              .to be_nil
-          end
-        end
-
-        context "when shared in the new project" do
-          let(:new_versions) { [version] }
-
-          it "keeps the version" do
-            subject
-
-            expect(work_package.version)
-              .to eql version
-          end
-        end
-      end
-
       context "for multiple versions" do
         before do
           work_package.target_version_ids_replacements = [version.id]

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       end
 
       before do
-        work_package.update(version:)
+        work_package.target_versions = [version]
       end
 
       context "with an unshared version" do
@@ -297,7 +297,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
 
       context "with an unshared observed in version" do
         before do
-          work_package.update(version: nil)
+          work_package.target_versions = []
           WorkPackageVersion.create!(work_package:, version:, kind: "observed_in")
         end
 
@@ -2283,8 +2283,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       subject(:service) { instance.call(version_id: version2.id, send_notifications: false) }
 
       before do
-        work_package.version = version1
-        work_package.save!
+        work_package.target_versions = [version1]
       end
 
       it { expect(service).to be_success }
@@ -2304,8 +2303,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       subject(:service) { instance.call(version_id: nil, send_notifications: false) }
 
       before do
-        work_package.version = nil
-        work_package.save!
+        work_package.target_versions = []
       end
 
       it { expect(service).to be_success }

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       end
 
       before do
-        work_package.update(version:)
+        work_package.target_versions = [version]
       end
 
       context "with an unshared version" do
@@ -297,7 +297,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
 
       context "with an unshared observed in version" do
         before do
-          work_package.update(version: nil)
+          work_package.target_versions = []
           WorkPackageVersion.create!(work_package:, version:, kind: "observed_in")
         end
 
@@ -2314,8 +2314,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       subject(:service) { instance.call(version_id: version2.id, send_notifications: false) }
 
       before do
-        work_package.version = version1
-        work_package.save!
+        work_package.target_versions = [version1]
       end
 
       it { expect(service).to be_success }
@@ -2335,8 +2334,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       subject(:service) { instance.call(version_id: nil, send_notifications: false) }
 
       before do
-        work_package.version = nil
-        work_package.save!
+        work_package.target_versions = []
       end
 
       it { expect(service).to be_success }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-863/activity

# What are you trying to accomplish?
This PR removes the associations between work_package & version
-> Version - has_many :work_packages
-> WorkPackage - belongs_to :version

In this PR a "version" reader on WorkPackage was added. This will be removed on a follow up PR.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
