### PR TITLE
[OP-19782] Text search is ignored when transitioning from quick filter to all filters

### DIFF
--- a/app/components/users/index_sub_header_component.html.erb
+++ b/app/components/users/index_sub_header_component.html.erb
@@ -1,5 +1,10 @@
 <%=
-  render(Primer::OpenProject::SubHeader.new(data: sub_header_data_attributes)) do |subheader|
+  render(
+    Primer::OpenProject::SubHeader.new(
+      collapsed_search: collapsed_search?,
+      data: sub_header_data_attributes
+    )
+  ) do |subheader|
     subheader.with_action_button(
       scheme: :primary,
       leading_icon: :plus,

--- a/app/components/users/index_sub_header_component.rb
+++ b/app/components/users/index_sub_header_component.rb
@@ -63,6 +63,10 @@ module Users
       "user-filters-form-clear-button"
     end
 
+    def collapsed_search?
+      filter_input_value.blank?
+    end
+
     def filters_expanded?
       params[:filters].present?
     end

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -42,7 +42,7 @@ interface PrimerTextFieldElement extends HTMLElement {
   inputElement:HTMLInputElement;
 }
 
-interface InternalFilterValue {
+export interface InternalFilterValue {
   name:string;
   operator:string;
   value:string[];
@@ -392,6 +392,13 @@ export default class FiltersFormController extends Controller {
     if (this.liveUpdatesEnabled) {
       this.sendForm();
     }
+  }
+
+  // Serialize the current DOM filter selection in this form's output format,
+  // ignoring anything in except while adding additions.
+  serializedFiltersWith(additions:InternalFilterValue[] = [], { except }:{ except?:string } = {}):string {
+    const filters = this.parseFilters().filter((filter) => filter.name !== except);
+    return this.buildFiltersParam([...filters, ...additions]);
   }
 
   sendForm() {

--- a/frontend/src/stimulus/controllers/dynamic/quick-filter/select-panel.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/quick-filter/select-panel.controller.ts
@@ -31,6 +31,10 @@
 import { Controller } from '@hotwired/stimulus';
 import { visit } from '@hotwired/turbo';
 import type { SelectPanelElement } from '@primer/view-components/app/components/primer/alpha/select_panel_element';
+import type FiltersFormController from '../filter/filters-form.controller';
+import type { InternalFilterValue } from '../filter/filters-form.controller';
+
+type FilterHash = Record<string, { operator:string; values:string[] }>;
 
 export default class SelectPanelQuickFilterController extends Controller {
   static values = {
@@ -44,7 +48,7 @@ export default class SelectPanelQuickFilterController extends Controller {
   declare operatorValue:string;
 
   clear() {
-    visit(this.baseUrlValue);
+    this.visitWith([]);
   }
 
   apply(event:Event) {
@@ -58,14 +62,67 @@ export default class SelectPanelQuickFilterController extends Controller {
       .map((item) => item.value)
       .filter((v):v is string => v != null && v.length > 0);
 
-    const url = new URL(this.baseUrlValue, window.location.origin);
+    this.visitWith(selectedValues);
+  }
 
-    if (selectedValues.length > 0) {
-      const filters = JSON.parse(url.searchParams.get('filters') ?? '[]') as unknown[];
-      filters.push({ [this.filterKeyValue]: { operator: this.operatorValue, values: selectedValues } });
-      url.searchParams.set('filters', JSON.stringify(filters));
+  private visitWith(selectedValues:string[]) {
+    const params = new URLSearchParams(window.location.search);
+    params.delete('page');
+
+    const filters = this.serializedFilters(selectedValues);
+    if (filters) {
+      params.set('filters', filters);
+    } else {
+      params.delete('filters');
     }
 
-    visit(url.toString());
+    const { pathname } = new URL(this.baseUrlValue, window.location.origin);
+    visit(`${pathname}?${params.toString()}`);
+  }
+
+  // The filters form is the single source of truth for the current filter state
+  // (its DOM always reflects both the committed and pending input from the user).
+  // We serialize it as it's the correct state to look for.
+  private serializedFilters(selectedValues:string[]):string {
+    const additions:InternalFilterValue[] = selectedValues.length > 0
+      ? [{ name: this.filterKeyValue, operator: this.operatorValue, value: selectedValues }]
+      : [];
+
+    const form = this.filtersForm;
+    if (form) {
+      return form.serializedFiltersWith(additions, { except: this.filterKeyValue });
+    }
+
+    return this.fallbackSerializedFilters(additions);
+  }
+
+  private get filtersForm():FiltersFormController|null {
+    const root = this.element.closest<HTMLElement>('[data-controller~="filter--filters-form"]');
+    if (!root) {
+      return null;
+    }
+
+    return this.application
+      .getControllerForElementAndIdentifier(root, 'filter--filters-form') as FiltersFormController|null;
+  }
+
+  // When the panel is not found in the form, we try to add the current state back to
+  // the filter URL we're building to ensure they are not dropped.
+  private fallbackSerializedFilters(additions:InternalFilterValue[]):string {
+    const raw = new URL(window.location.href).searchParams.get('filters');
+    let current:FilterHash[] = [];
+    if (raw) {
+      try {
+        current = (JSON.parse(raw) as FilterHash[])
+          .filter((filter) => Object.keys(filter)[0] !== this.filterKeyValue);
+      } catch {
+        console.error('Failed to parse JSON filter set from URL params');
+      }
+    }
+
+    const added = additions.map((f) => ({ [f.name]: { operator: f.operator, values: f.value } }));
+    const filters = [...current, ...added];
+
+    return filters.length > 0 ? JSON.stringify(filters) : '';
   }
 }

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -88,6 +88,38 @@ RSpec.describe "index users", :js do
       index_page.expect_listed(alice)
       index_page.expect_not_listed(current_user, bob)
     end
+
+    it "preserves the name search when applying a quick filter" do
+      index_page.visit!
+      index_page.expect_listed(current_user, alice, bob)
+
+      index_page.filter_by_name("Alice")
+      index_page.expect_listed(alice)
+
+      index_page.quick_filter_by_group("My group")
+
+      index_page.expect_listed(alice)
+      index_page.expect_not_listed(current_user, bob)
+      # Search stays visibly expanded when a name filter is present after the reload.
+      expect(page).to have_field("Search", with: "Alice")
+    end
+
+    it "preserves the name search when clearing a quick filter" do
+      index_page.visit!
+
+      index_page.filter_by_name("Alice")
+      index_page.expect_listed(alice)
+
+      index_page.quick_filter_by_group("My group")
+      index_page.expect_listed(alice)
+
+      index_page.clear_quick_filter_group
+
+      # The group filter is gone but the name search still applies (and stays visible).
+      index_page.expect_listed(alice)
+      index_page.expect_not_listed(current_user, bob)
+      expect(page).to have_field("Search", with: "Alice")
+    end
   end
 
   describe "with some sortable users" do

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -122,6 +122,18 @@ module Pages
           wait_for_network_idle
         end
 
+        def clear_quick_filter_group
+          within("[data-quick-filter--select-panel-filter-key-value='group']") do
+            click_button "Group"
+
+            within("select-panel") do
+              click_button "Clear"
+            end
+          end
+
+          wait_for_network_idle
+        end
+
         def expect_group_filter(value)
           open_filter_panel
 


### PR DESCRIPTION
Respect the filter value in params and keep the input open in that case

https://community.openproject.org/wp/OP-19782
