### PR TITLE
[COMMS-920] Include target versions on automatic subjects

### DIFF
--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -64,7 +64,7 @@ module WorkPackageTypes
         attribute(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
         attribute(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status }),
         attribute(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type }),
-        attribute(:parent_version, -> { WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.version }),
+        attribute(:parent_version, -> { WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, ARRAY),
         attribute(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
         attribute(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
         attribute(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
@@ -75,13 +75,19 @@ module WorkPackageTypes
         attribute(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, DATE),
         attribute(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status }),
         attribute(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type }),
-        attribute(:version, -> { WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.version })
+        attribute(:version, -> { WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, ARRAY)
+      ].freeze
+
+      CONDITIONAL_VERSION_ATTRIBUTE_TOKENS = [
+        attribute(:parent_target_versions, -> { WorkPackage.human_attribute_name(:target_versions) }, ->(parent) { parent.target_versions }, ARRAY),
+        attribute(:target_versions, -> { WorkPackage.human_attribute_name(:target_versions) }, ->(wp) { wp.target_versions }, ARRAY)
       ].freeze
       # rubocop:enable Layout/LineLength
 
       def partitioned_tokens_for_type(type)
         enabled_tokens = [
           *BASE_ATTRIBUTE_TOKENS,
+          *version_tokens,
           *tokenize(work_package_cfs_for(type)),
           *tokenize(project_cfs, "project_"),
           *tokenize(all_work_package_cfs, "parent_")
@@ -95,6 +101,7 @@ module WorkPackageTypes
       def all_tokens
         [
           *BASE_ATTRIBUTE_TOKENS,
+          *version_tokens,
           *tokenize(all_work_package_cfs),
           *tokenize(project_cfs, "project_"),
           *tokenize(all_work_package_cfs, "parent_")
@@ -140,6 +147,12 @@ module WorkPackageTypes
             formatter
           )
         end
+      end
+
+      def version_tokens
+        return [] unless Setting::WorkPackageMultipleVersions.active?
+
+        CONDITIONAL_VERSION_ATTRIBUTE_TOKENS
       end
 
       def work_package_cfs_for(type)

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -64,7 +64,7 @@ module WorkPackageTypes
         attribute(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
         attribute(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status }),
         attribute(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type }),
-        attribute(:parent_version, -> { WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, ARRAY),
+        attribute(:parent_version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, ARRAY),
         attribute(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
         attribute(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
         attribute(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
@@ -75,19 +75,13 @@ module WorkPackageTypes
         attribute(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, DATE),
         attribute(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status }),
         attribute(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type }),
-        attribute(:version, -> { WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, ARRAY)
-      ].freeze
-
-      CONDITIONAL_VERSION_ATTRIBUTE_TOKENS = [
-        attribute(:parent_target_versions, -> { WorkPackage.human_attribute_name(:target_versions) }, ->(parent) { parent.target_versions }, ARRAY),
-        attribute(:target_versions, -> { WorkPackage.human_attribute_name(:target_versions) }, ->(wp) { wp.target_versions }, ARRAY)
+        attribute(:version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, ARRAY)
       ].freeze
       # rubocop:enable Layout/LineLength
 
       def partitioned_tokens_for_type(type)
         enabled_tokens = [
           *BASE_ATTRIBUTE_TOKENS,
-          *version_tokens,
           *tokenize(work_package_cfs_for(type)),
           *tokenize(project_cfs, "project_"),
           *tokenize(all_work_package_cfs, "parent_")
@@ -101,7 +95,6 @@ module WorkPackageTypes
       def all_tokens
         [
           *BASE_ATTRIBUTE_TOKENS,
-          *version_tokens,
           *tokenize(all_work_package_cfs),
           *tokenize(project_cfs, "project_"),
           *tokenize(all_work_package_cfs, "parent_")
@@ -147,12 +140,6 @@ module WorkPackageTypes
             formatter
           )
         end
-      end
-
-      def version_tokens
-        return [] unless Setting::WorkPackageMultipleVersions.active?
-
-        CONDITIONAL_VERSION_ATTRIBUTE_TOKENS
       end
 
       def work_package_cfs_for(type)

--- a/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
@@ -212,70 +212,24 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
       context "when work package multiple versions is active",
               with_flag: { work_package_multiple_versions: true },
               with_settings: { work_package_multiple_versions: true } do
-        it "renders an array of values for target_version" do
+        it "renders an array of values" do
           enabled, = subject
-          token = detect(enabled, :target_versions)
+          token = detect(enabled, :version)
 
           expect(token.call(work_package)).to eq("#{version.name}, #{second_version.name}")
         end
 
-        it "resolves the same value for version and target versions" do
+        it "label is target versions" do
           enabled, = subject
-          version_token = detect(enabled, :version)
-          target_version_token = detect(enabled, :target_versions)
-
-          expect(version_token.call(work_package)).to eq(target_version_token.call(work_package))
-        end
-
-        it "resolves the same value for parent version and parent target versions" do
-          enabled, = subject
-          version_token = detect(enabled, :parent_version)
-          target_version_token = detect(enabled, :parent_target_versions)
-
-          expect(version_token.call(work_package)).to eq(target_version_token.call(work_package))
-        end
-
-        it "target_versions is enabled" do
-          enabled, = subject
-          expect(detect(enabled, :target_versions)).to be_present
-        end
-
-        it "parent_target_versions is enabled" do
-          enabled, = subject
-          expect(detect(enabled, :parent_target_versions)).to be_present
-        end
-
-        it "version is enabled" do
-          enabled, = subject
-          expect(detect(enabled, :version)).to be_present
-        end
-
-        it "parent_version is enabled" do
-          enabled, = subject
-          expect(detect(enabled, :parent_version)).to be_present
+          expect(detect(enabled, :version)&.label).to eq("Target versions")
         end
       end
 
       context "when work package multiple versions is not active",
               with_settings: { work_package_multiple_versions: false } do
-        it "target_versions is not enabled" do
+        it "label is version" do
           enabled, = subject
-          expect(detect(enabled, :target_versions)).not_to be_present
-        end
-
-        it "parent_target_versions is not enabled" do
-          enabled, = subject
-          expect(detect(enabled, :parent_target_versions)).not_to be_present
-        end
-
-        it "version is enabled" do
-          enabled, = subject
-          expect(detect(enabled, :version)).to be_present
-        end
-
-        it "parent_version is enabled" do
-          enabled, = subject
-          expect(detect(enabled, :parent_version)).to be_present
+          expect(detect(enabled, :version)&.label).to eq("Version")
         end
       end
     end

--- a/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
@@ -201,6 +201,84 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
         expect(token.call(sub_work_package)).to eq("Task")
       end
     end
+
+    context "for versions" do
+      shared_let(:second_version) { create(:version, project:) }
+
+      before do
+        create(:work_package_version, work_package:, version: second_version, kind: :target)
+      end
+
+      context "when work package multiple versions is active",
+              with_flag: { work_package_multiple_versions: true },
+              with_settings: { work_package_multiple_versions: true } do
+        it "renders an array of values for target_version" do
+          enabled, = subject
+          token = detect(enabled, :target_versions)
+
+          expect(token.call(work_package)).to eq("#{version.name}, #{second_version.name}")
+        end
+
+        it "resolves the same value for version and target versions" do
+          enabled, = subject
+          version_token = detect(enabled, :version)
+          target_version_token = detect(enabled, :target_versions)
+
+          expect(version_token.call(work_package)).to eq(target_version_token.call(work_package))
+        end
+
+        it "resolves the same value for parent version and parent target versions" do
+          enabled, = subject
+          version_token = detect(enabled, :parent_version)
+          target_version_token = detect(enabled, :parent_target_versions)
+
+          expect(version_token.call(work_package)).to eq(target_version_token.call(work_package))
+        end
+
+        it "target_versions is enabled" do
+          enabled, = subject
+          expect(detect(enabled, :target_versions)).to be_present
+        end
+
+        it "parent_target_versions is enabled" do
+          enabled, = subject
+          expect(detect(enabled, :parent_target_versions)).to be_present
+        end
+
+        it "version is enabled" do
+          enabled, = subject
+          expect(detect(enabled, :version)).to be_present
+        end
+
+        it "parent_version is enabled" do
+          enabled, = subject
+          expect(detect(enabled, :parent_version)).to be_present
+        end
+      end
+
+      context "when work package multiple versions is not active",
+              with_settings: { work_package_multiple_versions: false } do
+        it "target_versions is not enabled" do
+          enabled, = subject
+          expect(detect(enabled, :target_versions)).not_to be_present
+        end
+
+        it "parent_target_versions is not enabled" do
+          enabled, = subject
+          expect(detect(enabled, :parent_target_versions)).not_to be_present
+        end
+
+        it "version is enabled" do
+          enabled, = subject
+          expect(detect(enabled, :version)).to be_present
+        end
+
+        it "parent_version is enabled" do
+          enabled, = subject
+          expect(detect(enabled, :parent_version)).to be_present
+        end
+      end
+    end
   end
 
   private


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-920/activity

# What are you trying to accomplish?
In the context of automatic subjects
- Allow versions to behave properly when we switch to target versions
- Include target versions as allowed values

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
