### PR TITLE
[OP-19809] Make Project#members return all principals, not users

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -55,20 +55,19 @@ class Project < ApplicationRecord
     portfolio: %i[]
   }.with_indifferent_access
 
-  has_many :members, -> {
-    # TODO: check whether this should
-    # remain to be limited to User only
+  # rubocop:disable Rails/HasManyOrHasOneDependent, Rails/InverseOf
+  has_many :members, -> { not_locked }
+
+  has_many :member_users, -> {
     includes(:principal, :roles)
       .merge(Principal.not_locked.user)
       .references(:principal, :roles)
-  }
+  }, class_name: "Member"
+  # rubocop:enable Rails/HasManyOrHasOneDependent, Rails/InverseOf
 
   has_many :memberships, class_name: "Member"
-  has_many :member_principals,
-           -> { not_locked },
-           class_name: "Member"
-  has_many :users, through: :members, source: :principal
-  has_many :principals, through: :member_principals, source: :principal
+  has_many :users, through: :member_users, source: :principal
+  has_many :principals, through: :members, source: :principal
   has_many :calculated_value_errors, dependent: :delete_all, as: :customized
 
   has_many :enabled_modules, dependent: :delete_all, after_remove: :module_disabled

--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -51,13 +51,13 @@ module Projects::Concerns
     # based on the setting ('new_project_user_role_id')
     # defined in the administration. Will either create a new membership
     # or add a role to an already existing one.
-    def set_default_role(new_project)
+    def set_default_role(new_project) # rubocop:disable Metrics/AbcSize
       role = ProjectRole.in_new_project
 
       return unless role && new_project.persisted?
 
       # Assuming the members are loaded anyway
-      user_member = new_project.members.detect { |m| m.principal == user }
+      user_member = new_project.member_users.detect { |m| m.principal == user }
 
       if user_member
         Members::UpdateService

--- a/app/services/projects/manage_memberships_from_custom_fields_service.rb
+++ b/app/services/projects/manage_memberships_from_custom_fields_service.rb
@@ -62,7 +62,7 @@ module Projects
     end
 
     def add_member_or_add_role_to_member(add_user) # rubocop:disable Metrics/AbcSize
-      user_member = project.member_principals.find_by(principal: add_user)
+      user_member = project.members.find_by(principal: add_user)
 
       if user_member
         new_role_ids = (user_member.role_ids + [custom_field.role.id]).uniq
@@ -78,7 +78,7 @@ module Projects
     end
 
     def remove_member_or_remove_role_from_member(remove_user)
-      user_member = project.member_principals.find_by(principal: remove_user)
+      user_member = project.members.find_by(principal: remove_user)
 
       return unless user_member
 

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do
       end
 
       it "removes the membership" do
-        expect(project.members.count).to eq 2
+        expect(project.member_users.count).to eq 2
         expect(project.users).to contain_exactly user_aa729, user_cc414
 
         subject
@@ -327,7 +327,7 @@ RSpec.describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do
         expect(group_foo.users).to eq([user_aa729])
         expect(synced_foo.users.pluck(:user_id)).to eq([user_aa729.id])
 
-        expect(project.members.count).to eq 1
+        expect(project.member_users.count).to eq 1
         expect(project.users).to contain_exactly user_aa729
       end
     end

--- a/spec/features/groups/group_memberships_spec.rb
+++ b/spec/features/groups/group_memberships_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "group memberships through groups page", :js do
       expect(members_page2).to have_user "Peter Pan", roles: [manager, developer]
       expect(members_page2).to have_user "Hannibal Smith", roles: [developer]
 
-      group_member = project2.member_principals.find_by(user_id: group.id)
+      group_member = project2.members.find_by(user_id: group.id)
       expect(group_member.member_roles.count).to eq 1
       group_member_role = group_member.member_roles.first
       expect(group_member_role.role).to eq developer

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Invite user modal", :js do
       assignee_field.expect_inactive!
       assignee_field.expect_display_value added_principal.name
 
-      new_member = project.reload.member_principals.find_by(user_id: added_principal.id)
+      new_member = project.reload.members.find_by(user_id: added_principal.id)
       expect(new_member).to be_present
       expect(new_member.roles).to eq [role]
 

--- a/spec/features/users/invite_user_modal/subproject_invite_spec.rb
+++ b/spec/features/users/invite_user_modal/subproject_invite_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Invite user modal subprojects", :js do
       assignee_field.expect_inactive!
       assignee_field.expect_display_value invitable_user.name
 
