### PR TITLE
[DREAM-784] Pilot LiveComponent on documents page header (experiment, do not merge)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -434,3 +434,6 @@ source "https://rubygems.org", cooldown: 0 do
   gem "openproject-octicons_helper", "~>19.35.0"
   gem "openproject-primer_view_components", "~>0.89.2"
 end
+
+# LiveComponent pilot — see https://community.openproject.org/wp/DREAM-784
+gem "live_component", "~> 0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -795,6 +795,11 @@ GEM
       logger
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    live_component (0.4.0)
+      railties (~> 8.0)
+      use_context (~> 1.2)
+      view_component (~> 4.0)
+      weak_key_map (~> 1.0)
     lobby_boy (0.1.3)
       omniauth (~> 1.1)
       omniauth-openid-connect (>= 0.2.1)
@@ -1481,6 +1486,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
+    use_context (1.2.0)
     useragent (0.16.11)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -1498,6 +1504,7 @@ GEM
       rack (>= 2.0.9)
     warden-basic_auth (0.2.1)
       warden (~> 1.2)
+    weak_key_map (1.0.0)
     webauthn (3.4.3)
       android_key_attestation (~> 0.3.0)
       bindata (~> 2.4)
@@ -1644,6 +1651,7 @@ DEPENDENCIES
   launchy (~> 3.1.0)
   letter_opener_web
   listen (~> 3.10.0)
+  live_component (~> 0.4.0)
   lograge (~> 0.15.0)
   lookbook (= 2.3.14)
   mail (= 2.9.1)
@@ -1995,6 +2003,7 @@ CHECKSUMS
   letter_opener_web (3.0.0) sha256=3f391efe0e8b9b24becfab5537dfb17a5cf5eb532038f947daab58cb4b749860
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  live_component (0.4.0) sha256=4518ef95d4cb771285c1c397db511d50f0cbd7db604fcfe9f3a64ada628ca43c
   lobby_boy (0.1.3) sha256=9460bb3c052aef158eb3f137b8f7679ca756b8e2983d140dbdc0caa85c018172
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   lograge (0.15.0) sha256=34072c1f50b95019dc185137f5fec1a6759f5a1b6d55c28163d0cba204e6df16
@@ -2287,6 +2296,7 @@ CHECKSUMS
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  use_context (1.2.0) sha256=887b430251034e06d1f6550fa487f8cec05f76650922f028da139c0c285a62c7
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   validate_email (0.1.6) sha256=9dfe9016d527b17a8d3a6e95e4dc50a125400eef899d13d4cc2a254393f82ee4
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451
@@ -2295,6 +2305,7 @@ CHECKSUMS
   view_component (4.12.0) sha256=b9a5979d1c43eba2aa21a06a86f661aab3990104855f2909ef7c3779acdcdcb4
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   warden-basic_auth (0.2.1) sha256=bfc752e0109c0182c3e69e930284c5e1e81e7b4a354aeb2b5914ead1391f3c6e
+  weak_key_map (1.0.0) sha256=dedbdb092955419f4a7c5c62cfda5b8427d91f9acbec4e2948d1ef7b78692ab7
   webauthn (3.4.3) sha256=9be6f5f838f3405b0226e560aa40b67cc8c15ec9154509b997caa7ec9a05e1fc
   webfinger (2.1.3) sha256=567a52bde77fb38ca6b67e55db755f988766ec4651c1d24916a65aa70540695c
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90

--- a/app/controllers/live_components_controller.rb
+++ b/app/controllers/live_components_controller.rb
@@ -12,15 +12,34 @@ class LiveComponentsController < ApplicationController
   # Cheap hardening beyond the approved experiment scope: only the pilot
   # component may be named as the root. (Child/slot classes are not yet
   # checked -- production adoption needs a full allowlist.)
+  #
+  # This controller performs no record-level authorization of its own: the
+  # client names the record to render, and the render endpoint reaches records
+  # a given user may not be allowed to view. Component-level read guards are
+  # therefore MANDATORY, not optional hardening. See the reporting notes in
+  # DREAM-784 for the disclosure details behind this requirement.
+  #
+  # IMPORTANT: a bare `render?` override is NOT sufficient. Every
+  # LiveComponent-adopting component added to this allowlist must `prepend`
+  # its own guard module (added *after* `include LiveComponent::Base`, so it
+  # sits above the gem's render wrapper in the ancestor chain) that
+  # short-circuits `render_in` to `"".html_safe` when `render?` is false --
+  # see PageHeaderComponent::RenderGuard for the pattern.
   ALLOWED_COMPONENTS = %w[Documents::ShowEditView::PageHeaderComponent].freeze
 
-  def render_component
-    data = JSON.parse(request.body.read)
-    payload, compressed = LiveComponent::Payload.decode(data["payload"])
+  # Client-supplied gzip is decompressed unbounded by the library (Payload.decode
+  # calls Zlib.gunzip with no size cap), so an attacker can trade a small request
+  # body for a large in-memory inflate. Reject oversized bodies before that runs.
+  MAX_BODY_BYTES = 1.megabyte
 
