### PR TITLE
[FND-169] Create primerized list showing all root types in a project

### DIFF
--- a/app/components/projects/settings/work_packages/types/add_dialog_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/add_dialog_component.html.erb
@@ -1,0 +1,60 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(
+      Primer::Alpha::Dialog.new(
+        id: DIALOG_ID,
+        title: t("projects.settings.types.add_dialog.title"),
+        size: :medium_portrait
+      )
+    ) do |dialog| %>
+  <% dialog.with_header(variant: :large) %>
+
+  <% if addable_types.any? %>
+    <%= primer_form_with(url: create_path, method: :post) do |form| %>
+      <%= render(Primer::Alpha::Dialog::Body.new(classes: "Overlay-body_autocomplete_height")) do %>
+        <%= render(Primer::Beta::Text.new(tag: :p)) { t("projects.settings.types.add_dialog.description") } %>
+        <%= render(Projects::Settings::WorkPackages::Types::AddForm.new(form, types: addable_types)) %>
+      <% end %>
+
+      <%= render(Primer::Alpha::Dialog::Footer.new) do %>
+        <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": DIALOG_ID })) { t(:button_cancel) } %>
+        <%= render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) { t("projects.settings.types.add_dialog.submit") } %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= render(Primer::Alpha::Dialog::Body.new) do %>
+      <%= render(Primer::Beta::Text.new(tag: :p)) { t("projects.settings.types.add_dialog.none_addable") } %>
+    <% end %>
+
+    <%= render(Primer::Alpha::Dialog::Footer.new) do %>
+      <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": DIALOG_ID })) { t(:button_close) } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/projects/settings/work_packages/types/add_dialog_component.rb
+++ b/app/components/projects/settings/work_packages/types/add_dialog_component.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        # Picks the type or variant a project should activate. Only families
+        # with no active member are offered; swapping the active member of a
+        # family is FND-188's switch dialog.
+        class AddDialogComponent < ApplicationComponent
+          include OpPrimer::ComponentHelpers
+          include OpTurbo::Streamable
+
+          DIALOG_ID = "project-types-add-dialog"
+
+          def initialize(project:)
+            super()
+
+            @project = project
+          end
+
+          private
+
+          attr_reader :project
+
+          def create_path
+            project_settings_work_packages_types_path(project)
+          end
+
+          # COALESCE(parent_id, id) is the SQL form of Type#root, which is
+          # defined as `parent || self`.
+          def addable_types
+            @addable_types ||= begin
+              scope = ::Type.global.order(:name)
+
+              if active_root_ids.any?
+                scope.where.not("COALESCE(types.parent_id, types.id) IN (?)", active_root_ids)
+              else
+                scope
+              end
+            end
+          end
+
+          def active_root_ids
+            @active_root_ids ||= project.types.pluck(:parent_id, :id).map { |parent_id, id| parent_id || id }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/work_packages/types/add_dialog_component.rb
+++ b/app/components/projects/settings/work_packages/types/add_dialog_component.rb
@@ -55,18 +55,15 @@ module Projects
             project_settings_work_packages_types_path(project)
           end
 
-          # COALESCE(parent_id, id) is the SQL form of Type#root, which is
-          # defined as `parent || self`.
+          # Roots are a single acts_as_list list, so their position order is
+          # meaningful; each family then contributes its members in display
+          # order via Type#family, shared with the admin family list.
           def addable_types
-            @addable_types ||= begin
-              scope = ::Type.global.order(:name)
+            @addable_types ||= addable_roots.flat_map(&:family)
+          end
 
-              if active_root_ids.any?
-                scope.where.not("COALESCE(types.parent_id, types.id) IN (?)", active_root_ids)
-              else
-                scope
-              end
-            end
+          def addable_roots
+            ::Type.global.roots.where.not(id: active_root_ids).includes(:children)
           end
 
           def active_root_ids

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -42,8 +42,15 @@ See COPYRIGHT and LICENSE files for more details.
             <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { type.root.name } %>
           <% end %>
           <% if type.variant? %>
-            <% row.with_column do %>
+            <% row.with_column(mr: 2) do %>
               <%= render(Primer::Beta::Label.new(scheme: :secondary)) { type.own_name } %>
