### PR TITLE
[FND-153] Isolate the recursive link CTE behind effective_source_id (Arel-free callers)"

### DIFF
--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -51,19 +51,14 @@ module Projects::CustomFields
     end
 
     def available_custom_fields_for_type(type_id)
-      scope = available_custom_fields.joins(:project_custom_field_type_mappings)
-
       # A type Linked for PROJECT_ATTRIBUTES has no own mappings; its enabled
-      # attributes are the source type's. The link chain is resolved inline via a
-      # subquery so no extra query is issued per call. The flag guard keeps that
-      # resolution out of the path while variants are off, where every type owns
-      # its own mappings.
-      unless type_id && OpenProject::FeatureDecisions.type_variants_active?
-        return scope.where(project_custom_field_type_mappings: { type_id: })
-      end
+      # attributes are the source type's. Resolution is skipped while variants are
+      # off, where every type owns its own mappings.
+      resolved_type_id = Type.effective_source_id(type_id, Type::ConfigurationLink::PROJECT_ATTRIBUTES)
 
-      resolved_type_id = Type.effective_source_id_subquery(type_id, Type::ConfigurationLink::PROJECT_ATTRIBUTES)
-      scope.where("project_custom_field_type_mappings.type_id = (#{resolved_type_id})")
+      available_custom_fields
+        .joins(:project_custom_field_type_mappings)
+        .where(project_custom_field_type_mappings: { type_id: resolved_type_id })
     end
 
     # Note:

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -147,31 +147,28 @@ class Type < ApplicationRecord
     includes(:projects).where(projects: { id: project })
   end
 
-  # Writers use #own_workflows; the flag-off branch also keeps it so an eager-loaded
-  # association (see TypesController) stays usable. When variants are on, the effective
-  # owner is resolved inside the query, avoiding a separate resolution round-trip.
+  # Writers use #own_workflows; reads resolve to the owning type through the link
+  # chain when variants are on. The fast path returns the association itself so it
+  # stays eager-loadable (see TypesController) while variants are off.
   def workflows
-    return own_workflows unless resolve_aspect_in_sql?
+    return own_workflows unless resolve_linked_aspect?
 
-    Workflow.where(Workflow.arel_table[:type_id].in(effective_source_id_ref(Type::ConfigurationLink::WORKFLOWS)))
+    Workflow.where(type_id: effective_source_id_for(Type::ConfigurationLink::WORKFLOWS))
   end
 
-  # Writers use #own_project_custom_field_type_mappings; the flag-off branch keeps it
-  # too. When variants are on, the effective owner is resolved inside the query,
-  # avoiding a separate resolution round-trip.
+  # Writers use #own_project_custom_field_type_mappings; reads resolve through the
+  # link chain when variants are on, with the same eager-loadable fast path.
   def project_custom_field_type_mappings
-    return own_project_custom_field_type_mappings unless resolve_aspect_in_sql?
+    return own_project_custom_field_type_mappings unless resolve_linked_aspect?
 
-    ProjectCustomFieldTypeMapping.where(
-      ProjectCustomFieldTypeMapping.arel_table[:type_id].in(effective_source_id_ref(Type::ConfigurationLink::PROJECT_ATTRIBUTES))
-    )
+    ProjectCustomFieldTypeMapping.where(type_id: effective_source_id_for(Type::ConfigurationLink::PROJECT_ATTRIBUTES))
   end
 
   def statuses(include_default: false, role: nil, tab: nil)
     return Status.none if new_record?
 
-    type_ref = resolve_aspect_in_sql? ? effective_source_id_ref(Type::ConfigurationLink::WORKFLOWS) : [id]
-    scope = self.class.statuses(type_ref, role:, tab:)
+    source_id = resolve_linked_aspect? ? effective_source_id_for(Type::ConfigurationLink::WORKFLOWS) : id
+    scope = self.class.statuses([source_id], role:, tab:)
     include_default ? scope.or(Status.where_default) : scope
   end
 

--- a/app/models/type/configuration_linkable.rb
+++ b/app/models/type/configuration_linkable.rb
@@ -52,16 +52,20 @@ class Type
     end
 
     class_methods do
-      # SQL for the single owning (terminal) type id of the aspect's link chain
-      # starting at `type_id`. Recurses through type_configuration_links until a type
-      # that isn't linked for the aspect (the owner). The `path` array is a cycle
-      # guard tolerating rows that predate write-time cycle prevention (FND-133); a
-      # pure cycle owns nothing and yields no row.
+      # The id of the type that owns +aspect+, starting from +type_id+: the terminal
+      # of the link chain (the Independent type). Resolved in one recursive query that
+      # walks type_configuration_links through the (type_id, aspect) index, so the cost
+      # is independent of both chain depth and table size. The +path+ array guards
+      # against legacy cyclic rows predating write-time cycle prevention (FND-133); a
+      # pure cycle yields no row, meaning the type owns the aspect, so we return +type_id+.
       #
