### PR TITLE
[OP-19734] Fix deletion of work packages with children, by looking at who we can delete and see

### DIFF
--- a/app/components/concerns/work_packages/delete_dialogs/descendants.rb
+++ b/app/components/concerns/work_packages/delete_dialogs/descendants.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module DeleteDialogs
+    # Module to include for the bulk and single delete dialogs.
+    # They take care of previewing the deletion of visible work packages, and filtering them.
+    #
+    # The dialogs provide +deletion_roots+ and +i18n_scope+ to use the correct set of work packages
+    # as input, and the respective I18n keys.
+    module Descendants
+      extend ActiveSupport::Concern
+
+      # DeletionPlanning is the module that computes the work packages
+      # and puts them into the categories deletable/unlinked.
+      # We need this here for the preview and the DeleteService later, so it's another separate module.
+      include ::WorkPackages::Shared::DeletionPlanning
+
+      private
+
+      def deletion_user
+        User.current
+      end
+
+      def variant
+        @variant ||=
+          if !has_descendants? then :none
+          elsif !unlinked_descendants? then :all
+          elsif visible_unlinked_descendants.none? then :hidden
+          else :undeletable
+          end
+      end
+
+      def has_descendants?
+        deleted_descendants.any? || unlinked_descendants?
+      end
+
+      def nothing_deleted?
+        deleted_descendants.none?
+      end
+
+      def hidden_warning_key
+        nothing_deleted? ? "hidden_descendants_only_warning" : "hidden_descendants_warning"
+      end
+
+      def undeletable_warning_key
+        base = "undeletable_descendants_warning"
+
+        hidden_unlinked_count.zero? ? "#{base}_html" : base
+      end
+
+      def undeletable_count
+        unlinked_descendants.size
+      end
+
+      # Filter the visible descendants to gather the project names,
+      # as we cannot show any other projects the user has no access to.
+      def undeletable_project_links
+        link_to_projects(visible_unlinked_descendants.filter_map(&:project).uniq)
+      end
+
+      def link_to_projects(projects)
+        safe_join(projects.map { |project| helpers.link_to(project.name, helpers.project_path(project)) }, ", ")
+      end
+
+      def t_dialog(key, **)
+        I18n.t("#{i18n_scope}.#{key}", **)
+      end
+    end
+  end
+end

--- a/app/components/work_packages/bulk_delete_dialog_component.html.erb
+++ b/app/components/work_packages/bulk_delete_dialog_component.html.erb
@@ -50,26 +50,45 @@
 
   <% dialog.with_additional_details(display: :block) do %>
     <% if multiple_projects? %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, icon: :info)) do %>
+        <%= helpers.t("work_packages.bulk_delete_dialog.cross_project_warning_html", projects: project_links) %>
+      <% end %>
+    <% end %>
+    <% if variant == :hidden %>
       <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-        <%= I18n.t("work_packages.bulk_delete_dialog.cross_project_warning", projects: project_names) %>
+        <%= I18n.t("work_packages.bulk_delete_dialog.#{hidden_warning_key}", count: undeletable_count) %>
+      <% end %>
+    <% end %>
+    <% if variant == :undeletable %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+        <%# helpers.t, not I18n.t: only the Rails helper honours the _html suffix %>
+        <%= helpers.t(
+              "work_packages.bulk_delete_dialog.#{undeletable_warning_key}",
+              count: undeletable_count,
+              projects: undeletable_project_links
+            ) %>
       <% end %>
     <% end %>
     <%= render(OpPrimer::InsetBoxComponent.new) do %>
       <% work_packages.each do |wp| %>
-        <%= render WorkPackages::InfoLineComponent.new(work_package: wp,
-                                                       show_subject: true,
-                                                       show_status: false,
-                                                       show_project: multiple_projects?) %>
+        <%= render WorkPackages::InfoLineComponent.new(
+              work_package: wp,
+              show_subject: true,
+              show_status: false,
+              show_project: multiple_projects?
+            ) %>
         <% if descendants_for(wp).any? %>
           <%= render(Primer::Box.new(pl: 2, my: 1)) do %>
             <%= render(Primer::Beta::Text.new(mt: 1, font_size: :small, font_weight: :bold, display: :block, mb: 1)) do %>
               <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
             <% end %>
             <% descendants_for(wp).each do |descendant| %>
-              <%= render WorkPackages::InfoLineComponent.new(work_package: descendant,
-                                                             show_subject: true,
-                                                             show_status: false,
-                                                             show_project: descendant.project != wp.project) %>
+              <%= render WorkPackages::InfoLineComponent.new(
+                    work_package: descendant,
+                    show_subject: true,
+                    show_status: false,
+                    show_project: descendant.project != wp.project
+                  ) %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/work_packages/bulk_delete_dialog_component.rb
+++ b/app/components/work_packages/bulk_delete_dialog_component.rb
@@ -31,6 +31,7 @@
 module WorkPackages
   class BulkDeleteDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
+    include WorkPackages::DeleteDialogs::Descendants
 
     attr_reader :work_packages
 
@@ -44,78 +45,61 @@ module WorkPackages
 
     def id = "wp-delete-dialog"
 
+    def i18n_scope = "work_packages.bulk_delete_dialog"
+
+    def deletion_roots = work_packages.to_a
+
     def title
-      I18n.t("work_packages.bulk_delete_dialog.title", count: total_count)
+      t_dialog("title", count: total_count)
     end
 
     def heading
-      I18n.t("work_packages.bulk_delete_dialog.heading", count: total_count)
+      t_dialog("heading", count: total_count)
     end
 
     def description
-      if has_descendants?
-        I18n.t("work_packages.bulk_delete_dialog.description_with_children")
-      else
-        I18n.t("work_packages.bulk_delete_dialog.description")
-      end
+      key =
+        case variant
+        when :all then "description_with_descendants"
+        when :hidden then nothing_deleted? ? "description" : "description_with_visible_descendants"
+        when :undeletable then nothing_deleted? ? "description" : "description_with_all_descendants"
+        else "description"
+        end
+
+      t_dialog(key)
     end
 
+    # Only the deleted descendants are listed, so only those can be confirmed.
     def confirmation_checkbox_text
-      if has_descendants?
-        I18n.t("work_packages.bulk_delete_dialog.confirm_children_deletion")
-      else
-        I18n.t("text_permanent_delete_confirmation_checkbox_label")
-      end
+      t_dialog(deleted_descendants.any? ? "confirm_descendants_deletion" : "confirm_deletion")
     end
 
     def total_count
-      @total_count ||= work_packages.count + descendants_by_work_package.values.sum(&:size)
+      @total_count ||= work_package_ids.size + deleted_descendants.size
     end
 
     def multiple_projects?
       projects.size > 1
     end
 
-    def project_names
-      projects.map(&:name).join(", ")
+    def project_links
+      link_to_projects(projects)
     end
 
     def descendants_for(work_package)
-      (descendants_by_work_package[work_package.id] || [])
-        .reject { |child| work_packages.include?(child) }
-    end
-
-    def has_descendants?
-      work_packages.any? { |wp| descendants_for(wp).any? }
+      deleted_descendants_under(work_package)
     end
 
     def form_action
-      helpers.work_packages_bulk_path(ids: work_packages.map(&:id), back_url: @back_url)
+      helpers.work_packages_bulk_path(ids: work_package_ids, back_url: @back_url)
     end
 
     def projects
-      @projects ||= begin
-        all_work_packages = work_packages + descendants_by_work_package.values.flatten
-        all_work_packages.filter_map(&:project).uniq
-      end
+      @projects ||= (work_packages.to_a + deleted_descendants).filter_map(&:project).uniq
     end
 