+            <% end %>
+          <% end %>
+          <% if type.is_in_roadmap? %>
+            <% row.with_column do %>
+              <%= render(Primer::Beta::Text.new(color: :muted, font_size: :small)) do %>
+                <%= t("projects.settings.types.in_roadmap") %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -1,0 +1,61 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= component_wrapper do %>
+  <%= render(OpenProject::Common::BorderBoxListComponent.new(container: "project-settings-types")) do |list| %>
+    <% active_types.each do |type| %>
+      <% list.with_item(data: { test_selector: "project-types-row-#{type.id}" }) do |item| %>
+        <% item.with_menu do |menu| %>
+          <% remove_action(menu, type) %>
+        <% end %>
+        <%= flex_layout(align_items: :center) do |row| %>
+          <% row.with_column(display: :inline_flex, align_items: :center, mr: 2) do %>
+            <%= helpers.icon_for_type(type.root) %>
+          <% end %>
+          <% row.with_column(mr: 2) do %>
+            <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { type.root.name } %>
+          <% end %>
+          <% if type.variant? %>
+            <% row.with_column do %>
+              <%= render(Primer::Beta::Label.new(scheme: :secondary)) { type.own_name } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if active_types.empty? %>
+      <% list.with_empty_state(
+           title: t("projects.settings.types.empty_state.title"),
+           description: t("projects.settings.types.empty_state.description"),
+           icon: :rows
+         ) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        # Lists the type families active in a project: one row per family,
+        # naming the active variant behind the parent type it presents as.
+        class ListComponent < ApplicationComponent
+          include OpPrimer::ComponentHelpers
+          include OpTurbo::Streamable
+
+          def initialize(project:)
+            super()
+
+            @project = project
+          end
+
+          private
+
+          attr_reader :project
+
+          # A variant's acts_as_list position is scoped to its parent, so only
+          # the family's own position is comparable across rows.
+          def active_types
+            @active_types ||= project
+                                .types
+                                .includes(:parent, :color)
+                                .sort_by { |type| type.root.position }
+          end
+
+          def remove_path(type)
+            project_settings_work_packages_type_path(project, type)
+          end
+
+          def remove_action(menu, type)
+            menu.with_item(
+              label: t("projects.settings.types.remove_from_project"),
+              scheme: :danger,
+              href: remove_path(type),
+              form_arguments: { method: :delete }
+            ) do |item|
+              item.with_leading_visual_icon(icon: :trash)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/settings/project_work_packages/header_component.html.erb
+++ b/app/components/settings/project_work_packages/header_component.html.erb
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+<% helpers.html_title(*title_parts) %>
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_work_package_plural) }

--- a/app/components/settings/project_work_packages/header_component.rb
+++ b/app/components/settings/project_work_packages/header_component.rb
@@ -96,13 +96,29 @@ module Settings
         tabs << {
           name: "internal_comments",
           path: project_settings_work_packages_internal_comments_path,
-          label: internal_comments_title
+          label: internal_comments_title,
+          # The nav label may carry an upsell icon; the browser title needs plain text.
+          title_label: internal_comments_translation
         }
 
         tabs
       end
 
+      # Read outwards from the active tab, so the browser title reverses the
+      # breadcrumb: "Types | Work packages | Project settings | <project> | <app>".
+      # html_title_parts prepends the project and page_title reverses the list.
+      def title_parts
+        [t(:label_project_settings), t(:label_work_package_plural), current_tab_label].compact
+      end
+
       private
+
+      def current_tab_label
+        tab = helpers.selected_tab(tabs)
+        return if tab.nil?
+
+        tab[:title_label] || helpers.tab_label(tab)
+      end
 
       def internal_comments_translation = t("ee.features.internal_comments")
     end

--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
             <% end %>
           <% end %>
 
-          <% sorted_children(root).each do |child| %>
+          <% root.sorted_variants.each do |child| %>
             <% list.with_item do |item| %>
               <% item.with_menu do |menu| %>
                 <% type_actions(menu, child) %>

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -175,11 +175,6 @@ module WorkPackageTypes
           "drop-url": drop_type_path(root)
         }
       end
-
-      # variants need to be displayed alphabetically sorted
-      def sorted_children(root)
-        root.children.sort_by { |child| child.own_name.downcase }
-      end
     end
   end
 end

--- a/app/controllers/projects/settings/work_packages/types_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types_controller.rb
@@ -30,14 +30,62 @@
 
 class Projects::Settings::WorkPackages::TypesController < Projects::SettingsController
   include WorkPackageTypes::TypeDeactivationErrorMessage
+  include WorkPackageTypes::TypeVariantsFeature
+  include OpTurbo::ComponentStream
+  include FlashMessagesOutputSafetyHelper
 
   menu_item :settings_work_packages
 
-  def show
+  before_action :require_type_variants_feature, only: %i[new create destroy]
+
+  def index
     @types = ::Type.all
   end
 
