### PR TITLE
Relabel user department blank option to (none). OP-19675

### DIFF
--- a/app/forms/users/form/attributes_form.rb
+++ b/app/forms/users/form/attributes_form.rb
@@ -134,9 +134,11 @@ module Users
       # The field is editable by administrators only and disabled when the current
       # department is managed by LDAP, since LDAP owns that membership.
       def render_department(group)
+        # Department is optional, so the blank entry clears the assignment rather than
+        # prompting a choice; "(none)" reads as an empty value, not a "please select" hint.
         group.select_list(name: :department_id,
                           label: User.human_attribute_name(:department),
-                          include_blank: "--- #{I18n.t(:actionview_instancetag_blank_option)} ---",
+                          include_blank: I18n.t(:label_none_parentheses),
                           input_width: :medium,
                           **department_editability) do |list|
           department_options.each do |department|

--- a/spec/forms/users/form/attributes_form_spec.rb
+++ b/spec/forms/users/form/attributes_form_spec.rb
@@ -76,6 +76,11 @@ RSpec.describe Users::Form::AttributesForm, type: :forms do
       it "renders an editable department select including the department" do
         expect(page).to have_select("user[department_id]", disabled: false, with_options: ["Engineering"])
       end
+
+      it "offers a blank-valued '(none)' option so the department can be cleared" do
+        expect(page).to have_css("select[name='user[department_id]'] option[value='']",
+                                 text: I18n.t(:label_none_parentheses))
+      end
     end
 
     context "when the current department is managed by LDAP" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19675

# What are you trying to accomplish?

The admin user-form department dropdown used the "--- Please select ---" prompt for its blank entry. Since a department is optional, that entry actually *clears* the assignment, but the prompt wording made that non-obvious. It is now labelled "(none)".

Unsetting already worked end-to-end; this is a wording fix only.

# What approach did you choose and why?

Switched the blank option to the existing `label_none_parentheses` ("(none)"), matching the codebase convention for optional selects (e.g. the parent-group and custom-field-role selects). No behaviour change.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