-    unless ALLOWED_COMPONENTS.include?(payload.dig("state", "ruby_class"))
-      return head :bad_request
-    end
+  def render_component
+    # Rack 2.2's SYMBOL_TO_STATUS_CODE has no :content_too_large -- the
+    # symbol for 413 is :payload_too_large (verified against the app's
+    # pinned Rack version; the "obvious" symbol name raises ArgumentError).
+    return head :payload_too_large if request.content_length.to_i > MAX_BODY_BYTES
+
+    payload, compressed = decode_payload
+    return head :bad_request unless allowed_payload?(payload)
 
     html = render_to_string(
       LiveComponent::RenderComponent.new(payload["state"], payload["reflexes"] || []),
@@ -35,5 +54,34 @@ class LiveComponentsController < ApplicationController
     # directly with no JSON wrapping.
     render plain: LiveComponent::Payload.encode(html, compress: compressed),
            content_type: "text/html"
+  end
+
+  private
+
+  # Returns [payload, compressed] on success. On failure returns bare nil
+  # (which destructures to payload: nil, compressed: nil for the caller) --
+  # the request body wasn't well-formed enough to decode: garbage JSON, a
+  # payload field that isn't valid base64/gzip/JSON, or a payload of the
+  # wrong shape entirely.
+  # The exact exception list was verified empirically (bundle exec rails
+  # runner fed garbage strings to JSON.parse/Payload.decode and recorded
+  # what actually raised): JSON::ParserError, TypeError, NoMethodError, and
+  # Zlib::Error (covers Zlib::GzipFile::Error/LengthError, both subclasses).
+  # ArgumentError never came up despite being the brief's first guess, so
+  # it's deliberately not rescued here.
+  def decode_payload
+    data = JSON.parse(request.body.read)
+    LiveComponent::Payload.decode(data["payload"])
+  rescue JSON::ParserError, Zlib::Error, TypeError, NoMethodError => e
+    Rails.logger.debug { "LiveComponentsController: rejecting malformed payload (#{e.class}: #{e.message})" }
+    nil
+  end
+
+  def allowed_payload?(payload)
+    # Valid JSON that isn't an object ("[1]", "\"x\"") survives decoding;
+    # reject it here rather than letting #dig raise on an Array or String.
+    return false unless payload.is_a?(Hash)
+
+    ALLOWED_COMPONENTS.include?(payload.dig("state", "ruby_class"))
   end
 end

--- a/app/controllers/live_components_controller.rb
+++ b/app/controllers/live_components_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Re-render endpoint for the LiveComponent pilot (DREAM-784).
+# Deliberately NOT the library's Rack middleware: inheriting from
+# ApplicationController runs user_setup so User.current is populated and
+# component-level permission checks behave like any other request.
+class LiveComponentsController < ApplicationController
+  # Renders a single component from client-provided state; the component
+  # itself performs its permission checks against User.current.
+  no_authorization_required! :render_component
+
+  # Cheap hardening beyond the approved experiment scope: only the pilot
+  # component may be named as the root. (Child/slot classes are not yet
+  # checked -- production adoption needs a full allowlist.)
+  ALLOWED_COMPONENTS = %w[Documents::ShowEditView::PageHeaderComponent].freeze
+
+  def render_component
+    data = JSON.parse(request.body.read)
+    payload, compressed = LiveComponent::Payload.decode(data["payload"])
+
+    unless ALLOWED_COMPONENTS.include?(payload.dig("state", "ruby_class"))
+      return head :bad_request
+    end
+
+    html = render_to_string(
+      LiveComponent::RenderComponent.new(payload["state"], payload["reflexes"] || []),
+      layout: false
+    )
+
+    # The request payload is JSON (Payload.decode always JSON-parses it),
+    # but the response is raw HTML: the JS client's Payload.decode only
+    # base64-decodes (and optionally gunzips) -- it never JSON.parses.
+    # This matches the library's own reference Rack middleware
+    # (LiveComponent::Middleware#call), which encodes the render result
+    # directly with no JSON wrapping.
+    render plain: LiveComponent::Payload.encode(html, compress: compressed),
+           content_type: "text/html"
+  end
+end

--- a/app/controllers/live_components_controller.rb
+++ b/app/controllers/live_components_controller.rb
@@ -5,13 +5,17 @@
 # ApplicationController runs user_setup so User.current is populated and
 # component-level permission checks behave like any other request.
 class LiveComponentsController < ApplicationController
-  # Renders a single component from client-provided state; the component
-  # itself performs its permission checks against User.current.
+  # `no_authorization_required!` is only OpenProject's "did you remember to
+  # authorize" tripwire -- it enforces nothing. Login is normally enforced by
+  # `check_if_login_required`, which is a no-op when `Setting.login_required?`
+  # is false (a supported configuration for public instances), so require it
+  # explicitly: this endpoint renders client-named state and has no anonymous
+  # use case.
   no_authorization_required! :render_component
+  before_action :require_login
 
-  # Cheap hardening beyond the approved experiment scope: only the pilot
-  # component may be named as the root. (Child/slot classes are not yet
-  # checked -- production adoption needs a full allowlist.)
+  # Every component reachable through this endpoint, mapped to the reflexes it
+  # may have dispatched on it.
   #
   # This controller performs no record-level authorization of its own: the
   # client names the record to render, and the render endpoint reaches records
@@ -20,17 +24,44 @@ class LiveComponentsController < ApplicationController
   # DREAM-784 for the disclosure details behind this requirement.
   #
   # IMPORTANT: a bare `render?` override is NOT sufficient. Every
-  # LiveComponent-adopting component added to this allowlist must `prepend`
-  # its own guard module (added *after* `include LiveComponent::Base`, so it
-  # sits above the gem's render wrapper in the ancestor chain) that
-  # short-circuits `render_in` to `"".html_safe` when `render?` is false --
-  # see PageHeaderComponent::RenderGuard for the pattern.
-  ALLOWED_COMPONENTS = %w[Documents::ShowEditView::PageHeaderComponent].freeze
+  # LiveComponent-adopting component added here must `prepend` its own guard
+  # module (added *after* `include LiveComponent::Base`, so it sits above the
+  # gem's render wrapper in the ancestor chain) that short-circuits `render_in`
+  # to `"".html_safe` when `render?` is false -- see
+  # PageHeaderComponent::RenderGuard for the pattern. And because
+  # LiveComponent::RenderComponent dispatches reflexes *before* it calls
+  # `component.render_in`, that guard does not cover reflexes either: each
+  # reflex must authorize itself as well.
+  ALLOWED_COMPONENTS = {
+    "Documents::ShowEditView::PageHeaderComponent" => %w[update_title].freeze
+  }.freeze
 
-  # Client-supplied gzip is decompressed unbounded by the library (Payload.decode
-  # calls Zlib.gunzip with no size cap), so an attacker can trade a small request
-  # body for a large in-memory inflate. Reject oversized bodies before that runs.
   MAX_BODY_BYTES = 1.megabyte
+
+  # No pilot interaction sends more than one reflex per render.
+  MAX_REFLEXES = 4
+
+  # `__lc_attributes` is merged *last* into the rendered element's attributes
+  # by LiveComponent::Base::Overrides#render_in, so an unfiltered client value
+  # can add event-handler attributes and override the framework's own
+  # data-controller / data-component / data-livecomponent / data-id -- the
+  # attributes the client-side morph and targeting logic keys on. Accept only
+  # the two keys the pilot legitimately round-trips.
+  ALLOWED_LC_ATTRIBUTE_KEYS = %w[id data-id].freeze
+
+  # The serializer records which of a hash's keys were Symbols in a sibling
+  # `_lc_symkeys` entry (LiveComponent::Serializer::SYMBOL_KEYS_KEY), so it
+  # rides along inside __lc_attributes and has to be permitted -- constrained
+  # to naming only the attributes above.
+  LC_SYMBOL_KEYS = LiveComponent::Serializer::SYMBOL_KEYS_KEY
+
+  # Reflex argument values are run through the full LiveComponent serializer,
+  # which turns client hashes into arbitrary records (`_lc_gid` -> an unsigned
+  # GlobalID::Locator.locate) or arbitrary constants (`_lc_ser: "Module"` ->
+  # String#constantize). The pilot's reflexes take scalars, so require scalars.
+  SCALAR_PROP_TYPES = [String, Numeric, TrueClass, FalseClass, NilClass].freeze
+
+  GZIP_MAGIC = "\x1F\x8B".b.freeze
 
   def render_component
     # Rack 2.2's SYMBOL_TO_STATUS_CODE has no :content_too_large -- the
@@ -38,50 +69,135 @@ class LiveComponentsController < ApplicationController
     # pinned Rack version; the "obvious" symbol name raises ArgumentError).
     return head :payload_too_large if request.content_length.to_i > MAX_BODY_BYTES
 
-    payload, compressed = decode_payload
+    payload = decode_payload
     return head :bad_request unless allowed_payload?(payload)
 
-    html = render_to_string(
-      LiveComponent::RenderComponent.new(payload["state"], payload["reflexes"] || []),
-      layout: false
-    )
-
-    # The request payload is JSON (Payload.decode always JSON-parses it),
-    # but the response is raw HTML: the JS client's Payload.decode only
-    # base64-decodes (and optionally gunzips) -- it never JSON.parses.
-    # This matches the library's own reference Rack middleware
-    # (LiveComponent::Middleware#call), which encodes the render result
-    # directly with no JSON wrapping.
-    render plain: LiveComponent::Payload.encode(html, compress: compressed),
+    # The request payload is JSON, but the response is raw HTML: the JS
+    # client's Payload.decode only base64-decodes (and optionally gunzips) --
+    # it never JSON.parses. This matches the library's own reference Rack
+    # middleware (LiveComponent::Middleware#call), which encodes the render
+    # result directly with no JSON wrapping.
+    render plain: LiveComponent::Payload.encode(rendered_html(payload), compress: false),
            content_type: "text/html"
   end
 
   private
 
-  # Returns [payload, compressed] on success. On failure returns bare nil
-  # (which destructures to payload: nil, compressed: nil for the caller) --
-  # the request body wasn't well-formed enough to decode: garbage JSON, a
-  # payload field that isn't valid base64/gzip/JSON, or a payload of the
-  # wrong shape entirely.
-  # The exact exception list was verified empirically (bundle exec rails
-  # runner fed garbage strings to JSON.parse/Payload.decode and recorded
-  # what actually raised): JSON::ParserError, TypeError, NoMethodError, and
-  # Zlib::Error (covers Zlib::GzipFile::Error/LengthError, both subclasses).
-  # ArgumentError never came up despite being the brief's first guess, so
-  # it's deliberately not rescued here.
+  def rendered_html(payload)
+    render_to_string(
+      LiveComponent::RenderComponent.new(payload["state"], payload["reflexes"] || []),
+      layout: false
+    )
+  end
+
+  def allowed_payload?(payload)
+    return false unless payload.is_a?(Hash)
+
+    state = payload["state"]
+
+    allowed_state?(state) && allowed_reflexes?(payload["reflexes"] || [], state["ruby_class"])
+  end
+
+  # Returns the decoded payload, or nil when the request body wasn't
+  # well-formed enough to decode: garbage JSON, a payload field that isn't
+  # valid base64/JSON, or a payload of the wrong shape entirely.
+  #
+  # This deliberately does not call LiveComponent::Payload.decode. That method
+  # hands a gzip body straight to Zlib.gunzip with no size cap, which puts the
+  # MAX_BODY_BYTES gate above on the wrong side of the decompression: 1 MB of
+  # gzip inflates to roughly 800 MB at DEFLATE's maximum ratio. Our transport
+  # (OpLiveComponentTransport) never compresses, so reject the compressed form
+  # outright rather than trying to bound the inflate.
   def decode_payload
     data = JSON.parse(request.body.read)
-    LiveComponent::Payload.decode(data["payload"])
-  rescue JSON::ParserError, Zlib::Error, TypeError, NoMethodError => e
+    return nil unless data.is_a?(Hash) && data["payload"].is_a?(String)
+
+    raw = Base64.decode64(data["payload"])
+    return nil if raw.start_with?(GZIP_MAGIC)
+
+    JSON.parse(raw, max_nesting: 32)
+  rescue JSON::ParserError, TypeError, NoMethodError, ArgumentError => e
     Rails.logger.debug { "LiveComponentsController: rejecting malformed payload (#{e.class}: #{e.message})" }
     nil
   end
 
-  def allowed_payload?(payload)
-    # Valid JSON that isn't an object ("[1]", "\"x\"") survives decoding;
-    # reject it here rather than letting #dig raise on an Array or String.
-    return false unless payload.is_a?(Hash)
+  # The allowlist has to bound the *whole* state tree, not just the root.
+  # LiveComponent::State.build recurses into `children` and `slots`, and each
+  # nested `ruby_class` is safe_constantize'd and has its own
+  # `deserialize_props` run -- which reaches ModelSerializer, and therefore
+  # arbitrary record loads, on a path with no `render?` and no RenderGuard.
+  # The pilot component declares no slots and renders no live children, so
+  # require both to be empty rather than trying to validate them.
+  def allowed_state?(state)
+    return false unless state.is_a?(Hash)
+    return false unless ALLOWED_COMPONENTS.key?(state["ruby_class"])
+    return false unless empty_tree?(state["children"]) && empty_tree?(state["slots"])
 
-    ALLOWED_COMPONENTS.include?(payload.dig("state", "ruby_class"))
+    allowed_props?(state["props"], state["ruby_class"])
+  end
+
+  def empty_tree?(value)
+    value.nil? || value == {}
+  end
+
+  # Unknown prop names are not merely useless. LiveComponent::Base's
+  # `deserialize_props` memoizes a serializer into a *class-level* hash keyed
+  # by the client's own prop name (`prop_serializers[k] ||= ...`), so every
+  # invented name is interned for the life of the process.
+  def allowed_props?(props, ruby_class)
+    return false unless props.is_a?(Hash)
+    return false unless props.keys.all? { |key| component_prop_names(ruby_class).include?(key.to_s) }
+
+    allowed_lc_attributes?(props["__lc_attributes"])
+  end
+
+  def component_prop_names(ruby_class)
+    @component_prop_names ||= {}
+    @component_prop_names[ruby_class] ||= begin
+      # Safe to constantize: allowed_state? has already checked the allowlist.
+      init_args = ruby_class.constantize.__lc_init_args
+      init_args.filter_map { |type, name| name.to_s if %i[key keyreq].include?(type) } + ["__lc_attributes"]
+    end
+  end
+
+  def allowed_lc_attributes?(attributes)
+    return true if attributes.nil?
+    return false unless attributes.is_a?(Hash)
+
+    attributes.all? { |key, value| allowed_lc_attribute?(key.to_s, value) }
+  end
+
+  def allowed_lc_attribute?(key, value)
+    return allowed_lc_symbol_keys?(value) if key == LC_SYMBOL_KEYS
+
+    ALLOWED_LC_ATTRIBUTE_KEYS.include?(key) && value.is_a?(String)
+  end
+
+  def allowed_lc_symbol_keys?(value)
+    value.is_a?(Array) && value.all? { |name| ALLOWED_LC_ATTRIBUTE_KEYS.include?(name.to_s) }
+  end
+
+  # LiveComponent::SafeDispatcher accepts any public method defined on any
+  # ViewComponent subclass in the receiver's ancestor chain -- `public` is an
+  # API-design signal, not an authorization statement -- so narrow the
+  # reachable set to an explicit per-component allowlist here.
+  def allowed_reflexes?(reflexes, ruby_class)
+    return false unless reflexes.is_a?(Array) && reflexes.size <= MAX_REFLEXES
+
+    allowed = ALLOWED_COMPONENTS.fetch(ruby_class)
+
+    reflexes.all? do |reflex|
+      reflex.is_a?(Hash) &&
+        allowed.include?(reflex["method_name"]) &&
+        allowed_reflex_props?(reflex["props"])
+    end
+  end
+
+  def allowed_reflex_props?(props)
+    return true if props.nil?
+
+    props.is_a?(Hash) && props.each_value.all? do |value|
+      SCALAR_PROP_TYPES.any? { |type| value.is_a?(type) }
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,15 @@ require "view_component"
 require "primer/view_components"
 require "primer/view_components/engine"
 
+# live_component (0.4.0) hooks on_load(:action_controller) and calls `helper`,
+# which ActionController::API does not implement. This hook registers earlier
+# than the gem's, so when an API base fires the load hooks it first gains a
+# no-op `helper` and the gem's hook becomes harmless (pilot workaround,
+# DREAM-784 — the upstream fix is hooking :action_controller_base instead).
+ActiveSupport.on_load(:action_controller) do
+  define_singleton_method(:helper) { |*, **, &_blk| } unless respond_to?(:helper)
+end
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups(:opf_plugins))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,6 +339,9 @@ Rails.application.routes.draw do
     delete "/favorite" => "favorites#unfavorite"
   end
 
+  # LiveComponent pilot (DREAM-784): client-initiated re-render endpoint
+  post "/live_components/render", to: "live_components#render_component"
+
   resources :project_queries, only: %i[show new create update destroy], controller: "projects/queries" do
     concerns :shareable
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "@blocknote/mantine": "^0.51.4",
         "@blocknote/react": "^0.51.3",
         "@braintree/sanitize-url": "^7.1.2",
+        "@camertron/live-component": "0.4.0",
         "@datorama/akita": "^8.0.1",
         "@floating-ui/dom": "^1.2.1",
         "@fullcalendar/angular": "^6.1.21",