-    def descendants_by_work_package
-      @descendants_by_work_package ||= begin
-        hierarchies = WorkPackageHierarchy
-          .where(ancestor_id: work_packages.map(&:id))
-          .where("generations > 0")
-          .order(:generations, :descendant_id)
-
-        descendant_records = WorkPackage
-          .where(id: hierarchies.pluck(:descendant_id))
-          .includes(:project, :type, :status)
-          .index_by(&:id)
-
-        hierarchies
-          .group_by(&:ancestor_id)
-          .transform_values { |rows| rows.filter_map { |r| descendant_records[r.descendant_id] } }
-      end
+    def work_package_ids
+      @work_package_ids ||= work_packages.map(&:id)
     end
   end
 end

--- a/app/components/work_packages/delete_dialog_component.html.erb
+++ b/app/components/work_packages/delete_dialog_component.html.erb
@@ -52,20 +52,39 @@
     <% dialog.with_additional_details(display: :block) do %>
       <% if cross_project_descendants? %>
         <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-          <%= I18n.t("work_packages.delete_dialog.cross_project_warning", projects: all_project_names) %>
+          <%= helpers.t("work_packages.delete_dialog.cross_project_warning_html", projects: all_project_links) %>
         <% end %>
       <% end %>
-      <%= render(OpPrimer::InsetBoxComponent.new) do %>
-        <%= render(Primer::Beta::Text.new(font_size: :small, font_weight: :bold, display: :block, mb: 2)) do %>
-          <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
+      <% if variant == :hidden %>
+        <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+          <%= I18n.t("work_packages.delete_dialog.#{hidden_warning_key}", count: undeletable_count) %>
         <% end %>
-        <% descendants.each do |descendant| %>
-          <%= render WorkPackages::InfoLineComponent.new(pl:2,
-                                                         my: 1,
-                                                         work_package: descendant,
-                                                         show_subject: true,
-                                                         show_status: false,
-                                                         show_project: descendant.project != work_package.project) %>
+      <% end %>
+      <% if variant == :undeletable %>
+        <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+          <%# helpers.t, not I18n.t: only the Rails helper honours the _html suffix %>
+          <%= helpers.t(
+                "work_packages.delete_dialog.#{undeletable_warning_key}",
+                count: undeletable_count,
+                projects: undeletable_project_links
+              ) %>
+        <% end %>
+      <% end %>
+      <% if deleted_descendants.any? %>
+        <%= render(OpPrimer::InsetBoxComponent.new) do %>
+          <%= render(Primer::Beta::Text.new(font_size: :small, font_weight: :bold, display: :block, mb: 2)) do %>
+            <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
+          <% end %>
+          <% deleted_descendants.each do |descendant| %>
+            <%= render WorkPackages::InfoLineComponent.new(
+                  pl: 2,
+                  my: 1,
+                  work_package: descendant,
+                  show_subject: true,
+                  show_status: false,
+                  show_project: descendant.project != work_package.project
+                ) %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/work_packages/delete_dialog_component.rb
+++ b/app/components/work_packages/delete_dialog_component.rb
@@ -31,6 +31,7 @@
 module WorkPackages
   class DeleteDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
+    include WorkPackages::DeleteDialogs::Descendants
 
     attr_reader :work_package
 
@@ -44,53 +45,39 @@ module WorkPackages
 
     def id = "wp-delete-dialog"
 
+    def i18n_scope = "work_packages.delete_dialog"
+
+    def deletion_roots = [work_package]
+
     def title
-      I18n.t("work_packages.delete_dialog.title")
+      t_dialog("title")
     end
 
     def heading
-      I18n.t("work_packages.delete_dialog.heading")
+      t_dialog("heading")
     end
 
     def description
-      I18n.t("work_packages.delete_dialog.description", name: work_package.to_s)
+      t_dialog("description", name: work_package.to_s)
     end
 
+    # Only the deleted descendants are listed, so only those can be confirmed.
     def confirmation_checkbox_text
-      if has_descendants?
-        I18n.t("work_packages.delete_dialog.confirm_descendants_deletion")
-      else
-        I18n.t("text_permanent_delete_confirmation_checkbox_label")
-      end
-    end
-
-    def descendants
-      @descendants ||= WorkPackage
-        .joins("INNER JOIN work_package_hierarchies ON work_package_hierarchies.descendant_id = work_packages.id")
-        .where(work_package_hierarchies: { ancestor_id: work_package.id })
-        .where("work_package_hierarchies.generations > 0")
-        .includes(:project, :type, :status)
-        .order("work_package_hierarchies.generations ASC, work_packages.id ASC")
-    end
-
-    def has_descendants?
-      descendants.any?
+      t_dialog(deleted_descendants.any? ? "confirm_descendants_deletion" : "confirm_deletion")
     end
 
     def cross_project_descendants?
-      descendants.any? { |d| d.project != work_package.project }
+      deleted_descendants.any? { |d| d.project != work_package.project }
     end
 
-    def all_project_names
-      names = descendants
+    def all_project_links
+      projects = deleted_descendants
         .filter_map(&:project)
         .uniq
         .reject { |p| p == work_package.project }
-        .map(&:name)
+        .unshift(work_package.project)
 
-      names
-        .unshift(work_package.project.name)
-        .join(", ")
+      link_to_projects(projects)
     end
 
     def form_action

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -87,8 +87,14 @@ class WorkPackages::BulkController < ApplicationController
       return redirect_to(action: :reassign, ids: @work_packages.map(&:id), back_url: params[:back_url])
     end
 
-    failures = destroy_work_packages(@work_packages)
-    flash[:error] = deletion_error_message(failures) if failures.any?
+    calls = destroy_work_packages(@work_packages)
+    failures = calls.reject(&:success?)
+
+    if failures.any?
+      flash[:error] = deletion_error_message(failures)
+    else
+      flash[:notice] = deletion_success_message(calls)
+    end
 
     respond_to do |format|
       format.html do
@@ -114,21 +120,27 @@ class WorkPackages::BulkController < ApplicationController
       WorkPackageCustomField.joins(:types).where(types: @types)
   end
 
-  # Returns the failed calls. Deletion is not all or nothing: one work package
-  # may be deleted while another one fails.
+  # Deletion is not all or nothing: one work package may be deleted while another
+  # one fails, so every call is returned.
   def destroy_work_packages(work_packages)
     work_packages.filter_map do |work_package|
-      call = WorkPackages::DeleteService
+      WorkPackages::DeleteService
         .new(user: current_user,
              model: work_package.reload)
         .call
-
-      call unless call.success?
     rescue ::ActiveRecord::RecordNotFound
       # raised by #reload if work package no longer exists
       # nothing to do, work package was already deleted (eg. by a parent)
       nil
     end
+  end
+
+  # A call also carries the descendants it deleted, next to work packages it only
+  # rescheduled, so count the ones that are actually gone.
+  def deletion_success_message(calls)
+    count = calls.sum { |call| call.all_results.count(&:destroyed?) }
+
+    t("work_packages.bulk.deletion_successful", count:)
   end
 
   def deletion_error_message(failures)

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -83,20 +83,21 @@ class WorkPackages::BulkController < ApplicationController
   end
 
   def destroy # rubocop:disable Metrics/AbcSize
-    if WorkPackage.cleanup_associated_before_destructing_if_required(@work_packages, current_user, params[:to_do])
-      destroy_work_packages(@work_packages)
+    unless WorkPackage.cleanup_associated_before_destructing_if_required(@work_packages, current_user, params[:to_do])
+      return redirect_to(action: :reassign, ids: @work_packages.map(&:id), back_url: params[:back_url])
+    end
 
