### PR TITLE
[FND-154, 163, 175] Add workflows matrix to type wizard step

### DIFF
--- a/app/components/work_package_types/reloadable_configuration_frame_component.rb
+++ b/app/components/work_package_types/reloadable_configuration_frame_component.rb
@@ -39,10 +39,11 @@ module WorkPackageTypes
     FRAME_ID = "type-configuration-frame"
     RELOAD_EVENT_NAME = "op-dispatched:types:configuration-changed"
 
-    def initialize(reload_url:)
+    def initialize(reload_url:, reload_from_location: false)
       super()
 
       @reload_url = reload_url
+      @reload_from_location = reload_from_location
     end
 
     def call
@@ -55,7 +56,8 @@ module WorkPackageTypes
       {
         controller: "reload-frame-on-event",
         "reload-frame-on-event-event-name-value": RELOAD_EVENT_NAME,
-        "reload-frame-on-event-url-value": @reload_url
+        "reload-frame-on-event-url-value": @reload_url,
+        "reload-frame-on-event-reload-from-location-value": @reload_from_location
       }
     end
   end

--- a/app/components/work_package_types/wizard/page_component.rb
+++ b/app/components/work_package_types/wizard/page_component.rb
@@ -122,6 +122,8 @@ module WorkPackageTypes
         case current_step
         when :form_configuration
           FormConfigurationStepComponent.new(type:)
+        when :workflows
+          WorkflowsStepComponent.new(type:)
         when :project_attributes
           ProjectAttributesStepComponent.new(type:)
         when :projects

--- a/app/components/work_package_types/wizard/step_editors.rb
+++ b/app/components/work_package_types/wizard/step_editors.rb
@@ -39,7 +39,6 @@ module WorkPackageTypes
         case step
         when :details then Details.new(type)
         when :defaults then Defaults.new(type)
-        when :workflows then Workflows.new(type)
         end
       end
 
@@ -64,10 +63,6 @@ module WorkPackageTypes
 
       class Details < Base
         def form_class = WorkPackageTypes::DetailsForm
-      end
-
-      class Workflows < Base
-        def form_class = WorkflowsForm
       end
 
       class Defaults < Base

--- a/app/components/work_package_types/wizard/workflows_step_component.html.erb
+++ b/app/components/work_package_types/wizard/workflows_step_component.html.erb
@@ -1,0 +1,36 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(WorkPackageTypes::ReloadableConfigurationFrameComponent.new(reload_url:)) do %>
+  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type:, aspect: Type::ConfigurationLink::WORKFLOWS)) %>
+
+  <% if roles.any? %>
+    <%= helpers.turbo_frame_tag "workflow-table", src: helpers.edit_type_workflow_tab_path(type, current_tab, role_ids: roles.map(&:id)) %>
+  <% end %>
+<% end %>

--- a/app/components/work_package_types/wizard/workflows_step_component.html.erb
+++ b/app/components/work_package_types/wizard/workflows_step_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(WorkPackageTypes::ReloadableConfigurationFrameComponent.new(reload_url:)) do %>
+<%= render(WorkPackageTypes::ReloadableConfigurationFrameComponent.new(reload_url:, reload_from_location: true)) do %>
   <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type:, aspect: Type::ConfigurationLink::WORKFLOWS)) %>
 
   <% if roles.any? %>

--- a/app/components/work_package_types/wizard/workflows_step_component.rb
+++ b/app/components/work_package_types/wizard/workflows_step_component.rb
@@ -30,27 +30,25 @@
 
 module WorkPackageTypes
   module Wizard
-    # Independent-mode workflows: optionally seed the variant's workflows by
-    # copying them from another type, otherwise start from an empty workflow.
-    class WorkflowsForm < ApplicationForm
-      form do |workflows_form|
-        workflows_form.select_list(
-          name: :copy_workflow_from,
-          input_width: :medium,
-          label: I18n.t(:label_copy_workflow_from),
-          caption: I18n.t("types.creation_wizard.workflows.copy_caption"),
-          include_blank: true
-        ) do |source_types|
-          copyable_types.each do |type|
-            source_types.option(value: type.id, label: type.name)
-          end
-        end
+    class WorkflowsStepComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+
+      def initialize(type:)
+        super(type)
       end
 
       private
 
-      def copyable_types
-        Type.where.not(id: model.id).order(:position)
+      def type = model
+
+      def reload_url
+        helpers.type_creation_wizard_path(model, step: :workflows)
+      end
+
+      def current_tab = "always"
+
+      def roles
+        Workflow.selected_roles(helpers.params[:role_ids])
       end
     end
   end

--- a/app/components/work_package_types/wizard/workflows_step_component.rb
+++ b/app/components/work_package_types/wizard/workflows_step_component.rb
@@ -45,7 +45,7 @@ module WorkPackageTypes
         helpers.type_creation_wizard_path(model, step: :workflows)
       end
 
-      def current_tab = "always"
+      def current_tab = helpers.params[:tab].presence || "always"
 
       def roles
         Workflow.selected_roles(helpers.params[:role_ids])

--- a/app/contracts/work_package_types/copy_workflow_attribute_contract.rb
+++ b/app/contracts/work_package_types/copy_workflow_attribute_contract.rb
@@ -29,6 +29,7 @@
 #++
 
 module WorkPackageTypes
+  # TODO: Remove with type_variants feature flag
   class CopyWorkflowAttributeContract < DryApplicationContract
     params do
       optional(:copy_workflow_from).filled(:string)

--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -162,6 +162,10 @@ module OpTurbo
       turbo_streams << turbo_stream.turbo_frame_reload(target)
     end
 
+    def set_frame_src_via_turbo_stream(target, src)
+      turbo_streams << turbo_stream.turbo_frame_set_src(target, src)
+    end
+
     # Prefix required for all events dispatched via the `dispatchEvent` turbo
     # stream action. The client-side action refuses any event without it; see
     # `frontend/src/turbo/dispatch-event-stream-action.ts` for the rationale.

