### PR TITLE
[AGILE-367] Check the presence of the Enterprise plan custom field

### DIFF
--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Add comment if no work package is linked
         if: steps.work-package-check.outputs.no_ticket == 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: version-mismatch-comment
           message: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Add comment if versions differ
         if: steps.work-package-check.outputs.version_mismatch == 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: version-mismatch-comment
           message: |
@@ -71,7 +71,7 @@ jobs:
 
       - name: Add comment if Enterprise Plan is missing
         if: steps.work-package-check.outputs.enterprise_plan_missing == 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: enterprise-plan-missing-comment
           message: |
@@ -90,14 +90,14 @@ jobs:
         if: |
           steps.work-package-check.outputs.behind_feature_flag == 'true' ||
           (steps.work-package-check.outputs.version_mismatch != 'true' && steps.work-package-check.outputs.no_ticket != 'true')
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: version-mismatch-comment
           delete: true
 
       - name: Enterprise plan check passed
         if: steps.work-package-check.outputs.enterprise_plan_missing != 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: enterprise-plan-missing-comment
           delete: true

--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
 
       - name: Verify linked version matches core version
         id: work-package-check

--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -1,4 +1,4 @@
-name: Check work package version
+name: Check work package version and Enterprise plan
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write # to comment on the PR
 
 jobs:
-  version-check:
+  work-package-check:
     # Skip automation PRs (dependabot, copilot, the release merge PRs opened by
     # openprojectci) as they never link a work package.
     if: >-
@@ -32,14 +32,14 @@ jobs:
         uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
 
       - name: Verify linked version matches core version
-        id: version-check
+        id: work-package-check
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: ./script/ci/version_check.sh
+        run: ./script/ci/work_package_check.sh
 
       - name: Add comment if no work package is linked
-        if: steps.version-check.outputs.no_ticket == 'true'
+        if: steps.work-package-check.outputs.no_ticket == 'true'
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment
@@ -51,7 +51,7 @@ jobs:
             title in square brackets, e.g. `[SLUG-123] My title here`.
 
       - name: Add comment if versions differ
-        if: steps.version-check.outputs.version_mismatch == 'true'
+        if: steps.work-package-check.outputs.version_mismatch == 'true'
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment
@@ -61,18 +61,43 @@ jobs:
 
             Details:
 
-             - Work package URL: ${{ steps.version-check.outputs.wp_url }}
-             - Work package version: ${{steps.version-check.outputs.wp_version}}
-             - Core version: ${{steps.version-check.outputs.core_version}}
+             - Work package URL: ${{ steps.work-package-check.outputs.wp_url }}
+             - Work package version: ${{steps.work-package-check.outputs.wp_version}}
+             - Core version: ${{steps.work-package-check.outputs.core_version}}
 
             Please make sure that:
 
              - The work package version OR your pull request target branch is correct
+
+      - name: Add comment if Enterprise Plan is missing
+        if: steps.work-package-check.outputs.enterprise_plan_missing == 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: enterprise-plan-missing-comment
+          message: |
+            > [!CAUTION]
+            > The Enterprise plan field is not set on the work package
+
+            Details:
+
+             - Work package URL: ${{ steps.work-package-check.outputs.wp_url }}
+
+            Please make sure that:
+
+             - The work package Enterprise plan field is set
+
       - name: Version check passed
         if: |
-          steps.version-check.outputs.behind_feature_flag == 'true' ||
-          (steps.version-check.outputs.version_mismatch != 'true' && steps.version-check.outputs.no_ticket != 'true')
+          steps.work-package-check.outputs.behind_feature_flag == 'true' ||
+          (steps.work-package-check.outputs.version_mismatch != 'true' && steps.work-package-check.outputs.no_ticket != 'true')
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment
+          delete: true
+
+      - name: Enterprise plan check passed
+        if: steps.work-package-check.outputs.enterprise_plan_missing != 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: enterprise-plan-missing-comment
           delete: true

--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
 
-      - name: Verify linked version matches core version
+      - name: Verify work package fields are set (linked version matches core version and Enterprise field is set)
         id: work-package-check
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -96,7 +96,9 @@ jobs:
           delete: true
 
       - name: Enterprise plan check passed