-  def update
+  def new
+    respond_with_dialog Projects::Settings::WorkPackages::Types::AddDialogComponent.new(project: @project)
+  end
+
+  def create # rubocop:disable Metrics/AbcSize
+    type = ::Type.global.find_by(id: params[:type_id])
+
+    return render_type_not_found if type.nil?
+
+    result = ::Projects::Types::AddService.new(user: current_user, model: @project).call(type:)
+
+    result.on_success do
+      close_dialog_via_turbo_stream("##{Projects::Settings::WorkPackages::Types::AddDialogComponent::DIALOG_ID}")
+      replace_types_list
+    end
+
+    result.on_failure do
+      render_error_flash_message_via_turbo_stream(message: join_flash_messages(result.errors.full_messages))
+    end
+
+    respond_to_with_turbo_streams(status: result)
+  end
+
+  def destroy # rubocop:disable Metrics/AbcSize
+    type = @project.types.find_by(id: params[:id])
+
+    return render_type_not_found if type.nil?
+
+    result = ::Projects::Types::RemoveService.new(user: current_user, model: @project).call(type:)
+
+    result.on_success { replace_types_list }
+
+    result.on_failure do
+      render_error_flash_message_via_turbo_stream(
+        message: join_flash_messages(
+          type_deactivation_error_messages(::Type.where(id: type.id), project_ids: [@project.id])
+        )
+      )
+    end
+
+    respond_to_with_turbo_streams(status: result)
+  end
+
+  def bulk_update
     type_ids = permitted_params.projects_type_ids
 
     if UpdateProjectsTypesService.new(@project).call(type_ids)
@@ -50,6 +98,19 @@ class Projects::Settings::WorkPackages::TypesController < Projects::SettingsCont
   end
 
   private
+
+  # Reload so the repainted list no longer sees the association's cached types.
+  def replace_types_list
+    replace_via_turbo_stream(
+      component: Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project.reload)
+    )
+  end
+
+  def render_type_not_found
+    render_error_flash_message_via_turbo_stream(message: t("projects.settings.types.type_not_found"))
+
+    respond_to_with_turbo_streams(status: :unprocessable_entity)
+  end
 
   def success_message
     ApplicationController.helpers.sanitize(

--- a/app/forms/projects/settings/work_packages/types/add_form.rb
+++ b/app/forms/projects/settings/work_packages/types/add_form.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        class AddForm < ApplicationForm
+          def initialize(types:)
+            super()
+
+            @types = types
+          end
+
+          form do |add_form|
+            add_form.autocompleter(
+              name: :type_id,
+              label: I18n.t("projects.settings.types.add_dialog.type_label"),
+              required: true,
+              autocomplete_options: {
+                placeholder: I18n.t("projects.settings.types.add_dialog.type_placeholder"),
+                decorated: true,
+                multiple: false,
+                focusDirectly: false,
+                append_to: "##{AddDialogComponent::DIALOG_ID}",
+                data: { test_selector: "project-types-add-select" }
+              }
+            ) do |list|
+              types.each do |type|
+                list.option(value: type.id, label: type.composite_name)
+              end
+            end
+          end
+
+          private
+
+          attr_reader :types
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -91,7 +91,18 @@ module ::TypesHelper
 
     content_tag(:span, " ",
                 class: css_class,
-                style: "background-color: #{color}")
+                style: "background-color: #{color}",
+                **accessible_type_icon_attributes(type))
+  end
+
+  # The diamond shape is the only thing distinguishing a milestone from an
+  # ordinary type, so it needs a text equivalent. role="img" is what lets the
+  # title count as the accessible name on an otherwise roleless span. Ordinary
+  # types say nothing: the type name follows in the adjacent text.
+  def accessible_type_icon_attributes(type)
+    return { aria: { hidden: true } } unless type.is_milestone?
+
+    { role: "img", title: I18n.t("types.milestone_indicator") }
   end
 
   ##

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -187,8 +187,15 @@ class Type < ApplicationRecord
     parent_id.present?
   end
 
+  # A variant's acts_as_list position is append order and users cannot reorder
+  # variants, so position is not a display order for them; alphabetical is.
+  # Every screen that lists a family reads this, so the orders cannot drift.
+  def sorted_variants
+    children.sort_by { |variant| variant.own_name.downcase }
+  end
+
   def family
-    [root, *root.children]
+    [root, *root.sorted_variants]
   end
 
   def name