--- a/app/controllers/work_package_types/creation_wizard_controller.rb
+++ b/app/controllers/work_package_types/creation_wizard_controller.rb
@@ -71,9 +71,6 @@ module WorkPackageTypes
         update_details
       when :defaults
         update_defaults
-      when :workflows
-        copy_workflows
-        advance
       else
         advance
       end
@@ -108,15 +105,6 @@ module WorkPackageTypes
       else
         render :show, status: :unprocessable_entity
       end
-    end
-
-    # The copy source is only offered in Independent mode; a Linked aspect inherits
-    # its workflows from the source instead.
-    def copy_workflows
-      return if @type.linked?(Type::ConfigurationLink::WORKFLOWS)
-
-      source = ::Type.find_by(id: params.dig(:type, :copy_workflow_from))
-      @type.own_workflows.copy_from_type(source) if source
     end
 
     def advance

--- a/app/controllers/work_package_types/types_controller.rb
+++ b/app/controllers/work_package_types/types_controller.rb
@@ -156,6 +156,7 @@ module WorkPackageTypes
 
     # copy_workflow_from is a creation-time instruction rather than a type attribute,
     # so it is read straight off the request and only passed on when one was chosen.
+    # TODO: Remove with type_variants feature flag
     def create_params
       copy_workflow_from = params.dig(:type, :copy_workflow_from)
       return permitted_type_params if copy_workflow_from.blank?

--- a/app/controllers/work_package_types/workflow_tab_controller.rb
+++ b/app/controllers/work_package_types/workflow_tab_controller.rb
@@ -36,15 +36,7 @@ module WorkPackageTypes
 
     def edit
       @current_tab = params[:tab] || "always"
-      @roles = optional_roles
-    end
-
-    private
-
-    def optional_roles
-      ordered = Workflow.eligible_roles.order(:builtin, :position)
-      selected = ordered.where(id: params[:role_ids])
-      selected.any? ? selected : [ordered.first]
+      @roles = Workflow.selected_roles(params[:role_ids])
     end
   end
 end

--- a/app/controllers/workflows/copies/from_roles_controller.rb
+++ b/app/controllers/workflows/copies/from_roles_controller.rb
@@ -54,9 +54,16 @@ class Workflows::Copies::FromRolesController < ApplicationController
       @turbo_status = :unprocessable_entity
     else
       Workflow.copy(@source_type, @source_role, [@source_type], @target_roles)
-      redirect_to edit_type_workflow_path(@source_type, role_id: @target_roles.first.id),
-                  notice: t(".notice", count: @target_roles.size, role_name: @target_roles.first.name)
-      return
+      # Reload the outer frame in place instead of redirecting, so the
+      # copy result appears wherever the matrix is embedded (tab or wizard)
+      close_dialog_via_turbo_stream("#copy_from_type_dialog")
+      render_success_flash_message_via_turbo_stream(
+        message: t(".notice", count: @target_roles.size, role_name: @target_roles.first.name)
+      )
+      dispatch_event_via_turbo_stream(
+        WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME,
+        detail: { type_id: @source_type.id, aspect: Type::ConfigurationLink::WORKFLOWS }
+      )
     end
 
     respond_with_turbo_streams

--- a/app/controllers/workflows/copies/from_roles_controller.rb
+++ b/app/controllers/workflows/copies/from_roles_controller.rb
@@ -54,15 +54,14 @@ class Workflows::Copies::FromRolesController < ApplicationController
       @turbo_status = :unprocessable_entity
     else
       Workflow.copy(@source_type, @source_role, [@source_type], @target_roles)
-      # Reload the outer frame in place instead of redirecting, so the
-      # copy result appears wherever the matrix is embedded (tab or wizard)
+
       close_dialog_via_turbo_stream("#copy_from_type_dialog")
       render_success_flash_message_via_turbo_stream(
         message: t(".notice", count: @target_roles.size, role_name: @target_roles.first.name)
       )
