### PR TITLE
[AGILE-358] Work packages are shuffled when dragging a work package to its original position

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -207,6 +207,14 @@ describe('Sortable lists controller', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
+    // The synthetic drop input below carries fixed coordinates that bear no
+    // relation to where the fixture's rows actually lay out, so a real
+    // hit-test would report the source's own row for every drop and the
+    // "released over the source row" guard would swallow them all. Report
+    // nothing under the pointer by default; the tests that exercise that
+    // guard mock their own element stack.
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([]);
+
     fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 200 })));
     renderStreamMessageMock = vi.fn(() => Promise.resolve());
     vi.stubGlobal('fetch', fetchMock);
@@ -275,6 +283,75 @@ describe('Sortable lists controller', () => {
 
     expect(itemIds(sourceList)).toEqual(['1', '2', '3']);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a list-only drop released over the source row itself', async () => {
+    const { sourceList } = renderFixture();
+    // A middle item: neither list boundary the configured drop position
+    // would resolve to, so a real (wrong) move would be observable if the
+    // guard that ignores a drop still over the source's own row failed to
+    // short-circuit it.
+    const middleSourceItem = sourceList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="2"]')!;
+
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([middleSourceItem]);
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(middleSourceItem, sourceList);
+
+    expect(itemIds(sourceList)).toEqual(['1', '2', '3']);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still appends the first item dropped over its own list background', async () => {
+    const { sourceList, firstSourceItem } = renderFixture();
+    // Releasing the first row over the list's empty space below the last
+    // row hit-tests to the rows container, not an item row. Descending
+    // into the container would resolve its first item -- the dragged row
+    // itself -- and wrongly swallow a genuine send-to-bottom as a drop
+    // back onto the source row.
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([sourceList]);
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, sourceList);
+
+    expect(itemIds(sourceList)).toEqual(['2', '3', '1']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sees past Pragmatic\'s honey-pot overlay to the source row underneath it', async () => {
+    const { sourceList } = renderFixture();
+    // A native drag can leave Pragmatic's own tracking overlay as the
+    // topmost element at the pointer; a raw hit-test that trusts it as-is
+    // would miss the source row underneath and wrongly move the item.
+    const middleSourceItem = sourceList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="2"]')!;
+    const honeyPot = document.createElement('div');
+    honeyPot.setAttribute('data-pdnd-honey-pot', 'true');
+
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([honeyPot, middleSourceItem]);
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(middleSourceItem, sourceList);
+
+    expect(itemIds(sourceList)).toEqual(['1', '2', '3']);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('moves a work package into an empty list despite its blankslate placeholder', async () => {
+    const { targetList, firstSourceItem } = renderFixture();
+    targetList.innerHTML = '';
+    const blankslate = document.createElement('li');
+    blankslate.setAttribute('data-empty-list-item', 'true');
+    targetList.append(blankslate);
+    // The element under the pointer at drop is the blankslate placeholder,
+    // not an item -- this must not be confused with dropping back onto the
+    // source's own row.
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([blankslate]);
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    expect(itemIds(targetList)).toEqual(['1']);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it('ignores drops that belong to another sortable lists root', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -247,7 +247,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       sourceData: source.data,
     });
     if (!intent) {
-      debugLog('sortable-lists: ignoring drop, it did not resolve to a move (dropped outside a list)');
+      debugLog('sortable-lists: ignoring drop, it did not resolve to a move');
       return;
     }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -30,8 +30,17 @@ import {
   type Edge,
   extractClosestEdge,
 } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+// Pragmatic drives native drag/drop through an invisible, pointer-tracking
+// overlay (a "honey pot") that works around a real cross-browser bug:
+// browsers incorrectly keep native "hover" active at the drag's start
+// position for its whole duration. A raw document.elementsFromPoint can
+// resolve to that overlay instead of the element actually under the
+// pointer; this helper reads past it the same way Pragmatic's own target
+// resolution (lifecycle-manager) does.
+import { getElementFromPointWithoutHoneypot } from '@atlaskit/pragmatic-drag-and-drop/private/get-element-from-point-without-honey-pot';
 import { type DragLocationHistory } from '@atlaskit/pragmatic-drag-and-drop/types';
 import {
+  resolveClosestItemElement,
   resolveItemElement,
   resolveItemId,
   resolveListAppendPreviousItemId,
@@ -266,6 +275,28 @@ export function resolveDropIntent({
   const listElement = targetList.element;
   const listData = targetList.data;
   const rowsContainer = listData.rowsContainer ?? listElement;
+
+  // An item never accepts itself as a drop target (see ItemController's
+  // canDrop: source.data.itemId !== this.idValue), so a drag that is
+  // released without ever leaving its own row resolves no item target here,
+  // exactly like a genuine drop on the list's background. Tell the two
+  // apart by asking what is actually under the pointer: if it is still the
+  // source's own row, nothing has moved and there is no signal to act on.
+  // Unlike the null for a drop outside the root above, this null rejects a
+  // drop the root does own; it must stay behind the target resolution so a
+  // background drop keeps resolving. Only an ancestor of the hit-tested
+  // element can be "the row under the pointer" -- descending into a
+  // container would resolve its first item and swallow that item's genuine
+  // list-only drops (a send-to-bottom of the first row).
+  if (!targetItem) {
+    const { input } = location.current;
+    const elementAtPoint = getElementFromPointWithoutHoneypot({ x: input.clientX, y: input.clientY });
+    const itemAtPoint = elementAtPoint ? resolveClosestItemElement(elementAtPoint) : null;
+
+    if (itemAtPoint && root.contains(itemAtPoint) && resolveItemId(itemAtPoint) === sourceData.itemId) {
+      return null;
+    }
+  }
 
   const previousItemId = targetItem
     ? resolvePreviousSortableItemId({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -124,24 +124,24 @@ export function resolveListAppendPreviousItemId({
 
 export interface RowPlacement {
   row:HTMLElement;
-  parent:Node|null;
-  nextSibling:Node|null;
+  parent:HTMLElement|null;
+  nextElementSibling:Element|null;
 }
 
 // Snapshot each row's current location so an optimistic move can be undone if
 // the server rejects it. Captured before the move; restored in reverse so the
-// stored nextSibling references are still valid when reinserting.
+// stored nextElementSibling references are still valid when reinserting.
 export function captureRowPositions(rows:HTMLElement[]):RowPlacement[] {
   return rows.map((row) => ({
     row,
-    parent: row.parentNode,
-    nextSibling: row.nextSibling,
+    parent: row.parentElement,
+    nextElementSibling: row.nextElementSibling,
   }));
 }
 
 export function restoreRowPositions(positions:RowPlacement[]):void {
   for (let i = positions.length - 1; i >= 0; i -= 1) {
-    const { row, parent, nextSibling } = positions[i];
+    const { row, parent, nextElementSibling } = positions[i];
     // A list-refresh morph can replace the captured parent mid-request; restoring
     // into a detached node would drop the row out of the live DOM until the next
     // reload. Skip it and let the pending refresh reconcile the position.
@@ -149,19 +149,19 @@ export function restoreRowPositions(positions:RowPlacement[]):void {
       continue;
     }
 
-    const insertionPoint = nextSibling?.parentNode === parent ? nextSibling : null;
+    const insertionPoint = nextElementSibling?.parentNode === parent ? nextElementSibling : null;
     parent.insertBefore(row, insertionPoint);
   }
 }
 
 // A rollback may only reinsert rows it still owns: if a concurrent morph
 // removed or repositioned a row after the optimistic move, the morph reflects
-// fresher server state and the rollback must yield. Deliberately strict —
-// any deviation from the captured placement (even a replaced or inserted
-// sibling) counts as foreign ownership.
+// fresher server state and the rollback must yield. The comparison is
+// element-level placement only — a changed parent or element sibling counts
+// as foreign ownership; text and comment nodes are deliberately ignored.
 export function rowsRemainAt(positions:RowPlacement[]):boolean {
-  return positions.every(({ row, parent, nextSibling }) => (
-    row.parentNode === parent && row.nextSibling === nextSibling
+  return positions.every(({ row, parent, nextElementSibling }) => (
+    row.parentElement === parent && row.nextElementSibling === nextElementSibling
   ));
 }
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     )
   end
 
+  it "does not move a middle work package to the top when it is picked up and released" do
+    backlogs_page.visit!
+
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+    )
+
+    backlogs_page.pick_up_and_release_work_package(alpha_wp2)
+
+    backlogs_page.expect_no_backlogs_move_request
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+    )
+  end
+
   context "when the bucket item was morphed by a Turbo update" do
     it "allows dragging the morphed item" do
       backlogs_page.visit!

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -774,7 +774,7 @@ module Pages
     def pick_up_and_release_backlogs_item(source)
       install_backlogs_dnd_probe(source:, target: source, edge: nil)
 
-      scroll_to_element(source)
+      scroll_backlogs_source_into_view(source)
 
       page
         .driver
@@ -812,10 +812,24 @@ module Pages
       expect(drop_summary.fetch("dropTargetTypes")).not_to include("work_package")
     end
 
+    # `block: :nearest` (rather than scroll_to_element's default `:start`)
+    # scrolls the minimum distance needed to bring the row into view, and
+    # does nothing at all if it is already visible, unlike `:start`,
+    # which unconditionally forces the row to the viewport's top edge.
+    # That edge happens to sit inside Pragmatic's auto-scroll trigger zone
+    # (autoScrollForElements): starting the drag right there makes the
+    # (correctly working) auto-scroll feature scroll the list's header
+    # back into view under a stationary pointer, independently of the
+    # drag's own movement, so the drop lands wherever the header
+    # auto-scrolled to, not where the drag aimed.
+    def scroll_backlogs_source_into_view(source)
+      scroll_to_element(source, block: :nearest)
+    end
+
     def selenium_drag_backlogs_item(source:, target:, edge: nil)
       install_backlogs_dnd_probe(source:, target:, edge:)
 
-      scroll_to_element(source)
+      scroll_backlogs_source_into_view(source)
 
       source_rect = source.native.rect
       target_rect = target.native.rect


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-358

# What are you trying to accomplish?
Do not move the dragged work package if the drag operation is a no-op, meaning, the element was dropped back to its original position.

## Screenshots

# What approach did you choose and why?
- [X] Update the `resolveDropIntent` method to ignore any drop actions when the source element lands its original location.
- [X] Use `nextElementSibling` in the `list-dom.ts` in order to avoid matching text nodes.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
