### PR TITLE
Bump standard-edition seeder query count expectation to 30

### DIFF
--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RootSeeder,
       expect(View.where(type: "work_packages_table").count).to eq 5
       expect(View.where(type: "team_planner").count).to eq 1
       expect(View.where(type: "gantt").count).to eq 2
-      expect(Query.count).to eq 28
+      expect(Query.count).to eq 30
       expect(ProjectRole.count).to eq 5
       expect(WorkPackageRole.count).to eq 3
       expect(GlobalRole.count).to eq 2
@@ -353,7 +353,7 @@ RSpec.describe RootSeeder,
         expect(View.where(type: "work_packages_table").count).to eq 5
         expect(View.where(type: "team_planner").count).to eq 1
         expect(View.where(type: "gantt").count).to eq 2
-        expect(Query.count).to eq 28
+        expect(Query.count).to eq 30
         expect(ProjectRole.count).to eq 5
         expect(WorkPackageRole.count).to eq 3
         expect(GlobalRole.count).to eq 2


### PR DESCRIPTION
Part of unbreaking the red `Units + Features` job on `dev`: `spec/seeders/root_seeder_standard_edition_spec.rb` fails with `Query.count` `expected: 28, got: 30`.

PR #24254 set the expectation to 28 (26 base queries + the 2 hidden Epic/User Story children queries). Afterwards, 492e7be ("Seed resource planner for the demo project") added the resource-management timeline query to the demo project, taking the total to 30 without the expectation being re-bumped. I enumerated all 30 seeded queries: they are distinct and legitimate (no duplication), so this just updates the stale count (both the initial-seed and the re-seed idempotency check). Spec is green again (136 examples, 0 failures).

the extra query comes from your resource-planner demo seeding in 492e7be
