### PR TITLE
[OP-19826] SSRF protection error when using custom design seeding with URLs

### DIFF
--- a/app/seeders/env_data/custom_design_seeder.rb
+++ b/app/seeders/env_data/custom_design_seeder.rb
@@ -85,10 +85,7 @@ module EnvData
     end
 
     def seed_remote_url(custom_style, key, url)
-      custom_style.public_send(:"remote_#{key}_url=", url)
-      custom_style.save!
-    rescue StandardError => e
-      Rails.logger.error "Failed to seed remote URL for design variable '#{key}': #{e.message}"
+      CustomStyles::SeedRemoteAssetJob.perform_later(custom_style, key, url)
     end
 
     class Base64StringIO < StringIO
@@ -115,7 +112,7 @@ module EnvData
         content_type = metadata.match(%r{data:([^;]+)})&.captures&.first
         raise ArgumentError, "Failed to parse content type from metadata: #{metadata}" if content_type.nil?
 
-        mime_type = MIME::Types[content_type].last
+        mime_type = MIME::Types[content_type].first
         raise ArgumentError, "Unknown mime type: #{content_type}" if mime_type.nil?
 
         mime_type.preferred_extension

--- a/app/seeders/env_data/custom_design_seeder.rb
+++ b/app/seeders/env_data/custom_design_seeder.rb
@@ -85,6 +85,8 @@ module EnvData
     end
 
     def seed_remote_url(custom_style, key, url)
+      print_status "      ↳ Downloading #{key} from #{url} in the background"
+
       CustomStyles::SeedRemoteAssetJob.perform_later(custom_style, key, url)
     end
 

--- a/app/workers/custom_styles/seed_remote_asset_job.rb
+++ b/app/workers/custom_styles/seed_remote_asset_job.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomStyles
+  # Downloads a design asset seeded through OPENPROJECT_SEED_DESIGN_* as a remote URL.
+  class SeedRemoteAssetJob < ApplicationJob
+    retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+    # Declared after retry_on StandardError so they take precedence
+    discard_on ActiveJob::DeserializationError
+    discard_on OpenProject::ServerSideRequestForgeryError
+
+    queue_with_priority :low
+
+    def perform(custom_style, key, url)
+      response = OpenProject.httpx.get(url)
+      response.raise_for_status
+
+      build_attachable_file(key.to_s, response.body.to_s) do |file|
+        custom_style.public_send("#{key}=", file)
+        custom_style.save!
+      end
+    end
+
+    private
+
+    def build_attachable_file(file_name, data)
+      Tempfile.open(file_name) do |tempfile|
+        tempfile.binmode
+        tempfile.write(data)
+        tempfile.rewind
+
+        content_type = OpenProject::ContentTypeDetector.new(tempfile.path).detect
+        mime_type = MIME::Types[content_type].first
+        raise ArgumentError, "Unknown mime type: #{content_type}" if mime_type.nil?
+
+        file = OpenProject::Files.build_uploaded_file(tempfile,
+                                                      content_type,
+                                                      file_name: "#{file_name}.#{mime_type.preferred_extension}")
+
+        yield(file)
+      end
+    end
+  end
+end

--- a/app/workers/custom_styles/seed_remote_asset_job.rb
+++ b/app/workers/custom_styles/seed_remote_asset_job.rb
@@ -40,6 +40,18 @@ module CustomStyles
     queue_with_priority :low
 
     def perform(custom_style, key, url)
+      download(custom_style, key, url)
+
+      Rails.logger.info "Seeded design asset '#{key}' from #{url}."
+    rescue StandardError => e
+      Rails.logger.error "Failed to seed design asset '#{key}' from #{url} " \
+                         "on attempt #{executions}: #{e.message}"
+      raise
+    end
+
+    private
+
+    def download(custom_style, key, url)
       response = OpenProject.httpx.get(url)
       response.raise_for_status
 
@@ -48,8 +60,6 @@ module CustomStyles
         custom_style.save!
       end
     end
-
-    private
 
     def build_attachable_file(file_name, data)
       Tempfile.open(file_name) do |tempfile|

--- a/spec/seeders/env_data/custom_design_seeder_spec.rb
+++ b/spec/seeders/env_data/custom_design_seeder_spec.rb
@@ -31,7 +31,6 @@
 require "spec_helper"
 
 RSpec.describe EnvData::CustomDesignSeeder, :webmock do