-        if: steps.work-package-check.outputs.enterprise_plan_missing != 'true'
+        if: |
+          steps.work-package-check.outputs.enterprise_plan_missing != 'true'
+          && steps.work-package-check.outputs.no_ticket != 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: enterprise-plan-missing-comment

--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Add comment if no work package is linked
         if: steps.work-package-check.outputs.no_ticket == 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: version-mismatch-comment
           message: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Add comment if versions differ
         if: steps.work-package-check.outputs.version_mismatch == 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: version-mismatch-comment
           message: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Add comment if Enterprise Plan is missing
         if: steps.work-package-check.outputs.enterprise_plan_missing == 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: enterprise-plan-missing-comment
           message: |
@@ -83,14 +83,14 @@ jobs:
 
       - name: Version check passed
         if: steps.work-package-check.outputs.version_mismatch != 'true' && steps.work-package-check.outputs.no_ticket != 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: version-mismatch-comment
           delete: true
 
       - name: Enterprise plan check passed
         if: steps.work-package-check.outputs.enterprise_plan_missing != 'true'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: enterprise-plan-missing-comment
           delete: true

--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -1,4 +1,4 @@
-name: Check work package version
+name: Check work package version and Enterprise plan
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write # to comment on the PR
 
 jobs:
-  version-check:
+  work-package-check:
     if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
@@ -27,14 +27,14 @@ jobs:
         uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
 
       - name: Verify linked version matches core version
-        id: version-check
+        id: work-package-check
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: ./script/ci/version_check.sh
+        run: ./script/ci/work_package_check.sh
 
       - name: Add comment if no work package is linked
-        if: steps.version-check.outputs.no_ticket == 'true'
+        if: steps.work-package-check.outputs.no_ticket == 'true'
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment
@@ -46,7 +46,7 @@ jobs:
             title in square brackets, e.g. `[SLUG-123] My title here`.
 
       - name: Add comment if versions differ
-        if: steps.version-check.outputs.version_mismatch == 'true'
+        if: steps.work-package-check.outputs.version_mismatch == 'true'
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment
@@ -56,16 +56,41 @@ jobs:
 
             Details:
 
-             - Work package URL: ${{ steps.version-check.outputs.wp_url }}
-             - Work package version: ${{steps.version-check.outputs.wp_version}}
-             - Core version: ${{steps.version-check.outputs.core_version}}
+             - Work package URL: ${{ steps.work-package-check.outputs.wp_url }}
+             - Work package version: ${{steps.work-package-check.outputs.wp_version}}
+             - Core version: ${{steps.work-package-check.outputs.core_version}}
 
             Please make sure that:
 
              - The work package version OR your pull request target branch is correct
+
+      - name: Add comment if Enterprise Plan is missing
+        if: steps.work-package-check.outputs.enterprise_plan_missing == 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: enterprise-plan-missing-comment
+          message: |
+            > [!CAUTION]
+            > The Enterprise plan field is not set on the work package
+
+            Details:
+
+             - Work package URL: ${{ steps.work-package-check.outputs.wp_url }}
+
+            Please make sure that:
+
+             - The work package Enterprise plan field is set
+
       - name: Version check passed
-        if: steps.version-check.outputs.version_mismatch != 'true' && steps.version-check.outputs.no_ticket != 'true'
+        if: steps.work-package-check.outputs.version_mismatch != 'true' && steps.work-package-check.outputs.no_ticket != 'true'
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: version-mismatch-comment
+          delete: true
+
+      - name: Enterprise plan check passed
+        if: steps.work-package-check.outputs.enterprise_plan_missing != 'true'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        with:
+          header: enterprise-plan-missing-comment
           delete: true

--- a/.github/workflows/work-package-check.yml
+++ b/.github/workflows/work-package-check.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
 
       - name: Verify linked version matches core version
         id: work-package-check

--- a/script/ci/work_package_check.sh
+++ b/script/ci/work_package_check.sh
@@ -29,7 +29,7 @@
 
 set -e
 
-# script/ci/version_check
+# script/ci/work_package_check.sh
 
 # Read from the PR_BODY / PR_TITLE environment variables, falling back to
 # positional arguments so the script can still be run manually for testing.