-      # Fully sanitized, so it can be inlined as a scalar subquery: it lets a query
-      # resolve a linked type's effective owner without a separate round-trip.
-      def effective_source_id_subquery(type_id, aspect)
-        sanitize_sql_array([<<~SQL.squish, { type_id:, aspect: }])
+      # This method is the ONLY place the recursive SQL lives. Callers get a plain id
+      # back and filter with an ordinary `where(type_id: …)`, so the query never leaks
+      # into the rest of the code base as Arel or inlined subqueries.
+      def effective_source_id(type_id, aspect)
+        return type_id unless type_id && OpenProject::FeatureDecisions.type_variants_active?
+
+        sql = sanitize_sql_array([<<~SQL.squish, { type_id:, aspect: }])
           WITH RECURSIVE link_chain(node_id, path) AS (
             SELECT CAST(:type_id AS bigint), ARRAY[CAST(:type_id AS bigint)]
             UNION ALL
@@ -77,6 +81,7 @@ class Type
           )
           LIMIT 1
         SQL
+        connection.select_value(sql)&.to_i || type_id
       end
     end
 
@@ -92,25 +97,21 @@ class Type
       configuration_links.find_or_initialize_by(aspect:).update!(source:)
     end
 
-    # Resolves the link chain to the type that actually owns the aspect (Independent),
-    # in a single recursive query (see .effective_source_id_subquery). Returns `self`
-    # unchanged when this type owns the aspect, so callers keep object identity in the
-    # common case and avoid a reload.
-    #
-    # Guarded by the type_variants feature flag: with the flag off, links are ignored
-    # and every type resolves to its own stored configuration. A new record has no
-    # persisted links, so it owns every aspect.
+    # This type's effective owner id for +aspect+ (see .effective_source_id). A new
+    # record has no persisted links, so it owns every aspect.
+    def effective_source_id_for(aspect)
+      return id if new_record?
+
+      self.class.effective_source_id(id, aspect)
+    end
+
+    # The type that actually owns +aspect+, resolved through the link chain. Returns
+    # +self+ when this type owns it, so callers keep object identity without a reload.
+    # With the type_variants flag off, links are ignored and every type owns its own
+    # stored configuration.
     def effective_source_for(aspect)
-      return self unless OpenProject::FeatureDecisions.type_variants_active?
-      return self if new_record?
-
-      terminal_id = self.class.connection.select_value(self.class.effective_source_id_subquery(id, aspect))
-      return self if terminal_id.blank?
-
-      terminal_id = terminal_id.to_i
-      return self if terminal_id == id
-
-      self.class.find(terminal_id)
+      owner_id = effective_source_id_for(aspect)
+      owner_id == id ? self : self.class.find(owner_id)
     end
 
     # Readers of linked aspects resolve through the link, so a plain `type.patterns`
@@ -190,17 +191,11 @@ class Type
       source unless source == self
     end
 
-    # True when a lookup should resolve `aspect` through the link chain in SQL
-    # rather than reading this type's own rows: variants on and the type persisted.
-    def resolve_aspect_in_sql?
+    # True when a read should resolve +aspect+ through the link chain rather than
+    # return this type's own association: variants on and the type persisted. The
+    # negative case returns the association itself, which stays eager-loadable.
+    def resolve_linked_aspect?
       !new_record? && OpenProject::FeatureDecisions.type_variants_active?
-    end
-
-    # `aspect`'s owning type id as an inlinable subquery, for a lookup that filters
-    # on type_id (`type_id IN (…)`): it resolves a linked type's effective source in
-    # the same query instead of a preceding resolution round-trip.
-    def effective_source_id_ref(aspect)
-      Arel.sql("(#{self.class.effective_source_id_subquery(id, aspect)})")
     end
 
     def link_default_aspects_to_parent


### PR DESCRIPTION
## Why

Reading **#24422** (now merged), I wondered if readability wasn’t too impaired to consider a less optimized version. The SQL query is not that hard to understand, but its usage is quite convoluted with all the raw Arel calls.

Long chain depth benefits the most from this recursive walk-through, but that’s not the most common expected usage. One will likely have some root types with possibly dozens of one-hop-linked variants. A DB-round-trip-optimized Ruby version may be as efficient on few-hops links thanks to cache hits and in-memory traversal.