-      dispatch_event_via_turbo_stream(
-        WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME,
-        detail: { type_id: @source_type.id, aspect: Type::ConfigurationLink::WORKFLOWS }
+      set_frame_src_via_turbo_stream(
+        "workflow-table",
+        edit_type_workflow_tab_path(@source_type, params[:tab].presence || "always", role_ids: @target_roles.map(&:id))
       )
     end
 

--- a/app/controllers/workflows/copies/from_types_controller.rb
+++ b/app/controllers/workflows/copies/from_types_controller.rb
@@ -38,7 +38,7 @@ class Workflows::Copies::FromTypesController < ApplicationController
   before_action :set_source_type
   before_action :set_target_types
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     if @source_type.nil?
       render_flash_message_via_turbo_stream(
         message: I18n.t(:error_workflow_copy_source),
@@ -53,9 +53,16 @@ class Workflows::Copies::FromTypesController < ApplicationController
       @turbo_status = :unprocessable_entity
     else
       Workflow.copy(@source_type, nil, @target_types, Workflow.eligible_roles)
-      redirect_to edit_type_workflow_path(@target_types.first),
-                  notice: t(".notice", count: @target_types.size, type_name: @target_types.first.name)
-      return
+      # Reload the outer frame in place instead of redirecting, so the
+      # copy result appears wherever the matrix is embedded (tab or wizard)
+      close_dialog_via_turbo_stream("#copy_from_type_dialog")
+      render_success_flash_message_via_turbo_stream(
+        message: t(".notice", count: @target_types.size, type_name: @target_types.first.name)
+      )
+      dispatch_event_via_turbo_stream(
+        WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME,
+        detail: { type_id: @target_types.first.id, aspect: Type::ConfigurationLink::WORKFLOWS }
+      )
     end
 
     respond_with_turbo_streams

--- a/app/controllers/workflows/copies/from_types_controller.rb
+++ b/app/controllers/workflows/copies/from_types_controller.rb
@@ -38,7 +38,7 @@ class Workflows::Copies::FromTypesController < ApplicationController
   before_action :set_source_type
   before_action :set_target_types
 
-  def create # rubocop:disable Metrics/AbcSize
+  def create
     if @source_type.nil?
       render_flash_message_via_turbo_stream(
         message: I18n.t(:error_workflow_copy_source),
@@ -53,16 +53,10 @@ class Workflows::Copies::FromTypesController < ApplicationController
       @turbo_status = :unprocessable_entity
     else
       Workflow.copy(@source_type, nil, @target_types, Workflow.eligible_roles)
-      # Reload the outer frame in place instead of redirecting, so the
-      # copy result appears wherever the matrix is embedded (tab or wizard)
-      close_dialog_via_turbo_stream("#copy_from_type_dialog")
-      render_success_flash_message_via_turbo_stream(
-        message: t(".notice", count: @target_types.size, type_name: @target_types.first.name)
-      )
-      dispatch_event_via_turbo_stream(
-        WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME,
-        detail: { type_id: @target_types.first.id, aspect: Type::ConfigurationLink::WORKFLOWS }
-      )
+
+      redirect_to edit_type_workflow_path(@target_types.first),
+                  notice: t(".notice", count: @target_types.size, type_name: @target_types.first.name)
+      return
     end
 
     respond_with_turbo_streams

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -157,12 +157,11 @@ class Workflows::TabsController < ApplicationController
   end
 
   def set_eligible_roles
-    @eligible_roles = Workflow.eligible_roles.order(:builtin, :position)
+    @eligible_roles = Workflow.ordered_eligible_roles
   end
 
   def set_roles
-    @roles = @eligible_roles.where(id: params[:role_ids])
-    @roles = [@eligible_roles.first] if @roles.empty?
+    @roles = Workflow.selected_roles(params[:role_ids])
   end
 
   def statuses_for_form

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -48,9 +48,11 @@ module WorkflowHelper
       tab.merge(
         partial: "workflows/form",
         path: edit_type_workflow_tab_path(type, tab[:name], params.permit(role_ids: [])),
-        data: { "admin--workflow-checkbox-state-confirmation-trigger": "click",
-                turbo_frame: "workflow-table",
-                turbo_action: "advance" }
+        data: { controller: "admin--workflow-tab-select",
+                action: "click->admin--workflow-tab-select#select",
+                "admin--workflow-tab-select-tab-value": tab[:name],
+                "admin--workflow-tab-select-admin--workflow-checkbox-state-outlet":
+                  "##{Workflows::StatusMatrixFormComponent::FORM_ID}" }
       )
     end
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -141,4 +141,14 @@ class Workflow < ApplicationRecord
       roles
     end
   end
+
+  def self.ordered_eligible_roles
+    eligible_roles.order(:builtin, :position)
+  end
+
+  def self.selected_roles(role_ids)
+    ordered = ordered_eligible_roles
+    selected = ordered.where(id: role_ids)
+    selected.any? ? selected : [ordered.first].compact
+  end
 end

--- a/app/services/work_package_types/create_service.rb
+++ b/app/services/work_package_types/create_service.rb
@@ -39,6 +39,7 @@ module WorkPackageTypes
 
     def after_perform(service_call)
       type = service_call.result
+      # TODO: Remove with type_variants feature flag
       if @params[:copy_workflow_from].present? && (copy_from = ::Type.find_by(id: @params[:copy_workflow_from]))
         type.own_workflows.copy_from_type(copy_from)
       end

--- a/app/services/work_package_types/independent_mode.rb
+++ b/app/services/work_package_types/independent_mode.rb
@@ -46,7 +46,7 @@ module WorkPackageTypes
       Type::ConfigurationLink::FORM_CONFIGURATION => [COPY, DEFAULT],
       Type::ConfigurationLink::DEFAULTS => [COPY, EMPTY],
       Type::ConfigurationLink::PDF_EXPORT => [COPY, DEFAULT],
-      Type::ConfigurationLink::WORKFLOWS => [COPY],
+      Type::ConfigurationLink::WORKFLOWS => [COPY, EMPTY],
       Type::ConfigurationLink::PROJECT_ATTRIBUTES => [COPY, EMPTY]
     }.freeze
 

--- a/app/services/work_package_types/set_attributes_service.rb
+++ b/app/services/work_package_types/set_attributes_service.rb
@@ -73,6 +73,7 @@ module WorkPackageTypes
       @param_validations.update({ patterns: :is_invalid })
     end
 
+    # TODO: Remove with type_variants feature flag
     def check_copy_workflow(params)
       return unless params.key?(:copy_workflow_from)
 

--- a/app/services/work_package_types/switch_to_independent_mode_service.rb
+++ b/app/services/work_package_types/switch_to_independent_mode_service.rb
@@ -36,9 +36,11 @@ module WorkPackageTypes
   # seeding result is aggregated with the severing, so a failed seed leaves the
   # link untouched.
   class SwitchToIndependentModeService
-    # Writes the blank configuration for the EMPTY mode, per aspect.
+    # How the EMPTY mode blanks each aspect.
+    # Column-backed aspects assign blank values, association-backed aspects delete their rows.
     EMPTY_CONFIGURATION = {
       Type::ConfigurationLink::DEFAULTS => ->(type) { type.update!(patterns: {}, description: nil) },
+      Type::ConfigurationLink::WORKFLOWS => ->(type) { type.own_workflows.destroy_all },
       Type::ConfigurationLink::PROJECT_ATTRIBUTES => ->(type) { type.own_project_custom_field_type_mappings.delete_all }
     }.freeze
 

--- a/app/views/work_package_types/workflow_tab/edit.html.erb
+++ b/app/views/work_package_types/workflow_tab/edit.html.erb
@@ -38,6 +38,6 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::WORKFLOWS)) %>
 
   <% if @type && @roles.any? %>