--- a/app/views/projects/settings/work_packages/types/index.html.erb
+++ b/app/views/projects/settings/work_packages/types/index.html.erb
@@ -29,9 +29,23 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Settings::ProjectWorkPackages::HeaderComponent.new(@project)) %>
 
-<% if Type.any? %>
+<% if OpenProject::FeatureDecisions.type_variants_active? %>
+  <%= render(Primer::OpenProject::SubHeader.new) do |subheader| %>
+    <% subheader.with_action_button(
+         scheme: :primary,
+         leading_icon: :plus,
+         label: t("projects.settings.types.add_type"),
+         tag: :a,
+         href: new_project_settings_work_packages_type_path(@project),
+         data: { controller: "async-dialog" },
+         test_selector: "project-types-add-button"
+       ) { t("activerecord.attributes.work_package.type") } %>
+  <% end %>
+
+  <%= render(Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project)) %>
+<% elsif Type.any? %>
   <%= form_for @project,
-               url: project_settings_work_packages_types_path(@project),
+               url: bulk_update_project_settings_work_packages_types_path(@project),
                method: :patch,
                html: { id: "types-form" } do |f| %>
     <%= render partial: "form",

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -239,7 +239,7 @@ Rails.application.reloader.to_prepare do
 
       map.permission :manage_types,
                      {
-                       "projects/settings/work_packages/types": %i[show update]
+                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update]
                      },
                      permissible_on: :project,
                      require: :member

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5027,9 +5027,22 @@ en:
         menu_title: "Template"
         title: "Template settings"
       types:
+        add_dialog:
+          description: "The project uses one member of each type family. Pick the type or the variant this project should use."
+          none_addable: "All available types are already active in this project."
+          submit: "Add"
+          title: "Add type"
+          type_label: "Type"
+          type_placeholder: "Select a type"
+        add_type: "Add type"
+        empty_state:
+          description: "Add a type to let people create work packages of that type in this project."
+          title: "No types are active in this project"
         form:
           enable_type_in_project: 'Enable type "%{type}"'
         no_results_title_text: There are currently no types available.
+        remove_from_project: "Remove from project"
+        type_not_found: "The selected type could not be found."
       versions:
         no_results_content_text: Create a new version
         no_results_title_text: There are currently no versions for the project.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6253,6 +6253,7 @@ en:
       variants_count:
         one: "1 variant"
         other: "%{count} variants"
+    milestone_indicator: "Milestone"
 
   unsupported_browser:
     close_warning: "Ignore this warning."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5040,6 +5040,7 @@ en:
           title: "No types are active in this project"
         form:
           enable_type_in_project: 'Enable type "%{type}"'
+        in_roadmap: "In roadmap"
         no_results_title_text: There are currently no types available.
         remove_from_project: "Remove from project"
         type_not_found: "The selected type could not be found."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -424,7 +424,9 @@ Rails.application.routes.draw do
         resource :work_packages, only: %i[show]
         namespace :work_packages do
           resource :internal_comments, only: %i[show update]
-          resource :types, only: %i[show update]
+          resources :types, only: %i[index new create destroy] do
+            patch :bulk_update, on: :collection
+          end
           resource :custom_fields, only: %i[show update]
           resource :categories, only: %i[show update]
         end

--- a/spec/components/projects/settings/work_packages/types/add_dialog_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/add_dialog_component_spec.rb
@@ -77,6 +77,25 @@ RSpec.describe Projects::Settings::WorkPackages::Types::AddDialogComponent,
     end
   end
 
+  context "with several addable families" do
+    # Positions are pinned after creation because acts_as_list overrides any
+    # passed at creation time. Names are chosen so position order and
+    # alphabetical order disagree.
+    let!(:zeta) { create(:type, name: "Zeta").tap { |type| type.update_column(:position, 1) } }
+    let!(:alpha) { create(:type, name: "Alpha").tap { |type| type.update_column(:position, 2) } }
+    let!(:yankee) { create(:type, name: "Yankee", parent: zeta) }
+    let!(:bravo) { create(:type, name: "Bravo", parent: zeta) }
+
+    # Keeps the file-wide Epic and Bug families out of the offered list.
+    let(:project) { create(:project, types: [design, bug]) }
+
+    before { render_inline(component) }
+
+    it "orders families by root position, each parent ahead of its variants alphabetically" do
+      expect(offered_items.pluck("name")).to eq(["Zeta", "Zeta: Bravo", "Zeta: Yankee", "Alpha"])
+    end
+  end
+
   context "when every family already has an active member" do
     let(:project) { create(:project, types: [design, bug]) }
 

