### PR TITLE
[SPPM-311] Add sprints to the timeline view

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -98,7 +98,7 @@
     color: var(--fgColor-default)
     font-size: var(--text-body-size-small)
     font-weight: var(--base-text-weight-semibold)
-    cursor: pointer
+    cursor: default
     padding: 0 var(--base-size-6)
 
   // Milestones: diamond shape via CSS rotate on the vis-dot
@@ -113,3 +113,17 @@
     border-width: 0
     border-radius: 0
     rotate: 45deg
+
+  .op-timeline-sprint-icon
+    color: var(--fgColor-accent)
+
+  // Sprints
+  .vis-item.vis-range.op-timeline-sprint
+    background-color: var(--bgColor-accent-muted)
+    color: var(--fgColor-accent)
+    border: 1px solid var(--borderColor-accent-muted)
+
+    &.op-timeline-sprint--active
+      background-color: var(--bgColor-accent-emphasis)
+      color: var(--fgColor-onEmphasis)
+      border-color: var(--bgColor-accent-emphasis)

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -41,6 +41,7 @@ describe('ProjectTimelineGraphComponent', () => {
         'js.grid.widgets.project_timeline.tooltip_type_phase': 'Phase',
         'js.grid.widgets.project_timeline.tooltip_type_gate': 'Gate',
         'js.grid.widgets.project_timeline.tooltip_type_milestone': 'Milestone',
+        'js.grid.widgets.project_timeline.tooltip_type_sprint': 'Sprint',
         'js.grid.widgets.project_timeline.accessible_phase': `Phase ${options.name}: ${options.date}`,
         'js.grid.widgets.project_timeline.accessible_gate': `Phase gate ${options.name}: ${options.date}`,
         'js.grid.widgets.project_timeline.accessible_date_range': `${options.start} to ${options.end}`,
@@ -105,13 +106,23 @@ describe('ProjectTimelineGraphComponent', () => {
     subject: 'Launch',
     date: '2024-06-30',
     typeId: 7,
+    row: 0,
+  };
+
+  const sprint = {
+    id: 20,
+    name: 'Sprint 1',
+    startDate: '2024-01-01',
+    endDate: '2024-01-14',
+    status: 'active',
+    row: 0,
   };
 
   let fixture:ComponentFixture<ProjectTimelineGraphComponent>;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let component:ProjectTimelineGraphComponent;
 
-  let buildData:(phases:unknown[], milestones:unknown[]) => { items:ProjectTimelineItem[]; groups:{ id:string; content:string }[] };
+  let buildData:(phases:unknown[], milestones:unknown[], sprints:unknown[]) => { items:ProjectTimelineItem[]; groups:{ id:string; content:string }[] };
   let tooltipTemplate:(item:ProjectTimelineItem) => HTMLElement|string;
   let buildAccessibleItems:(phases:unknown[]) => { id:string; text:string }[];
 
@@ -144,7 +155,7 @@ describe('ProjectTimelineGraphComponent', () => {
 
   describe('buildData', () => {
     it('creates a range item for a phase with dates', () => {
-      const { items } = buildData([phaseWithDates], []);
+      const { items } = buildData([phaseWithDates], [], []);
       const item = items.find((i) => i.id === 'phase-1');
 
       expect(item).toBeDefined();
@@ -157,12 +168,12 @@ describe('ProjectTimelineGraphComponent', () => {
     });
 
     it('skips a phase without dates', () => {
-      const { items } = buildData([phaseWithoutDates], []);
+      const { items } = buildData([phaseWithoutDates], [], []);
       expect(items.find((i) => i.id === 'phase-3')).toBeUndefined();
     });
 
     it('creates start and finish gate items when configured', () => {
-      const { items } = buildData([phaseWithGates], []);
+      const { items } = buildData([phaseWithGates], [], []);
 
       const startGate = items.find((i) => i.id === 'gate-start-2');
       expect(startGate).toBeDefined();
@@ -180,7 +191,7 @@ describe('ProjectTimelineGraphComponent', () => {
     });
 
     it('does not create gate items when gates are disabled', () => {
-      const { items } = buildData([phaseWithDates], []);
+      const { items } = buildData([phaseWithDates], [], []);
       expect(items.find((i) => i.id === 'gate-start-1')).toBeUndefined();
       expect(items.find((i) => i.id === 'gate-finish-1')).toBeUndefined();
     });
@@ -189,7 +200,7 @@ describe('ProjectTimelineGraphComponent', () => {
       let item:ProjectTimelineItem;
 
       beforeEach(() => {
-        ({ items: [item] } = buildData([oneDayPhase], []));
+        ({ items: [item] } = buildData([oneDayPhase], [], []));
       });
 
       it('creates a range item', () => {
@@ -217,7 +228,7 @@ describe('ProjectTimelineGraphComponent', () => {
     });
 
     it('creates a milestone item', () => {
-      const { items } = buildData([], [milestone]);
+      const { items } = buildData([], [milestone], []);
       const item = items.find((i) => i.id === 'milestone-10');
 
       expect(item).toBeDefined();
@@ -229,9 +240,30 @@ describe('ProjectTimelineGraphComponent', () => {
       expect(item!.itemType).toBe('milestone');
     });
 
-    it('always creates gates, lifecycle, and milestones groups', () => {
-      const { groups } = buildData([], []);
-      expect(groups.map((g) => g.id)).toEqual(['gates', 'phases', 'milestones']);
+    it('creates a sprint item', () => {
+      const { items } = buildData([], [], [sprint]);
+      const item = items.find((i) => i.id === 'sprint-20');
+
+      expect(item).toBeDefined();
+      expect(item!.type).toBe('range');
+      expect(item!.group).toBe('sprints');
+      expect(item!.start).toBe('2024-01-01');
+      expect(item!.end).toBe('2024-01-14');
+      expect(item!.content).toBe('Sprint 1');
+      expect(item!.className).toContain('op-timeline-sprint');
+      expect(item!.className).toContain('op-timeline-sprint--active');
+      expect(item!.itemType).toBe('sprint');
+    });
+
+    it('does not add the active class for non-active sprints', () => {
+      const { items } = buildData([], [], [{ ...sprint, status: 'in_planning' }]);
+      const item = items.find((i) => i.id === 'sprint-20');
+      expect(item!.className).not.toContain('op-timeline-sprint--active');
+    });
+
+    it('always creates gates, phases, milestones, and sprints groups', () => {
+      const { groups } = buildData([], [], []);
+      expect(groups.map((g) => g.id)).toEqual(['gates', 'phases', 'milestones', 'sprints']);
     });
   });
 
@@ -249,8 +281,8 @@ describe('ProjectTimelineGraphComponent', () => {
           id: 'phase-1',
           group: 'lifecycle',
           type: 'range',
-          start: new Date('2024-01-01'),
-          end: new Date('2024-03-31'),
+          start: '2024-01-01',
+          end: '2024-03-31',
           content: 'Design',
           title: 'Design',
           className: '__hl_background_project_phase_definition_3',
@@ -263,9 +295,16 @@ describe('ProjectTimelineGraphComponent', () => {
         expect(result instanceof HTMLElement).toBe(true);
       });
 
-      it('shows the date range in the meta row', () => {
+      it('shows "Phase" as the type label', () => {
         const meta = result.querySelector('.op-timeline-tooltip--meta-row');
         expect(meta?.textContent).toContain('Phase');
+      });
+
+      it('shows the date range', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('2024-01-01');
+        expect(meta?.textContent).toContain('2024-03-31');
+        expect(meta?.textContent).toContain('–');
       });
 
       it('shows the phase name', () => {
@@ -286,8 +325,8 @@ describe('ProjectTimelineGraphComponent', () => {
           id: 'phase-4',
           group: 'lifecycle',
           type: 'range',
-          start: new Date('2024-05-14T12:00:00'),
-          end: new Date('2024-05-15T12:00:00'),
+          start: '2024-05-14',
+          end: '2024-05-15',
           originalEnd: '2024-05-15',
           content: 'Kickoff',
           title: 'Kickoff',
@@ -298,6 +337,7 @@ describe('ProjectTimelineGraphComponent', () => {
 
       it('shows only a single date (no range)', () => {
         const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('2024-05-15');
         expect(meta?.textContent).not.toContain('–');
       });
 
@@ -315,7 +355,7 @@ describe('ProjectTimelineGraphComponent', () => {
           id: 'gate-start-2',
           group: 'gates',
           type: 'point',
-          start: new Date('2024-04-01'),
+          start: '2024-04-01',
           content: document.createElement('i'),
           title: 'Build Start',
           className: 'op-timeline-gate __hl_background_project_phase_definition_5',
@@ -331,6 +371,7 @@ describe('ProjectTimelineGraphComponent', () => {
 
       it('shows only a single date (no range)', () => {
         const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('2024-04-01');
         expect(meta?.textContent).not.toContain('–');
       });
 
@@ -352,7 +393,7 @@ describe('ProjectTimelineGraphComponent', () => {
           id: 'milestone-10',
           group: 'milestones',
           type: 'point',
-          start: new Date('2024-06-30'),
+          start: '2024-06-30',
           content: '',
           title: 'Launch',
           className: 'op-timeline-milestone __hl_background_type_7',
@@ -368,6 +409,7 @@ describe('ProjectTimelineGraphComponent', () => {
 
       it('shows only a single date (no range)', () => {
         const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('2024-06-30');
         expect(meta?.textContent).not.toContain('–');
       });
 
@@ -381,12 +423,47 @@ describe('ProjectTimelineGraphComponent', () => {
       });
     });
 
+    describe('for a sprint item', () => {
+      let result:HTMLElement;
+
+      beforeEach(() => {
+        result = tooltipTemplate({
+          id: 'sprint-20',
+          group: 'sprints',
+          type: 'range',
+          start: '2024-01-01',
+          end: '2024-01-14',
+          content: 'Sprint 1',
+          title: 'Sprint 1',
+          className: 'op-timeline-sprint op-timeline-sprint--active',
+          itemType: 'sprint',
+        }) as HTMLElement;
+      });
+
+      it('shows "Sprint" as the type label', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('Sprint');
+      });
+
+      it('shows the date range', () => {
+        const meta = result.querySelector('.op-timeline-tooltip--meta-row');
+        expect(meta?.textContent).toContain('2024-01-01');
+        expect(meta?.textContent).toContain('2024-01-14');
+        expect(meta?.textContent).toContain('–');
+      });
+
+      it('shows the sprint name', () => {
+        const name = result.querySelector('.op-timeline-tooltip--name');
+        expect(name?.textContent).toBe('Sprint 1');
+      });
+    });
+
     describe('for a clustered gate item', () => {
       const octoberGate:ProjectTimelineItem = {
         id: 'gate-oct',
         group: 'gates',
         type: 'point',
-        start: new Date('2024-10-01'),
+        start: '2024-10-01',
         content: document.createElement('i'),
         title: 'October Gate',
         className: 'op-timeline-gate',
@@ -395,7 +472,7 @@ describe('ProjectTimelineGraphComponent', () => {
         id: 'gate-nov',
         group: 'gates',
         type: 'point',
-        start: new Date('2024-11-01'),
+        start: '2024-11-01',
         content: document.createElement('i'),
         title: 'November Gate',
         className: 'op-timeline-gate',
@@ -405,7 +482,7 @@ describe('ProjectTimelineGraphComponent', () => {
         id: 'cluster-1',
         group: 'gates',
         type: 'point',
-        start: new Date('2024-10-01'),
+        start: '2024-10-01',
         content: document.createElement('i'),
         title: '',
         className: 'op-timeline-gate',
@@ -424,9 +501,9 @@ describe('ProjectTimelineGraphComponent', () => {
       });
 
       it('sorts dates chronologically even when items arrive in reverse order', () => {
-        const formattedDates:Date[] = [];
+        const formattedDates:string[] = [];
         vi.spyOn(timezoneStub, 'formattedDate').mockImplementation((d:unknown) => {
-          formattedDates.push(d as Date);
+          formattedDates.push(d as string);
           return String(d);
         });
 
@@ -434,7 +511,7 @@ describe('ProjectTimelineGraphComponent', () => {
         makeCluster([novemberGate, octoberGate]);
 
         expect(formattedDates.length).toBe(2);
-        expect(formattedDates[0].getTime()).toBeLessThan(formattedDates[1].getTime());
+        expect(formattedDates[0] < formattedDates[1]).toBe(true);
       });
     });
   });

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -51,7 +51,7 @@ import {
   GROUP_GATES,
   ProjectTimelineItemBuilder,
 } from './project-timeline-item.builder';
-import type { AccessibleProjectTimelineItem, ProjectPhaseData, ProjectMilestoneData, ProjectTimelineItem } from './project-timeline-item.builder';
+import type { AccessibleProjectTimelineItem, ProjectPhaseData, ProjectMilestoneData, ProjectSprintData, ProjectTimelineItem } from './project-timeline-item.builder';
 import { ProjectTimelineTooltipBuilder } from './project-timeline-tooltip.builder';
 
 export type { ProjectTimelineItem } from './project-timeline-item.builder';
@@ -70,6 +70,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
   readonly phasesData = input.required<string>();
   readonly milestonesData = input.required<string>();
+  readonly sprintsData = input<string>('[]');
 
   readonly phases = computed<ProjectPhaseData[]>(
     () => JSON.parse(this.phasesData()) as ProjectPhaseData[],
@@ -77,6 +78,10 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
   readonly milestones = computed<ProjectMilestoneData[]>(
     () => JSON.parse(this.milestonesData()) as ProjectMilestoneData[],
+  );
+
+  readonly sprints = computed<ProjectSprintData[]>(
+    () => JSON.parse(this.sprintsData()) as ProjectSprintData[],
   );
 
   readonly accessibleItems = computed<AccessibleProjectTimelineItem[]>(
@@ -99,8 +104,9 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
     effect(() => {
       const phases = this.phases();
       const milestones = this.milestones();
+      const sprints = this.sprints();
       if (this.timeline) {
-        this.updateTimeline(phases, milestones);
+        this.updateTimeline(phases, milestones, sprints);
       }
     });
   }
@@ -108,7 +114,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit():void {
     requestAnimationFrame(() => {
       if (!this.destroyed) {
-        this.initTimeline(this.phases(), this.milestones());
+        this.initTimeline(this.phases(), this.milestones(), this.sprints());
       }
     });
   }
@@ -123,8 +129,8 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
     this.timeline = null;
   }
 
-  private initTimeline(phases:ProjectPhaseData[], milestones:ProjectMilestoneData[]):void {
-    const { items, groups } = this.itemBuilder.buildData(phases, milestones);
+  private initTimeline(phases:ProjectPhaseData[], milestones:ProjectMilestoneData[], sprints:ProjectSprintData[]):void {
+    const { items, groups } = this.itemBuilder.buildData(phases, milestones, sprints);
     this.itemsDataset = new DataSet(items);
 
     this.timeline = new Timeline(
@@ -159,8 +165,8 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
     this.revealWhenReady();
   }
 
-  private updateTimeline(phases:ProjectPhaseData[], milestones:ProjectMilestoneData[]):void {
-    const { items, groups } = this.itemBuilder.buildData(phases, milestones);
+  private updateTimeline(phases:ProjectPhaseData[], milestones:ProjectMilestoneData[], sprints:ProjectSprintData[]):void {
+    const { items, groups } = this.itemBuilder.buildData(phases, milestones, sprints);
     this.itemsDataset = new DataSet(items);
     this.timeline!.setData({ items: this.itemsDataset as unknown as DataSet<DataItem>, groups: new DataSet(groups) });
   }

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-item.builder.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-item.builder.ts
@@ -49,6 +49,16 @@ export interface ProjectMilestoneData {
   subject:string;
   date:string;
   typeId:number;
+  row:number;
+}
+
+export interface ProjectSprintData {
+  id:number;
+  name:string;
+  startDate:string;
+  endDate:string;
+  status:string;
+  row:number;
 }
 
 export interface ProjectTimelineItem {
@@ -61,7 +71,7 @@ export interface ProjectTimelineItem {
   title:string;
   type:'range'|'point'|'background';
   className:string;
-  itemType?:'phase'|'gate'|'milestone';
+  itemType?:'phase'|'gate'|'milestone'|'sprint';
   subgroup?:string;
   definitionId?:number;
   typeId?:number;
@@ -78,13 +88,14 @@ export interface AccessibleProjectTimelineItem {
 export const GROUP_GATES = 'gates';
 export const GROUP_PHASES = 'phases';
 export const GROUP_MILESTONES = 'milestones';
+export const GROUP_SPRINTS = 'sprints';
 
 @Injectable()
 export class ProjectTimelineItemBuilder {
   private readonly i18n = inject(I18nService);
   private readonly timezone = inject(TimezoneService);
 
-  buildData(phases:ProjectPhaseData[], milestones:ProjectMilestoneData[]):{items:ProjectTimelineItem[]; groups:{id:string; content:string}[]} {
+  buildData(phases:ProjectPhaseData[], milestones:ProjectMilestoneData[], sprints:ProjectSprintData[]):{items:ProjectTimelineItem[]; groups:{id:string; content:string}[]} {
     const items:ProjectTimelineItem[] = [];
 
     for (const phase of phases) {
@@ -99,17 +110,19 @@ export class ProjectTimelineItemBuilder {
       }
     }
 
-    const milestoneSubgroupIndex:Record<string, number> = {};
     for (const milestone of milestones) {
-      const subGroupIndex = milestoneSubgroupIndex[milestone.date] ?? 0;
-      milestoneSubgroupIndex[milestone.date] = subGroupIndex + 1;
-      items.push(this.buildMilestoneItem(milestone, subGroupIndex));
+      items.push(this.buildMilestoneItem(milestone));
+    }
+
+    for (const sprint of sprints) {
+      items.push(this.buildSprintItem(sprint));
     }
 
     const groups = [
       { id: GROUP_GATES, content: '' },
       { id: GROUP_PHASES, content: '' },
       { id: GROUP_MILESTONES, content: '' },
+      { id: GROUP_SPRINTS, content: '' },
     ];
 
     return { items, groups };
@@ -159,12 +172,12 @@ export class ProjectTimelineItemBuilder {
     };
   }
 
-  buildMilestoneItem(milestone:ProjectMilestoneData, subgroupIndex:number):ProjectTimelineItem {
+  buildMilestoneItem(milestone:ProjectMilestoneData):ProjectTimelineItem {
     const hlClass = `__hl_background_type_${milestone.typeId}`;
     return {
       id: `milestone-${milestone.id}`,
       group: GROUP_MILESTONES,
-      subgroup: String(subgroupIndex),
+      subgroup: String(milestone.row),
       start: milestone.date,
       content: '',
       title: milestone.subject,
@@ -173,6 +186,22 @@ export class ProjectTimelineItemBuilder {
       itemType: 'milestone',
       typeId: milestone.typeId,
       workPackageId: milestone.id,
+    };
+  }
+
+  buildSprintItem(sprint:ProjectSprintData):ProjectTimelineItem {
+    const isActive = sprint.status === 'active';
+    return {
+      id: `sprint-${sprint.id}`,
+      group: GROUP_SPRINTS,
+      subgroup: String(sprint.row),
+      start: sprint.startDate,
+      end: sprint.endDate,
+      content: sprint.name,
+      title: sprint.name,
+      type: 'range',
+      className: `op-timeline-sprint${isActive ? ' op-timeline-sprint--active' : ''}`,
+      itemType: 'sprint',
     };
   }
 

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-tooltip.builder.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-tooltip.builder.ts
@@ -27,7 +27,7 @@
 //++
 
 import { Injectable, inject } from '@angular/core';
-import { diamondIconData, opGateIconData, opPhaseIconData } from '@openproject/octicons-angular';
+import { diamondIconData, opGateIconData, opPhaseIconData, zapIconData } from '@openproject/octicons-angular';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { octiconElement } from 'core-app/shared/helpers/op-icon-builder';
@@ -93,12 +93,16 @@ export class ProjectTimelineTooltipBuilder {
   tooltipTypeLabel(itemType:ProjectTimelineItem['itemType']):string {
     if (itemType === 'milestone') return this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_milestone');
     if (itemType === 'gate') return this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_gate');
+    if (itemType === 'sprint') return this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_sprint');
     return this.i18n.t('js.grid.widgets.project_timeline.tooltip_type_phase');
   }
 
   tooltipIcon(item:ProjectTimelineItem):HTMLElement {
     if (item.itemType === 'milestone') {
       return octiconElement(diamondIconData, 'xsmall', `octicon __hl_inline_type_${item.typeId!}`);
+    }
+    if (item.itemType === 'sprint') {
+      return octiconElement(zapIconData, 'small', 'octicon op-timeline-sprint-icon');
     }
     const iconData = item.itemType === 'gate' ? opGateIconData : opPhaseIconData;
     return octiconElement(iconData, 'small', `octicon __hl_inline_project_phase_definition_${item.definitionId!}`);

--- a/modules/grids/app/components/grids/widgets/project_timeline.html.erb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.html.erb
@@ -33,7 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
     <%= helpers.angular_component_tag(
           "opce-project-timeline-graph",
           "phases-data": phases_data,
-          "milestones-data": milestones_data
+          "milestones-data": milestones_data,
+          "sprints-data": sprints_data
         ) %>
   <% else %>
     <%= render(Primer::Beta::Blankslate.new(test_selector: "project-timeline-widget-empty")) do |blankslate| %>
@@ -42,9 +43,24 @@ See COPYRIGHT and LICENSE files for more details.
       <% blankslate.with_description { I18n.t("grids.widgets.empty") } %>
     <% end %>
   <% end %>
-  <% if (link = gantt_link) %>
+  <% if gantt_link || sprints_link %>
     <% container.with_footer do %>
-      <%= render(Primer::Beta::Link.new(href: link)) { t("grids.widgets.project_timeline.gantt_link") } %>
+      <%= render(Primer::Alpha::ActionMenu.new) do |menu| %>
+        <% menu.with_show_button(scheme: :invisible, "aria-label": t("grids.widgets.project_timeline.footer_actions_label")) do |button| %>
+          <% button.with_trailing_visual_icon(icon: :"triangle-down") %>
+          <% t("grids.widgets.project_timeline.footer_actions_label") %>
+        <% end %>
+        <% if (link = gantt_link) %>
+          <% menu.with_item(label: t("grids.widgets.project_timeline.gantt_link"), href: link) do |item| %>
+            <% item.with_leading_visual_icon(icon: :"op-view-timeline") %>
+          <% end %>
+        <% end %>
+        <% if (link = sprints_link) %>
+          <% menu.with_item(label: t("grids.widgets.project_timeline.sprints_link"), href: link) do |item| %>
+            <% item.with_leading_visual_icon(icon: :zap) %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -54,17 +54,28 @@ module Grids
       end
 
       def milestones_data
-        milestones_scope
-          .map { |wp| { id: wp.id, subject: wp.subject, date: wp.due_date.iso8601, typeId: wp.type_id } }
+        assign_milestone_rows(milestones_scope)
+          .map { |wp, row| { id: wp.id, subject: wp.subject, date: wp.due_date.iso8601, typeId: wp.type_id, row: } }
+          .to_json
+      end
+
+      def sprints_data
+        return [].to_json unless view_sprints_allowed?
+
+        assign_sprint_rows(sprints_scope)
+          .map do |sprint, row|
+          { id: sprint.id, name: sprint.name, startDate: sprint.start_date.iso8601,
+            endDate: sprint.finish_date.iso8601, status: sprint.status, row: }
+        end
           .to_json
       end
 
       def any_content?
-        any_phases? || milestones_scope.exists?
+        any_phases? || milestones_scope.exists? || any_sprints?
       end
 
       def render?
-        view_project_phases_allowed? || view_work_packages_allowed?
+        view_project_phases_allowed? || view_work_packages_allowed? || view_sprints_allowed?
       end
 
       def gantt_link
@@ -76,6 +87,12 @@ module Grids
         params = JSON.parse(result[:query_props])
         params["hi"] = false
         helpers.project_gantt_index_path(project, query_props: params.to_json)
+      end
+
+      def sprints_link
+        return unless view_sprints_allowed? && any_sprints?
+
+        helpers.project_backlogs_sprints_path(project)
       end
 
       def wrapper_arguments
@@ -92,8 +109,17 @@ module Grids
         @view_project_phases_allowed ||= User.current.allowed_in_project?(:view_project_phases, project)
       end
 
+      def view_sprints_allowed?
+        @view_sprints_allowed ||= project.module_enabled?(:backlogs) &&
+          User.current.allowed_in_project?(:view_sprints, project)
+      end
+
       def any_phases?
         view_project_phases_allowed? && project.phases.active.with_timeline_content.exists?
+      end
+
+      def any_sprints?
+        view_sprints_allowed? && sprints_scope.exists?
       end
 
       def milestones_scope
@@ -104,6 +130,36 @@ module Grids
           .where(types: { is_milestone: true })
           .where.not(due_date: nil)
           .order(:due_date)
+      end
+
+      def sprints_scope
+        @sprints_scope ||= Sprint
+          .for_project(project)
+          .where.not(start_date: nil)
+          .where.not(finish_date: nil)
+          .order(:start_date)
+      end
+
+      def assign_milestone_rows(milestones)
+        date_rows = Hash.new(-1)
+        milestones.map do |wp|
+          date_rows[wp.due_date] += 1
+          [wp, date_rows[wp.due_date]]
+        end
+      end
+
+      def assign_sprint_rows(sprints)
+        row_ends = []
+        sprints.map do |sprint|
+          row_index = row_ends.index { |end_date| end_date < sprint.start_date }
+          if row_index
+            row_ends[row_index] = sprint.finish_date
+          else
+            row_index = row_ends.size
+            row_ends << sprint.finish_date
+          end
+          [sprint, row_index]
+        end
       end
 
       def phase_data(phase) # rubocop:disable Metrics/AbcSize

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -32,8 +32,10 @@ en:
         no_results: "Nothing new to report."
       not_available: "This widget is not available."
       project_timeline:
-        gantt_link: "View milestones in Gantt"
+        footer_actions_label: "See more details"
+        gantt_link: "Milestones Gantt"
         no_results_title: "No project timeline content configured"
+        sprints_link: "Sprints overview"
         title: "Project timeline"
         title_portfolio: "Portfolio timeline"
         title_program: "Program timeline"

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -41,6 +41,7 @@ en:
           tooltip_type_gate: 'Phase gate'
           tooltip_type_milestone: 'Milestone'
           tooltip_type_phase: 'Phase'
+          tooltip_type_sprint: 'Sprint'
         subprojects:
           title: 'Subitems'
         time_entries_current_user:

--- a/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
   let(:user) { create(:user) }
   let(:phases_role) { create(:project_role, permissions: [:view_project_phases]) }
   let(:wp_role) { create(:project_role, permissions: [:view_work_packages]) }
+  let(:sprints_role) { create(:project_role, permissions: [:view_sprints]) }
   let(:component) { described_class.new(project) }
 
   before { login_as(user) }
@@ -50,6 +51,21 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
       before { create(:member, user:, project:, roles: [wp_role]) }
 
       it { expect(component.render?).to be(true) }
+    end
+
+    context "with view_sprints permission and backlogs module enabled" do
+      before { create(:member, user:, project:, roles: [sprints_role]) }
+
+      it { expect(component.render?).to be(true) }
+    end
+
+    context "with view_sprints permission but backlogs module disabled" do
+      before do
+        project.update!(enabled_module_names: project.enabled_module_names - ["backlogs"])
+        create(:member, user:, project:, roles: [sprints_role])
+      end
+
+      it { expect(component.render?).to be(false) }
     end
 
     context "without either permission" do
@@ -95,6 +111,31 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
       end
 
       it { expect(component.any_content?).to be(true) }
+    end
+
+    context "with a sprint, view_sprints permission and backlogs module enabled" do
+      before do
+        create(:member, user:, project:, roles: [sprints_role])
+        create(:sprint, project:)
+      end
+
+      it { expect(component.any_content?).to be(true) }
+    end
+
+    context "with a sprint but without view_sprints permission" do
+      before { create(:sprint, project:) }
+
+      it { expect(component.any_content?).to be(false) }
+    end
+
+    context "with a sprint and view_sprints permission but backlogs module disabled" do
+      before do
+        project.update!(enabled_module_names: project.enabled_module_names - ["backlogs"])
+        create(:member, user:, project:, roles: [sprints_role])
+        create(:sprint, project:)
+      end
+
+      it { expect(component.any_content?).to be(false) }
     end
   end
 
@@ -156,7 +197,8 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
         "id" => milestone.id,
         "subject" => milestone.subject,
         "date" => milestone.due_date.iso8601,
-        "typeId" => milestone_type.id
+        "typeId" => milestone_type.id,
+        "row" => 0
       )
     end
 
@@ -173,6 +215,109 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
     it "orders by due date" do
       earlier = create(:work_package, project:, type: milestone_type, due_date: Time.zone.today - 1)
       expect(data.pluck("id")).to eq([earlier.id, milestone.id])
+    end
+
+    it "assigns different rows to milestones on the same date" do
+      create(:work_package, project:, type: milestone_type, due_date: Time.zone.today)
+      expect(data.pluck("row")).to contain_exactly(0, 1)
+    end
+
+    it "assigns row 0 to milestones on different dates" do
+      create(:work_package, project:, type: milestone_type, due_date: Time.zone.today + 1)
+      expect(data.pluck("row")).to eq([0, 0])
+    end
+  end
+
+  describe "#sprints_data" do
+    let!(:sprint) { create(:sprint, project:, start_date: Time.zone.today, finish_date: Time.zone.today + 14.days) }
+
+    subject(:data) { JSON.parse(component.sprints_data) }
+
+    context "without view_sprints permission" do
+      it { expect(data).to eq([]) }
+    end
+
+    context "with view_sprints permission but backlogs module disabled" do
+      before do
+        project.update!(enabled_module_names: project.enabled_module_names - ["backlogs"])
+        create(:member, user:, project:, roles: [sprints_role])
+      end
+
+      it { expect(data).to eq([]) }
+    end
+
+    context "with view_sprints permission and backlogs module enabled" do
+      before { create(:member, user:, project:, roles: [sprints_role]) }
+
+      it "includes all required fields" do
+        expect(data.first).to include(
+          "id" => sprint.id,
+          "name" => sprint.name,
+          "startDate" => sprint.start_date.iso8601,
+          "endDate" => sprint.finish_date.iso8601,
+          "status" => sprint.status,
+          "row" => 0
+        )
+      end
+
+      it "excludes sprints without a start_date" do
+        create(:sprint, project:, start_date: nil)
+        expect(data.size).to eq(1)
+      end
+
+      it "excludes sprints without a finish_date" do
+        create(:sprint, project:, finish_date: nil)
+        expect(data.size).to eq(1)
+      end
+
+      it "orders by start_date" do
+        earlier = create(:sprint, project:, start_date: Time.zone.today - 7.days, finish_date: Time.zone.today - 1.day)
+        expect(data.pluck("id")).to eq([earlier.id, sprint.id])
+      end
+
+      it "assigns row 0 to non-overlapping sprints" do
+        create(:sprint, project:, start_date: Time.zone.today + 15.days, finish_date: Time.zone.today + 28.days)
+        expect(data.pluck("row")).to eq([0, 0])
+      end
+
+      it "assigns different rows to overlapping sprints" do
+        create(:sprint, project:, start_date: sprint.start_date, finish_date: sprint.finish_date)
+        expect(data.pluck("row")).to contain_exactly(0, 1)
+      end
+    end
+  end
+
+  describe "#sprints_link" do
+    context "without view_sprints permission" do
+      it { expect(component.sprints_link).to be_nil }
+    end
+
+    context "with view_sprints permission but backlogs module disabled" do
+      before do
+        project.update!(enabled_module_names: project.enabled_module_names - ["backlogs"])
+        create(:member, user:, project:, roles: [sprints_role])
+        create(:sprint, project:)
+        render_inline(component)
+      end
+
+      it { expect(component.sprints_link).to be_nil }
+    end
+
+    context "with view_sprints permission and backlogs module enabled" do
+      before { create(:member, user:, project:, roles: [sprints_role]) }
+
+      context "when there are no sprints" do
+        it { expect(component.sprints_link).to be_nil }
+      end
+
+      context "when sprints exist" do
+        before do
+          create(:sprint, project:)
+          render_inline(component)
+        end
+
+        it { expect(component.sprints_link).to include("backlogs/sprints") }
+      end
     end
   end
 
@@ -264,6 +409,7 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
 
       it { expect(page).to have_css("opce-project-timeline-graph") }
       it { expect(page).to have_css("opce-project-timeline-graph[phases-data='[]']") }
+      it { expect(page).to have_css("opce-project-timeline-graph[sprints-data='[]']") }
       it { expect(page).to have_link(I18n.t("grids.widgets.project_timeline.gantt_link")) }
     end
 
@@ -276,7 +422,36 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
 
       it { expect(page).to have_css("opce-project-timeline-graph") }
       it { expect(page).to have_css("opce-project-timeline-graph[milestones-data='[]']") }
+      it { expect(page).to have_css("opce-project-timeline-graph[sprints-data='[]']") }
       it { expect(page).to have_no_link(I18n.t("grids.widgets.project_timeline.gantt_link")) }
+    end
+
+    context "with only view_sprints permission and backlogs module enabled" do
+      before do
+        Member.find_by(user_id: user.id, project_id: project.id).update!(roles: [sprints_role])
+        create(:sprint, project:)
+        render_inline(component)
+      end
+
+      it { expect(page).to have_css("opce-project-timeline-graph") }
+      it { expect(page).to have_css("opce-project-timeline-graph[phases-data='[]']") }
+      it { expect(page).to have_css("opce-project-timeline-graph[milestones-data='[]']") }
+      it { expect(page).to have_link(I18n.t("grids.widgets.project_timeline.sprints_link")) }
+      it { expect(page).to have_no_link(I18n.t("grids.widgets.project_timeline.gantt_link")) }
+    end
+
+    context "with only view_sprints permission but backlogs module disabled" do
+      before do
+        project.update!(enabled_module_names: project.enabled_module_names - ["backlogs"])
+        Member.find_by(user_id: user.id, project_id: project.id).update!(roles: [sprints_role])
+        create(:sprint, project:)
+        render_inline(component)
+      end
+
+      it "does not render the component at all" do
+        expect(page).to have_no_css("opce-project-timeline-graph")
+        expect(page).to have_no_test_selector("project-timeline-widget-empty")
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-311

# What are you trying to accomplish?

- [x] The "Project timeline" widget on the overview is extended to show sprints of that project
  - [x] The sprint objects: 
    - [x] are shown below the milestones
    - [x] show a tooltip on hover similar to the project phases
    - [x] are not shown if the user is lacking permissions
    - [x] if possible are shown in one row. If they overlap, they are shown in multiple rows
  - [x] The timeline widget is changed to:
    - [x] be hidden when the user has neither permission to view project lifecycle attributes nor work packages nor sprints
    - [x] show a Blankslate when there are neither project lifecycle attributes nor milestones nor sprints
  - [x] In the footer of the widget, there is an ActionMenu triggered by an invisible button which containsthe link to the Gantt view of all milestones called "Milestones Gantt" 
- [x] If the backlogs module is disabled, there is no footer link to the sprints overview and no sprints in the timeline

## Screenshots

<img width="1625" height="423" alt="Bildschirmfoto 2026-07-23 um 15 19 18" src="https://github.com/user-attachments/assets/39ed05d5-c7f5-4d0f-a45b-362f77a644dc" />
