### PR TITLE
[COMMS-923] Reopen work packages validates on target_versions instead of version

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -599,7 +599,9 @@ module WorkPackages
     end
 
     def validate_no_reopen_on_closed_version
-      if model.version_id && model.reopened? && model.version.closed?
+      return unless model.effective_target_versions.any?(&:closed?)
+
+      if model.reopened?
         errors.add :base, I18n.t(:error_can_not_reopen_work_package_on_closed_version)
       end
     end

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -152,6 +152,22 @@ module WorkPackage::Versions
   def override_target_versions? = !target_version_ids_replacements.nil?
   def override_observed_in_versions? = !observed_in_version_ids_replacements.nil?
 
+  # List of target versions, but takes into account pending overrides that were
+  # not written yet
+  #
+  # By precedence:
+  #   * target_version_ids_replacements
+  #   * pending version_id change
+  #   * actual written target_versions
+  def effective_target_versions
+    if target_version_ids_replacements.nil?
+      return version_id_changed? ? Array(version) : target_versions
+    end
+
+    versions_by_id = Version.where(id: target_version_ids_replacements).index_by(&:id)
+    target_version_ids_replacements.filter_map { |id| versions_by_id[id] }
+  end
+
   # An override can also originate from the system, e.g. when versions that are
   # not shared with the (new) project are cleared on a project change. Such
   # overrides are marked here so that contracts don't attribute them to the

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -65,6 +65,9 @@ module WorkPackage::Versions
     # that the journal snapshot sees the current version sets in the database.
     after_save :persist_version_associations
 
+    # Store in memory values that will replace target/observed_in version values
+    # This is used by the contracts/services flow in order to do checks and validations
+    # before persisting any actual data to the database
     attr_accessor :target_version_ids_replacements,
                   :observed_in_version_ids_replacements
   end
@@ -161,6 +164,7 @@ module WorkPackage::Versions
   #   * actual written target_versions
   def effective_target_versions
     if target_version_ids_replacements.nil?
+      # TODO(COMMS-863)
       return version_id_changed? ? Array(version) : target_versions
     end
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -587,12 +587,12 @@ module API
                              getter: ->(*) {
                                next unless embed_link?(:target_versions)
 
-                               effective_target_versions.map do |version|
+                               represented.effective_target_versions.map do |version|
                                  ::API::V3::Versions::VersionRepresenter.create(version, current_user:)
                                end
                              },
                              link: ->(*) {
-                               effective_target_versions.map do |version|
+                               represented.effective_target_versions.map do |version|
                                  ::API::Decorators::LinkObject
                                    .new(version,
                                         property_name: :itself,
@@ -784,15 +784,6 @@ module API
 
         def visible_children
           @visible_children ||= represented.children.select(&:visible?)
-        end
-
-        # returns pending replacements if they are present, or the association itself otherwise
-        def effective_target_versions
-          replacement_ids = represented.target_version_ids_replacements
-          return represented.target_versions if replacement_ids.nil?
-
-          versions_by_id = Version.where(id: replacement_ids).index_by(&:id)
-          replacement_ids.filter_map { |id| versions_by_id[id] }
         end
 
         delegate :schedule_manually=, to: :represented

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1181,6 +1181,38 @@ RSpec.describe WorkPackages::BaseContract do
           expect(subject.errors).to be_empty
         end
       end
+
+      context "when the closed version is assigned through target_versions" do
+        before do
+          allow(work_package)
+            .to receive(:target_versions)
+            .and_return([assignable_version])
+        end
+
+        context "and reopening the work package" do
+          before do
+            allow(work_package)
+              .to receive(:reopened?)
+              .and_return(true)
+
+            subject.validate
+          end
+
+          it "is invalid" do
+            expect(subject.errors[:base]).to eql [I18n.t(:error_can_not_reopen_work_package_on_closed_version)]
+          end
+        end
+
+        context "and not reopening the work package" do
+          before do
+            subject.validate
+          end
+
+          it "is valid" do
+            expect(subject.errors).to be_empty
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/COMMS-923/activity

# What are you trying to accomplish?
Adjust the validation when reopening work packages, so that it works through target_versions instead of version.

I ended up refactoring a check to also validate in memory data. It was something being done on the API level, but because of DRY I moved to the model.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
