### PR TITLE
[COMMS-931] Adapt `MigrateVersionSprintJournalsJob` to target versions model

### DIFF
--- a/modules/backlogs/app/workers/backlogs/migrate_version_sprint_journals_job.rb
+++ b/modules/backlogs/app/workers/backlogs/migrate_version_sprint_journals_job.rb
@@ -37,9 +37,7 @@ module Backlogs
       system_user = User.system
 
       Journal::NotificationConfiguration.with(false) do
-        WorkPackage.joins(:sprint, :version)
-                   .select("work_packages.*, versions.name AS version_name")
-                   .find_each do |work_package|
+        qualified_work_packages.find_each do |work_package|
           cause = Journal::CausedBySystemUpdate.new(
             feature: "sprint_migration",
             version_name: work_package.version_name
@@ -49,6 +47,41 @@ module Backlogs
             .call(cause:)
         end
       end
+    end
+
+    private
+
+    # Reads the version name through work_package_versions where available,
+    # falling back to the legacy version_id column: a worker can pick this job
+    # up between the migration enqueuing it and the much later migration that
+    # introduces work_package_versions.
+    def qualified_work_packages
+      scope = WorkPackage.joins(:sprint)
+
+      if work_package_versions_available?
+        # A work package can have several target versions; journal once, for
+        # the primary one (lowest version id, matching the version_id mirror).
+        scope
+          .joins(<<~SQL.squish)
+            INNER JOIN work_package_versions
+              ON work_package_versions.work_package_id = work_packages.id
+              AND work_package_versions.kind = 'target'
+              AND work_package_versions.version_id = (
+                SELECT MIN(wpv.version_id) FROM work_package_versions wpv
+                WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target'
+              )
+          SQL
+          .joins("INNER JOIN versions ON versions.id = work_package_versions.version_id")
+          .select("work_packages.*, versions.name AS version_name")
+      else
+        scope
+          .joins("INNER JOIN versions ON versions.id = work_packages.version_id")
+          .select("work_packages.*, versions.name AS version_name")
+      end
+    end
+
+    def work_package_versions_available?
+      WorkPackage.connection.table_exists?("work_package_versions")
     end
   end
 end

--- a/modules/backlogs/app/workers/backlogs/migrate_version_sprint_journals_job.rb
+++ b/modules/backlogs/app/workers/backlogs/migrate_version_sprint_journals_job.rb
@@ -51,33 +51,28 @@ module Backlogs
 
     private
 
-    # Reads the version name through work_package_versions where available,
-    # falling back to the legacy version_id column: a worker can pick this job
-    # up between the migration enqueuing it and the much later migration that
-    # introduces work_package_versions.
     def qualified_work_packages
-      scope = WorkPackage.joins(:sprint)
+      WorkPackage
+        .joins(:sprint)
+        .joins("INNER JOIN versions ON versions.id = #{primary_target_version_id}")
+        .select("work_packages.*, versions.name AS version_name")
+    end
 
-      if work_package_versions_available?
-        # A work package can have several target versions; journal once, for
-        # the primary one (lowest version id, matching the version_id mirror).
-        scope
-          .joins(<<~SQL.squish)
-            INNER JOIN work_package_versions
-              ON work_package_versions.work_package_id = work_packages.id
-              AND work_package_versions.kind = 'target'
-              AND work_package_versions.version_id = (
-                SELECT MIN(wpv.version_id) FROM work_package_versions wpv
-                WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target'
-              )
-          SQL
-          .joins("INNER JOIN versions ON versions.id = work_package_versions.version_id")
-          .select("work_packages.*, versions.name AS version_name")
-      else
-        scope
-          .joins("INNER JOIN versions ON versions.id = work_packages.version_id")
-          .select("work_packages.*, versions.name AS version_name")
-      end
+    # A work package can have several target versions; journal once, for the
+    # primary one (lowest version id, matching the version_id mirror). The
+    # legacy column stays the fallback per work package because a worker can
+    # pick this job up before the migrations that create and backfill
+    # work_package_versions have run.
+    def primary_target_version_id
+      return "work_packages.version_id" unless work_package_versions_available?
+
+      <<~SQL.squish
+        COALESCE(
+          (SELECT MIN(wpv.version_id) FROM work_package_versions wpv
+           WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target'),
+          work_packages.version_id
+        )
+      SQL
     end
 
     def work_package_versions_available?

--- a/modules/backlogs/app/workers/backlogs/migrate_version_sprint_journals_job.rb
+++ b/modules/backlogs/app/workers/backlogs/migrate_version_sprint_journals_job.rb
@@ -55,7 +55,21 @@ module Backlogs
       WorkPackage
         .joins(:sprint)
         .joins("INNER JOIN versions ON versions.id = #{primary_target_version_id}")
+        .where(not_journalled_yet)
         .select("work_packages.*, versions.name AS version_name")
+    end
+
+    # A run that dies part way through can be enqueued again without doubling
+    # up the entries it already wrote.
+    def not_journalled_yet
+      <<~SQL.squish
+        NOT EXISTS (
+          SELECT 1 FROM journals
+          WHERE journals.journable_type = 'WorkPackage'
+            AND journals.journable_id = work_packages.id
+            AND journals.cause ->> 'feature' = 'sprint_migration'
+        )
+      SQL
     end
 
     # A work package can have several target versions; journal once, for the

--- a/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
+++ b/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
@@ -196,10 +196,12 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
       expect(wp2.reload.sprint_id).to eq(sprint.id)
     end
 
-    it "keeps the version_id on associated work packages" do
+    it "keeps the version associations on associated work packages" do
       migrate
-      expect(wp1.reload.version_id).to eq(version.id)
-      expect(wp2.reload.version_id).to eq(version.id)
+      expect(wp1.reload.target_versions).to contain_exactly(version)
+      expect(wp2.reload.target_versions).to contain_exactly(version)
+      expect(wp1.version_id).to eq(version.id)
+      expect(wp2.version_id).to eq(version.id)
     end
 
     context "with multiple versions" do
@@ -245,6 +247,49 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
         expect(wp2.reload.sprint_id).to eq(sprint.id)
         expect(wp_in_other_project.reload.sprint_id).to be_nil
       end
+    end
+  end
+
+  describe "multiple versions feature" do
+    let!(:secondary_version) { create(:version, project:, name: "Secondary") }
+
+    shared_examples "migrates by the primary version" do
+      context "when the sprint version is the primary (version_id) target" do
+        let!(:wp_multi) do
+          create(:work_package, project:, version:).tap do |wp|
+            create(:work_package_version, work_package: wp, version: secondary_version, kind: :target)
+          end
+        end
+
+        it "assigns the work package to the sprint and keeps all target versions" do
+          migrate
+          expect(wp_multi.reload.sprint_id).to eq(Sprint.last.id)
+          expect(wp_multi.target_versions).to contain_exactly(version, secondary_version)
+        end
+      end
+
+      context "when the sprint version is only a secondary target" do
+        let!(:wp_secondary) do
+          create(:work_package, project:, version: secondary_version).tap do |wp|
+            create(:work_package_version, work_package: wp, version:, kind: :target)
+          end
+        end
+
+        it "does not assign the work package to the sprint" do
+          migrate
+          expect(wp_secondary.reload.sprint_id).to be_nil
+        end
+      end
+    end
+
+    context "when the feature is active",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      include_examples "migrates by the primary version"
+    end
+
+    context "when the feature is inactive" do
+      include_examples "migrates by the primary version"
     end
   end
 

--- a/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
+++ b/modules/backlogs/spec/migrations/migrate_versions_to_sprints_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe MigrateVersionsToSprints, type: :model do
         it "assigns the work package to the sprint and keeps all target versions" do
           migrate
           expect(wp_multi.reload.sprint_id).to eq(Sprint.last.id)
+          expect(wp_multi.sprint.name).to eq(version.name)
           expect(wp_multi.target_versions).to contain_exactly(version, secondary_version)
         end
       end

--- a/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
+++ b/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
@@ -87,16 +87,36 @@ RSpec.describe Backlogs::MigrateVersionSprintJournalsJob, type: :model do
 
     context "when a work package has multiple target versions" do
       shared_let(:wp_multi) do
-        create(:work_package, project:, version: version_b, sprint: sprint_a).tap do |wp|
+        create(:work_package, project:, sprint: sprint_a).tap do |wp|
+          create(:work_package_version, work_package: wp, version: version_b, kind: :target)
           create(:work_package_version, work_package: wp, version: version_a, kind: :target)
         end
       end
 
-      it "creates one journal entry naming the primary (lowest id) target version" do
+      it "creates one journal entry naming the primary (lowest version id) target version" do
         perform
         journals = wp_multi.reload.journals.select { it.cause_feature == "sprint_migration" }
         expect(journals.size).to eq(1)
         expect(journals.first.cause["version_name"]).to eq("Version A")
+      end
+    end
+
+    context "when the job runs a second time" do
+      shared_let(:wp_migrated) do
+        create(:work_package, project:).tap do |wp|
+          create(:work_package_version, work_package: wp, version: version_a, kind: :target)
+          wp.update_column(:sprint_id, sprint_a.id)
+        end
+      end
+
+      it "does not journal a work package twice" do
+        described_class.new.perform
+        # Past the journal aggregation window, which would otherwise merge a
+        # second entry into the first.
+        travel(10.minutes) { described_class.new.perform }
+
+        journals = wp_migrated.reload.journals.select { it.cause_feature == "sprint_migration" }
+        expect(journals.size).to eq(1)
       end
     end
 

--- a/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
+++ b/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
@@ -100,6 +100,19 @@ RSpec.describe Backlogs::MigrateVersionSprintJournalsJob, type: :model do
       end
     end
 
+    context "when work_package_versions exists but has not been backfilled yet" do
+      shared_let(:wp_legacy_only) do
+        create(:work_package, project:, sprint: sprint_b).tap do |wp|
+          wp.update_column(:version_id, version_a.id)
+        end
+      end
+
+      it "journals via the legacy version_id column" do
+        perform
+        expect(wp_legacy_only.reload.last_journal.cause["version_name"]).to eq("Version A")
+      end
+    end
+
     context "when the work_package_versions table does not exist yet" do
       before do
         allow(job).to receive(:work_package_versions_available?).and_return(false)

--- a/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
+++ b/modules/backlogs/spec/workers/backlogs/migrate_version_sprint_journals_job_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe Backlogs::MigrateVersionSprintJournalsJob, type: :model do
   shared_let(:wp2) { create(:work_package, project:, version: version_b, sprint: sprint_b) }
   shared_let(:wp_no_version) { create(:work_package, project:, sprint: sprint_a) }
 
-  subject(:perform) { described_class.new.perform }
+  subject(:perform) { job.perform }
+
+  let(:job) { described_class.new }
 
   describe "#perform" do
     context "when there are work packages associated with a sprint and a version" do
@@ -79,6 +81,38 @@ RSpec.describe Backlogs::MigrateVersionSprintJournalsJob, type: :model do
       it "does not create a system update journal entry" do
         perform
         expect(wp_no_version.reload.last_journal.cause_type).not_to eq("system_update")
+        expect(wp_no_version.reload.last_journal.cause_feature).not_to eq("sprint_migration")
+      end
+    end
+
+    context "when a work package has multiple target versions" do
+      shared_let(:wp_multi) do
+        create(:work_package, project:, version: version_b, sprint: sprint_a).tap do |wp|
+          create(:work_package_version, work_package: wp, version: version_a, kind: :target)
+        end
+      end
+
+      it "creates one journal entry naming the primary (lowest id) target version" do
+        perform
+        journals = wp_multi.reload.journals.select { it.cause_feature == "sprint_migration" }
+        expect(journals.size).to eq(1)
+        expect(journals.first.cause["version_name"]).to eq("Version A")
+      end
+    end
+
+    context "when the work_package_versions table does not exist yet" do
+      before do
+        allow(job).to receive(:work_package_versions_available?).and_return(false)
+      end
+
+      it "journals via the legacy version_id column" do
+        perform
+        expect(wp1.reload.last_journal.cause["version_name"]).to eq("Version A")
+        expect(wp2.reload.last_journal.cause["version_name"]).to eq("Version B")
+      end
+
+      it "does not create a system update journal entry for a work package without a version" do
+        perform
         expect(wp_no_version.reload.last_journal.cause_feature).not_to eq("sprint_migration")
       end
     end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-931

`work_packages.version_id` FK is scheduled for deprecation and in its place a new 1:m `work_package_versions` join table was introduced. Since the `MigrateVersionSprintJournalsJob` precedes it, this PR proposes a dynamic read that deduces the primary target version (lowest version id, the convention proposed in #24486), falling back to the legacy `version_id` column per work package. The fallback is per work package rather than a one off check on the table because the join table is created in one migration and backfilled in a later one, so a worker can pick this job up while the table exists but is still empty.

The job also skips work packages it already journalled, so enqueuing it again after a failed run no longer writes a second entry for each one. **_Reading `version_id` is a migration time read rather than a runtime dependency:_** the migration that enqueues this job predates the join table, so at that point the column is the only populated source. Dropping the column will still need to account for this job, as it will for other migration era code.