-    <%= turbo_frame_tag "workflow-table", src: edit_type_workflow_tab_path(@type, @current_tab, role_ids: @roles.map(&:id), status_ids: params[:status_ids]) %>
+    <%= turbo_frame_tag "workflow-table", class: "workflow-table--pinned-save-bar", src: edit_type_workflow_tab_path(@type, @current_tab, role_ids: @roles.map(&:id), status_ids: params[:status_ids]) %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6036,8 +6036,6 @@ en:
         projects: "Projects"
         workflows: "Workflows"
       success: "Variant created successfully."
-      workflows:
-        copy_caption: "Copy the workflow configuration from an existing type as a starting point."
     edit:
       defaults:
         automatically_generated_subjects:

--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -1,9 +1,12 @@
-.controller-workflows
-  #content-body
-    overflow-x: scroll
+// Only the transition table scrolls; the surrounding elements (banner, buttons) live outside this frame and stay put.
+// The outer configuration frame must be a block for the inner frame's width to stay bounded and scroll.
+turbo-frame#type-configuration-frame
+  display: block
 
-  turbo-frame#workflow-table
-    width: 100%
+turbo-frame#workflow-table
+  display: block
+  width: 100%
+  overflow-x: auto
 
   #workflows-status-matrix-form-component
     display: contents
@@ -74,13 +77,18 @@
   th:first-child
     z-index: 3
 
-.workflow-save-bar
-  position: fixed
-  bottom: 0
-  left: var(--main-menu-width)
-  right: 0
-  background: var(--body-background)
-  z-index: 100
+// Edit tab pins the save button; wizard step keeps it together to not mess with the footer
+.workflow-table--pinned-save-bar
+  // Clear the pinned save bar so the last rows aren't hidden behind it
+  padding-bottom: 72px // 16px (mt: 3) + 32px (button) + 24px (mb: 4)
+
+  .workflow-save-bar
+    position: fixed
+    bottom: 0
+    left: var(--main-menu-width)
+    right: 0
+    background: var(--body-background)
+    z-index: 100
 
 .workflow-status-dialog-body
   min-height: 480px

