### PR TITLE
[COMMS-918] Make WP BaseContract correctly detect WPs with closed versions

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -764,7 +764,7 @@ module WorkPackages
     end
 
     def closed_version_and_status?(status = model.status)
-      model.version&.closed? && status.is_closed?
+      model.target_versions.any?(&:closed?) && status.is_closed?
     end
 
     def new_statuses_by_workflow(status)

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -212,6 +212,14 @@ module WorkPackage::Versions
     update_columns(version_id: new_version_id) unless version_id == new_version_id
   end
 
+  # Resets any cached values. Necessary because we do insert_all.
+  def reset_version_associations
+    work_package_versions.reset
+    versions.reset
+    target_versions.reset
+    observed_in_versions.reset
+  end
+
   # Sets the work package's associations of the given kind to exactly the
   # given version_ids.
   def replace_versions(kind, version_ids)
@@ -220,9 +228,16 @@ module WorkPackage::Versions
     to_remove = existing - version_ids
     to_add    = version_ids - existing
 
-    # remove associations that are not present in the new list of versions
+    return if to_remove.empty? && to_add.empty?
+
+    apply_version_changes(kind, to_remove, to_add)
+    reset_version_associations
+  end
+
+  # remove associations that are not present in the new list of versions and
+  # add those that were not already there
+  def apply_version_changes(kind, to_remove, to_add)
     work_package_versions.where(kind:, version_id: to_remove).delete_all if to_remove.any?
-    # add new associations that were not already there
     work_package_versions.insert_all(to_add.map { |vid| { version_id: vid, kind: } }) if to_add.any?
   end
 end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -178,7 +178,9 @@ RSpec.describe WorkPackages::BaseContract do
       before do
         version = build_stubbed(:version, status: "closed")
 
-        work_package.version = version
+        allow(work_package)
+          .to receive(:target_versions)
+          .and_return([version])
         allow(work_package.status)
           .to receive(:is_closed?)
           .and_return(true)
@@ -1728,6 +1730,12 @@ RSpec.describe WorkPackages::BaseContract do
       context "if the current status is closed and the version is closed as well" do
         let(:version) { build_stubbed(:version, status: "closed") }
         let(:current_status) { build_stubbed(:status, is_closed: true) }
+
+        before do
+          allow(work_package)
+            .to receive(:target_versions)
+            .and_return([version])
+        end
 
         it "only allows the current status" do
           expect(contract.assignable_statuses.to_sql)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/COMMS-918/activity

# What are you trying to accomplish?
A validation if the status of a work package can be updated checks if both version and status is closed. If so, it does not allow changing.

This behaviour needs to be updated to work with multiple versions. This PR addresses that by validating if **any** associated version is closed, then it does not allow changing the status.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
