### PR TITLE
Bug: PageLinkMetadataService didn't handle empty relations

### DIFF
--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -38,19 +38,26 @@ module Wikis
 
     # @return [ServiceResult<ActiveRecord::Relation<Wikis::PageLink>]
     def call
-      metadata = relation.group_by(&:provider).flat_map do |provider, page_links|
-        build_inputs(page_links).filter_map do |(page_link_id, input_data)|
-          request_page_info(input_data, provider).either(->(info) { [page_link_id, info.title] }, ->(*) {})
-        end
-      end
+      @result.result = if relation.any?
+                         enrich_models(fetch_metadata)
+                       else
+                         relation
+                       end
 
-      @result.result = enrich_models(metadata)
       @result
     end
 
     private
 
     attr_reader :relation
+
+    def fetch_metadata
+      relation.group_by(&:provider).flat_map do |provider, page_links|
+        build_inputs(page_links).filter_map do |(page_link_id, input_data)|
+          request_page_info(input_data, provider).either(->(info) { [page_link_id, info.title] }, ->(*) {})
+        end
+      end
+    end
 
     def request_page_info(input_data, provider)
       provider.auth_strategy_for(User.current).bind do |auth_strategy|

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -212,8 +212,18 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
         get "#{path}?filters=#{CGI.escape(filter.to_json)}"
       end
 
-      it_behaves_like "API V3 collection response", 3, 3, "WikiPageLink", "WikiPageLinkCollection" do
-        let(:elements) { Wikis::PageLink.where(identifier: "shared_identifier").order(id: :desc).all }
+      context "when a link with the requested identifier exists" do
+        it_behaves_like "API V3 collection response", 3, 3, "WikiPageLink", "WikiPageLinkCollection" do
+          let(:elements) { Wikis::PageLink.where(identifier: "shared_identifier").order(id: :desc).all }
+        end
+      end
+
+      context "when a page link with the requested identifier does not exist" do
+        let(:filter) { [{ identifier: { operator: "=", values: "non_existent_identifier" } }] }
+
+        it_behaves_like "API V3 collection response", 0, 0, "WikiPageLink", "WikiPageLinkCollection" do
+          let(:elements) { [] }
+        end
       end
     end
   end


### PR DESCRIPTION
This resulted on a 500 error.

I added a guard clause to it to solve the problem.