-  let(:safe_public_ip) { "93.184.216.34" }
   let(:seed_data) { Source::SeedData.new({}) }
   let(:base64_image) do
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wQACfsD/QqnFgAAAABJRU5ErkJggg=="
@@ -40,25 +39,23 @@ RSpec.describe EnvData::CustomDesignSeeder, :webmock do
     "data:image/png;base64,#{base64_image}"
   end
   let(:png_stub) do
-    stub_request(:get, "http://test.foobar.com/image.png")
+    stub_request(:get, "https://example.com/image.png")
       .to_return(
         status: 200,
         body: Rails.root.join("spec/fixtures/files/image.png").read
       )
   end
   let(:svg_stub) do
-    stub_request(:get, "http://test.foobar.com/image.svg")
+    stub_request(:get, "https://example.com/image.svg")
       .to_return(
         status: 200,
         body: Rails.root.join("spec/fixtures/files/icon_logo.svg").read
       )
   end
+
   subject(:seeder) { described_class.new(seed_data) }
 
   before do
-    # CarrierWave remote URL downloading resolves hostnames with SsrfFilter.
-    allow(Resolv).to receive(:getaddresses).with("test.foobar.com").and_return([safe_public_ip])
-
     png_stub
     svg_stub
   end
@@ -81,13 +78,13 @@ RSpec.describe EnvData::CustomDesignSeeder, :webmock do
             OPENPROJECT_SEED_DESIGN_HEADER__BG__COLOR: "#FFFFFF",
             OPENPROJECT_SEED_DESIGN_MAIN__MENU__BG__COLOR: "#FFFFFF",
             OPENPROJECT_SEED_DESIGN_MAIN__MENU__BG__SELECTED__BACKGROUND: "#571EFA",
-            OPENPROJECT_SEED_DESIGN_TOUCH__ICON: "http://test.foobar.com/image.png",
+            OPENPROJECT_SEED_DESIGN_TOUCH__ICON: "https://example.com/image.png",
             OPENPROJECT_SEED_DESIGN_LOGO: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wQACfsD/QqnFgAAAABJRU5ErkJggg=="
           } do
     it "uses those variables" do
       reset(:seed_design)
 
-      seeder.seed!
+      perform_enqueued_jobs { seeder.seed! }
 
       expect(DesignColor.find_by(variable: "primary-button-color").hexcode).to eq("#571EFA")
       expect(DesignColor.find_by(variable: "accent-color").hexcode).to eq("#571EFA")
@@ -108,17 +105,26 @@ RSpec.describe EnvData::CustomDesignSeeder, :webmock do
   context "when setting logo as svg",
           :settings_reset,
           with_env: {
-            OPENPROJECT_SEED_DESIGN_LOGO: "http://test.foobar.com/image.svg"
+            OPENPROJECT_SEED_DESIGN_LOGO: "https://example.com/image.svg"
           } do
     it "sets the content type" do
       reset(:seed_design)
 
-      seeder.seed!
+      perform_enqueued_jobs { seeder.seed! }
 
+      RequestStore.clear!
       custom_style = CustomStyle.current
 
       expect(custom_style.logo.file).to be_present
       expect(custom_style.logo.file.content_type).to eq "image/svg+xml"
+    end
+
+    it "downloads the asset in a job" do
+      reset(:seed_design)
+
+      expect { seeder.seed! }
+        .to have_enqueued_job(CustomStyles::SeedRemoteAssetJob)
+        .with(an_instance_of(CustomStyle), :logo, "https://example.com/image.svg")
     end
   end
 

--- a/spec/workers/custom_styles/seed_remote_asset_job_spec.rb
+++ b/spec/workers/custom_styles/seed_remote_asset_job_spec.rb
@@ -44,11 +44,14 @@ RSpec.describe CustomStyles::SeedRemoteAssetJob do
     end
 
     it "stores it on the custom style" do
+      allow(Rails.logger).to receive(:info)
+
       perform
 
       expect(custom_style.reload.logo.file).to be_present
       expect(custom_style.logo.file.content_type).to eq "image/png"
       expect(custom_style.logo.file.filename).to eq "logo.png"
+      expect(Rails.logger).to have_received(:info).with("Seeded design asset 'logo' from #{url}.")
     end
 
     context "when it is an svg" do
@@ -73,9 +76,21 @@ RSpec.describe CustomStyles::SeedRemoteAssetJob do
       stub_request(:get, url).to_return(status: 404)
     end
 
