### PR TITLE
[COMMS-932] Handle group queries when the value is not a model association

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -102,6 +102,7 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
     },
     version: {
       if: -> { !Setting::WorkPackageMultipleVersions.active? },
+      group_by_class_name: "Version",
       sortable: <<~SQL.squish,
         (SELECT LOWER(v.name)
            FROM work_package_versions wpv

--- a/app/models/queries/work_packages/selects/work_package_select.rb
+++ b/app/models/queries/work_packages/selects/work_package_select.rb
@@ -35,6 +35,7 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
               :groupable_join,
               :groupable_select,
               :group_by_column_name,
+              :group_by_class_name,
               :summable,
               :default_order,
               :association,
@@ -136,6 +137,7 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
       summable_work_packages_select
       association
       group_by_column_name
+      group_by_class_name
       null_handling
       default_order
     ].each do |attribute|

--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -163,16 +163,24 @@ module ::Query::Results::GroupBy
     association = find_association_for_group
 
     if association.nil?
-      groups
+      transform_declared_class_keys(groups)
     elsif association.collection?
       transform_collection_association_property_keys(association, groups)
     else
-      transform_association_property_keys(association, groups)
+      transform_record_keys(association.class_name.constantize, groups)
     end
   end
 
-  def transform_association_property_keys(association, groups)
-    ar_keys = association.class_name.constantize.find(groups.keys.compact)
+  def transform_declared_class_keys(groups)
+    klass = query.group_by_column.group_by_class_name&.constantize
+
+    return groups if klass.nil?
+
+    transform_record_keys(klass, groups)
+  end
+
+  def transform_record_keys(klass, groups)
+    ar_keys = klass.find(groups.keys.compact)
 
     groups.transform_keys do |key|
       ar_keys.detect { |ar_key| ar_key.id == key }

--- a/spec/models/query/results_version_integration_spec.rb
+++ b/spec/models/query/results_version_integration_spec.rb
@@ -124,6 +124,17 @@ RSpec.describe Query::Results, "Grouping and sorting for version" do
       expect(query_results.work_packages.pluck(:id))
         .to match work_packages_asc.map(&:id)
     end
+
+    context "when no work package association matches the column" do
+      before do
+        allow(query_results).to receive(:find_association_for_group).and_return(nil)
+      end
+
+      it "still returns version records as group keys" do
+        expect(query_results.work_package_count_by_group)
+          .to eql(old_version => 1, no_date_version => 1, new_version => 1, nil => 1)
+      end
+    end
   end
 
   describe "sorting ASC by version" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-932/activity

# What are you trying to accomplish?
When the property being queried is not a model association, we can explicitly define the class form which the result will be loaded from.

This is necessary because https://community.openproject.org/wp/COMMS-863 will remove the `belongs_to :version` association from `work_package.rb`

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