-      new_member = subproject.reload.member_principals.find_by(user_id: invitable_user.id)
+      new_member = subproject.reload.members.find_by(user_id: invitable_user.id)
       expect(new_member).to be_present
       expect(new_member.roles).to eq [role]
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -229,12 +229,46 @@ RSpec.describe Project do
     let(:active_user) { create(:user) }
     let!(:active_member) { create(:member, project:, user: active_user, roles: [role]) }
 
+    let(:group) { create(:group) }
+    let!(:group_member) { create(:member, project:, principal: group, roles: [role]) }
+
     let(:inactive_user) { create(:user, status: Principal.statuses[:locked]) }
     let!(:inactive_member) { create(:member, project:, user: inactive_user, roles: [role]) }
 
-    it "only includes active members" do
+    it "includes active members of any principal type but excludes locked ones" do
       expect(project.members)
+        .to contain_exactly(active_member, group_member)
+    end
+  end
+
+  describe "#member_users" do
+    let(:role) { create(:project_role) }
+    let(:active_user) { create(:user) }
+    let!(:active_member) { create(:member, project:, user: active_user, roles: [role]) }
+
+    let(:group) { create(:group) }
+    let!(:group_member) { create(:member, project:, principal: group, roles: [role]) }
+
+    let(:inactive_user) { create(:user, status: Principal.statuses[:locked]) }
+    let!(:inactive_member) { create(:member, project:, user: inactive_user, roles: [role]) }
+
+    it "only includes active user members, excluding groups" do
+      expect(project.member_users)
         .to eq [active_member]