--- a/script/ci/work_package_check.sh
+++ b/script/ci/work_package_check.sh
@@ -69,6 +69,8 @@ if [ "$HTTP_STATUS" -ne 200 ]; then
   exit 0
 fi
 
+# Extract and compare the version from the api response
+
 VERSION_FROM_API=$(jq -r '._links.version.title // "not set"' response.json)
 if [ -z "$VERSION_FROM_API" ]; then
   echo "::warning::Failed to extract version from API response."
@@ -98,4 +100,23 @@ if [[ "$VERSION_FROM_API" != "$VERSION_FROM_FILE" ]]; then
   echo "core_version=${VERSION_FROM_FILE}" >> "$GITHUB_OUTPUT"
 else
   echo "Version from the work package ${WORK_PACKAGE_ID} matches the version in the version file this PR targets."
+fi
+
+# Extract and check the presence of an Enterprise plan field from the api response
+
+ENTERPRISE_PLAN_FROM_API=$(jq -r '._links.customField426.title // "not set"' response.json)
+TYPE_FROM_API=$(jq -r '._links.type.title // "not set"' response.json)
+
+if [[ ! "$TYPE_FROM_API" =~ ^(Feature|Epic)$ ]]; then
+  echo "Work package with type $TYPE_FROM_API does not require an Enterprise plan field to be set."
+  exit 0
+fi
+
+if [ "$ENTERPRISE_PLAN_FROM_API" = "not set" ]; then
+  echo "::warning::Failed to extract Enterprise plan from API response."
+
+  echo "enterprise_plan_missing=true" >> "$GITHUB_OUTPUT"
+  echo "wp_url=${WP_URL}" >> "$GITHUB_OUTPUT"
+else
+  echo "Enterprise Plan is set to ${ENTERPRISE_PLAN_FROM_API} for the work package ${WORK_PACKAGE_ID}."
 fi

--- a/script/ci/work_package_check.sh
+++ b/script/ci/work_package_check.sh
@@ -69,6 +69,8 @@ if [ "$HTTP_STATUS" -ne 200 ]; then
   exit 0
 fi
 
+# Extract and compare the version from the api response
+
 VERSION_FROM_API=$(jq -r '._links.version.title // "not set"' response.json)
 if [ -z "$VERSION_FROM_API" ]; then
   echo "::warning::Failed to extract version from API response."
@@ -92,4 +94,23 @@ if [[ "$VERSION_FROM_API" != "$VERSION_FROM_FILE" ]]; then
   echo "core_version=${VERSION_FROM_FILE}" >> "$GITHUB_OUTPUT"
 else
   echo "Version from the work package ${WORK_PACKAGE_ID} matches the version in the version file this PR targets."
+fi
+
+# Extract and check the presence of an Enterprise plan field from the api response
+
+ENTERPRISE_PLAN_FROM_API=$(jq -r '._links.customField426.title // "not set"' response.json)
+TYPE_FROM_API=$(jq -r '._links.type.title // "not set"' response.json)
+
+if [[ ! "$TYPE_FROM_API" =~ ^(Feature|Epic)$ ]]; then
+  echo "Work package with type $TYPE_FROM_API does not require an Enterprise plan field to be set."
+  exit 0
+fi
+
+if [ "$ENTERPRISE_PLAN_FROM_API" = "not set" ]; then
+  echo "::warning::Failed to extract Enterprise plan from API response."
+
+  echo "enterprise_plan_missing=true" >> "$GITHUB_OUTPUT"
+  echo "wp_url=${WP_URL}" >> "$GITHUB_OUTPUT"
+else
+  echo "Enterprise Plan is set to ${ENTERPRISE_PLAN_FROM_API} for the work package ${WORK_PACKAGE_ID}."
 fi


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-367

# What are you trying to accomplish?
Implement a github action to check the work package's Premium plan field.

# What approach did you choose and why?
Rename the version check action to work package check and incorporate the premium plan check alongside the version check.

<img width="952" height="374" alt="image" src="https://github.com/user-attachments/assets/a2900316-935d-4bd5-b058-b2b822a6cc2e" />



# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
