### PR TITLE
[FND-148] Make types index page action menus async

### DIFF
--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -47,16 +47,12 @@ See COPYRIGHT and LICENSE files for more details.
               <% end %>
             <% end %>
             <% add_default_label(header, root) %>
-            <% header.with_menu do |menu| %>
-              <% type_actions(menu, root) %>
-            <% end %>
+            <% header.with_menu(menu_id: menu_id(root), src: menu_src(root)) %>
           <% end %>
 
           <% root.sorted_variants.each do |child| %>
             <% list.with_item do |item| %>
-              <% item.with_menu do |menu| %>
-                <% type_actions(menu, child) %>
-              <% end %>
+              <% item.with_menu(menu_id: menu_id(child), src: menu_src(child)) %>
               <%= flex_layout(align_items: :center, justify_content: :space_between) do |variant| %>
                 <% variant.with_column(display: :inline_flex, align_items: :center) do %>
                   <%= render(

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -73,112 +73,16 @@ module WorkPackageTypes
         new_creation_wizard_types_path(parent_id: root.id)
       end
 
-      def type_actions(menu, type)
-        configure_action(menu, type)
-        default_action(menu, type)
-        menu.with_divider
-
-        add_variant_action(menu, type) unless type.variant?
-        duplicate_action(menu, type)
-        menu.with_divider
-
-        if reorderable?(type)
-          move_action(menu, type)
-          menu.with_divider
-        end
-
-        delete_action(menu, type)
+      def menu_id(type)
+        TypeActionsComponent.menu_id(type)
       end
 
-      def add_variant_action(menu, type)
-        menu.with_item(label: t("types.index.add_variant_action"), href: add_variant_path(type)) do |item|
-          item.with_leading_visual_icon(icon: :plus)
-        end
-      end
-
-      def duplicate_action(menu, type)
-        menu.with_item(
-          label: t(:button_duplicate),
-          href: duplicate_type_path(type),
-          form_arguments: { method: :post }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :duplicate)
-        end
-      end
-
-      def configure_action(menu, type)
-        menu.with_item(label: t(:button_configure), href: edit_type_details_path(type_id: type.id)) do |item|
-          item.with_leading_visual_icon(icon: :gear)
-        end
-      end
-
-      def default_action(menu, type)
-        if type.is_default?
-          remove_default_action(menu, type)
-        else
-          make_default_action(menu, type)
-        end
-      end
-
-      def make_default_action(menu, type)
-        menu.with_item(
-          label: t("types.index.make_default"),
-          href: make_default_type_path(type),
-          form_arguments: { method: :post }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :"check-circle")
-        end
-      end
-
-      def remove_default_action(menu, type)
-        menu.with_item(
-          label: t("types.index.remove_default"),
-          href: remove_default_type_path(type),
-          form_arguments: { method: :post }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :"circle-slash")
-        end
-      end
-
-      def delete_action(menu, type)
-        menu.with_item(
-          label: t(:button_delete),
-          scheme: :danger,
-          href: type_path(type),
-          form_arguments: { method: :delete, data: { turbo_confirm: t(:text_are_you_sure) } }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :trash)
-        end
+      def menu_src(type)
+        menu_type_path(type)
       end
 
       def reorderable?(type)
         !type.variant? && !(type.first? && type.last?)
-      end
-
-      def move_action(menu, type)
-        menu.with_sub_menu_item(label: t(:button_move)) do |submenu|
-          submenu.with_leading_visual_icon(icon: :"op-arrow-in")
-
-          unless type.first?
-            move_item(submenu, type, :highest, t(:label_sort_highest), "move-to-top")
-            move_item(submenu, type, :higher, t(:label_sort_higher), "chevron-up")
-          end
-
-          unless type.last?
-            move_item(submenu, type, :lower, t(:label_sort_lower), "chevron-down")
-            move_item(submenu, type, :lowest, t(:label_sort_lowest), "move-to-bottom")
-          end
-        end
-      end
-
-      def move_item(submenu, type, move_to, label, icon)
-        submenu.with_item(
-          label:,
-          href: helpers.url_for(action: :move, id: type.id, type: { move_to: }),
-          form_arguments: { method: :post }
-        ) do |item|
-          item.with_leading_visual_icon(icon:)
-        end
       end
 
       def drop_target_config

--- a/app/components/work_package_types/types/type_actions_component.html.erb
+++ b/app/components/work_package_types/types/type_actions_component.html.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(Primer::Alpha::ActionMenu::List.new(menu_id:)) do |menu| %>
+  <% type_actions(menu) %>
+<% end %>

--- a/app/components/work_package_types/types/type_actions_component.rb
+++ b/app/components/work_package_types/types/type_actions_component.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module Types
+    class TypeActionsComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+
+      def self.menu_id(type)
+        "type-#{type.id}-action-menu"
+      end
+
+      def initialize(type:)
+        super()
+
+        @type = type
+      end
+
+      def menu_id
+        self.class.menu_id(type)
+      end
+
+      private
+
+      attr_reader :type
+
+      def type_actions(menu)
+        configure_action(menu)
+        default_action(menu)
+        menu.with_divider
+
+        add_variant_action(menu) unless type.variant?
+        duplicate_action(menu)
+        menu.with_divider
+
+        if reorderable?
+          move_action(menu)
+          menu.with_divider
+        end
+
+        delete_action(menu)
+      end
+
+      def add_variant_action(menu)
+        menu.with_item(label: t("types.index.add_variant_action"),
+                       href: new_creation_wizard_types_path(parent_id: type.id)) do |item|
+          item.with_leading_visual_icon(icon: :plus)
+        end
+      end
+
+      def duplicate_action(menu)
+        menu.with_item(
+          label: t(:button_duplicate),
+          href: duplicate_type_path(type),
+          form_arguments: { method: :post }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :duplicate)
+        end
+      end
+
+      def configure_action(menu)
+        menu.with_item(label: t(:button_configure), href: edit_type_details_path(type_id: type.id)) do |item|
+          item.with_leading_visual_icon(icon: :gear)
+        end
+      end
+
+      def default_action(menu)
+        if type.is_default?
+          remove_default_action(menu)
+        else
+          make_default_action(menu)
+        end
+      end
+
+      def make_default_action(menu)
+        menu.with_item(
+          label: t("types.index.make_default"),
+          href: make_default_type_path(type),
+          form_arguments: { method: :post }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :"check-circle")
+        end
+      end
+
+      def remove_default_action(menu)
+        menu.with_item(
+          label: t("types.index.remove_default"),
+          href: remove_default_type_path(type),
+          form_arguments: { method: :post }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :"circle-slash")
+        end
+      end
+
+      def delete_action(menu)
+        menu.with_item(
+          label: t(:button_delete),
+          scheme: :danger,
+          href: type_path(type),
+          form_arguments: { method: :delete, data: { turbo_confirm: t(:text_are_you_sure) } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :trash)
+        end
+      end
+
+      def reorderable?
+        !type.variant? && !(type.first? && type.last?)
+      end
+
+      def move_action(menu)
+        menu.with_item(
+          component_klass: Primer::Alpha::ActionMenu::SubMenuItem,
+          label: t(:button_move),
+          select_variant: :none,
+          form_arguments: {}
+        ) do |submenu|
+          submenu.with_leading_visual_icon(icon: :"op-arrow-in")
+
+          unless type.first?
+            move_item(submenu, :highest, t(:label_sort_highest), "move-to-top")
+            move_item(submenu, :higher, t(:label_sort_higher), "chevron-up")
+          end
+
+          unless type.last?
+            move_item(submenu, :lower, t(:label_sort_lower), "chevron-down")
+            move_item(submenu, :lowest, t(:label_sort_lowest), "move-to-bottom")
+          end
+        end
+      end
+
+      def move_item(submenu, move_to, label, icon)
+        submenu.with_item(
+          label:,
+          href: move_types_path(type, type: { move_to: }),
+          form_arguments: { method: :post }
+        ) do |item|
+          item.with_leading_visual_icon(icon:)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/work_package_types/types_controller.rb
+++ b/app/controllers/work_package_types/types_controller.rb
@@ -37,8 +37,8 @@ module WorkPackageTypes
     layout "admin"
 
     before_action :require_admin
-    before_action :require_type_variants_feature, only: %i[drop duplicate]
-    before_action :find_type, only: %i[move destroy drop make_default remove_default duplicate]
+    before_action :require_type_variants_feature, only: %i[drop duplicate menu]
+    before_action :find_type, only: %i[move destroy drop make_default remove_default duplicate menu]
 
     current_menu_item do
       :types
@@ -143,6 +143,10 @@ module WorkPackageTypes
 
       update_via_turbo_stream(component: Types::GroupedListComponent.new(types: root_types))
       respond_to_with_turbo_streams
+    end
+
+    def menu
+      render Types::TypeActionsComponent.new(type: @type), layout: false
     end
 
     protected

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,13 +237,14 @@ Rails.application.routes.draw do
     end
 
     collection do
-      post "move/:id", action: "move"
+      post "move/:id", action: "move", as: :move
       get "creation_wizard/new", to: "creation_wizard#new", as: :new_creation_wizard
       post "creation_wizard", to: "creation_wizard#create", as: :creation_wizard
       get :workflow_summary, to: "/workflows/summaries#show"
     end
 
     member do
+      get :menu
       put :drop
       post :make_default
       post :remove_default

--- a/spec/components/work_package_types/types/type_actions_component_spec.rb
+++ b/spec/components/work_package_types/types/type_actions_component_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::Types::TypeActionsComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:root_type) { create(:type, name: "Bug") }
+  shared_let(:sibling_type) { create(:type, name: "Feature") }
+  shared_let(:variant_type) { create(:type, name: "Alpha variant", parent: root_type) }
+
+  current_user { create(:admin) }
+
+  describe "menu items" do
+    context "for a root type" do
+      subject(:rendered_component) { render_inline(described_class.new(type: root_type)) }
+
+      it "offers configure, make default, add variant, duplicate, move and delete", :aggregate_failures do
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_configure) do |item|
+          expect(item[:href]).to eq edit_type_details_path(type_id: root_type.id)
+        end
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t("types.index.make_default")
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t("types.index.add_variant_action")
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_duplicate)
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_move)
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_delete)
+      end
+    end
+
+    context "for a variant" do
+      subject(:rendered_component) { render_inline(described_class.new(type: variant_type)) }
+
+      it "omits add variant and move but keeps configure, duplicate and delete", :aggregate_failures do
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_configure)
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_duplicate)
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t(:button_delete)
+        expect(rendered_component).to have_no_selector :menuitem, text: I18n.t("types.index.add_variant_action")
+        expect(rendered_component).to have_no_selector :menuitem, text: I18n.t(:button_move)
+      end
+    end
+
+    context "when the type is the current default" do
+      subject(:rendered_component) { render_inline(described_class.new(type: root_type)) }
+
+      before { allow(root_type).to receive(:is_default?).and_return(true) }
+
+      it "offers removing the default instead of setting it", :aggregate_failures do
+        expect(rendered_component).to have_selector :menuitem, text: I18n.t("types.index.remove_default")
+        expect(rendered_component).to have_no_selector :menuitem, text: I18n.t("types.index.make_default")
+      end
+    end
+
+    context "when there is only one root" do
+      subject(:rendered_component) { render_inline(described_class.new(type: root_type)) }
+
+      before { allow(root_type).to receive_messages(first?: true, last?: true) }
+
+      it "omits move" do
+        expect(rendered_component).to have_no_selector :menuitem, text: I18n.t(:button_move)
+      end
+    end
+  end
+end

