### PR TITLE
[DREAM-786] Extend sortable-lists for admin surfaces and migrate project attributes

### DIFF
--- a/app/components/settings/project_custom_field_sections/custom_field_row_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/custom_field_row_component.html.erb
@@ -3,7 +3,7 @@
     flex_layout(justify_content: :space_between, align_items: :center) do |main_container|
       main_container.with_column(flex_layout: true, align_items: :center) do |content_container|
         content_container.with_column(mr: 2) do
-          render(Primer::OpenProject::DragHandle.new(classes: "handle"))
+          render(Primer::OpenProject::DragHandle.new(classes: "handle", data: { sortable_lists__item_target: "handle" }))
         end
         content_container.with_column(mr: 2) do
           render(

--- a/app/components/settings/project_custom_field_sections/custom_field_row_component.rb
+++ b/app/components/settings/project_custom_field_sections/custom_field_row_component.rb
@@ -45,6 +45,10 @@ module Settings
 
       private
 
+      def wrapper_uniq_by
+        @project_custom_field.id
+      end
+
       def edit_action_item(menu)
         menu.with_item(label: t("label_edit"),
                        href: edit_admin_settings_project_custom_field_path(@project_custom_field),

--- a/app/components/settings/project_custom_field_sections/index_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/index_component.html.erb
@@ -1,10 +1,10 @@
 <%=
   component_wrapper(data: wrapper_data_attributes) do
     if @project_custom_field_sections.any?
-      flex_layout(classes: "dragula-container", data: { "allowed-drop-type": "section" }.merge(drop_target_config)) do |flex|
+      flex_layout(data: sections_list_data) do |flex|
         @project_custom_field_sections.each do |section|
           flex.with_row(
-            data: draggable_item_config(section)
+            data: section_item_data(section)
           ) do
             render(row_component_class.new(project_custom_field_section: section, first_and_last:))
           end

--- a/app/components/settings/project_custom_field_sections/index_component.rb
+++ b/app/components/settings/project_custom_field_sections/index_component.rb
@@ -53,22 +53,37 @@ module Settings
 
       def wrapper_data_attributes
         {
-          controller: "generic-drag-and-drop"
+          controller: "sortable-lists",
+          sortable_lists_move_url_templates_value: move_url_templates.to_json,
+          sortable_lists_sortable_lists__list_outlet: "##{wrapper_key} [data-controller~='sortable-lists--list']",
+          sortable_lists_sortable_lists__item_outlet: "##{wrapper_key} [data-controller~='sortable-lists--item']"
         }
       end
 
-      def drop_target_config
+      # Built from route helpers with a sentinel so relative-URL-root
+      # installations keep working; {id} is expanded client-side.
+      def move_url_templates
+        id_placeholder = "__id__"
         {
-          generic_drag_and_drop_target: "container",
-          "target-allowed-drag-type": "section" # the type of dragged items which are allowed to be dropped in this target
+          section: drop_admin_settings_project_custom_field_section_path(id_placeholder).sub(id_placeholder, "{id}"),
+          custom_field: drop_admin_settings_project_custom_field_path(id_placeholder).sub(id_placeholder, "{id}")
         }
       end
 
-      def draggable_item_config(section)
+      def sections_list_data
         {
-          "draggable-id": section.id,
-          "draggable-type": "section",
-          "drop-url": drop_admin_settings_project_custom_field_section_path(section)
+          controller: "sortable-lists--list",
+          sortable_lists__list_type_value: "section",
+          sortable_lists__list_accepted_type_value: "section"
+        }
+      end
+
+      def section_item_data(section)
+        {
+          controller: "sortable-lists--item",
+          sortable_lists__item_id_value: section.id,
+          sortable_lists__item_type_value: "section",
+          sortable_lists__item_label_value: section.name
         }
       end
     end

--- a/app/components/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/show_component.html.erb
@@ -1,11 +1,11 @@
 <%=
   component_wrapper(class: "op-project-custom-field-section-container", data: { test_selector: "project-custom-field-section-container-#{@project_custom_field_section.id}" }) do
-    render(border_box_container(mt: 3, data: drag_and_drop_target_config)) do |component|
+    render(border_box_container(mt: 3, data: field_list_data)) do |component|
       component.with_header(font_weight: :bold) do
         flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
           section_header_container.with_column(flex_layout: true, align_items: :center) do |content_container|
             content_container.with_column(mr: 2) do
-              render(Primer::OpenProject::DragHandle.new(classes: "handle"))
+              render(Primer::OpenProject::DragHandle.new(classes: "handle", data: { sortable_lists__item_target: "handle" }))
             end
             content_container.with_column do
               render(Primer::Beta::Text.new(font_weight: :bold)) do
@@ -120,7 +120,7 @@
         end
       else
         @ordered_cfs.each_with_index do |cf, index|
-          component.with_row(data: draggable_item_config(cf)) do
+          component.with_row(data: field_item_data(cf)) do
             render(
               custom_field_row_component_class.new(
                 project_custom_field: cf,

--- a/app/components/settings/project_custom_field_sections/show_component.rb
+++ b/app/components/settings/project_custom_field_sections/show_component.rb
@@ -54,20 +54,22 @@ module Settings
         @project_custom_field_section.id
       end
 
-      def drag_and_drop_target_config
+      def field_list_data
         {
-          generic_drag_and_drop_target: "container",
-          "target-container-accessor": ".Box > ul",
-          "target-id": @project_custom_field_section.id,
-          "target-allowed-drag-type": "custom-field"
+          controller: "sortable-lists--list",
+          sortable_lists__list_type_value: "custom_field",
+          sortable_lists__list_accepted_type_value: "custom_field",
+          sortable_lists__list_id_value: @project_custom_field_section.id,
+          sortable_lists__list_name_value: @project_custom_field_section.name
         }
       end
 
-      def draggable_item_config(project_custom_field)
+      def field_item_data(project_custom_field)
         {
-          "draggable-id": project_custom_field.id,
-          "draggable-type": "custom-field",
-          "drop-url": drop_admin_settings_project_custom_field_path(project_custom_field)
+          controller: "sortable-lists--item",
+          sortable_lists__item_id_value: project_custom_field.id,
+          sortable_lists__item_type_value: "custom_field",
+          sortable_lists__item_label_value: project_custom_field.name
         }
       end
 

--- a/app/components/settings/project_custom_field_sections/show_component.rb
+++ b/app/components/settings/project_custom_field_sections/show_component.rb
@@ -60,7 +60,11 @@ module Settings
           sortable_lists__list_type_value: "custom_field",
           sortable_lists__list_accepted_type_value: "custom_field",
           sortable_lists__list_id_value: @project_custom_field_section.id,
-          sortable_lists__list_name_value: @project_custom_field_section.name
+          sortable_lists__list_name_value: @project_custom_field_section.name,
+          # The section's drag preview snapshots the box itself rather than
+          # the browser's native capture of the row wrapper, which paints the
+          # box's top margin and squares off the rounded corners.
+          sortable_lists__item_target: "preview"
         }
       end
 

--- a/app/controllers/admin/settings/project_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/project_custom_field_sections_controller.rb
@@ -95,17 +95,17 @@ module Admin::Settings
     end
 
     def drop
-      call = ::ProjectCustomFieldSections::UpdateService.new(user: current_user, model: @project_custom_field_section).call(
-        position: params[:position].to_i
-      )
+      moved = valid_drop_request? &&
+        @project_custom_field_section.move_after_anchor(drop_params[:prev_id], scope: ProjectCustomFieldSection.all)
 
-      if call.success?
+      if moved
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
+        respond_with_turbo_streams
       else
-        render_section_error_via_turbo_stream(call)
+        render_error_flash_message_via_turbo_stream(message: I18n.t(:error_invalid_list_move_anchor))
+        respond_with_turbo_streams(status: :unprocessable_entity)
       end
-      respond_with_turbo_streams
     end
 
     def new_link
@@ -124,6 +124,26 @@ module Admin::Settings
 
     def set_project_custom_field_section
       @project_custom_field_section = ProjectCustomFieldSection.find(params[:id])
+    end
+
+    # The sortable-lists wire for the one global sections list: the type must
+    # match and no list id may be addressed. prev_id must be present as a
+    # scalar parameter (blank means top): an accidentally omitted anchor
+    # cannot read as a move-to-top request, and a collection-valued id
+    # (prev_id[]=...) cannot reach the anchor lookup as an IN list. The
+    # raw list_id check stays deliberately: permit cannot distinguish an
+    # absent list_id from a filtered-out collection one, and both a
+    # nonblank and a collection value are contract violations here.
+    def valid_drop_request?
+      drop_params[:list_type] == "section" &&
+        params[:list_id].blank? &&
+        drop_params.key?(:prev_id)
+    end
+
+    # permit's scalar filter drops collection-valued parameters, so a
+    # missing and a non-scalar prev_id both fail the key check above.
+    def drop_params
+      @drop_params ||= params.permit(:list_type, :list_id, :prev_id)
     end
 
     def allow_custom_field_creation?

--- a/app/controllers/admin/settings/project_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/project_custom_field_sections_controller.rb
@@ -96,7 +96,7 @@ module Admin::Settings
 
     def drop
       moved = valid_drop_request? &&
-        @project_custom_field_section.move_after_anchor(params[:prev_id], scope: ProjectCustomFieldSection.all)
+        @project_custom_field_section.move_after_anchor(drop_params[:prev_id], scope: ProjectCustomFieldSection.all)
 
       if moved
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
@@ -128,10 +128,22 @@ module Admin::Settings
 
     # The sortable-lists wire for the one global sections list: the type must
     # match and no list id may be addressed. prev_id must be present as a
-    # parameter (blank means top) so an accidentally omitted anchor cannot
-    # read as a move-to-top request.
+    # scalar parameter (blank means top): an accidentally omitted anchor
+    # cannot read as a move-to-top request, and a collection-valued id
+    # (prev_id[]=...) cannot reach the anchor lookup as an IN list. The
+    # raw list_id check stays deliberately: permit cannot distinguish an
+    # absent list_id from a filtered-out collection one, and both a
+    # nonblank and a collection value are contract violations here.
     def valid_drop_request?
-      params[:list_type] == "section" && params[:list_id].blank? && params.key?(:prev_id)
+      drop_params[:list_type] == "section" &&
+        params[:list_id].blank? &&
+        drop_params.key?(:prev_id)
+    end
+
+    # permit's scalar filter drops collection-valued parameters, so a
+    # missing and a non-scalar prev_id both fail the key check above.
+    def drop_params
+      @drop_params ||= params.permit(:list_type, :list_id, :prev_id)
     end
 
     def allow_custom_field_creation?

--- a/app/controllers/admin/settings/project_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/project_custom_field_sections_controller.rb
@@ -95,17 +95,17 @@ module Admin::Settings
     end
 
     def drop
-      call = ::ProjectCustomFieldSections::UpdateService.new(user: current_user, model: @project_custom_field_section).call(
-        position: params[:position].to_i
-      )
+      moved = valid_drop_request? &&
+        @project_custom_field_section.move_after_anchor(params[:prev_id], scope: ProjectCustomFieldSection.all)
 
-      if call.success?
+      if moved
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
+        respond_with_turbo_streams
       else
-        render_section_error_via_turbo_stream(call)
+        render_error_flash_message_via_turbo_stream(message: I18n.t(:error_invalid_list_move_anchor))
+        respond_with_turbo_streams(status: :unprocessable_entity)
       end
-      respond_with_turbo_streams
     end
 
     def new_link
@@ -124,6 +124,14 @@ module Admin::Settings
 
     def set_project_custom_field_section
       @project_custom_field_section = ProjectCustomFieldSection.find(params[:id])
+    end
+
+    # The sortable-lists wire for the one global sections list: the type must
+    # match and no list id may be addressed. prev_id must be present as a
+    # parameter (blank means top) so an accidentally omitted anchor cannot
+    # read as a move-to-top request.
+    def valid_drop_request?
+      params[:list_type] == "section" && params[:list_id].blank? && params.key?(:prev_id)
     end
 
     def allow_custom_field_creation?

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -159,20 +159,20 @@ module Admin::Settings
     end
 
     def drop
+      return render_invalid_drop_request unless valid_drop_request?
+
       result = CustomFields::DropService.new(user: current_user, custom_field: @custom_field).call(
-        target_id: params[:target_id],
-        position: params[:position]
+        list_id: drop_params[:list_id],
+        prev_id: drop_params[:prev_id]
       )
 
       if result.success?
         drop_success_streams(result)
+        respond_with_turbo_streams
       else
-        render_error_flash_message_via_turbo_stream(
-          message: join_flash_messages(result.errors)
-        )
+        render_error_flash_message_via_turbo_stream(message: join_flash_messages(result.errors))
+        respond_with_turbo_streams(status: :unprocessable_entity)
       end
-
-      respond_with_turbo_streams
     end
 
     def destroy
@@ -263,6 +263,26 @@ module Admin::Settings
 
     def find_custom_field
       @custom_field = ProjectCustomField.find(params.expect(:id))
+    end
+
+    # Ids must be scalar strings: a collection-valued list_id would pick an
+    # arbitrary target section out of an IN lookup, and a collection-valued
+    # prev_id would 500 instead of answering the promised 422. permit's
+    # scalar filter drops collection values, so the presence checks below
+    # reject them alongside genuinely missing parameters.
+    def valid_drop_request?
+      drop_params[:list_type] == "custom_field" &&
+        drop_params[:list_id].present? &&
+        drop_params.key?(:prev_id)
+    end
+
+    def drop_params
+      @drop_params ||= params.permit(:list_type, :list_id, :prev_id)
+    end
+
+    def render_invalid_drop_request
+      render_error_flash_message_via_turbo_stream(message: I18n.t(:error_invalid_list_move_anchor))
+      respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
     def drop_success_streams(call)

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -159,20 +159,20 @@ module Admin::Settings
     end
 
     def drop
+      return render_invalid_drop_request unless valid_drop_request?
+
       result = CustomFields::DropService.new(user: current_user, custom_field: @custom_field).call(
-        target_id: params[:target_id],
-        position: params[:position]
+        list_id: params[:list_id],
+        prev_id: params[:prev_id]
       )
 
       if result.success?
         drop_success_streams(result)
+        respond_with_turbo_streams
       else
-        render_error_flash_message_via_turbo_stream(
-          message: join_flash_messages(result.errors)
-        )
+        render_error_flash_message_via_turbo_stream(message: join_flash_messages(result.errors))
+        respond_with_turbo_streams(status: :unprocessable_entity)
       end
-
-      respond_with_turbo_streams
     end
 
     def destroy
@@ -263,6 +263,15 @@ module Admin::Settings
 
     def find_custom_field
       @custom_field = ProjectCustomField.find(params.expect(:id))
+    end
+
+    def valid_drop_request?
+      params[:list_type] == "custom_field" && params[:list_id].present? && params.key?(:prev_id)
+    end
+
+    def render_invalid_drop_request
+      render_error_flash_message_via_turbo_stream(message: I18n.t(:error_invalid_list_move_anchor))
+      respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
     def drop_success_streams(call)

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -162,8 +162,8 @@ module Admin::Settings
       return render_invalid_drop_request unless valid_drop_request?
 
       result = CustomFields::DropService.new(user: current_user, custom_field: @custom_field).call(
-        list_id: params[:list_id],
-        prev_id: params[:prev_id]
+        list_id: drop_params[:list_id],
+        prev_id: drop_params[:prev_id]
       )
 
       if result.success?
@@ -265,8 +265,19 @@ module Admin::Settings
       @custom_field = ProjectCustomField.find(params.expect(:id))
     end
 
+    # Ids must be scalar strings: a collection-valued list_id would pick an
+    # arbitrary target section out of an IN lookup, and a collection-valued
+    # prev_id would 500 instead of answering the promised 422. permit's
+    # scalar filter drops collection values, so the presence checks below
+    # reject them alongside genuinely missing parameters.
     def valid_drop_request?
-      params[:list_type] == "custom_field" && params[:list_id].present? && params.key?(:prev_id)
+      drop_params[:list_type] == "custom_field" &&
+        drop_params[:list_id].present? &&
+        drop_params.key?(:prev_id)
+    end
+
+    def drop_params
+      @drop_params ||= params.permit(:list_type, :list_id, :prev_id)
     end
 
     def render_invalid_drop_request

--- a/app/controllers/concerns/admin/settings/project_custom_fields/component_streams.rb
+++ b/app/controllers/concerns/admin/settings/project_custom_fields/component_streams.rb
@@ -50,7 +50,8 @@ module Admin
                 # a single custom field section, and not a list of sections. Calling first?
                 # and last? method in the component will not result in an N+1 in this case.
                 project_custom_field_section:
-              )
+              ),
+              method: :morph
             )
           end
 
