### PR TITLE
[SPPM-324] Milestone tooltip is off screen if milestone name is long

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -36,6 +36,9 @@
     border-radius: var(--borderRadius-default)
     box-shadow: var(--shadow-floating-small)
     padding: var(--base-size-12)
+    max-width: 350px
+    @include text-shortener(false)
+    white-space: normal
 
   .op-timeline-tooltip--meta-row
     display: inline-flex


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-324

# What are you trying to accomplish?

Limit the width of the tooltip to avoid weird positioning in smaller widgets