--- a/spec/components/projects/settings/work_packages/types/add_dialog_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/add_dialog_component_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::WorkPackages::Types::AddDialogComponent,
+               type: :component,
+               with_flag: { type_variants: true } do
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+  shared_let(:bug) { create(:type, name: "Bug") }
+
+  subject(:component) { described_class.new(project:) }
+
+  # The decorated autocompleter is an Angular custom element: its choices ride
+  # along as JSON in data-items rather than as <option> tags.
+  def offered_items
+    JSON.parse(page.find("opce-autocompleter", visible: :all)["data-items"])
+  end
+
+  context "when one family is already active" do
+    let(:project) { create(:project, types: [bug]) }
+
+    before { render_inline(component) }
+
+    it "offers the members of families that have none active" do
+      expect(offered_items.pluck("id")).to contain_exactly(epic.id, design.id)
+    end
+
+    it "labels a variant with its composite name" do
+      expect(offered_items.pluck("name")).to include("Epic: Design")
+    end
+
+    it "omits every member of the already-active family" do
+      expect(offered_items.pluck("id")).not_to include(bug.id)
+    end
+  end
+
+  context "when a variant is active" do
+    let(:project) { create(:project, types: [design]) }
+
+    before { render_inline(component) }
+
+    it "omits the parent and its siblings" do
+      expect(offered_items.pluck("id")).not_to include(epic.id, design.id)
+    end
+
+    it "still offers unrelated families" do
+      expect(offered_items.pluck("id")).to include(bug.id)
+    end
+  end
+
+  context "when every family already has an active member" do
+    let(:project) { create(:project, types: [design, bug]) }
+
+    before { render_inline(component) }
+
+    it "explains there is nothing to add instead of rendering the field" do
+      expect(page).to have_text("All available types are already active in this project")
+      expect(page).to have_no_css("opce-autocompleter", visible: :all)
+    end
+  end
+end

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
+               type: :component,
+               with_flag: { type_variants: true } do
+  include Rails.application.routes.url_helpers
+
+  # acts_as_list overrides positions passed at creation, so pin them afterwards.
+  # The family order is Epic(1) then Bug(2), while the variant's own position (9)
+  # is scoped to its parent and must not influence the row order.
+  shared_let(:epic) { create(:type, name: "Epic").tap { |type| type.update_column(:position, 1) } }
+  shared_let(:bug) { create(:type, name: "Bug").tap { |type| type.update_column(:position, 2) } }
+  shared_let(:design) do
+    create(:type, name: "Design", parent: epic).tap { |type| type.update_column(:position, 9) }
+  end
+
+  subject(:component) { described_class.new(project:) }
+
+  context "when a family is active through its parent" do
+    let(:project) { create(:project, types: [bug]) }
+
+    before { render_inline(component) }
+
+    it "names the type" do
+      expect(page).to have_text("Bug")
+    end
+
+    it "offers the remove action" do
+      expect(page).to have_button("Remove from project", visible: :all)
+      expect(page).to have_css(
+        "form[action='#{project_settings_work_packages_type_path(project, bug)}']",
+        visible: :all
+      )
+    end
+  end
+
+  context "when a family is active through a variant" do
+    let(:project) { create(:project, types: [design]) }
+
+    before { render_inline(component) }
+
+    it "names the parent type, not the composite name" do
+      expect(page).to have_text("Epic")
+      expect(page).to have_no_text("Epic: Design")
+    end
+
+    it "labels the active variant" do
+      expect(page).to have_css(".Label", text: "Design")
+    end
+
+    it "points the remove action at the variant" do
+      expect(page).to have_css(
+        "form[action='#{project_settings_work_packages_type_path(project, design)}']",
+        visible: :all
+      )
+    end
+  end
+
+  context "with several active families" do
+    let(:project) { create(:project, types: [design, bug]) }
+
+    before { render_inline(component) }
+
+    it "orders rows by the family's position rather than the member's" do
+      expect(page.all("[data-test-selector^='project-types-row-']").pluck(:"data-test-selector"))
+        .to eq(["project-types-row-#{design.id}", "project-types-row-#{bug.id}"])
+    end
+  end
+
+  context "without any active type" do
+    # The workspace factory pushes the standard type whenever types is empty.
+    let(:project) { create(:project, types: [], no_types: true) }
+
+    before { render_inline(component) }
+
+    it "renders the empty state" do
+      expect(page).to have_text("No types are active in this project")
+    end
+  end
+end

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -86,6 +86,26 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
+  describe "the roadmap indicator" do
+    let(:project) { create(:project, types: [bug]) }
+
+    it "marks a type that is shown in the roadmap by default" do
+      render_inline(component)
+
+      expect(page).to have_text("In roadmap")
+    end
+
+    context "when the type is not shown in the roadmap" do
+      before { bug.update!(is_in_roadmap: false) }
+
+      it "says nothing rather than stating the negative" do
+        render_inline(component)
+
+        expect(page).to have_no_text("In roadmap")
+      end
+    end
+  end
+
   context "with several active families" do
     let(:project) { create(:project, types: [design, bug]) }
 