-    it "retries the job" do
-      expect { perform }.to have_enqueued_job(described_class)
+    it "swallows the error and reschedules itself instead" do
+      expect { perform }.not_to raise_error
+
+      expect(described_class).to have_been_enqueued.with(custom_style, :logo, url)
       expect(custom_style.reload.logo.file).to be_nil
+    end
+
+    it "logs the failed attempt" do
+      allow(Rails.logger).to receive(:error)
+
+      perform
+
+      expect(Rails.logger)
+        .to have_received(:error)
+        .with(a_string_starting_with("Failed to seed design asset 'logo' from #{url} on attempt 1: HTTP Error: 404"))
     end
   end
 
@@ -104,6 +119,17 @@ RSpec.describe CustomStyles::SeedRemoteAssetJob do
     it "discards the job without downloading" do
       expect { perform }.not_to have_enqueued_job(described_class)
       expect(custom_style.reload.logo.file).to be_nil
+    end
+
+    it "logs why it was blocked" do
+      allow(Rails.logger).to receive(:error)
+
+      perform
+
+      expect(Rails.logger)
+        .to have_received(:error)
+        .with(a_string_including("resolves only to private IP addresses",
+                                 "OPENPROJECT_SSRF_PROTECTION_IP_ALLOWLIST"))
     end
 
     context "when the IP address is on the SSRF allowlist", with_ssrf_ip_allowlist: %w[127.0.0.1] do

--- a/spec/workers/custom_styles/seed_remote_asset_job_spec.rb
+++ b/spec/workers/custom_styles/seed_remote_asset_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "webrick"
+
+RSpec.describe CustomStyles::SeedRemoteAssetJob do
+  let(:custom_style) { CustomStyle.create! }
+  let(:url) { "https://example.com/image.png" }
+
+  subject(:perform) { described_class.perform_now(custom_style, :logo, url) }
+
+  context "with a downloadable asset", :webmock do
+    before do
+      stub_request(:get, url)
+        .to_return(status: 200, body: Rails.root.join("spec/fixtures/files/image.png").read)
+    end
+
+    it "stores it on the custom style" do
+      perform
+
+      expect(custom_style.reload.logo.file).to be_present
+      expect(custom_style.logo.file.content_type).to eq "image/png"
+      expect(custom_style.logo.file.filename).to eq "logo.png"
+    end
+
+    context "when it is an svg" do
+      let(:url) { "https://example.com/image.svg" }
+
+      before do
+        stub_request(:get, url)
+          .to_return(status: 200, body: Rails.root.join("spec/fixtures/files/icon_logo.svg").read)
+      end
+
+      it "detects the content type and extension" do
+        perform
+
+        expect(custom_style.reload.logo.file.content_type).to eq "image/svg+xml"
+        expect(custom_style.logo.file.filename).to eq "logo.svg"
+      end
+    end
+  end
+
+  context "when the asset is not available", :webmock do
+    before do
+      stub_request(:get, url).to_return(status: 404)
+    end
+
+    it "retries the job" do
+      expect { perform }.to have_enqueued_job(described_class)
+      expect(custom_style.reload.logo.file).to be_nil
+    end
+  end
+
+  # Served by a real server, as WebMock would intercept the request before the SSRF filter kicks in
+  context "when the asset is served from a private IP address" do
+    let(:server) do
+      WEBrick::HTTPServer.new(Port: 0,
+                              BindAddress: "127.0.0.1",
+                              Logger: WEBrick::Log.new(StringIO.new),
+                              AccessLog: [])
+    end
+    let(:url) { "http://127.0.0.1:#{server.listeners[0].addr[1]}/image.png" }
+
+    before do
+      server.mount_proc "/image.png" do |_request, response|
+        response.body = Rails.root.join("spec/fixtures/files/image.png").read
+      end
+
+      Thread.new { server.start }
+    end
+
+    after do
+      server.shutdown
+    end
+
+    it "discards the job without downloading" do
+      expect { perform }.not_to have_enqueued_job(described_class)
+      expect(custom_style.reload.logo.file).to be_nil
+    end
+
+    context "when the IP address is on the SSRF allowlist", with_ssrf_ip_allowlist: %w[127.0.0.1] do
+      it "stores the asset on the custom style" do
+        Timeout.timeout(10) { perform }
+
+        expect(custom_style.reload.logo.file).to be_present
+        expect(custom_style.logo.file.content_type).to eq "image/png"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Do not use Carrierwave downloader after all, but our own httpx/ssrf implementation inside a background job, so failures can be retried.

https://community.openproject.org/wp/OP-19826
