### PR TITLE
Fixes CodeQL findings exposed by headers

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -117,7 +117,6 @@ import {
 } from 'core-app/features/team-planner/team-planner/planner/background-events';
 import moment from 'moment-timezone';
 import allLocales from '@fullcalendar/core/locales-all';
-import { octiconElement } from 'core-app/shared/helpers/op-icon-builder';
 import {
   personIconData,
   toDOMString,

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
@@ -51,7 +51,6 @@ import {
 } from 'core-app/features/work-packages/components/wp-baseline/baseline-helpers';
 import moment from 'moment-timezone';
 import { BannersService } from 'core-app/core/enterprise/banners.service';
-import { enterpriseDocsUrl } from 'core-app/core/setup/globals/constants.const';
 import { DayElement } from 'flatpickr/dist/types/instance';
 
 const DEFAULT_SELECTED_TIME = '08:00';

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/cell-builder.ts
@@ -37,7 +37,6 @@ import { Injector } from '@angular/core';
 import { QueryColumn } from 'core-app/features/work-packages/components/wp-query/query-column';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { LazyInject } from 'core-app/shared/helpers/angular/lazy-inject.decorator';
-import { IWorkPackageTimestamp } from 'core-app/features/hal/resources/work-package-timestamp-resource';
 import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service';
 
 export const tdClassName = 'wp-table--cell-td';

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
@@ -46,11 +46,9 @@ import URI from 'urijs';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { splitViewRoute } from 'core-app/features/work-packages/routing/split-view-routes.helper';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { OpTitleService } from 'core-app/core/html/op-title.service';
 import { WorkPackageCreateService } from './wp-create.service';
 import { HalError } from 'core-app/features/hal/services/hal-error';
-import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { HalSource } from 'core-app/features/hal/interfaces';
 

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
@@ -36,8 +36,6 @@ describe('UrlParamsHelper', () => {
   } as any;
 
   let UrlParamsHelper:UrlParamsHelperService;
-  let queryString;
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -28,9 +28,8 @@
 
 import { ChangeDetectionStrategy, Component, ElementRef, Injector, OnInit, inject } from '@angular/core';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { State } from '@openproject/reactivestates';
 import { combineLatest } from 'rxjs';
-import { filter, map, take } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { States } from 'core-app/core/states/states.service';
 import {
   WorkPackageViewTimelineService,

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table-scroll-sync.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table-scroll-sync.ts
@@ -99,13 +99,11 @@ export function createScrollSync(element:HTMLElement) {
         syncWheelEvent(ev, elTable, elTimeline);
       });
       target(elTable).on(`scroll${scrollSyncEventNamespace}`, (ev:Event) => {
-        syncedLeft = true;
-        if (!syncedRight) {
-          elTimeline.scrollTop = (ev.target as HTMLElement).scrollTop;
-        }
-        if (syncedLeft && syncedRight) {
-          syncedLeft = false;
+        if (syncedRight) {
           syncedRight = false;
+        } else {
+          syncedLeft = true;
+          elTimeline.scrollTop = (ev.target as HTMLElement).scrollTop;
         }
       });
 
@@ -114,13 +112,11 @@ export function createScrollSync(element:HTMLElement) {
         syncWheelEvent(ev, elTable, elTimeline);
       });
       target(elTimeline).on(`scroll${scrollSyncEventNamespace}`, (ev:Event) => {
-        syncedRight = true;
-        if (!syncedLeft) {
-          elTable.scrollTop = (ev.target as HTMLElement).scrollTop;
-        }
-        if (syncedLeft && syncedRight) {
+        if (syncedLeft) {
           syncedLeft = false;
-          syncedRight = false;
+        } else {
+          syncedRight = true;
+          elTable.scrollTop = (ev.target as HTMLElement).scrollTop;
         }
       });
     } else {

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table-scroll-sync.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table-scroll-sync.ts
@@ -103,7 +103,7 @@ export function createScrollSync(element:HTMLElement) {
         if (!syncedRight) {
           elTimeline.scrollTop = (ev.target as HTMLElement).scrollTop;
         }
-        if (syncedLeft && syncedRight) {
+        if (syncedRight) {
           syncedLeft = false;
           syncedRight = false;
         }
@@ -118,7 +118,7 @@ export function createScrollSync(element:HTMLElement) {
         if (!syncedLeft) {
           elTable.scrollTop = (ev.target as HTMLElement).scrollTop;
         }
-        if (syncedLeft && syncedRight) {
+        if (syncedLeft) {
           syncedLeft = false;
           syncedRight = false;
         }

--- a/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
@@ -26,16 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { WpTabWrapperComponent } from 'core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/wp-tab-wrapper.component';
-import { WorkPackagesFullViewComponent } from 'core-app/features/work-packages/routing/wp-full-view/wp-full-view.component';
 import { WorkPackageSplitViewComponent } from 'core-app/features/work-packages/routing/wp-split-view/wp-split-view.component';
 import { Ng2StateDeclaration } from '@uirouter/angular';
 import { WorkPackagesBaseComponent } from 'core-app/features/work-packages/routing/wp-base/wp--base.component';
 import { WorkPackageListViewComponent } from 'core-app/features/work-packages/routing/wp-list-view/wp-list-view.component';
 import { WorkPackageViewPageComponent } from 'core-app/features/work-packages/routing/wp-view-page/wp-view-page.component';
 import { makeSplitViewRoutes } from 'core-app/features/work-packages/routing/split-view-routes.template';
-import { WorkPackageCopyFullViewComponent } from 'core-app/features/work-packages/components/wp-copy/wp-copy-full-view.component';
-import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 
 export const menuItemClass = 'work-packages-menu-item';
 export const sidemenuId = 'work_packages_sidemenu';

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -30,17 +30,12 @@ import {
   input,
   InputState,
 } from '@openproject/reactivestates';
-import { take } from 'rxjs/operators';
 import { cloneDeep } from 'lodash-es';
 
 import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import {
-  ChangeItem,
-  ChangeMap,
-  Changeset,
-} from 'core-app/shared/components/fields/changeset/changeset';
+import { ChangeMap, Changeset } from 'core-app/shared/components/fields/changeset/changeset';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';

--- a/frontend/src/app/shared/components/fields/openproject-fields.module.ts
+++ b/frontend/src/app/shared/components/fields/openproject-fields.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule, inject, provideAppInitializer } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule, inject, provideAppInitializer } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OpenprojectModalModule } from 'core-app/shared/components/modal/modal.module';
 import { OpenprojectEditorModule } from 'core-app/shared/components/editor/openproject-editor.module';

--- a/frontend/src/app/shared/components/grids/widgets/add/add.modal.ts
+++ b/frontend/src/app/shared/components/grids/widgets/add/add.modal.ts
@@ -35,7 +35,6 @@ import { GridWidgetsService } from 'core-app/shared/components/grids/widgets/wid
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { BannersService } from 'core-app/core/enterprise/banners.service';
 import { LoadingIndicatorService } from 'core-app/core/loading-indicator/loading-indicator.service';
-import { enterpriseDocsUrl } from 'core-app/core/setup/globals/constants.const';
 import { BehaviorSubject } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 

--- a/frontend/src/app/shared/components/toaster/toast.service.spec.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.spec.ts
@@ -101,7 +101,7 @@ describe('ToastService', () => {
 
   it('sends a broadcast to remove the first toaster upon adding a second success toaster',
     () => {
-      const firstToast = toastService.addSuccess('blubs');
+      toastService.addSuccess('blubs');
 
       expect(toastService.current.value!.length).toEqual(1);
 
@@ -112,7 +112,7 @@ describe('ToastService', () => {
 
   it('sends a broadcast to remove the first toaster upon adding a second error toaster',
     () => {
-      const firstToast = toastService.addSuccess('blubs');
+      toastService.addSuccess('blubs');
       toastService.addError('blubs2');
 
       expect(toastService.current.value!.length).toEqual(1);

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
@@ -1,0 +1,39 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { escapeFilterValue } from './filters-form.controller';
+
+describe('escapeFilterValue', () => {
+  it('escapes backslashes before double quotes', () => {
+    expect(escapeFilterValue('C:\\path "name"')).toEqual('C:\\\\path \\"name\\"');
+  });
+
+  it('handles a trailing backslash', () => {
+    expect(escapeFilterValue('\\')).toEqual('\\\\');
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -33,6 +33,7 @@ import {
   hideElement,
   showElement,
 } from 'core-app/shared/helpers/dom-helpers';
+import { escapeFilterValue } from 'core-stimulus/helpers/filter-helpers';
 import { PrimerMultiInputElement } from '@primer/view-components/app/lib/primer/forms/primer_multi_input';
 
 interface PrimerTextFieldElement extends HTMLElement {
@@ -543,7 +544,7 @@ export default class FiltersFormController extends Controller {
   }
 
   private buildFilterString(filter:InternalFilterValue) {
-    const valuesString = filter.value.length > 1 ? `[${filter.value.map((v) => `"${this.replaceDoubleQuotes(v)}"`).join(',')}]` : `"${this.replaceDoubleQuotes(filter.value[0])}"`;
+    const valuesString = filter.value.length > 1 ? `[${filter.value.map((v) => `"${escapeFilterValue(v)}"`).join(',')}]` : `"${escapeFilterValue(filter.value[0])}"`;
 
     return `${filter.name} ${filter.operator} ${valuesString}`;
   }
@@ -557,10 +558,6 @@ export default class FiltersFormController extends Controller {
       return JSON.stringify(filters.map((filter) => this.buildFilterJSON(filter)));
     }
     return filters.map((filter) => this.buildFilterString(filter)).join('&');
-  }
-
-  private replaceDoubleQuotes(value:string) {
-    return value && value.length > 0 ? value.replace(/"/g, '\\"') : '';
   }
 
   private readonly dateFilterTypes = ['datetime_past', 'date'];

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -45,6 +45,10 @@ export interface InternalFilterValue {
   value:string[];
 }
 
+export function escapeFilterValue(value:string|undefined):string {
+  return value?.replace(/\\/g, '\\\\').replace(/"/g, '\\"') ?? '';
+}
+
 type FilterFunc<T> = (_value:T) => boolean;
 
 export default class FiltersFormController extends Controller {
@@ -505,7 +509,7 @@ export default class FiltersFormController extends Controller {
   }
 
   private buildFilterString(filter:InternalFilterValue) {
-    const valuesString = filter.value.length > 1 ? `[${filter.value.map((v) => `"${this.replaceDoubleQuotes(v)}"`).join(',')}]` : `"${this.replaceDoubleQuotes(filter.value[0])}"`;
+    const valuesString = filter.value.length > 1 ? `[${filter.value.map((v) => `"${escapeFilterValue(v)}"`).join(',')}]` : `"${escapeFilterValue(filter.value[0])}"`;
 
     return `${filter.name} ${filter.operator} ${valuesString}`;
   }
@@ -519,10 +523,6 @@ export default class FiltersFormController extends Controller {
       return JSON.stringify(filters.map((filter) => this.buildFilterJSON(filter)));
     }
     return filters.map((filter) => this.buildFilterString(filter)).join('&');
-  }
-
-  private replaceDoubleQuotes(value:string) {
-    return value && value.length > 0 ? value.replace(/"/g, '\\"') : '';
   }
 
   private readonly dateFilterTypes = ['datetime_past', 'date'];

--- a/frontend/src/stimulus/helpers/filter-helpers.spec.ts
+++ b/frontend/src/stimulus/helpers/filter-helpers.spec.ts
@@ -1,0 +1,39 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { escapeFilterValue } from './filter-helpers';
+
+describe('escapeFilterValue', () => {
+  it('escapes backslashes before double quotes', () => {
+    expect(escapeFilterValue('C:\\path "name"')).toEqual('C:\\\\path \\"name\\"');
+  });
+
+  it('handles a trailing backslash', () => {
+    expect(escapeFilterValue('\\')).toEqual('\\\\');
+  });
+});

--- a/frontend/src/stimulus/helpers/filter-helpers.ts
+++ b/frontend/src/stimulus/helpers/filter-helpers.ts
@@ -1,0 +1,31 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+export function escapeFilterValue(value:string|undefined):string {
+  return value?.replace(/\\/g, '\\\\').replace(/"/g, '\\"') ?? '';
+}


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Header-only line shifts surfaced pre-existing unused code and two static-analysis defects. Clearing them keeps follow-up remediation separate from the copyright-header change.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [X] Added/updated tests

