### PR TITLE
Bug/op 19811 accidentally using a date for calculated value will cause either 500 or cause unknown error

### DIFF
--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -79,7 +79,7 @@ module CustomField::CalculatedValue
   FIELD_FORMATS_FOR_FORMULA = %w[int float calculated_value weighted_item_list].freeze
 
   def self.calculator_instance
-    Dentaku::Calculator.new(case_sensitive: true)
+    Dentaku::Calculator.new(case_sensitive: true, raw_date_literals: false)
   end
 
   class_methods do

--- a/spec/models/acts_as_customizable/calculated_value_spec.rb
+++ b/spec/models/acts_as_customizable/calculated_value_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_ee: %i[calculated_value
           "1 + 2" => 3,
           "2 - 3" => -1,
           "3 * 4" => 12,
-          "5 / 4" => 5/4r,
-          "6 % 5" => 1,
+          "5 / 4" => BigDecimal("1.25"),
+          "6 % 5" => BigDecimal("1"),
           "2 ^ 10" => 1024,
-          "6 + 7%" => 607/100r,
+          "6 + 7%" => BigDecimal("6.07"),
           "2 * (1 + 2)" => 6
         }
       end

--- a/spec/models/acts_as_customizable/calculated_value_spec.rb
+++ b/spec/models/acts_as_customizable/calculated_value_spec.rb
@@ -122,6 +122,23 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_ee: %i[calculated_value
       it_behaves_like "handles operations"
     end
 
+    context "with arythmetic operations looking like date literals (#OP-19811)" do
+      let(:formulae_and_results) do
+        {
+          "10-1-1" => 8,
+          "10-01-01" => 8,
+          "10-10-10" => -10,
+          "10-20-30" => -40, # invalid date
+          "2010-1-1" => 2008,
+          "2010-01-01" => 2008,
+          "2010-10-10" => 1990,
+          "2010-20-30" => 1960 # invalid date
+        }
+      end
+
+      it_behaves_like "handles operations"
+    end
+
     context "with comparison operators" do
       let(:formulae_and_results) do
         {

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -670,6 +670,20 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
       end
     end
 
+    describe "when a formula looks like a date (#OP-19811)" do
+      context "when it looks like an invalid date" do
+        let(:formula) { "10-20-30" }
+
+        it_behaves_like "valid formula"
+      end
+
+      context "when it looks like a valid date" do
+        let(:formula) { "2026-04-03" }
+
+        it_behaves_like "valid formula"
+      end
+    end
+
     context "with a formula containing unexpected constant" do
       let(:formula) { "abc + 2" }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19811

# What are you trying to accomplish?
Prevent odd behaviour when dentaku parses arythmetic formula as date literal

# What approach did you choose and why?
Disable using dentaku option

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
