### PR TITLE
Revert `BorderBoxListComponent` header action label API change

### DIFF
--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -139,23 +139,6 @@
     // Unfortunately, the invisible button style bites us here again.
     margin-top: -6px
 
-  &--actions
-    display: flex
-    align-items: center
-    gap: var(--stack-gap-condensed)
-
-    // A label-only area pins to the track end. It keeps the base flex-start
-    // anchor (not the -6px button nudge) so the label's centre lands on the
-    // same line as the adjacent kebab glyph, independent of the row height.
-    &:not(:has(.Button))
-      justify-self: end
-      margin-top: 0
-
-      // An informational label has no room next to the title on a phone, so it
-      // is dropped there. Action buttons stay, as they are functional.
-      @media screen and (max-width: $breakpoint-sm)
-        display: none
-
   &--heading-line
     display: flex
     align-items: center

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -89,19 +89,9 @@ module OpenProject
         #   # @return [ViewComponent::Slot]
         #   def with_action_button(**system_arguments, &block)
         #   end
-        #
-        #   # Adds a label to the header actions area.
-        #   #
-        #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Label`.
-        #   # @return [ViewComponent::Slot]
-        #   def with_action_label(**system_arguments, &block)
-        #   end
         renders_many :actions, types: {
           button: ->(scheme: DEFAULT_ACTION_SCHEME, **system_arguments) do
             Primer::Beta::Button.new(scheme:, **system_arguments)
-          end,
-          label: ->(**system_arguments) do
-            Primer::Beta::Label.new(**system_arguments)
           end
         }
 

--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -45,8 +45,10 @@ See COPYRIGHT and LICENSE files for more details.
               <% if root.children.any? %>
                 <%= render(Primer::Beta::Text.new(tag: :span, font_weight: :semibold, ml: 2)) { variants_count_label(root) } %>
               <% end %>
+              <% if (label = default_label(root)) %>
+                <%= render(Primer::Beta::Label.new(scheme: label[:scheme], ml: 2)) { label[:text] } %>
+              <% end %>
             <% end %>
-            <% add_default_label(header, root) %>
             <% header.with_menu do |menu| %>
               <% type_actions(menu, root) %>
             <% end %>

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -55,13 +55,11 @@ module WorkPackageTypes
 
       # A default variant is only visible once the group is expanded, so the
       # collapsed header names it instead.
-      def add_default_label(header, root)
+      def default_label(root)
         if root.is_default?
-          header.with_action_label { t("types.index.enabled_in_new_projects") }
+          { scheme: :default, text: t("types.index.enabled_in_new_projects") }
         elsif (variant = default_variant(root))
-          header.with_action_label(scheme: :secondary) do
-            t("types.index.variant_enabled_in_new_projects", name: variant.own_name)
-          end
+          { scheme: :secondary, text: t("types.index.variant_enabled_in_new_projects", name: variant.own_name) }
         end
       end
 

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -216,51 +216,6 @@ module OpenProject
         end
       end
 
-      # @label With header action label
-      # Header action area holding a status label, optionally next to an action button.
-      # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
-      # @param with_action_button toggle
-      # @param padding [Symbol] select [default, condensed, spacious]
-      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
-      def with_header_action_label(
-        label_scheme: :default,
-        with_action_button: false,
-        padding: :default,
-        header_padding: :inherit
-      )
-        render_action_label_list(
-          container: "border-box-list-header-action-label-preview",
-          label_scheme:,
-          with_action_button:,
-          padding:,
-          header_padding:,
-          collapsible: false
-        )
-      end
-
-      # @label With collapsible header action label
-      # The collapsible header renders through its own heading markup, so the action
-      # label alignment is worth checking separately.
-      # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
-      # @param with_action_button toggle
-      # @param padding [Symbol] select [default, condensed, spacious]
-      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
-      def with_collapsible_header_action_label(
-        label_scheme: :default,
-        with_action_button: false,
-        padding: :default,
-        header_padding: :inherit
-      )
-        render_action_label_list(
-          container: "border-box-list-collapsible-header-action-label-preview",
-          label_scheme:,
-          with_action_button:,
-          padding:,
-          header_padding:,
-          collapsible: true
-        )
-      end
-
       # @label With header drag handle
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
@@ -280,34 +235,6 @@ module OpenProject
       end
 
       private
-
-      def render_action_label_list(container:, label_scheme:, with_action_button:, padding:, header_padding:,
-                                   collapsible:)
-        render OpenProject::Common::BorderBoxListComponent.new(
-          container:,
-          padding:,
-          header_padding:,
-          collapsible:
-        ) do |list|
-          list.with_header(title: "Bug", count: true) do |header|
-            header.with_action_label(scheme: label_scheme) { "Default" }
-            if boolean_preview_param(with_action_button)
-              header.with_action_button do |button|
-                button.with_leading_visual_icon(icon: :pencil)
-                "Edit"
-              end
-            end
-            header.with_menu(button_aria_label: "Type actions") do |menu|
-              menu.with_item(label: "Configure") do |menu_item|
-                menu_item.with_leading_visual_icon(icon: :gear)
-              end
-            end
-          end
-
-          list.with_item { "Agile bug" }
-          list.with_item { "API bug" }
-        end
-      end
 
       def preview_count(count)
         case count.to_sym

--- a/spec/components/open_project/common/border_box_list_component_preview_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_preview_spec.rb
@@ -98,29 +98,4 @@ RSpec.describe OpenProject::Common::BorderBoxListComponentPreview, type: :compon
 
     expect(page).to have_css(".Box.Box--condensed.op-border-box-list_header-padding-default")
   end
-
-  it "renders the header action label preview" do
-    render_preview(:with_header_action_label, from: described_class)
-
-    expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
-    expect(page).to have_no_css(".op-border-box-list-header--actions .Button")
-  end
-
-  it "renders the header action label preview alongside an action button" do
-    render_preview(
-      :with_header_action_label,
-      from: described_class,
-      params: { with_action_button: true }
-    )
-
-    expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
-    expect(page).to have_css(".op-border-box-list-header--actions .Button", text: "Edit")
-  end
-
-  it "renders the collapsible header action label preview" do
-    render_preview(:with_collapsible_header_action_label, from: described_class)
-
-    expect(page).to have_css(".op-border-box-list-header_collapsible")
-    expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
-  end
 end


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Removes the label action type that PR #24399 added to the shared BorderBoxListComponent header, pending further internal discussion, along with its Sass, Lookbook previews, and preview specs. The types index now renders its default badge inline in the header title slot, matching the variant-row label pattern.

This partially reverts commit ee368c3b4a347800bdeb9143799691b16ff8cab2.

## Screenshots

| Before | After |
|--------|--------|
| <img width="990" height="1164" alt="Screenshot 2026-07-23 at 14 46 31" src="https://github.com/user-attachments/assets/3f3176e1-c47c-4633-b2a5-504079f19bad" /> | <img width="991" height="1164" alt="Screenshot 2026-07-23 at 14 47 39" src="https://github.com/user-attachments/assets/31a136f5-2d32-4734-a524-e97280a3bb71" /> | 

# What approach did you choose and why?

This is a temporary visual change to help unblock #23812


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
