### PR TITLE
Allow form configuration to toggle linked attributes on/off

### DIFF
--- a/app/components/concerns/work_package_types/form_configuration/exclusion_toggle.rb
+++ b/app/components/concerns/work_package_types/form_configuration/exclusion_toggle.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module FormConfiguration
+    # The switch a read-only row carries to stop inheriting its element. Rows keep rendering
+    # whatever the source configures, so the switch is the only thing that says whether this
+    # type takes the element over: On means inherited, Off means excluded.
+    #
+    # Including components implement #exclusion_element_key and #exclusion_toggle_label.
+    module ExclusionToggle
+      ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
+
+      def render_exclusion_toggle?
+        @exclusions.present? && exclusion_element_key.present?
+      end
+
+      private
+
+      def exclusion_element_key
+        raise SubclassResponsibilityError
+      end
+
+      # The switch's accessible name. "Inherited" alone does not say what is inherited, and the
+      # row's own text is not associated with the switch.
+      def exclusion_toggle_label
+        raise SubclassResponsibilityError
+      end
+
+      def excluded?
+        @exclusions.excluded?(exclusion_element_key)
+      end
+
+      # Excluded by a link above this type. This type cannot narrow an ancestor's link, so the
+      # switch has nothing to write and is rendered disabled.
+      def inherited_exclusion?
+        @exclusions.inherited?(exclusion_element_key)
+      end
+
+      def exclusion_toggle_path
+        type_excluded_element_toggle_path(
+          type_id: @exclusions.type.id,
+          aspect: ASPECT,
+          element: exclusion_element_key
+        )
+      end
+
+      def exclusion_on_label
+        t("types.edit.form_configuration.exclusions.inherited")
+      end
+
+      def exclusion_off_label
+        t("types.edit.form_configuration.exclusions.excluded")
+      end
+
+      # Names the link the exclusion arrives through rather than the type that set it: the
+      # chain's exclusions are unioned, so a grandparent's link can be the one responsible,
+      # and either way the element is already missing from what this source hands down.
+      def exclusion_description
+        return nil unless inherited_exclusion?
+
+        t("types.edit.form_configuration.exclusions.excluded_in_source", source: @exclusions.source_name)
+      end
+
+      def exclusion_toggle_arguments
+        {
+          src: inherited_exclusion? ? nil : exclusion_toggle_path,
+          csrf_token: helpers.form_authenticity_token,
+          checked: !excluded?,
+          enabled: !inherited_exclusion?,
+          on_label: exclusion_on_label,
+          off_label: exclusion_off_label,
+          size: :small,
+          status_label_position: :start,
+          title: exclusion_description,
+          aria: { label: exclusion_toggle_label },
+          classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator",
+          data: { test_selector: "toggle-form-config-exclusion-#{exclusion_element_key}" }
+        }.compact
+      end
+    end
+  end
+end

--- a/app/components/concerns/work_package_types/form_configuration/exclusion_toggle.rb
+++ b/app/components/concerns/work_package_types/form_configuration/exclusion_toggle.rb
@@ -30,11 +30,7 @@
 
 module WorkPackageTypes
   module FormConfiguration
-    # The switch a read-only row carries to stop inheriting its element. Rows keep rendering
-    # whatever the source configures, so the switch is the only thing that says whether this
-    # type takes the element over: On means inherited, Off means excluded.
-    #
-    # Including components implement #exclusion_element_key and #exclusion_toggle_label.
+    # Reusable module for rendering exclusion toggles for attributes and query group components
     module ExclusionToggle
       ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
@@ -48,8 +44,6 @@ module WorkPackageTypes
         raise SubclassResponsibilityError
       end
 
-      # The switch's accessible name. "Inherited" alone does not say what is inherited, and the
-      # row's own text is not associated with the switch.
       def exclusion_toggle_label
         raise SubclassResponsibilityError
       end
@@ -58,8 +52,8 @@ module WorkPackageTypes
         @exclusions.excluded?(exclusion_element_key)
       end
 
-      # Excluded by a link above this type. This type cannot narrow an ancestor's link, so the
-      # switch has nothing to write and is rendered disabled.
+      # A type cannot narrow an ancestor's link, so such a switch has nothing to write and is
+      # rendered disabled.
       def inherited_exclusion?
         @exclusions.inherited?(exclusion_element_key)
       end
@@ -80,9 +74,8 @@ module WorkPackageTypes
         t("types.edit.form_configuration.exclusions.excluded")
       end
 
-      # Names the link the exclusion arrives through rather than the type that set it: the
-      # chain's exclusions are unioned, so a grandparent's link can be the one responsible,
-      # and either way the element is already missing from what this source hands down.
+      # As we can chain linked form configurations, the reason why this field is disables
+      # may be anywhere in the linked chain. But it is useful to find out where it comes from.
       def exclusion_description
         return nil unless inherited_exclusion?
 

--- a/app/components/concerns/work_package_types/form_configuration/exclusion_toggle.rb
+++ b/app/components/concerns/work_package_types/form_configuration/exclusion_toggle.rb
@@ -52,12 +52,6 @@ module WorkPackageTypes
         @exclusions.excluded?(exclusion_element_key)
       end
 
-      # A type cannot narrow an ancestor's link, so such a switch has nothing to write and is
-      # rendered disabled.
-      def inherited_exclusion?
-        @exclusions.inherited?(exclusion_element_key)
-      end
-
       def exclusion_toggle_path
         type_excluded_element_toggle_path(
           type_id: @exclusions.type.id,
@@ -74,29 +68,19 @@ module WorkPackageTypes
         t("types.edit.form_configuration.exclusions.excluded")
       end
 
-      # As we can chain linked form configurations, the reason why this field is disables
-      # may be anywhere in the linked chain. But it is useful to find out where it comes from.
-      def exclusion_description
-        return nil unless inherited_exclusion?
-
-        t("types.edit.form_configuration.exclusions.excluded_in_source", source: @exclusions.source_name)
-      end
-
       def exclusion_toggle_arguments
         {
-          src: inherited_exclusion? ? nil : exclusion_toggle_path,
+          src: exclusion_toggle_path,
           csrf_token: helpers.form_authenticity_token,
           checked: !excluded?,
-          enabled: !inherited_exclusion?,
           on_label: exclusion_on_label,
           off_label: exclusion_off_label,
           size: :small,
           status_label_position: :start,
-          title: exclusion_description,
           aria: { label: exclusion_toggle_label },
           classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator",
           data: { test_selector: "toggle-form-config-exclusion-#{exclusion_element_key}" }
-        }.compact
+        }
       end
     end
   end

--- a/app/components/work_package_types/form_configuration/exclusion_toggle_component.rb
+++ b/app/components/work_package_types/form_configuration/exclusion_toggle_component.rb
@@ -61,7 +61,7 @@ module WorkPackageTypes
           src: toggle_path,
           csrf_token: helpers.form_authenticity_token,
           checked: !excluded?,
-          on_label: t("types.edit.form_configuration.exclusions.inherited"),
+          on_label: "",
           off_label: t("types.edit.form_configuration.exclusions.excluded"),
           size: :small,
           status_label_position: :start,

--- a/app/components/work_package_types/form_configuration/exclusion_toggle_component.rb
+++ b/app/components/work_package_types/form_configuration/exclusion_toggle_component.rb
@@ -30,57 +30,57 @@
 
 module WorkPackageTypes
   module FormConfiguration