--- a/frontend/src/stimulus/controllers/dynamic/admin/navigate-workflow-frame.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/navigate-workflow-frame.ts
@@ -1,0 +1,54 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import type WorkflowCheckboxStateController from './workflow-checkbox-state.controller';
+
+// Reloads the frame from `frameUrl` (backend) but pushes `historyUrl` (host page) to the address bar,
+// keeping the matrix host agnostic and letting the selection survive reload/back actions
+export function navigateWorkflowFrame(
+  origin:Element,
+  frameUrl:string,
+  historyUrl:string,
+  gate:WorkflowCheckboxStateController | null,
+):void {
+  const run = ():void => {
+    const frame = origin.closest('turbo-frame');
+    if (!frame) return;
+
+    frame.setAttribute('src', frameUrl);
+    history.pushState({}, '', historyUrl);
+  };
+
+  if (gate) {
+    gate.confirmNavigation(run);
+  } else {
+    run();
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -309,41 +309,25 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
   // Trigger navigation with dirty-state confirmation.
   //
 
-  navigateTo(url:string) {
-    if (this.isDirtyValue) {
-      this.confirmThenNavigate(url);
-    } else {
-      this.frameNavigateTo(url);
+  confirmNavigation(navigate:() => void) {
+    if (!this.isDirtyValue) {
+      navigate();
+      return;
     }
-  }
 
-  private confirmThenNavigate(url:string) {
     this.openConfirmationDialog(
       () => {
         this.hasCheckboxChangesValue = false;
         this.hasStatusChangesValue = false;
         this.confirmationDialogTarget.close();
-        setTimeout(() => { this.frameNavigateTo(url); }, 0);
+        setTimeout(navigate, 0);
       },
       () => {
         this.element.requestSubmit();
         this.confirmationDialogTarget.close();
         // Delay to allow the flash message from the form submission to appear.
-        setTimeout(() => { this.frameNavigateTo(url); }, 1000);
+        setTimeout(navigate, 1000);
       },
     );
-  }
-
-  // This keeps the url in the /tabs/:tab/edit format consistently,
-  // rather than doing a Turbo.visit which changes the format.
-  // It also keeps history usable, similar to data-turbo-action="advance".
-  private frameNavigateTo(url:string) {
-    const turboFrame = this.element.closest('turbo-frame') as HTMLElement | null;
-    if (turboFrame) {
-      turboFrame.setAttribute('src', url);
-      history.pushState({}, '', url);
-    } else {
-      Turbo.visit(url);
-    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
@@ -50,30 +50,47 @@ export default class WorkflowRoleSelectController extends Controller {
     const selectedIds = panel.items
       .filter((item) => panel.isItemChecked(item))
       .map((item) => item.getAttribute('data-item-id'))
-      .filter(Boolean);
+      .filter(Boolean) as string[];
 
     // For when all roles are deselected
     if (!selectedIds.length) {
-      this.navigateTo(this.buildUrl([]));
+      this.navigate([]);
       return;
     }
 
     if (selectedIds.slice().sort().join(',') === this.currentRoleIdsValue.slice().sort().join(',')) return;
 
-    this.navigateTo(this.buildUrl(selectedIds as string[]));
+    this.navigate(selectedIds);
   }
 
-  private buildUrl(roleIds:string[]):string {
-    const url = new URL(this.baseUrlValue, window.location.origin);
+  // Reloads the matrix frame from its base url while keeping the host
+  // page in the address bar, making it possible for reload/back behaviour
+  // to correctly keep the selected options without knowing/caring where
+  // the matrix is being rendered (edit tab or wizard step)
+  private navigate(roleIds:string[]) {
+    const frameUrl = this.buildUrl(this.baseUrlValue, roleIds);
+    const historyUrl = this.buildUrl(window.location.href, roleIds);
+    const run = ():void => this.navigateFrame(frameUrl, historyUrl);
+
+    if (this.hasAdminWorkflowCheckboxStateOutlet) {
+      this.adminWorkflowCheckboxStateOutlet.confirmNavigation(run);
+    } else {
+      run();
+    }
+  }
+
+  private navigateFrame(frameUrl:string, historyUrl:string) {
+    const frame = this.element.closest('turbo-frame') as HTMLElement | null;
+    if (!frame) return;
+
+    frame.setAttribute('src', frameUrl);
+    history.pushState({}, '', historyUrl);
+  }
+
+  private buildUrl(base:string, roleIds:string[]):string {
+    const url = new URL(base, window.location.origin);
+    url.searchParams.delete('role_ids[]');
     roleIds.forEach((id) => url.searchParams.append('role_ids[]', id));
     return url.toString();
-  }
-
-  private navigateTo(url:string) {
-    if (this.hasAdminWorkflowCheckboxStateOutlet) {
-      this.adminWorkflowCheckboxStateOutlet.navigateTo(url);
-    } else {
-      Turbo.visit(url);
-    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-tab-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-tab-select.controller.ts
@@ -29,54 +29,32 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import type { SelectPanelElement } from '@primer/view-components/app/components/primer/alpha/select_panel_element';
-import WorkflowCheckboxStateController from './workflow-checkbox-state.controller';
+import type WorkflowCheckboxStateController from './workflow-checkbox-state.controller';
 import { navigateWorkflowFrame } from './navigate-workflow-frame';
 
 /**
- * When the panel closes, it navigates to the workflow edit page with the selected role IDs.
+ * Switches the workflow transition tab, keeping the tab in the host page's URL.
  * Delegates dirty-state confirmation to the workflow-checkbox-state controller via an outlet.
  */
-export default class WorkflowRoleSelectController extends Controller {
+export default class WorkflowTabSelectController extends Controller<HTMLAnchorElement> {
   static outlets = ['admin--workflow-checkbox-state'];
-  static values = { baseUrl: String, currentRoleIds: Array };
+  static values = { tab: String };
 
   declare readonly adminWorkflowCheckboxStateOutlet:WorkflowCheckboxStateController;
   declare readonly hasAdminWorkflowCheckboxStateOutlet:boolean;
-  declare baseUrlValue:string;
-  declare currentRoleIdsValue:unknown[];
+  declare tabValue:string;
 
-  apply() {
-    const panel = this.element as HTMLElement as SelectPanelElement;
-    const selectedIds = panel.items
-      .filter((item) => panel.isItemChecked(item))
-      .map((item) => item.getAttribute('data-item-id'))
-      .filter(Boolean) as string[];
+  select(event:Event) {
+    event.preventDefault();
 
-    // For when all roles are deselected
-    if (!selectedIds.length) {
-      this.navigate([]);
-      return;
-    }
+    const historyUrl = new URL(window.location.href);
+    historyUrl.searchParams.set('tab', this.tabValue);
 
-    if (selectedIds.slice().sort().join(',') === this.currentRoleIdsValue.slice().sort().join(',')) return;
-
-    this.navigate(selectedIds);
-  }
-
-  private navigate(roleIds:string[]) {
     navigateWorkflowFrame(
       this.element,
-      this.buildUrl(this.baseUrlValue, roleIds),
-      this.buildUrl(window.location.href, roleIds),
+      this.element.href,
+      historyUrl.toString(),
       this.hasAdminWorkflowCheckboxStateOutlet ? this.adminWorkflowCheckboxStateOutlet : null,
     );
-  }
-
-  private buildUrl(base:string, roleIds:string[]):string {
-    const url = new URL(base, window.location.origin);
-    url.searchParams.delete('role_ids[]');
-    roleIds.forEach((id) => url.searchParams.append('role_ids[]', id));
-    return url.toString();
   }
 }

--- a/frontend/src/stimulus/controllers/reload-frame-on-event.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/reload-frame-on-event.controller.spec.ts
@@ -77,6 +77,25 @@ describe('ReloadFrameOnEventController', () => {
     expect(calls.count).toBe(1);
   });
 
+  it('reloads from the current location when reloadFromLocation is set', async () => {
+    await ctx.mount(`
+      <turbo-frame id="location-frame"
+                   data-controller="reload-frame-on-event"
+                   data-reload-frame-on-event-event-name-value="op-dispatched:resource-allocations:changed"
+                   data-reload-frame-on-event-url-value="/planner/view"
+                   data-reload-frame-on-event-reload-from-location-value="true">
+        content
+      </turbo-frame>
+    `);
+
+    const frame = ctx.container.querySelector('#location-frame') as unknown as ReloadableFrame;
+
+    document.dispatchEvent(new CustomEvent('op-dispatched:resource-allocations:changed'));
+
+    expect(frame.src).toBe(window.location.href);
+    expect(frame.src).not.toContain('/planner/view');
+  });
+
   it('ignores unrelated events', async () => {
     const { frame, calls } = await mountFrame();
 

--- a/frontend/src/stimulus/controllers/reload-frame-on-event.controller.ts
+++ b/frontend/src/stimulus/controllers/reload-frame-on-event.controller.ts
@@ -36,12 +36,24 @@ import { FrameElement } from '@hotwired/turbo';
 // not fetched on load); the first event points it at `urlValue`, later events
 // reload it. Pair the frame with `refresh="morph"` to reload without flicker.
 export default class ReloadFrameOnEventController extends Controller<FrameElement> {
-  static values = { eventName: String, url: String };
+  static values = { eventName: String, url: String, reloadFromLocation: Boolean };
 
   declare eventNameValue:string;
   declare urlValue:string;
+  declare reloadFromLocationValue:boolean;
 
   private readonly listener = ():void => {
+    // Optionally reload from the live address bar rather than the
+    // urlValue, so query state that changed client-side is preserved across the reload.
+    if (this.reloadFromLocationValue) {
+      if (this.element.src === window.location.href) {
+        void this.element.reload();
+      } else {
+        this.element.src = window.location.href;
+      }
+      return;
+    }
+
     if (this.element.src) {
       void this.element.reload();
     } else {

--- a/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
+++ b/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe WorkPackageTypes::CreationWizardController, with_flag: { type_var
         it "advances to the next step" do
           patch :update, params: { type_id: variant.id, step: :workflows }
 
-          expect(response).to redirect_to(type_creation_wizard_path(variant, step: :automations))
+          expect(response).to redirect_to(type_creation_wizard_path(variant, step: :projects))
         end
       end
 

--- a/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
+++ b/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe WorkPackageTypes::CreationWizardController, with_flag: { type_var
 
     describe "existing variant" do
       shared_let(:variant) { create(:type, name: "Critical", parent: parent_type) }
+      shared_let(:role) { create(:project_role) }
 
       describe "GET show" do
         before { get :show, params: { type_id: variant.id, step: :projects } }
@@ -114,27 +115,11 @@ RSpec.describe WorkPackageTypes::CreationWizardController, with_flag: { type_var
       end
 
       describe "PATCH update on the workflows step" do
-        shared_let(:workflow_source) { create(:type, name: "Task") }
-        shared_let(:status) { create(:status) }
-        shared_let(:role) { create(:project_role) }
-        shared_let(:workflow) do
-          create(:workflow, type: workflow_source, role:, old_status: status, new_status: status)
-        end
+        # The wizard step only advances as the matrix saves via its own turbo endpoint
+        it "advances to the next step" do
+          patch :update, params: { type_id: variant.id, step: :workflows }
 
-        it "copies workflows from the chosen source and advances" do
-          expect do
-            patch :update, params: { type_id: variant.id, step: :workflows,
-                                     type: { copy_workflow_from: workflow_source.id } }
-          end.to change { variant.reload.workflows.count }.from(0).to(1)
-
-          expect(response).to redirect_to(type_creation_wizard_path(variant, step: :projects))
-        end
-
-        it "advances without copying when no source is chosen" do
-          patch :update, params: { type_id: variant.id, step: :workflows, type: { copy_workflow_from: "" } }
-
-          expect(variant.reload.workflows).to be_empty
-          expect(response).to redirect_to(type_creation_wizard_path(variant, step: :projects))
+          expect(response).to redirect_to(type_creation_wizard_path(variant, step: :automations))
         end
       end
 

--- a/spec/controllers/workflows/copies/from_roles_controller_spec.rb
+++ b/spec/controllers/workflows/copies/from_roles_controller_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe Workflows::Copies::FromRolesController do
               .with(source_type, source_role, [source_type], target_roles)
     end
 
-    it "reloads the configuration frame with a flash notice" do
+    it "points the matrix frame at the first target role with a flash notice" do
       expect(response).to have_http_status(:ok)
       expect(response).to have_turbo_stream(action: "flash", target: "op-primer-flash-component")
       expect(response.body).to include("Successfully copied workflow to 2 roles.")
-      expect(response.body).to include(WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME)
+      expect(response).to have_turbo_stream(action: "turbo_frame_set_src", target: "workflow-table")
     end
   end
 end

--- a/spec/controllers/workflows/copies/from_roles_controller_spec.rb
+++ b/spec/controllers/workflows/copies/from_roles_controller_spec.rb
@@ -88,9 +88,11 @@ RSpec.describe Workflows::Copies::FromRolesController do
               .with(source_type, source_role, [source_type], target_roles)
     end
 
-    it "redirects with a flash notice" do
-      expect(response).to redirect_to(edit_type_workflow_path(source_type, role_id: target_roles.first.id))
-      expect(flash[:notice]).to eq("Successfully copied workflow to 2 roles.")
+    it "reloads the configuration frame with a flash notice" do
+      expect(response).to have_http_status(:ok)
+      expect(response).to have_turbo_stream(action: "flash", target: "op-primer-flash-component")
+      expect(response.body).to include("Successfully copied workflow to 2 roles.")
+      expect(response.body).to include(WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME)
     end
   end
 end

--- a/spec/controllers/workflows/copies/from_types_controller_spec.rb
+++ b/spec/controllers/workflows/copies/from_types_controller_spec.rb
@@ -71,11 +71,9 @@ RSpec.describe Workflows::Copies::FromTypesController do
               .with(source_type, nil, target_types, roles)
     end
 
-    it "reloads the configuration frame with a flash notice" do
-      expect(response).to have_http_status(:ok)
-      expect(response).to have_turbo_stream(action: "flash", target: "op-primer-flash-component")
-      expect(response.body).to include("Successfully copied workflow to 2 types.")
-      expect(response.body).to include(WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME)
+    it "redirects to the first target type with a flash notice" do
+      expect(response).to redirect_to(edit_type_workflow_path(target_types.first))
+      expect(flash[:notice]).to eq("Successfully copied workflow to 2 types.")
     end
   end
 end

--- a/spec/controllers/workflows/copies/from_types_controller_spec.rb
+++ b/spec/controllers/workflows/copies/from_types_controller_spec.rb
@@ -71,9 +71,11 @@ RSpec.describe Workflows::Copies::FromTypesController do
               .with(source_type, nil, target_types, roles)
     end
 
-    it "redirects with a flash notice" do
-      expect(response).to redirect_to(edit_type_workflow_path(target_types.first))
-      expect(flash[:notice]).to eq("Successfully copied workflow to 2 types.")
+    it "reloads the configuration frame with a flash notice" do
+      expect(response).to have_http_status(:ok)
+      expect(response).to have_turbo_stream(action: "flash", target: "op-primer-flash-component")
+      expect(response.body).to include("Successfully copied workflow to 2 types.")
+      expect(response.body).to include(WorkPackageTypes::ReloadableConfigurationFrameComponent::RELOAD_EVENT_NAME)
     end
   end
 end

--- a/spec/features/types/creation_wizard_workflows_spec.rb
+++ b/spec/features/types/creation_wizard_workflows_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Variant creation wizard workflows step", :js, with_flag: { type_variants: true } do
+  include Toasts::Expectations
+  include Workflows::EditHelpers
+
+  let(:parent_type) { create(:type) }
+  let(:type) { create(:type, parent: parent_type) }
+  let(:role) { create(:project_role) }
+  let(:role2) { create(:project_role) }
+  let(:admin) { create(:admin) }
+  let(:statuses) { (1..3).map { create(:status) } }
+  let!(:workflow) do
+    create(:workflow, role_id: role.id, type_id: type.id,
+                      old_status_id: statuses[0].id, new_status_id: statuses[1].id,
+                      author: false, assignee: false)
+  end
+
+  current_user { admin }
+
+  # Parallels Workflows::EditHelpers#visit_workflow_edit, but for the wizard
+  def visit_workflow_wizard(roles: [], tab: nil)
+    params = { step: :workflows }
+    params[:role_ids] = roles.map(&:id) if roles.any?
+    params[:tab] = tab if tab
+    visit type_creation_wizard_path(type, **params)
+  end
+
+  it "allows adding another workflow" do
+    visit_workflow_wizard(roles: [role])
+
+    expect(page).to have_field workflow_checkbox(1, 0), checked: false
+    expect(Workflow.where(type_id: type.id, role_id: role.id).count).to be 1
+
+    check workflow_checkbox(1, 0)
+
+    click_button "Save"
+
+    expect_flash(message: "Successful update.")
+
+    expect(page).to have_field workflow_checkbox(0, 1), checked: true
+    expect(page).to have_field workflow_checkbox(1, 0), checked: true
+
+    expect(Workflow.where(type_id: type.id, role_id: role.id).count).to be 2
+  end
+
+  context "when switching tabs" do
+    let!(:author_workflow) do
+      create(:workflow, role_id: role.id, type_id: type.id,
+                        old_status_id: statuses[1].id, new_status_id: statuses[2].id,
+                        author: true, assignee: false)
+    end
+
+    before { visit_workflow_wizard(roles: [role]) }
+
+    it "shows the author matrix when switching to the author tab" do
+      expect(page).to have_no_css "#workflow_form_author"
+
+      switch_transition_tab "User is author"
+
+      within "#workflow_form_author" do
+        expect(page).to have_field workflow_checkbox(1, 2), checked: true
+        expect(page).to have_no_field workflow_checkbox(0, 1)
+      end
+    end
+  end
+
+  context "when switching roles" do
+    before { visit_workflow_wizard(roles: [role, role2]) }
+
+    it "shows the matrix for the selected role" do
+      expect(page).to have_text("2 roles selected")
+      expect(page).to have_no_button(role.name)
+
+      click_button "2 roles selected"
+      find("[data-item-id='#{role2.id}']").click
+      within("select-panel") { click_button "Apply" }
+
+      expect(page).to have_no_text("2 roles selected")
+      expect(page).to have_button(role.name)
+    end
+  end
+
+  describe "when the workflow is linked from a source" do
+    let(:source_type) { create(:type) }
+    let!(:source_workflow) do
+      create(:workflow, role_id: role.id,
+                        type_id: source_type.id,
+                        old_status_id: statuses[0].id,
+                        new_status_id: statuses[1].id,
+                        author: false,
+                        assignee: false)
+    end
+
+    before do
+      type.link!(Type::ConfigurationLink::WORKFLOWS, source: source_type)
+      visit_workflow_wizard(roles: [role])
+    end
+
+    it "shows the source's transitions read-only without editing actions" do
+      expect(page).to have_field(workflow_checkbox(0, 1), checked: true, disabled: true)
+      expect(page).to have_field(workflow_checkbox(1, 0), disabled: true)
+      expect(page).to have_no_button "Save"
+
+      within "#workflow-table" do
+        expect(page).to have_no_link "Status"
+        expect(page).to have_no_link "Copy"
+      end
+    end
+  end
+
+  describe "reuse mode banner" do
+    context "when the workflow configuration is independent" do
+      before { visit_workflow_wizard(roles: [role]) }
+
+      it "shows the independent banner offering to switch to linked, or to copy from type" do
+        expect(page).to have_text("Independent mode")
+        expect(page).to have_link("Switch to linked mode")
+        expect(page).to have_link("Copy from type")
+      end
+    end
+
+    context "when the workflow configuration is linked to a source" do
+      let(:source_type) { create(:type, name: "Feature") }
+
+      before do
+        type.link!(Type::ConfigurationLink::WORKFLOWS, source: source_type)
+        visit_workflow_wizard(roles: [role])
+      end
+
+      it "shows the linked banner naming the source with change and switch actions" do
+        expect(page).to have_text("Linked mode")
+        expect(page).to have_link("Change source type")
+        expect(page).to have_link("Switch to independent mode")
+      end
+    end
+  end
+end

--- a/spec/features/workflows/copies/from_role_spec.rb
+++ b/spec/features/workflows/copies/from_role_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Workflow copy from role", :js do
 
   current_user { admin }
 
-  shared_examples "a copy-to-other-roles dialog" do |with_source_role:|
+  shared_examples "a copy-to-other-roles dialog" do |with_source_role:, host:|
     it "permits to select a source role and target roles" do
       unless with_source_role
         choose "Copy to other roles"
@@ -54,8 +54,10 @@ RSpec.describe "Workflow copy from role", :js do
       click_button "Copy"
 
       expect(page).to have_css(".flash-success", text: "Successfully copied workflow to 2 roles.")
-      expect(page).to have_current_path(edit_type_workflow_path(type))
-      expect(page).to have_button(text: "2 roles selected")
+      # Copying to other roles stays within the same type, so the current path is kept
+      current_path = host == :wizard ? type_creation_wizard_path(type, step: :workflows) : edit_type_workflow_path(type)
+      expect(page).to have_current_path(current_path)
+      expect(page).to have_text("2 roles selected")
     end
   end
 
@@ -65,6 +67,16 @@ RSpec.describe "Workflow copy from role", :js do
       click_link "Copy"
     end
 
-    it_behaves_like "a copy-to-other-roles dialog", with_source_role: true
+    it_behaves_like "a copy-to-other-roles dialog", with_source_role: true, host: :tab
+  end
+
+  describe "from the creation wizard", with_flag: { type_variants: true } do
+    before do
+      visit type_creation_wizard_path(type, step: :workflows)
+      # Scope to the matrix; the wizard's reuse banner also has a "Copy from type" button.
+      within("#workflow-table") { click_link "Copy" }
+    end
+
+    it_behaves_like "a copy-to-other-roles dialog", with_source_role: true, host: :wizard
   end
 end

--- a/spec/features/workflows/copies/from_role_spec.rb
+++ b/spec/features/workflows/copies/from_role_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe "Workflow copy from role", :js do
       click_button "Copy"
 
       expect(page).to have_css(".flash-success", text: "Successfully copied workflow to 2 roles.")
-      expect(page).to have_current_path(edit_type_workflow_path(type, role_id: roles.first.id))
+      expect(page).to have_current_path(edit_type_workflow_path(type))
+      expect(page).to have_button(text: "2 roles selected")
     end
   end
 

--- a/spec/features/workflows/copies/from_type_spec.rb
+++ b/spec/features/workflows/copies/from_type_spec.rb
@@ -63,4 +63,14 @@ RSpec.describe "Workflow copy from type", :js do
 
     it_behaves_like "a copy-to-another-type dialog", with_source_role: true
   end
+
+  # Copying to another type targets a different type, so it redirects there and leaves the wizard
+  describe "from the creation wizard", with_flag: { type_variants: true } do
+    before do
+      visit type_creation_wizard_path(type, step: :workflows)
+      within("#workflow-table") { click_link "Copy" }
+    end
+
+    it_behaves_like "a copy-to-another-type dialog", with_source_role: true
+  end
 end

--- a/spec/features/workflows/missing_for_sharing_wp_spec.rb
+++ b/spec/features/workflows/missing_for_sharing_wp_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Configuring the workflow for work package sharing", :js,
 
     click_button "Copy"
 
-    # Copying succeeds which results in the edit role having a workflow and the warning disappearing.
+    # Copying succeeds which results in the edit role having a workflow.
     expect(page)
       .to have_content "Successfully copied workflow"
 
@@ -87,6 +87,10 @@ RSpec.describe "Configuring the workflow for work package sharing", :js,
                           new_status_id: end_status.id,
                           author: false,
                           assignee: false).count).to eq(1)
+
+    # Copying to another role stays in place and only updates the matrix frame;
+    # the layout warning bar recomputes on the next page load.
+    page.refresh
 
     expect(page)
       .to have_no_css(".warning-bar--item")

--- a/spec/services/work_package_types/independent_mode_spec.rb
+++ b/spec/services/work_package_types/independent_mode_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe WorkPackageTypes::IndependentMode do
         .to eq([described_class::COPY, described_class::DEFAULT])
     end
 
-    it "offers only copy for workflows" do
+    it "offers copy and empty for workflows" do
       expect(described_class.available_for(Type::ConfigurationLink::WORKFLOWS))
-        .to eq([described_class::COPY])
+        .to eq([described_class::COPY, described_class::EMPTY])
     end
 
     it "offers copy and empty for project attributes" do

--- a/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
+++ b/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
@@ -86,6 +86,29 @@ RSpec.describe WorkPackageTypes::SwitchToIndependentModeService do
       end
     end
 
+    context "with the empty mode (workflows)", with_flag: { type_variants: true } do
+      let(:aspect) { Type::ConfigurationLink::WORKFLOWS }
+
+      it "removes all transitions and severs the link" do
+        source = create(:type)
+        source.own_workflows.create!(role: create(:project_role),
+                                     old_status: create(:status), new_status: create(:status),
+                                     author: false, assignee: false)
+        type.link!(aspect, source:)
+
+        # The type owns no transitions but sees the source's through the link
+        expect(type.own_workflows).to be_empty
+        expect(type.workflows).not_to be_empty
+
+        result = service.call(mode: WorkPackageTypes::IndependentMode::EMPTY)
+
+        expect(result).to be_success
+        expect(type.reload).not_to be_linked(aspect)
+        expect(type.own_workflows).to be_empty
+        expect(type.workflows).to be_empty
+      end
+    end
+
     context "with the copy mode (project attributes)" do
       let(:aspect) { Type::ConfigurationLink::PROJECT_ATTRIBUTES }
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/FND-154
https://community.openproject.org/wp/FND-163
https://community.openproject.org/wp/FND-175

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Changes

- 1st commit - Add an empty option when switching to independent mode
- Remaining commits - Add the workflows matrix to the wizard step
   - Updated the workflows checkbox table to work from either location, as previously it hard coded some redirects/refreshes to the edit tab
   - Update tab switches to use the same mechanism as role switches, as this was now possible after moving them to an action menu. This was also necessary to keep the reloads location agnostic
   - Fixed styling. It was already broken for the edit tab, and needed further changes to fit into the wizard step
   - Note: 
      - Copying to another type is a bit janky right now and redirects out of the wizard. This is on purpose as I didn't spend too much time on that as we intend to remove/update that flow anyway
      - Saving via the wizard continue button instead of the dedicated save button will be tackled next, separately. Alerts for navigating out with unsaved changes will also be added here
      - Workflows should also start with the linked state (like all other steps). This will also be done in the follow up PR

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