@@ -66,7 +67,8 @@ module Admin
             replace_via_turbo_stream(
               component: ::Settings::ProjectCustomFieldSections::IndexComponent.new(
                 project_custom_field_sections:
-              )
+              ),
+              method: :morph
             )
           end
         end

--- a/app/models/concerns/lists/move_after_anchor.rb
+++ b/app/models/concerns/lists/move_after_anchor.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Lists
+  # Anchor-based reordering for acts_as_list models: moves the record
+  # directly below another record of the same list, addressed by id.
+  module MoveAfterAnchor
+    # Moves the record below the record identified by `prev_id` within
+    # `scope` (a relation over the same acts_as_list list). A blank
+    # `prev_id` moves the record to the top.
+    #
+    # Returns false without mutating when the anchor is unknown, outside
+    # the scope, or the record itself.
+    def move_after_anchor(prev_id, scope:) # rubocop:disable Naming/PredicateMethod -- verb command, not a query
+      if prev_id.blank?
+        move_to_top
+        return true
+      end
+
+      anchor = scope.find_by(id: prev_id)
+      return false if anchor.nil? || anchor.id == id
+
+      # Removing the record first shifts the anchor up by one when the
+      # record currently sits above it, so the target slot differs by
+      # direction of travel.
+      insert_at(position > anchor.position ? anchor.position + 1 : anchor.position)
+      true
+    end
+  end
+end

--- a/app/models/custom_field_section.rb
+++ b/app/models/custom_field_section.rb
@@ -34,6 +34,7 @@ class CustomFieldSection < ApplicationRecord
   DEFAULT_OVERVIEW_KEY = OVERVIEW__SIDEBAR_KEY
 
   acts_as_list scope: [:type]
+  include Lists::MoveAfterAnchor
 
   validates :name, presence: true
 

--- a/app/models/custom_field_section.rb
+++ b/app/models/custom_field_section.rb
@@ -62,6 +62,26 @@ class CustomFieldSection < ApplicationRecord
     update_column(:attribute_order, keys)
   end
 
+  # Insert key directly after prev_key in the ordered list, or at the head
+  # for a blank prev_key. Idempotent for key (any existing occurrence is
+  # removed first). Returns false without mutating when prev_key does not
+  # resolve to another key in the order.
+  def insert_after_key(key, prev_key) # rubocop:disable Naming/PredicateMethod -- verb command, not a query
+    keys = attribute_order.reject { |k| k == key }
+
+    if prev_key.blank?
+      keys.insert(0, key)
+    else
+      idx = keys.index(prev_key)
+      return false if idx.nil?
+
+      keys.insert(idx + 1, key)
+    end
+
+    update_column(:attribute_order, keys)
+    true
+  end
+
   def remove_from_order(key)
     update_column(:attribute_order, attribute_order.reject { |k| k == key })
   end

--- a/app/services/custom_fields/drop_service.rb
+++ b/app/services/custom_fields/drop_service.rb
@@ -38,7 +38,13 @@ module CustomFields
 
     def perform
       service_call = validate_permissions
-      service_call = perform_drop(service_call, params) if service_call.success?
+      if service_call.success?
+        service_call = if params.key?(:prev_id)
+                         perform_anchor_drop(service_call, params)
+                       else
+                         perform_drop(service_call, params)
+                       end
+      end
       service_call
     end
 
@@ -77,6 +83,74 @@ module CustomFields
       @custom_field.update!(custom_field_section_id: current_section.id)
 
       [true, current_section, old_section.reload]
+    end
+
+    # The sortable-lists wire: list_id names the target section, prev_id the
+    # custom field to insert after (blank = top). Anchors are validated
+    # against the target section before any mutation; source and target
+    # section rows are locked in deterministic id order so concurrent
+    # read-modify-write updates of attribute_order cannot lose each other.
+    # The `raise ActiveRecord::Rollback unless moved` guard is defense-in-depth
+    # for the cross-section branch (reparent already applied before the
+    # insert is attempted); `requires_new: true` makes it an effective
+    # savepoint even when nested inside a spec's outer transaction.
+    # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity -- validate, lock, and move is one linear flow
+    def perform_anchor_drop(service_call, params)
+      source_section = @custom_field.custom_field_section
+      target_section = source_section.class.find_by(id: params[:list_id])
+      return invalid_anchor(service_call) if target_section.nil?
+
+      # Keep a single object identity for the same-row case so every read
+      # and write below goes through the one instance that gets `lock!`ed.
+      target_section = source_section if target_section.id == source_section.id
+
+      section_changed = source_section.id != target_section.id
+      moved = false
+
+      CustomField.transaction(requires_new: true) do
+        [source_section, target_section].uniq.sort_by(&:id).each(&:lock!)
+        @custom_field.reload
+
+        prev_key = anchor_key_in(target_section, params[:prev_id])
+        if prev_key != :invalid && @custom_field.custom_field_section_id == source_section.id
+          if section_changed
+            source_section.remove_from_order(@custom_field.column_name)
+            @custom_field.update!(custom_field_section_id: target_section.id)
+          end
+          moved = target_section.insert_after_key(@custom_field.column_name, prev_key)
+        end
+
+        raise ActiveRecord::Rollback unless moved
+      end
+
+      return invalid_anchor(service_call) unless moved
+
+      service_call.success = true
+      service_call.result = {
+        section_changed:,
+        current_section: target_section.reload,
+        old_section: section_changed ? source_section.reload : nil
+      }
+      service_call
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+
+    # nil anchors the top; :invalid rejects the move. A valid anchor is a
+    # different custom field already ordered in the target section.
+    def anchor_key_in(target_section, prev_id)
+      return nil if prev_id.blank?
+      return :invalid if prev_id.to_i == @custom_field.id
+
+      anchor = target_section.custom_fields.find_by(id: prev_id)
+      return :invalid if anchor.nil? || target_section.attribute_order.exclude?(anchor.column_name)
+
+      anchor.column_name
+    end
+
+    def invalid_anchor(service_call)
+      service_call.success = false
+      service_call.errors = I18n.t(:error_invalid_list_move_anchor)
+      service_call
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2611,6 +2611,7 @@ en:
   error_failed_to_delete_entry: "Failed to delete this entry."
   error_in_dependent: "Error attempting to alter dependent object: %{dependent_class} #%{related_id} - %{related_subject}: %{error}"
   error_in_new_dependent: "Error attempting to create dependent object: %{dependent_class} - %{related_subject}: %{error}"
+  error_invalid_list_move_anchor: "The item cannot be moved to the requested position. Please reload the page and try again."
   error_invalid_selected_value: "Invalid selected value."
   error_journal_attribute_not_present: "Journal does not contain attribute %{attribute}."
   error_menu_item_not_created: Menu item could not be added

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2609,6 +2609,7 @@ en:
   error_failed_to_delete_entry: "Failed to delete this entry."
   error_in_dependent: "Error attempting to alter dependent object: %{dependent_class} #%{related_id} - %{related_subject}: %{error}"
   error_in_new_dependent: "Error attempting to create dependent object: %{dependent_class} - %{related_subject}: %{error}"
+  error_invalid_list_move_anchor: "The item cannot be moved to the requested position. Please reload the page and try again."
   error_invalid_selected_value: "Invalid selected value."
   error_journal_attribute_not_present: "Journal does not contain attribute %{attribute}."
   error_menu_item_not_created: Menu item could not be added

--- a/frontend/src/global_styles/content/drag_and_drop.sass
+++ b/frontend/src/global_styles/content/drag_and_drop.sass
@@ -36,3 +36,12 @@
   @include d_n_d--preview
   // Allow dragged items to appear before modals
   z-index: 10000 !important