--- a/spec/controllers/projects/settings/work_packages/types_controller_spec.rb
+++ b/spec/controllers/projects/settings/work_packages/types_controller_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe Projects::Settings::WorkPackages::TypesController do
 
   current_user { user }
 
-  describe "PATCH #update" do
+  describe "PATCH #bulk_update" do
     let(:type) { create(:type_bug) }
     let(:other_type) { create(:type_task) }
     let(:project) { create(:project, types: [type, other_type]) }
     let!(:work_package) { create(:work_package, project:, type:) }
 
     before do
-      patch :update,
+      patch :bulk_update,
             params: {
               project_id: project.identifier,
               project: { type_ids: [other_type.id.to_s] }
@@ -63,6 +63,49 @@ RSpec.describe Projects::Settings::WorkPackages::TypesController do
 
     it "keeps the type active in the project" do
       expect(project.reload.types).to include(type)
+    end
+  end
+
+  describe "POST #create" do
+    shared_let(:type) { create(:type_bug) }
+
+    let(:project) { create(:project, types: []) }
+
+    context "with the type variants feature active", with_flag: { type_variants: true } do
+      it "reports a missing type rather than raising" do
+        post :create, params: { project_id: project.identifier }, format: :turbo_stream
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("The selected type could not be found.")
+      end
+
+      it "activates the type" do
+        post :create, params: { project_id: project.identifier, type_id: type.id }, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(project.reload.types).to include(type)
+      end
+    end
+
+    context "with the type variants feature inactive", with_flag: { type_variants: false } do
+      it "renders 404" do
+        post :create, params: { project_id: project.identifier, type_id: type.id }, format: :turbo_stream
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "DELETE #destroy", with_flag: { type_variants: true } do
+    shared_let(:type) { create(:type_bug) }
+
+    let(:project) { create(:project, types: [type]) }
+
+    it "reports a missing type rather than raising" do
+      delete :destroy, params: { project_id: project.identifier, id: 0 }, format: :turbo_stream
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("The selected type could not be found.")
     end
   end
 end

--- a/spec/features/projects/settings/work_package_types_spec.rb
+++ b/spec/features/projects/settings/work_package_types_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "support/pages/projects/settings/work_package_types"
+
+RSpec.describe "Project settings work package types", :js, with_flag: { type_variants: true } do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+  shared_let(:bug) { create(:type, name: "Bug") }
+  shared_let(:milestone) { create(:type, name: "Milestone") }
+  shared_let(:feature) { create(:type, name: "Feature") }
+  shared_let(:research) { create(:type, name: "Research", parent: feature) }
+
+  let(:project) { create(:project, types: [design, bug]) }
+  let(:settings_page) { Pages::Projects::Settings::WorkPackageTypes.new(project) }
+
+  current_user do
+    create(:user, member_with_permissions: { project => %i[edit_project manage_types view_work_packages] })
+  end
+
+  before { settings_page.visit! }
+
+  it "lists each active family, naming the active variant behind its parent type" do
+    settings_page.expect_type_row(design, variant: "Design")
+    settings_page.expect_type_row(bug)
+  end
+
+  it "activates a root type through the dialog" do
+    add_type("Milestone")
+
+    settings_page.expect_type_row(milestone)
+    expect(project.reload.types).to include(milestone)
+  end
+
+  it "activates a variant through the dialog" do
+    add_type("Research", select_text: "Feature: Research")
+
+    settings_page.expect_type_row(research, variant: "Research")
+    expect(project.reload.types).to include(research)
+  end
+
+  it "removes a type that has no work packages" do
+    settings_page.remove_type(bug)
+
+    settings_page.expect_no_type_row(bug)
+    expect(project.reload.types).not_to include(bug)
+  end
+
+  context "when work packages of that type exist" do
+    let!(:work_package) { create(:work_package, project:, type: bug) }
+
+    it "refuses the removal and explains why" do
+      settings_page.remove_type(bug)
+
+      expect_flash(type: :error, message: "Unable to deactivate type Bug because it's still in use by work packages")
+      settings_page.expect_type_row(bug)
+      expect(project.reload.types).to include(bug)
+    end
+  end
+
+  # Located by test selector because the tab nav above renders a "Types" link,
+  # which Capybara's non-exact text matching would confuse with this button.
+  def add_type(query, select_text: query)
+    page.find("[data-test-selector='project-types-add-button']").click
+
+    expect(page).to have_text("Add type")
+
+    select_autocomplete(page.find("[data-test-selector='project-types-add-select']"),
+                        query:,
+                        select_text:)
+    click_on "Add"
+  end
+end

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -111,4 +111,29 @@ RSpec.describe TypesHelper do
       end
     end
   end
+
+  describe "#icon_for_type" do
+    subject(:icon) { helper.icon_for_type(type) }
+
+    context "with a milestone type" do
+      let(:type) { build_stubbed(:type, is_milestone: true) }
+
+      it "names the shape, which is otherwise the only milestone cue" do
+        expect(icon).to have_css("span.color--milestone-icon[role='img'][title='Milestone']", visible: :all)
+      end
+    end
+
+    context "with an ordinary type" do
+      let(:type) { build_stubbed(:type, is_milestone: false) }
+
+      it "stays decorative, since the type name follows in text" do
+        expect(icon).to have_css("span.color--phase-icon[aria-hidden='true']", visible: :all)
+        expect(icon).to have_no_css("span[title]", visible: :all)
+      end
+    end
+
+    it "renders nothing without a type" do
+      expect(helper.icon_for_type(nil)).to be_nil
+    end
+  end
 end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -411,10 +411,35 @@ RSpec.describe Type do
       end
     end
 
+    # Isolated from the shared parent/child so the factory's generated names
+    # cannot land between the names under test.
+    describe "#sorted_variants" do
+      let!(:family_root) { create(:type, name: "Family") }
+      let!(:yankee) { create(:type, name: "Yankee", parent: family_root) }
+      let!(:bravo) { create(:type, name: "Bravo", parent: family_root) }
+
+      it "orders variants alphabetically by their own name" do
+        expect(family_root.sorted_variants.map(&:own_name)).to eq(%w[Bravo Yankee])
+      end
+
+      it "does not fall back to position, which is append order" do
+        expect(family_root.children.map(&:own_name)).to eq(%w[Yankee Bravo])
+      end
+    end
+
     describe "#family" do
       it "returns the root followed by its children" do
         expect(child.family).to eq([parent, child])
         expect(parent.family).to eq([parent, child])
+      end
+
+      it "orders the variants the same way #sorted_variants does" do
+        family_root = create(:type, name: "Family")
+        create(:type, name: "Yankee", parent: family_root)
+        create(:type, name: "Bravo", parent: family_root)
+
+        expect(family_root.family).to eq([family_root, *family_root.sorted_variants])
+        expect(family_root.family.map(&:own_name)).to eq(%w[Family Bravo Yankee])
       end
     end
 

--- a/spec/requests/projects/settings/work_packages_titles_spec.rb
+++ b/spec/requests/projects/settings/work_packages_titles_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Projects::Settings::WorkPackages page titles", type: :rails_request do
+  shared_let(:project) { create(:project, name: "My Project") }
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: {
+             project => %i[edit_project manage_types manage_categories select_custom_fields]
+           })
+  end
+
+  before { login_as user }
+
+  def rendered_title
+    response.body[%r{<title>(.*?)</title>}m, 1]
+  end
+
+  it "names the active tab first, then the breadcrumb outwards" do
+    get project_settings_work_packages_types_path(project)
+
+    expect(rendered_title).to eq("Types | Work packages | Project settings | My Project | OpenProject")
+  end
+
+  it "varies the first segment per tab" do
+    get project_settings_work_packages_categories_path(project)
+
+    expect(rendered_title).to eq("Categories | Work packages | Project settings | My Project | OpenProject")
+  end
+
+  # The internal comments nav label carries an Enterprise upsell octicon.
+  it "keeps the upsell icon out of the title" do
+    get project_settings_work_packages_internal_comments_path(project)
+
+    expect(rendered_title).to eq("Internal Comments | Work packages | Project settings | My Project | OpenProject")
+  end
+end

