### PR TITLE
[FND-152] Form configuration wizard step (and fix disabled color field submitting)

### DIFF
--- a/app/components/work_package_types/wizard/sidebar_component.html.erb
+++ b/app/components/work_package_types/wizard/sidebar_component.html.erb
@@ -1,6 +1,6 @@
 <%= flex_layout do |list| %>
   <% steps.each do |step| %>
-    <% list.with_row(mb: 2) do %>
+    <% list.with_row(mb: 2, test_selector: "wizard-step-#{step}") do %>
       <%= flex_layout(align_items: :center) do |row| %>
         <% row.with_column(mr: 2) do %>
           <%= render(Primer::Beta::Octicon.new(icon: leading_icon(step), color: current?(step) ? :accent : :muted)) %>

--- a/lib/primer/open_project/forms/color_select.html.erb
+++ b/lib/primer/open_project/forms/color_select.html.erb
@@ -1,6 +1,6 @@
 <%= render(FormControl.new(input: @input)) do %>
   <%= content_tag(:div, **@field_wrap_arguments) do %>
-    <%= builder.hidden_field :color_id %>
+    <%= builder.hidden_field :color_id, disabled: @input.disabled? %>
     <%= angular_component_tag(
           "opce-colors-autocompleter",
           class: "colors-autocomplete form--select-container",

--- a/spec/components/work_package_types/wizard/page_component_spec.rb
+++ b/spec/components/work_package_types/wizard/page_component_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe WorkPackageTypes::Wizard::PageComponent, type: :component, with_f
     expect(page).to have_text("Phase")
   end
 
+  describe "sidebar step markers" do
+    it "distinguishes completed, current, and pending steps" do
+      render_inline(described_class.new(type:, current_step: :defaults))
+
+      expect(find_test_selector("wizard-step-details")).to have_css(".octicon-check-circle-fill")
+      expect(find_test_selector("wizard-step-defaults")).to have_css(".octicon-dot-fill")
+      expect(find_test_selector("wizard-step-workflows")).to have_css(".octicon-circle")
+    end
+  end
+
   describe "breadcrumbs" do
     it "links the parent the variant is being created under" do
       render_inline(described_class.new(type: build(:type, parent:), current_step: :details))

--- a/spec/features/types/creation_wizard_spec.rb
+++ b/spec/features/types/creation_wizard_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Variant creation wizard", :js, with_flag: { type_variants: true } do
   shared_let(:admin) { create(:admin) }
-  shared_let(:bug_type) { create(:type, name: "Bug") }
+  shared_let(:bug_type) { create(:type, name: "Bug", color: create(:color)) }
 
   before { login_as(admin) }
 

--- a/spec/features/types/creation_wizard_spec.rb
+++ b/spec/features/types/creation_wizard_spec.rb
@@ -50,9 +50,20 @@ RSpec.describe "Variant creation wizard", :js, with_flag: { type_variants: true 
     )
   end
 
+  # There is no flash message; a step's sidebar marker turning into a success check is
+  # what tells us its submission was accepted. Asserting the completed step's own state
+  # (rather than the next step's content) keeps the specs correct if the order changes.
+  def expect_step_saved(step)
+    within_test_selector("wizard-step-#{step}") do
+      expect(page).to have_css(".octicon-check-circle-fill")
+    end
+  end
+
   def complete_details_step(name)
     fill_in Type.human_attribute_name(:name), with: name
     click_on I18n.t(:button_continue)
+
+    expect_step_saved(:details)
 
     bug_type.children.find_by(name:).tap { |variant| expect(variant).to be_present }
   end
@@ -72,14 +83,32 @@ RSpec.describe "Variant creation wizard", :js, with_flag: { type_variants: true 
     # the footer, not a Save button, drives submission.
     expect(page).to have_text(I18n.t("types.edit.defaults.description.label"))
     expect(page).to have_no_button(I18n.t(:button_save))
+    click_on I18n.t(:button_continue)
 
-    click_on I18n.t(:button_continue) # Defaults -> Form configuration
-    click_on I18n.t(:button_continue) # -> Workflows
-    click_on I18n.t(:button_continue) # -> Automations
-    click_on I18n.t(:button_continue) # -> Projects
-    click_on I18n.t(:button_continue) # -> PDF generation
+    # Step 3 - Form configuration: independent on creation,
+    # so it renders the whole form and the footer drives submission.
+    expect(page).to have_heading("Form configuration") # the main content, not the sidebar entry
+    expect(page).to have_text("Independent mode")
+    expect(page).to have_text("Inactive attributes")
+    click_on I18n.t(:button_continue)
+    expect_step_saved(:form_configuration)
+
+    # Step 4 - Workflow
+    click_on I18n.t(:button_continue)
+    expect_step_saved(:workflows)
+
+    # Step 5 - Automations
+    click_on I18n.t(:button_continue)
+    expect_step_saved(:automations)
+
+    # Step 6 - Projects
+    click_on I18n.t(:button_continue)
+    expect_step_saved(:projects)
+
+    # Step 7 - PDF generation
     click_on I18n.t("types.creation_wizard.finish")
 
+    expect_flash(message: "Variant created successfully.")
     expect(page).to have_current_path(types_path)
     expect(variant.reload.parent).to eq(bug_type)
   end
@@ -96,6 +125,7 @@ RSpec.describe "Variant creation wizard", :js, with_flag: { type_variants: true 
     check Type.human_attribute_name(:is_milestone)
     click_on I18n.t(:button_continue)
 
+    expect_step_saved(:details)
     expect(Type.find_by(name: "Incident")).to have_attributes(parent: nil, is_milestone: true)
   end
 
@@ -110,6 +140,7 @@ RSpec.describe "Variant creation wizard", :js, with_flag: { type_variants: true 
     Components::WysiwygEditor.new.set_markdown("Reproduce the bug first")
     click_on I18n.t(:button_continue)
 
+    expect_step_saved(:defaults)
     expect(variant.reload.description).to eq("Reproduce the bug first")
   end
 

--- a/spec/lib/primer/open_project/forms/color_select_spec.rb
+++ b/spec/lib/primer/open_project/forms/color_select_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Primer::OpenProject::Forms::ColorSelect, type: :forms do
+  include_context "with rendered inline form"
+
+  let(:model) { build_stubbed(:status) }
+  let(:hidden_color_field) { "input[type=hidden][name='status[color_id]']" }
+
+  def render_color_select(**)
+    vc_render_inline_form do |form|
+      form.color_select_list(name: :color_id, label: "Color", **)
+    end
+  end
+
+  it "submits the color through an enabled hidden field" do
+    render_color_select
+
+    expect(page).to have_css("#{hidden_color_field}:not([disabled])", visible: :all)
+  end
+
+  it "disables the hidden field when the input is disabled, so no color is submitted" do
+    render_color_select(disabled: true)
+
+    expect(page).to have_css("#{hidden_color_field}[disabled]", visible: :all)
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/FND-152

# What are you trying to accomplish?

- Add feature-spec coverage for the variant creation wizard's form-configuration step (FND-152) — asserts it renders in independent mode with the full editor.
- Fix a bug surfaced while testing: creating a variant of a type that **has a color** failed on the Details step with *"Color was attempted to be written but is not writable."*

# What approach did you choose and why?

Changes:

- `color_select.html.erb`: disable the hidden `color_id` input when the field is disabled, so an inherited (read-only) color is no longer submitted.
- Wizard specs: wait on each step's sidebar success marker (the only "saved" signal — there is no flash) instead of reading the DB right after an async submit; walk the full step sequence.
- Sidebar: per-step `test_selector` + a component spec pinning the completed/current/pending markers.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox)