@@ -2369,6 +2370,21 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@camertron/live-component": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@camertron/live-component/-/live-component-0.4.0.tgz",
+      "integrity": "sha512-J1b7/nPRlRMku+hyLZkolRCr5nXF1pnNTCITqARDnxEGcPlRqczpJ2eoKfftuW+UQyt9cZNq//G1p01AaDWaOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "idiomorph": "^0.7"
+      },
+      "peerDependencies": {
+        "@hotwired/stimulus": "^3.2",
+        "@vitejs/plugin-react": "^5.0",
+        "react": "^19.1",
+        "react-dom": "^19.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
     "@blocknote/mantine": "^0.51.4",
     "@blocknote/react": "^0.51.3",
     "@braintree/sanitize-url": "^7.1.2",
+    "@camertron/live-component": "0.4.0",
     "@datorama/akita": "^8.0.1",
     "@floating-ui/dom": "^1.2.1",
     "@fullcalendar/angular": "^6.1.21",

--- a/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
@@ -8,26 +8,32 @@ export default class PageHeaderLiveController extends LiveController {
 
   edit(event:Event):void {
     event.preventDefault();
-    void this.render((component) => { component.props.state = 'edit'; });
+    this.render((component) => { component.props.state = 'edit'; }).catch(() => undefined);
   }
 
   cancel(event:Event):void {
     event.preventDefault();
-    void this.render((component) => { component.props.state = 'show'; });
+    this.render((component) => { component.props.state = 'show'; }).catch(() => undefined);
   }
 
   save(event:Event):void {
     event.preventDefault();
     const title = this.titleInputTarget.value;
-    void this.render((component) => {
+    this.render((component) => {
       component.call('update_title', { title });
-    });
+    }).catch(() => undefined);
   }
 
   after_update():void {
     if (this.hasTitleInputTarget) {
       this.titleInputTarget.focus();
       this.titleInputTarget.select();
+    }
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.has('state')) {
+      url.searchParams.delete('state');
+      window.history.replaceState({}, document.title, url.toString());
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
@@ -1,0 +1,25 @@
+import { LiveController } from '@camertron/live-component';
+
+export default class PageHeaderLiveController extends LiveController {
+  static targets = ['titleInput'];
+
+  declare readonly titleInputTarget:HTMLInputElement;
+  declare readonly hasTitleInputTarget:boolean;
+
+  edit(event:Event):void {
+    event.preventDefault();
+    void this.render((component) => { component.props.state = 'edit'; });
+  }
+
+  cancel(event:Event):void {
+    event.preventDefault();
+    void this.render((component) => { component.props.state = 'show'; });
+  }
+
+  after_update():void {
+    if (this.hasTitleInputTarget) {
+      this.titleInputTarget.focus();
+      this.titleInputTarget.select();
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
@@ -1,4 +1,5 @@
 import { LiveController } from '@camertron/live-component';
+import { OPToastEvent } from 'core-app/shared/components/toaster/toast-event';
 
 export default class PageHeaderLiveController extends LiveController {
   static targets = ['titleInput'];
@@ -8,12 +9,14 @@ export default class PageHeaderLiveController extends LiveController {
 
   edit(event:Event):void {
     event.preventDefault();
-    this.render((component) => { component.props.state = 'edit'; }).catch(() => undefined);
+    this.render((component) => { component.props.state = 'edit'; })
+      .catch((error:unknown) => this.reportRenderFailure(error));
   }
 
   cancel(event:Event):void {
     event.preventDefault();
-    this.render((component) => { component.props.state = 'show'; }).catch(() => undefined);
+    this.render((component) => { component.props.state = 'show'; })
+      .catch((error:unknown) => this.reportRenderFailure(error));
   }
 
   save(event:Event):void {
@@ -21,9 +24,13 @@ export default class PageHeaderLiveController extends LiveController {
     const title = this.titleInputTarget.value;
     this.render((component) => {
       component.call('update_title', { title });
-    }).catch(() => undefined);
+    }).catch((error:unknown) => this.reportRenderFailure(error));
   }
 
+  // Also runs on connect(): the library calls after_update() at the end of
+  // propagate_state, and connect() reaches it via
+  // propagate_state_from_element(). Both effects below are idempotent, but
+  // the name implies a narrower trigger than it has.
   after_update():void {
     if (this.hasTitleInputTarget) {
       this.titleInputTarget.focus();
@@ -35,5 +42,21 @@ export default class PageHeaderLiveController extends LiveController {
       url.searchParams.delete('state');
       window.history.replaceState({}, document.title, url.toString());
     }
+  }
+
+  // LiveController's task queue logs a render failure but re-rejects it, so
+  // every caller has to handle the rejection itself. Without this, a 4xx/5xx,
+  // a dropped connection, an expired session (302 to the sign-in page) and a
+  // permission-denied empty body -- which makes the library's own state
+  // lookup throw -- all present identically as "the button did nothing".
+  private reportRenderFailure(error:unknown):void {
+    console.error('LiveComponent render failed', error);
+
+    window.dispatchEvent(new CustomEvent(OPToastEvent, {
+      detail: {
+        message: I18n.t('js.error.internal'),
+        type: 'error',
+      },
+    }));
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/page-header-live.controller.ts
@@ -16,6 +16,14 @@ export default class PageHeaderLiveController extends LiveController {
     void this.render((component) => { component.props.state = 'show'; });
   }
 
+  save(event:Event):void {
+    event.preventDefault();
+    const title = this.titleInputTarget.value;
+    void this.render((component) => {
+      component.call('update_title', { title });
+    });
+  }
+
   after_update():void {
     if (this.hasTitleInputTarget) {
       this.titleInputTarget.focus();

--- a/frontend/src/stimulus/live-component-transport.ts
+++ b/frontend/src/stimulus/live-component-transport.ts
@@ -1,0 +1,50 @@
+import { RenderRequest, Transport } from '@camertron/live-component';
+
+// Replaces the library's HTTPTransport, which sends no CSRF token
+// (library gap, v0.4.0). Skips gzip: the server's Payload.decode sniffs
+// the gzip magic bytes and accepts plain base64.
+//
+// Note: Transport#render returns Promise<string> (the decoded HTML), not
+// a RenderResponse object -- the package's public types export no such
+// type, and HTTPTransport itself just resolves/rejects a string. On a
+// non-2xx response we throw; LiveController's internal task queue
+// catches and logs it rather than crashing the app.
+export class OpLiveComponentTransport implements Transport {
+  constructor(public url:string) {}
+
+  start():void {
+    // No connection/handshake to establish; fetch() is stateless per-request.
+  }
+
+  async render(request:RenderRequest):Promise<string> {
+    const json = JSON.stringify(request);
+    const bytes = new TextEncoder().encode(json);
+    let binary = '';
+    bytes.forEach((b) => { binary += String.fromCharCode(b); });
+    const payload = btoa(binary);
+
+    const csrfToken = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '';
+
+    const response = await fetch(this.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/html',
+        'X-CSRF-Token': csrfToken,
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify({ payload }),
+    });
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw new Error(`LiveComponent render failed (${response.status}): ${text}`);
+    }
+
+    const decodedBinary = atob(text.trim());
+    const decodedBytes = Uint8Array.from(decodedBinary, (c) => c.charCodeAt(0));
+
+    return new TextDecoder().decode(decodedBytes);
+  }
+}

--- a/frontend/src/stimulus/live-component-transport.ts
+++ b/frontend/src/stimulus/live-component-transport.ts
@@ -7,8 +7,9 @@ import { RenderRequest, Transport } from '@camertron/live-component';
 // Note: Transport#render returns Promise<string> (the decoded HTML), not
 // a RenderResponse object -- the package's public types export no such
 // type, and HTTPTransport itself just resolves/rejects a string. On a
-// non-2xx response we throw; LiveController's internal task queue
-// catches and logs it rather than crashing the app.
+// non-2xx response we throw; LiveController's internal task queue logs
+// the error but still re-rejects it, so callers of `render()` must
+// attach their own `.catch()` or the rejection is unhandled.
 export class OpLiveComponentTransport implements Transport {
   constructor(public url:string) {}
 

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -40,6 +40,9 @@ import RevealController from '@stimulus-components/reveal';
 import AutoThemeSwitcher from './controllers/auto-theme-switcher.controller';
 import { OpenProjectStimulusApplication } from 'core-stimulus/openproject-stimulus-application';
 import { Application } from '@hotwired/stimulus';
+import { Application as LiveComponentApplication, LiveComponent } from '@camertron/live-component';
+import { OpLiveComponentTransport } from './live-component-transport';
+import PageHeaderLiveController from './controllers/dynamic/documents/page-header-live.controller';
 import { BeforeunloadController } from './controllers/beforeunload.controller';
 import ExternalLinksController from './controllers/external-links.controller';
 import DisableWhenClickedController from 'core-stimulus/controllers/disable-when-clicked.controller';
@@ -105,10 +108,22 @@ OpenProjectStimulusApplication.preregister('header-project-select', HeaderProjec
 OpenProjectStimulusApplication.preregister('checkable', CheckableController);
 OpenProjectStimulusApplication.preregister('expandable-text', ExpandableTextController);
 
+// Manual LiveComponent registration. The library's @live decorator derives
+// identifiers with String#replace('::', '-'), which only replaces the first
+// occurrence and breaks two-level namespaces (v0.4.0 bug).
+const PAGE_HEADER_LC_IDENTIFIER = 'documents-showeditview-pageheadercomponent';
+if (!window.customElements.get(PAGE_HEADER_LC_IDENTIFIER)) {
+  window.customElements.define(PAGE_HEADER_LC_IDENTIFIER, class extends LiveComponent {});
+}
+PageHeaderLiveController.identifier = PAGE_HEADER_LC_IDENTIFIER;
+OpenProjectStimulusApplication.preregister(PAGE_HEADER_LC_IDENTIFIER, PageHeaderLiveController);
+
 installElements();
 
 const instance = OpenProjectStimulusApplication.start();
 window.Stimulus = instance;
+
+LiveComponentApplication.start(instance, new OpLiveComponentTransport('/live_components/render'));
 
 instance.debug = !environment.production;
 instance.handleError = (error, message, detail) => {

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -50,7 +50,7 @@
     )
   ) do |layout|
     layout.with_header do
-      render Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:)
+      render Documents::ShowEditView::PageHeaderComponent.new(document:, project:, state:)
     end
 
     layout.with_tab(name: I18n.t("activerecord.models.document"), show_left: true) do

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -51,7 +51,7 @@
   ) do |layout|
     layout.with_header do
       render Documents::ShowEditView::PageHeaderComponent.new(
-        document:, project:, state:,
+        document:, state:,
         __lc_attributes: { "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID }
       )
     end

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -50,7 +50,10 @@
     )
   ) do |layout|
     layout.with_header do
-      render Documents::ShowEditView::PageHeaderComponent.new(document:, project:, state:)
+      render Documents::ShowEditView::PageHeaderComponent.new(
+        document:, project:, state:,
+        __lc_attributes: { "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID }
+      )
     end
 
     layout.with_tab(name: I18n.t("activerecord.models.document"), show_left: true) do

--- a/modules/documents/app/components/documents/show_edit_view/collaboration_disabled_notice_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/collaboration_disabled_notice_component.html.erb
@@ -34,7 +34,7 @@
     component.with_main(classes: "op-document-view--main") do
       flex_layout(align_items: :center) do |flex|
         flex.with_row(classes: "op-document-view--header") do
-          render Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:)
+          render Documents::ShowEditView::PageHeaderComponent.new(document:, project:, state:)
         end
 
         flex.with_row(classes: "op-document-view--editor") do

--- a/modules/documents/app/components/documents/show_edit_view/collaboration_disabled_notice_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/collaboration_disabled_notice_component.html.erb
@@ -34,7 +34,10 @@
     component.with_main(classes: "op-document-view--main") do
       flex_layout(align_items: :center) do |flex|
         flex.with_row(classes: "op-document-view--header") do
-          render Documents::ShowEditView::PageHeaderComponent.new(document:, project:, state:)
+          render Documents::ShowEditView::PageHeaderComponent.new(
+            document:, project:, state:,
+            __lc_attributes: { "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID }
+          )
         end
 
         flex.with_row(classes: "op-document-view--editor") do

--- a/modules/documents/app/components/documents/show_edit_view/collaboration_disabled_notice_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/collaboration_disabled_notice_component.html.erb
@@ -35,7 +35,7 @@
       flex_layout(align_items: :center) do |flex|
         flex.with_row(classes: "op-document-view--header") do
           render Documents::ShowEditView::PageHeaderComponent.new(
-            document:, project:, state:,
+            document:, state:,
             __lc_attributes: { "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID }
           )
         end

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
@@ -30,61 +30,59 @@
 %>
 
 <%=
-  component_wrapper do
-    render(Primer::OpenProject::PageHeader.new(**page_header_attributes)) do |header|
-      header.with_title do |title|
-        if allowed_to_manage_documents?
-          title.with_editable_form(
-            model: document,
-            update_path: update_title_document_path(document),
-            cancel_path: cancel_title_edit_document_path(document),
-            label: Document.human_attribute_name(:title),
-            placeholder: Document.human_attribute_name(:title)
-          )
-        end
-
-        document.title
+  render(Primer::OpenProject::PageHeader.new(**page_header_attributes)) do |header|
+    header.with_title do |title|
+      if allowed_to_manage_documents?
+        title.with_editable_form(
+          model: document,
+          update_path: update_title_document_path(document),
+          cancel_path: cancel_title_edit_document_path(document),
+          label: Document.human_attribute_name(:title),
+          placeholder: Document.human_attribute_name(:title)
+        )
       end
 
-      header.with_description do
-        render(Documents::ShowEditView::PageHeader::InfoLineComponent.new(document))
-      end
+      document.title
+    end
 
-      header.with_breadcrumbs(breadcrumbs_items)
+    header.with_description do
+      render(Documents::ShowEditView::PageHeader::InfoLineComponent.new(document))
+    end
 
-      header.with_action_menu(**action_menu_options) do |menu|
-        if allowed_to_manage_documents?
-          menu.with_item(
-            label: I18n.t("documents.page_header.action_menu.edit_title"),
-            href: edit_title_document_path(document),
-            content_arguments: {
-              data: { turbo_stream: true }
-            }
-          ) do |item|
-            item.with_leading_visual_icon(icon: :pencil)
-          end
-        end
+    header.with_breadcrumbs(breadcrumbs_items)
 
+    header.with_action_menu(**action_menu_options) do |menu|
+      if allowed_to_manage_documents?
         menu.with_item(
-          label: I18n.t("button_copy_link_to_clipboard"),
-          tag: :"clipboard-copy",
-          content_arguments: { value: document_url(document) }
+          label: I18n.t("documents.page_header.action_menu.edit_title"),
+          href: edit_title_document_path(document),
+          content_arguments: {
+            data: { turbo_stream: true }
+          }
         ) do |item|
-          item.with_leading_visual_icon(icon: :paste)
+          item.with_leading_visual_icon(icon: :pencil)
         end
+      end
 
-        if allowed_to_manage_documents?
-          menu.with_item(
-            label: I18n.t(:button_delete),
-            scheme: :danger,
-            tag: :a,
-            content_arguments: {
-              data: { controller: "async-dialog" }
-            },
-            href: delete_dialog_document_path(document)
-          ) do |item|
-            item.with_leading_visual_icon(icon: :trash)
-          end
+      menu.with_item(
+        label: I18n.t("button_copy_link_to_clipboard"),
+        tag: :"clipboard-copy",
+        content_arguments: { value: document_url(document) }
+      ) do |item|
+        item.with_leading_visual_icon(icon: :paste)
+      end
+
+      if allowed_to_manage_documents?
+        menu.with_item(
+          label: I18n.t(:button_delete),
+          scheme: :danger,
+          tag: :a,
+          content_arguments: {
+            data: { controller: "async-dialog" }
+          },
+          href: delete_dialog_document_path(document)
+        ) do |item|
+          item.with_leading_visual_icon(icon: :trash)
         end
       end
     end

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
@@ -35,7 +35,7 @@
       header.with_title do |title|
         if allowed_to_manage_documents?
           title.with_editable_form(
-            model:,
+            model: document,
             update_path: update_title_document_path(document),
             cancel_path: cancel_title_edit_document_path(document),
             label: Document.human_attribute_name(:title),

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
@@ -31,18 +31,12 @@
 
 <%=
   render(Primer::OpenProject::PageHeader.new(**page_header_attributes)) do |header|
-    header.with_title do |title|
-      if allowed_to_manage_documents?
-        title.with_editable_form(
-          model: document,
-          update_path: update_title_document_path(document),
-          cancel_path: cancel_title_edit_document_path(document),
-          label: Document.human_attribute_name(:title),
-          placeholder: Document.human_attribute_name(:title)
-        )
+    header.with_title do
+      if display_state == :edit
+        render_title_edit_form
+      else
+        document.title
       end
-
-      document.title
     end
 
     header.with_description do
@@ -55,9 +49,9 @@
       if allowed_to_manage_documents?
         menu.with_item(
           label: I18n.t("documents.page_header.action_menu.edit_title"),
-          href: edit_title_document_path(document),
+          tag: :button,
           content_arguments: {
-            data: { turbo_stream: true }
+            data: { action: "#{self.class.__lc_controller}#edit" }
           }
         ) do |item|
           item.with_leading_visual_icon(icon: :pencil)

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -34,10 +34,16 @@ module Documents
     class PageHeaderComponent < ApplicationComponent
       include OpTurbo::Streamable
 
-      alias_method :document, :model
+      STATES = %i[show edit].freeze
 
-      options :project
-      options state: :show
+      attr_reader :document, :project, :state
+
+      def initialize(document:, project:, state: :show)
+        super()
+        @document = document
+        @project = project
+        @state = state.to_sym.presence_in(STATES) || :show
+      end
 
       def page_header_attributes
         {

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -93,6 +93,22 @@ module Documents
         safe_join([title_edit_error_banner, title_edit_form])
       end
 
+      # Reflex: invoked from the client via SafeDispatcher before re-render
+      # (see LiveComponent::RenderComponent#render_in). Public on purpose --
+      # that is the dispatch contract, so this method authorizes itself
+      # rather than relying on the render endpoint (which performs no
+      # authorization -- see LiveComponentsController).
+      def update_title(title:)
+        return unless allowed_to_manage_documents?
+
+        call = Documents::UpdateService
+          .new(user: User.current, model: document)
+          .call(title:)
+
+        @document = call.result
+        @state = call.success? ? :show : :edit
+      end
+
       private
 
       def __lc_tag_name = LC_IDENTIFIER
@@ -104,8 +120,9 @@ module Documents
       end
 
       def title_edit_form
-        form_with(model: document, url: update_title_document_path(document), method: :put,
-                  class: "d-flex") do |f|
+        form_with(model: document, url: "#",
+                  class: "d-flex",
+                  data: { action: "#{self.class.__lc_controller}#save" }) do |f|
           safe_join([title_edit_input(f), title_edit_save_button, title_edit_cancel_button])
         end
       end

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -32,9 +32,13 @@
 module Documents
   module ShowEditView
     class PageHeaderComponent < ApplicationComponent
-      include OpTurbo::Streamable
+      include LiveComponent::Base
 
       STATES = %i[show edit].freeze
+      DOM_ID = "document-page-header-live"
+
+      serializes :document, with: :model_serializer, reload: true
+      serializes :project, with: :model_serializer, reload: true
 
       attr_reader :document, :project, :state
 

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -36,13 +36,18 @@ module Documents
 
       # LiveComponent::Base::Overrides#render_in is prepended by `include
       # LiveComponent::Base` above, and it unconditionally serializes the
-      # full props (document/project attributes included) into the
-      # `data-state` HTML attribute before ViewComponent's `render?` is ever
-      # consulted -- so a bare `render?` guard suppresses only the visible
-      # markup, not that serialized payload. Prepending a module *after* the
-      # include puts it above Overrides in the ancestor chain, so it runs
-      # first and can short-circuit the entire render -- including
-      # `data-state` -- before Overrides ever serializes anything.
+      # full props (document attributes included) into the `data-state` HTML
+      # attribute before ViewComponent's `render?` is ever consulted -- so a
+      # bare `render?` guard suppresses only the visible markup, not that
+      # serialized payload. Prepending a module *after* the include puts it
+      # above Overrides in the ancestor chain, so it runs first and can
+      # short-circuit the entire render -- including `data-state` -- before
+      # Overrides ever serializes anything.
+      #
+      # IMPORTANT: this guards *rendering only*. LiveComponent::RenderComponent
+      # dispatches every client-named reflex BEFORE it calls
+      # `component.render_in` (see its #render_in), so RenderGuard cannot gate
+      # a reflex. Reflexes must authorize themselves -- see #update_title.
       module RenderGuard
         def render_in(view_context, &)
           return "".html_safe unless render?
@@ -61,24 +66,45 @@ module Documents
       # JS registration.
       LC_IDENTIFIER = "documents-showeditview-pageheadercomponent"
 
-      serializes :document, with: :model_serializer, reload: true
-      serializes :project, with: :model_serializer, reload: true
+      # `attributes: false` matters twice over: with `reload: true` the
+      # deserialized attribute hash is discarded anyway (ModelSerializer
+      # re-locates from the database), and the default `attributes: true`
+      # would dump every column of the record into the `data-state` attribute
+      # of the served page.
+      serializes :document, with: :model_serializer, reload: true, attributes: false
 
-      attr_reader :document, :project, :state
+      attr_reader :document, :state
 
       def self.__lc_controller = LC_IDENTIFIER
+
+      # Derived, never a prop. An independently deserialized `project:` would
+      # be authorized by nothing -- `render?` guards the document, so a
+      # mismatched (document, project) pair would leak the foreign project's
+      # name and identifier through the breadcrumbs and evaluate
+      # `manage_documents` against a project of the client's choosing.
+      delegate :project, to: :document
 
       # The render endpoint (LiveComponentsController) performs no record-level
       # authorization of its own and the client names the record to render, so
       # the component must enforce read permission itself. See the controller's
       # ALLOWED_COMPONENTS comment and DREAM-784.
-      def render? = User.current.allowed_in_project?(:view_documents, document.project)
+      #
+      # The type check is not redundant: a GlobalID names its own model class,
+      # so the client picks what `document` actually is. Several models answer
+      # `#project` and `#title`, and without this the render only fails later,
+      # by accident, at the first Document-specific method call.
+      def render?
+        document.is_a?(Document) &&
+          User.current.allowed_in_project?(:view_documents, document.project)
+      end
 
-      def initialize(document:, project:, state: :show)
+      def initialize(document:, state: :show)
         super()
         @document = document
-        @project = project
-        @state = state.to_sym.presence_in(STATES) || :show
+        # `to_s` first: `state` arrives from client-controlled props and is not
+        # necessarily a Symbol or String (`to_sym` on a Hash or Integer would
+        # raise NoMethodError and surface as a 500).
+        @state = state.to_s.to_sym.presence_in(STATES) || :show
       end
 
       # A client-requested :edit without manage_documents permission
@@ -118,8 +144,15 @@ module Documents
       # that is the dispatch contract, so this method authorizes itself
       # rather than relying on the render endpoint (which performs no
       # authorization -- see LiveComponentsController).
+      #
+      # `render?` is repeated here deliberately: reflexes are dispatched
+      # before RenderGuard runs, so a reflex is reachable on a document the
+      # caller may not even read. Authorizing the read here as well as the
+      # write keeps that from being the contract's problem to catch.
       def update_title(title:)
+        return unless render?
         return unless allowed_to_manage_documents?
+        return unless title.is_a?(String)
 
         call = Documents::UpdateService
           .new(user: User.current, model: document)

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -37,10 +37,18 @@ module Documents
       STATES = %i[show edit].freeze
       DOM_ID = "document-page-header-live"
 
+      # The gem derives tag/controller names from JS sidecar files, which
+      # OpenProject does not use (controllers live under frontend/src); pin
+      # both so the custom element and Stimulus identifier match the manual
+      # JS registration.
+      LC_IDENTIFIER = "documents-showeditview-pageheadercomponent"
+
       serializes :document, with: :model_serializer, reload: true
       serializes :project, with: :model_serializer, reload: true
 
       attr_reader :document, :project, :state
+
+      def self.__lc_controller = LC_IDENTIFIER
 
       def initialize(document:, project:, state: :show)
         super()
@@ -49,14 +57,25 @@ module Documents
         @state = state.to_sym.presence_in(STATES) || :show
       end
 
+      # A client-requested :edit without manage_documents permission
+      # renders as :show instead of raising. See #page_header_attributes
+      # for why this is also the only state ever forwarded to Primer's
+      # PageHeader/Title.
+      def display_state
+        state == :edit && !allowed_to_manage_documents? ? :show : state
+      end
+
       def page_header_attributes
         {
           test_selector: "document-page-header",
-          state:,
-          data: {
-            controller: "editable-page-header-title",
-            "editable-page-header-title-input-id-value": "document_title"
-          }
+          # Always :show: Primer::OpenProject::PageHeader::Title#render?
+          # raises unless state is :show or its editable_form slot is
+          # populated, and that slot only knows how to build a
+          # server-round-trip form (fixed update_path/cancel_path). We
+          # don't use that slot -- the edit form is rendered as ordinary
+          # title content instead (see #render_title_edit_form) -- so
+          # Title must never see anything but :show.
+          state: :show
         }
       end
 
@@ -70,7 +89,44 @@ module Documents
         }
       end
 
+      def render_title_edit_form
+        safe_join([title_edit_error_banner, title_edit_form])
+      end
+
       private
+
+      def __lc_tag_name = LC_IDENTIFIER
+
+      def title_edit_error_banner
+        return unless document.errors.any?
+
+        render(Primer::Alpha::Banner.new(scheme: :danger, mb: 2)) { document.errors.full_messages.to_sentence }
+      end
+
+      def title_edit_form
+        form_with(model: document, url: update_title_document_path(document), method: :put,
+                  class: "d-flex") do |f|
+          safe_join([title_edit_input(f), title_edit_save_button, title_edit_cancel_button])
+        end
+      end
+
+      def title_edit_input(form)
+        form.text_field(:title,
+                        id: "document_title",
+                        required: false,
+                        value: document.title,
+                        "aria-label": Document.human_attribute_name(:title),
+                        data: { "#{self.class.__lc_controller}_target": "titleInput" })
+      end
+
+      def title_edit_save_button
+        render(Primer::Beta::Button.new(type: :submit, scheme: :primary, ml: 2)) { I18n.t("button_save") }
+      end
+
+      def title_edit_cancel_button
+        cancel_action = "#{self.class.__lc_controller}#cancel"
+        render(Primer::Beta::Button.new(type: :button, ml: 2, data: { action: cancel_action })) { I18n.t(:button_cancel) }
+      end
 
       def breadcrumbs_items
         [{ href: project_overview_path(project.id), text: project.name },

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -144,6 +144,11 @@ module Documents
       end
 
       def title_edit_form
+        # url: "#" is a harmless no-JS fallback (a GET to the current page) --
+        # submission is normally intercepted by the Stimulus #save action
+        # before it ever hits the network. There is no real route to point
+        # this at (saving goes through the reflex, not a controller action),
+        # so don't "fix" this into one.
         form_with(model: document, url: "#",
                   class: "d-flex",
                   data: { action: "#{self.class.__lc_controller}#save" }) do |f|
@@ -166,7 +171,7 @@ module Documents
 
       def title_edit_cancel_button
         cancel_action = "#{self.class.__lc_controller}#cancel"
-        render(Primer::Beta::Button.new(type: :button, ml: 2, data: { action: cancel_action })) { I18n.t(:button_cancel) }
+        render(Primer::Beta::Button.new(type: :button, ml: 2, data: { action: cancel_action })) { I18n.t("button_cancel") }
       end
 
       def breadcrumbs_items

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -34,6 +34,24 @@ module Documents
     class PageHeaderComponent < ApplicationComponent
       include LiveComponent::Base
 
+      # LiveComponent::Base::Overrides#render_in is prepended by `include
+      # LiveComponent::Base` above, and it unconditionally serializes the
+      # full props (document/project attributes included) into the
+      # `data-state` HTML attribute before ViewComponent's `render?` is ever
+      # consulted -- so a bare `render?` guard suppresses only the visible
+      # markup, not that serialized payload. Prepending a module *after* the
+      # include puts it above Overrides in the ancestor chain, so it runs
+      # first and can short-circuit the entire render -- including
+      # `data-state` -- before Overrides ever serializes anything.
+      module RenderGuard
+        def render_in(view_context, &)
+          return "".html_safe unless render?
+
+          super
+        end
+      end
+      prepend RenderGuard
+
       STATES = %i[show edit].freeze
       DOM_ID = "document-page-header-live"
 
@@ -49,6 +67,12 @@ module Documents
       attr_reader :document, :project, :state
 
       def self.__lc_controller = LC_IDENTIFIER
+
+      # The render endpoint (LiveComponentsController) performs no record-level
+      # authorization of its own and the client names the record to render, so
+      # the component must enforce read permission itself. See the controller's
+      # ALLOWED_COMPONENTS comment and DREAM-784.
+      def render? = User.current.allowed_in_project?(:view_documents, document.project)
 
       def initialize(document:, project:, state: :show)
         super()
@@ -89,10 +113,6 @@ module Documents
         }
       end
 
-      def render_title_edit_form
-        safe_join([title_edit_error_banner, title_edit_form])
-      end
-
       # Reflex: invoked from the client via SafeDispatcher before re-render
       # (see LiveComponent::RenderComponent#render_in). Public on purpose --
       # that is the dispatch contract, so this method authorizes itself
@@ -112,6 +132,10 @@ module Documents
       private
 
       def __lc_tag_name = LC_IDENTIFIER
+
+      def render_title_edit_form
+        safe_join([title_edit_error_banner, title_edit_form])
+      end
 
       def title_edit_error_banner
         return unless document.errors.any?

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -88,7 +88,7 @@ class DocumentsController < ApplicationController
   end
 
   def edit_title
-    update_header_component_via_turbo_stream(state: :edit)
+    replace_header_via_turbo_stream(state: :edit)
 
     respond_with_turbo_streams
   end
@@ -102,7 +102,7 @@ class DocumentsController < ApplicationController
   end
 
   def cancel_title_edit
-    update_header_component_via_turbo_stream(state: :show)
+    replace_header_via_turbo_stream(state: :show)
 
     respond_with_turbo_streams
   end
@@ -127,7 +127,7 @@ class DocumentsController < ApplicationController
       .call(document_params.slice(:title))
 
     state = call.success? ? :show : :edit
-    update_header_component_via_turbo_stream(state:)
+    replace_header_via_turbo_stream(state:)
 
     respond_with_turbo_streams
   end
@@ -227,9 +227,13 @@ class DocumentsController < ApplicationController
     @token_expires_in_seconds = token_result.result[:expires_in_seconds]
   end
 
-  def update_header_component_via_turbo_stream(state: :show)
-    update_via_turbo_stream(
-      component: Documents::ShowEditView::PageHeaderComponent.new(document: @document, project: @project, state:)
+  def replace_header_via_turbo_stream(state: :show)
+    turbo_streams << turbo_stream.replace(
+      Documents::ShowEditView::PageHeaderComponent::DOM_ID,
+      Documents::ShowEditView::PageHeaderComponent.new(
+        document: @document, project: @project, state:,
+        __lc_attributes: { "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID }
+      )
     )
   end
 

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -109,17 +109,6 @@ class DocumentsController < ApplicationController
     end
   end
 
-  def update_title
-    call = Documents::UpdateService
-      .new(user: current_user, model: @document)
-      .call(document_params.slice(:title))
-
-    state = call.success? ? :show : :edit
-    replace_header_via_turbo_stream(state:)
-
-    respond_with_turbo_streams
-  end
-
   def update_type
     service_call = Documents::UpdateService
       .new(user: current_user, model: @document)
@@ -213,16 +202,6 @@ class DocumentsController < ApplicationController
     @resource_url = token_result.result[:resource_url]
     @readonly = token_result.result[:readonly]
     @token_expires_in_seconds = token_result.result[:expires_in_seconds]
-  end
-
-  def replace_header_via_turbo_stream(state: :show)
-    turbo_streams << turbo_stream.replace(
-      Documents::ShowEditView::PageHeaderComponent::DOM_ID,
-      Documents::ShowEditView::PageHeaderComponent.new(
-        document: @document, project: @project, state:,
-        __lc_attributes: { "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID }
-      )
-    )
   end
 
   def derive_show_edit_state_from_params

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -87,24 +87,12 @@ class DocumentsController < ApplicationController
     render_400 unless @document.classic?
   end
 
-  def edit_title
-    replace_header_via_turbo_stream(state: :edit)
-
-    respond_with_turbo_streams
-  end
-
   def create
     if document_params[:kind] == "classic"
       create_classic_document
     else
       create_collaborative_document
     end
-  end
-
-  def cancel_title_edit
-    replace_header_via_turbo_stream(state: :show)
-
-    respond_with_turbo_streams
   end
 
   def update

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -229,7 +229,7 @@ class DocumentsController < ApplicationController
 
   def update_header_component_via_turbo_stream(state: :show)
     update_via_turbo_stream(
-      component: Documents::ShowEditView::PageHeaderComponent.new(@document, project: @project, state:)
+      component: Documents::ShowEditView::PageHeaderComponent.new(document: @document, project: @project, state:)
     )
   end
 

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -42,9 +42,7 @@ Rails.application.routes.draw do
 
   resources :documents, except: %i[create new index] do
     member do
-      get :edit_title, defaults: { format: :turbo_stream }
       put :update_title, defaults: { format: :turbo_stream }
-      get :cancel_title_edit, defaults: { format: :turbo_stream }
       put :update_type, defaults: { format: :turbo_stream }
       get :delete_dialog
       get :render_avatars, defaults: { format: :turbo_stream }

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -42,7 +42,6 @@ Rails.application.routes.draw do
 
   resources :documents, except: %i[create new index] do
     member do
-      put :update_title, defaults: { format: :turbo_stream }
       put :update_type, defaults: { format: :turbo_stream }
       get :delete_dialog
       get :render_avatars, defaults: { format: :turbo_stream }

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -65,7 +65,7 @@ module OpenProject::Documents
         permission :manage_documents,
                    {
                      documents: %i[
-                       new create edit update update_title update_type delete_dialog destroy
+                       new create edit update update_type delete_dialog destroy
                      ]
                    },
                    permissible_on: :project,

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -65,7 +65,7 @@ module OpenProject::Documents
         permission :manage_documents,
                    {
                      documents: %i[
-                       new create edit edit_title cancel_title_edit update update_title update_type delete_dialog destroy
+                       new create edit update update_title update_type delete_dialog destroy
                      ]
                    },
                    permissible_on: :project,

--- a/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
@@ -62,13 +62,14 @@ RSpec.describe "Show/Edit Document View",
     end
 
     aggregate_failures "can edit document title" do
-      # The Save turbo_stream.replace swaps the whole
-      # document-page-header custom element (LiveComponent's render
-      # boundary), detaching any within-node captured before it -- so
-      # each Save needs a fresh within_test_selector scope afterwards.
-      # Edit/Cancel are client-side Idiomorph morphs that preserve the
-      # node, so they're safe to chain with prior interactions in the
-      # same block; only a Save requires re-entering the scope.
+      # Edit/Cancel/Save all run through LiveComponent's client-side
+      # Idiomorph morph now (Save dispatches a reflex rather than
+      # posting to a controller action), which preserves the
+      # document-page-header custom element node across every
+      # transition -- a single within_test_selector scope would work.
+      # The split scoping below is kept anyway for robustness: it
+      # re-enters the scope after each Save so the spec doesn't
+      # depend on morph semantics never changing.
       within_test_selector("document-page-header") do
         click_button accessible_name: "Document actions"
         expect(page).to have_selector :menuitem, "Edit title"

--- a/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe "Show/Edit Document View",
     end
 
     aggregate_failures "can edit document title" do
+      # The Save turbo_stream.replace swaps the whole
+      # document-page-header custom element (LiveComponent's render
+      # boundary), detaching any within-node captured before it -- so
+      # each Save needs a fresh within_test_selector scope afterwards.
+      # Edit/Cancel are client-side Idiomorph morphs that preserve the
+      # node, so they're safe to chain with prior interactions in the
+      # same block; only a Save requires re-entering the scope.
       within_test_selector("document-page-header") do
         click_button accessible_name: "Document actions"
         expect(page).to have_selector :menuitem, "Edit title"
@@ -70,11 +77,16 @@ RSpec.describe "Show/Edit Document View",
 
         fill_in "document_title", with: ""
         click_on "Save"
+      end
+
+      within_test_selector("document-page-header") do
         expect(page).to have_content("Title can't be blank")
 
         fill_in "document_title", with: "Updated collaborative document"
         click_on "Save"
+      end
 
+      within_test_selector("document-page-header") do
         expect(page).to have_content("Updated collaborative document")
 
         click_button accessible_name: "Document actions"

--- a/spec/requests/live_components_spec.rb
+++ b/spec/requests/live_components_spec.rb
@@ -85,6 +85,89 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
       expect(html).to include("data-component=\"Documents::ShowEditView::PageHeaderComponent\"")
       expect(html).to include("document_title") # edit-state input rendered
     end
+
+    context "with an update_title reflex" do
+      let(:body) do
+        {
+          payload: LiveComponent::Payload.encode(
+            {
+              state:,
+              reflexes: [{ method_name: "update_title", props: { title: "Reflexed title" } }]
+            }.to_json,
+            compress: false
+          )
+        }.to_json
+      end
+
+      it "updates the document and re-renders in the show state" do
+        post_render
+
+        expect(response).to have_http_status(:ok)
+        expect(document.reload.title).to eq("Reflexed title")
+
+        html = decoded_response_html
+        expect(html).to include("Reflexed title")
+        expect(html).not_to include("document_title") # edit-state input gone
+      end
+    end
+
+    context "with an update_title reflex sending a blank title" do
+      let(:body) do
+        {
+          payload: LiveComponent::Payload.encode(
+            {
+              state:,
+              reflexes: [{ method_name: "update_title", props: { title: "" } }]
+            }.to_json,
+            compress: false
+          )
+        }.to_json
+      end
+
+      it "leaves the document unchanged and re-renders in the edit state with the error" do
+        post_render
+
+        expect(response).to have_http_status(:ok)
+        expect(document.reload.title).not_to eq("")
+
+        html = decoded_response_html
+        expect(html).to match(/can(?:&#39;|')t be blank/)
+        expect(html).to include("document_title") # still in edit state
+      end
+    end
+  end
+
+  context "when logged in without manage_documents permission" do
+    let(:view_only_user) do
+      create(:user, member_with_permissions: { project => %i[view_documents] })
+    end
+
+    let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :show)) }
+
+    let(:body) do
+      {
+        payload: LiveComponent::Payload.encode(
+          {
+            state:,
+            reflexes: [{ method_name: "update_title", props: { title: "Attacker title" } }]
+          }.to_json,
+          compress: false
+        )
+      }.to_json
+    end
+
+    before { login_as(view_only_user) }
+
+    it "does not update the document or render an edit affordance" do
+      post_render
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.title).not_to eq("Attacker title")
+
+      html = decoded_response_html
+      expect(html).to include(document.title)
+      expect(html).not_to include("document_title")
+    end
   end
 
   context "when logged in without project permission" do

--- a/spec/requests/live_components_spec.rb
+++ b/spec/requests/live_components_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "LiveComponents render endpoint", :skip_csrf do
+  subject(:response) { last_response }
+
+  shared_let(:project) { create(:project, enabled_module_names: %i[documents]) }
+  shared_let(:document) { create(:document, project:) }
+  shared_let(:user) { create(:user, member_with_permissions: { project => %i[view_documents manage_documents] }) }
+
+  let(:state) do
+    {
+      ruby_class: "Documents::ShowEditView::PageHeaderComponent",
+      props: Documents::ShowEditView::PageHeaderComponent.serialize_props(
+        document:, project:, state: :edit
+      ),
+      slots: {},
+      children: {}
+    }
+  end
+
+  let(:body) do
+    { payload: LiveComponent::Payload.encode({ state:, reflexes: [] }.to_json, compress: false) }.to_json
+  end
+
+  # This is a plain `type: :request` spec (auto-inferred from the file's
+  # location under spec/requests), which wires up `post`/`get` via
+  # Rack::Test::Methods (see spec/support/rspec_request_specs.rb) rather
+  # than ActionDispatch::Integration -- hence the positional params/env
+  # args here, matching the house style used by the JSON API request specs
+  # (e.g. spec/requests/api/v3/work_packages/create_form_resource_spec.rb).
+  def post_render
+    post "/live_components/render", body, "CONTENT_TYPE" => "application/json"
+  end
+
+  # Request/response payloads are asymmetric BY DESIGN: request payloads
+  # are JSON (state/reflexes), so `LiveComponent::Payload.decode` is right
+  # for those -- it always JSON.parses. But *response* HTML is decoded by
+  # the JS client's own `decode` (base64 -> optional gunzip -> raw text,
+  # no JSON.parse), matching the library's reference Rack middleware
+  # (`LiveComponent::Middleware#call`, which encodes the render result
+  # directly with no JSON wrapping). Don't use `Payload.decode` on the
+  # response body -- decode it the way the real client does.
+  def decoded_response_html
+    Base64.decode64(response.body) # spec always posts compress: false
+  end
+
+  context "when logged in with permission" do
+    before { login_as(user) }
+
+    it "re-renders the component in the requested state" do
+      post_render
+
+      expect(response).to have_http_status(:ok)
+      html = decoded_response_html
+      expect(html).to include("data-component=\"Documents::ShowEditView::PageHeaderComponent\"")
+      expect(html).to include("document_title") # edit-state input rendered
+    end
+  end
+
+  context "when logged in without project permission" do
+    # A user with no membership/permission at all on the project. The
+    # controller performs no authorization itself -- the component is
+    # expected to gate its own edit affordances based on User.current.
+    #
+    # NOTE: requesting state: :edit here (rather than :show) would raise
+    # inside Primer::OpenProject::PageHeader::Title#render?, because the
+    # editable_form slot is only populated when
+    # PageHeaderComponent#allowed_to_manage_documents? is true, and Title
+    # requires either show state or a populated editable_form. So an
+    # unprivileged client requesting the edit state is expected to never
+    # happen from the real UI (it doesn't offer the "Edit title" action in
+    # the first place); we exercise the realistic case here (show state)
+    # rather than the component's unhandled edge case, which is out of
+    # scope for this endpoint.
+    let(:unprivileged_user) { create(:user) }
+
+    let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :show)) }
+
+    before { login_as(unprivileged_user) }
+
+    it "renders the component without edit affordances" do
+      post_render
+
+      expect(response).to have_http_status(:ok)
+      html = decoded_response_html
+      expect(html).to include(document.title)
+      expect(html).not_to include("Edit title")
+    end
+  end
+
+  context "when not logged in" do
+    it "does not render" do
+      post_render
+
+      # Observed: 302, not 401. OpenProject's default `login_required`
+      # setting is true, and ApplicationController#require_login redirects
+      # HTML-format requests to the sign-in page rather than returning a
+      # 401 (that branch is reserved for xml/js/json/turbo_stream formats,
+      # and this request doesn't set an Accept header). Either way, this
+      # must not be a 200 with rendered component HTML.
+      expect(response).to have_http_status(:found)
+      expect(response.body).not_to include(document.title)
+    end
+  end
+
+  context "with a component class outside the allowlist" do
+    before { login_as(user) }
+
+    let(:state) { super().merge(ruby_class: "Users::AvatarComponent") }
+
+    it "rejects the request" do
+      post_render
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/requests/live_components_spec.rb
+++ b/spec/requests/live_components_spec.rb
@@ -91,17 +91,6 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
     # A user with no membership/permission at all on the project. The
     # controller performs no authorization itself -- the component is
     # expected to gate its own edit affordances based on User.current.
-    #
-    # NOTE: requesting state: :edit here (rather than :show) would raise
-    # inside Primer::OpenProject::PageHeader::Title#render?, because the
-    # editable_form slot is only populated when
-    # PageHeaderComponent#allowed_to_manage_documents? is true, and Title
-    # requires either show state or a populated editable_form. So an
-    # unprivileged client requesting the edit state is expected to never
-    # happen from the real UI (it doesn't offer the "Edit title" action in
-    # the first place); we exercise the realistic case here (show state)
-    # rather than the component's unhandled edge case, which is out of
-    # scope for this endpoint.
     let(:unprivileged_user) { create(:user) }
 
     let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :show)) }
@@ -115,6 +104,24 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
       html = decoded_response_html
       expect(html).to include(document.title)
       expect(html).not_to include("Edit title")
+    end
+
+    # A client-forged request for state: :edit. PageHeaderComponent#display_state
+    # downgrades this to :show rather than raising (see the component), which
+    # is also what keeps Primer::OpenProject::PageHeader::Title#render? happy --
+    # it requires either show state or a populated editable_form slot, and this
+    # component never populates that slot.
+    context "and requesting edit state" do
+      let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :edit)) }
+
+      it "still renders as show, without the edit form" do
+        post_render
+
+        expect(response).to have_http_status(:ok)
+        html = decoded_response_html
+        expect(html).to include(document.title)
+        expect(html).not_to include("document_title")
+      end
     end
   end
 

--- a/spec/requests/live_components_spec.rb
+++ b/spec/requests/live_components_spec.rb
@@ -37,20 +37,23 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
   shared_let(:document) { create(:document, project:) }
   shared_let(:user) { create(:user, member_with_permissions: { project => %i[view_documents manage_documents] }) }
 
+  let(:component_state) { :edit }
+  let(:props) do
+    Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, state: component_state)
+  end
+  let(:reflexes) { [] }
+
   let(:state) do
     {
       ruby_class: "Documents::ShowEditView::PageHeaderComponent",
-      props: Documents::ShowEditView::PageHeaderComponent.serialize_props(
-        document:, project:, state: :edit
-      ),
+      props:,
       slots: {},
       children: {}
     }
   end
 
-  let(:body) do
-    { payload: LiveComponent::Payload.encode({ state:, reflexes: [] }.to_json, compress: false) }.to_json
-  end
+  let(:payload) { { state:, reflexes: }.to_json }
+  let(:body) { { payload: LiveComponent::Payload.encode(payload, compress: false) }.to_json }
 
   # This is a plain `type: :request` spec (auto-inferred from the file's
   # location under spec/requests), which wires up `post`/`get` via
@@ -58,8 +61,8 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
   # than ActionDispatch::Integration -- hence the positional params/env
   # args here, matching the house style used by the JSON API request specs
   # (e.g. spec/requests/api/v3/work_packages/create_form_resource_spec.rb).
-  def post_render
-    post "/live_components/render", body, "CONTENT_TYPE" => "application/json"
+  def post_render(content_type: "application/json")
+    post "/live_components/render", body, "CONTENT_TYPE" => content_type
   end
 
   # Request/response payloads are asymmetric BY DESIGN: request payloads
@@ -71,7 +74,11 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
   # directly with no JSON wrapping). Don't use `Payload.decode` on the
   # response body -- decode it the way the real client does.
   def decoded_response_html
-    Base64.decode64(response.body) # spec always posts compress: false
+    Base64.decode64(response.body) # the endpoint never compresses
+  end
+
+  def update_title_reflex(title)
+    [{ method_name: "update_title", props: { title: } }]
   end
 
   context "when logged in with permission" do
@@ -86,18 +93,21 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
       expect(html).to include("document_title") # edit-state input rendered
     end
 
+    # `serializes :document, attributes: false`. The library's default
+    # (`attributes: true`) writes every column of the record into the
+    # `data-state` attribute of the served markup, and with `reload: true`
+    # deserialization discards it anyway -- so it is pure disclosure.
+    it "does not serialize the document's columns into data-state" do
+      post_render
+
+      # `created_at` is a column on both records and appears nowhere in the
+      # rendered markup, so it only shows up here if the props were serialized
+      # with the library's default `attributes: true`.
+      expect(decoded_response_html).not_to include("created_at")
+    end
+
     context "with an update_title reflex" do
-      let(:body) do
-        {
-          payload: LiveComponent::Payload.encode(
-            {
-              state:,
-              reflexes: [{ method_name: "update_title", props: { title: "Reflexed title" } }]
-            }.to_json,
-            compress: false
-          )
-        }.to_json
-      end
+      let(:reflexes) { update_title_reflex("Reflexed title") }
 
       it "updates the document and re-renders in the show state" do
         post_render
@@ -112,17 +122,7 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
     end
 
     context "with an update_title reflex sending a blank title" do
-      let(:body) do
-        {
-          payload: LiveComponent::Payload.encode(
-            {
-              state:,
-              reflexes: [{ method_name: "update_title", props: { title: "" } }]
-            }.to_json,
-            compress: false
-          )
-        }.to_json
-      end
+      let(:reflexes) { update_title_reflex("") }
 
       it "leaves the document unchanged and re-renders in the edit state with the error" do
         original_title = document.title
@@ -144,19 +144,8 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
       create(:user, member_with_permissions: { project => %i[view_documents] })
     end
 
-    let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :show)) }
-
-    let(:body) do
-      {
-        payload: LiveComponent::Payload.encode(
-          {
-            state:,
-            reflexes: [{ method_name: "update_title", props: { title: "Attacker title" } }]
-          }.to_json,
-          compress: false
-        )
-      }.to_json
-    end
+    let(:component_state) { :show }
+    let(:reflexes) { update_title_reflex("Attacker title") }
 
     before { login_as(view_only_user) }
 