--- a/spec/features/types/variants_index_spec.rb
+++ b/spec/features/types/variants_index_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
   shared_let(:bug_type) { create(:type, name: "Bug") }
   shared_let(:feature_type) { create(:type, name: "Feature") }
   shared_let(:zeta_variant) { create(:type, name: "Zeta variant", parent: bug_type) }
-  shared_let(:alfa_variant) { create(:type, name: "Alfa variant", parent: bug_type) }
+  shared_let(:alfa_variant) { create(:type, name: "Alpha variant", parent: bug_type) }
 
   before { login_as(admin) }
 
@@ -59,18 +59,21 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
   end
 
   it "offers 'Move' only on roots, while both roots and variants can be configured and deleted" do
-    visit types_path
+    visit types_path(expand: bug_type.id)
 
     within("[data-draggable-id='#{bug_type.id}'] .Box-header") do
-      expect(page).to have_link(I18n.t(:button_configure), visible: :all)
-      expect(page).to have_button(I18n.t(:button_move), visible: :all)
-      expect(page).to have_button(I18n.t(:button_delete), visible: :all)
+      find("action-menu > button").click
+      expect(page).to have_link(I18n.t(:button_configure))
+      expect(page).to have_button(I18n.t(:button_move))
+      expect(page).to have_button(I18n.t(:button_delete))
     end
