### PR TITLE
Try setting git gem version to prevent danger error

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -28,6 +28,7 @@ jobs:
           bundler-cache: true
       - name: Setup danger
         run: |
+          gem install git -v '< 5.0'
           gem install danger
       - name: Run inconsistent translations check
         env:


### PR DESCRIPTION
<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Fix the failing dangerfile CI step

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
Add explicit `gem install git -v '< 5.0'` to the dangerfile to ensure danger doesn't try to use the breaking 5.0 version
