### PR TITLE
Remove hidden attributes when moving form configuration to independent

### DIFF
--- a/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
+++ b/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
@@ -71,6 +71,52 @@ RSpec.describe WorkPackageTypes::SwitchToIndependentModeService do
       end
     end
 
+    # Going Independent freezes what the type was presenting, not what its source owns: an
+    # excluded attribute was not on its form and must not reappear as an own group member.
+    context "with the copy mode and exclusions (form configuration)", with_flag: { type_variants: true } do
+      let(:aspect) { Type::ConfigurationLink::FORM_CONFIGURATION }
+      let(:owner) do
+        create(:type).tap do |owner_type|
+          owner_type.attribute_groups = [["Numbers", [kept_field.attribute_name, excluded_field.attribute_name]],
+                                         ["People", %w[assignee]]]
+          owner_type.custom_field_ids = [kept_field.id, excluded_field.id]
+          owner_type.save!
+        end
+      end
+
+      shared_let(:kept_field) { create(:issue_custom_field, :integer, name: "Kept", is_for_all: true) }
+      shared_let(:excluded_field) { create(:issue_custom_field, :integer, name: "Dropped", is_for_all: true) }
+
+      def own_groups
+        type.reload.read_attribute(:attribute_groups).to_h { |key, members| [key.to_s, members] }
+      end
+
+      it "leaves out what the type's own link excluded", :aggregate_failures do
+        create(:type_configuration_link, type:, source: owner, aspect:,
+                                         excluded_elements: [excluded_field.attribute_name, "assignee"])
+
+        result = service.call(mode: WorkPackageTypes::IndependentMode::COPY)
+
+        expect(result).to be_success
+        expect(type.reload).not_to be_linked(aspect)
+        expect(own_groups.keys).to contain_exactly("Numbers")
+        expect(own_groups["Numbers"]).to eq([kept_field.attribute_name])
+        expect(type.custom_field_ids).to contain_exactly(kept_field.id)
+      end
+
+      it "leaves out what an ancestor's link excluded, which the type could not see either" do
+        middle = create(:type)
+        create(:type_configuration_link, type: middle, source: owner, aspect:,
+                                         excluded_elements: [excluded_field.attribute_name])
+        create(:type_configuration_link, type:, source: middle, aspect:)
+
+        result = service.call(mode: WorkPackageTypes::IndependentMode::COPY)
+
+        expect(result).to be_success
+        expect(own_groups["Numbers"]).to eq([kept_field.attribute_name])
+      end
+    end
+
     context "with the empty mode (patterns)" do
       let(:aspect) { Type::ConfigurationLink::DEFAULTS }
 


### PR DESCRIPTION
This was already implemented, but lacked a proper test

https://community.openproject.org/projects/FND/work_packages/FND-193/activity