-    # Reusable module for rendering exclusion toggles for attributes and query group components
-    module ExclusionToggle
+    # The switch each linked attribute row renders to control exclusion of one element.
+    #
+    # +element_key+ the attribute or query key ("assignee", "custom_field_3", "query_7");
+    # +label+ Readable attribute label for the aria-label of the toggle
+    class ExclusionToggleComponent < ApplicationComponent
       ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
-      def render_exclusion_toggle?
-        @exclusions.present? && exclusion_element_key.present?
+      def initialize(exclusions:, element_key:, label:)
+        super
+
+        @exclusions = exclusions
+        @element_key = element_key
+        @label = label
+      end
+
+      # Exclusion or element_key being empty means the type owns its configuration, so there is nothing to render
+      def render?
+        @exclusions.present? && @element_key.present?
+      end
+
+      def call
+        render(Primer::Alpha::ToggleSwitch.new(**toggle_arguments))
       end
 
       private
 
-      def exclusion_element_key
-        raise SubclassResponsibilityError
-      end
-
-      def exclusion_toggle_label
-        raise SubclassResponsibilityError
+      def toggle_arguments
+        {
+          src: toggle_path,
+          csrf_token: helpers.form_authenticity_token,
+          checked: !excluded?,
+          on_label: t("types.edit.form_configuration.exclusions.inherited"),
+          off_label: t("types.edit.form_configuration.exclusions.excluded"),
+          size: :small,
+          status_label_position: :start,
+          aria: { label: @label },
+          classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator",
+          data: { test_selector: test_selector }
+        }
       end
 
       def excluded?
-        @exclusions.excluded?(exclusion_element_key)
+        @exclusions.excluded?(@element_key)
       end
 
-      def exclusion_toggle_path
-        type_excluded_element_toggle_path(
-          type_id: @exclusions.type.id,
-          aspect: ASPECT,
-          element: exclusion_element_key
-        )
+      def toggle_path
+        type_excluded_element_toggle_path(type_id: @exclusions.type.id, aspect: ASPECT, element: @element_key)
       end
 
-      def exclusion_on_label
-        t("types.edit.form_configuration.exclusions.inherited")
-      end
-
-      def exclusion_off_label
-        t("types.edit.form_configuration.exclusions.excluded")
-      end
-
-      def exclusion_toggle_arguments
-        {
-          src: exclusion_toggle_path,
-          csrf_token: helpers.form_authenticity_token,
-          checked: !excluded?,
-          on_label: exclusion_on_label,
-          off_label: exclusion_off_label,
-          size: :small,
-          status_label_position: :start,
-          aria: { label: exclusion_toggle_label },
-          classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator",
-          data: { test_selector: "toggle-form-config-exclusion-#{exclusion_element_key}" }
-        }
+      def test_selector
+        "toggle-form-config-exclusion-#{@element_key}"
       end
     end
   end

--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
@@ -22,6 +22,12 @@
       end
     end
 
+    if render_exclusion_toggle?
+      row.with_column(py: 1, mr: 2) do
+        render(Primer::Alpha::ToggleSwitch.new(**exclusion_toggle_arguments))
+      end
+    end
+
     unless readonly?
       row.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
         render(Primer::Alpha::ActionMenu.new) do |menu|

--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
@@ -22,10 +22,8 @@
       end
     end
 
-    if render_exclusion_toggle?
-      row.with_column(py: 1, mr: 2) do
-        render(Primer::Alpha::ToggleSwitch.new(**exclusion_toggle_arguments))
-      end
+    if exclusion_toggle.render?
+      row.with_column(py: 1, mr: 2) { render(exclusion_toggle) }
     end
 
     unless readonly?

--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.rb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.rb
@@ -32,14 +32,16 @@ module WorkPackageTypes
   module FormConfiguration
     class GroupAttributeRowComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
+      include WorkPackageTypes::FormConfiguration::ExclusionToggle
 
-      def initialize(attribute:, type:, index:, total_count:, readonly: false)
+      def initialize(attribute:, type:, index:, total_count:, readonly: false, exclusions: nil)
         super
         @attribute = attribute
         @type = type
         @index = index
         @total_count = total_count
         @readonly = readonly
+        @exclusions = exclusions
       end
 
       def readonly?
@@ -47,6 +49,14 @@ module WorkPackageTypes
       end
 
       private
+
+      def exclusion_element_key
+        @attribute[:key]
+      end
+
+      def exclusion_toggle_label
+        t("types.edit.form_configuration.exclusions.attribute_label", attribute: @attribute[:translation])
+      end
 
       def multiple_attributes?
         @total_count > 1

--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.rb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.rb
@@ -32,7 +32,6 @@ module WorkPackageTypes
   module FormConfiguration
     class GroupAttributeRowComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
-      include WorkPackageTypes::FormConfiguration::ExclusionToggle
 
       def initialize(attribute:, type:, index:, total_count:, readonly: false, exclusions: nil)
         super
@@ -48,15 +47,15 @@ module WorkPackageTypes
         @readonly
       end
 
+      def exclusion_toggle
+        @exclusion_toggle ||= ExclusionToggleComponent.new(
+          exclusions: @exclusions,
+          element_key: @attribute[:key],
+          label: t("types.edit.form_configuration.exclusions.attribute_label", attribute: @attribute[:translation])
+        )
+      end
+
       private
-
-      def exclusion_element_key
-        @attribute[:key]
-      end
-
-      def exclusion_toggle_label
-        t("types.edit.form_configuration.exclusions.attribute_label", attribute: @attribute[:translation])
-      end
 
       def multiple_attributes?
         @total_count > 1

--- a/app/components/work_package_types/form_configuration/group_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_component.html.erb
@@ -53,7 +53,8 @@ See COPYRIGHT and LICENSE files for more details.
             WorkPackageTypes::FormConfiguration::GroupQueryRowComponent.new(
               group: @group,
               ee_available: ee_available?,
-              readonly: readonly?
+              readonly: readonly?,
+              exclusions: @exclusions
             )
           )
         end
@@ -89,7 +90,8 @@ See COPYRIGHT and LICENSE files for more details.
                 type: @type,
                 index:,
                 total_count: attributes.length,
-                readonly: readonly?
+                readonly: readonly?,
+                exclusions: @exclusions
               )
             )
           end

--- a/app/components/work_package_types/form_configuration/group_component.rb
+++ b/app/components/work_package_types/form_configuration/group_component.rb
@@ -35,7 +35,7 @@ module WorkPackageTypes
       include OpPrimer::ComponentHelpers
 
       def initialize(group:, type: nil, ee_available: false, first: false, last: false, edit_mode: false,
-                     form_model: nil, readonly: false)
+                     form_model: nil, readonly: false, exclusions: nil)
         super(group)
         @group = group
         @type = type
@@ -45,6 +45,7 @@ module WorkPackageTypes
         @edit_mode = edit_mode
         @form_model = form_model
         @readonly = readonly
+        @exclusions = exclusions
         @instance_uid = SecureRandom.hex(4)
       end
 

--- a/app/components/work_package_types/form_configuration/group_query_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_query_row_component.html.erb
@@ -20,10 +20,8 @@
       end
     end
 
-    if render_exclusion_toggle?
-      row.with_column(py: 1, mr: 2) do
-        render(Primer::Alpha::ToggleSwitch.new(**exclusion_toggle_arguments))
-      end
+    if exclusion_toggle.render?
+      row.with_column(py: 1, mr: 2) { render(exclusion_toggle) }
     end
 
     if ee_available? && !readonly?