--- a/spec/routing/project_settings_routing_spec.rb
+++ b/spec/routing/project_settings_routing_spec.rb
@@ -105,14 +105,35 @@ RSpec.describe Projects::SettingsController do
     it do
       expect(get("/projects/123/settings/work_packages/types"))
         .to route_to(
-          controller: "projects/settings/work_packages/types", action: "show", project_id: "123"
+          controller: "projects/settings/work_packages/types", action: "index", project_id: "123"
         )
     end
 
     it do
-      expect(patch("/projects/123/settings/work_packages/types"))
+      expect(get("/projects/123/settings/work_packages/types/new"))
         .to route_to(
-          controller: "projects/settings/work_packages/types", action: "update", project_id: "123"
+          controller: "projects/settings/work_packages/types", action: "new", project_id: "123"
+        )
+    end
+
+    it do
+      expect(post("/projects/123/settings/work_packages/types"))
+        .to route_to(
+          controller: "projects/settings/work_packages/types", action: "create", project_id: "123"
+        )
+    end
+
+    it do
+      expect(delete("/projects/123/settings/work_packages/types/5"))
+        .to route_to(
+          controller: "projects/settings/work_packages/types", action: "destroy", project_id: "123", id: "5"
+        )
+    end
+
+    it do
+      expect(patch("/projects/123/settings/work_packages/types/bulk_update"))
+        .to route_to(
+          controller: "projects/settings/work_packages/types", action: "bulk_update", project_id: "123"
         )
     end
 

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "support/pages/page"
+
+module Pages
+  module Projects
+    module Settings
+      class WorkPackageTypes < Pages::Page
+        attr_accessor :project
+
+        def initialize(project)
+          super()
+
+          self.project = project
+        end
+
+        def path
+          "/projects/#{project.identifier}/settings/work_packages/types"
+        end
+
+        def expect_type_row(type, variant: nil)
+          row = find_row(type)
+
+          expect(row).to have_text(type.root.name)
+          expect(row).to have_css(".Label", text: variant) if variant
+        end
+
+        def expect_no_type_row(type)
+          expect(page).to have_no_css("[data-test-selector='project-types-row-#{type.id}']")
+        end
+
+        def remove_type(type)
+          within(find_row(type)) { find("action-menu > button").click }
+          click_on "Remove from project"
+        end
+
+        def find_row(type)
+          page.find("[data-test-selector='project-types-row-#{type.id}']")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/FND-169