@@ -172,24 +161,42 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
       expect(html).to include(document.title)
       expect(html).not_to include("document_title")
     end
+
+    # #display_state downgrades a client-requested :edit to :show when the
+    # caller cannot manage documents. This is the only example that exercises
+    # that branch: the reader *can* see the document, so RenderGuard lets the
+    # render through and the downgrade is what suppresses the form.
+    context "and requesting the edit state" do
+      let(:component_state) { :edit }
+      let(:reflexes) { [] }
+
+      it "downgrades to the show state instead of rendering the edit form" do
+        post_render
+
+        expect(response).to have_http_status(:ok)
+        html = decoded_response_html
+        expect(html).to include(document.title)
+        expect(html).not_to include("document_title")
+      end
+    end
   end
 
   context "when logged in without project permission" do
     # A user with no membership/permission at all on the project. The
-    # controller performs no authorization itself -- PageHeaderComponent's
-    # `RenderGuard` (prepended above LiveComponent::Base::Overrides in the
-    # ancestor chain -- see the component) short-circuits render_in entirely
-    # when render? is false, so a request for a document the user cannot
-    # view yields a 200 with a genuinely empty body: no visible markup, no
-    # edit affordance, and no `data-state` attribute either. (An earlier
-    # version of this guard used a bare `render?` without the prepended
-    # short-circuit; that suppressed only the visible markup while
-    # `data-state` still leaked the document's full serialized attributes.
-    # RenderGuard closes that gap by never letting LiveComponent::Base's
-    # render_in wrapper run at all.)
+    # controller performs no record-level authorization itself --
+    # PageHeaderComponent's `RenderGuard` (prepended above
+    # LiveComponent::Base::Overrides in the ancestor chain -- see the
+    # component) short-circuits render_in entirely when render? is false, so a
+    # request for a document the user cannot view yields a 200 with a
+    # genuinely empty body: no visible markup, no edit affordance, and no
+    # `data-state` attribute either. (An earlier version of this guard used a
+    # bare `render?` without the prepended short-circuit; that suppressed only
+    # the visible markup while `data-state` still leaked the document's full
+    # serialized attributes. RenderGuard closes that gap by never letting
+    # LiveComponent::Base's render_in wrapper run at all.)
     let(:unprivileged_user) { create(:user) }
 