--- a/app/components/work_package_types/form_configuration/group_query_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_query_row_component.html.erb
@@ -20,6 +20,12 @@
       end
     end
 
+    if render_exclusion_toggle?
+      row.with_column(py: 1, mr: 2) do
+        render(Primer::Alpha::ToggleSwitch.new(**exclusion_toggle_arguments))
+      end
+    end
+
     if ee_available? && !readonly?
       row.with_column(classes: "hide-when-print type-form-configuration-page--actions") do
         render(Primer::Alpha::ActionMenu.new) do |menu|

--- a/app/components/work_package_types/form_configuration/group_query_row_component.rb
+++ b/app/components/work_package_types/form_configuration/group_query_row_component.rb
@@ -32,7 +32,6 @@ module WorkPackageTypes
   module FormConfiguration
     class GroupQueryRowComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
-      include WorkPackageTypes::FormConfiguration::ExclusionToggle
 
       def initialize(group:, ee_available:, readonly: false, exclusions: nil)
         super
@@ -46,16 +45,17 @@ module WorkPackageTypes
         @readonly
       end
 
+      # A query group holds a single query, so its key excludes the whole section rather than a row,
+      # which is why the label names the section.
+      def exclusion_toggle
+        @exclusion_toggle ||= ExclusionToggleComponent.new(
+          exclusions: @exclusions,
+          element_key: @group[:element_key],
+          label: t("types.edit.form_configuration.exclusions.section_label", section: @group[:name])
+        )
+      end
+
       private
-
-      # A query group holds a single query, so excluding its key drops the whole group rather than a row.
-      def exclusion_element_key
-        @group[:element_key]
-      end
-
-      def exclusion_toggle_label
-        t("types.edit.form_configuration.exclusions.section_label", section: @group[:name])
-      end
 
       def ee_available?
         @ee_available

--- a/app/components/work_package_types/form_configuration/group_query_row_component.rb
+++ b/app/components/work_package_types/form_configuration/group_query_row_component.rb
@@ -48,8 +48,7 @@ module WorkPackageTypes
 
       private
 
-      # A query group holds a single query, so excluding its key drops the whole group rather
-      # than a row. Nil for a group whose query was deleted: there is no id to build a key from.
+      # A query group holds a single query, so excluding its key drops the whole group rather than a row.
       def exclusion_element_key
         @group[:element_key]
       end

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -35,17 +35,18 @@ module WorkPackageTypes
 
     ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
-    # What this type does not inherit.
+    # The elements this type does not show.
     #  - own: this type's own link
     #  - effective: the union over the whole link chain
     #
-    # an element in effective but not in own was excluded somewhere in the link BEFORE this type
+    # An element in effective but not in own was excluded by a link above this type, which is
+    # what #excluded_by_source? answers: this type cannot reach that link to undo it.
     ExclusionState = Data.define(:type, :own, :effective) do
       def excluded?(key)
         effective.include?(key.to_s)
       end
 
-      def inherited?(key)
+      def excluded_by_source?(key)
         excluded?(key) && own.exclude?(key.to_s)
       end
     end
@@ -85,7 +86,7 @@ module WorkPackageTypes
       attributes = readonly? ? helpers.form_configuration_groups(source) : @form_attributes
       groups = attributes[:actives].reject { |g| g[:key].to_s == "__empty" }
 
-      readonly? ? without_inherited_exclusions(groups) : groups
+      readonly? ? without_source_exclusions(groups) : groups
     end
 
     def wrapper_data
@@ -139,7 +140,7 @@ module WorkPackageTypes
     # This drops groups that some source link excludes.
     # This type can only reduce attributes that it still sees.
     # If the group was toggled off somewhere in the link, we hide it here completely.
-    def without_inherited_exclusions(groups)
+    def without_source_exclusions(groups)
       return groups if exclusion_state.nil?
 
       groups.filter_map do |group|
@@ -153,15 +154,15 @@ module WorkPackageTypes
 
     def narrowed_attribute_group(group)
       attributes = group[:attributes].to_a
-      remaining = attributes.reject { |attribute| exclusion_state.inherited?(attribute[:key]) }
+      remaining = attributes.reject { |attribute| exclusion_state.excluded_by_source?(attribute[:key]) }
       return if remaining.empty? && attributes.any?
 
       group.merge(attributes: remaining)
     end
 
-    # A query group is a single entry in the section, so an inherited exclusion drops the whole section.
+    # A query group is a single entry in the section, so a source exclusion drops the whole section.
     def retained_query_group(group)
-      group unless group[:element_key].present? && exclusion_state.inherited?(group[:element_key])
+      group unless group[:element_key].present? && exclusion_state.excluded_by_source?(group[:element_key])
     end
 
     def build_exclusion_state

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -35,9 +35,12 @@ module WorkPackageTypes
 
     ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
-    # What this type does not inherit. `own` is this type's own link, `effective` the union over
-    # the whole chain, so an element in `effective` but not in `own` was excluded above this type.
-    ExclusionState = Data.define(:type, :own, :effective, :source_name) do
+    # What this type does not inherit.
+    #  - own: this type's own link
+    #  - effective: the union over the whole link chain
+    #
+    # an element in effective but not in own was excluded somewhere in the link BEFORE this type
+    ExclusionState = Data.define(:type, :own, :effective) do
       def excluded?(key)
         effective.include?(key.to_s)
       end
@@ -78,11 +81,12 @@ module WorkPackageTypes
       @form_attributes[:inactives]
     end
 
-    # In read-only mode the visible configuration is the linked source's, resolved at
-    # render time; independent types show their own stored configuration.
+    # In read-only mode the visible configuration is the linked source's
     def active_groups
       attributes = readonly? ? helpers.form_configuration_groups(source) : @form_attributes
-      attributes[:actives].reject { |g| g[:key].to_s == "__empty" }
+      groups = attributes[:actives].reject { |g| g[:key].to_s == "__empty" }
+
+      readonly? ? without_inherited_exclusions(groups) : groups
     end
 
     def wrapper_data
@@ -133,6 +137,34 @@ module WorkPackageTypes
 
     private
 
+    # This drops groups that some source link excludes.
+    # This type can only reduce attributes that it still sees.
+    # If the group was toggled off somewhere in the link, we hide it here completely.
+    def without_inherited_exclusions(groups)
+      return groups if exclusion_state.nil?
+
+      groups.filter_map do |group|
+        if group[:type].to_s == "query"
+          retained_query_group(group)
+        else
+          narrowed_attribute_group(group)
+        end
+      end
+    end
+
+    def narrowed_attribute_group(group)
+      attributes = group[:attributes].to_a
+      remaining = attributes.reject { |attribute| exclusion_state.inherited?(attribute[:key]) }
+      return if remaining.empty? && attributes.any?
+
+      group.merge(attributes: remaining)
+    end
+
+    # A query group is a single entry in the section, so an inherited exclusion drops the whole section.
+    def retained_query_group(group)
+      group unless group[:element_key].present? && exclusion_state.inherited?(group[:element_key])
+    end
+
     def build_exclusion_state
       link = @type.configuration_links.find_by(aspect: ASPECT)
       return nil unless link
@@ -140,8 +172,7 @@ module WorkPackageTypes
       ExclusionState.new(
         type: @type,
         own: link.excluded_elements.map(&:to_s),
-        effective: @type.effective_excluded_elements(ASPECT).map(&:to_s),
-        source_name: link.source.composite_name
+        effective: @type.effective_excluded_elements(ASPECT).map(&:to_s)
       )
     end
   end

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -67,10 +67,9 @@ module WorkPackageTypes
 
     # We memoize the exclusion state here to avoid an n+1 query
     def exclusion_state