+    find("body").send_keys :escape
 
-    within(".Box-row", text: alfa_variant.own_name, visible: :all) do
-      expect(page).to have_link(I18n.t(:button_configure), visible: :all)
-      expect(page).to have_button(I18n.t(:button_delete), visible: :all)
-      expect(page).to have_no_button(I18n.t(:button_move), visible: :all)
+    within(".Box-row", text: alfa_variant.own_name) do
+      find("action-menu > button").click
+      expect(page).to have_link(I18n.t(:button_configure))
+      expect(page).to have_button(I18n.t(:button_delete))
+      expect(page).to have_no_button(I18n.t(:button_move))
     end
   end
 
@@ -127,21 +130,26 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
   it "offers activating on every type and variant, and deactivating on the current default" do
     alfa_variant.update!(is_default: true)
 
-    visit types_path
+    visit types_path(expand: bug_type.id)
 
     within("[data-draggable-id='#{bug_type.id}'] .Box-header") do
-      expect(page).to have_button(I18n.t("types.index.make_default"), visible: :all)
-      expect(page).to have_no_button(I18n.t("types.index.remove_default"), visible: :all)
+      find("action-menu > button").click
+      expect(page).to have_button(I18n.t("types.index.make_default"))
+      expect(page).to have_no_button(I18n.t("types.index.remove_default"))
     end
