### PR TITLE
Bugfix/COMMS-918: Validate closed versions against pending version changes

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -772,7 +772,7 @@ module WorkPackages
     end
 
     def closed_version_and_status?(status = model.status)
-      model.target_versions.any?(&:closed?) && status.is_closed?
+      status&.is_closed? && model.effective_target_versions.any?(&:closed?)
     end
 
     def new_statuses_by_workflow(status)

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -178,9 +178,7 @@ RSpec.describe WorkPackages::BaseContract do
       before do
         version = build_stubbed(:version, status: "closed")
 
-        allow(work_package)
-          .to receive(:target_versions)
-          .and_return([version])
+        work_package.version = version
         allow(work_package.status)
           .to receive(:is_closed?)
           .and_return(true)
@@ -200,6 +198,43 @@ RSpec.describe WorkPackages::BaseContract do
         it "is writable" do
           expect(contract).to be_writable(:status)
         end
+      end
+    end
+
+    context "when work_package has multiple versions of which only one is closed" do
+      before do
+        open_version = build_stubbed(:version)
+        closed_version = build_stubbed(:version, status: "closed")
+
+        allow(work_package)
+          .to receive(:effective_target_versions)
+          .and_return([open_version, closed_version])
+        allow(work_package.status)
+          .to receive(:is_closed?)
+          .and_return(true)
+      end
+
+      it "is not writable" do
+        expect(contract).not_to be_writable(:status)
+      end
+    end
+
+    context "when work_package is being moved out of a closed version while the status is closed" do
+      before do
+        closed_version = build_stubbed(:version, status: "closed")
+        open_version = build_stubbed(:version)
+
+        allow(work_package)
+          .to receive(:target_versions)
+          .and_return([closed_version])
+        work_package.version = open_version
+        allow(work_package.status)
+          .to receive(:is_closed?)
+          .and_return(true)
+      end
+
+      it "is writable" do
+        expect(contract).to be_writable(:status)
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/FND/work_packages/COMMS-918/activity

# What are you trying to accomplish?

Follow-up to #24409. The closed-version status lock reads `target_versions`, which only reflects persisted join rows, so a pending version change is invisible during validation: moving a work package out of a closed version and reopening it in one request fails with `status_transition_invalid`, and a closed version is never detected on new records. The contract now reads `effective_target_versions`, the same pending-aware reader `validate_no_reopen_on_closed_version` uses, so both validations judge the same version set. Specs pin the any-of-multiple-versions semantics and the pending-change scenario.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)