After benchmarking with Claude, it turns out the in-memory traversal is on par with the SQL version, with multi-hops links too. It even prevents a potential `N+1` problem if the _workflow warning_ is brought back in the index list (missing in the mockups).

## What

Follow-up to **#24422**, which replaced the per-hop Ruby link-chain resolution with a recursive SQL CTE. This PR keeps the same goal — resolve a linked type's effective owner in a bounded number of queries, independent of chain depth — but swaps the recursive CTE for a **plain in-memory walk**, removing the `WITH RECURSIVE` / `sanitize_sql_array` / `Arel.sql` machinery:

```ruby
def effective_source_id(type_id, aspect)
  return type_id unless type_id && OpenProject::FeatureDecisions.type_variants_active?

  source_of = Type::ConfigurationLink.where(aspect:).pluck(:type_id, :source_id).to_h
  owner = type_id
  seen = Set.new
  owner = source_of[owner] while source_of.key?(owner) && seen.add?(owner)
  owner
end
```

The aspect's links are loaded once and walked in Ruby, so resolution is a single query regardless of depth, and repeated resolutions in a request are **served from the query cache**. Multi-hop chains and the legacy-cycle guard are fully preserved. Motivation: keep multi-hop support (which we want) without the recursive-CTE surface, which reads poorly and — because it inlines per-row-unique SQL — can't be reused by the query cache.

The diff is a direct swap: **− recursive CTE / `Arel.sql` / `sanitize_sql_array` / `effective_source_id_subquery` / `effective_source_id_ref` / `resolve_aspect_in_sql?`, + the in-memory `effective_source_id` walk.** Readers (`workflows`, `statuses`, `patterns`, `attribute_groups`, …) resolve to the owning **id**; the flag-off fast path keeps the eager-loadable `own_*` association.

## Benchmark environment

Measured via `rails runner` against the **local Docker Postgres** (unix socket, near-zero round-trip latency), inside a rolled-back transaction, feature flag forced on unless stated. Read as:

- **Query counts / real DB round-trips: exact and latency-independent.**
- **Wall-clock: directional only.** A local socket round-trip is microseconds, so these times *under*-represent production round-trip cost on a networked/PgBouncer DB — which favours fewer round-trips (this PR) more than shown.

## Results

### 1. WP details page — resolution per page load (flag **ON**)

One type, multiple aspects (`workflows` + `patterns` + `description` + `attribute_groups`), 3000 loads, fresh request cache each.

