### PR TITLE
Add MCP tools to list and create WP comments

### DIFF
--- a/app/services/mcp_output_filters/hash_filter.rb
+++ b/app/services/mcp_output_filters/hash_filter.rb
@@ -33,29 +33,27 @@ module McpOutputFilters
   # It will descend into the values of arrays and hashes and call #on_hash for each hash found
   # along the way, allowing for the implementation to modify the given hash along the way.
   class HashFilter
-    class << self
-      def filter(hash_or_array)
-        case hash_or_array
-        when Hash
-          filter_hash(hash_or_array)
-        when Array
-          hash_or_array.each { |value| filter(value) }
-        end
+    def filter(hash_or_array)
+      case hash_or_array
+      when Hash
+        filter_hash(hash_or_array)
+      when Array
+        hash_or_array.each { |value| filter(value) }
       end
+    end
 
-      private
+    private
 
-      def filter_hash(hash)
-        if on_hash(hash)
-          hash.each_value { |value| filter(value) }
-        end
+    def filter_hash(hash)
+      if on_hash(hash)
+        hash.each_value { |value| filter(value) }
       end
+    end
 
-      # Expected to be overwritten by subclasses. Should return a truthy value to descend further into
-      # values of the given hash or false to stop descending here.
-      def on_hash(_hash)
-        raise SubclassResponsibilityError
-      end
+    # Expected to be overwritten by subclasses and may perform output filtering on the passed hash (e.g. deleting keys).
+    # Should return a truthy value to descend further into values of the given hash or false to stop descending here.
+    def on_hash(_hash)
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/app/services/mcp_output_filters/remove_activity_action_links.rb
+++ b/app/services/mcp_output_filters/remove_activity_action_links.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpOutputFilters
+  class RemoveActivityActionLinks < HashFilter
+    BLOCKED_LINKS = %w[
+      update
+      addAttachment
+    ].to_set
+
+    class << self
+      private
+
+      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
+        links = hash["_links"]
+        if links
+          links.delete_if { |key| BLOCKED_LINKS.include?(key) }
+          return false
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/app/services/mcp_output_filters/remove_activity_details.rb
+++ b/app/services/mcp_output_filters/remove_activity_details.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpOutputFilters
+  class RemoveActivityDetails < HashFilter
+    class << self
+      private
+
+      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
+        details = hash["details"]
+        if details.is_a?(Array)
+          hash["details"] = []
+          return false
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/app/services/mcp_output_filters/remove_activity_details.rb
+++ b/app/services/mcp_output_filters/remove_activity_details.rb
@@ -30,18 +30,16 @@
 
 module McpOutputFilters
   class RemoveActivityDetails < HashFilter
-    class << self
-      private
+    private
 
-      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
-        details = hash["details"]
-        if details.is_a?(Array)
-          hash["details"] = []
-          return false
-        end
-
-        true
+    def on_hash(hash) # rubocop:disable Naming/PredicateMethod
+      details = hash["details"]
+      if details.is_a?(Array)
+        hash["details"] = []
+        return false
       end
+
+      true
     end
   end
 end

--- a/app/services/mcp_output_filters/remove_formattable_html.rb
+++ b/app/services/mcp_output_filters/remove_formattable_html.rb
@@ -30,21 +30,19 @@
 
 module McpOutputFilters
   class RemoveFormattableHtml < HashFilter
-    class << self
-      private
+    private
 
-      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
-        if formattable?(hash)
-          hash.delete("html")
-          return false
-        end
-
-        true
+    def on_hash(hash) # rubocop:disable Naming/PredicateMethod
+      if formattable?(hash)
+        hash.delete("html")
+        return false
       end
 
-      def formattable?(hash)
-        hash.key?("format") && hash.key?("raw") && hash.key?("html")
-      end
+      true
+    end
+
+    def formattable?(hash)
+      hash.key?("format") && hash.key?("raw") && hash.key?("html")
     end
   end
 end

--- a/app/services/mcp_output_filters/remove_links.rb
+++ b/app/services/mcp_output_filters/remove_links.rb
@@ -29,24 +29,25 @@
 #++
 
 module McpOutputFilters
-  class RemoveActivityActionLinks < HashFilter
-    BLOCKED_LINKS = %w[
-      update
-      addAttachment
-    ].to_set
+  class RemoveLinks < HashFilter
+    attr_reader :blocked_links
 
-    class << self
-      private
+    def initialize(blocked_links)
+      super()
 
-      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
-        links = hash["_links"]
-        if links
-          links.delete_if { |key| BLOCKED_LINKS.include?(key) }
-          return false
-        end
+      @blocked_links = blocked_links.to_set
+    end
 
-        true
+    private
+
+    def on_hash(hash) # rubocop:disable Naming/PredicateMethod
+      links = hash["_links"]
+      if links
+        links.delete_if { |key| blocked_links.include?(key) }
+        return false
       end