+
+// Primer's DragHandle ships `cursor: move`; grab/grabbing signals dragging
+// better. Only the press is stylable — once the native drag is under way the
+// browser owns the cursor.
+.DragHandle[data-sortable-lists--item-target~="handle"]
+  cursor: grab
+
+  &:active
+    cursor: grabbing

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -118,12 +118,14 @@ describe('Sortable lists controller', () => {
 
   function renderFixture({
     moveUrlTemplate = '/move/{id}',
-  }:{ moveUrlTemplate?:string|null } = {}) {
+    optimistic = false,
+  }:{ moveUrlTemplate?:string|null; optimistic?:boolean } = {}) {
     fixture.innerHTML = `
       <div
         id="sortable-root"
         data-controller="sortable-lists"
         ${moveUrlTemplate ? `data-sortable-lists-move-url-template-value="${moveUrlTemplate}"` : ''}
+        ${optimistic ? 'data-sortable-lists-optimistic-value="true"' : ''}
         data-sortable-lists-sortable-lists--list-outlet="#sortable-root [data-controller~='sortable-lists--list']"
         data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
         data-sortable-lists-sortable-lists--scrollable-outlet="#sortable-root [data-controller~='sortable-lists--scrollable']"
@@ -537,6 +539,7 @@ describe('Sortable lists controller', () => {
   it('builds the move URL from the controller URI template', async () => {
     const { targetList, firstSourceItem } = renderFixture({
       moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+      optimistic: true,
     });
 
     await ctx.nextFrame();
@@ -551,6 +554,32 @@ describe('Sortable lists controller', () => {
   it('flags the move request as optimistic', async () => {
     const { targetList, firstSourceItem } = renderFixture({
       moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+      optimistic: true,
+    });
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    const calledUrl = fetchMock.mock.lastCall?.[0] as string;
+    expect(new URL(calledUrl, 'http://localhost').searchParams.get('optimistic')).toBe('true');
+  });
+
+  it('omits the optimistic flag by default', async () => {
+    const { targetList, firstSourceItem } = renderFixture({
+      moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+    });
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    const calledUrl = fetchMock.mock.lastCall?.[0] as string;
+    expect(new URL(calledUrl, 'http://localhost').searchParams.has('optimistic')).toBe(false);
+  });
+
+  it('appends optimistic=true when the root opts in', async () => {
+    const { targetList, firstSourceItem } = renderFixture({
+      moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+      optimistic: true,
     });
 
     await ctx.nextFrame();
@@ -570,6 +599,7 @@ describe('Sortable lists controller', () => {
         src="/projects/demo/backlogs/backlog?bucket_ids%5B%5D=1&bucket_ids%5B%5D=inbox&sprint_ids%5B%5D=2"
         data-controller="sortable-lists"
         data-sortable-lists-move-url-template-value="/projects/demo/backlogs/work_packages/{id}/move"
+        data-sortable-lists-optimistic-value="true"
         data-sortable-lists-sortable-lists--list-outlet="#backlogs-list [data-controller~='sortable-lists--list']"
         data-sortable-lists-sortable-lists--item-outlet="#backlogs-list [data-controller~='sortable-lists--item']"
       >

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -143,13 +143,13 @@ describe('Sortable lists controller', () => {
     };
   }
 
-  async function dropCurrentItemOnList(sourceElement:HTMLElement, list:HTMLElement) {
+  async function dropCurrentItemOnList(sourceElement:HTMLElement, list:HTMLElement, type = 'work_package') {
     const monitorOptions = vi.mocked(monitorForElements).mock.lastCall?.[0];
 
     monitorOptions?.onDrop?.({
       source: sourcePayload(
         sourceElement,
-        itemData(sourceElement.getAttribute('data-sortable-lists--item-id-value')!),
+        itemData(sourceElement.getAttribute('data-sortable-lists--item-id-value')!, type),
       ),
       location: {
         initial: {
@@ -218,6 +218,41 @@ describe('Sortable lists controller', () => {
     row.setAttribute('data-sortable-lists--item-type-value', 'custom_field');
     row.setAttribute('data-sortable-lists--item-label-value', `Field ${id}`);
     return row;
+  }
+
+  function sectionRow(id:string):HTMLLIElement {
+    const row = document.createElement('li');
+    row.setAttribute('data-controller', 'sortable-lists--item');
+    row.setAttribute('data-sortable-lists--item-id-value', id);
+    row.setAttribute('data-sortable-lists--item-type-value', 'section');
+    row.setAttribute('data-sortable-lists--item-label-value', `Section ${id}`);
+    return row;
+  }
+
+  // A root serving two item types (sections and custom fields) with distinct
+  // move endpoints, each type's items living in their own list.
+  function renderTypeMapFixture({
+    moveUrlTemplates = '{"section":"/sections/{id}/drop","custom_field":"/fields/{id}/drop"}',
+    moveUrlTemplate,
+  }:{ moveUrlTemplates?:string|null; moveUrlTemplate?:string } = {}) {
+    fixture.innerHTML = `
+      <div
+        id="sortable-root"
+        data-controller="sortable-lists"
+        ${moveUrlTemplates ? `data-sortable-lists-move-url-templates-value='${moveUrlTemplates}'` : ''}
+        ${moveUrlTemplate ? `data-sortable-lists-move-url-template-value="${moveUrlTemplate}"` : ''}
+        data-sortable-lists-sortable-lists--list-outlet="#sortable-root [data-controller~='sortable-lists--list']"
+        data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
+      >
+        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="custom_field" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="custom_field" data-sortable-lists--list-name-value="Fields"></ul>
+        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="section" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="section" data-sortable-lists--list-name-value="Sections"></ul>
+      </div>
+    `;
+    const root = fixture.querySelector<HTMLElement>('#sortable-root')!;
+    const fieldList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="custom_field"]')!;
+    const sectionList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="section"]')!;
+
+    return { root, fieldList, sectionList };
   }
 
   // A nested dual-role topology: the outer list's rows are section items
@@ -1097,6 +1132,69 @@ describe('Sortable lists controller', () => {
       const options = fetchMock.mock.lastCall?.[1] as { body:FormData };
       expect(options.body.get('list_type')).toEqual('section');
       expect(options.body.get('list_id')).toEqual('1');
+    });
+  });
+
+  describe('per-type move URL map', () => {
+    it('resolves the drop move URL from the per-type template map', async () => {
+      const { fieldList, sectionList } = renderTypeMapFixture();
+      fieldList.append(fieldRow('42'), fieldRow('99'));
+      sectionList.append(sectionRow('3'), sectionRow('8'));
+
+      await ctx.nextFrame();
+
+      const fieldItem = fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="42"]')!;
+      await dropCurrentItemOnList(fieldItem, fieldList, 'custom_field');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/fields\/42\/drop/),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+
+      fetchMock.mockClear();
+
+      const sectionItem = sectionList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="3"]')!;
+      await dropCurrentItemOnList(sectionItem, sectionList, 'section');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/sections\/3\/drop/),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    it('falls back to the single template for an unmapped type', async () => {
+      const { fieldList } = renderTypeMapFixture({
+        moveUrlTemplates: '{"section":"/sections/{id}/drop"}',
+        moveUrlTemplate: '/move/{id}',
+      });
+      fieldList.append(fieldRow('7'), fieldRow('8'));
+
+      await ctx.nextFrame();
+
+      const fieldItem = fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="7"]')!;
+      await dropCurrentItemOnList(fieldItem, fieldList, 'custom_field');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/move\/7/),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    it('resolves the menu move URL from the map', async () => {
+      const { root, fieldList } = renderTypeMapFixture();
+      fieldList.append(fieldRow('1'), fieldRow('2'));
+
+      await ctx.nextFrame();
+
+      const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+      const secondFieldItem = fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="2"]')!;
+      controller.moveInDirection(secondFieldItem, 'up');
+      await flushPromises();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/fields\//),
+        expect.objectContaining({ method: 'PUT' }),
+      );
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -204,6 +204,81 @@ describe('Sortable lists controller', () => {
       .map((element) => element.getAttribute('data-sortable-lists--item-id-value')!);
   }
 
+  // Direct-child ids only: a section row can itself host a nested list of its
+  // own items, and querySelectorAll (used by itemIds above) would pick those
+  // up too, muddying assertions about the outer list's own row order.
+  function directItemIds(container:HTMLElement):(string|null)[] {
+    return Array.from(container.children).map((child) => child.getAttribute('data-sortable-lists--item-id-value'));
+  }
+
+  function fieldRow(id:string):HTMLLIElement {
+    const row = document.createElement('li');
+    row.setAttribute('data-controller', 'sortable-lists--item');
+    row.setAttribute('data-sortable-lists--item-id-value', id);
+    row.setAttribute('data-sortable-lists--item-type-value', 'custom_field');
+    row.setAttribute('data-sortable-lists--item-label-value', `Field ${id}`);
+    return row;
+  }
+
+  // A nested dual-role topology: the outer list's rows are section items
+  // (a <div>, not an <li>, hosting their own inner list of custom_field
+  // items). Sections and fields share one root, so a section item is
+  // contained by both the outer list (directly) and, for fields, by the
+  // outer list transitively through the section row.
+  function renderNestedFixture() {
+    fixture.innerHTML = `
+      <div
+        id="sortable-root"
+        data-controller="sortable-lists"
+        data-sortable-lists-move-url-template-value="/move/{id}"
+        data-sortable-lists-sortable-lists--list-outlet="#sortable-root [data-controller~='sortable-lists--list']"
+        data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
+      >
+        <ul
+          data-controller="sortable-lists--list"
+          data-sortable-lists--list-type-value="section"
+          data-sortable-lists--list-id-value="1"
+          data-sortable-lists--list-accepted-type-value="section"
+          data-sortable-lists--list-name-value="Sections"
+        >
+          <div
+            data-controller="sortable-lists--item"
+            data-sortable-lists--item-id-value="s1"
+            data-sortable-lists--item-type-value="section"
+            data-sortable-lists--item-label-value="Section 1"
+          >
+            <ul
+              data-controller="sortable-lists--list"
+              data-sortable-lists--list-type-value="custom_field"
+              data-sortable-lists--list-id-value="s1"
+              data-sortable-lists--list-accepted-type-value="custom_field"
+              data-sortable-lists--list-name-value="Fields"
+            ></ul>
+          </div>
+          <div
+            data-controller="sortable-lists--item"
+            data-sortable-lists--item-id-value="s2"
+            data-sortable-lists--item-type-value="section"
+            data-sortable-lists--item-label-value="Section 2"
+          ></div>
+        </ul>
+      </div>
+    `;
+    const root = fixture.querySelector<HTMLElement>('#sortable-root')!;
+    const sectionList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="section"]')!;
+    const sectionItem = fixture.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="s1"]')!;
+    const fieldList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="custom_field"]')!;
+    fieldList.append(fieldRow('cf1'), fieldRow('cf2'));
+
+    return {
+      root,
+      sectionList,
+      sectionItem,
+      fieldList,
+      firstFieldItem: fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="cf1"]')!,
+    };
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks();
 
@@ -987,5 +1062,41 @@ describe('Sortable lists controller', () => {
 
     expect(controller.ownerListElementOf(firstSourceItem)).toBe(sourceList);
     expect(controller.ownerListElementOf(document.createElement('li'))).toBeNull();
+  });
+
+  describe('nested list topology', () => {
+    it('resolves the source row of a nested item against its innermost list', async () => {
+      const { fieldList, firstFieldItem } = renderNestedFixture();
+
+      await ctx.nextFrame();
+      await dropCurrentItemOnList(firstFieldItem, fieldList);
+
+      // The dragged custom_field item's own row moved within its innermost
+      // (field) list; the outer section row it lives under is untouched.
+      expect(directItemIds(fieldList)).toEqual(['cf2', 'cf1']);
+
+      const options = fetchMock.mock.lastCall?.[1] as { body:FormData };
+      expect(options.body.get('list_type')).toEqual('custom_field');
+      expect(options.body.get('list_id')).toEqual('s1');
+    });
+
+    it('resolves a section row that is not an <li>', async () => {
+      const { sectionList, sectionItem } = renderNestedFixture();
+
+      await ctx.nextFrame();
+      // A list-only drop onto the section list's own default ('end')
+      // position: with two section rows this reorders them, so it is a real
+      // move rather than a same-position no-op.
+      await dropCurrentItemOnList(sectionItem, sectionList);
+
+      // closest('li') on a <div> row returns null and the drop would
+      // silently be ignored; a fired move proves the row resolved.
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(directItemIds(sectionList)).toEqual(['s2', 's1']);
+
+      const options = fetchMock.mock.lastCall?.[1] as { body:FormData };
+      expect(options.body.get('list_type')).toEqual('section');
+      expect(options.body.get('list_id')).toEqual('1');
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -143,13 +143,13 @@ describe('Sortable lists controller', () => {
     };
   }
 
-  async function dropCurrentItemOnList(sourceElement:HTMLElement, list:HTMLElement) {
+  async function dropCurrentItemOnList(sourceElement:HTMLElement, list:HTMLElement, type = 'work_package') {
     const monitorOptions = vi.mocked(monitorForElements).mock.lastCall?.[0];
 
     monitorOptions?.onDrop?.({
       source: sourcePayload(
         sourceElement,
-        itemData(sourceElement.getAttribute('data-sortable-lists--item-id-value')!),
+        itemData(sourceElement.getAttribute('data-sortable-lists--item-id-value')!, type),
       ),
       location: {
         initial: {
@@ -218,6 +218,41 @@ describe('Sortable lists controller', () => {
     row.setAttribute('data-sortable-lists--item-type-value', 'custom_field');
     row.setAttribute('data-sortable-lists--item-label-value', `Field ${id}`);
     return row;
+  }
+
+  function sectionRow(id:string):HTMLLIElement {
+    const row = document.createElement('li');
+    row.setAttribute('data-controller', 'sortable-lists--item');
+    row.setAttribute('data-sortable-lists--item-id-value', id);
+    row.setAttribute('data-sortable-lists--item-type-value', 'section');
+    row.setAttribute('data-sortable-lists--item-label-value', `Section ${id}`);
+    return row;
+  }
+
+  // A root serving two item types (sections and custom fields) with distinct
+  // move endpoints, each type's items living in their own list.
+  function renderTypeMapFixture({
+    moveUrlTemplates = '{"section":"/sections/{id}/drop","custom_field":"/fields/{id}/drop"}',
+    moveUrlTemplate,
+  }:{ moveUrlTemplates?:string|null; moveUrlTemplate?:string } = {}) {
+    fixture.innerHTML = `
+      <div
+        id="sortable-root"
+        data-controller="sortable-lists"
+        ${moveUrlTemplates ? `data-sortable-lists-move-url-templates-value='${moveUrlTemplates}'` : ''}
+        ${moveUrlTemplate ? `data-sortable-lists-move-url-template-value="${moveUrlTemplate}"` : ''}
+        data-sortable-lists-sortable-lists--list-outlet="#sortable-root [data-controller~='sortable-lists--list']"
+        data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
+      >
+        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="custom_field" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="custom_field" data-sortable-lists--list-name-value="Fields"></ul>
+        <ul data-controller="sortable-lists--list" data-sortable-lists--list-type-value="section" data-sortable-lists--list-id-value="1" data-sortable-lists--list-accepted-type-value="section" data-sortable-lists--list-name-value="Sections"></ul>
+      </div>
+    `;
+    const root = fixture.querySelector<HTMLElement>('#sortable-root')!;
+    const fieldList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="custom_field"]')!;
+    const sectionList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="section"]')!;
+
+    return { root, fieldList, sectionList };
   }
 
   // A nested dual-role topology: the outer list's rows are section items
@@ -1011,6 +1046,69 @@ describe('Sortable lists controller', () => {
       const options = fetchMock.mock.lastCall?.[1] as { body:FormData };
       expect(options.body.get('list_type')).toEqual('section');
       expect(options.body.get('list_id')).toEqual('1');
+    });
+  });
+
+  describe('per-type move URL map', () => {
+    it('resolves the drop move URL from the per-type template map', async () => {
+      const { fieldList, sectionList } = renderTypeMapFixture();
+      fieldList.append(fieldRow('42'), fieldRow('99'));
+      sectionList.append(sectionRow('3'), sectionRow('8'));
+
+      await ctx.nextFrame();
+
+      const fieldItem = fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="42"]')!;
+      await dropCurrentItemOnList(fieldItem, fieldList, 'custom_field');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/fields\/42\/drop/),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+
+      fetchMock.mockClear();
+
+      const sectionItem = sectionList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="3"]')!;
+      await dropCurrentItemOnList(sectionItem, sectionList, 'section');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/sections\/3\/drop/),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    it('falls back to the single template for an unmapped type', async () => {
+      const { fieldList } = renderTypeMapFixture({
+        moveUrlTemplates: '{"section":"/sections/{id}/drop"}',
+        moveUrlTemplate: '/move/{id}',
+      });
+      fieldList.append(fieldRow('7'), fieldRow('8'));
+
+      await ctx.nextFrame();
+
+      const fieldItem = fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="7"]')!;
+      await dropCurrentItemOnList(fieldItem, fieldList, 'custom_field');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/move\/7/),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    it('resolves the menu move URL from the map', async () => {
+      const { root, fieldList } = renderTypeMapFixture();
+      fieldList.append(fieldRow('1'), fieldRow('2'));
+
+      await ctx.nextFrame();
+
+      const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+      const secondFieldItem = fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="2"]')!;
+      controller.moveInDirection(secondFieldItem, 'up');
+      await flushPromises();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/fields\//),
+        expect.objectContaining({ method: 'PUT' }),
+      );
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -118,12 +118,14 @@ describe('Sortable lists controller', () => {
 
   function renderFixture({
     moveUrlTemplate = '/move/{id}',
-  }:{ moveUrlTemplate?:string|null } = {}) {
+    optimistic = false,
+  }:{ moveUrlTemplate?:string|null; optimistic?:boolean } = {}) {
     fixture.innerHTML = `
       <div
         id="sortable-root"
         data-controller="sortable-lists"
         ${moveUrlTemplate ? `data-sortable-lists-move-url-template-value="${moveUrlTemplate}"` : ''}
+        ${optimistic ? 'data-sortable-lists-optimistic-value="true"' : ''}
         data-sortable-lists-sortable-lists--list-outlet="#sortable-root [data-controller~='sortable-lists--list']"
         data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
         data-sortable-lists-sortable-lists--scrollable-outlet="#sortable-root [data-controller~='sortable-lists--scrollable']"
@@ -460,6 +462,7 @@ describe('Sortable lists controller', () => {
   it('builds the move URL from the controller URI template', async () => {
     const { targetList, firstSourceItem } = renderFixture({
       moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+      optimistic: true,
     });
 
     await ctx.nextFrame();
@@ -474,6 +477,32 @@ describe('Sortable lists controller', () => {
   it('flags the move request as optimistic', async () => {
     const { targetList, firstSourceItem } = renderFixture({
       moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+      optimistic: true,
+    });
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    const calledUrl = fetchMock.mock.lastCall?.[0] as string;
+    expect(new URL(calledUrl, 'http://localhost').searchParams.get('optimistic')).toBe('true');
+  });
+
+  it('omits the optimistic flag by default', async () => {
+    const { targetList, firstSourceItem } = renderFixture({
+      moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+    });
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    const calledUrl = fetchMock.mock.lastCall?.[0] as string;
+    expect(new URL(calledUrl, 'http://localhost').searchParams.has('optimistic')).toBe(false);
+  });
+
+  it('appends optimistic=true when the root opts in', async () => {
+    const { targetList, firstSourceItem } = renderFixture({
+      moveUrlTemplate: '/projects/demo/backlogs/work_packages/{id}/move',
+      optimistic: true,
     });
 
     await ctx.nextFrame();
@@ -493,6 +522,7 @@ describe('Sortable lists controller', () => {
         src="/projects/demo/backlogs/backlog?bucket_ids%5B%5D=1&bucket_ids%5B%5D=inbox&sprint_ids%5B%5D=2"
         data-controller="sortable-lists"
         data-sortable-lists-move-url-template-value="/projects/demo/backlogs/work_packages/{id}/move"
+        data-sortable-lists-optimistic-value="true"
         data-sortable-lists-sortable-lists--list-outlet="#backlogs-list [data-controller~='sortable-lists--list']"
         data-sortable-lists-sortable-lists--item-outlet="#backlogs-list [data-controller~='sortable-lists--item']"
       >

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -204,6 +204,81 @@ describe('Sortable lists controller', () => {
       .map((element) => element.getAttribute('data-sortable-lists--item-id-value')!);
   }
 
+  // Direct-child ids only: a section row can itself host a nested list of its
+  // own items, and querySelectorAll (used by itemIds above) would pick those
+  // up too, muddying assertions about the outer list's own row order.
+  function directItemIds(container:HTMLElement):(string|null)[] {
+    return Array.from(container.children).map((child) => child.getAttribute('data-sortable-lists--item-id-value'));
+  }
+
+  function fieldRow(id:string):HTMLLIElement {
+    const row = document.createElement('li');
+    row.setAttribute('data-controller', 'sortable-lists--item');
+    row.setAttribute('data-sortable-lists--item-id-value', id);
+    row.setAttribute('data-sortable-lists--item-type-value', 'custom_field');
+    row.setAttribute('data-sortable-lists--item-label-value', `Field ${id}`);
+    return row;
+  }
+
+  // A nested dual-role topology: the outer list's rows are section items
+  // (a <div>, not an <li>, hosting their own inner list of custom_field
+  // items). Sections and fields share one root, so a section item is
+  // contained by both the outer list (directly) and, for fields, by the
+  // outer list transitively through the section row.
+  function renderNestedFixture() {
+    fixture.innerHTML = `
+      <div
+        id="sortable-root"
+        data-controller="sortable-lists"
+        data-sortable-lists-move-url-template-value="/move/{id}"
+        data-sortable-lists-sortable-lists--list-outlet="#sortable-root [data-controller~='sortable-lists--list']"
+        data-sortable-lists-sortable-lists--item-outlet="#sortable-root [data-controller~='sortable-lists--item']"
+      >
+        <ul
+          data-controller="sortable-lists--list"
+          data-sortable-lists--list-type-value="section"
+          data-sortable-lists--list-id-value="1"
+          data-sortable-lists--list-accepted-type-value="section"
+          data-sortable-lists--list-name-value="Sections"
+        >
+          <div
+            data-controller="sortable-lists--item"
+            data-sortable-lists--item-id-value="s1"
+            data-sortable-lists--item-type-value="section"
+            data-sortable-lists--item-label-value="Section 1"
+          >
+            <ul
+              data-controller="sortable-lists--list"
+              data-sortable-lists--list-type-value="custom_field"
+              data-sortable-lists--list-id-value="s1"
+              data-sortable-lists--list-accepted-type-value="custom_field"
+              data-sortable-lists--list-name-value="Fields"
+            ></ul>
+          </div>
+          <div
+            data-controller="sortable-lists--item"
+            data-sortable-lists--item-id-value="s2"
+            data-sortable-lists--item-type-value="section"
+            data-sortable-lists--item-label-value="Section 2"
+          ></div>
+        </ul>
+      </div>
+    `;
+    const root = fixture.querySelector<HTMLElement>('#sortable-root')!;
+    const sectionList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="section"]')!;
+    const sectionItem = fixture.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="s1"]')!;
+    const fieldList = fixture.querySelector<HTMLElement>('[data-sortable-lists--list-type-value="custom_field"]')!;
+    fieldList.append(fieldRow('cf1'), fieldRow('cf2'));
+
+    return {
+      root,
+      sectionList,
+      sectionItem,
+      fieldList,
+      firstFieldItem: fieldList.querySelector<HTMLElement>('[data-sortable-lists--item-id-value="cf1"]')!,
+    };
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks();
 
@@ -901,5 +976,41 @@ describe('Sortable lists controller', () => {
     const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
 
     expect(controller.moveAvailability(document.createElement('li'))).toBeNull();
+  });
+
+  describe('nested list topology', () => {
+    it('resolves the source row of a nested item against its innermost list', async () => {
+      const { fieldList, firstFieldItem } = renderNestedFixture();
+
+      await ctx.nextFrame();
+      await dropCurrentItemOnList(firstFieldItem, fieldList);
+
+      // The dragged custom_field item's own row moved within its innermost
+      // (field) list; the outer section row it lives under is untouched.
+      expect(directItemIds(fieldList)).toEqual(['cf2', 'cf1']);
+
+      const options = fetchMock.mock.lastCall?.[1] as { body:FormData };
+      expect(options.body.get('list_type')).toEqual('custom_field');
+      expect(options.body.get('list_id')).toEqual('s1');
+    });
+
+    it('resolves a section row that is not an <li>', async () => {
+      const { sectionList, sectionItem } = renderNestedFixture();
+
+      await ctx.nextFrame();
+      // A list-only drop onto the section list's own default ('end')
+      // position: with two section rows this reorders them, so it is a real
+      // move rather than a same-position no-op.
+      await dropCurrentItemOnList(sectionItem, sectionList);
+
+      // closest('li') on a <div> row returns null and the drop would
+      // silently be ignored; a fired move proves the row resolved.
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(directItemIds(sectionList)).toEqual(['s2', 's1']);
+
+      const options = fetchMock.mock.lastCall?.[1] as { body:FormData };
+      expect(options.body.get('list_type')).toEqual('section');
+      expect(options.body.get('list_id')).toEqual('1');
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -52,6 +52,7 @@ import {
   resolveItemId,
   resolveItemLabel,
   resolveItemPosition,
+  resolveItemType,
   resolveMoveAvailability,
   restoreRowPositions,
   rowOf,
@@ -71,6 +72,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
   static values = {
     moveUrlTemplate: String,
+    moveUrlTemplates: Object,
   };
 
   declare readonly sortableListsListOutlets:import('./sortable-lists/list.controller').default[];
@@ -79,6 +81,8 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
   declare readonly moveUrlTemplateValue:string;
   declare readonly hasMoveUrlTemplateValue:boolean;
+  declare readonly moveUrlTemplatesValue:Record<string, string>;
+  declare readonly hasMoveUrlTemplatesValue:boolean;
 
   private monitorCleanupFn?:CleanupFn;
   private healScheduled = false;
@@ -200,7 +204,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    const moveUrl = this.resolveMoveUrl({ itemId });
+    const moveUrl = this.resolveMoveUrl({ itemId, type: resolveItemType(itemElement) });
     const sourceRow = rowOf(list.rowsContainer, itemElement);
     if (!moveUrl || !sourceRow) {
       return;
@@ -251,7 +255,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    const moveUrl = this.resolveMoveUrl(source.data);
+    const moveUrl = this.resolveMoveUrl({ itemId: source.data.itemId, type: source.data.type });
     if (!moveUrl) {
       debugLog('sortable-lists: ignoring drop, no move URL for item', source.data.itemId);
       return;
@@ -352,12 +356,13 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   // The template must expand to a same-origin relative URL: the expansion is
   // reduced to path + search + hash, so an absolute template's origin would
   // be dropped silently.
-  private resolveMoveUrl(data:{ itemId:string }):string|null {
-    if (!this.hasMoveUrlTemplateValue) {
+  private resolveMoveUrl({ itemId, type }:{ itemId:string; type:string|null }):string|null {
+    const template = this.moveUrlTemplateFor(type);
+    if (!template) {
       return null;
     }
 
-    const expanded = parseTemplate(this.moveUrlTemplateValue).expand({ id: data.itemId });
+    const expanded = parseTemplate(template).expand({ id: itemId });
     const url = new URL(expanded, window.location.href);
     // Both drag and menu moves share this path and are flagged optimistic=true
     // (the move is already applied in the DOM), so the server skips the frame
@@ -365,6 +370,16 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     url.searchParams.set('optimistic', 'true');
 
     return `${url.pathname}${url.search}${url.hash}`;
+  }
+
+  // The dragged item's type keys the template: the move endpoint belongs to
+  // the item being moved, not to the destination list.
+  private moveUrlTemplateFor(type:string|null):string|null {
+    if (type !== null && this.hasMoveUrlTemplatesValue && this.moveUrlTemplatesValue[type]) {
+      return this.moveUrlTemplatesValue[type];
+    }
+
+    return this.hasMoveUrlTemplateValue ? this.moveUrlTemplateValue : null;
   }
 
   private async moveItem({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -73,6 +73,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   static values = {
     moveUrlTemplate: String,
     moveUrlTemplates: Object,
+    optimistic: { type: Boolean, default: false },
   };
 
   declare readonly sortableListsListOutlets:import('./sortable-lists/list.controller').default[];
@@ -83,6 +84,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   declare readonly hasMoveUrlTemplateValue:boolean;
   declare readonly moveUrlTemplatesValue:Record<string, string>;
   declare readonly hasMoveUrlTemplatesValue:boolean;
+  declare readonly optimisticValue:boolean;
 
   private monitorCleanupFn?:CleanupFn;
   private healScheduled = false;
@@ -364,10 +366,11 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
     const expanded = parseTemplate(template).expand({ id: itemId });
     const url = new URL(expanded, window.location.href);
-    // Both drag and menu moves share this path and are flagged optimistic=true
-    // (the move is already applied in the DOM), so the server skips the frame
-    // reload for a same-list move.
-    url.searchParams.set('optimistic', 'true');
+    // Only consumers whose success response is event-only (Backlogs) opt in;
+    // morph-reconciled surfaces need the server to stream the canonical order.
+    if (this.optimisticValue) {
+      url.searchParams.set('optimistic', 'true');
+    }
 
     return `${url.pathname}${url.search}${url.hash}`;
   }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -221,8 +221,18 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     return this.ownerListOf(itemElement)?.element ?? null;
   }
 
+  // The owning list of an item is the innermost list outlet containing its
+  // element: in nested topologies (a section item hosting a field list) the
+  // item is contained by every ancestor list, and only the innermost one
+  // holds its row.
   private ownerListOf(itemElement:HTMLElement) {
-    return this.sortableListsListOutlets.find((list) => list.element.contains(itemElement)) ?? null;
+    const containing = this.sortableListsListOutlets.filter((list) => list.element.contains(itemElement));
+
+    return containing.find((list) => !containing.some((other) => other !== list && list.element.contains(other.element))) ?? null;
+  }
+
+  ownerRowsContainer(itemElement:HTMLElement):HTMLElement|null {
+    return this.ownerListOf(itemElement)?.rowsContainer ?? null;
   }
 
   private async handleDrop({ location, source }:ElementDropPayload) {
@@ -257,12 +267,9 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    // The dragged source row is still resolved as an <li>, the one place the
-    // subsystem is not yet tag-agnostic: reaching its rows container structurally
-    // needs the source list (not the root) on the item payload. Backlogs rows are
-    // <li>, so this holds today; generalising it is a tracked follow-up.
-    const sourceRow = source.element.closest('li');
-    if (!(sourceRow instanceof HTMLElement)) {
+    const sourceList = this.ownerListOf(source.element);
+    const sourceRow = sourceList ? rowOf(sourceList.rowsContainer, source.element) : null;
+    if (!sourceRow) {
       debugLog('sortable-lists: ignoring drop, could not resolve the source row element');
       return;
     }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -73,6 +73,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   static values = {
     moveUrlTemplate: String,
     moveUrlTemplates: Object,
+    optimistic: { type: Boolean, default: false },
   };
 
   declare readonly sortableListsListOutlets:import('./sortable-lists/list.controller').default[];
@@ -83,6 +84,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   declare readonly hasMoveUrlTemplateValue:boolean;
   declare readonly moveUrlTemplatesValue:Record<string, string>;
   declare readonly hasMoveUrlTemplatesValue:boolean;
+  declare readonly optimisticValue:boolean;
 
   private monitorCleanupFn?:CleanupFn;
   private healScheduled = false;
@@ -358,10 +360,11 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
     const expanded = parseTemplate(template).expand({ id: itemId });
     const url = new URL(expanded, window.location.href);
-    // Both drag and menu moves share this path and are flagged optimistic=true
-    // (the move is already applied in the DOM), so the server skips the frame
-    // reload for a same-list move.
-    url.searchParams.set('optimistic', 'true');
+    // Only consumers whose success response is event-only (Backlogs) opt in;
+    // morph-reconciled surfaces need the server to stream the canonical order.
+    if (this.optimisticValue) {
+      url.searchParams.set('optimistic', 'true');
+    }
 
     return `${url.pathname}${url.search}${url.hash}`;
   }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -215,8 +215,18 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     });
   }
 
+  // The owning list of an item is the innermost list outlet containing its
+  // element: in nested topologies (a section item hosting a field list) the
+  // item is contained by every ancestor list, and only the innermost one
+  // holds its row.
   private ownerListOf(itemElement:HTMLElement) {
-    return this.sortableListsListOutlets.find((list) => list.element.contains(itemElement)) ?? null;
+    const containing = this.sortableListsListOutlets.filter((list) => list.element.contains(itemElement));
+
+    return containing.find((list) => !containing.some((other) => other !== list && list.element.contains(other.element))) ?? null;
+  }
+
+  ownerRowsContainer(itemElement:HTMLElement):HTMLElement|null {
+    return this.ownerListOf(itemElement)?.rowsContainer ?? null;
   }
 
   private async handleDrop({ location, source }:ElementDropPayload) {
@@ -251,12 +261,9 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    // The dragged source row is still resolved as an <li>, the one place the
-    // subsystem is not yet tag-agnostic: reaching its rows container structurally
-    // needs the source list (not the root) on the item payload. Backlogs rows are
-    // <li>, so this holds today; generalising it is a tracked follow-up.
-    const sourceRow = source.element.closest('li');
-    if (!(sourceRow instanceof HTMLElement)) {
+    const sourceList = this.ownerListOf(source.element);
+    const sourceRow = sourceList ? rowOf(sourceList.rowsContainer, source.element) : null;
+    if (!sourceRow) {
       debugLog('sortable-lists: ignoring drop, could not resolve the source row element');
       return;
     }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -52,6 +52,7 @@ import {
   resolveItemId,
   resolveItemLabel,
   resolveItemPosition,
+  resolveItemType,
   resolveMoveAvailability,
   restoreRowPositions,
   rowOf,
@@ -71,6 +72,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
   static values = {
     moveUrlTemplate: String,
+    moveUrlTemplates: Object,
   };
 
   declare readonly sortableListsListOutlets:import('./sortable-lists/list.controller').default[];
@@ -79,6 +81,8 @@ export default class SortableListsController extends Controller<HTMLElement> imp
 
   declare readonly moveUrlTemplateValue:string;
   declare readonly hasMoveUrlTemplateValue:boolean;
+  declare readonly moveUrlTemplatesValue:Record<string, string>;
+  declare readonly hasMoveUrlTemplatesValue:boolean;
 
   private monitorCleanupFn?:CleanupFn;
   private healScheduled = false;
@@ -200,7 +204,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    const moveUrl = this.resolveMoveUrl({ itemId });
+    const moveUrl = this.resolveMoveUrl({ itemId, type: resolveItemType(itemElement) });
     const sourceRow = rowOf(list.rowsContainer, itemElement);
     if (!moveUrl || !sourceRow) {
       return;
@@ -245,7 +249,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
       return;
     }
 
-    const moveUrl = this.resolveMoveUrl(source.data);
+    const moveUrl = this.resolveMoveUrl({ itemId: source.data.itemId, type: source.data.type });
     if (!moveUrl) {
       debugLog('sortable-lists: ignoring drop, no move URL for item', source.data.itemId);
       return;
@@ -346,12 +350,13 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   // The template must expand to a same-origin relative URL: the expansion is
   // reduced to path + search + hash, so an absolute template's origin would
   // be dropped silently.
-  private resolveMoveUrl(data:{ itemId:string }):string|null {
-    if (!this.hasMoveUrlTemplateValue) {
+  private resolveMoveUrl({ itemId, type }:{ itemId:string; type:string|null }):string|null {
+    const template = this.moveUrlTemplateFor(type);
+    if (!template) {
       return null;
     }
 
-    const expanded = parseTemplate(this.moveUrlTemplateValue).expand({ id: data.itemId });
+    const expanded = parseTemplate(template).expand({ id: itemId });
     const url = new URL(expanded, window.location.href);
     // Both drag and menu moves share this path and are flagged optimistic=true
     // (the move is already applied in the DOM), so the server skips the frame
@@ -359,6 +364,16 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     url.searchParams.set('optimistic', 'true');
 
     return `${url.pathname}${url.search}${url.hash}`;
+  }
+
+  // The dragged item's type keys the template: the move endpoint belongs to
+  // the item being moved, not to the destination list.
+  private moveUrlTemplateFor(type:string|null):string|null {
+    if (type !== null && this.hasMoveUrlTemplatesValue && this.moveUrlTemplatesValue[type]) {
+      return this.moveUrlTemplatesValue[type];
+    }
+
+    return this.hasMoveUrlTemplateValue ? this.moveUrlTemplateValue : null;
   }
 
   private async moveItem({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -98,6 +98,9 @@ export interface SortableListsRoot {
   // The element of the list an item currently belongs to; null outside any
   // registered list. Items carry no list reference, so the root resolves it.
   ownerListElementOf(itemElement:HTMLElement):HTMLElement|null;
+  // The rows container of the item's innermost owning list, or null when the
+  // item is not (yet) inside a list the root knows about.
+  ownerRowsContainer(itemElement:HTMLElement):HTMLElement|null;
 }
 
 // Implemented by the list, item and scrollable controllers so the root can

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -236,7 +236,7 @@ export function resolvePreviousSortableItemId({
   closestEdge:Edge|null;
   rowsContainer:Element;
 }):string|null {
-  const targetItemElement = resolveItemElement(targetItem);
+  const targetItemElement = resolveItemElement(targetItem, rowsContainer);
   const targetItemId = targetItemElement ? resolveItemId(targetItemElement) : null;
 
   if (closestEdge === 'bottom' && targetItemId !== sourceItemId) {
@@ -247,7 +247,7 @@ export function resolvePreviousSortableItemId({
   let row = targetRow?.previousElementSibling ?? null;
 
   while (row) {
-    const itemId = resolvePreviousItemId(row);
+    const itemId = resolvePreviousItemId(row, rowsContainer);
     if (itemId && itemId !== sourceItemId) {
       return itemId;
     }
@@ -334,7 +334,7 @@ export function resolveDropIntent({
   if (!targetItem) {
     const { input } = location.current;
     const elementAtPoint = getElementFromPointWithoutHoneypot({ x: input.clientX, y: input.clientY });
-    const itemAtPoint = elementAtPoint ? resolveClosestItemElement(elementAtPoint) : null;
+    const itemAtPoint = elementAtPoint ? resolveClosestItemElement(elementAtPoint, rowsContainer) : null;
 
     if (itemAtPoint && root.contains(itemAtPoint) && resolveItemId(itemAtPoint) === sourceData.itemId) {
       return null;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -78,6 +78,9 @@ export interface SortableListsRoot {
   moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void;
   // A snapshot for menu gating; the click path re-resolves against the live DOM.
   moveAvailability(itemElement:HTMLElement):MoveAvailability|null;
+  // The rows container of the item's innermost owning list, or null when the
+  // item is not (yet) inside a list the root knows about.
+  ownerRowsContainer(itemElement:HTMLElement):HTMLElement|null;
 }
 
 // Implemented by the list, item and scrollable controllers so the root can

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -189,7 +189,7 @@ export function resolvePreviousSortableItemId({
   closestEdge:Edge|null;
   rowsContainer:Element;
 }):string|null {
-  const targetItemElement = resolveItemElement(targetItem);
+  const targetItemElement = resolveItemElement(targetItem, rowsContainer);
   const targetItemId = targetItemElement ? resolveItemId(targetItemElement) : null;
 
   if (closestEdge === 'bottom' && targetItemId !== sourceItemId) {
@@ -200,7 +200,7 @@ export function resolvePreviousSortableItemId({
   let row = targetRow?.previousElementSibling ?? null;
 
   while (row) {
-    const itemId = resolvePreviousItemId(row);
+    const itemId = resolvePreviousItemId(row, rowsContainer);
     if (itemId && itemId !== sourceItemId) {
       return itemId;
     }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -91,7 +91,11 @@ describe('Sortable lists item controller', () => {
 
   function fakeRoot(
     element = document.createElement('div'),
-    { busy = false, ownerListElement = null }:{ busy?:boolean; ownerListElement?:HTMLElement|null } = {},
+    { busy = false, ownerListElement = null, ownerRowsContainer = () => null }:{
+      busy?:boolean;
+      ownerListElement?:HTMLElement|null;
+      ownerRowsContainer?:(itemElement:HTMLElement) => HTMLElement|null;
+    } = {},
   ):SortableListsRoot {
     Object.defineProperty(element, 'isConnected', { value: true, configurable: true });
     return {
@@ -100,6 +104,7 @@ describe('Sortable lists item controller', () => {
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
       ownerListElementOf: vi.fn(() => ownerListElement),
+      ownerRowsContainer: vi.fn(ownerRowsContainer),
     };
   }
 
@@ -383,6 +388,24 @@ describe('Sortable lists item controller', () => {
       connectedControllerFor(row);
 
       expect(stickyAt(row, 0)).toBe(false);
+    });
+
+    it('uses the root-resolved rows container when the DOM parent is not the rows container', () => {
+      const [first, , third] = mountedRows();
+      const list = first.parentElement!;
+      // Wrap the item in an intermediate div, so its DOM parent (the wrapper,
+      // holding only itself) no longer matches its actual rows container
+      // (the list, holding all three rows). Only a root-resolved lookup can
+      // still see the full rows span.
+      const wrapper = document.createElement('div');
+      first.replaceWith(wrapper);
+      wrapper.append(first);
+
+      connectedControllerFor(first, { root: fakeRoot(document.createElement('div'), { ownerRowsContainer: () => list }) });
+
+      // Reachable only if the sticky bounds span the whole list (root-resolved);
+      // the DOM-parent fallback (the one-row wrapper) would release well before it.
+      expect(stickyAt(first, third.getBoundingClientRect().bottom - 1)).toBe(true);
     });
   });
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -91,7 +91,10 @@ describe('Sortable lists item controller', () => {
 
   function fakeRoot(
     element = document.createElement('div'),
-    { busy = false } = {},
+    { busy = false, ownerRowsContainer = () => null }:{
+      busy?:boolean;
+      ownerRowsContainer?:(itemElement:HTMLElement) => HTMLElement|null;
+    } = {},
   ):SortableListsRoot {
     Object.defineProperty(element, 'isConnected', { value: true, configurable: true });
     return {
@@ -99,6 +102,7 @@ describe('Sortable lists item controller', () => {
       busy,
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
+      ownerRowsContainer: vi.fn(ownerRowsContainer),
     };
   }
 
@@ -370,6 +374,24 @@ describe('Sortable lists item controller', () => {
       connectedControllerFor(row);
 
       expect(stickyAt(row, 0)).toBe(false);
+    });
+
+    it('uses the root-resolved rows container when the DOM parent is not the rows container', () => {
+      const [first, , third] = mountedRows();
+      const list = first.parentElement!;
+      // Wrap the item in an intermediate div, so its DOM parent (the wrapper,
+      // holding only itself) no longer matches its actual rows container
+      // (the list, holding all three rows). Only a root-resolved lookup can
+      // still see the full rows span.
+      const wrapper = document.createElement('div');
+      first.replaceWith(wrapper);
+      wrapper.append(first);
+
+      connectedControllerFor(first, { root: fakeRoot(document.createElement('div'), { ownerRowsContainer: () => list }) });
+
+      // Reachable only if the sticky bounds span the whole list (root-resolved);
+      // the DOM-parent fallback (the one-row wrapper) would release well before it.
+      expect(stickyAt(first, third.getBoundingClientRect().bottom - 1)).toBe(true);
     });
   });
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -314,10 +314,11 @@ export default class ItemController extends Controller<HTMLElement> implements R
   // flicker while the pointer crosses them. Above the first row (the list
   // header) or below the last row (empty space) the pointer has left the rows
   // region, and the list's configured drop position must take over, so the
-  // sticky target lets go there. Rows are direct children of the rows
-  // container, so the item's parent element is that container.
+  // sticky target lets go there. Rows are direct children of the owning
+  // list's rows container, resolved through the root; the item's own parent
+  // element is only a fallback for a rootless item (not yet wired to one).
   private isWithinRowsSpan(input:Input):boolean {
-    const rowsContainer = this.element.parentElement;
+    const rowsContainer = this.root?.ownerRowsContainer(this.element) ?? this.element.parentElement;
     const firstRow = rowsContainer?.firstElementChild;
     const lastRow = rowsContainer?.lastElementChild;
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -303,10 +303,11 @@ export default class ItemController extends Controller<HTMLElement> implements R
   // flicker while the pointer crosses them. Above the first row (the list
   // header) or below the last row (empty space) the pointer has left the rows
   // region, and the list's configured drop position must take over, so the
-  // sticky target lets go there. Rows are direct children of the rows
-  // container, so the item's parent element is that container.
+  // sticky target lets go there. Rows are direct children of the owning
+  // list's rows container, resolved through the root; the item's own parent
+  // element is only a fallback for a rootless item (not yet wired to one).
   private isWithinRowsSpan(input:Input):boolean {
-    const rowsContainer = this.element.parentElement;
+    const rowsContainer = this.root?.ownerRowsContainer(this.element) ?? this.element.parentElement;
     const firstRow = rowsContainer?.firstElementChild;
     const lastRow = rowsContainer?.lastElementChild;
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -165,6 +165,25 @@ describe('sortable lists DOM helpers', () => {
       expect(itemIdOrder(list)).toEqual(['1', '3', '4', '2']);
     });
 
+    it('anchors on the outer list row, not a nested item with a colliding id', () => {
+      // Section and custom-field ids come from different tables, so a field
+      // nested inside section "1" may carry the same id as section "2".
+      // Resolving section "2" as the anchor must match the outer row, never
+      // descend into the nested field list.
+      const list = listElement();
+      const [sectionOne, sectionTwo, sectionThree] = ['1', '2', '3'].map(divItemRow);
+      const nestedList = listElement();
+      const collidingField = itemRow('2');
+
+      nestedList.append(collidingField);
+      sectionOne.append(nestedList);
+      list.append(sectionOne, sectionTwo, sectionThree);
+
+      reorderRows({ rows: [sectionThree], rowsContainer: list, previousItemId: '2' });
+
+      expect(Array.from(list.children)).toEqual([sectionOne, sectionTwo, sectionThree]);
+    });
+
     it('anchors on a truncation marker row when the previous item is hidden', () => {
       const list = listElement();
       const [one, two, three] = ['1', '2', '3'].map(itemRow);

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -94,6 +94,22 @@ describe('sortable lists DOM helpers', () => {
 
       expect(resolveListAppendPreviousItemId({ sourceItemId: '1', rowsContainer: list })).toBeNull();
     });
+
+    it('returns null for an empty list nested inside an outer item, not the outer item\'s id', () => {
+      // Nested topology: a section item hosting its own field list. The only
+      // row is a non-item placeholder (no item id, no prev-item-id marker),
+      // and every ancestor up to the root belongs to the outer (section)
+      // item/list pair. Regression: resolving a "previous item" here must not
+      // climb past the list boundary and match the outer section's item id.
+      const outerItem = divItemRow('outer-section');
+      const list = listElement();
+      const placeholder = document.createElement('li');
+
+      list.append(placeholder);
+      outerItem.append(list);
+
+      expect(resolveListAppendPreviousItemId({ sourceItemId: 'field-1', rowsContainer: list })).toBeNull();
+    });
   });
 
   describe('reorderRows', () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.spec.ts
@@ -34,6 +34,7 @@ import {
   resolveListAppendPreviousItemId,
   resolveItemPosition,
   resolveItemLabel,
+  resolveItemType,
   restoreRowPositions,
   rowOf,
   rowsRemainAt,
@@ -533,5 +534,20 @@ describe('resolveItemLabel', () => {
 
     expect(resolveItemLabel(labelled)).toEqual('Story one');
     expect(resolveItemLabel(bare)).toBeNull();
+  });
+});
+
+describe('resolveItemType', () => {
+  it('reads the item type value attribute', () => {
+    const el = document.createElement('div');
+    el.setAttribute('data-sortable-lists--item-type-value', 'custom_field');
+    expect(resolveItemType(el)).toBe('custom_field');
+  });
+
+  it('returns null when the attribute is absent or empty', () => {
+    const el = document.createElement('div');
+    expect(resolveItemType(el)).toBeNull();
+    el.setAttribute('data-sortable-lists--item-type-value', '');
+    expect(resolveItemType(el)).toBeNull();
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -116,11 +116,13 @@ export function resolvePreviousItemId(element:Element, boundary:Element):string|
 // Anchor on that marker so the row lands next to the collapsed block instead
 // of jumping to the top.
 function resolveAnchorRow(rowsContainer:HTMLElement, previousItemId:string):HTMLElement|null {
-  const escaped = CSS.escape(previousItemId);
-  const anchor = rowsContainer.querySelector(`[data-sortable-lists--item-id-value="${escaped}"]`)
-    ?? rowsContainer.querySelector(`[${sortablePreviousItemIdAttribute}="${escaped}"]`);
+  // Match against the list's own rows rather than querying descendants:
+  // ids of different item types come from different tables, so a nested
+  // inner list may contain an unrelated item with a colliding id.
+  const anchor = listRows(rowsContainer)
+    .find((row) => resolvePreviousItemId(row, rowsContainer) === previousItemId);
 
-  return anchor ? rowOf(rowsContainer, anchor) : null;
+  return (anchor as HTMLElement|undefined) ?? null;
 }
 
 export function resolveListAppendPreviousItemId({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -69,6 +69,14 @@ export function resolveItemId(element:Element):string|null {
   return element.getAttribute('data-sortable-lists--item-id-value');
 }
 
+export const sortableItemTypeAttribute = 'data-sortable-lists--item-type-value';
+
+export function resolveItemType(element:Element):string|null {
+  const type = element.getAttribute(sortableItemTypeAttribute);
+
+  return type === '' ? null : type;
+}
+
 export function resolveClosestItemElement(element:Element):HTMLElement|null {
   if (element instanceof HTMLElement && element.matches(sortableItemSelector)) {
     return element;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list-dom.ts
@@ -77,21 +77,33 @@ export function resolveItemType(element:Element):string|null {
   return type === '' ? null : type;
 }
 
-export function resolveClosestItemElement(element:Element):HTMLElement|null {
-  if (element instanceof HTMLElement && element.matches(sortableItemSelector)) {
-    return element;
+// Ancestor-or-self, but never past `boundary` (the rows container `element`
+// belongs to): `element` is typically a row, or something inside one, and in
+// a nested topology (a section item hosting a field list) every ancestor
+// above the rows container belongs to an outer list. An unbounded
+// `closest()` would match the outer item that happens to contain this row —
+// wrong list entirely — which is exactly what a non-item marker row (e.g. an
+// empty list's placeholder) would otherwise resolve to instead of "no item
+// here". `boundary.contains(match)` accepts a self-or-ancestor match found
+// inside the rows container and rejects one outside it. Only this ancestor
+// climb is bounded — resolveItemElement's querySelector fallback below
+// descends unbounded and can match an item belonging to a nested inner list.
+export function resolveClosestItemElement(element:Element, boundary:Element):HTMLElement|null {
+  if (!(element instanceof HTMLElement)) {
+    return null;
   }
 
-  return element.closest<HTMLElement>(sortableItemSelector);
+  const match = element.closest<HTMLElement>(sortableItemSelector);
+  return match && boundary.contains(match) ? match : null;
 }
 
-export function resolveItemElement(element:Element):HTMLElement|null {
-  return resolveClosestItemElement(element) ??
+export function resolveItemElement(element:Element, boundary:Element):HTMLElement|null {
+  return resolveClosestItemElement(element, boundary) ??
     element.querySelector<HTMLElement>(sortableItemSelector);
 }
 
-export function resolvePreviousItemId(element:Element):string|null {
-  const item = resolveItemElement(element);
+export function resolvePreviousItemId(element:Element, boundary:Element):string|null {
+  const item = resolveItemElement(element, boundary);
 
   // Non-item rows, such as truncated "show more" rows, can mark the last
   // omitted item so position resolution remains correct in sparse lists.
@@ -121,7 +133,7 @@ export function resolveListAppendPreviousItemId({
   const rows = listRows(rowsContainer).reverse();
 
   for (const row of rows) {
-    const itemId = resolvePreviousItemId(row);
+    const itemId = resolvePreviousItemId(row, rowsContainer);
     if (itemId && itemId !== sourceItemId) {
       return itemId;
     }
@@ -220,8 +232,8 @@ export function isMoveDirection(value:unknown):value is MoveDirection {
   return typeof value === 'string' && (moveDirections as readonly string[]).includes(value);
 }
 
-function isItemRow(row:Element|undefined):boolean {
-  return !!row && resolveItemElement(row) !== null;
+function isItemRow(row:Element|undefined, rowsContainer:Element):boolean {
+  return !!row && resolveItemElement(row, rowsContainer) !== null;
 }
 
 // Hidden items a non-item row stands in for (a truncation marker annotated
@@ -251,7 +263,7 @@ export function resolveItemPosition({
   let found = false;
 
   for (const current of listRows(rowsContainer)) {
-    if (isItemRow(current)) {
+    if (isItemRow(current, rowsContainer)) {
       total += 1;
       if (current === row) {
         found = true;
@@ -265,16 +277,24 @@ export function resolveItemPosition({
   return found ? { position, total } : null;
 }
 
+// Self only: unlike resolvePreviousItemId, the row passed here is always the
+// dragged item's own row (never a marker or an arbitrary drop target), so no
+// ancestor climb is needed. That matters mid cross-list move: the label is
+// read before the row is reparented into the target list's rows container,
+// so bounding this by that container (which does not yet contain the row)
+// would wrongly reject a legitimate self-match.
 export function resolveItemLabel(row:Element):string|null {
-  return resolveItemElement(row)?.getAttribute('data-sortable-lists--item-label-value') ?? null;
+  return row instanceof HTMLElement && row.matches(sortableItemSelector)
+    ? row.getAttribute('data-sortable-lists--item-label-value')
+    : null;
 }
 
 // A row a predecessor id can be read from: an item row, or a non-item row
 // annotated with the id of the last hidden item it stands in for (a
 // truncation marker). Unannotated non-item rows (a divider, a heading) give
 // no anchor, so a move over them cannot be expressed.
-function isAddressableRow(row:Element):boolean {
-  return isItemRow(row) || row.hasAttribute(sortablePreviousItemIdAttribute);
+function isAddressableRow(row:Element, rowsContainer:Element):boolean {
+  return isItemRow(row, rowsContainer) || row.hasAttribute(sortablePreviousItemIdAttribute);
 }
 
 // The previous item id to insert `itemElement` after for a directional move:
@@ -299,7 +319,7 @@ export function resolveDirectionalPreviousItemId({
 }):string|null|undefined {
   const context = resolveRowContext(itemElement, rowsContainer);
 
-  return context ? directionalPreviousItemIdIn(context, direction) : undefined;
+  return context ? directionalPreviousItemIdIn(context, direction, rowsContainer) : undefined;
 }
 
 export type MoveAvailability = Record<MoveDirection, boolean>;
@@ -320,10 +340,10 @@ export function resolveMoveAvailability({
   }
 
   return {
-    top: directionalPreviousItemIdIn(context, 'top') !== undefined,
-    up: directionalPreviousItemIdIn(context, 'up') !== undefined,
-    down: directionalPreviousItemIdIn(context, 'down') !== undefined,
-    bottom: directionalPreviousItemIdIn(context, 'bottom') !== undefined,
+    top: directionalPreviousItemIdIn(context, 'top', rowsContainer) !== undefined,
+    up: directionalPreviousItemIdIn(context, 'up', rowsContainer) !== undefined,
+    down: directionalPreviousItemIdIn(context, 'down', rowsContainer) !== undefined,
+    bottom: directionalPreviousItemIdIn(context, 'bottom', rowsContainer) !== undefined,
   };
 }
 
@@ -345,7 +365,7 @@ function resolveRowContext(itemElement:HTMLElement, rowsContainer:Element):RowCo
     return null;
   }
 
-  const itemRows = rows.filter((row) => resolveItemElement(row) !== null);
+  const itemRows = rows.filter((row) => resolveItemElement(row, rowsContainer) !== null);
 
   return { rows, rowIndex, itemRows, itemIndex: itemRows.indexOf(sourceRow!) };
 }
@@ -353,6 +373,7 @@ function resolveRowContext(itemElement:HTMLElement, rowsContainer:Element):RowCo
 function directionalPreviousItemIdIn(
   { rows, rowIndex, itemRows, itemIndex }:RowContext,
   direction:MoveDirection,
+  rowsContainer:Element,
 ):string|null|undefined {
   const isFirstItem = itemIndex === 0;
   const isLastItem = itemIndex === itemRows.length - 1;
@@ -362,26 +383,26 @@ function directionalPreviousItemIdIn(
       return isFirstItem ? undefined : null;
     case 'bottom':
       // After the last visible item; the server appends past the hidden block.
-      return isLastItem ? undefined : resolvePreviousItemId(itemRows[itemRows.length - 1]);
+      return isLastItem ? undefined : resolvePreviousItemId(itemRows[itemRows.length - 1], rowsContainer);
     case 'up': {
       if (isFirstItem) return undefined;
       // One slot up crosses a hidden block (marker row above) or an
       // uncrossable gap (unannotated row above) -- unavailable either way.
-      if (!isItemRow(rows[rowIndex - 1])) return undefined;
+      if (!isItemRow(rows[rowIndex - 1], rowsContainer)) return undefined;
       const anchor = rows[rowIndex - 2];
       // The row two above becomes the predecessor (its own id, or a marker's
       // hidden id); an unannotated row there means "before the item above but
       // after the gap", which cannot be expressed. No row means the top.
-      if (anchor && !isAddressableRow(anchor)) return undefined;
-      return anchor ? resolvePreviousItemId(anchor) : null;
+      if (anchor && !isAddressableRow(anchor, rowsContainer)) return undefined;
+      return anchor ? resolvePreviousItemId(anchor, rowsContainer) : null;
     }
     case 'down': {
       if (isLastItem) return undefined;
       const below = rows[rowIndex + 1];
       // One slot down needs the row below as predecessor: a marker row would
       // mean crossing its hidden block, an unannotated row gives no anchor.
-      if (!isItemRow(below)) return undefined;
-      return resolvePreviousItemId(below);
+      if (!isItemRow(below, rowsContainer)) return undefined;
+      return resolvePreviousItemId(below, rowsContainer);
     }
     default:
       return undefined;

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -77,6 +77,7 @@ describe('Sortable lists list controller', () => {
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
       ownerListElementOf: vi.fn(() => null),
+      ownerRowsContainer: vi.fn(() => null),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -76,6 +76,7 @@ describe('Sortable lists list controller', () => {
       busy,
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
+      ownerRowsContainer: vi.fn(() => null),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
@@ -120,6 +120,18 @@ describe('sortable lists drag preview', () => {
       expect(preview.hasAttribute('data-controller')).toBe(false);
     });
 
+    it('zeroes the clone margin so source spacing utilities render no whitespace', () => {
+      const target = withWidth(previewTarget(), 320);
+      target.classList.add('mt-3');
+      const container = document.createElement('div');
+
+      renderDragPreview({ previewTarget: target, sourceElement: target, container });
+
+      const preview = container.firstElementChild as HTMLElement;
+
+      expect(preview.style.margin).toEqual('0px');
+    });
+
     it('leaves the width unset when the preview target has no measured width', () => {
       const target = withWidth(previewTarget(), 0);
       const container = document.createElement('div');

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
@@ -70,6 +70,10 @@ export function renderDragPreview({
     preview.style.width = `${previewWidth}px`;
   }
 
+  // Margin utility classes on the source (e.g. mt-3 on a section box) would
+  // render as whitespace inside the preview container.
+  preview.style.margin = '0';
+
   const box = sourceElement.closest('.Box');
 
   BOX_DENSITY_VARIANT_CLASSES.forEach((variant) => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -73,6 +73,7 @@ describe('Sortable lists scrollable controller', () => {
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
       ownerListElementOf: vi.fn(() => null),
+      ownerRowsContainer: vi.fn(() => null),
     };
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -72,6 +72,7 @@ describe('Sortable lists scrollable controller', () => {
       busy: false,
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
+      ownerRowsContainer: vi.fn(() => null),
     };
   }
 

--- a/modules/backlogs/app/views/backlogs/backlog/show.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/show.html.erb
@@ -49,6 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
                       class: "op-backlogs-page",
                       data: {
                         controller: "backlogs--list-refresh backlogs--split-view-sync sortable-lists",
+                        sortable_lists_optimistic_value: true,
                         action: "#{Backlogs::WorkPackagesController::WORK_PACKAGE_MOVED_EVENT}@document->backlogs--split-view-sync#onWorkPackageMoved",
                         sortable_lists_move_url_template_value: backlogs_move_url_template(@project),
                         sortable_lists_sortable_lists__list_outlet: "#backlogs_container [data-controller~='sortable-lists--list']",

--- a/spec/components/settings/project_custom_field_sections/custom_field_row_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/custom_field_row_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Settings::ProjectCustomFieldSections::CustomFieldRowComponent, type: :component do
+  let(:field) { create(:project_custom_field) }
+
+  it "keys its wrapper by the custom field so morphs match rows" do
+    render_inline(described_class.new(project_custom_field: field, first: true, last: false))
+
+    expect(page).to have_css(
+      "##{described_class.component_id(field)}"
+    )
+  end
+end

--- a/spec/components/settings/project_custom_field_sections/custom_field_row_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/custom_field_row_component_spec.rb
@@ -40,4 +40,15 @@ RSpec.describe Settings::ProjectCustomFieldSections::CustomFieldRowComponent, ty
       "##{described_class.component_id(field)}"
     )
   end
+
+  it "wires its drag handle as the sortable-lists item handle target" do
+    # The sortable-lists--item controller itself lives on the enclosing
+    # BorderBox <li> rendered by ShowComponent, not on this row's own
+    # wrapper div; only the handle target is asserted here.
+    render_inline(described_class.new(project_custom_field: field, first: true, last: false))
+
+    expect(page).to have_css(
+      "##{described_class.component_id(field)} .handle[data-sortable-lists--item-target='handle']"
+    )
+  end
 end

--- a/spec/components/settings/project_custom_field_sections/index_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/index_component_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Settings::ProjectCustomFieldSections::IndexComponent, type: :component do
+  let(:section_a) { create(:project_custom_field_section) }
+  let(:section_b) { create(:project_custom_field_section) }
+
+  subject do
+    with_request_url "/admin/settings/project_custom_fields" do
+      render_inline(described_class.new(project_custom_field_sections: [section_a, section_b]))
+    end
+  end
+
+  before do
+    section_a
+    section_b
+  end
+
+  it "wires the wrapper as the sortable-lists root with per-type move URL templates and no optimistic flag" do
+    subject
+
+    root = page.find("[data-controller='sortable-lists']", visible: :all)
+    move_url_templates = JSON.parse(root["data-sortable-lists-move-url-templates-value"])
+
+    expect(move_url_templates["section"]).to include("/admin/settings/project_custom_field_sections/{id}/drop")
+    expect(move_url_templates["custom_field"]).to include("/admin/settings/project_custom_fields/{id}/drop")
+    expect(root["data-sortable-lists-optimistic-value"]).to be_nil
+  end
+
+  it "wires the root's outlet selectors so they actually resolve to the rendered list/items" do
+    subject
+
+    root = page.find("[data-controller='sortable-lists']", visible: :all)
+    list_outlet_selector = root["data-sortable-lists-sortable-lists--list-outlet"]
+    item_outlet_selector = root["data-sortable-lists-sortable-lists--item-outlet"]
+
+    expect(list_outlet_selector).to be_present
+    expect(item_outlet_selector).to be_present
+
+    # Prove the selector-to-DOM link, not just attribute presence: if the
+    # dasherization or the `##{wrapper_key}` interpolation drifts, these
+    # selectors silently stop matching anything and the outlets connect
+    # to nothing with no failing test or console warning.
+    expect(page).to have_css(list_outlet_selector)
+    expect(page).to have_css(item_outlet_selector)
+  end
+
+  it "wires the sections flex container as a sortable-lists list of type section without a list id" do
+    subject
+
+    expect(page).to have_css(
+      "[data-controller~='sortable-lists--list']" \
+      "[data-sortable-lists--list-type-value='section']" \
+      "[data-sortable-lists--list-accepted-type-value='section']" \
+      ":not([data-sortable-lists--list-id-value])"
+    )
+  end
+
+  it "wires each section row as a sortable-lists item of type section" do
+    subject
+
+    [section_a, section_b].each do |section|
+      expect(page).to have_css(
+        "[data-controller~='sortable-lists--item']" \
+        "[data-sortable-lists--item-id-value='#{section.id}']" \
+        "[data-sortable-lists--item-type-value='section']" \
+        "[data-sortable-lists--item-label-value='#{section.name}']"
+      )
+    end
+  end
+
+  it "has no generic-drag-and-drop remnants" do
+    subject
+
+    expect(page.native.to_html).not_to match(/generic-drag-and-drop|dragula/)
+  end
+end

--- a/spec/components/settings/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/show_component_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Settings::ProjectCustomFieldSections::ShowComponent, type: :component do
+  let(:section) { create(:project_custom_field_section) }
+  let(:field_a) { create(:project_custom_field, project_custom_field_section: section) }
+  let(:field_b) { create(:project_custom_field, project_custom_field_section: section) }
+
+  subject do
+    with_request_url "/admin/settings/project_custom_fields" do
+      # `custom_fields_in_order` reads the section's in-memory
+      # `attribute_order`, which the fields' after_create_commit
+      # callback updates via a separate `section` instance in the
+      # association chain, so this `let`-bound object must be
+      # reloaded to see it.
+      render_inline(described_class.new(project_custom_field_section: section.reload))
+    end
+  end
+
+  before do
+    field_a
+    field_b
+  end
+
+  it "wires the BorderBox as a sortable-lists list of type custom_field scoped to the section" do
+    subject
+
+    expect(page).to have_css(
+      "[data-controller~='sortable-lists--list']" \
+      "[data-sortable-lists--list-type-value='custom_field']" \
+      "[data-sortable-lists--list-accepted-type-value='custom_field']" \
+      "[data-sortable-lists--list-id-value='#{section.id}']" \
+      "[data-sortable-lists--list-name-value='#{section.name}']"
+    )
+  end
+
+  it "wires the section-header drag handle as the sortable-lists item handle target" do
+    subject
+
+    # Scoped to the header: the two field-row handles carry the same
+    # class + data attribute, so an unscoped assertion here would stay
+    # green even if the header's own handle lost its `data:` hash.
+    expect(page).to have_css(
+      ".Box-header .handle[data-sortable-lists--item-target='handle']",
+      count: 1
+    )
+  end
+
+  it "wires each field row's li as a sortable-lists item of type custom_field" do
+    subject
+
+    [field_a, field_b].each do |field|
+      expect(page).to have_css(
+        "li[data-controller~='sortable-lists--item']" \
+        "[data-sortable-lists--item-id-value='#{field.id}']" \
+        "[data-sortable-lists--item-type-value='custom_field']" \
+        "[data-sortable-lists--item-label-value='#{field.name}']"
+      )
+    end
+  end
+
+  it "has no generic-drag-and-drop remnants" do
+    subject
+
+    expect(page.native.to_html).not_to match(
+      /generic-drag-and-drop|target-container-accessor|target-allowed-drag-type|draggable-type|drop-url/
+    )
+  end
+end

--- a/spec/components/settings/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/show_component_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe Settings::ProjectCustomFieldSections::ShowComponent, type: :compo
     )
   end
 
+  it "wires the BorderBox as the section item's drag preview target" do
+    subject
+
+    # The box, not the row wrapper, is the preview so the native drag
+    # snapshot's margin whitespace and squared-off corners never show.
+    expect(page).to have_css(
+      "[data-sortable-lists--list-type-value='custom_field']" \
+      "[data-sortable-lists--item-target='preview']"
+    )
+  end
+
   it "wires the section-header drag handle as the sortable-lists item handle target" do
     subject
 

--- a/spec/features/admin/custom_fields/projects/reorder_spec.rb
+++ b/spec/features/admin/custom_fields/projects/reorder_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "shared_context"
+
+# Selenium-driven: Pragmatic drag and drop needs real native drag events,
+# which Cuprite cannot reliably synthesize (see the backlogs DnD specs, the
+# reference consumer for this drag helper style).
+RSpec.describe "Reordering project attribute sections and fields", :js, :selenium do
+  include_context "with seeded project custom fields"
+
+  let(:cf_index_page) { Pages::Admin::Settings::ProjectCustomFields::Index.new }
+
+  before do
+    login_as(admin)
+    cf_index_page.visit!
+  end
+
+  it "drags a field below another field within the same section, and it persists" do
+    drag_field(boolean_project_custom_field, after: string_project_custom_field)
+
+    expect_fields_in_order(string_project_custom_field, boolean_project_custom_field, integer_project_custom_field)
+
+    cf_index_page.visit!
+
+    expect_fields_in_order(string_project_custom_field, boolean_project_custom_field, integer_project_custom_field)
+  end
+
+  it "drags a field into another section, including an empty one, and it persists" do
+    drag_field(user_project_custom_field, before: multi_list_project_custom_field)
+
+    expect_no_field_in_section(section_for_select_fields, user_project_custom_field)
+    expect_fields_in_order(user_project_custom_field, multi_list_project_custom_field)
+
+    empty_section = create(:project_custom_field_section, name: "Empty section")
+    cf_index_page.visit!
+
+    # persisted across the reload
+    expect_no_field_in_section(section_for_select_fields, user_project_custom_field)
+    expect_fields_in_order(user_project_custom_field, multi_list_project_custom_field)
+
+    drag_field(version_project_custom_field, into: empty_section)
+
+    expect_no_field_in_section(section_for_select_fields, version_project_custom_field)
+    expect_field_in_section(empty_section, version_project_custom_field)
+    within_project_custom_field_section_container(empty_section) do
+      expect(page).to have_no_css("[data-empty-list-item]")
+    end
+
+    cf_index_page.visit!
+
+    expect_no_field_in_section(section_for_select_fields, user_project_custom_field)
+    expect_no_field_in_section(section_for_select_fields, version_project_custom_field)
+    expect_field_in_section(empty_section, version_project_custom_field)
+    expect_fields_in_order(user_project_custom_field, multi_list_project_custom_field)
+  end
+
+  it "drags a section below another section, and it persists" do
+    # Adjacent sections: input_fields (8 fields) sits at the top of a tall
+    # page, so dragging it clear across would require a native pointer move
+    # beyond the viewport. select_fields already sits right above
+    # multi_select_fields, keeping the drag distance short regardless of
+    # scroll position.
+    drag_section(section_for_select_fields, after: section_for_multi_select_fields)
+
+    expect_sections_in_order(section_for_input_fields, section_for_multi_select_fields, section_for_select_fields)
+
+    cf_index_page.visit!
+
+    expect_sections_in_order(section_for_input_fields, section_for_multi_select_fields, section_for_select_fields)
+  end
+
+  it "still reorders sections and fields via the kebab move menus" do
+    perform_section_menu_action(section_for_multi_select_fields, "Move up")
+
+    expect_sections_in_order(section_for_input_fields, section_for_multi_select_fields, section_for_select_fields)
+
+    perform_field_menu_action(user_project_custom_field, "Move to top")
+
+    expect_fields_in_order(user_project_custom_field, list_project_custom_field)
+
+    cf_index_page.visit!
+
+    expect_sections_in_order(section_for_input_fields, section_for_multi_select_fields, section_for_select_fields)
+    expect_fields_in_order(user_project_custom_field, list_project_custom_field)
+  end
+
+  it "allows a second drag on a field whose section was morphed by the first drag" do
+    drag_field(boolean_project_custom_field, after: string_project_custom_field)
+
+    expect_fields_in_order(string_project_custom_field, boolean_project_custom_field, integer_project_custom_field)
+
+    # string_project_custom_field's row was patched (not replaced) by the morph
+    # that reconciled the first drag; drag it again to prove it is still wired.
+    drag_field(string_project_custom_field, after: date_project_custom_field)
+
+    expect_fields_in_order(date_project_custom_field, string_project_custom_field, text_project_custom_field)
+
+    cf_index_page.visit!
+
+    expect_fields_in_order(date_project_custom_field, string_project_custom_field, text_project_custom_field)
+  end
+
+  # helper methods:
+
+  def within_project_custom_field_section_container(section, &)
+    within_test_selector("project-custom-field-section-container-#{section.id}", &)
+  end
+
+  def within_project_custom_field_container(custom_field, &)
+    within_test_selector("project-custom-field-container-#{custom_field.id}", &)
+  end
+
+  def within_project_custom_field_section_menu(section, &)
+    within_project_custom_field_section_container(section) do
+      page.find_test_selector("project-custom-field-section-action-menu").click
+      within("anchored-position", &)
+    end
+  end
+
+  def within_project_custom_field_menu(custom_field, &)
+    within_project_custom_field_container(custom_field) do
+      page.find_test_selector("project-custom-field-action-menu").click
+      within("anchored-position", &)
+    end
+  end
+
+  def perform_section_menu_action(section, action)
+    within_project_custom_field_section_menu(section) do
+      wait_for_turbo_stream { click_on(action) }
+    end
+  end
+
+  def perform_field_menu_action(custom_field, action)
+    within_project_custom_field_menu(custom_field) do
+      wait_for_turbo_stream { click_on(action) }
+    end
+  end
+
+  def field_row_selector(custom_field)
+    "[data-sortable-lists--item-id-value='#{custom_field.id}'][data-sortable-lists--item-type-value='custom_field']"
+  end
+
+  def section_row_selector(section)
+    "[data-sortable-lists--item-id-value='#{section.id}'][data-sortable-lists--item-type-value='section']"
+  end
+
+  def field_item(custom_field)
+    find(field_row_selector(custom_field))
+  end
+
+  def section_item(section)
+    find(section_row_selector(section))
+  end
+
+  # A section row nests its own field list (with its fields' handles), so a
+  # plain descendant search inside a section's item element matches every
+  # nested handle too. The item's own handle always renders in its header,
+  # before any rows it nests, so it is reliably the first match.
+  def drag_handle(item_element)
+    item_element.first("[data-sortable-lists--item-target~='handle']")
+  end
+
+  def empty_section_drop_target(section)
+    within_project_custom_field_section_container(section) do
+      find("[data-empty-list-item]")
+    end
+  end
+
+  def expect_fields_in_order(*custom_fields)
+    expect(page).to have_css(custom_fields.map { |cf| field_row_selector(cf) }.join(" + "))
+  end
+
+  def expect_sections_in_order(*sections)
+    expect(page).to have_css(sections.map { |s| section_row_selector(s) }.join(" + "))
+  end
+
+  def expect_field_in_section(section, custom_field)
+    within_project_custom_field_section_container(section) do
+      expect(page).to have_css(field_row_selector(custom_field))
+    end
+  end
+
+  def expect_no_field_in_section(section, custom_field)
+    within_project_custom_field_section_container(section) do
+      expect(page).to have_no_css(field_row_selector(custom_field))
+    end
+  end
+
+  # Drags a project custom field row via its drag handle. Exactly one of
+  # before:, after: or into: (an empty section) must be given.
+  #
+  # Retries on a stale reference: a drop can trigger a Turbo morph mid-drag
+  # bookkeeping (e.g. re-locating the target after a previous drag in the same
+  # example), and this suite runs Selenium only, so the Selenium-specific
+  # error is what actually surfaces here (unlike Cuprite-driven specs
+  # elsewhere, which raise Capybara::Cuprite::ObsoleteNode instead).
+  def drag_field(custom_field, before: nil, after: nil, into: nil)
+    unless [before, after, into].compact.one?
+      raise ArgumentError, "You must specify exactly one of before, after or into"
+    end
+
+    handle = drag_handle(field_item(custom_field))
+
+    target_element, edge =
+      if before
+        [field_item(before), :top]
+      elsif after
+        [field_item(after), :bottom]
+      else
+        [empty_section_drop_target(into), nil]
+      end
+
+    wait_for_turbo_stream { drag_via_handle(handle:, target_element:, edge:) }
+  rescue Selenium::WebDriver::Error::StaleElementReferenceError
+    retry
+  end
+
+  def drag_section(section, before: nil, after: nil)
+    unless [before, after].compact.one?
+      raise ArgumentError, "You must specify exactly one of before or after"
+    end
+
+    handle = drag_handle(section_item(section))
+    target_element, edge = before ? [section_item(before), :top] : [section_item(after), :bottom]
+
+    wait_for_turbo_stream { drag_via_handle(handle:, target_element:, edge:) }
+  rescue Selenium::WebDriver::Error::StaleElementReferenceError
+    retry
+  end
+
+  def drag_via_handle(handle:, target_element:, edge: nil)
+    scroll_to_element(handle)
+
+    target_x, target_y = selenium_target_point(target_element.native.rect, edge:)
+    perform_native_drag(source: handle, target_x:, target_y:)
+
+    # Assert Pragmatic DnD tore down its own honey-pot overlay before we force
+    # a cleanup, so a regression that leaves the overlay stuck is caught here
+    # instead of being masked by the JS removal below.
+    expect(page).to have_no_css("[data-pdnd-honey-pot]", wait: 2, visible: :all)
+    clear_pragmatic_dnd_honey_pot
+  end
+
+  def selenium_target_point(rect, edge:)
+    offset = [6, rect.height / 4].min
+
+    [
+      rect.x + (rect.width / 2),
+      case edge
+      when :top
+        rect.y + offset
+      when :bottom
+        rect.y + rect.height - offset
+      else
+        rect.y + (rect.height / 2)
+      end
+    ].map(&:round)
+  end
+
+  def clear_pragmatic_dnd_honey_pot
+    page.execute_script(<<~JS)
+      document
+        .querySelectorAll('[data-pdnd-honey-pot]')
+        .forEach((element) => element.remove());
+    JS
+  end
+end

--- a/spec/models/concerns/lists/move_after_anchor_spec.rb
+++ b/spec/models/concerns/lists/move_after_anchor_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Lists::MoveAfterAnchor do
+  shared_let(:section_a) { create(:project_custom_field_section, name: "A") }
+  shared_let(:section_b) { create(:project_custom_field_section, name: "B") }
+  shared_let(:section_c) { create(:project_custom_field_section, name: "C") }
+
+  let(:scope) { ProjectCustomFieldSection.all }
+
+  def order = scope.reload.order(:position).pluck(:name)
+
+  it "moves to the top for a blank anchor" do
+    expect(section_c.move_after_anchor("", scope:)).to be(true)
+    expect(order).to eq(%w[C A B])
+  end
+
+  it "moves downward directly below the anchor" do
+    expect(section_a.move_after_anchor(section_b.id.to_s, scope:)).to be(true)
+    expect(order).to eq(%w[B A C])
+  end
+
+  it "moves upward directly below the anchor" do
+    expect(section_c.move_after_anchor(section_a.id.to_s, scope:)).to be(true)
+    expect(order).to eq(%w[A C B])
+  end
+
+  it "rejects an unknown anchor without mutating" do
+    expect(section_a.move_after_anchor("999999", scope:)).to be(false)
+    expect(order).to eq(%w[A B C])
+  end
+
+  it "rejects a self anchor without mutating" do
+    expect(section_b.move_after_anchor(section_b.id.to_s, scope:)).to be(false)
+    expect(order).to eq(%w[A B C])
+  end
+
+  it "rejects an out-of-scope anchor without mutating" do
+    foreign = create(:user_custom_field_section)
+    expect(section_a.move_after_anchor(foreign.id.to_s, scope:)).to be(false)
+    expect(order).to eq(%w[A B C])
+  end
+end

--- a/spec/models/project_custom_field_section_spec.rb
+++ b/spec/models/project_custom_field_section_spec.rb
@@ -129,6 +129,47 @@ RSpec.describe ProjectCustomFieldSection do
     end
   end
 
+  describe "#insert_after_key" do
+    let(:section) { create(:project_custom_field_section) }
+    # Creation order determines initial attribute_order within the section.
+    let!(:cf1) { create(:string_project_custom_field, name: "CF1", project_custom_field_section: section) }
+    let!(:cf2) { create(:string_project_custom_field, name: "CF2", project_custom_field_section: section) }
+    let!(:cf3) { create(:string_project_custom_field, name: "CF3", project_custom_field_section: section) }
+    let(:k1) { cf1.column_name }
+    let(:k2) { cf2.column_name }
+    let(:k3) { cf3.column_name }
+
+    # cf1/cf2/cf3 are created via a separately-loaded custom_field_section
+    # association (add_to_section_order), so section's in-memory
+    # attribute_order is stale until reloaded.
+    before { section.reload }
+
+    it "inserts at the head for a blank prev_key" do
+      expect(section.insert_after_key(k3, "")).to be(true)
+      expect(section.reload.attribute_order).to eq([k3, k1, k2])
+    end
+
+    it "inserts directly after the anchor moving down" do
+      expect(section.insert_after_key(k1, k2)).to be(true)
+      expect(section.reload.attribute_order).to eq([k2, k1, k3])
+    end
+
+    it "inserts directly after the anchor moving up" do
+      expect(section.insert_after_key(k3, k1)).to be(true)
+      expect(section.reload.attribute_order).to eq([k1, k3, k2])
+    end
+
+    it "rejects an unknown anchor key without mutating" do
+      expect(section.insert_after_key(k1, "cf_unknown")).to be(false)
+      expect(section.reload.attribute_order).to eq([k1, k2, k3])
+    end
+
+    it "rejects a self anchor without mutating" do
+      expect(section.insert_after_key(k2, k2)).to be(false)
+      expect(section.reload.attribute_order).to eq([k1, k2, k3])
+    end
+  end
+
   describe ".grouped_in_order" do
     let!(:section_a) { create(:project_custom_field_section, name: "Section A", position: 1) }
     let!(:section_b) { create(:project_custom_field_section, name: "Section B", position: 2) }

--- a/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe "Project custom field sections drop", :skip_csrf, type: :rails_re
   end
 
   it "morphs the sections list on success" do
-    pending "morph streams land in the next commit"
     drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
     expect(response.body).to include('method="morph"')
   end

--- a/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project custom field sections drop", :skip_csrf, type: :rails_request do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:section_a) { create(:project_custom_field_section) }
+  shared_let(:section_b) { create(:project_custom_field_section) }
+
+  current_user { admin }
+
+  def drop(section, params)
+    put drop_admin_settings_project_custom_field_section_path(section),
+        params:, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  it "moves the section below the anchor" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
+    expect(response).to have_http_status(:ok)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_b.id, section_a.id])
+  end
+
+  it "moves the section to the top for a blank prev_id" do
+    drop(section_b, { list_type: "section", list_id: "", prev_id: "" })
+    expect(response).to have_http_status(:ok)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_b.id, section_a.id])
+  end
+
+  it "422s without mutation for an unknown anchor" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: "999999" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s when prev_id is omitted entirely" do
+    drop(section_a, { list_type: "section", list_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s for a wrong list_type" do
+    drop(section_a, { list_type: "custom_field", list_id: "", prev_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s for a nonblank list_id" do
+    drop(section_a, { list_type: "section", list_id: section_b.id.to_s, prev_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s without mutation for a collection-valued prev_id" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: [section_b.id.to_s] })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s without mutation for an empty collection prev_id" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: [""] })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s for a collection-valued list_id" do
+    drop(section_a, { list_type: "section", list_id: [""], prev_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "morphs the sections list on success" do
+    pending "morph streams land in the next commit"
+    drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
+    expect(response.body).to include('method="morph"')
+  end
+end

--- a/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
@@ -78,6 +78,24 @@ RSpec.describe "Project custom field sections drop", :skip_csrf, type: :rails_re
     expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
   end
 
+  it "422s without mutation for a collection-valued prev_id" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: [section_b.id.to_s] })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s without mutation for an empty collection prev_id" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: [""] })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s for a collection-valued list_id" do
+    drop(section_a, { list_type: "section", list_id: [""], prev_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
   it "morphs the sections list on success" do
     drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
     expect(response.body).to include('method="morph"')

--- a/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project custom field sections drop", :skip_csrf, type: :rails_request do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:section_a) { create(:project_custom_field_section) }
+  shared_let(:section_b) { create(:project_custom_field_section) }
+
+  current_user { admin }
+
+  def drop(section, params)
+    put drop_admin_settings_project_custom_field_section_path(section),
+        params:, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  it "moves the section below the anchor" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
+    expect(response).to have_http_status(:ok)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_b.id, section_a.id])
+  end
+
+  it "moves the section to the top for a blank prev_id" do
+    drop(section_b, { list_type: "section", list_id: "", prev_id: "" })
+    expect(response).to have_http_status(:ok)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_b.id, section_a.id])
+  end
+
+  it "422s without mutation for an unknown anchor" do
+    drop(section_a, { list_type: "section", list_id: "", prev_id: "999999" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s when prev_id is omitted entirely" do
+    drop(section_a, { list_type: "section", list_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s for a wrong list_type" do
+    drop(section_a, { list_type: "custom_field", list_id: "", prev_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "422s for a nonblank list_id" do
+    drop(section_a, { list_type: "section", list_id: section_b.id.to_s, prev_id: "" })
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(ProjectCustomFieldSection.order(:position).ids).to eq([section_a.id, section_b.id])
+  end
+
+  it "morphs the sections list on success" do
+    pending "morph streams land in the next commit"
+    drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
+    expect(response.body).to include('method="morph"')
+  end
+end

--- a/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_field_sections_drop_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe "Project custom field sections drop", :skip_csrf, type: :rails_re
   end
 
   it "morphs the sections list on success" do
-    pending "morph streams land in the next commit"
     drop(section_a, { list_type: "section", list_id: "", prev_id: section_b.id.to_s })
     expect(response.body).to include('method="morph"')
   end

--- a/spec/requests/admin/settings/project_custom_fields_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_fields_drop_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project custom fields drop", :skip_csrf, type: :rails_request do
+  shared_let(:section_a) { create(:project_custom_field_section) }
+  shared_let(:section_b) { create(:project_custom_field_section) }
+  shared_let(:section_c) { create(:project_custom_field_section) }
+  shared_let(:cf1) { create(:project_custom_field, project_custom_field_section: section_a) }
+  shared_let(:cf2) { create(:project_custom_field, project_custom_field_section: section_a) }
+  shared_let(:cf3) { create(:project_custom_field, project_custom_field_section: section_a) }
+  shared_let(:cf4) { create(:project_custom_field, project_custom_field_section: section_b) }
+
+  def drop(field, params)
+    put drop_admin_settings_project_custom_field_path(field),
+        params:, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  context "as admin" do
+    current_user { create(:admin) }
+
+    it "reorders the field within its section after the anchor" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf1.id.to_s })
+      expect(response).to have_http_status(:ok)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf3.column_name, cf2.column_name])
+    end
+
+    it "moves the field to the top of its section for a blank prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: "" })
+      expect(response).to have_http_status(:ok)
+      expect(section_a.reload.attribute_order).to eq([cf3.column_name, cf1.column_name, cf2.column_name])
+    end
+
+    it "moves the field across sections, updating both sections and the field's section" do
+      drop(cf2, { list_type: "custom_field", list_id: section_b.id.to_s, prev_id: cf4.id.to_s })
+      expect(response).to have_http_status(:ok)
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name, cf2.column_name])
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf3.column_name])
+      expect(cf2.reload.custom_field_section_id).to eq(section_b.id)
+    end
+
+    it "moves the field into an empty section with a blank prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_c.id.to_s, prev_id: "" })
+      expect(response).to have_http_status(:ok)
+      expect(section_c.reload.attribute_order).to eq([cf3.column_name])
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_c.id)
+    end
+
+    it "422s without mutation for an unknown prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: "999999" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "422s without mutation for a self prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf3.id.to_s })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "422s without mutation for a prev_id from another section" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf4.id.to_s })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "422s when prev_id is omitted entirely" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s for a wrong list_type" do
+      drop(cf3, { list_type: "section", list_id: section_a.id.to_s, prev_id: "" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s for a blank list_id" do
+      drop(cf3, { list_type: "custom_field", list_id: "", prev_id: "" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s without mutation for a collection-valued prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: [cf1.id.to_s] })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s without mutation for a collection-valued list_id" do
+      drop(cf3, { list_type: "custom_field", list_id: [section_b.id.to_s], prev_id: "" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+  end
+
+  context "as a non-admin" do
+    current_user { create(:user) }
+
+    it "is forbidden" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf1.id.to_s })
+      expect(response).to have_http_status(:forbidden)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+  end
+end

--- a/spec/requests/admin/settings/project_custom_fields_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_fields_drop_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project custom fields drop", :skip_csrf, type: :rails_request do
+  shared_let(:section_a) { create(:project_custom_field_section) }
+  shared_let(:section_b) { create(:project_custom_field_section) }
+  shared_let(:section_c) { create(:project_custom_field_section) }
+  shared_let(:cf1) { create(:project_custom_field, project_custom_field_section: section_a) }
+  shared_let(:cf2) { create(:project_custom_field, project_custom_field_section: section_a) }
+  shared_let(:cf3) { create(:project_custom_field, project_custom_field_section: section_a) }
+  shared_let(:cf4) { create(:project_custom_field, project_custom_field_section: section_b) }
+
+  def drop(field, params)
+    put drop_admin_settings_project_custom_field_path(field),
+        params:, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  context "as admin" do
+    current_user { create(:admin) }
+
+    it "reorders the field within its section after the anchor" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf1.id.to_s })
+      expect(response).to have_http_status(:ok)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf3.column_name, cf2.column_name])
+    end
+
+    it "moves the field to the top of its section for a blank prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: "" })
+      expect(response).to have_http_status(:ok)
+      expect(section_a.reload.attribute_order).to eq([cf3.column_name, cf1.column_name, cf2.column_name])
+    end
+
+    it "moves the field across sections, updating both sections and the field's section" do
+      drop(cf2, { list_type: "custom_field", list_id: section_b.id.to_s, prev_id: cf4.id.to_s })
+      expect(response).to have_http_status(:ok)
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name, cf2.column_name])
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf3.column_name])
+      expect(cf2.reload.custom_field_section_id).to eq(section_b.id)
+    end
+
+    it "moves the field into an empty section with a blank prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_c.id.to_s, prev_id: "" })
+      expect(response).to have_http_status(:ok)
+      expect(section_c.reload.attribute_order).to eq([cf3.column_name])
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_c.id)
+    end
+
+    it "422s without mutation for an unknown prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: "999999" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "422s without mutation for a self prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf3.id.to_s })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "422s without mutation for a prev_id from another section" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf4.id.to_s })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "422s when prev_id is omitted entirely" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s for a wrong list_type" do
+      drop(cf3, { list_type: "section", list_id: section_a.id.to_s, prev_id: "" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s for a blank list_id" do
+      drop(cf3, { list_type: "custom_field", list_id: "", prev_id: "" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+  end
+
+  context "as a non-admin" do
+    current_user { create(:user) }
+
+    it "is forbidden" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: cf1.id.to_s })
+      expect(response).to have_http_status(:forbidden)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+  end
+end

--- a/spec/requests/admin/settings/project_custom_fields_drop_spec.rb
+++ b/spec/requests/admin/settings/project_custom_fields_drop_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe "Project custom fields drop", :skip_csrf, type: :rails_request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
     end
+
+    it "422s without mutation for a collection-valued prev_id" do
+      drop(cf3, { list_type: "custom_field", list_id: section_a.id.to_s, prev_id: [cf1.id.to_s] })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+    end
+
+    it "422s without mutation for a collection-valued list_id" do
+      drop(cf3, { list_type: "custom_field", list_id: [section_b.id.to_s], prev_id: "" })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
   end
 
   context "as a non-admin" do

--- a/spec/services/custom_fields/drop_service_spec.rb
+++ b/spec/services/custom_fields/drop_service_spec.rb
@@ -100,4 +100,106 @@ RSpec.describe CustomFields::DropService do
                      section_factory: :project_custom_field_section,
                      section_assoc: :project_custom_field_section
   end
+
+  describe "anchor wire (list_id/prev_id)" do
+    let(:section_a) { create(:project_custom_field_section, position: 1) }
+    let(:section_b) { create(:project_custom_field_section, position: 2) }
+    let(:section_c) { create(:project_custom_field_section, position: 3) }
+    let!(:cf1) { create(:project_custom_field, project_custom_field_section: section_a) }
+    let!(:cf2) { create(:project_custom_field, project_custom_field_section: section_a) }
+    let!(:cf3) { create(:project_custom_field, project_custom_field_section: section_a) }
+    let!(:cf4) { create(:project_custom_field, project_custom_field_section: section_b) }
+
+    subject(:service) { described_class.new(user: admin, custom_field: cf3) }
+
+    it "reorders within the section after the anchor field" do
+      result = service.call(list_id: section_a.id, prev_id: cf1.id)
+
+      expect(result).to be_success
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf3.column_name, cf2.column_name])
+      expect(result.result[:section_changed]).to be(false)
+      expect(result.result[:old_section]).to be_nil
+    end
+
+    it "moves to the top of the section for a blank prev_id" do
+      result = service.call(list_id: section_a.id, prev_id: "")
+
+      expect(result).to be_success
+      expect(section_a.reload.attribute_order).to eq([cf3.column_name, cf1.column_name, cf2.column_name])
+    end
+
+    it "moves across sections after the target-section anchor, transactionally" do
+      service_for_cf2 = described_class.new(user: admin, custom_field: cf2)
+      result = service_for_cf2.call(list_id: section_b.id, prev_id: cf4.id)
+
+      expect(result).to be_success
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name, cf2.column_name])
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf3.column_name])
+      expect(cf2.reload.custom_field_section_id).to eq(section_b.id)
+      expect(result.result[:section_changed]).to be(true)
+      expect(result.result[:current_section]).to eq(section_b)
+      expect(result.result[:old_section]).to eq(section_a)
+    end
+
+    it "fails without mutation when the insert fails after reparenting across sections" do
+      service_for_cf2 = described_class.new(user: admin, custom_field: cf2)
+
+      # Instance stub (not allow_any_instance_of): force the post-reparent
+      # insert to fail so the rollback guard's un-reachable-in-practice
+      # branch (remove_from_order + update! already applied, then
+      # insert_after_key false) is actually exercised.
+      allow(ProjectCustomFieldSection).to receive(:find_by).with(id: section_b.id).and_return(section_b)
+      allow(section_b).to receive(:insert_after_key).and_return(false)
+
+      result = service_for_cf2.call(list_id: section_b.id, prev_id: cf4.id)
+
+      expect(result).not_to be_success
+      expect(cf2.reload.custom_field_section_id).to eq(section_a.id)
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name])
+    end
+
+    it "moves into an empty section with a blank prev_id" do
+      result = service.call(list_id: section_c.id, prev_id: "")
+
+      expect(result).to be_success
+      expect(section_c.reload.attribute_order).to eq([cf3.column_name])
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_c.id)
+    end
+
+    it "fails without mutation for an unknown prev_id" do
+      result = service.call(list_id: section_a.id, prev_id: 0)
+
+      expect(result).not_to be_success
+      expect(result.errors).to eq(I18n.t(:error_invalid_list_move_anchor))
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "fails without mutation for a prev_id from another section" do
+      result = service.call(list_id: section_a.id, prev_id: cf4.id)
+
+      expect(result).not_to be_success
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(section_b.reload.attribute_order).to eq([cf4.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "fails without mutation for a self prev_id" do
+      result = service.call(list_id: section_a.id, prev_id: cf3.id)
+
+      expect(result).not_to be_success
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+
+    it "fails without mutation for an unknown list_id" do
+      result = service.call(list_id: 0, prev_id: cf1.id)
+
+      expect(result).not_to be_success
+      expect(section_a.reload.attribute_order).to eq([cf1.column_name, cf2.column_name, cf3.column_name])
+      expect(cf3.reload.custom_field_section_id).to eq(section_a.id)
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-786

# What are you trying to accomplish?

Extends the shared `sortable-lists` Stimulus suite so admin surfaces can adopt it, and proves the extended contract by migrating Administration → Projects → Project attributes (sections + fields) off Dragula (`generic-drag-and-drop`).

- Suite extensions (all additive, Backlogs keeps working unmodified): rows may be any element — an item's owning list is the innermost list outlet containing it (replaces the `closest('li')` assumption); a per-type move-URL template map so one root can host item types with different endpoints; the `optimistic=true` flag is now opt-in (Backlogs opts in to keep its event-only success contract, admin surfaces reconcile through morph streams).
- Backend: anchor-based (`prev_id`) ordering primitives with strict validation — a blank anchor means top; an unknown, out-of-scope, self, or omitted anchor is a 422 with zero mutation. Both project-attribute `drop` endpoints convert in-place to the `list_type`/`list_id`/`prev_id` wire (the page migrates in the same PR, so no dual-wire period).
- Server responses switch to `method="morph"` turbo streams; field rows gain unique per-field wrapper IDs so the morph matcher associates rows correctly on reorder.
- Sections and fields render a custom drag preview and grab/grabbing handle cursors (the native drag snapshot painted margin whitespace and squared-off corners).
- Also fixes a suite bug the new feature spec exposed: the row lookup climbed ancestors unbounded, so dropping into an empty section resolved the enclosing section itself as the `prev_id` anchor; the lookup is now bounded to the row's own list.

> [!NOTE]
> Visually this is more or less a like-for-like migration. The newer Backlogs-style styling improvements (e.g. drop indicators) land when this page migrates to `BorderBoxListComponent`: https://community.openproject.org/wp/DREAM-697

Covered by vitest suite specs (nested dual-role topology), model/service/request/component specs, and a Selenium feature spec (same-section, cross-section and empty-section drags, menu moves, drag-after-morph).

# What approach did you choose and why?

- **Ordering primitives are model concerns, not services.** `Lists::MoveAfterAnchor` (for `acts_as_list` models) and `CustomFieldSection#insert_after_key` (for the `attribute_order` array) live next to the state they mutate. `ProjectCustomFieldSections::UpdateService` is no longer in the drop path (it carried no validation or side effects relevant to positioning).
- **`CustomFields::DropService` keeps a legacy adapter path.** The user-custom-fields surface still sends the old `target_id`/`position` wire; the path is pinned by a regression spec and dies with https://community.openproject.org/wp/DREAM-790.
- **Concurrency:** cross-section field moves are transactional and lock both section rows in deterministic id order before reading `attribute_order` (a read-modify-write array). The `acts_as_list` side needs no equivalent lock — position shifts are single SQL statements, so the worst concurrent case is a surprising order, not corruption.
- **Move-URL templates come from route helpers** with a sentinel substitution (`__id__` → `{id}`), never hardcoded paths, so relative-URL-root installations keep working.
- The existing `move_to` menu actions and `CustomFields::MoveService` are untouched (shared four-direction menu descriptor is https://community.openproject.org/wp/DREAM-775).

## Screen recording

https://github.com/user-attachments/assets/32e6cbbe-5474-4353-9982-9c4b3ab5f629

Follow-up notes:

- Auto-scroll while dragging is not wired on this page (it never had it under Dragula); wiring `sortable-lists--scrollable` needs a scroll-container decision.
- The sortable-lists consumer contract documentation lands with https://community.openproject.org/wp/DREAM-774.
- The Selenium drag helpers (`selenium_target_point`, honey-pot cleanup) are duplicated between the backlogs and admin specs — worth extracting when the next surface migrates.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
