### PR TITLE
Fix custom fields MCP tool

### DIFF
--- a/app/services/mcp_tools/search_custom_fields.rb
+++ b/app/services/mcp_tools/search_custom_fields.rb
@@ -56,12 +56,13 @@ module McpTools
 
     def call(page: nil, **filters)
       custom_fields = apply_filters(CustomField.visible, filters)
-      custom_fields = apply_pagination(custom_fields, page)
+      custom_fields, total = apply_pagination(custom_fields, page)
 
       {
         items: custom_fields.map do |custom_field|
           ::API::V3::CustomFields::CustomFieldRepresenter.create(custom_field, current_user:)
-        end
+        end,
+        total:
       }
     end
   end


### PR DESCRIPTION
This broke, because it was merged indepdently from a change that introduced total pagination counts.