-    let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :show)) }
+    let(:component_state) { :show }
 
     before { login_as(unprivileged_user) }
 
@@ -208,7 +215,7 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
     # :edit-downgrade logic (or any serialization) even runs, so the
     # response is empty either way.
     context "and requesting edit state" do
-      let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :edit)) }
+      let(:component_state) { :edit }
 
       it "still renders nothing, without the edit form" do
         post_render
@@ -220,32 +227,252 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
         expect(html).not_to include("document_title")
       end
     end
+
+    # RenderGuard cannot cover this: LiveComponent::RenderComponent dispatches
+    # every reflex *before* it calls component.render_in. The empty body below
+    # comes from the guard, but what stops the write is #update_title's own
+    # `render?` check.
+    context "and sending an update_title reflex" do
+      let(:reflexes) { update_title_reflex("Attacker title") }
+
+      it "does not dispatch the reflex" do
+        original_title = document.title
+
+        post_render
+
+        expect(response).to have_http_status(:ok)
+        expect(document.reload.title).to eq(original_title)
+        expect(decoded_response_html).to eq("")
+      end
+    end
   end
 
   context "when not logged in" do
     it "does not render" do
       post_render
 
-      # Observed: 302, not 401. OpenProject's default `login_required`
-      # setting is true, and ApplicationController#require_login redirects
-      # HTML-format requests to the sign-in page rather than returning a
-      # 401 (that branch is reserved for xml/js/json/turbo_stream formats,
-      # and this request doesn't set an Accept header). Either way, this
-      # must not be a 200 with rendered component HTML.
+      # Observed: 302, not 401. ApplicationController#require_login redirects
+      # HTML-format requests to the sign-in page rather than returning a 401
+      # (that branch is reserved for xml/js/json/turbo_stream formats, and
+      # this request doesn't set an Accept header). Either way, this must not
+      # be a 200 with rendered component HTML.
       expect(response).to have_http_status(:found)
       expect(response.body).not_to include(document.title)
     end
