### PR TITLE
[COMMS-915] Count work package summary versions from target_versions

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -418,18 +418,20 @@ class WorkPackage < ApplicationRecord
     # Counts via the target version associations rather than the deprecated
     # version_id column, so a work package assigned to several versions is
     # counted under each of them.
-    ActiveRecord::Base.connection.select_all(
-      "SELECT s.id AS status_id,
-              s.is_closed AS closed,
-              wpv.version_id AS version_id,
-              COUNT(i.id) AS total
-         FROM #{WorkPackage.table_name} i
-         INNER JOIN #{Status.table_name} s ON i.status_id = s.id
-         INNER JOIN #{WorkPackageVersion.table_name} wpv
-            ON wpv.work_package_id = i.id AND wpv.kind = '#{WorkPackageVersion.kinds[:target]}'
-        WHERE i.project_id = #{project.id}
-        GROUP BY s.id, s.is_closed, wpv.version_id"
-    ).to_a
+    sql = sanitize_sql_array(
+      ["SELECT s.id AS status_id,
+               s.is_closed AS closed,
+               wpv.version_id AS version_id,
+               COUNT(i.id) AS total
+          FROM #{WorkPackage.table_name} i
+          INNER JOIN #{Status.table_name} s ON i.status_id = s.id
+          INNER JOIN #{WorkPackageVersion.table_name} wpv
+             ON wpv.work_package_id = i.id AND wpv.kind = :kind
+         WHERE i.project_id = :project_id
+         GROUP BY s.id, s.is_closed, wpv.version_id",
+       { kind: WorkPackageVersion.kinds[:target], project_id: project.id }]
+    )
+    ActiveRecord::Base.connection.select_all(sql).to_a
   end
 
   def self.by_priority(project)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -426,7 +426,7 @@ class WorkPackage < ApplicationRecord
          FROM #{WorkPackage.table_name} i
          INNER JOIN #{Status.table_name} s ON i.status_id = s.id
          INNER JOIN #{WorkPackageVersion.table_name} wpv
-            ON wpv.work_package_id = i.id AND wpv.kind = 'target'
+            ON wpv.work_package_id = i.id AND wpv.kind = '#{WorkPackageVersion.kinds[:target]}'
         WHERE i.project_id = #{project.id}
         GROUP BY s.id, s.is_closed, wpv.version_id"
     ).to_a

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -415,9 +415,21 @@ class WorkPackage < ApplicationRecord
   end
 
   def self.by_version(project)
-    count_and_group_by project:,
-                       field: "version_id",
-                       joins: Version.table_name
+    # Counts via the target version associations rather than the deprecated
+    # version_id column, so a work package assigned to several versions is
+    # counted under each of them.
+    ActiveRecord::Base.connection.select_all(
+      "SELECT s.id AS status_id,
+              s.is_closed AS closed,
+              wpv.version_id AS version_id,
+              COUNT(i.id) AS total
+         FROM #{WorkPackage.table_name} i
+         INNER JOIN #{Status.table_name} s ON i.status_id = s.id
+         INNER JOIN #{WorkPackageVersion.table_name} wpv
+            ON wpv.work_package_id = i.id AND wpv.kind = 'target'
+        WHERE i.project_id = #{project.id}
+        GROUP BY s.id, s.is_closed, wpv.version_id"
+    ).to_a
   end
 
   def self.by_priority(project)

--- a/app/services/reports/subproject_report.rb
+++ b/app/services/reports/subproject_report.rb
@@ -46,6 +46,6 @@ class Reports::SubprojectReport < Reports::Report
   end
 
   def title
-    I18n.t(:label_subproject_plural)
+    I18n.t(:label_subproject)
   end
 end

--- a/app/services/reports/version_report.rb
+++ b/app/services/reports/version_report.rb
@@ -46,7 +46,7 @@ class Reports::VersionReport < Reports::Report
   end
 
   def title
-    attribute = Setting::WorkPackageMultipleVersions.active? ? :target_versions : :version
+    attribute = Setting::WorkPackageMultipleVersions.active? ? :target_version : :version
     @title ||= WorkPackage.human_attribute_name(attribute)
   end
 end

--- a/app/services/reports/version_report.rb
+++ b/app/services/reports/version_report.rb
@@ -46,6 +46,7 @@ class Reports::VersionReport < Reports::Report
   end
 
   def title
-    @title ||= WorkPackage.human_attribute_name(:version)
+    attribute = Setting::WorkPackageMultipleVersions.active? ? :target_versions : :version
+    @title ||= WorkPackage.human_attribute_name(attribute)
   end
 end

--- a/app/views/work_packages/reports/_report_category.html.erb
+++ b/app/views/work_packages/reports/_report_category.html.erb
@@ -28,13 +28,13 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div class="form--fieldset">
-  <div class="form--fieldset-legend"><%= WorkPackage.human_attribute_name(report.report_type) %></div>
+  <div class="form--fieldset-legend"><%= report.title %></div>
   <div class="form--toolbar">
     <span class="form--toolbar-item">
     <%= link_to(
-          icon_wrapper("icon icon-zoom-in", t(:text_analyze, subject: WorkPackage.human_attribute_name(report.report_type))),
+          icon_wrapper("icon icon-zoom-in", t(:text_analyze, subject: report.title)),
           { action: "report_details", detail: report.report_type },
-          title: t(:text_analyze, subject: WorkPackage.human_attribute_name(report.report_type)),
+          title: t(:text_analyze, subject: report.title),
           class: "no-decoration-on-hover"
         ) %></span>
   </div>