+    find("body").send_keys :escape
 
-    within(".Box-row", text: zeta_variant.own_name, visible: :all) do
-      expect(page).to have_button(I18n.t("types.index.make_default"), visible: :all)
-      expect(page).to have_no_button(I18n.t("types.index.remove_default"), visible: :all)
+    within(".Box-row", text: zeta_variant.own_name) do
+      find("action-menu > button").click
+      expect(page).to have_button(I18n.t("types.index.make_default"))
+      expect(page).to have_no_button(I18n.t("types.index.remove_default"))
     end
+    find("body").send_keys :escape
 
-    within(".Box-row", text: alfa_variant.own_name, visible: :all) do
-      expect(page).to have_button(I18n.t("types.index.remove_default"), visible: :all)
-      expect(page).to have_no_button(I18n.t("types.index.make_default"), visible: :all)
+    within(".Box-row", text: alfa_variant.own_name) do
+      find("action-menu > button").click
+      expect(page).to have_button(I18n.t("types.index.remove_default"))
+      expect(page).to have_no_button(I18n.t("types.index.make_default"))
     end
   end
 
@@ -225,18 +233,20 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
   end
 
   it "offers 'Add variant' only on roots, linking to the creation wizard for that root" do
-    visit types_path
+    visit types_path(expand: bug_type.id)
 
     within("[data-draggable-id='#{bug_type.id}'] .Box-header") do
+      find("action-menu > button").click
       expect(page).to have_link(
         I18n.t("types.index.add_variant_action"),
-        href: new_creation_wizard_types_path(parent_id: bug_type.id),
-        visible: :all
+        href: new_creation_wizard_types_path(parent_id: bug_type.id)
       )
     end
+    find("body").send_keys :escape
 
-    within(".Box-row", text: alfa_variant.own_name, visible: :all) do
-      expect(page).to have_no_link(I18n.t("types.index.add_variant_action"), visible: :all)
+    within(".Box-row", text: alfa_variant.own_name) do
+      find("action-menu > button").click
+      expect(page).to have_no_link(I18n.t("types.index.add_variant_action"))
     end
   end
 
@@ -254,14 +264,17 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
   end
 
   it "offers 'Duplicate' on both roots and variants" do
-    visit types_path
+    visit types_path(expand: bug_type.id)
 
     within("[data-draggable-id='#{bug_type.id}'] .Box-header") do
-      expect(page).to have_button(I18n.t(:button_duplicate), visible: :all)
+      find("action-menu > button").click
+      expect(page).to have_button(I18n.t(:button_duplicate))
     end
+    find("body").send_keys :escape
 
-    within(".Box-row", text: alfa_variant.own_name, visible: :all) do
-      expect(page).to have_button(I18n.t(:button_duplicate), visible: :all)
+    within(".Box-row", text: alfa_variant.own_name) do
+      find("action-menu > button").click
+      expect(page).to have_button(I18n.t(:button_duplicate))
     end
   end
 
@@ -276,5 +289,20 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
     drag_n_drop_element(from: drag_handle, to: target)
 
     wait_for { feature_type.reload.position }.to be < bug_type.reload.position
+  end
+
+  it "reorders a root type via the async 'Move' submenu" do
+    visit types_path
+
+    expect(bug_type.position).to be < feature_type.position
+
+    within("[data-draggable-id='#{feature_type.id}'] .Box-header") do
+      find("action-menu > button").click
+      click_on I18n.t(:button_move)
+      click_on I18n.t(:label_sort_highest)
+    end
+
+    expect(page).to have_text(I18n.t(:notice_successful_update))
+    expect(feature_type.reload.position).to be < bug_type.reload.position
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/FND-148

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
I copied what already seems to work for backlogs for the async submenus: https://github.com/opf/openproject/blob/dev/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb#L107-L119

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