+
+      true
     end
   end
 end

--- a/app/services/mcp_output_filters/remove_work_package_action_links.rb
+++ b/app/services/mcp_output_filters/remove_work_package_action_links.rb
@@ -29,44 +29,32 @@
 #++
 
 module McpOutputFilters
-  class RemoveWorkPackageActionLinks < HashFilter
-    BLOCKED_LINKS = %w[
-      update
-      updateImmediately
-      delete
-      logTime
-      move
-      copy
-      generate_pdf
-      configureForm
-      availableWatchers
-      watch
-      unwatch
-      addWatcher
-      removeWatcher
-      addRelation
-      addChild
-      changeParent
-      addComment
-      addAttachment
-      previewMarkup
-      timeEntries
-      showCosts
-      addFileLink
-    ].to_set
-
-    class << self
-      private
-
-      def on_hash(hash) # rubocop:disable Naming/PredicateMethod
-        links = hash["_links"]
-        if links
-          links.delete_if { |key| BLOCKED_LINKS.include?(key) }
-          return false
-        end
-
-        true
-      end
+  class RemoveWorkPackageActionLinks < RemoveLinks
+    def initialize
+      super(%w[
+        update
+        updateImmediately
+        delete
+        logTime
+        move
+        copy
+        generate_pdf
+        configureForm
+        availableWatchers
+        watch
+        unwatch
+        addWatcher
+        removeWatcher
+        addRelation
+        addChild
+        changeParent
+        addComment
+        addAttachment
+        previewMarkup
+        timeEntries
+        showCosts
+        addFileLink
+      ])
     end
   end
 end

--- a/app/services/mcp_tools/create_work_package_comment.rb
+++ b/app/services/mcp_tools/create_work_package_comment.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class CreateWorkPackageComment < Base
+    default_title "Create work package comment"
+    default_description "Add a comment to a work package."
+
+    name "create_work_package_comment"
+    annotations read_only: false, idempotent: false, destructive: false
+
+    input_schema(
+      required: %i[work_package_id comment],
+      properties: {
+        work_package_id: {
+          type: :number,
+          description: "The ID of the work package to which a comment shall be added."
+        },
+        comment: {
+          type: :string,
+          description: "The comment text to be added."
+        },
+        internal: {
+          type: :boolean,
+          description: "Whether the comment should only be visible to users with the permission to read internal comments. " \
+                       "Default: false"
+        }
+      }
+    )
+
+    def call(work_package_id:, comment:, internal: false)
+      work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
+      return { error: "The given work package could not be found." } if work_package.nil?
+
+      result = AddWorkPackageNoteService.new(user: current_user, work_package:).call(comment, send_notifications: true, internal:)
+
+      if result.success?
+        API::V3::Activities::ActivityRepresenter.create(result.result, current_user:)
+      else
+        { error: result.message }
+      end
+    end
+  end
+end

--- a/app/services/mcp_tools/list_work_package_comments.rb
+++ b/app/services/mcp_tools/list_work_package_comments.rb
@@ -47,9 +47,9 @@ module McpTools
       }
     )
 
-    output_filter McpOutputFilters::RemoveActivityDetails
-    output_filter McpOutputFilters::RemoveFormattableHtml
-    output_filter McpOutputFilters::RemoveActivityActionLinks
+    output_filter McpOutputFilters::RemoveActivityDetails.new
+    output_filter McpOutputFilters::RemoveFormattableHtml.new
+    output_filter McpOutputFilters::RemoveLinks.new(%w[update addAttachment])
 
     def call(work_package_id:, page: nil)
       work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)

--- a/app/services/mcp_tools/list_work_package_comments.rb
+++ b/app/services/mcp_tools/list_work_package_comments.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class ListWorkPackageComments < Base
+    default_title "List work package comments"
+    default_description "List comments of the given work package."
+
+    name "list_work_package_comments"
+    annotations read_only: true, idempotent: true, destructive: false
+    enable_pagination
+
+    input_schema(
+      required: %i[work_package_id],
+      properties: {
+        work_package_id: {
+          type: :number,
+          description: "The ID of the work package whose comments shall be listed."
+        }
+      }
+    )
+
+    output_filter McpOutputFilters::RemoveActivityDetails
+    output_filter McpOutputFilters::RemoveFormattableHtml
+    output_filter McpOutputFilters::RemoveActivityActionLinks
+
+    def call(work_package_id:, page: nil)
+      work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
+      return { error: "Can't find given work package." } if work_package.nil?
+
+      comments = work_package
+                  .journals
+                  .internal_visible
+                  .includes(:data,
+                            :customizable_journals,
+                            :attachable_journals,
+                            :storable_journals,
+                            :bcf_comment)
+                  .where.not(notes: "")
+                  .order(created_at: :desc)
+
+      comments, total = apply_pagination(comments, page)
+      {
+        items: comments.map { |c| ::API::V3::Activities::ActivityRepresenter.new(c, current_user:, embed_emoji_reactions: true) },
+        total:
+      }
+    end
+  end
+end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -90,8 +90,8 @@ module McpTools
       }
     )
 