+    end
+  end
+
+  describe "#principals" do
+    let(:role) { create(:project_role) }
+    let(:active_user) { create(:user) }
+    let!(:active_member) { create(:member, project:, user: active_user, roles: [role]) }
+
+    let(:group) { create(:group) }
+    let!(:group_member) { create(:member, project:, principal: group, roles: [role]) }
+
+    it "includes principals of any member type" do
+      expect(project.principals)
+        .to contain_exactly(active_user, group)
     end
   end
 

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -582,11 +582,11 @@ RSpec.describe(
           expect(source.users).to include current_user
           expect(source.users).to include user
           expect(project_copy.groups).to include group
-          expect(source.member_principals.count).to eq 3
+          expect(source.members.count).to eq 3
 
           expect(subject).to be_success
 
-          expect(project_copy.member_principals.count).to eq 3
+          expect(project_copy.members.count).to eq 3
           expect(project_copy.groups).to include group
           expect(project_copy.users).to include current_user
           expect(project_copy.users).to include user
@@ -1345,11 +1345,11 @@ RSpec.describe(
           expect(source.users).to include current_user
           expect(source.users).to include user
           expect(project_copy.groups).to be_empty
-          expect(source.member_principals.count).to eq 4
+          expect(source.members.count).to eq 4
 
           expect(subject).to be_success
 
-          expect(project_copy.member_principals.count).to eq 1
+          expect(project_copy.members.count).to eq 1
           expect(project_copy.groups).to be_empty
           expect(project_copy.users).to contain_exactly current_user
 

--- a/spec/services/projects/manage_memberships_from_custom_fields_service_spec.rb
+++ b/spec/services/projects/manage_memberships_from_custom_fields_service_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "adds the user as a member to the project with the role from the custom field" do
         expect do
           subject
-        end.to change { project.member_principals.count }.by(1)
+        end.to change { project.members.count }.by(1)
 
-        membership = project.member_principals.find_by(principal: user1)
+        membership = project.members.find_by(principal: user1)
         expect(membership).to be_present
         expect(membership.roles).to contain_exactly(custom_field.role)
       end
@@ -89,9 +89,9 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "adds the placeholder user as a member to the project with the role from the custom field" do
         expect do
           subject
-        end.to change { project.member_principals.count }.by(1)
+        end.to change { project.members.count }.by(1)
 
-        membership = project.member_principals.find_by(principal: placeholder_user)
+        membership = project.members.find_by(principal: placeholder_user)
         expect(membership).to be_present
         expect(membership.roles).to contain_exactly(custom_field.role)
       end
@@ -104,7 +104,7 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "does not change the project membership, and also shows no error" do
         expect do
           subject
-        end.not_to change { project.member_principals.count }
+        end.not_to change { project.members.count }
       end
     end
   end
@@ -121,9 +121,9 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "adds the role to the membership, but does not create a new one" do
         expect do
           subject
-        end.not_to change { project.member_principals.count }
+        end.not_to change { project.members.count }
 
-        membership = project.member_principals.find_by(principal: user1)
+        membership = project.members.find_by(principal: user1)
         expect(membership).to be_present
         expect(membership.roles).to contain_exactly(custom_field.role, other_role)
       end
@@ -137,9 +137,9 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "removes the role from the membership but keeps the membership" do
         expect do
           subject
-        end.not_to change { project.member_principals.count }
+        end.not_to change { project.members.count }
 
-        membership = project.member_principals.find_by(principal: user1)
+        membership = project.members.find_by(principal: user1)
         expect(membership).to be_present
         expect(membership.roles).to contain_exactly(other_role)
       end
@@ -156,9 +156,9 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "does not change the project membership but also does not return an error" do
         expect do
           subject
-        end.not_to change { project.member_principals.count }
+        end.not_to change { project.members.count }
 
-        membership = project.member_principals.find_by(principal: user1)
+        membership = project.members.find_by(principal: user1)
         expect(membership).to be_present
         expect(membership.roles).to contain_exactly(custom_field.role)
       end
@@ -171,9 +171,9 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       it "removes the membership from the project" do
         expect do
           subject
-        end.to change { project.member_principals.count }.by(-1)
+        end.to change { project.members.count }.by(-1)
 
-        membership = project.member_principals.find_by(principal: user1)
+        membership = project.members.find_by(principal: user1)
         expect(membership).to be_nil
       end
     end
@@ -194,26 +194,26 @@ RSpec.describe Projects::ManageMembershipsFromCustomFieldsService, type: :model 
       subject
 
       # user 1 is added as a new member
-      membership1 = project.member_principals.find_by(principal: user1)
+      membership1 = project.members.find_by(principal: user1)
       expect(membership1).to be_present
       expect(membership1.roles).to contain_exactly(custom_field.role)
 
       # user 2 gets one role removed but is still a member due to other roles
-      membership2 = project.member_principals.find_by(principal: user2)
+      membership2 = project.members.find_by(principal: user2)
       expect(membership2).to be_present
       expect(membership2.roles).to contain_exactly(other_role)
 
       # user 3 remains unchanged
-      membership3 = project.member_principals.find_by(principal: user3)
+      membership3 = project.members.find_by(principal: user3)
       expect(membership3).to be_present
       expect(membership3.roles).to contain_exactly(custom_field.role)
 
       # user 4 is removed entirely
-      membership4 = project.member_principals.find_by(principal: user4)
+      membership4 = project.members.find_by(principal: user4)
       expect(membership4).to be_nil
 
       # user 5 gets the role added
-      membership5 = project.member_principals.find_by(principal: user5)
+      membership5 = project.members.find_by(principal: user5)
       expect(membership5).to be_present
       expect(membership5.roles).to contain_exactly(other_role, custom_field.role)
     end

--- a/spec/services/reports/principal_rows_spec.rb
+++ b/spec/services/reports/principal_rows_spec.rb
@@ -28,24 +28,31 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Reports::AuthorReport < Reports::Report
-  def self.report_type
-    "author"
+require "spec_helper"
+
+# Assignee and responsible can both be groups (see Principals::Scopes::PossibleAssignee),
+# so their reports list group members. Authors are always users, so the author report does not.
+RSpec.describe "Reports principal rows", type: :model do
+  shared_let(:project) { create(:project) }
+  shared_let(:role) { create(:project_role) }
+  shared_let(:user) { create(:user, member_with_roles: { project => role }) }
+  shared_let(:group) { create(:group, member_with_roles: { project => role }) }
+
+  describe Reports::AssigneeReport do
+    it "includes group members" do
+      expect(described_class.new(project).rows).to contain_exactly(user, group)
+    end
   end
 
-  def field
-    "author_id"
+  describe Reports::ResponsibleReport do
+    it "includes group members" do
+      expect(described_class.new(project).rows).to contain_exactly(user, group)
+    end
   end
 
-  def rows
-    @rows ||= @project.member_users.map(&:principal).sort
-  end
-
-  def data
-    @data ||= WorkPackage.by_author(@project)
-  end
-
-  def title
-    @title ||= WorkPackage.human_attribute_name(:author)
+  describe Reports::AuthorReport do
+    it "excludes groups, listing only user members" do
+      expect(described_class.new(project).rows).to contain_exactly(user)
+    end
   end
 end


### PR DESCRIPTION
Added new specs to confirm the behavior is unchanged for previous callers of the user-specific association. This possibly fixes a bug in the assignee report, which allows groups to be assigned, but was only returning users.

https://community.openproject.org/projects/OP/work_packages/OP-19809
