### PR TITLE
[PIR-109] PIR PDF and PMflex artefacts are only shown after 2nd WP st…

### DIFF
--- a/app/workers/work_packages/workflow_job.rb
+++ b/app/workers/work_packages/workflow_job.rb
@@ -32,7 +32,7 @@ module WorkPackages
   class WorkflowJob < ApplicationJob
     def perform(journal, changes)
       work_package = journal.journable
-      return if journal.initial?
+      return unless status_transition?(changes)
 
       services = applicable_services(work_package, changes)
       return if services.empty?
@@ -48,6 +48,13 @@ module WorkPackages
     end
 
     private
+
+    def status_transition?(changes)
+      # journal.initial? can not be used here, because any change by the creating user is aggregated
+      # into the initial journal entry (for a user defined period of time).
+      # the services needs to be executed on every status change after creation
+      Array(changes["status_id"]).first.present?
+    end
 
     def applicable_services(work_package, changes)
       [

--- a/spec/workers/work_packages/workflow_job_spec.rb
+++ b/spec/workers/work_packages/workflow_job_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe WorkPackages::WorkflowJob do
   let(:work_package) { build_stubbed(:work_package) }
   let(:changes) { { "status_id" => [1, 2] } }
   let(:journal_user) { build_stubbed(:user) }
-  let(:journal) { instance_double(Journal, journable: work_package, initial?: initial, user: journal_user) }
-  let(:initial) { false }
+  let(:journal) { instance_double(Journal, journable: work_package, user: journal_user) }
 
   let(:reupload_service) do
     instance_double(Projects::CreationWizard::ReuploadArtifactOnStatusChangesService, call!: nil)
@@ -56,7 +55,7 @@ RSpec.describe WorkPackages::WorkflowJob do
 
   subject(:perform) { described_class.new.perform(journal, changes) }
 
-  context "when the journal is not the initial one" do
+  context "when the status changes from an existing value" do
     it "invokes both the creation-wizard reupload and the type artefact export" do
       perform
 
@@ -98,10 +97,33 @@ RSpec.describe WorkPackages::WorkflowJob do
         expect(WorkPackages::TypeArtefactExport::ExportOnStatusChangeService).not_to have_received(:new)
       end
     end
+
+    context "even when the journal is still the initial one (aggregated change)" do
+      # The creator's status change within the aggregation window is folded into the
+      # version 1 journal. The change payload still carries a non-nil previous status,
+      # so the workflows must run despite the journal remaining the initial one.
+      it "invokes both handlers" do
+        perform
+
+        expect(reupload_service).to have_received(:call!).with(changes:)
+        expect(type_export_service).to have_received(:call!).with(changes:)
+      end
+    end
   end
 
-  context "when the journal is the initial one" do
-    let(:initial) { true }
+  context "when the status is set for the first time (work package creation)" do
+    let(:changes) { { "status_id" => [nil, 1] } }
+
+    it "does not invoke either handler" do
+      perform
+
+      expect(reupload_service).not_to have_received(:call!)
+      expect(type_export_service).not_to have_received(:call!)
+    end
+  end
+
+  context "when the changes do not touch the status" do
+    let(:changes) { { "subject" => ["Old", "New"] } }
 
     it "does not invoke either handler" do
       perform


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/PIR-109

PDFs one status change were not created because of journal aggregation did not update journal.version beyond 1 in the first aggregation period. So the code to avoid duplicate files after work package creation called "journal.initial?" which was always true for the work package (by any change of the creating user).
We now check for a status change from nil instead of journal.initial?.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