-    output_filter McpOutputFilters::RemoveFormattableHtml
-    output_filter McpOutputFilters::RemoveWorkPackageActionLinks
+    output_filter McpOutputFilters::RemoveFormattableHtml.new
+    output_filter McpOutputFilters::RemoveWorkPackageActionLinks.new
 
     def call(page: nil, **filters)
       filtered = apply_filters(WorkPackage.visible, filters)

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -49,6 +49,7 @@ Rails.application.config.after_initialize do
                     McpTools::CurrentUser,
                     McpTools::ListStatuses,
                     McpTools::ListTypes,
+                    McpTools::ListWorkPackageComments,
                     McpTools::ListWorkPackageRelations,
                     McpTools::SearchCustomFields,
                     McpTools::SearchCustomFieldItems,

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -46,6 +46,7 @@ end
 
 Rails.application.config.after_initialize do
   McpTools.register McpTools::CreateWorkPackage,
+                    McpTools::CreateWorkPackageComment,
                     McpTools::CurrentUser,
                     McpTools::ListStatuses,
                     McpTools::ListTypes,

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -37,6 +37,11 @@ module API
         include ::API::V3::Attachments::AttachableRepresenterMixin
         include ActivityPropertyFormatters
 
+        def initialize(*, embed_emoji_reactions: false, **)
+          @embed_emoji_reactions = embed_emoji_reactions
+          super(*, **)
+        end
+
         self_link path: :activity,
                   title_getter: ->(*) {}
 
@@ -93,7 +98,7 @@ module API
         property :emoji_reactions,
                  embedded: true,
                  exec_context: :decorator,
-                 if: ->(*) { embed_links },
+                 if: ->(*) { embed_links || embed_emoji_reactions },
                  uncacheable: true
 
         date_time_property :created_at
@@ -127,6 +132,8 @@ module API
         end
 
         private
+
+        attr_reader :embed_emoji_reactions
 
         def current_user_allowed_to_edit?
           represented.editable_by?(current_user)

--- a/spec/requests/mcp/mcp_tools/create_work_package_comment_spec.rb
+++ b/spec/requests/mcp/mcp_tools/create_work_package_comment_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpTools::CreateWorkPackageComment do
+  subject(:mcp_request) do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) { create(:oauth_access_token, scopes: "mcp", resource_owner: user) }
+  let(:user) { create(:admin) }
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "create_work_package_comment",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) do
+    {
+      work_package_id: work_package.id,
+      comment: "This is a comment I'd like to add."
+    }
+  end
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+  let(:result_item) { parsed_results.fetch("structuredContent") }
+
+  let(:work_package) { create(:work_package).reload }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  before do
+    server_config.save!
+    tool_config.save!
+    work_package.save!
+
+    work_package.project.update!(enabled_internal_comments: true)
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server internal_comments] do
+    it_behaves_like "MCP text tool"
+
+    it "adds a work package comment" do
+      expect { mcp_request }.to change { work_package.reload.journals.count }.by(1)
+
+      expect(work_package.reload.journals.last.notes).to eq("This is a comment I'd like to add.")
+    end
+
+    it "responds with a properly formatted activity" do
+      mcp_request
+
+      expect(result_item.to_json).to match_json_schema.from_docs("work_package_activities_model")
+    end
+
+    context "when requesting to create an internal comment" do
+      let(:call_args) do
+        {
+          work_package_id: work_package.id,
+          comment: "This is a comment I'd like to add.",
+          internal: true
+        }
+      end
+
+      it "creates an internal comment" do
+        expect { mcp_request }.to change { work_package.reload.journals.count }.by(1)
+
+        expect(work_package.reload.journals.last).to be_restricted
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds with a 404" do
+      mcp_request
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end