+
+    # `login_required` defaults to true, so the example above would pass even
+    # without the controller's own `before_action :require_login`. Public
+    # instances turn it off, which makes `check_if_login_required` a no-op --
+    # this endpoint must still refuse anonymous callers.
+    context "on a public instance", with_settings: { login_required: false } do
+      it "still does not render" do
+        post_render
+
+        expect(response).to have_http_status(:found)
+        expect(response.body).not_to include(document.title)
+      end
+    end
   end
 
-  context "with a component class outside the allowlist" do
+  describe "payload validation" do
     before { login_as(user) }
 
-    let(:state) { super().merge(ruby_class: "Users::AvatarComponent") }
+    shared_examples "a rejected payload" do
+      it "responds 400 without rendering" do
+        post_render
 
-    it "rejects the request" do
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).not_to include(document.title)
+      end
+    end
+
+    context "with a component class outside the allowlist" do
+      let(:state) { super().merge(ruby_class: "Users::AvatarComponent") }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # State.build recurses into children and slots, safe_constantize'ing each
+    # nested ruby_class and running its deserialize_props -- reaching
+    # ModelSerializer, and so arbitrary record loads, on a path with no
+    # render? and no RenderGuard. Allowlisting the root alone does not bound
+    # that, so the pilot requires both to be empty.
+    context "with client-supplied children" do
+      let(:state) do
+        super().merge(children: { "x" => { "ruby_class" => "Users::AvatarComponent", "props" => {} } })
+      end
+
+      it_behaves_like "a rejected payload"
+    end
+
+    context "with client-supplied slots" do
+      let(:state) { super().merge(slots: { "header" => [{ "props" => {} }] }) }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # `project` used to be a prop of its own, deserialized independently of
+    # `document` and authorized by nothing -- a mismatched pair leaked the
+    # foreign project's name through the breadcrumbs and evaluated
+    # manage_documents against a project of the client's choosing. It is now
+    # derived from document.project, and naming it is rejected outright.
+    context "with a project prop the component no longer accepts" do
+      let(:other_project) { create(:project) }
+
+      let(:props) do
+        super().merge(project: { "_lc_ar" => { "gid" => other_project.to_global_id.to_s, "signed" => false } })
+      end
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # Unknown prop names are not merely inert: LiveComponent::Base's
+    # deserialize_props memoizes a serializer into a class-level hash keyed by
+    # the client's own prop name, so each invented name is interned for the
+    # life of the process.
+    context "with an unknown prop name" do
+      let(:props) { super().merge(nonsense_prop_name: 1) }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # __lc_attributes is merged last into the rendered element's attributes,
+    # so an unfiltered value can inject event handlers and override the
+    # framework's own data-controller / data-component / data-id.
+    context "with an event handler in __lc_attributes" do
+      let(:props) { super().merge(__lc_attributes: { "onmouseover" => "alert(1)" }) }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # What a real client actually posts: the server emits `__lc_attributes`
+    # into data-state and the JS round-trips it verbatim, including the
+    # serializer's own `_lc_symkeys` marker. Rejecting that marker breaks
+    # every render (it did, until the browser spec caught it).
+    context "with the __lc_attributes a real client round-trips" do
+      let(:props) do
+        super().merge(__lc_attributes: {
+                        "id" => Documents::ShowEditView::PageHeaderComponent::DOM_ID,
+                        "data-id" => "0865fbdf-b6e1-4675-ad6e-61773d2cb740",
+                        LiveComponent::Serializer::SYMBOL_KEYS_KEY => []
+                      })
+      end
+
+      it "renders" do
+        post_render
+
+        expect(response).to have_http_status(:ok)
+        expect(decoded_response_html).to include("document_title")
+      end
+    end
+
+    context "with _lc_symkeys naming an attribute outside the allowlist" do
+      let(:props) do
+        super().merge(__lc_attributes: { LiveComponent::Serializer::SYMBOL_KEYS_KEY => ["onmouseover"] })
+      end
+
+      it_behaves_like "a rejected payload"
+    end
+
+    context "with __lc_attributes overriding the framework's own attributes" do
+      let(:props) { super().merge(__lc_attributes: { "data-controller" => "some-other-controller" }) }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # SafeDispatcher permits any public method defined on any ViewComponent
+    # subclass in the ancestor chain, so the reachable set is narrowed to an
+    # explicit per-component allowlist in the controller.
+    context "with a reflex outside the component's allowlist" do
+      let(:reflexes) { [{ method_name: "display_state", props: {} }] }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # Reflex argument values run through the full LiveComponent serializer,
+    # which turns a client hash into an arbitrary record via an unsigned
+    # GlobalID::Locator.locate.
+    context "with a non-scalar reflex argument" do
+      let(:reflexes) do
+        [{ method_name: "update_title",
+           props: { title: { "_lc_gid" => document.to_global_id.to_s } } }]
+      end
+
+      it_behaves_like "a rejected payload"
+    end
+
+    context "with more reflexes than the endpoint accepts" do
+      let(:reflexes) { Array.new(LiveComponentsController::MAX_REFLEXES + 1) { update_title_reflex("x").first } }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # Posted as text/plain on purpose: Rails' own params parser rejects a
+    # malformed application/json body before the controller is reached, so
+    # that route would exercise the middleware rather than #decode_payload.
+    context "with a body that isn't JSON" do
+      let(:body) { "not json at all" }
+
+      it "responds 400 without rendering" do
+        post_render(content_type: "text/plain")
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).not_to include(document.title)
+      end
+    end
+
+    context "with a payload that isn't valid base64-encoded JSON" do
+      let(:body) { { payload: "%%%" }.to_json }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    context "with valid JSON that isn't an object" do
+      let(:body) { { payload: LiveComponent::Payload.encode("[1]", compress: false) }.to_json }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    # Payload.decode hands a gzip body straight to Zlib.gunzip with no size
+    # cap, so the MAX_BODY_BYTES gate would sit on the wrong side of the
+    # decompression. Our transport never compresses, so the compressed form
+    # is refused outright.
+    context "with a gzip-compressed payload" do
+      let(:body) { { payload: LiveComponent::Payload.encode(payload, compress: true) }.to_json }
+
+      it_behaves_like "a rejected payload"
+    end
+
+    context "with a body over the size cap" do
+      let(:body) { { payload: "A" * (LiveComponentsController::MAX_BODY_BYTES + 1) }.to_json }
+
+      it "responds 413 without decoding the body" do
+        post_render
+
+        expect(response).to have_http_status(:payload_too_large)
+      end
+    end
+  end
+
+  # The whole point of OpLiveComponentTransport sending X-CSRF-Token. Every
+  # other example here runs with forgery protection disabled (:skip_csrf), so
+  # this is the only one that exercises it.
+  describe "forgery protection", skip_csrf: false do
+    around do |example|
+      previous = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = previous
+    end
+
+    before { login_as(user) }
+
+    it "rejects a request without a CSRF token" do
       post_render
 