-      respond_to do |format|
-        format.html do
-          redirect_back_or_default(project_work_packages_path(@work_packages.first.project),
-                                   status: :see_other)
-        end
-        format.json do
-          head :ok
-        end
+    failures = destroy_work_packages(@work_packages)
+    flash[:error] = deletion_error_message(failures) if failures.any?
+
+    respond_to do |format|
+      format.html do
+        redirect_back_or_default(project_work_packages_path(@work_packages.first.project),
+                                 status: :see_other)
       end
-    else
-      redirect_to(action: :reassign, ids: @work_packages.map(&:id), back_url: params[:back_url])
+      format.json do
+        failures.any? ? head(:unprocessable_entity) : head(:ok)
+      end
     end
   end
 
@@ -113,16 +114,29 @@ class WorkPackages::BulkController < ApplicationController
       WorkPackageCustomField.joins(:types).where(types: @types)
   end
 
+  # Returns the failed calls. Deletion is not all or nothing: one work package
+  # may be deleted while another one fails.
   def destroy_work_packages(work_packages)
-    work_packages.each do |work_package|
-      WorkPackages::DeleteService
+    work_packages.filter_map do |work_package|
+      call = WorkPackages::DeleteService
         .new(user: current_user,
              model: work_package.reload)
         .call
+
+      call unless call.success?
     rescue ::ActiveRecord::RecordNotFound
       # raised by #reload if work package no longer exists
       # nothing to do, work package was already deleted (eg. by a parent)
+      nil
     end
+  end
+
+  def deletion_error_message(failures)
+    messages = failures.map do |call|
+      "#{call.result.formatted_id}: #{call.errors.full_messages.to_sentence}"
+    end
+
+    "#{t('work_packages.bulk.could_not_be_deleted')} #{messages.join(' ')}"
   end
 
   def attributes_for_update

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -98,6 +98,7 @@ class Journal < ApplicationRecord
     total_percent_complete_mode_changed_to_work_weighted_average
     work_package_children_changed_times
     work_package_parent_changed_times
+    work_package_parent_deleted
     work_package_predecessor_changed_times
     work_package_related_changed_times
     work_package_duplicate_closed

--- a/app/models/journal/caused_by_work_package_parent_deletion.rb
+++ b/app/models/journal/caused_by_work_package_parent_deletion.rb
@@ -28,51 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Components
-  module WorkPackages
-    class DestroyModal
-      include Capybara::DSL
-      include Capybara::RSpecMatchers
-      include RSpec::Matchers
-
-      def initialize(bulk_mode: false)
-        @bulk_mode = bulk_mode
-      end
-
-      def dialog_id
-        "wp-delete-dialog"
-      end
-
-      def dialog_css_selector
-        "dialog##{dialog_id}"
-      end
-
-      def within_dialog(&)
-        within(dialog_css_selector, &)
-      end
-
-      def expect_listed(*work_packages)
-        within_dialog do
-          work_packages.each do |work_package|
-            expect(page).to have_text(work_package.subject)
-          end
-        end
-      end
-
-      def confirm_deletion
-        within_dialog do
-          # By id: the label says what is being deleted and so varies with the hierarchy.
-          check "#{dialog_id}-check_box", allow_label_click: true
-          expect(page).to have_button "Delete permanently", disabled: false
-          click_button "Delete permanently"
-        end
-      end
-
-      def cancel_deletion
-        within_dialog do
-          click_button "Cancel"
-        end
-      end
-    end
+# The deleted parent is deliberately not referenced. Readers of the detached work
+# package may have no access to the project the parent was in.
+class Journal::CausedByWorkPackageParentDeletion < CauseOfChange::Base
+  def initialize
+    super("work_package_parent_deleted")
   end
 end

--- a/app/services/work_packages/delete_service.rb
+++ b/app/services/work_packages/delete_service.rb
@@ -30,22 +30,32 @@
 
 class WorkPackages::DeleteService < BaseServices::Delete
   include ::WorkPackages::Shared::UpdateAncestors
+  include ::WorkPackages::Shared::DeletionPlanning
 
   private
 
+  def deletion_roots = [model]
+
+  def deletion_user = user
+
+  def deletable?(descendant)
+    validate(descendant, user, options: contract_options).first
+  end
+
   def persist(service_result)
-    # `to_a` is used to avoid lazy loading. If the relation is laded after the
-    # work package is deleted, it would return an empty array.
-    descendants = model.descendants.to_a
-    descendants_check = validate_descendant_deletions(descendants)
-    return descendants_check if descendants_check.failure?
+    # Read before the work package is gone, or the hierarchy comes back empty.
+    detachable = unlinked_descendants
+    deletable = deleted_descendants
+
+    detachment_result = detach(detachable)
+    return detachment_result if detachment_result.failure?
 
     successors = find_successors_of_self_and_descendants(model).to_a
 
     result = super
 
     if result.success?
-      destroy_descendants(descendants, result)
+      destroy_descendants(deletable, result)
       update_ancestors_and_successors(successors, result)
       delete_associated_notifications(model)
     end
@@ -53,12 +63,13 @@ class WorkPackages::DeleteService < BaseServices::Delete
     result
   end
 
-  def validate_descendant_deletions(descendants)
-    descendants.each do |descendant|
-      success, errors = validate(descendant, user, options: contract_options)
-      next if success
+  def detach(detachable)
+    detachable.each do |descendant|
+      result = WorkPackages::UpdateService
+        .new(user:, model: descendant, contract_class: EmptyContract)
+        .call(parent: nil, journal_cause: Journal::CausedByWorkPackageParentDeletion.new)
 
-      return ServiceResult.failure(result: model, errors:)
+      return result if result.failure?
     end
 
     ServiceResult.success(result: model)

--- a/app/services/work_packages/shared/deletion_planning.rb
+++ b/app/services/work_packages/shared/deletion_planning.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Shared
+    # Splits the descendants of the work packages about to be deleted into those
+    #  - that the user may see and delete, so they go with their root
+    #  - and the rest, which survive and only lose their parent
+    #
+    # WorkPackages::DeleteService and the delete dialogs both use this module
+    # to preview what will happen, and to find the work packages to be deleted.
+    module DeletionPlanning
+      def deleted_descendants
+        deletion_partition[:deleted]
+      end
+
+      def deleted_descendants_under(root)
+        deletion_partition[:deleted_by_root][root.id] || []
+      end
+
+      def unlinked_descendants
+        deletion_partition[:unlinked]
+      end
+
+      def unlinked_descendants?
+        unlinked_descendants.any?
+      end
+
+      def visible_unlinked_descendants
+        @visible_unlinked_descendants ||=
+          unlinked_descendants.select { |descendant| visible_descendant_ids.include?(descendant.id) }
+      end
+
+      def hidden_unlinked_count
+        unlinked_descendants.size - visible_unlinked_descendants.size
+      end
+
+      private
+
+      # Unlinking a survivor is a side effect of the deletion, so this deliberately does not
+      # consider the "manage_subtasks" permission.
+      def deleted_with_roots?(descendant)
+        visible_descendant_ids.include?(descendant.id) && deletable?(descendant)
+      end
+
+      def deletable?(descendant)
+        descendant.project && deletion_user.allowed_in_project?(:delete_work_packages, descendant.project)
+      end
+
+      def deletion_root_ids
+        @deletion_root_ids ||= deletion_roots.map(&:id)
+      end
+
+      def descendants_of_deletion_roots
+        @descendants_of_deletion_roots ||= WorkPackage
+          .where(id: descendant_ids_of_deletion_roots)
+          .includes(:project, :type, :status)
+          .order(:id)
+          .to_a
+      end
+
+      def descendant_ids_of_deletion_roots
+        @descendant_ids_of_deletion_roots ||= WorkPackageHierarchy
+          .where(ancestor_id: deletion_root_ids)
+          .where("generations > 0")
+          .distinct
+          .pluck(:descendant_id) - deletion_root_ids
+      end
+
+      def visible_descendant_ids
+        @visible_descendant_ids ||= WorkPackage
+          .where(id: descendant_ids_of_deletion_roots)
+          .visible(deletion_user)
+          .pluck(:id)
+          .to_set
+      end
+
+      def deletion_partition
+        @deletion_partition ||= begin
+          partition = { deleted: [], unlinked: [], deleted_by_root: {} }
+          queue = deletion_root_ids.flat_map { |root_id| children_to_visit(root_id, root_id) }
+
+          until queue.empty?
+            root_id, descendant = queue.shift
+
+            if deleted_with_roots?(descendant)
+              record_deleted(partition, descendant, root_id)
+              queue.concat(children_to_visit(descendant.id, root_id))
+            else
+              partition[:unlinked] << descendant
+            end
+          end
+
+          partition
+        end
+      end
+
+      def record_deleted(partition, descendant, root_id)
+        partition[:deleted] << descendant
+        (partition[:deleted_by_root][root_id] ||= []) << descendant
+      end
+
+      def children_to_visit(parent_id, root_id)
+        descendants_by_parent[parent_id].to_a.map { |descendant| [root_id, descendant] }
+      end
+
+      def descendants_by_parent
+        @descendants_by_parent ||= descendants_of_deletion_roots.group_by(&:parent_id)
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2939,6 +2939,7 @@ en:
       work_package_children_changed_times: by changes to child %{link}
       work_package_duplicate_closed: The status was automatically updated by the duplicated work package %{link}
       work_package_parent_changed_times: by changes to parent %{link}
