### PR TITLE
Add documentation about configuration via environment variables

### DIFF
--- a/docs/installation-and-operations/configuration/environment/README.md
+++ b/docs/installation-and-operations/configuration/environment/README.md
@@ -6,7 +6,8 @@ sidebar_navigation:
 
 # Environment variables
 
-> **NOTE:** This documentation is for OpenProject on-premises Installations only, if you would like to setup similar in your OpenProject cloud instance, please contact us at [support@openproject.com](mailto:support@openproject.com)
+> [!NOTE]
+> This documentation applies to OpenProject on-premises installations only. If you would like to configure a similar setup for your OpenProject Cloud instance, please contact us at [support@openproject.com](mailto:support@openproject.com)
 
 When using environment variables, you can set the options by setting environment variables with the name of the options below in uppercase. So for example, to configure email delivery via an SMTP server, you can set the following environment variables:
 

--- a/docs/system-admin-guide/authentication/scim/README.md
+++ b/docs/system-admin-guide/authentication/scim/README.md
@@ -105,3 +105,32 @@ The SCIM client must be able to obtain a JWT from the OpenID Connect provider (e
 3. The `scope` claim includes `scim_v2`.
 
 This could for example be achieved by performing a client credentials token request towards the identity provider. In the case of Keycloak as an IDP, the sub claim would then equal to the UUID of the service account that's associated to the client obtaining the token.
+
+## Configuration using environment variables
+
+For some deployment scenarios, it might be desirable to configure a SCIM client through environment variables. Those variables follow the
+rules defined in the [documentation about using environment variables](../../../installation-and-operations/configuration/environment/).
+
+The configuration `OPENPROJECT_SCIM__CLIENTS` accepts an array of JSON objects to configure SCIM clients.
+For each SCIM client you can define the following attributes:
+
+* `name`: Defines the user-visible name of the SCIM client.
+* `jwt_sub`: The sub claim that JWTs of the client can be identified with. For example, for Keycloak, this is the UUID of the service account  associated with the SCIM client.
+* `auth_provider_slug`: The slug of the OpenID Connect provider that shall be associated to the SCIM client. For example a provider configured via `OPENPROJECT_OPENID__CONNECT_KEYCLOAK` would use a slug of `keycloak`.
+
+Note that this only allows configuring SCIM clients that authenticate via JSON web tokens issued from an OpenID Connect provider.
+
+The following is a configuration example for a single SCIM client:
+
+```
+[{ "name": "My SCIM Client", "jwt_sub": "b7c8ed62-840d-451e-9ed2-6161310b4f22", "auth_provider_slug": "keycloak" }]
+```
+
+### Applying the configuration
+
+To apply the configuration after changes, you need to run the `db:seed` rake task. In all installations, this command is run automatically when you upgrade or install your application. Use the following commands based on your installation method:
+
+- **Packaged installation**: `sudo openproject run bundle exec rake db:seed`
+- **Docker**: `docker exec -it <container of all-in-one or web> bundle exec rake db:seed`.
+
+Changes will also be applied to existing SCIM clients this way. Existing SCIM clients will be matched to the ones defined in environment variables by their human-readable name.

--- a/docs/system-admin-guide/authentication/scim/README.md
+++ b/docs/system-admin-guide/authentication/scim/README.md
@@ -115,7 +115,7 @@ The configuration `OPENPROJECT_SCIM__CLIENTS` accepts an array of JSON objects t
 For each SCIM client you can define the following attributes:
 
 * `name`: Defines the user-visible name of the SCIM client.
-* `jwt_sub`: The sub claim that JWTs of the client can be identified with. For example, for Keycloak, this is the UUID of the service account  associated with the SCIM client.
+* `jwt_sub`: The sub claim that JWTs of the client can be identified with. For example, for Keycloak, this is the UUID of the service account associated with the SCIM client.
 * `auth_provider_slug`: The slug of the OpenID Connect provider that shall be associated to the SCIM client. For example a provider configured via `OPENPROJECT_OPENID__CONNECT_KEYCLOAK` would use a slug of `keycloak`.
 
 Note that this only allows configuring SCIM clients that authenticate via JSON web tokens issued from an OpenID Connect provider.

--- a/docs/system-admin-guide/authentication/scim/README.md
+++ b/docs/system-admin-guide/authentication/scim/README.md
@@ -108,17 +108,17 @@ This could for example be achieved by performing a client credentials token requ
 
 ## Configuration using environment variables
 
-For some deployment scenarios, it might be desirable to configure a SCIM client through environment variables. Those variables follow the
-rules defined in the [documentation about using environment variables](../../../installation-and-operations/configuration/environment/).
+For some deployment scenarios, it might be desirable to configure a SCIM client through environment variables. These variables follow the rules defined in the [documentation about using environment variables](../../../installation-and-operations/configuration/environment/).
 
 The configuration `OPENPROJECT_SCIM__CLIENTS` accepts an array of JSON objects to configure SCIM clients.
 For each SCIM client you can define the following attributes:
 
-* `name`: Defines the user-visible name of the SCIM client.
-* `jwt_sub`: The sub claim that JWTs of the client can be identified with. For example, for Keycloak, this is the UUID of the service account associated with the SCIM client.
-* `auth_provider_slug`: The slug of the OpenID Connect provider that shall be associated to the SCIM client. For example a provider configured via `OPENPROJECT_OPENID__CONNECT_KEYCLOAK` would use a slug of `keycloak`.
+- `name`: Defines the user-visible name of the SCIM client.
+- `jwt_sub`: The sub claim that JWTs of the client can be identified with. For example, for Keycloak, this is the UUID of the service account associated with the SCIM client.
+- `auth_provider_slug`: The slug of the OpenID Connect provider that shall be associated to the SCIM client. For example a provider configured via `OPENPROJECT_OPENID__CONNECT_KEYCLOAK` would use a slug of `keycloak`.
 
-Note that this only allows configuring SCIM clients that authenticate via JSON web tokens issued from an OpenID Connect provider.
+> [!NOTE]
+> This only allows configuring SCIM clients that authenticate via JSON web tokens issued from an OpenID Connect provider.
 
 The following is a configuration example for a single SCIM client:
 

--- a/docs/system-admin-guide/integrations/xwiki/README.md
+++ b/docs/system-admin-guide/integrations/xwiki/README.md
@@ -98,3 +98,38 @@ new values over to the corresponding XWiki forms.
 > reconnected.
 
 To learn how to link a wiki to a work package or create a new one, refer to [this user guide](../../../user-guide/work-packages/edit-work-package/#link-to-or-create-a-wiki-page).
+
+## Configuration using environment variables
+
+For some deployment scenarios, it might be desirable to configure a provider through environment variables. Those variables follow the
+rules defined in the [documentation about using environment variables](../../../installation-and-operations/configuration/environment/).
+
+The configuration `OPENPROJECT_WIKI__PROVIDERS` accepts an array of JSON objects to configure external wiki providers, such as XWiki.
+For each XWiki provider you can define the following attributes:
+
+* `type`: Must be set to `xwiki`
+* `name`: Defines the user-visible name of the wiki provider.
+* `url`: The wiki provider's base URL.
+* `uid` (optional): The XWiki installation id of the related XWiki instance. If not provided, this will be asynchronously fetched later.
+* `openproject_oauth`
+    * `client_id`: The client ID that XWiki will be able to use to authenticate towards OpenProject via OAuth.
+    * `client_secret`: The client secret that XWiki will be able to use to authenticate towards OpenProject via OAuth. Make sure to pick a strong password.
+* `xwiki_oauth`
+    * `client_id`: The client ID that OpenProject shall use to authenticate towards XWiki via OAuth.
+    * `client_secret`: The client secret that OpenProject shall use to authenticate towards XWiki via OAuth.
+
+The following is a configuration example for a single XWiki provider:
+
+```
+[{ "type": "xwiki", "name": "XWiki knowledge base", "url": "https://xwiki.example.com", "openproject_oauth": { "client_id": "xwiki", "client_secret": "secret" }, "xwiki_oauth": { "client_id": "openproject", "client_secret": "secret" } }]
+```
+
+### Applying the configuration
+
+To apply the configuration after changes, you need to run the `db:seed` rake task. In all installations, this command is run automatically when you upgrade or install your application. Use the following commands based on your installation method:
+
+- **Packaged installation**: `sudo openproject run bundle exec rake db:seed`
+- **Docker**: `docker exec -it <container of all-in-one or web> bundle exec rake db:seed`.
+
+Changes will also be applied to existing wiki providers this way. Existing wiki providers will be matched to the ones defined in environment variables preferably
+by their `uid` (if one was defined) and otherwise by their human-readable name.

--- a/docs/system-admin-guide/integrations/xwiki/README.md
+++ b/docs/system-admin-guide/integrations/xwiki/README.md
@@ -101,22 +101,21 @@ To learn how to link a wiki to a work package or create a new one, refer to [thi
 
 ## Configuration using environment variables
 
-For some deployment scenarios, it might be desirable to configure a provider through environment variables. Those variables follow the
-rules defined in the [documentation about using environment variables](../../../installation-and-operations/configuration/environment/).
+For some deployment scenarios, it might be desirable to configure a provider through environment variables. These variables follow the rules defined in the [documentation about using environment variables](../../../installation-and-operations/configuration/environment/).
 
 The configuration `OPENPROJECT_WIKI__PROVIDERS` accepts an array of JSON objects to configure external wiki providers, such as XWiki.
 For each XWiki provider you can define the following attributes:
 
-* `type`: Must be set to `xwiki`
-* `name`: Defines the user-visible name of the wiki provider.
-* `url`: The wiki provider's base URL.
-* `uid` (optional): The XWiki installation id of the related XWiki instance. If not provided, this will be asynchronously fetched later.
-* `openproject_oauth`
-    * `client_id`: The client ID that XWiki will be able to use to authenticate towards OpenProject via OAuth.
-    * `client_secret`: The client secret that XWiki will be able to use to authenticate towards OpenProject via OAuth. Make sure to pick a strong password.
-* `xwiki_oauth`
-    * `client_id`: The client ID that OpenProject shall use to authenticate towards XWiki via OAuth.
-    * `client_secret`: The client secret that OpenProject shall use to authenticate towards XWiki via OAuth.
+- `type`: Must be set to `xwiki`
+- `name`: Defines the user-visible name of the wiki provider.
+- `url`: The wiki provider's base URL.
+- `uid` (optional): The XWiki installation id of the related XWiki instance. If not provided, this will be asynchronously fetched later.
+- `openproject_oauth`
+    - `client_id`: The client ID that XWiki will be able to use to authenticate towards OpenProject via OAuth.
+    - `client_secret`: The client secret that XWiki will be able to use to authenticate towards OpenProject via OAuth. Make sure to pick a strong password.
+- `xwiki_oauth`
+    - `client_id`: The client ID that OpenProject shall use to authenticate towards XWiki via OAuth.
+   - `client_secret`: The client secret that OpenProject shall use to authenticate towards XWiki via OAuth.
 
 The following is a configuration example for a single XWiki provider:
 

--- a/docs/system-admin-guide/wikis/README.md
+++ b/docs/system-admin-guide/wikis/README.md
@@ -38,6 +38,19 @@ Permissions for pages accessed through the internal wiki provider are determined
 
 ![OpenProject administration showing internal wiki settings](openproject_system_admin_wikis_internal_wiki.png)
 
+### Configuration using environment variables
+
+The internal wiki provider can also be configured through environment variables, should this be desirable for the own deployment scenario.
+It's configured via a JSON object passed to `OPENPROJECT_INTERNAL__WIKI__PROVIDER`. Right now there's only one option that can be configured:
+
+* `enabled`: A boolean indicating, whether the internal wiki provider should be enabled or not
+
+An example disabling it:
+
+```
+{ "enabled": false }
+```
+
 ## External wikis
 
 Under [Wiki providers](./wiki-providers) you can configure external wiki providers. External wiki providers manage their own user permissions, so each OpenProject user must be connected to a corresponding user account on the external wiki instance.

--- a/docs/system-admin-guide/wikis/README.md
+++ b/docs/system-admin-guide/wikis/README.md
@@ -40,12 +40,13 @@ Permissions for pages accessed through the internal wiki provider are determined
 
 ### Configuration using environment variables
 
-The internal wiki provider can also be configured through environment variables, should this be desirable for the own deployment scenario.
-It's configured via a JSON object passed to `OPENPROJECT_INTERNAL__WIKI__PROVIDER`. Right now there's only one option that can be configured:
+The internal wiki provider can also be configured using environment variables, if this better suits your deployment scenario.
 
-* `enabled`: A boolean indicating, whether the internal wiki provider should be enabled or not
+It is configured via a JSON object passed to `OPENPROJECT_INTERNAL__WIKI__PROVIDER`. At the moment there is only one option that can be configured:
 
-An example disabling it:
+- `enabled`: A boolean indicating, whether the internal wiki provider should be enabled or not
+
+This example shows how to disable it:
 
 ```
 { "enabled": false }


### PR DESCRIPTION
OpenProject 17.7 added the possibility to configure more things via environment variables, but documentation for this wasn't added yet.

# Ticket
https://community.openproject.org/wp/DOCU-854