--- a/spec/requests/mcp/mcp_tools/list_work_package_comments_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_work_package_comments_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe McpTools::ListWorkPackageComments do
+  subject(:mcp_request) do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) do
+    # avoid owner for application, so that we don't have additional users created
+    create(:oauth_access_token, scopes: "mcp", resource_owner: user, application: create(:oauth_application, owner: nil))
+  end
+  let(:user) { create(:user) }
+
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "list_work_package_comments",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) { { work_package_id: work_package.id } }
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+
+  let!(:work_package) { create(:work_package, project: allowed_project, created_at: 5.days.ago, updated_at: 5.days.ago) }
+  let(:comment) { "I am a comment about the work package." }
+
+  let(:allowed_project) { create(:project, enabled_internal_comments: true) }
+  let(:disallowed_project) { create(:project) }
+
+  let(:permissions) { %i[view_work_packages view_internal_comments] }
+
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
+
+  let(:activity_creator) do
+    # creating three journals and adding a comment to the last one
+    (1..3).to_a.reverse_each do |i|
+      Timecop.travel(i.hours.ago) do
+        WorkPackages::UpdateService.new(model: work_package, user: User.system).call(subject: "Subject ##{i}")
+      end
+    end
+
+    work_package.journals.last.update!(notes: comment)
+  end
+
+  before do
+    server_config.save!
+    tool_config.save!
+
+    create(:member, project: allowed_project, user:, roles: [create(:project_role, permissions:)])
+    create(:member, project: disallowed_project, user:, roles: [create(:project_role, permissions: %i[])])
+
+    activity_creator
+  end
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server internal_comments] do
+    it_behaves_like "MCP text tool"
+
+    it "finds all comments of the work package" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+    end
+
+    it "hides pure activity updates" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "items").pluck("comment")).to all(be_present)
+    end
+
+    it "hides change details" do
+      mcp_request
+      expect(parsed_results.dig("structuredContent", "items").pluck("details")).to all(eq([]))
+    end
+
+    it "responds with properly formatted activities" do
+      mcp_request
+      parsed_results.dig("structuredContent", "items").each do |rel|
+        expect(rel.to_json).to match_json_schema.from_docs("work_package_activities_model")
+      end
+    end
+
+    context "when not passing a work_package_id" do
+      let(:call_args) { {} }
+
+      it_behaves_like "MCP tool execution error response"
+    end
+
+    context "when the comment has emoji reactions" do
+      before do
+        create(:emoji_reaction, reactable: work_package.journals.last)
+      end
+
+      it "embeds the emoji reactions" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items", 0, "_embedded", "emojiReactions", "_embedded", "elements", 0,
+                                  "emoji")).to be_present
+      end
+
+      it "does not embed other huge resources, such as work packages" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items", 0, "_embedded", "workPackage")).to be_nil
+      end
+    end
+
+    context "when not allowed to see the source work package" do
+      let!(:work_package) { create(:work_package, project: disallowed_project) }
+
+      it "shows an error response" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "error")).to eq("Can't find given work package.")
+      end
+    end
+
+    context "when there are internal comments" do
+      before do
+        work_package.journals.last.update!(restricted: true)
+      end
+
+      it "shows the internal comments" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+      end
+
+      context "and when the user is not allowed to see internal comments" do
+        let(:permissions) { %i[view_work_packages] }
+
+        it "hides the internal comments" do
+          mcp_request
+          expect(parsed_results.dig("structuredContent", "items").size).to eq(0)
+        end
+      end
+    end
+
+    describe "pagination" do
+      let(:page_size) { 10 }
+      let(:overspilling_comments) { 5 }
+      let(:comments_count) { page_size + overspilling_comments }
+      let(:call_args) { { work_package_id: work_package.id } }
+
+      let(:activity_creator) do
+        (1..comments_count).to_a.reverse_each do |i|
+          Timecop.travel(i.hours.ago) do
+            WorkPackages::UpdateService.new(model: work_package, user: User.system).call(subject: "Comment update ##{i}")
+            work_package.journals.last.update!(notes: "Comment ##{i}")
+          end
+        end
+      end
+
+      before do
+        allow(described_class).to receive(:page_size).and_return(page_size)
+      end
+
+      it "returns only results up to the page size" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
+      end
+
+      it "indicates the total number of results" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "total")).to eq(comments_count)
+      end
+
+      context "if another page is requested" do
+        let(:call_args) { { work_package_id: work_package.id, page: 2 } }
+
+        it "returns the requested page" do
+          mcp_request
+          expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_comments)
+        end
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds in a 404" do
+      mcp_request
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end

--- a/spec/requests/mcp/mcp_tools/list_work_package_relations_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_work_package_relations_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe McpTools::ListWorkPackageRelations do
     # avoid owner for application, so that we don't have additional users created
     create(:oauth_access_token, scopes: "mcp", resource_owner: user, application: create(:oauth_application, owner: nil))
   end
-  let(:user) { create(:user) } # TODO: properly test permissions
+  let(:user) { create(:user) }
 
   let(:request_body) do
     {


### PR DESCRIPTION
This only offers a limited version of what the regular activities APIs would offer, mostly based on the assumption that the amount of data returned by the regular APIs would not have a practical application and be hard to digest.

On the other hand interaction with comments is essential for all kinds of automations, so MCP should also offer it.

# Ticket
https://community.openproject.org/wp/AI-103