| Implementation | variant — queries | variant — ms/page | root — queries | root — ms/page |
|---|---|---|---|---|
| old (per-hop walk) | 11 | 1.66 | 5 | 0.22 |
| CTE (#24422, now on dev) | 6 | 0.60 | 4 | 0.15 |
| **in-memory (this PR)** | **5** | **0.58** | **2** | 0.18 |

Flag **OFF** (current default): **2 queries, ~0.002 ms/page — identical for all three** (readers short-circuit to `own_*` / `self`). No page-load impact until `type_variants` is enabled.

### 2. List render — real DB round-trips (50 one-hop variants, one request)

Each row resolves `workflows`  if the workflow warning is brought back; this is where the approaches diverge.

| Implementation | real DB round-trips |
|---|---|
| old | 103 |
| CTE (#24422) | 50 |
| **in-memory (this PR)** | **2** |

## Reading it

- **On single-record hot paths (WP page) the CTE and in-memory are a wash** — sub-millisecond, ~5 queries, within local-DB noise. in-memory does marginally fewer queries (it dedupes shared-aspect reads + the owner `find` via the query cache).
- **On list rendering they diverge decisively.** The CTE bakes each row's id into unique SQL → uncacheable round-trips that scale with list size. in-memory fires identical SQL (edge load + shared-owner fetch) → **2** round-trips, query-cache-served. This is the latency-independent advantage, and it grows with list size and network latency.
- Behaviourally identical to the merged CTE, including the legacy-cycle case (returns the re-entry node; the CTE returned `self` there — no spec covers it either way).
- The types index does **not** trigger resolution in either flag state (verified): the flag-on grouped list reads only own/root attributes, and the flag-off table's workflow-warning column resolves to the eager-loaded `own_workflows`.

## Verification

- Specs (unchanged — behaviour is identical, no spec edits): `configuration_linkable_spec`, `custom_fields_spec`, `configuration_link_spec`, `type_spec`, `copy_configuration/project_attributes_service_spec` — **122 examples, 0 failures** on the current dev.
- RuboCop clean on the changed files (pre-existing offenses only, none in edited regions).

---

## Addendum — from review to a best-of-both-worlds resolution

> ⚠️ The current code **supersedes the in-memory version described above.** Everything above is preserved as the exploration that led here; this section is the approach that actually shipped in the branch.

The in-memory version held up on the benchmarks above — but those only exercised small link tables (tens of rows). @klaustopher's review raised the right question: in a big installation with several thousand `type_configuration_links`, loading the whole aspect's edge set into Ruby (`pluck` → cast values → build hash → GC) could dominate, because the cost there is Ruby object churn, not the query.

Benchmarking at scale confirmed it. The in-memory walk is **O(N) in the aspect's link count**, while the CTE stays flat (indexed on `(type_id, aspect)`):

| Links for aspect | CTE — CPU/call | in-memory — CPU/call | in-memory allocs/call |
|---|---|---|---|
| ~1,000 | 0.23 ms | 0.45 ms | 1,168 |
| ~6,000 | 0.13 ms | 2.41 ms | 6,142 |
| ~16,000 | 0.05 ms | 5.08 ms | 16,150 |
| ~36,000 | 0.04 ms | **12.4 ms** | 36,158 |

An index on `aspect` doesn't rescue it: the predicate isn't selective (you want *every* link for the aspect), so Postgres keeps a Seq Scan even with a covering index, and the dominant cost is the Ruby-side casting + hash build + GC — which no index touches.

So the in-memory approach was the wrong trade for scale. But the review also isolated what actually made the CTE unpleasant: not the SQL, but its **usage** — the `Arel.sql` / inlined-subquery plumbing leaking into every reader.

**Resolution (current code):** keep the recursive CTE for its scale-flat, depth-independent lookup, but run it as a scalar query inside `effective_source_id` that returns a plain id. The SQL now lives in exactly one method; every caller just does `where(type_id: effective_source_id_for(…))` — no Arel anywhere else.

```ruby
def effective_source_id(type_id, aspect)
  return type_id unless type_id && OpenProject::FeatureDecisions.type_variants_active?

  sql = sanitize_sql_array([<<~SQL.squish, { type_id:, aspect: }])
    WITH RECURSIVE link_chain(node_id, path) AS ( … )
    SELECT cl.node_id FROM link_chain cl WHERE NOT EXISTS ( … ) LIMIT 1
  SQL
  connection.select_value(sql)&.to_i || type_id
end
```

Resolution stays flat with table size — same profile as #24422, ~50× cheaper than the in-memory walk at 21k links:

| Links for aspect | `effective_source_id_for` |
|---|---|
| 1,000 | 0.088 ms/call |
| 21,000 | 0.435 ms/call |

The one trade versus the inlined form in #24422: resolving to an id and then filtering is **2 queries per read** instead of 1. The extra one is a cheap indexed CTE (~0.1 ms), and in list rendering the fetch usually dedupes via the query cache (≈ N+1 vs N). In exchange, the readers are plain Ruby and the SQL is quarantined to a single documented method.

Tracing all four versions on the WP details page as `type_configuration_links` grows shows the whole set of trade-offs — the improvements from each step, and why in-memory was the wrong turn:

> **WP details page — resolution cost per page load, vs links-table size.** `type_variants` **on**; one type resolving four aspects (`workflows`, `patterns`, `description`, `attribute_groups`); _N_ links **per aspect**; measured uncached (cold request), `ANALYZE`d so the CTE plans correctly; same harness for all rows. Values are **CPU ms/page** (the stable signal).

| Version | queries/page | 1k | 6k | 16k | 36k | scaling |
|:---|---:|---:|---:|---:|---:|:---|
| old (per-hop Ruby) | 20 | 4.0 | 2.2 | 2.9 | 2.1 | flat, but chatty |
| CTE + Arel (#24422) | 10 | 1.8 | 1.5 | 1.2 | 1.7 | flat, fewest queries |
| in-memory (rejected) | 11 | 11.9 | 21.3 | 45.8 | **95.8** | **O(_N_) — blows up** |
| **isolated CTE (this PR)** | 11 | 2.1 | 3.4 | 2.0 | 1.0 | flat, clean callers |

The steps: **old → #24422** cut 20 chatty round-trips to 10 and halved CPU (still flat). **#24422 → in-memory** kept queries low and made callers plain Ruby, but each resolution now `pluck`s the whole aspect table → **O(_N_)**, ~96 ms/page at 36k. **in-memory → this PR** restores flat, scale-safe resolution _and_ keeps the plain-Ruby callers, for the price of one extra query per read (11 vs 10).

Thanks @klaustopher — the back-and-forth turned a readability-vs-scale either/or into a version that keeps both, in my opinion.


