### PR TITLE
[OP-19785] Seeded users take up all the free active user slots on trial instances

### DIFF
--- a/app/seeders/demo_data/department_seeder.rb
+++ b/app/seeders/demo_data/department_seeder.rb
@@ -99,7 +99,7 @@ module DemoData
         firstname:,
         lastname:,
         mail: "#{login}@example.com",
-        status: User.statuses[:active],
+        status: User.statuses[:invited],
         language: I18n.locale.to_s,
         password: login,
         force_password_change: false

--- a/spec/seeders/demo_data/department_seeder_spec.rb
+++ b/spec/seeders/demo_data/department_seeder_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe DemoData::DepartmentSeeder do
       lastname: "Marketing",
       login: "marko.marketing",
       mail: "marko.marketing@example.com",
-      status: "active"
+      status: "invited"
     )
 
     expect(seed_data.find_reference(:marketing).users).to include(marko)

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe RootSeeder,
       )
 
       fritz = root_seeder.seed_data.find_reference(:user__fritz_finance)
-      expect(fritz).to have_attributes(login: "fritz.finance", mail: "fritz.finance@example.com", status: "active")
+      expect(fritz).to have_attributes(login: "fritz.finance", mail: "fritz.finance@example.com", status: "invited")
       expect(root_seeder.seed_data.find_reference(:department__finance_administration).users)
         .to include(fritz)
     end


### PR DESCRIPTION
Make seeded users invited, not active users. They don't count towards the trial limit, but can still be selected

https://community.openproject.org/wp/OP-19785
