### PR TITLE
[DREAM-779] Timeline widget footer shown even if there is no content

### DIFF
--- a/modules/grids/app/components/grids/widgets/project_timeline.html.erb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% blankslate.with_description { I18n.t("grids.widgets.empty") } %>
     <% end %>
   <% end %>
-  <% if gantt_link || sprints_link %>
+  <% if show_footer? %>
     <% container.with_footer do %>
       <%= render(Primer::Alpha::ActionMenu.new) do |menu| %>
         <% menu.with_show_button(scheme: :invisible, "aria-label": t("grids.widgets.project_timeline.footer_actions_label")) do |button| %>

--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -71,11 +71,15 @@ module Grids
       end
 
       def any_content?
-        any_phases? || milestones_scope.exists? || any_sprints?
+        @any_content ||= any_phases? || milestones_scope.exists? || any_sprints?
       end
 
       def render?
         view_project_phases_allowed? || view_work_packages_allowed? || view_sprints_allowed?
+      end
+
+      def show_footer?
+        any_content? && (gantt_link || sprints_link)
       end
 
       def gantt_link
@@ -115,11 +119,11 @@ module Grids
       end
 
       def any_phases?
-        view_project_phases_allowed? && project.phases.active.with_timeline_content.exists?
+        @any_phases ||= view_project_phases_allowed? && project.phases.active.with_timeline_content.exists?
       end
 
       def any_sprints?
-        view_sprints_allowed? && sprints_scope.exists?
+        @any_sprints ||= view_sprints_allowed? && sprints_scope.exists?
       end
 
       def milestones_scope


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-779

# What are you trying to accomplish?
Only show the footer if there is some content in the widget