-      return nil unless readonly?
       return @exclusion_state if defined?(@exclusion_state)
 
-      @exclusion_state = build_exclusion_state
+      @exclusion_state = readonly? ? build_exclusion_state : nil
     end
 
     def ee_available?

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -35,6 +35,19 @@ module WorkPackageTypes
 
     ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
+    # What this type does not inherit, resolved once for the page. `own` is this type's own
+    # link, `effective` the union over the whole chain: an element in `effective` but not in
+    # `own` was excluded above this type, which cannot narrow an ancestor's link.
+    ExclusionState = Data.define(:type, :own, :effective, :source_name) do
+      def excluded?(key)
+        effective.include?(key.to_s)
+      end
+
+      def inherited?(key)
+        excluded?(key) && own.exclude?(key.to_s)
+      end
+    end
+
     def initialize(type:, form_attributes:, no_filter_query:)
       super(type)
       @type = type
@@ -48,6 +61,16 @@ module WorkPackageTypes
 
     def source
       @type.effective_source_for(ASPECT)
+    end
+
+    # Resolved once and handed to every row: #effective_excluded_elements is not memoized and
+    # runs a recursive query per call, so asking per row would cost one of those per attribute.
+    # nil outside read-only mode, which is what tells the rows to render no toggle.
+    def exclusion_state
+      return nil unless readonly?
+      return @exclusion_state if defined?(@exclusion_state)
+
+      @exclusion_state = build_exclusion_state
     end
 
     def ee_available?
@@ -98,7 +121,8 @@ module WorkPackageTypes
           ee_available: ee_available?,
           first: i == 0,
           last: i == groups.length - 1,
-          readonly: readonly?
+          readonly: readonly?,
+          exclusions: exclusion_state
         )
       end
 
@@ -107,6 +131,20 @@ module WorkPackageTypes
         group_components:,
         ee_available: ee_available?,
         readonly: readonly?
+      )
+    end
+
+    private
+
+    def build_exclusion_state
+      link = @type.configuration_links.find_by(aspect: ASPECT)
+      return nil unless link
+
+      ExclusionState.new(
+        type: @type,
+        own: link.excluded_elements.map(&:to_s),
+        effective: @type.effective_excluded_elements(ASPECT).map(&:to_s),
+        source_name: link.source.composite_name
       )
     end
   end

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -35,9 +35,8 @@ module WorkPackageTypes
 
     ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
-    # What this type does not inherit, resolved once for the page. `own` is this type's own
-    # link, `effective` the union over the whole chain: an element in `effective` but not in
-    # `own` was excluded above this type, which cannot narrow an ancestor's link.
+    # What this type does not inherit. `own` is this type's own link, `effective` the union over
+    # the whole chain, so an element in `effective` but not in `own` was excluded above this type.
     ExclusionState = Data.define(:type, :own, :effective, :source_name) do
       def excluded?(key)
         effective.include?(key.to_s)
@@ -63,9 +62,7 @@ module WorkPackageTypes
       @type.effective_source_for(ASPECT)
     end
 
-    # Resolved once and handed to every row: #effective_excluded_elements is not memoized and
-    # runs a recursive query per call, so asking per row would cost one of those per attribute.
-    # nil outside read-only mode, which is what tells the rows to render no toggle.
+    # We memoize the exclusion state here to avoid an n+1 query
     def exclusion_state
       return nil unless readonly?
       return @exclusion_state if defined?(@exclusion_state)

--- a/app/components/work_package_types/reuse_mode_banner_component.rb
+++ b/app/components/work_package_types/reuse_mode_banner_component.rb
@@ -67,7 +67,7 @@ module WorkPackageTypes
     def linked_description
       helpers.link_translate(
         "types.edit.reuse_mode.linked.description",
-        i18n_args: { source_name: source.name, source_suffix: parent_suffix },
+        i18n_args: { source_name: source.composite_name, source_suffix: parent_suffix },
         links: { source_url: source_path },
         external: false
       )

--- a/app/controllers/work_package_types/excluded_elements_controller.rb
+++ b/app/controllers/work_package_types/excluded_elements_controller.rb
@@ -29,9 +29,6 @@
 #++
 
 module WorkPackageTypes
-  # The exclusion switches on a type's read-only configuration tabs: one element at a time,
-  # driven by Primer's ToggleSwitch, which sends "value: 0 | 1" and keeps or reverts the switch
-  # based on the response status. Built to mirror ConfigurationLinksController.
   class ExcludedElementsController < BaseTabController
     include TypeVariantsFeature
 
@@ -42,7 +39,7 @@ module WorkPackageTypes
       :types
     end
 
-    # On means the type inherits the element, so switching on removes the exclusion.
+    # For clarification: If we toggle the element on, it means we remove the exclusion from the array.
     def toggle
       call = toggle_service
         .new(user: current_user, type: @type)

--- a/app/controllers/work_package_types/excluded_elements_controller.rb
+++ b/app/controllers/work_package_types/excluded_elements_controller.rb
@@ -29,38 +29,48 @@
 #++
 
 module WorkPackageTypes
-  module FormConfiguration
-    class GroupQueryRowComponent < ApplicationComponent
-      include OpPrimer::ComponentHelpers
-      include WorkPackageTypes::FormConfiguration::ExclusionToggle
+  # The exclusion switches on a type's read-only configuration tabs: one element at a time,
+  # driven by Primer's ToggleSwitch, which sends "value: 0 | 1" and keeps or reverts the switch
+  # based on the response status. Built to mirror ConfigurationLinksController.
+  class ExcludedElementsController < BaseTabController
+    include TypeVariantsFeature
 
-      def initialize(group:, ee_available:, readonly: false, exclusions: nil)
-        super
-        @group = group
-        @ee_available = ee_available
-        @readonly = readonly
-        @exclusions = exclusions
+    before_action :require_type_variants_feature
+    before_action :require_valid_aspect
+
+    current_menu_item do
+      :types
+    end
+
+    # On means the type inherits the element, so switching on removes the exclusion.
+    def toggle
+      call = toggle_service
+        .new(user: current_user, type: @type)
+        .call(aspect:, elements: [element])
+
+      render json: {}, status: call.success? ? :ok : :unprocessable_entity
+    end
+
+    private
+
+    def aspect = params[:aspect]
+
+    def element = params.require(:element)
+
+    def toggle_service
+      if inherit?
+        ExcludedElements::RemoveService
+      else
+        ExcludedElements::AddService
       end
+    end
 
-      def readonly?
-        @readonly
-      end
+    def inherit?
+      ActiveRecord::Type::Boolean.new.cast(params.permit(:value)[:value])
+    end
 
-      private
-
-      # A query group holds a single query, so excluding its key drops the whole group rather
-      # than a row. Nil for a group whose query was deleted: there is no id to build a key from.
-      def exclusion_element_key
-        @group[:element_key]
-      end
-
-      def exclusion_toggle_label
-        t("types.edit.form_configuration.exclusions.section_label", section: @group[:name])
-      end
-
-      def ee_available?
-        @ee_available
-      end
+    def require_valid_aspect
+      render_404 unless Type::ConfigurationLink::ASPECTS.include?(aspect)
     end
   end
 end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -168,9 +168,8 @@ module ::TypesHelper
     end
   end
 