-      expect(response).to have_http_status(:bad_request)
+      expect(response).to have_http_status(422)
+      expect(response.body).not_to include(document.title)
     end
   end
 end

--- a/spec/requests/live_components_spec.rb
+++ b/spec/requests/live_components_spec.rb
@@ -125,10 +125,12 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
       end
 
       it "leaves the document unchanged and re-renders in the edit state with the error" do
+        original_title = document.title
+
         post_render
 
         expect(response).to have_http_status(:ok)
-        expect(document.reload.title).not_to eq("")
+        expect(document.reload.title).to eq(original_title)
 
         html = decoded_response_html
         expect(html).to match(/can(?:&#39;|')t be blank/)
@@ -159,10 +161,12 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
     before { login_as(view_only_user) }
 
     it "does not update the document or render an edit affordance" do
+      original_title = document.title
+
       post_render
 
       expect(response).to have_http_status(:ok)
-      expect(document.reload.title).not_to eq("Attacker title")
+      expect(document.reload.title).to eq(original_title)
 
       html = decoded_response_html
       expect(html).to include(document.title)
@@ -172,37 +176,47 @@ RSpec.describe "LiveComponents render endpoint", :skip_csrf do
 
   context "when logged in without project permission" do
     # A user with no membership/permission at all on the project. The
-    # controller performs no authorization itself -- the component is
-    # expected to gate its own edit affordances based on User.current.
+    # controller performs no authorization itself -- PageHeaderComponent's
+    # `RenderGuard` (prepended above LiveComponent::Base::Overrides in the
+    # ancestor chain -- see the component) short-circuits render_in entirely
+    # when render? is false, so a request for a document the user cannot
+    # view yields a 200 with a genuinely empty body: no visible markup, no
+    # edit affordance, and no `data-state` attribute either. (An earlier
+    # version of this guard used a bare `render?` without the prepended
+    # short-circuit; that suppressed only the visible markup while
+    # `data-state` still leaked the document's full serialized attributes.
+    # RenderGuard closes that gap by never letting LiveComponent::Base's
+    # render_in wrapper run at all.)
     let(:unprivileged_user) { create(:user) }
 
     let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :show)) }
 
     before { login_as(unprivileged_user) }
 
