### PR TITLE
[DREAM-761] Use FullCalendar Draggable in team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.sass
@@ -31,3 +31,12 @@
     padding: 8px 16px
     background: white
     border-radius: 5px
+
+  // Source card while it is being dragged onto the calendar
+  &--wp_dragging
+    opacity: 0.2
+
+  // FullCalendar's drag mirror: a body-level clone of the card that keeps
+  // this component's style-scoping attributes
+  &--wp.fc-event-dragging
+    opacity: 0.8

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
@@ -57,7 +57,6 @@ export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnI
     // ViewChild reference may be undefined initially
     // due to ngIf
     if (v !== undefined) {
-      this.calendarDrag.destroyDrake();
       this.calendarDrag.registerDrag(v, '.op-add-existing-pane--wp');
     }
   }
@@ -143,7 +142,7 @@ export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnI
 
   ngOnDestroy():void {
     super.ngOnDestroy();
-    this.calendarDrag.destroyDrake();
+    this.calendarDrag.destroyDraggable();
   }
 
   searchWorkPackages(searchString:string):Observable<WorkPackageResource[]> {

--- a/frontend/src/app/features/team-planner/team-planner/calendar-drag-drop.service.ts
+++ b/frontend/src/app/features/team-planner/team-planner/calendar-drag-drop.service.ts
@@ -1,7 +1,6 @@
 import { ElementRef, Injectable, inject } from '@angular/core';
-import { ThirdPartyDraggable } from '@fullcalendar/interaction';
-import { DragMetaInput } from '@fullcalendar/common';
-import dragula, { Drake } from 'dragula';
+import { Draggable } from '@fullcalendar/interaction';
+import { DragMetaInput, PointerDragEvent } from '@fullcalendar/core/internal';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { BehaviorSubject } from 'rxjs';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
@@ -17,7 +16,9 @@ export class CalendarDragDropService {
   readonly workPackagesCalendarService = inject(OpWorkPackagesCalendarService);
   readonly I18n = inject(I18nService);
 
-  drake:Drake;
+  private draggable:Draggable|undefined;
+
+  private draggedElement:HTMLElement|undefined;
 
   draggableWorkPackages$ = new BehaviorSubject<WorkPackageResource[]>([]);
 
@@ -30,31 +31,35 @@ export class CalendarDragDropService {
     },
   };
 
-  destroyDrake():void {
-    if (this.drake) {
-      this.drake.destroy();
-    }
+  destroyDraggable():void {
+    this.draggable?.destroy();
+    this.draggable = undefined;
   }
 
   registerDrag(container:ElementRef<HTMLElement>, itemSelector:string):void {
-    this.drake = dragula({
-      containers: [container.nativeElement],
-      revertOnSpill: true,
-    });
+    this.destroyDraggable();
 
-    this.drake.on('drag', (el:HTMLElement) => {
-      el.classList.add('gu-transit');
-      this.isDragging$.next(el.dataset.dragHelperId);
-    });
-
-    this.drake.on('dragend', () => {
-      this.isDragging$.next(undefined);
-    });
-
-    new ThirdPartyDraggable(container.nativeElement, {
+    this.draggable = new Draggable(container.nativeElement, {
       itemSelector,
-      mirrorSelector: '.gu-mirror', // the dragging element that dragula renders
       eventData: this.eventData.bind(this),
+    });
+
+    // `dragging` is typed public but undocumented: FullCalendar treats the
+    // pointer-drag engine as internal, so an upgrade may move or rename it.
+    const { emitter } = this.draggable.dragging;
+
+    emitter.on('dragstart', (ev:PointerDragEvent) => {
+      this.draggedElement = ev.subjectEl as HTMLElement;
+      this.draggedElement.classList.add('op-add-existing-pane--wp_dragging');
+      this.isDragging$.next(this.draggedElement.dataset.dragHelperId);
+    });
+
+    // A mid-drag destroy() delivers a dragend without subjectEl, so the
+    // dragged element is tracked in a field instead.
+    emitter.on('dragend', () => {
+      this.draggedElement?.classList.remove('op-add-existing-pane--wp_dragging');
+      this.draggedElement = undefined;
+      this.isDragging$.next(undefined);
     });
   }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-761

# What are you trying to accomplish?

Drop Dragula from the team planner's add-existing pane. Dragula only supplied the pointer-drag mirror, bridged into FullCalendar via `ThirdPartyDraggable`; FullCalendar's own `Draggable` covers the same ground directly.

This also fixes a leak: a new `ThirdPartyDraggable` was created on every re-render of the pane, with no previous instance ever destroyed.

Dragula stays a dependency — it is still used by the Stimulus drag-and-drop controllers and `DragAndDropService`.

## Screenshots

No significant visual changes.

# What approach did you choose and why?

`registerDrag` now constructs a FullCalendar `Draggable`, destroying any previous instance first. Both draggables feed the same drop pipeline, so `eventData` and `eventReceive` are unchanged.

The dragging state was previously expressed through Dragula's `gu-transit` class and `gu-mirror` element. It is now toggled from the drag engine's `dragstart`/`dragend` events, with the source-card and mirror styling moved into the component's own sass. That emitter (`draggable.dragging`) is typed public but undocumented — an upgrade may move it — which is called out at the access site.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