-  # The key a query group is excluded by. Attribute groups have none: their rows carry
-  # their own keys. A group whose query was deleted has none either, since the key is
-  # derived from the query id.
+  # The key a query group is excluded by. Attribute groups have none, their rows carry their own,
+  # and neither does a group whose query was deleted: the key is derived from the query id.
   def exclusion_element_key(group)
     return nil unless group.group_type == :query && group.query.present?
 

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -138,6 +138,7 @@ module ::TypesHelper
     return nil unless group.group_type == :query
 
     query = group.attributes
+    return nil if query.blank?
 
     # Reduce the query to its valid subset to avoid errors loading the form
     query.valid_subset!
@@ -160,10 +161,20 @@ module ::TypesHelper
         key: group.key,
         type: group.group_type,
         name: group.translated_key,
+        element_key: exclusion_element_key(group),
         attributes: active_group_attributes_map(group, available, inactive),
         query: query_to_query_props(group)
       }
     end
+  end
+
+  # The key a query group is excluded by. Attribute groups have none: their rows carry
+  # their own keys. A group whose query was deleted has none either, since the key is
+  # derived from the query id.
+  def exclusion_element_key(group)
+    return nil unless group.group_type == :query && group.query.present?
+
+    group.query_attribute_name.to_s
   end
 
   def attr_form_map(key, represented)

--- a/app/services/work_package_types/excluded_elements/base_service.rb
+++ b/app/services/work_package_types/excluded_elements/base_service.rb
@@ -67,10 +67,8 @@ module WorkPackageTypes
 
       private
 
-      # Every exclusion for an aspect lives in one array column, so two switches toggled at once
-      # contend for the same row. The lock serialises them; the reload is what makes the read
-      # current, as #perform loaded the link before the lock was taken and `updated_elements`
-      # would otherwise recompute from a pre-lock array and drop the other write.
+      # Excluded attributes are stored in an array of the link aspect.
+      # That's why we need to add a mutex for saving that array to prevent race conditions.
       def narrow(link)
         OpenProject::Mutex.with_advisory_lock_transaction(link, "excluded_elements") do
           link.reload

--- a/app/services/work_package_types/excluded_elements/base_service.rb
+++ b/app/services/work_package_types/excluded_elements/base_service.rb
@@ -67,8 +67,15 @@ module WorkPackageTypes
 
       private
 
+      # Every exclusion for an aspect lives in one array column, so two switches toggled at once
+      # contend for the same row. The lock serialises them; the reload is what makes the read
+      # current, as #perform loaded the link before the lock was taken and `updated_elements`
+      # would otherwise recompute from a pre-lock array and drop the other write.
       def narrow(link)
-        link.update!(excluded_elements: updated_elements(link.excluded_elements, elements_param))
+        OpenProject::Mutex.with_advisory_lock_transaction(link, "excluded_elements") do
+          link.reload
+          link.update!(excluded_elements: updated_elements(link.excluded_elements, elements_param))
+        end
 
         ServiceResult.success(result: type)
       rescue ActiveRecord::RecordInvalid

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6148,8 +6148,7 @@ en:
         empty_group_hint: "Drag attributes here"
         exclusions:
           attribute_label: "Inherit %{attribute}"
-          excluded: "Excluded"
-          inherited: "Inherited"
+          excluded: "Hidden"
           section_label: "Inherit section %{section}"
         filter_inactive: "Filter attributes"
         group_actions: "Section actions"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6149,7 +6149,6 @@ en:
         exclusions:
           attribute_label: "Inherit %{attribute}"
           excluded: "Excluded"
-          excluded_in_source: "Excluded in the configuration inherited from %{source}"
           inherited: "Inherited"
           section_label: "Inherit section %{section}"
         filter_inactive: "Filter attributes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6146,6 +6146,12 @@ en:
         drag_to_reorder: "Drag to reorder"
         edit_query: "Edit query"
         empty_group_hint: "Drag attributes here"
+        exclusions:
+          attribute_label: "Inherit %{attribute}"
+          excluded: "Excluded"
+          excluded_in_source: "Excluded in the configuration inherited from %{source}"
+          inherited: "Inherited"
+          section_label: "Inherit section %{section}"
         filter_inactive: "Filter attributes"
         group_actions: "Section actions"
         group_name_label: "Section name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,10 @@ Rails.application.routes.draw do
         post :confirm
         post :copy
       end
+
+      scope "exclusions/:aspect", controller: "excluded_elements", as: :excluded_element do
+        post :toggle
+      end
     end
 
     resource :creation_wizard, controller: "creation_wizard", only: %i[show update]

--- a/spec/components/work_package_types/form_configuration/exclusion_toggle_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/exclusion_toggle_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::FormConfiguration::ExclusionToggleComponent, type: :component do
+  let(:type) { create(:type) }
+
+  def exclusion_state(effective: [])
+    WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(type:, own: effective, effective:)
+  end
+
+  def component(exclusions: exclusion_state, element_key: "assignee", label: "Inherit Assignee")
+    described_class.new(exclusions:, element_key:, label:)
+  end
+
+  describe "#render?" do
+    it "is false without exclusion state, which means the type owns its configuration" do
+      expect(component(exclusions: nil).render?).to be(false)
+    end
+
+    it "is false without an element key, as for a query group whose query was deleted" do
+      expect(component(element_key: nil).render?).to be(false)
+    end
+
+    it "is true once there is state and a key" do
+      expect(component.render?).to be(true)
+    end
+  end
+
+  describe "the rendered switch" do
+    subject(:toggle) { page.find("[data-test-selector='toggle-form-config-exclusion-assignee']") }
+
+    it "is on and posts to the element's toggle endpoint when nothing excludes it", :aggregate_failures do
+      render_inline(component)
+
+      expect(toggle.find("button")["aria-pressed"]).to eq("true")
+      expect(toggle.find("button")["aria-label"]).to eq("Inherit Assignee")
+      expect(toggle["src"]).to eq("/types/#{type.id}/exclusions/form_configuration/toggle?element=assignee")
+    end
+
+    it "is off when the element is excluded" do
+      render_inline(component(exclusions: exclusion_state(effective: %w[assignee])))
+
+      expect(toggle.find("button")["aria-pressed"]).to eq("false")
+    end
+
+    it "keys the endpoint and selector on the element, not on an attribute name", :aggregate_failures do
+      render_inline(component(element_key: "query_7", label: "Inherit section Related"))
+
+      switch = page.find("[data-test-selector='toggle-form-config-exclusion-query_7']")
+      expect(switch["src"]).to eq("/types/#{type.id}/exclusions/form_configuration/toggle?element=query_7")
+      expect(switch.find("button")["aria-label"]).to eq("Inherit section Related")
+    end
+  end
+end

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -24,15 +24,11 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
     expect(page).to have_text("Assignee")
   end
 
+  # The switch itself is covered by ExclusionToggleComponent; what matters here is that the row
+  # hands it this attribute's key and label, and asks for it only in read-only mode.
   describe "the exclusion toggle" do
-    subject(:toggle) { page.find("[data-test-selector='toggle-form-config-exclusion-assignee']") }
-
     def render_row(exclusions:, readonly: true)
       render_inline(described_class.new(attribute:, type:, index: 0, total_count: 2, readonly:, exclusions:))
-    end
-
-    def exclusion_state(own:, effective:)
-      WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(type:, own:, effective:)
     end
 
     it "is not rendered in editable mode" do
