### PR TITLE
Indicate total number of results in paginated MCP responses

### DIFF
--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -228,12 +228,13 @@ module McpTools
     end
 
     def apply_pagination(scope, page)
-      return scope unless self.class.pagination_enabled?
+      total = scope.count
+      return [scope, total] unless self.class.pagination_enabled?
 
       page_number = page || 1
       page_size = self.class.page_size
 
-      scope.offset((page_number - 1) * page_size).limit(page_size)
+      [scope.offset((page_number - 1) * page_size).limit(page_size), total]
     end
   end
 end

--- a/app/services/mcp_tools/search_portfolios.rb
+++ b/app/services/mcp_tools/search_portfolios.rb
@@ -55,10 +55,11 @@ module McpTools
 
     def call(page: nil, **filters)
       filtered = apply_filters(Project.portfolio.visible, filters)
-      portfolios = apply_pagination(filtered, page)
+      portfolios, total = apply_pagination(filtered, page)
 
       {
-        items: portfolios.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
+        items: portfolios.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) },
+        total:
       }
     end
   end

--- a/app/services/mcp_tools/search_programs.rb
+++ b/app/services/mcp_tools/search_programs.rb
@@ -55,10 +55,11 @@ module McpTools
 
     def call(page: nil, **filters)
       filtered = apply_filters(Project.program.visible, filters)
-      programs = apply_pagination(filtered, page)
+      programs, total = apply_pagination(filtered, page)
 
       {
-        items: programs.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
+        items: programs.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) },
+        total:
       }
     end
   end

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -55,10 +55,11 @@ module McpTools
 
     def call(page: nil, **filters)
       filtered = apply_filters(Project.project.visible, filters)
-      projects = apply_pagination(filtered, page)
+      projects, total = apply_pagination(filtered, page)
 
       {
-        items: projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
+        items: projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) },
+        total:
       }
     end
   end

--- a/app/services/mcp_tools/search_users.rb
+++ b/app/services/mcp_tools/search_users.rb
@@ -53,10 +53,11 @@ module McpTools
 
     def call(page: nil, **filters)
       users = apply_filters(User.visible.not_builtin, filters)
-      users = apply_pagination(users, page)
+      users, total = apply_pagination(users, page)
 
       {
-        items: users.map { |user| API::V3::Users::UserRepresenter.create(user, current_user:) }
+        items: users.map { |user| API::V3::Users::UserRepresenter.create(user, current_user:) },
+        total:
       }
     end
   end

--- a/app/services/mcp_tools/search_versions.rb
+++ b/app/services/mcp_tools/search_versions.rb
@@ -57,10 +57,11 @@ module McpTools
 
     def call(page: nil, **filters)
       filtered = apply_filters(Version.visible, filters)
-      versions = apply_pagination(filtered, page)
+      versions, total = apply_pagination(filtered, page)
 
       {
-        items: versions.map { |v| API::V3::Versions::VersionRepresenter.create(v, current_user:) }
+        items: versions.map { |v| API::V3::Versions::VersionRepresenter.create(v, current_user:) },
+        total:
       }
     end
   end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -93,10 +93,11 @@ module McpTools
 
     def call(page: nil, **filters)
       filtered = apply_filters(WorkPackage.visible, filters)
-      work_packages = apply_pagination(filtered, page)
+      work_packages, total = apply_pagination(filtered, page)
 
       {
-        items: work_packages.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) }
+        items: work_packages.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) },
+        total:
       }
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
@@ -130,6 +130,11 @@ RSpec.describe McpTools::SearchPortfolios do
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(portfolio_count)
+      end
+
       context "if another page is requested" do
         let(:call_args) { { name: "Death Star", page: 2 } }
 

--- a/spec/requests/mcp/mcp_tools/search_programs_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_programs_spec.rb
@@ -130,6 +130,11 @@ RSpec.describe McpTools::SearchPrograms do
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(program_count)
+      end
+
       context "if another page is requested" do
         let(:call_args) { { name: "Death Star", page: 2 } }
 

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -129,6 +129,11 @@ RSpec.describe McpTools::SearchProjects do
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(project_count)
+      end
+
       context "if another page is requested" do
         let(:call_args) { { name: "Death Star", page: 2 } }
 

--- a/spec/requests/mcp/mcp_tools/search_users_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_users_spec.rb
@@ -162,6 +162,11 @@ RSpec.describe McpTools::SearchUsers do
         expect(parsed_results.dig("structuredContent", "items").size).to eq(page_size)
       end
 
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(user_count)
+      end
+
       context "if another page is requested" do
         let(:call_args) { { search_term: "Konrad", page: 2 } }
 

--- a/spec/requests/mcp/mcp_tools/search_versions_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_versions_spec.rb
@@ -146,6 +146,11 @@ RSpec.describe McpTools::SearchVersions do
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(version_count)
+      end
+
       context "if another page is requested" do
         let(:call_args) { { name: "beta", page: 2 } }
 

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -298,6 +298,11 @@ RSpec.describe McpTools::SearchWorkPackages do
         expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
       end
 
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(work_packages_count)
+      end
+
       context "if another page is requested" do
         let(:call_args) { { subject: "Stormtrooper", page: 2 } }
 


### PR DESCRIPTION
Making it easier for agents to answer questions like "how many X do exist?"
but also to figure out how many pages need to be requested to completely answer a certain request.

# Ticket
https://community.openproject.org/wp/AI-68