+      work_package_parent_deleted: because the parent work package was deleted
       work_package_predecessor_changed_times: by changes to predecessor %{link}
       work_package_related_changed_times: by changes to related %{link}
       working_days_changed:
@@ -2960,6 +2961,7 @@ en:
       total_percent_complete_mode_changed_to_simple_average: "Calculation of % Complete totals now based on a simple average of only % Complete values."
       total_percent_complete_mode_changed_to_work_weighted_average: "Calculation of % Complete totals now weighted by Work."
       work_package_duplicate_closed: "Duplicate work package updated:"
+      work_package_parent_deleted: "Parent removed"
 
     changes_retracted: "The changes were retracted."
   label_accessibility: "Accessibility"
@@ -6524,6 +6526,7 @@ en:
   work_packages:
     bulk:
       copy_failed: "The work packages could not be copied."
+      could_not_be_deleted: "The following work packages could not be deleted:"
       could_not_be_saved: "The following work packages could not be saved:"
       descendant: "descendant of selected"
       move_failed: "The work packages could not be moved."
@@ -6532,13 +6535,43 @@ en:
       x_out_of_y_could_be_saved: "%{failing} out of the %{total} work packages could not be updated while %{success} could."
 
     bulk_delete_dialog:
-      children_label: "The following children will also be deleted:"
-      confirm_children_deletion: "I acknowledge that all selected work packages and their children will be permanently deleted."
-      cross_project_warning: "These work packages span multiple projects: %{projects}"
-      description: "The following work packages and all associated data will be permanently deleted:"
-      description_with_children: "The following work packages, including children and all associated data, will be permanently deleted:"
+      children_label: "The following descendants will also be deleted:"
+      confirm_deletion: "I confirm that the selected work packages and all associated data will be deleted."
+      confirm_descendants_deletion: "I confirm that all descendants listed above will also be deleted."
+      cross_project_warning_html: "These work packages span multiple projects: %{projects}"
+      description: "Are you sure you want to delete the selected work packages and all associated data?"
+      description_with_all_descendants: "Are you sure you want to delete the selected work packages and all of their descendants?"
+      description_with_descendants: "Are you sure you want to delete the selected work packages and all the following descendants?"
+      description_with_visible_descendants: "Are you sure you want to delete the selected work packages and all visible descendants?"
       heading: "Permanently delete these %{count} work packages?"
+      hidden_descendants_only_warning:
+        one: >-
+          There is one descendant that you cannot see. It will not be deleted but the relation will be removed.
+        other: >-
+          There are %{count} descendants that you cannot see. They will not be deleted but any hierarchical relations will
+          be removed.
+      hidden_descendants_warning:
+        one: >-
+          All visible descendants will be removed. However, there is one descendant that you cannot see.
+          It will not be deleted but the relation will be removed.
+        other: >-
+          All visible descendants will be removed. However, there are %{count} descendants that you cannot see.
+          They will not be deleted but any hierarchical relations will be removed.
       title: "Delete %{count} work packages"
+      undeletable_descendants_warning:
+        one: >-
+          You are not able to delete one descendant because you lack the necessary permissions. It will be
+          preserved but the hierarchical relation will be removed.
+        other: >-
+          You are not able to delete %{count} descendants because you lack the necessary permissions. These
+          will be preserved but any hierarchical relations will be removed.
+      undeletable_descendants_warning_html:
+        one: >-
+          You are not able to delete one descendant because you lack the necessary permissions in %{projects}.
+          It will be preserved but the hierarchical relation will be removed.
+        other: >-
+          You are not able to delete %{count} descendants because you lack the necessary permissions in
+          %{projects}. These will be preserved but any hierarchical relations will be removed.
     datepicker_modal:
       banner:
         description:
@@ -6582,11 +6615,40 @@ en:
         successors: "Successors"
       update_inputs_aria_live_message: "Date picker updated. %{message}"
     delete_dialog:
-      confirm_descendants_deletion: "I acknowledge that ALL descendants of this work package will be recursively removed."
-      cross_project_warning: "Work packages from the following projects will be deleted: %{projects}"
-      description: 'Are you sure you want to delete the work package "%{name}"?'
+      confirm_deletion: "I confirm that the work package and all associated data will be deleted."
+      confirm_descendants_deletion: "I confirm that all descendants listed above will also be deleted."
+      cross_project_warning_html: "Work packages from the following projects will be deleted: %{projects}"
+      description: 'Are you sure you want to delete "%{name}"?'
       heading: "Permanently delete this work package?"
+      hidden_descendants_only_warning:
+        one: >-
+          This work package has one descendant that you cannot see. It will not be deleted but the hierarchical relation
+          will be removed.
+        other: >-
+          This work package has %{count} descendants that you cannot see. They will not be deleted but the
+          hierarchical relation will be removed.
+      hidden_descendants_warning:
+        one: >-
+          All visible descendants will be deleted. However, this work package has one descendant that you
+          cannot see. It will not be deleted but the hierarchical relation will be removed.
+        other: >-
+          All visible descendants will be deleted. However, this work package has %{count} descendants that you
+          cannot see. They will not be deleted but the hierarchical relation will be removed.
       title: "Delete work package"
+      undeletable_descendants_warning:
+        one: >-
+          You are not able to delete one descendant because you lack the necessary permissions. It will be
+          preserved but the hierarchical relation will be removed.
+        other: >-
+          You are not able to delete %{count} descendants because you lack the necessary permissions. These
+          will be preserved but any hierarchical relations will be removed.
+      undeletable_descendants_warning_html:
+        one: >-
+          You are not able to delete one descendant because you lack the necessary permissions in %{projects}.
+          It will be preserved but the hierarchical relation will be removed.
+        other: >-
+          You are not able to delete %{count} descendants because you lack the necessary permissions in
+          %{projects}. These will be preserved but any hierarchical relations will be removed.
 
     move:
       bulk_current_type_not_available_in_target_project: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6528,6 +6528,9 @@ en:
       copy_failed: "The work packages could not be copied."
       could_not_be_deleted: "The following work packages could not be deleted:"
       could_not_be_saved: "The following work packages could not be saved:"
