### PR TITLE
[COMMS-930] "Autocompleter" should not be an option for sorting work package tables

### DIFF
--- a/db/migrate/20260727111530_migrate_typeahead_sort_criteria_to_updated_at.rb
+++ b/db/migrate/20260727111530_migrate_typeahead_sort_criteria_to_updated_at.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require Rails.root.join("db/migrate/migration_utils/utils")
+
+class MigrateTypeaheadSortCriteriaToUpdatedAt < ActiveRecord::Migration[8.1]
+  include Migration::Utils
+
+  # "Autocomplete" (the typeahead select) is no longer offered as a Sort-by option (see COMMS-930)
+  # since its sortable SQL was always just "updated_at DESC" under the hood — so any query
+  # currently sorting by it behaves identically to sorting by updated_at desc. Migrate persisted
+  # sort_criteria accordingly, leaving any other sort criteria entries on the same query untouched.
+  def up
+    in_configurable_batches(Query) do |batches|
+      batches.each_record do |query|
+        criteria = query.sort_criteria
+        next unless criteria.any? { |key, _direction| key == "typeahead" }
+
+        migrated = criteria.map { |key, direction| key == "typeahead" ? ["updated_at", "desc"] : [key, direction] }
+        migrated = migrated.uniq { |key, _direction| key }
+
+        query.update_column(:sort_criteria, migrated)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/frontend/src/app/features/hal/resources/query-sort-by-resource.ts
+++ b/frontend/src/app/features/hal/resources/query-sort-by-resource.ts
@@ -43,6 +43,8 @@ export class QuerySortByResource extends HalResource {
   public column:QueryColumn;
 
   public direction:QuerySortByDirection;
+
+  public displayable:boolean;
 }
 
 /**

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
@@ -18,6 +18,7 @@ export class SortModalObject {
 export interface SortColumn {
   name:string;
   href:string | null;
+  displayable?:boolean;
 }
 
 export type SortingMode = 'automatic'|'manual';
@@ -86,7 +87,7 @@ export class WpTableConfigurationSortByTabComponent implements TabComponent, OnI
         const allColumns:SortColumn[] = this.wpTableSortBy.available.filter(
           (sort:QuerySortByResource) => !sort.column.href!.endsWith('/parent'),
         ).map(
-          (sort:QuerySortByResource) => ({ name: sort.column.name, href: sort.column.href }),
+          (sort:QuerySortByResource) => ({ name: sort.column.name, href: sort.column.href, displayable: sort.displayable }),
         );
 
         // For whatever reason, even though the UI doesn't implement it,
@@ -123,7 +124,10 @@ export class WpTableConfigurationSortByTabComponent implements TabComponent, OnI
       .filter((o) => o.column !== null)
       .map((object:SortModalObject) => object.column);
 
-    this.availableColumns = sortBy(this.allColumns.filter((col) => !usedColumns.some((used) => used.href === col.href)), 'name');
+    this.availableColumns = sortBy(
+      this.allColumns.filter((col) => (col.displayable ?? true) && !usedColumns.some((used) => used.href === col.href)),
+      'name',
+    );
   }
 
   public updateSortingMode(mode:SortingMode) {

--- a/lib/api/v3/queries/sort_bys/query_sort_by_representer.rb
+++ b/lib/api/v3/queries/sort_bys/query_sort_by_representer.rb
@@ -58,6 +58,14 @@ module API
 
           property :name
 
+          # rubocop:disable Naming/PredicateMethod -- name must match the "displayable" property below
+          def displayable
+            represented.displayable?
+          end
+          # rubocop:enable Naming/PredicateMethod
+
+          property :displayable, exec_context: :decorator
+
           def self_link_params
             [represented.converted_name, represented.direction_name]
           end

--- a/lib/api/v3/queries/sort_bys/sort_by_decorator.rb
+++ b/lib/api/v3/queries/sort_bys/sort_by_decorator.rb
@@ -74,6 +74,8 @@ module API
 
           delegate :caption, to: :column, prefix: true
 
+          delegate :displayable?, to: :column
+
           private
 
           def convert_attribute(attribute)

--- a/spec/features/work_packages/table/configuration_modal/sort_by_spec.rb
+++ b/spec/features/work_packages/table/configuration_modal/sort_by_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Work Package table configuration modal sort-by spec", :js do
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
+  let!(:work_package) { create(:work_package, project:) }
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:modal) { Components::WorkPackages::TableConfigurationModal.new }
+
+  before do
+    login_as(user)
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package)
+  end
+
+  it "does not offer internal, non-displayable columns as sort options (COMMS-930)" do
+    modal.open_and_switch_to("Sort by")
+
+    option_texts = page.all("#modal-sorting select.form--select option").map(&:text)
+
+    expect(option_texts).not_to include("Autocomplete")
+    expect(option_texts).to include("Status")
+  end
+end

--- a/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
@@ -71,6 +71,22 @@ RSpec.describe API::V3::Queries::SortBys::QuerySortByRepresenter do
         .at_path("name")
     end
 
+    it "has displayable attribute" do
+      expect(subject)
+        .to be_json_eql(true.to_json)
+        .at_path("displayable")
+    end
+
+    context "for a non-displayable column" do
+      let(:column) { Queries::WorkPackages::Selects::TypeaheadSelect.instances }
+
+      it "has displayable attribute set to false" do
+        expect(subject)
+          .to be_json_eql(false.to_json)
+          .at_path("displayable")
+      end
+    end
+
     it_behaves_like "has a titled link" do
       let(:link) { "column" }
       let(:href) { api_v3_paths.query_column "status" }

--- a/spec/migrations/migrate_typeahead_sort_criteria_to_updated_at_spec.rb
+++ b/spec/migrations/migrate_typeahead_sort_criteria_to_updated_at_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20260727111530_migrate_typeahead_sort_criteria_to_updated_at")
+
+RSpec.describe MigrateTypeaheadSortCriteriaToUpdatedAt, type: :model do
+  shared_let(:typeahead_only) { create(:query, sort_criteria: [["typeahead", "desc"]]) }
+  shared_let(:typeahead_with_other_criteria) { create(:query, sort_criteria: [["typeahead", "asc"], ["subject", "asc"]]) }
+  shared_let(:unrelated_query) { create(:query, sort_criteria: [["subject", "asc"]]) }
+  shared_let(:already_has_updated_at) { create(:query, sort_criteria: [["updated_at", "asc"], ["typeahead", "desc"]]) }
+
+  it "migrates typeahead sort criteria to updated_at desc, leaving everything else alone" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(typeahead_only.reload.sort_criteria).to eq([["updated_at", "desc"]])
+    expect(typeahead_with_other_criteria.reload.sort_criteria).to eq([["updated_at", "desc"], ["subject", "asc"]])
+    expect(unrelated_query.reload.sort_criteria).to eq([["subject", "asc"]])
+    # The pre-existing updated_at entry wins over the typeahead-derived replacement (first occurrence kept).
+    expect(already_has_updated_at.reload.sort_criteria).to eq([["updated_at", "asc"]])
+  end
+end


### PR DESCRIPTION
This is a bug I found during work on "[COMMS-720] Rank exact identifier matches above fuzzy ones in work package searching and autocompleters" where I probably will add a new sort order which is also `displayable: false` and should not be rendered in the dropdown for sorting work package tables as well.

# Ticket
https://community.openproject.org/wp/COMMS-930

# What are you trying to accomplish?
Remove the "Autocompleter" option from work packages table automated sort dropdowns, because it is just a "updated_at desc" under the hood and all other options in that dropdown refer to columns or attributes.

## Screenshots

BEFORE
<img width="1702" height="926" alt="Screenshot from 2026-07-27 10-42-30" src="https://github.com/user-attachments/assets/72135dec-72ed-4527-974a-f87ceba9d4c6" />

AFTER
<img width="1670" height="1364" alt="Screenshot from 2026-07-27 14-02-17" src="https://github.com/user-attachments/assets/86a119a1-d2b0-4910-9aba-c33c0f1b4451" />
(different query)

# What approach did you choose and why?
Remove all that are `displayable: false` from the dropdown list (`displayable` must therefore be exposed via the API). I decided against removing items with `displayable: false` from the API entirely, since there might be places in the future where we want to include them and also the `::Queries::WorkPackages::Selects::ManualSortingSelect` was necessary for that dialog as well even though it is `displayable: false` (it is not used in the dropdown though but for the radio buttons)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