@@ -47,24 +43,12 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
       expect(page).to have_no_test_selector("toggle-form-config-exclusion-assignee")
     end
 
-    it "is on and posts to the toggle endpoint when the element is not excluded", :aggregate_failures do
-      render_row(exclusions: exclusion_state(own: [], effective: []))
+    it "is keyed on the attribute and labelled with its translation", :aggregate_failures do
+      render_row(exclusions: WorkPackageTypes::FormConfigurationComponent::ExclusionState
+                               .new(type:, own: [], effective: []))
 
-      expect(toggle.find("button")["aria-pressed"]).to eq("true")
+      toggle = page.find("[data-test-selector='toggle-form-config-exclusion-assignee']")
       expect(toggle.find("button")["aria-label"]).to eq("Inherit Assignee")
-      expect(toggle["src"]).to eq(
-        "/types/#{type.id}/exclusions/form_configuration/toggle?element=assignee"
-      )
-    end
-
-    # Rows an ancestor excludes never reach this component: FormConfigurationComponent leaves them
-    # out, so the switch here is always writable.
-    it "is off and still writable when this type excludes the element itself", :aggregate_failures do
-      render_row(exclusions: exclusion_state(own: %w[assignee], effective: %w[assignee]))
-
-      expect(toggle.find("button")["aria-pressed"]).to eq("false")
-      expect(toggle["src"]).to be_present
-      expect(toggle["class"]).not_to include("ToggleSwitch--disabled")
     end
   end
 end

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
       expect(page).to have_no_test_selector("toggle-form-config-exclusion-assignee")
     end
 
-    it "is on and posts to the toggle endpoint when the element is inherited", :aggregate_failures do
+    it "is on and posts to the toggle endpoint when the element is not excluded", :aggregate_failures do
       render_row(exclusions: exclusion_state(own: [], effective: []))
 
       expect(toggle.find("button")["aria-pressed"]).to eq("true")

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -23,4 +23,59 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
     expect(page).to have_no_test_selector("type-form-configuration-attribute-actions-assignee")
     expect(page).to have_text("Assignee")
   end
+
+  describe "the exclusion toggle" do
+    subject(:toggle) { page.find("[data-test-selector='toggle-form-config-exclusion-assignee']") }
+
+    def render_row(exclusions:, readonly: true)
+      render_inline(described_class.new(attribute:, type:, index: 0, total_count: 2, readonly:, exclusions:))
+    end
+
+    def exclusion_state(own:, effective:)
+      WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(
+        type:, own:, effective:, source_name: "Bug"
+      )
+    end
+
+    it "is not rendered in editable mode" do
+      render_row(exclusions: nil, readonly: false)
+
+      expect(page).to have_no_test_selector("toggle-form-config-exclusion-assignee")
+    end
+
+    it "is not rendered when the type owns the configuration" do
+      render_row(exclusions: nil)
+
+      expect(page).to have_no_test_selector("toggle-form-config-exclusion-assignee")
+    end
+
+    it "is on and posts to the toggle endpoint when the element is inherited", :aggregate_failures do
+      render_row(exclusions: exclusion_state(own: [], effective: []))
+
+      expect(toggle.find("button")["aria-pressed"]).to eq("true")
+      expect(toggle.find("button")["aria-label"]).to eq("Inherit Assignee")
+      expect(toggle["src"]).to eq(
+        "/types/#{type.id}/exclusions/form_configuration/toggle?element=assignee"
+      )
+      expect(toggle["class"]).not_to include("ToggleSwitch--disabled")
+    end
+
+    it "is off and still writable when this type excludes the element itself", :aggregate_failures do
+      render_row(exclusions: exclusion_state(own: %w[assignee], effective: %w[assignee]))
+
+      expect(toggle.find("button")["aria-pressed"]).to eq("false")
+      expect(toggle["src"]).to be_present
+      expect(toggle["class"]).not_to include("ToggleSwitch--disabled")
+      expect(toggle["title"]).to be_nil
+    end
+
+    it "is off, disabled and names the source when an ancestor excludes the element", :aggregate_failures do
+      render_row(exclusions: exclusion_state(own: [], effective: %w[assignee]))
+
+      expect(toggle.find("button")["aria-pressed"]).to eq("false")
+      expect(toggle["src"]).to be_nil
+      expect(toggle["class"]).to include("ToggleSwitch--disabled")
+      expect(toggle["title"]).to eq("Excluded in the configuration inherited from Bug")
+    end
+  end
 end

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
     end
 
     def exclusion_state(own:, effective:)
-      WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(
-        type:, own:, effective:, source_name: "Bug"
-      )
+      WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(type:, own:, effective:)
     end
 
     it "is not rendered in editable mode" do
@@ -57,25 +55,16 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
       expect(toggle["src"]).to eq(
         "/types/#{type.id}/exclusions/form_configuration/toggle?element=assignee"
       )
-      expect(toggle["class"]).not_to include("ToggleSwitch--disabled")
     end
 
+    # Rows an ancestor excludes never reach this component: FormConfigurationComponent leaves them
+    # out, so the switch here is always writable.
     it "is off and still writable when this type excludes the element itself", :aggregate_failures do
       render_row(exclusions: exclusion_state(own: %w[assignee], effective: %w[assignee]))
 
       expect(toggle.find("button")["aria-pressed"]).to eq("false")
       expect(toggle["src"]).to be_present
       expect(toggle["class"]).not_to include("ToggleSwitch--disabled")
-      expect(toggle["title"]).to be_nil
-    end
-
-    it "is off, disabled and names the source when an ancestor excludes the element", :aggregate_failures do
-      render_row(exclusions: exclusion_state(own: [], effective: %w[assignee]))
-
-      expect(toggle.find("button")["aria-pressed"]).to eq("false")
-      expect(toggle["src"]).to be_nil
-      expect(toggle["class"]).to include("ToggleSwitch--disabled")
-      expect(toggle["title"]).to eq("Excluded in the configuration inherited from Bug")
     end
   end
 end

--- a/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupQueryRowComponent, type
     let(:type) { create(:type) }
     let(:exclusions) do
       WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(
-        type:, own: [], effective: [], source_name: "Bug"
+        type:, own: [], effective: []
       )
     end
 

--- a/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupQueryRowComponent, type
       )
     end
 
-    it "excludes the whole section by its query key", :aggregate_failures do
+    it "is keyed on the query and labelled with the section name", :aggregate_failures do
       render_inline(described_class.new(group: group.merge(element_key: "query_7"),
                                         ee_available: false, readonly: true, exclusions:))
 
       toggle = page.find("[data-test-selector='toggle-form-config-exclusion-query_7']")
-      expect(toggle["src"]).to eq("/types/#{type.id}/exclusions/form_configuration/toggle?element=query_7")
       expect(toggle.find("button")["aria-label"]).to eq("Inherit section Related")
     end
 

--- a/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
@@ -17,4 +17,29 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupQueryRowComponent, type
     expect(page).to have_no_test_selector("type-form-configuration-query-actions-query-1")
     expect(page).to have_text("Related work packages table")
   end