+      deletion_successful:
+        one: "Successfully deleted 1 work package."
+        other: "Successfully deleted %{count} work packages."
       descendant: "descendant of selected"
       move_failed: "The work packages could not be moved."
       none_could_be_saved: "None of the %{total} work packages could be updated."

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -85,6 +85,8 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
       total_percent_complete_mode_changed_to_simple_average_message
     when "import"
       import_message
+    when "work_package_parent_deleted"
+      I18n.t("journals.cause_descriptions.work_package_parent_deleted")
     else
       related_work_package_changed_message
     end

--- a/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
@@ -31,6 +31,8 @@
 require "rails_helper"
 
 RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   let(:user) { create(:admin) }
 
   let(:main_project) { create(:project, name: "Main Project") }
@@ -71,8 +73,179 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
         expect(component.send(:multiple_projects?)).to be true
       end
 
-      it "lists all project names" do
-        expect(component.send(:project_names)).to include("Main Project", "Sub Project", "Sub Sub Project")
+      it "links every project name" do
+        render_inline(component)
+
+        [main_project, sub_project, sub_sub_project].each do |project|
+          expect(page).to have_link project.name, href: project_path(project)
+        end
+      end
+    end
+  end
+
+  describe "descendants the user may not delete" do
+    shared_let(:permitted_project) { create(:project, name: "Permitted Project") }
+    shared_let(:view_only_project) { create(:project, name: "View Only Project") }
+    shared_let(:invisible_project) { create(:project, name: "Invisible Project") }
+
+    let(:permitted_permissions) { %i[view_work_packages delete_work_packages] }
+    let(:permitted_user) do
+      create(:user,
+             member_with_permissions: {
+               permitted_project => permitted_permissions,
+               view_only_project => %i[view_work_packages]
+             })
+    end
+
+    shared_let(:parent_wp) { create(:work_package, project: permitted_project, subject: "Parent to delete") }
+
+    subject do
+      render_inline(described_class.new(work_packages: [parent_wp]))
+      page
+    end
+
+    before do
+      login_as(permitted_user)
+    end
+
+    def t(key, **)
+      I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
+    end
+
+    context "with a child in an invisible project" do
+      shared_let(:invisible_child) do
+        create(:work_package, project: invisible_project, parent: parent_wp, subject: "Secret child")
+      end
+
+      it "does not disclose the invisible work package or its project" do
+        expect(subject).to have_no_text "Secret child"
+        expect(subject).to have_no_text "Invisible Project"
+      end
+
+      it "asks about the selection alone, since nothing else gets deleted" do
+        expect(subject).to have_text t("description")
+        expect(subject).to have_text t("hidden_descendants_only_warning", count: 1)
+        expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
+      end
+
+      it "does not claim the deletion spans multiple projects" do
+        expect(subject).to have_no_text "span multiple projects"
+      end
+
+      it "does not claim descendants will be deleted" do
+        expect(subject).to have_no_text t("children_label")
+        expect(subject).to have_text t("confirm_deletion")
+      end
+    end
+
+    context "with a visible child the user may not delete" do
+      shared_let(:view_only_child) do
+        create(:work_package, project: view_only_project, parent: parent_wp, subject: "View only child")
+      end
+
+      it "does not offer to delete it" do
+        expect(subject).to have_no_text t("children_label")
+      end
+
+      it "warns that it is preserved and links its project" do
+        expect(subject).to have_text t("description")
+        expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                       count: 1,
+                                       projects: view_only_project.name)
+        expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
+      end
+
+      it "counts only the selection" do
+        expect(subject).to have_text t("heading", count: 1)
+      end
+    end
+
+    context "with a grandchild in an invisible project" do
+      shared_let(:visible_child) do
+        create(:work_package, project: permitted_project, parent: parent_wp, subject: "Visible child")
+      end
+      shared_let(:invisible_grandchild) do
+        create(:work_package, project: invisible_project, parent: visible_child, subject: "Secret grandchild")
+      end
+
+      it "lists only the descendant it deletes" do
+        expect(subject).to have_text "Visible child"
+        expect(subject).to have_no_text "Secret grandchild"
+        expect(subject).to have_no_text "Invisible Project"
+      end
+
+      it "warns about the grandchild it cannot see" do
+        expect(subject).to have_text t("hidden_descendants_warning", count: 1)
+      end
+    end
+
+    context "with one child hidden and another visible but undeletable" do
+      shared_let(:view_only_child) do
+        create(:work_package, project: view_only_project, parent: parent_wp, subject: "View only child")
+      end
+      shared_let(:invisible_child) do
+        create(:work_package, project: invisible_project, parent: parent_wp, subject: "Secret child")
+      end
+
+      it "uses the permission wording and folds the hidden one into the count" do
+        expect(subject).to have_text t("undeletable_descendants_warning", count: 2)
+        expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
+      end
+
+      it "names no project, since the count covers one it cannot show" do
+        expect(subject).to have_no_text "Invisible Project"
+        expect(subject).to have_no_link view_only_project.name
+      end
+    end
+  end
+
+  describe "#total_count" do
+    context "when a selected work package is itself a descendant of another selection" do
+      let(:child_wp) { create(:work_package, project: main_project, parent: wp_main) }
+      let(:grandchild_wp) { create(:work_package, project: main_project, parent: child_wp) }
+      let(:work_packages) { [wp_main, child_wp] }
+
+      before do
+        grandchild_wp
+      end
+
+      it "counts every affected work package once" do
+        expect(component.send(:total_count)).to eq(3)
+      end
+    end
+
+    context "with a descendant the user may not delete" do
+      let(:restricted_project) { create(:project, name: "Restricted Project") }
+      let(:restricted_user) do
+        create(:user,
+               member_with_permissions: {
+                 main_project => %i[view_work_packages delete_work_packages]
+               })
+      end
+      let(:selected_wp) { create(:work_package, project: main_project) }
+      let(:deleted_child) { create(:work_package, project: main_project, parent: selected_wp) }
+      let(:unlinked_child) { create(:work_package, project: restricted_project, parent: selected_wp) }
+
+      let(:work_packages) { [selected_wp] }
+
+      before do
+        deleted_child
+        unlinked_child
+        login_as(restricted_user)
+      end
+
+      it "counts only the selection and the descendants it deletes" do
+        expect(component.send(:total_count)).to eq(2)
+      end
+
+      it "reports the one that is only unlinked separately" do
+        expect(component.send(:undeletable_count)).to eq(1)
+      end
+
+      it "puts the listed count in the heading" do
+        render_inline(component)
+
+        expect(page).to have_text I18n.t("work_packages.bulk_delete_dialog.heading", count: 2)
       end
     end
   end
@@ -81,7 +254,7 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
     context "when work packages have no descendants" do
       it "returns the description without children mention" do
         expect(component.send(:description)).to eq(
-          "The following work packages and all associated data will be permanently deleted:"
+          I18n.t("work_packages.bulk_delete_dialog.description")
         )
       end
     end
@@ -95,7 +268,7 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
 
       it "returns the description mentioning children" do
         expect(component.send(:description)).to eq(
-          "The following work packages, including children and all associated data, will be permanently deleted:"
+          I18n.t("work_packages.bulk_delete_dialog.description_with_descendants")
         )
       end
     end

