### PR TITLE
[DREAM-19680] When user receives a new notification while having the top one open in split view, then both top notifications look active

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
@@ -2,6 +2,7 @@
   <div
     class="op-ian-center--content"
     [class.op-ian-center--content_empty]="(loading$ | async) === true || (hasNotifications$ | async) === false"
+    [class.op-ian-center--content_first-selected]="firstNotificationIsSelected$ | async"
     >
     @if ((loading$ | async) === false) {
       @if ((hasNotifications$ | async)) {

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
@@ -18,8 +18,8 @@
       display: flex
       align-items: center
 
-  :has(.op-ian-item_selected:first-child)
-    border-top-color: var(--box-list-item-pressed-border-color)
+    &_first-selected
+      border-top-color: var(--box-list-item-pressed-border-color)
 
   &--viewport
     height: 100%

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -28,6 +28,7 @@
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { combineLatest } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { StateService } from '@uirouter/angular';
 import { IanCenterService } from 'core-app/features/in-app-notifications/center/state/ian-center.service';
@@ -87,6 +88,16 @@ export class InAppNotificationCenterComponent implements OnInit {
     );
 
   selectedWorkPackage$ = this.storeService.selectedWorkPackage$;
+
+  firstNotificationIsSelected$ = combineLatest([
+    this.notifications$,
+    this.selectedWorkPackage$,
+  ]).pipe(
+    map(([notifications, selected]) => {
+      if (!notifications?.length || !selected) return false;
+      return this.notificationMatchesSelectedWorkPackage(notifications[0][0], selected);
+    }),
+  );
 
   reasonMenuItems = [
     {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19680

# What are you trying to accomplish?
Use observable instead of `:has` as Firefox seems to be not able to handle async dom changes for a `:has` selector


