### PR TITLE
[SPPM-325] Line between phases and gates should be removed

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -90,6 +90,12 @@
     .vis-item-content
       transform: translateX(-100%)
 
+  // Gates group row: we override the height so that the gates appear visually closer to the phases
+  .vis-group.op-timeline-group--gates
+    border-bottom-color: transparent
+    height: 2.25rem !important
+    overflow: visible
+
   // Cluster items
   .vis-item.vis-cluster
     background: var(--body-background)

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-item.builder.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-item.builder.ts
@@ -119,7 +119,7 @@ export class ProjectTimelineItemBuilder {
     }
 
     const groups = [
-      { id: GROUP_GATES, content: '' },
+      { id: GROUP_GATES, content: '', className: 'op-timeline-group--gates' },
       { id: GROUP_PHASES, content: '' },
       { id: GROUP_MILESTONES, content: '' },
       { id: GROUP_SPRINTS, content: '' },


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-325

# What are you trying to accomplish?
Move gates visually closer to the phase. Unfortunately, we cannot use subgroups here as the cluster mechanism does not work well with subgroups.

## Screenshots

<img width="1608" height="438" alt="Bildschirmfoto 2026-07-28 um 11 10 39" src="https://github.com/user-attachments/assets/0e491677-6a62-4758-857d-9211b5821c23" />