--- a/spec/components/work_packages/delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/delete_dialog_component_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::DeleteDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:home_project) { create(:project, name: "Home project") }
+  shared_let(:deletable_project) { create(:project, name: "Deletable project") }
+  shared_let(:view_only_project) { create(:project, name: "View only project") }
+  shared_let(:invisible_project) { create(:project, name: "Invisible project") }
+
+  let(:home_permissions) { %i[view_work_packages delete_work_packages] }
+  let(:user) do
+    create(:user,
+           member_with_permissions: {
+             home_project => home_permissions,
+             deletable_project => %i[view_work_packages delete_work_packages],
+             view_only_project => %i[view_work_packages]
+           })
+  end
+
+  shared_let(:work_package) { create(:work_package, project: home_project, subject: "Parent to delete") }
+
+  subject do
+    render_inline(described_class.new(work_package:))
+    page
+  end
+
+  before do
+    login_as(user)
+  end
+
+  def t(key, **)
+    I18n.t("work_packages.delete_dialog.#{key}", **)
+  end
+
+  def deletable_child
+    create(:work_package, project: deletable_project, parent: work_package, subject: "Deletable child")
+  end
+
+  def view_only_child
+    create(:work_package, project: view_only_project, parent: work_package, subject: "View only child")
+  end
+
+  def invisible_child
+    create(:work_package, project: invisible_project, parent: work_package, subject: "Secret child")
+  end
+
+  context "with no descendants" do
+    it "asks about the work package alone and mentions no descendants" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text t("confirm_deletion")
+      expect(subject).to have_no_text "descendant"
+    end
+  end
+
+  context "with every descendant deletable" do
+    before { deletable_child }
+
+    it "asks about the listed descendants and lists them" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text I18n.t("work_packages.bulk_delete_dialog.children_label")
+      expect(subject).to have_text "Deletable child"
+      expect(subject).to have_text t("confirm_descendants_deletion")
+    end
+
+    it "names the projects it deletes from and links each one" do
+      expect(subject).to have_text t("cross_project_warning_html",
+                                     projects: "#{home_project.name}, #{deletable_project.name}")
+      expect(subject).to have_link home_project.name, href: project_path(home_project)
+      expect(subject).to have_link deletable_project.name, href: project_path(deletable_project)
+    end
+
+    it "warns about nothing surviving" do
+      expect(subject).to have_no_text "will not be deleted"
+      expect(subject).to have_no_text "cannot be deleted"
+    end
+  end
+
+  context "with a deletable descendant and one the user cannot see" do
+    before do
+      deletable_child
+      invisible_child
+    end
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+    end
+
+    it "leads with what gets deleted, then the hidden one" do
+      expect(subject).to have_text t("hidden_descendants_warning", count: 1)
+    end
+
+    it "discloses neither the hidden work package nor its project" do
+      expect(subject).to have_no_text "Secret child"
+      expect(subject).to have_no_text "Invisible project"
+    end
+  end
+
+  context "with nothing deletable and the only descendant hidden" do
+    before { invisible_child }
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text t("confirm_deletion")
+    end
+
+    it "drops the clause about what gets deleted" do
+      expect(subject).to have_text t("hidden_descendants_only_warning", count: 1)
+      expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
+    end
+  end
+
+  context "with a deletable descendant and one the user cannot delete" do
+    before do
+      deletable_child
+      view_only_child
+    end
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+    end
+
+    it "counts only the preserved one" do
+      expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                     count: 1,
+                                     projects: view_only_project.name)
+    end
+
+    it "links the project it cannot delete in" do
+      expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
+    end
+
+    it "lists only the descendant it deletes" do
+      expect(subject).to have_text "Deletable child"
+      expect(subject).to have_no_text "View only child"
+    end
+  end
+
+  context "with nothing deletable and the only descendant undeletable" do
+    before { view_only_child }
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text t("confirm_deletion")
+    end
+
+    it "drops the clause about what gets deleted and still links the project" do
+      expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                     count: 1,
+                                     projects: view_only_project.name)
+      expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
+    end
+
+    it "does not offer to delete it" do
+      expect(subject).to have_no_text I18n.t("work_packages.bulk_delete_dialog.children_label")
+    end
+  end
+
+  context "with one preserved descendant visible and another hidden" do
+    before do
+      deletable_child
+      view_only_child
+      invisible_child
+    end
+
+    it "uses the permission wording and folds the hidden one into the count" do
+      expect(subject).to have_text t("undeletable_descendants_warning", count: 2)
+    end
+
+    it "names no project, since the count covers one it cannot show" do
+      expect(subject).to have_no_text "Invisible project"
+      expect(subject).to have_no_link view_only_project.name
+    end
+  end
+
+  context "with a deletable work package below an undeletable one" do
+    before do
+      child = view_only_child
+      create(:work_package, project: deletable_project, parent: child, subject: "Deletable grandchild")
+    end
+
+    it "counts only the survivor and never mentions its subtree" do
+      expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                     count: 1,
+                                     projects: view_only_project.name)
+      expect(subject).to have_no_text "Deletable grandchild"
+    end
+  end
+end

--- a/spec/components/work_packages/delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/delete_dialog_component_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe WorkPackages::DeleteDialogComponent, type: :component do
     end
   end
 
-  context "with nothing deletable and the only descendant undeletable" do
+  context "with one visible descendant the user cannot delete" do
     before { view_only_child }
 
     it "asks about the work package alone" do

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -818,6 +818,47 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
         expect(WorkPackage.find_by(id: [work_package1.id, work_package2.id])).to be_nil
         expect(response).to redirect_to(project_work_packages_path(work_package1.project))
       end
+
+      it "reports how many were deleted" do
+        send_destroy_request
+
+        expect(flash[:notice]).to eq(I18n.t("work_packages.bulk.deletion_successful", count: 2))
+      end
+    end
+
+    context "with a selected work package that has descendants" do
+      shared_let(:child) { create(:work_package, type:, status:, project: project1, parent: work_package1) }
+      shared_let(:grandchild) { create(:work_package, type:, status:, project: project1, parent: child) }
+
+      let(:params) { { "ids" => [work_package1.id] } }
+
+      it "counts the descendants it deleted along the way" do
+        send_destroy_request
+
+        expect(flash[:notice]).to eq(I18n.t("work_packages.bulk.deletion_successful", count: 3))
+      end
+    end
+
+    context "with an ancestor that is only rescheduled" do
+      shared_let(:parent) do
+        create(:work_package, type:, status:, project: project1, schedule_manually: false)
+      end
+      shared_let(:child) do
+        create(:work_package, type:, status:, project: project1, parent:,
+                              start_date: Date.parse("2026-01-05"), due_date: Date.parse("2026-01-09"))
+      end
+      shared_let(:sibling) do
+        create(:work_package, type:, status:, project: project1, parent:,
+                              start_date: Date.parse("2026-02-02"), due_date: Date.parse("2026-02-06"))
+      end
+
+      let(:params) { { "ids" => [child.id] } }
+
+      it "does not count the ancestor as deleted" do
+        send_destroy_request
+
+        expect(flash[:notice]).to eq(I18n.t("work_packages.bulk.deletion_successful", count: 1))
+      end
     end
 
     describe "with the cleanup being unsuccessful" do

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -118,6 +118,41 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
     allow(User).to receive(:current).and_return user
   end
 
+  describe "#delete_dialog" do
+    shared_let(:invisible_project) { create(:project, types: [type]) }
+    shared_let(:invisible_work_package) { create(:work_package, type:, status:, project: invisible_project) }
+
+    context "with a work package the user cannot see" do
+      before do
+        get :delete_dialog, params: { ids: [invisible_work_package.id] }, format: :turbo_stream
+      end
+
+      it "denies access" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with a mix of visible and invisible work packages" do
+      before do
+        get :delete_dialog, params: { ids: [work_package1.id, invisible_work_package.id] }, format: :turbo_stream
+      end
+
+      it "denies access instead of offering to delete the visible subset" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with a visible work package" do
+      before do
+        get :delete_dialog, params: { ids: [work_package1.id] }, format: :turbo_stream
+      end
+
+      it "renders the dialog" do
+        expect(response).to be_successful
+      end
+    end
+  end
+
   describe "#edit" do
     shared_examples_for "response" do
       subject { response }