# What are you trying to accomplish?

Replaces the legacy work package types table in project settings with a Primer list of the type *families* active in the project, matching the model where a project uses exactly one member per family.

- Border box list of active families, one row per family, the active variant named behind its parent type
- Primary action opens a dialog to activate a type or one of its variants
- Row action deactivates a type, refused — with a link to the offending work packages — while any still use it
- Replaces the two read-only checkmark columns with inline indicators, so the row carries the information without a table:
  - Milestone needs no column of its own — the type icon already renders milestones as a diamond. It now carries a text equivalent instead of relying on shape alone, which also fixes the other three screens using that icon.
  - "In roadmap" reads as muted text on the row
- All four *Work packages* settings tabs now get a reverse-breadcrumb browser title (`Types | Work packages | Project settings | <project> | OpenProject`); previously every tab rendered the same `<project> | OpenProject`
- Gated behind the `type_variants` flag; with the flag off the legacy checkbox table is unchanged, apart from its form posting to an explicit `bulk_update` action

Out of scope: switching which member of an already-active family a project uses (FND-187 / FND-188). The dialog only offers families with no active member, so the conflict is unreachable by construction rather than by validation.

## Screenshots

<!-- TODO: before/after of the types tab, and the add dialog -->

<img width="1092" height="507" alt="Screenshot from the types list" src="https://github.com/user-attachments/assets/9c37590f-c4c0-47cb-a6d3-15f2b31c4361" />

# What approach did you choose and why?

- Wired the UI to `Projects::Types::AddService` / `RemoveService` — the migration `UpdateProjectsTypesService` documented itself as waiting for. The bulk service now only serves the flag-off table.
- Made the routes RESTful, with the legacy bulk save moved to a `bulk_update` collection action. The plural collection helper is spelled like the old singular one, so the tab nav and the `/settings/types` redirect are untouched.
- Family display order lives on `Type#sorted_variants` / `Type#family`, read by both this dialog and the admin family list so the two cannot drift.
- The milestone and roadmap indicators are each their own commit, so either can be dropped without touching the rest. Worth a look in review: `is_in_roadmap` defaults to true, so the indicator currently marks the majority of types rather than the exception.
- Two pre-existing defects found on the way are written up as separate WPs rather than folded in here: `Type`'s `default_scope` silently defeats callers' `.order(...)`, and `ConfigurationLinks::SourceForm` labels variants ambiguously.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a, new components are outside the namespaces the preview cop covers
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) — Chrome only so far
