### PR TITLE
[OP-19741] Meeting of a meeting series cannot be duplicated as a one-time meeting  

### DIFF
--- a/modules/meeting/app/services/meetings/copy_service.rb
+++ b/modules/meeting/app/services/meetings/copy_service.rb
@@ -94,7 +94,7 @@ module Meetings
     end
 
     def writable_meeting_attributes(meeting)
-      instantiate_contract(meeting, user).writable_attributes - %w[start_date start_time_hour uid sharing]
+      instantiate_contract(meeting, user).writable_attributes - %w[start_date start_time_hour uid sharing recurrence_start_time]
     end
 
     def copy_meeting_attachment(copy)

--- a/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
+++ b/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
@@ -237,4 +237,27 @@ RSpec.describe Meetings::CopyService, "integration", type: :model do
       expect(deleted_item.work_package_id).to be_nil
     end
   end
+
+  describe "copying a recurring series occurrence as a one-time meeting" do
+    shared_let(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+    let(:meeting) do
+      create(:recurring_meeting_occurrence,
+             recurring_meeting:,
+             project:)
+    end
+
+    # Simulate a series occurrence being copied as a one-time meeting
+    let(:attributes) { { recurring_meeting_id: nil } }
+
+    it "creates a valid one-time meeting without the recurrence metadata" do
+      expect(meeting).to be_recurring
+      expect(meeting.recurrence_start_time).to be_present
+
+      expect(service_result).to be_success
+      expect(copy).not_to be_recurring
+      expect(copy.recurring_meeting_id).to be_nil
+      expect(copy.recurrence_start_time).to be_nil
+      expect(copy.template).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-19741

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What?
Removing scheduled meetings some time ago added `recurrence_start_time` as a Meeting column. The contract guarding against this attribute being writable only when recurring is what failed and caused a rollback.

Adding it to the list of excluded attributes when making changes/copying as one-time fixes the bug.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