@@ -816,6 +851,23 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
         send_destroy_request
         expect(WorkPackage.count).to eq(0)
         expect(response).to redirect_to(project_work_packages_path(work_package1.project))
+      end
+    end
+
+    context "with a child in a project the user has no access to" do
+      shared_let(:foreign_project) { create(:project, types: [type]) }
+      shared_let(:foreign_child) do
+        create(:work_package, type:, status:, project: foreign_project, parent: work_package1)
+      end
+
+      let(:params) { { "ids" => [work_package1.id] } }
+
+      it "deletes the work package and detaches the child" do
+        send_destroy_request
+
+        expect(WorkPackage).not_to exist(work_package1.id)
+        expect(foreign_child.reload.parent_id).to be_nil
+        expect(flash[:error]).to be_nil
       end
     end
 

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -281,6 +281,28 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
     end
   end
 
+  context "when the change was caused by the deletion of the parent" do
+    subject(:cause) do
+      {
+        "type" => "work_package_parent_deleted"
+      }
+    end
+
+    it do
+      expect(cause).to render_html_variant(
+        "<strong>#{I18n.t('journals.caused_changes.work_package_parent_deleted')}</strong> " \
+        "#{I18n.t('journals.cause_descriptions.work_package_parent_deleted')}"
+      )
+    end
+
+    it do
+      expect(cause).to render_raw_variant(
+        "#{I18n.t('journals.caused_changes.work_package_parent_deleted')} " \
+        "#{I18n.t('journals.cause_descriptions.work_package_parent_deleted')}"
+      )
+    end
+  end
+
   context "when the change was caused by working day changes" do
     subject(:cause) do
       {

--- a/spec/services/work_packages/delete_service_cross_project_authorization_spec.rb
+++ b/spec/services/work_packages/delete_service_cross_project_authorization_spec.rb
@@ -31,15 +31,17 @@
 require "spec_helper"
 
 RSpec.describe WorkPackages::DeleteService, "integration", type: :model,
-                                            with_settings: { cross_project_work_package_relations: true } do
+                                                           with_settings: { cross_project_work_package_relations: true } do
   let(:project_a) { create(:project_with_types) }
   let(:project_b) { create(:project_with_types) }
-  let(:role_a) { create(:project_role, permissions: %i[view_work_packages delete_work_packages]) }
-  let(:role_b) { create(:project_role, permissions: %i[view_work_packages]) }
+  let(:permissions_a) { %i[view_work_packages delete_work_packages] }
+  let(:permissions_b) { %i[view_work_packages] }
+  let(:role_a) { create(:project_role, permissions: permissions_a) }
+  let(:role_b) { create(:project_role, permissions: permissions_b) }
   let(:user) do
     create(:user).tap do |u|
       create(:member, project: project_a, principal: u, roles: [role_a])
-      create(:member, project: project_b, principal: u, roles: [role_b])
+      create(:member, project: project_b, principal: u, roles: [role_b]) if permissions_b.any?
     end
   end
 
@@ -48,10 +50,79 @@ RSpec.describe WorkPackages::DeleteService, "integration", type: :model,
 
   subject(:call) { described_class.new(user:, model: parent).call }
 
-  it "does not delete descendants in projects where the user lacks delete permission" do
-    expect(call).to be_failure
-    expect(WorkPackage.exists?(parent.id)).to be_truthy
-    expect(WorkPackage.exists?(child.id)).to be_truthy
-    expect(call.includes_error?(:base, :error_unauthorized)).to be(true)
+  shared_examples "detaches the child" do
+    it "deletes the parent" do
+      expect(call).to be_success
+      expect(WorkPackage).not_to exist(parent.id)
+    end
+
+    it "keeps the child without a parent" do
+      call
+
+      expect(child.reload.parent_id).to be_nil
+    end
+
+    it "records the reason as a journal cause on the child" do
+      call
+
+      expect(child.reload.journals.last.cause_type).to eq("work_package_parent_deleted")
+    end
+
+    it "does not name the deleted parent in the journal cause" do
+      call
+
+      expect(child.reload.journals.last.cause.keys).to contain_exactly("type")
+    end
+  end
+
+  context "when the child is only visible to the user" do
+    it_behaves_like "detaches the child"
+  end
+
+  context "when the child is in a project invisible to the user" do
+    let(:permissions_b) { [] }
+
+    it_behaves_like "detaches the child"
+  end
+
+  context "when every descendant is deletable" do
+    let!(:child) { create(:work_package, project: project_a, parent:, subject: "Child") }
+    let!(:grandchild) { create(:work_package, project: project_a, parent: child, subject: "Grandchild") }
+
+    it "deletes the whole subtree" do
+      expect(call).to be_success
+      expect(WorkPackage).not_to exist(parent.id)
+      expect(WorkPackage).not_to exist(child.id)
+      expect(WorkPackage).not_to exist(grandchild.id)
+    end
+  end
+
+  context "when the undeletable work package is a grandchild" do
+    let!(:child) { create(:work_package, project: project_a, parent:, subject: "Child") }
+    let!(:grandchild) { create(:work_package, project: project_b, parent: child, subject: "Grandchild") }
+
+    it "deletes the parent and the child" do
+      expect(call).to be_success
+      expect(WorkPackage).not_to exist(parent.id)
+      expect(WorkPackage).not_to exist(child.id)
+    end
+
+    it "detaches the grandchild from the deleted child" do
+      call
+
+      expect(grandchild.reload.parent_id).to be_nil
+      expect(grandchild.journals.last.cause_type).to eq("work_package_parent_deleted")
+    end
+  end
+
+  context "when a deletable work package hangs below an undeletable one" do
+    let!(:grandchild) { create(:work_package, project: project_a, parent: child, subject: "Grandchild") }
+
+    it "keeps the whole subtree below the detached child" do
+      expect(call).to be_success
+      expect(WorkPackage).not_to exist(parent.id)
+      expect(child.reload.parent_id).to be_nil
+      expect(grandchild.reload.parent_id).to eq(child.id)
+    end
   end
 end

--- a/spec/services/work_packages/delete_service_spec.rb
+++ b/spec/services/work_packages/delete_service_spec.rb
@@ -135,12 +135,12 @@ RSpec.describe WorkPackages::DeleteService do
 
   context "with descendants" do
     let(:child) do
-      build_stubbed(:work_package, project: work_package.project).tap do |wp|
+      build_stubbed(:work_package, project: work_package.project, parent: work_package).tap do |wp|
         allow(wp).to receive(:reload).and_return(wp)
       end
     end
     let(:grandchild) do
-      build_stubbed(:work_package, project: work_package.project).tap do |wp|
+      build_stubbed(:work_package, project: work_package.project, parent: child).tap do |wp|
         allow(wp).to receive(:reload).and_return(wp)
       end
     end
@@ -149,13 +149,9 @@ RSpec.describe WorkPackages::DeleteService do
     end
 
     before do
-      allow(instance)
-        .to receive(:validate_descendant_deletions)
-        .and_return(ServiceResult.success(result: work_package))
-
-      allow(work_package)
-        .to receive(:descendants)
-        .and_return(descendants)
+      # The stubbed descendants are not in the database, so no walk can find them.
+      # WorkPackages::Shared::DeletionPlanning has its own spec for that.
+      allow(instance).to receive_messages(deleted_descendants: descendants, unlinked_descendants: [])
 
       descendants.each do |descendant|
         allow(descendant)

--- a/spec/services/work_packages/shared/deletion_planning_spec.rb
+++ b/spec/services/work_packages/shared/deletion_planning_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::Shared::DeletionPlanning do
+  # A bare host, so the walk can be checked without a service or a dialog around it.
+  let(:host_class) do
+    Class.new do
+      include WorkPackages::Shared::DeletionPlanning
+
+      attr_reader :deletion_roots, :deletion_user
+
+      def initialize(roots, user)
+        @deletion_roots = Array(roots)
+        @deletion_user = user
+      end
+    end
+  end
+
+  let(:home_permissions) { %i[view_work_packages delete_work_packages] }
+  let(:user) do
+    create(:user,
+           member_with_permissions: {
+             home_project => home_permissions,
+             view_only_project => %i[view_work_packages]
+           })
+  end
+
+  shared_let(:home_project) { create(:project) }
+  shared_let(:view_only_project) { create(:project) }
+  shared_let(:invisible_project) { create(:project) }
+
+  subject(:plan) { host_class.new(roots, user) }
+
+  describe "a chain of deletable descendants" do
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: home_project, parent: root) }
+    let!(:grandchild) { create(:work_package, project: home_project, parent: child) }
+    let(:roots) { root }
+
+    it "deletes all of them, nearest first" do
+      expect(plan.deleted_descendants).to eq([child, grandchild])
+      expect(plan.unlinked_descendants).to be_empty
+    end
+
+    it "reports them under the root they hang from" do
+      expect(plan.deleted_descendants_under(root)).to eq([child, grandchild])
+    end
+  end
+
+  describe "a descendant the user may not delete" do
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: view_only_project, parent: root) }
+    let(:roots) { root }
+
+    it "cuts it loose rather than deleting it" do
+      expect(plan.deleted_descendants).to be_empty
+      expect(plan.unlinked_descendants).to eq([child])
+    end
+
+    it "counts it as visible" do
+      expect(plan.visible_unlinked_descendants).to eq([child])
+      expect(plan.hidden_unlinked_count).to eq(0)
+    end
+
+    # Filtering flat instead of walking would delete the grandchild while its
+    # parent survives.
+    context "with a deletable subtree below it" do
+      let!(:grandchild) { create(:work_package, project: home_project, parent: child) }
+
+      it "leaves the subtree out of both lists" do
+        expect(plan.deleted_descendants).to be_empty
+        expect(plan.unlinked_descendants).to eq([child])
+      end
+    end
+  end
+
+  describe "an invisible descendant" do
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: invisible_project, parent: root) }
+    let(:roots) { root }
+
+    it "is cut loose but not counted as visible" do
+      expect(plan.unlinked_descendants).to eq([child])
+      expect(plan.visible_unlinked_descendants).to be_empty
+      expect(plan.hidden_unlinked_count).to eq(1)
+    end
+  end
+
+  # Seeing and deleting are separate permissions, so a role can carry the second
+  # without the first. Either one missing means the descendant is cut loose.
+  describe "a descendant the user may delete but not see" do
+    shared_let(:delete_only_project) { create(:project) }
+    let(:user) do
+      create(:user,
+             member_with_permissions: {
+               home_project => home_permissions,
+               delete_only_project => %i[delete_work_packages]
+             })
+    end
+
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: delete_only_project, parent: root) }
+    let(:roots) { root }
+
+    it "is cut loose rather than deleted" do
+      expect(plan.deleted_descendants).to be_empty
+      expect(plan.unlinked_descendants).to eq([child])
+    end
+  end
+
+  describe "several roots where one is a descendant of another" do
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: home_project, parent: root) }
+    let!(:grandchild) { create(:work_package, project: home_project, parent: child) }
+    let(:roots) { [root, child] }
+
+    it "reports the grandchild once, under the nearest selected root" do
+      expect(plan.deleted_descendants).to eq([grandchild])
+      expect(plan.deleted_descendants_under(root)).to be_empty
+      expect(plan.deleted_descendants_under(child)).to eq([grandchild])
+    end
+  end
+
+  describe "with an overridden deletability check" do
+    let(:host_class) do
+      Class.new do
+        include WorkPackages::Shared::DeletionPlanning
+
+        attr_reader :deletion_roots, :deletion_user
+
+        def initialize(roots, user)
+          @deletion_roots = Array(roots)
+          @deletion_user = user
+        end
+
+        def deletable?(_descendant) = false
+      end
+    end
+
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: home_project, parent: root) }
+    let(:roots) { root }
+
+    it "uses the override instead of the delete permission" do
+      expect(plan.deleted_descendants).to be_empty
+      expect(plan.unlinked_descendants).to eq([child])
+    end
+  end
+end