--- a/app/views/work_packages/reports/report_details.html.erb
+++ b/app/views/work_packages/reports/report_details.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <div class="form--fieldset">
-  <div class="form--fieldset-legend"><%= @report.report_type %></div>
+  <div class="form--fieldset-legend"><%= @report.title %></div>
 
   <%= render partial: "report", locals: { statuses: @statuses,
                                           rows: @rows,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,6 +477,7 @@ en:
         spent_hours: "Spent time"
         spent_time: "Spent time"
         subproject: "Subproject"
+        target_version: "Target version"
         target_versions: "Target versions"
         time_entries: "Log time"
         type: "Type"

--- a/spec/features/work_packages/reports_spec.rb
+++ b/spec/features/work_packages/reports_spec.rb
@@ -121,4 +121,34 @@ RSpec.describe "work package reports", :js do
     wp_table_page.expect_work_package_listed(wp1)
     wp_table_page.ensure_work_package_not_listed!(wp2)
   end
+
+  context "with the multiple versions feature enabled",
+          with_flag: { work_package_multiple_versions: true },
+          with_settings: { work_package_multiple_versions: true } do
+    let!(:version_a) { create(:version, project:, name: "Alpha 1.0") }
+    let!(:version_b) { create(:version, project:, name: "Beta 2.0") }
+    let!(:wp_multi) do
+      create(:work_package, project:, type: type_a, status: type_a.statuses.first, version: version_a)
+        .tap { |wp| wp.work_package_versions.create!(version: version_b, kind: "target") }
+    end
+
+    it "counts a work package with several target versions under each of them" do
+      wp_table_page.visit!
+
+      within ".main-menu--children" do
+        click_on "Summary"
+      end
+
+      expect(page).to have_text "TARGET VERSIONS"
+
+      click_link "Further analyze: Target versions"
+
+      aggregate_failures do
+        [version_a, version_b].each do |version|
+          row = page.find(:xpath, "//tbody/tr[td[normalize-space()='#{version.name}']]")
+          expect(row).to have_css("td:last-child", text: "1")
+        end
+      end
+    end
+  end
 end

--- a/spec/features/work_packages/reports_spec.rb
+++ b/spec/features/work_packages/reports_spec.rb
@@ -139,9 +139,9 @@ RSpec.describe "work package reports", :js do
         click_on "Summary"
       end
 
-      expect(page).to have_text "TARGET VERSIONS"
+      expect(page).to have_text "TARGET VERSION"
 
-      click_link "Further analyze: Target versions"
+      click_link "Further analyze: Target version"
 
       aggregate_failures do
         [version_a, version_b].each do |version|

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -542,6 +542,25 @@ RSpec.describe WorkPackage do
       let(:groups) { described_class.by_version(project) }
 
       it_behaves_like "group by"
+
+      context "with a work package assigned to multiple target versions" do
+        shared_let(:multi_version_work_package) do
+          create(:work_package, project:, type:, version: version1)
+            .tap { |wp| wp.work_package_versions.create!(version: version2, kind: "target") }
+        end
+
+        def total_for(version)
+          groups.select { |row| row["version_id"].to_i == version.id }
+                .sum { |row| row["total"].to_i }
+        end
+
+        it "counts the work package under each of its target versions" do
+          # version1: work_package1 + multi_version_work_package
+          expect(total_for(version1)).to eq(2)
+          # version2: work_package2 + multi_version_work_package
+          expect(total_for(version2)).to eq(2)
+        end
+      end
     end
 
     describe "by priority" do

--- a/spec/services/reports/version_report_spec.rb
+++ b/spec/services/reports/version_report_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Reports::VersionReport do
+  let(:project) { create(:project) }
+
+  subject(:report) { described_class.new(project) }
+
+  describe "#title" do
+    context "with the multiple versions feature enabled",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      it "labels the report as the target versions attribute" do
+        expect(report.title).to eq(WorkPackage.human_attribute_name(:target_versions))
+      end
+    end
+
+    context "with the multiple versions feature disabled",
+            with_flag: { work_package_multiple_versions: false } do
+      it "labels the report as the deprecated single version attribute" do
+        expect(report.title).to eq(WorkPackage.human_attribute_name(:version))
+      end
+    end
+  end
+end

--- a/spec/services/reports/version_report_spec.rb
+++ b/spec/services/reports/version_report_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Reports::VersionReport do
     context "with the multiple versions feature enabled",
             with_flag: { work_package_multiple_versions: true },
             with_settings: { work_package_multiple_versions: true } do
-      it "labels the report as the target versions attribute" do
-        expect(report.title).to eq(WorkPackage.human_attribute_name(:target_versions))
+      it "labels the report with the singular target version attribute" do
+        expect(report.title).to eq(WorkPackage.human_attribute_name(:target_version))
       end
     end
 


### PR DESCRIPTION
[COMMS-915](https://community.openproject.org/wp/COMMS-915)

The work package summary page counted versions through the deprecated `version_id` column, which only ever holds a work package's first target version. Work packages assigned to several target versions were therefore counted under a single version, and the totals no longer matched the filtered list a cell links to (that drill-down already filters on `target_versions`). The summary now counts through the `work_package_versions` target associations, so each work package is counted under every version it targets and the counts agree with the list behind them. The section heading also follows the multiple versions feature flag, reading "Target versions" when it is on, matching how the rest of the UI labels the field.

> _Work package #42 targets both 1.0.0 and 2.0.0. Before, it was counted only under 1.0.0, so 2.0.0 read 3; after, it is counted under both and 2.0.0 reads 4._

**Before**
<img width="2700" height="594" alt="comms-915-summary-before" src="https://github.com/user-attachments/assets/c2334584-6211-448b-8b01-068919758550" />

**After**

<img width="1132" height="240" alt="comms-915-summary-after-UPDATED" src="https://github.com/user-attachments/assets/8b24e326-81e5-41c2-a6bf-685fb73d3384" />