+
+  describe "the exclusion toggle" do
+    let(:type) { create(:type) }
+    let(:exclusions) do
+      WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(
+        type:, own: [], effective: [], source_name: "Bug"
+      )
+    end
+
+    it "excludes the whole section by its query key", :aggregate_failures do
+      render_inline(described_class.new(group: group.merge(element_key: "query_7"),
+                                        ee_available: false, readonly: true, exclusions:))
+
+      toggle = page.find("[data-test-selector='toggle-form-config-exclusion-query_7']")
+      expect(toggle["src"]).to eq("/types/#{type.id}/exclusions/form_configuration/toggle?element=query_7")
+      expect(toggle.find("button")["aria-label"]).to eq("Inherit section Related")
+    end
+
+    it "is omitted for a group whose query was deleted" do
+      render_inline(described_class.new(group: group.merge(element_key: nil),
+                                        ee_available: true, readonly: true, exclusions:))
+
+      expect(page).to have_no_css("toggle-switch")
+    end
+  end
 end

--- a/spec/components/work_package_types/form_configuration_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration_component_spec.rb
@@ -35,6 +35,81 @@ RSpec.describe WorkPackageTypes::FormConfigurationComponent, type: :component do
       expect(page).to have_no_test_selector("type-form-configuration-add-button")
       expect(page).to have_no_css("[data-draggable-type='group']")
     end
+
+    # An exclusion this type owns is reversible from here, so its row stays and the switch shows
+    # it off. One inherited from an ancestor's link is not, so the row is left out instead.
+    describe "exclusions" do
+      let(:link) { type.configuration_links.find_by(aspect: Type::ConfigurationLink::FORM_CONFIGURATION) }
+
+      before do
+        source.attribute_groups = [["People", %w[assignee responsible]]]
+        source.save!
+      end
+
+      it "lists a row this type excludes itself, switched off", :aggregate_failures do
+        link.update!(excluded_elements: %w[assignee])
+
+        render_component
+
+        expect(page).to have_text("People")
+        toggle = page.find("[data-test-selector='toggle-form-config-exclusion-assignee'] > button")
+        expect(toggle["aria-pressed"]).to eq("false")
+      end
+
+      it "omits a row an ancestor's link excludes", :aggregate_failures do
+        middle = create(:type, name: "Middle")
+        link.update!(source: middle)
+        create(:type_configuration_link, type: middle, source:,
+                                         aspect: Type::ConfigurationLink::FORM_CONFIGURATION,
+                                         excluded_elements: %w[assignee])
+
+        render_component
+
+        expect(page).to have_text("People")
+        expect(page).to have_no_test_selector("toggle-form-config-exclusion-assignee")
+        expect(page).to have_test_selector("toggle-form-config-exclusion-responsible")
+      end
+
+      # Paired with the example below on purpose: it proves the section name renders at all, so
+      # the absence asserted there is the exclusion doing its job.
+      it "renders a query section nothing excludes" do
+        source.attribute_groups = [["People", %w[assignee]], ["Related", [create(:query)]]]
+        source.save!
+
+        render_component
+
+        expect(page).to have_text("Related")
+      end
+
+      it "drops a query section an ancestor's link excludes", :aggregate_failures do
+        query = create(:query, name: "Embedded list")
+        source.attribute_groups = [["People", %w[assignee]], ["Related", [query]]]
+        source.save!
+
+        middle = create(:type, name: "Middle")
+        link.update!(source: middle)
+        create(:type_configuration_link, type: middle, source:,
+                                         aspect: Type::ConfigurationLink::FORM_CONFIGURATION,
+                                         excluded_elements: ["query_#{query.id}"])
+
+        render_component
+
+        expect(page).to have_text("People")
+        expect(page).to have_no_text("Related")
+      end
+
+      it "drops a group an ancestor's exclusions empty" do
+        middle = create(:type, name: "Middle")
+        link.update!(source: middle)
+        create(:type_configuration_link, type: middle, source:,
+                                         aspect: Type::ConfigurationLink::FORM_CONFIGURATION,
+                                         excluded_elements: %w[assignee responsible])
+
+        render_component
+
+        expect(page).to have_no_text("People")
+      end
+    end
   end
 
   context "when independent" do

--- a/spec/components/work_package_types/form_configuration_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WorkPackageTypes::FormConfigurationComponent, type: :component do
     end
 
     # An exclusion this type owns is reversible from here, so its row stays and the switch shows
-    # it off. One inherited from an ancestor's link is not, so the row is left out instead.
+    # it off. One coming from a link above it is not, so the row is left out instead.
     describe "exclusions" do
       let(:link) { type.configuration_links.find_by(aspect: Type::ConfigurationLink::FORM_CONFIGURATION) }
 

--- a/spec/features/types/form_configuration_exclusions_spec.rb
+++ b/spec/features/types/form_configuration_exclusions_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "form configuration exclusions", :js,
+               with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+
+  let(:aspect) { Type::ConfigurationLink::FORM_CONFIGURATION }
+
+  let(:owner) do
+    create(:type).tap do |type|
+      type.attribute_groups = [["People", %w[assignee responsible]]]
+      type.save!
+    end
+  end
+
+  let(:variant) { create(:type, parent: owner) }
+  let(:link) { variant.configuration_links.find_by(aspect:) }
+
+  def toggle_for(key)
+    page.find("[data-test-selector='toggle-form-config-exclusion-#{key}'] > button")
+  end
+
+  def expect_toggle(key, pressed:)
+    expect(page)
+      .to have_css("[data-test-selector='toggle-form-config-exclusion-#{key}'] > button[aria-pressed='#{pressed}']")
+  end
+
+  before do
+    variant.link!(aspect, source: owner)
+    login_as admin
+    visit edit_type_form_configuration_path(variant)
+  end
+
+  it "stops and resumes inheriting an attribute" do
+    expect(page).to have_text("Assignee")
+    expect_toggle("assignee", pressed: true)
+
+    toggle_for("assignee").click
+
+    expect_toggle("assignee", pressed: false)
+    expect(link.reload.excluded_elements).to eq(%w[assignee])
+
+    # The row stays listed so the switch remains reachable: the page shows the source's
+    # configuration annotated with this variant's choices, not the resulting form.
+    refresh
+
+    expect(page).to have_text("Assignee")
+    expect_toggle("assignee", pressed: false)
+    expect_toggle("responsible", pressed: true)
+
+    toggle_for("assignee").click
+
+    expect_toggle("assignee", pressed: true)
+    expect(link.reload.excluded_elements).to be_empty
+  end
+end

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -87,6 +87,38 @@ RSpec.describe TypesHelper do
 
         expect(subject.first[:key]).to eq :details
       end
+
+      it "carries no exclusion element key for attribute groups" do
+        expect(subject.first[:element_key]).to be_nil
+      end
+
+      context "with a query group" do
+        let(:query) { create(:query) }
+
+        before do
+          allow(type)
+            .to receive(:attribute_groups)
+            .and_return [Type::QueryGroup.new(type, "Related", query)]
+        end
+
+        it "carries the query key the group is excluded by" do
+          expect(subject.first[:element_key]).to eq "query_#{query.id}"
+        end
+      end
+
+      context "with a query group whose query was deleted" do
+        before do
+          allow(type)
+            .to receive(:attribute_groups)
+            .and_return [Type::QueryGroup.new(type, "Related", nil)]
+        end
+
+        it "renders without a query or an element key", :aggregate_failures do
+          expect { subject }.not_to raise_error
+          expect(subject.first[:element_key]).to be_nil
+          expect(subject.first[:query]).to be_nil
+        end
+      end
     end
 
     describe "field_format_label" do