### PR DESCRIPTION
Both delete dialogs built their descendant list with a plain WorkPackage query and no proper permission check.
Selecting a work package with a child in a project you have no access to resulted in a visibility violation.

The dialogs now filter descendants with WorkPackage.visible and count the rest.
A warning banner says how many descendants you cannot see, without naming them or their projects.

The bulk dialog now renders the multi-project warning as an info banner instead.

As discussed with product, we want to unlink descendants rather than preventing deletion of the parent.
For that,DeleteService now iterates all descendants. The ones without permission keep their own hierarchy, but get the parent unlinked depending on:

- with manage_subtasks in the parent's project they are detached (parent: nil) and carry a new Journal::CausedByWorkPackageParentDeletion, rendering as "Parent removed because the parent work package was deleted"
- without it the call fails with :cannot_detach_undeletable_descendants and nothing is deleted

Adds substantial test coverage for invisible descendants in children, grandchildren in other projects, etc.

Adds a cause for deleted parents
<img width="1310" height="232" alt="2026-07-28_16-07-52@2x" src="https://github.com/user-attachments/assets/58e6d990-f356-41d7-87a1-c52d58148158" />

https://community.openproject.org/work_packages/OP-19734


Case 1 - no children
<img width="510" height="305" alt="2026-07-28_15-36-06" src="https://github.com/user-attachments/assets/d0abd940-f0f8-48ae-9504-bcb3842b6567" />


Case 2: children that I can delete


<img width="494" height="388" alt="2026-07-28_15-36-34" src="https://github.com/user-attachments/assets/1da3c64c-f4ed-4e9a-bfb9-87ff76b5480a" />



Case 3(a) One invisible

<img width="500" height="433" alt="2026-07-28_15-37-31" src="https://github.com/user-attachments/assets/06989636-13e3-4257-811e-9b3cda28638d" />


Case 3(b) Multiple invisible

<img width="512" height="448" alt="2026-07-28_15-38-18" src="https://github.com/user-attachments/assets/0ebe5737-ab94-4437-bb23-38b13973da7e" />




Case 4(a) can't delete one, can't view one, CAN delete one

<img width="502" height="480" alt="image" src="https://github.com/user-attachments/assets/4fb18fda-f482-4395-9a82-5decef24145f" />



Case 5 - Bulk delete, can't see some descendants
<img width="504" height="503" alt="2026-07-28_15-38-51" src="https://github.com/user-attachments/assets/15e2ebed-51db-4f06-8ff7-58e81dfd9989" />



Case 5(a) - Bulk delete, with some visible descendants to be deleted

<img width="510" height="579" alt="2026-07-28_15-39-45" src="https://github.com/user-attachments/assets/d732a743-7995-4b6d-aec3-91b14316ce26" />


Case 5(b) - Delete with some children viewable, not deletable
<img width="510" height="524" alt="2026-07-28_15-41-17" src="https://github.com/user-attachments/assets/caea8338-ffb1-4f6e-97f1-1bef5b69100d" />


Project names linked

<img width="1038" height="1244" alt="2026-07-28_15-44-53@2x" src="https://github.com/user-attachments/assets/d64a13b6-2dd6-4ec0-b175-dd7df729c7bc" />

