### PR TITLE
[OP-19830] PDF table export grouped by a hierarchy custom field stops the full export

### DIFF
--- a/app/models/exports/pdf/components/wp_table.rb
+++ b/app/models/exports/pdf/components/wp_table.rb
@@ -80,7 +80,14 @@ module Exports::PDF::Components::WpTable
   #   [#<CustomOption … value: "Bar">, #<CustomOption value: "Foo"">] …,
   # }
   #
-  #  we therefor transform the keys of sums from b) to a)
+  # c) for hierarchy custom fields the same call keys by an array of items, even for single value ones, e.g.
+  # {
+  # { []: …,
+  #   [#<HierarchyItemAdapter … label: "Foo">]: …,
+  #   [#<HierarchyItemAdapter … label: "Bar">, #<HierarchyItemAdapter … label: "Foo">] …,
+  # }
+  #
+  #  we therefor transform the keys of sums from b) and c) to a)
 
   def transformed_sum_group(query)
     sums = query.results.all_group_sums
@@ -95,6 +102,8 @@ module Exports::PDF::Components::WpTable
     custom_field = query.group_by_column.custom_field
     if custom_field.list?
       transform_list_custom_field_keys(custom_field, groups)
+    elsif custom_field.field_format_hierarchy?
+      transform_hierarchy_custom_field_keys(custom_field, groups)
     else
       transform_single_custom_field_keys(custom_field, groups)
     end
@@ -107,19 +116,21 @@ module Exports::PDF::Components::WpTable
   def transform_list_custom_field_keys(custom_field, groups)
     groups.transform_keys do |key|
       if custom_field.multi_value?
-        transform_multi_list_custom_field_key(key)
+        key.map { |option| option&.value }.presence
       else
         key&.value
       end
     end
   end
 
-  def transform_multi_list_custom_field_key(key)
-    list = key.map { |v| v&.value }
-    if list.empty?
-      nil
-    else
-      list
+  # hierarchy groups from c) are keyed by an array of items, even for single value custom fields
+  def transform_hierarchy_custom_field_keys(custom_field, groups)
+    groups.transform_keys do |key|
+      if custom_field.multi_value?
+        key.map { |item| item&.to_s }.presence
+      else
+        key.first&.to_s
+      end
     end
   end
 

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
@@ -301,6 +301,101 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
         ].join(" ")
       end
     end
+
+    describe "grouped by a hierarchy custom field", with_ee: %i[custom_field_hierarchies] do
+      let!(:hierarchy_custom_field) do
+        create(:hierarchy_wp_custom_field, name: "Location", types: [type_standard, type_bug], projects: [project])
+      end
+      let!(:hierarchy_items) do
+        service = CustomFields::Hierarchy::HierarchicalItemService.new
+        %w[Berlin Lisbon].map do |label|
+          service.insert_item(contract_class: CustomFields::Hierarchy::InsertListItemContract,
+                              parent: hierarchy_custom_field.hierarchy_root,
+                              label:).value!
+        end
+      end
+
+      before do
+        work_package_parent.update!(hierarchy_custom_field.attribute_name => hierarchy_items.first.id.to_s)
+        work_package_child.update!(hierarchy_custom_field.attribute_name => hierarchy_items.last.id.to_s)
+      end
+
+      context "with sums" do
+        let(:query_attributes) { { group_by: hierarchy_custom_field.column_name, display_sums: true } }
+
+        it "contains correct data" do
+          strings = pdf_strings_without_footers(1)
+          expect(strings).to eq [
+            query.name,
+            "Berlin",
+            *column_titles,
+            *work_package_columns(work_package_parent),
+            I18n.t("js.label_sum"), work_package_parent.story_points.to_s, "25%",
+            "Lisbon",
+            *column_titles,
+            *work_package_columns(work_package_child),
+            I18n.t("js.label_sum"), work_package_child.story_points.to_s, "50%"
+          ].join(" ")
+        end
+      end
+
+      context "without sums" do
+        let(:query_attributes) { { group_by: hierarchy_custom_field.column_name, display_sums: false } }
+
+        it "contains correct data" do
+          strings = pdf_strings_without_footers(1)
+          expect(strings).to eq [
+            query.name,
+            "Berlin",
+            *column_titles,
+            *work_package_columns(work_package_parent),
+            "Lisbon",
+            *column_titles,
+            *work_package_columns(work_package_child)
+          ].join(" ")
+        end
+      end
+    end
+
+    describe "grouped by a multi value hierarchy custom field with sums", with_ee: %i[custom_field_hierarchies] do
+      let!(:multi_hierarchy_custom_field) do
+        create(:multi_hierarchy_wp_custom_field, name: "Locations", types: [type_standard, type_bug], projects: [project])
+      end
+      let!(:multi_hierarchy_items) do
+        service = CustomFields::Hierarchy::HierarchicalItemService.new
+        %w[Berlin Lisbon].map do |label|
+          service.insert_item(contract_class: CustomFields::Hierarchy::InsertListItemContract,
+                              parent: multi_hierarchy_custom_field.hierarchy_root,
+                              label:).value!
+        end
+      end
+
+      let(:query_attributes) { { group_by: multi_hierarchy_custom_field.column_name, display_sums: true } }
+
+      before do
+        work_package_parent.update!(
+          multi_hierarchy_custom_field.attribute_name => multi_hierarchy_items.map { |item| item.id.to_s }
+        )
+        work_package_child.update!(
+          multi_hierarchy_custom_field.attribute_name => [multi_hierarchy_items.first.id.to_s]
+        )
+      end
+
+      it "contains correct data" do
+        strings = pdf_strings_without_footers(1)
+        expect(strings).to eq [
+          query.name,
+          "Berlin",
+          *column_titles,
+          *work_package_columns(work_package_child),
+          I18n.t("js.label_sum"), work_package_child.story_points.to_s, "50%",
+          "Berlin, Lisbon",
+          *column_titles,
+          *work_package_columns(work_package_parent),
+          I18n.t("js.label_sum"), work_package_parent.story_points.to_s, "25%"
+        ].join(" ")
+      end
+    end
   end
 
   context "with a request for a PDF Report" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19830

# What are you trying to achieve?

PDF work package table export did not support grouping by hierarchy custom field  

# What approach did you choose and why?

Support hierarchy custom field  grouping

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
