### PR TITLE
[FND-156] Cover the PDF generation wizard step and step dispatch

### DIFF
--- a/spec/components/work_package_types/wizard/page_component_spec.rb
+++ b/spec/components/work_package_types/wizard/page_component_spec.rb
@@ -34,16 +34,29 @@ RSpec.describe WorkPackageTypes::Wizard::PageComponent, type: :component, with_f
   let(:parent) { create(:type, name: "Phase") }
   let(:type) { create(:type) }
 
-  before do
-    login_as(create(:admin))
-    type.link!(Type::ConfigurationLink::PDF_EXPORT, source: parent)
-  end
+  before { login_as(create(:admin)) }
 
-  it "shows the linked PDF banner on the pdf step" do
-    render_inline(described_class.new(type:, current_step: :pdf))
+  describe "step dispatch" do
+    # The page's job is to render the right body per step; each body's own content is
+    # its responsibility, so we stub it. Inline-form steps (details/defaults/workflows)
+    # render through StepEditors and are covered by their editors' specs.
+    {
+      form_configuration: WorkPackageTypes::Wizard::FormConfigurationStepComponent,
+      projects: WorkPackageTypes::ProjectsComponent,
+      pdf: WorkPackageTypes::Wizard::PdfStepComponent,
+      # A known step with no dedicated body yet falls back to the placeholder.
+      automations: WorkPackageTypes::Wizard::PlaceholderComponent
+    }.each do |step, component|
+      it "renders #{component} on the #{step} step" do
+        stubbed = instance_double(component, render_in: "STUB[#{step}]")
+        allow(component).to receive(:new).and_return(stubbed)
 
-    expect(page).to have_text("Linked mode")
-    expect(page).to have_text("Phase")
+        render_inline(described_class.new(type:, current_step: step))
+
+        expect(component).to have_received(:new)
+        expect(page).to have_text("STUB[#{step}]")
+      end
+    end
   end
 
   describe "sidebar step markers" do

--- a/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
+++ b/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe WorkPackageTypes::CreationWizardController, with_flag: { type_var
         end
       end
 
+      describe "GET show with an unrecognised step" do
+        it "falls back to the first step" do
+          get :show, params: { type_id: variant.id, step: "does-not-exist" }
+
+          expect(assigns(:current_step)).to eq(WorkPackageTypes::Wizard::Steps.first)
+        end
+      end
+
       describe "PATCH update on the details step" do
         it "updates and advances to the next step" do
           patch :update, params: { type_id: variant.id, step: :details, type: { name: "Blocker" } }

--- a/spec/features/types/creation_wizard_spec.rb
+++ b/spec/features/types/creation_wizard_spec.rb
@@ -105,7 +105,9 @@ RSpec.describe "Variant creation wizard", :js, with_flag: { type_variants: true 
     click_on I18n.t(:button_continue)
     expect_step_saved(:projects)
 
-    # Step 7 - PDF generation
+    # Step 7 - PDF generation: linked to the parent on creation, so it renders read-only.
+    expect(page).to have_heading("PDF generation") # the main content, not the sidebar entry
+    expect(page).to have_text("Linked mode")
     click_on I18n.t("types.creation_wizard.finish")
 
     expect_flash(message: "Variant created successfully.")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/FND-156

# What are you trying to accomplish?

- Add test coverage for the variant creation wizard's PDF generation step (FND-156): linked to the parent on creation so it renders read-only, switchable to independent. The behaviour already shipped with the generic reuse machinery, so this is coverage-only — no product change.
- Pin the wizard's page-level responsibilities while I was there: which body each step renders, and the fallback for an unrecognised step.

# What approach did you choose and why?

Changes:

- `creation_wizard_spec.rb`: the walk-through asserts the PDF step renders in linked/read-only mode — the one end-to-end check that the whole chain renders for real.
- `page_component_spec.rb`: test the page's step dispatch with stubbed step bodies, so it verifies the right component renders per step without depending on each body's content (owned by their own specs). Dropped a banner test that duplicated `reuse_mode_banner_component_spec`.
- `creation_wizard_controller_spec.rb`: cover the fallback to the first step for an unrecognised `step` param — that responsibility lives in the controller, not the page component.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