-    it "renders the component without edit affordances" do
+    it "renders nothing at all -- not even data-state (component self-guards the read)" do
       post_render
 
       expect(response).to have_http_status(:ok)
       html = decoded_response_html
-      expect(html).to include(document.title)
-      expect(html).not_to include("Edit title")
+      expect(html).to eq("")
+      expect(html).not_to include(document.title)
+      expect(html).not_to include("document_title")
     end
 
-    # A client-forged request for state: :edit. PageHeaderComponent#display_state
-    # downgrades this to :show rather than raising (see the component), which
-    # is also what keeps Primer::OpenProject::PageHeader::Title#render? happy --
-    # it requires either show state or a populated editable_form slot, and this
-    # component never populates that slot.
+    # A client-forged request for state: :edit. Same as above: RenderGuard
+    # denies the read before PageHeaderComponent#display_state's
+    # :edit-downgrade logic (or any serialization) even runs, so the
+    # response is empty either way.
     context "and requesting edit state" do
       let(:state) { super().merge(props: Documents::ShowEditView::PageHeaderComponent.serialize_props(document:, project:, state: :edit)) }
 
-      it "still renders as show, without the edit form" do
+      it "still renders nothing, without the edit form" do
         post_render
 
         expect(response).to have_http_status(:ok)
         html = decoded_response_html
-        expect(html).to include(document.title)
+        expect(html).to eq("")
+        expect(html).not_to include(document.title)
         expect(html).not_to include("document_title")
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-784

> **Draft / visibility only — not for merge.** This is an experiment evaluating [LiveComponent](https://livecomponent.org) (client-owned component state + server re-render for ViewComponent) on a single component. It carries library workarounds in `config/application.rb` and a not-adoption-ready verdict; it is shared so the team can see the shape of the integration, not to land.

# What are you trying to accomplish?

Pilot LiveComponent 0.4.0 on the documents page-header title toggle, replacing the current `state:` + `turbo_stream` house pattern (three controller actions whose only job is re-rendering the component) with client-owned state and a server-authoritative reflex.

The title toggle now works as:

- **Edit / Cancel** — client-state flips (`this.render({ state })`) through an authenticated render endpoint, morphed in at the component boundary.
- **Save** — a LiveComponent reflex (`component.call("update_title", { title })`), server-authoritative.

Net: three controller actions + their routes + OpTurbo wiring deleted, replaced by one reflex method plus a small sidecar `LiveController`. The full edit → blank-save (validation banner) → save → cancel cycle passes in real Chrome via Cuprite.

## Screenshots

_To add before/after of the title toggle if this goes further._

# What approach did you choose and why?

Eight commits, built and reviewed task-by-task:

1. Add `live_component` 0.4.0 (gem + npm), with a boot-crash workaround in `config/application.rb` (the engine's `on_load(:action_controller)` hook crashes on `ActionController::API`).
2. Convert the component to a kwargs-only initializer (LiveComponent round-trips only keyword props).
3. `include LiveComponent::Base` + re-target the title turbo streams (the custom element renders outside the OpTurbo wrapper).
4. Authenticated render endpoint — `LiveComponentsController < ApplicationController`, NOT the library's Rack middleware, so `User.current`/session/CSRF apply. Root-component allowlist.
5. Client-side edit/cancel toggle (commit A).
6. Reflex save (commit B); delete `update_title`/`edit_title`/`cancel_title_edit`.
7. Hardening — body-size cap, malformed-payload rejection, per-component read guard.
8. Polish.

**Why a custom endpoint instead of the shipped middleware:** the library's Rack middleware bypasses the controller stack, so `User.current` is never set and permission-dependent UI renders as anonymous. Routing through a real controller costs the "no Rails overhead" speed claim but is the only correct option here.

**Verdict:** the programming model is genuinely pleasant and collapsed the boilerplate as hoped, but v0.4.0 is **not adoption-ready** — nine library gaps, eight filed upstream (`livecomponent/livecomponent#3`–`#10`), one held for private security disclosure. Full write-up lives in the team KB. Headline blockers: the engine boot crash, a global `turbo:submit-end` handler that throws on every non-LiveComponent Turbo form once the library loads, and a serializer trust issue requiring a per-component read guard.

# Merge checklist

_Not applicable — draft for visibility, not for merge._

- [ ] Added/updated tests — request spec (8 examples) + feature-spec coverage adapted; browser gate green
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — Chrome only (pilot)