--- a/spec/requests/work_package_types/excluded_elements_spec.rb
+++ b/spec/requests/work_package_types/excluded_elements_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package type excluded elements",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:source) { create(:type) }
+
+  let(:aspect) { Type::ConfigurationLink::FORM_CONFIGURATION }
+  let(:type) { create(:type) }
+  let(:link) { type.configuration_links.find_by(aspect:) }
+
+  before { login_as admin }
+
+  def toggle(value:, element: "assignee")
+    post type_excluded_element_toggle_path(type_id: type.id, aspect:, element:), params: { value: }
+  end
+
+  context "when the type is Linked for the aspect" do
+    before { type.link!(aspect, source:) }
+
+    it "excludes the element when switched off", :aggregate_failures do
+      toggle(value: "0")
+
+      expect(response).to have_http_status(:ok)
+      expect(link.excluded_elements).to contain_exactly("assignee")
+    end
+
+    it "restores the element when switched on", :aggregate_failures do
+      link.update!(excluded_elements: %w[assignee custom_field_1])
+
+      toggle(value: "1")
+
+      expect(response).to have_http_status(:ok)
+      expect(link.reload.excluded_elements).to contain_exactly("custom_field_1")
+    end
+
+    it "leaves the other aspects alone" do
+      type.link!(Type::ConfigurationLink::PDF_EXPORT, source:)
+
+      toggle(value: "0")
+
+      expect(type.configuration_links.find_by(aspect: Type::ConfigurationLink::PDF_EXPORT).excluded_elements)
+        .to be_empty
+    end
+  end
+
+  it "is unprocessable when the type owns the aspect" do
+    toggle(value: "0")
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "is not found for an unknown aspect" do
+    post type_excluded_element_toggle_path(type_id: type.id, aspect: "not_an_aspect", element: "assignee"),
+         params: { value: "0" }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  context "when the variants feature is disabled", with_flag: { type_variants: false } do
+    before { type.link!(aspect, source:) }
+
+    it "blocks the endpoint and excludes nothing", :aggregate_failures do
+      toggle(value: "0")
+
+      expect(response).to have_http_status(:not_found)
+      expect(link.excluded_elements).to be_empty
+    end
+  end
+
+  context "when the user is not an admin" do
+    before { login_as create(:user) }
+
+    it "is forbidden" do
+      type.link!(aspect, source:)
+
+      toggle(value: "0")
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/services/work_package_types/excluded_elements/add_service_spec.rb
+++ b/spec/services/work_package_types/excluded_elements/add_service_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe WorkPackageTypes::ExcludedElements::AddService, with_flag: { type
       expect(excluded_elements).to contain_exactly("custom_field_1", "assignee")
     end
 
-    # Two switches toggled at once contend for the one array column, so the write has to
-    # recompute from the row rather than from the copy loaded before the lock was taken.
+    # The stub hands the service a link loaded before the row changed, standing in for the
+    # concurrent toggle that #narrow's reload exists to survive.
     it "recomputes from the persisted list, not from a stale read" do
       allow(type.configuration_links).to receive(:find_by).and_return(link)
       Type::ConfigurationLink.find(link.id).update!(excluded_elements: %w[assignee])

--- a/spec/services/work_package_types/excluded_elements/add_service_spec.rb
+++ b/spec/services/work_package_types/excluded_elements/add_service_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe WorkPackageTypes::ExcludedElements::AddService, with_flag: { type
       expect(excluded_elements).to contain_exactly("custom_field_1", "assignee")
     end
 
+    # Two switches toggled at once contend for the one array column, so the write has to
+    # recompute from the row rather than from the copy loaded before the lock was taken.
+    it "recomputes from the persisted list, not from a stale read" do
+      allow(type.configuration_links).to receive(:find_by).and_return(link)
+      Type::ConfigurationLink.find(link.id).update!(excluded_elements: %w[assignee])
+
+      expect(service_call).to be_success
+      expect(excluded_elements).to contain_exactly("assignee", "custom_field_1")
+    end
+
     it "narrows what the type inherits" do
       source.update!(attribute_groups: [["numbers", %w[assignee responsible]]])
       described_class.new(user: admin, type:).call(aspect:, elements: %w[assignee])

--- a/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
+++ b/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
@@ -71,6 +71,52 @@ RSpec.describe WorkPackageTypes::SwitchToIndependentModeService do
       end
     end
 
+    # Going Independent freezes what the type was presenting, not what its source owns: an
+    # excluded attribute was not on its form and must not reappear as an own group member.
+    context "with the copy mode and exclusions (form configuration)", with_flag: { type_variants: true } do
+      let(:aspect) { Type::ConfigurationLink::FORM_CONFIGURATION }
+      let(:owner) do
+        create(:type).tap do |owner_type|
+          owner_type.attribute_groups = [["Numbers", [kept_field.attribute_name, excluded_field.attribute_name]],
+                                         ["People", %w[assignee]]]
+          owner_type.custom_field_ids = [kept_field.id, excluded_field.id]
+          owner_type.save!
+        end
+      end
+
+      shared_let(:kept_field) { create(:issue_custom_field, :integer, name: "Kept", is_for_all: true) }
+      shared_let(:excluded_field) { create(:issue_custom_field, :integer, name: "Dropped", is_for_all: true) }
+
+      def own_groups
+        type.reload.read_attribute(:attribute_groups).to_h { |key, members| [key.to_s, members] }
+      end
+
+      it "leaves out what the type's own link excluded", :aggregate_failures do
+        create(:type_configuration_link, type:, source: owner, aspect:,
+                                         excluded_elements: [excluded_field.attribute_name, "assignee"])
+
+        result = service.call(mode: WorkPackageTypes::IndependentMode::COPY)
+
+        expect(result).to be_success
+        expect(type.reload).not_to be_linked(aspect)
+        expect(own_groups.keys).to contain_exactly("Numbers")
+        expect(own_groups["Numbers"]).to eq([kept_field.attribute_name])
+        expect(type.custom_field_ids).to contain_exactly(kept_field.id)
+      end
+
+      it "leaves out what an ancestor's link excluded, which the type could not see either" do
+        middle = create(:type)
+        create(:type_configuration_link, type: middle, source: owner, aspect:,
+                                         excluded_elements: [excluded_field.attribute_name])
+        create(:type_configuration_link, type:, source: middle, aspect:)
+
+        result = service.call(mode: WorkPackageTypes::IndependentMode::COPY)
+
+        expect(result).to be_success
+        expect(own_groups["Numbers"]).to eq([kept_field.attribute_name])
+      end
+    end
+
     context "with the empty mode (patterns)" do
       let(:aspect) { Type::ConfigurationLink::DEFAULTS }
 


### PR DESCRIPTION
Build the UI for https://github.com/opf/openproject/pull/24468 to allow disabling certain attributes or queries within a linked type.

When the chain of type configurations links is > 1, so for example:

```
Bug
  Mobile Bug
     Special Bug
```

and all inherit the previous form configuration, Mobile Bug MAY already have disabled certain attributes. The CTE from the base PR already inherits them correctly. Visually, I've decided to keep the attribute, but disable them rather than hiding. This allows us to add a label to it: 

<img width="2700" height="840" alt="2026-07-29_15-59-51@2x" src="https://github.com/user-attachments/assets/d42c7d37-39a9-4a1e-a497-f5101f045a6c" />

https://community.openproject.org/projects/FND/work_packages/FND-192/activity

Also adds a spec for, and finalizes https://community.openproject.org/work_packages/FND-193

Part of, but does not finish: https://community.openproject.org/projects/FND/work_packages/FND-183/activity