### PR TITLE
[FND-191] Variants are indistinguishable from their parent type when choosing a configuration source

### DIFF
--- a/app/components/projects/settings/work_packages/types/add_dialog_component.rb
+++ b/app/components/projects/settings/work_packages/types/add_dialog_component.rb
@@ -55,17 +55,11 @@ module Projects
             project_settings_work_packages_types_path(project)
           end
 
-          # Roots are a single acts_as_list list, so their position order is
-          # meaningful; each family then contributes its members in display
-          # order via Type#family, shared with the admin family list.
           def addable_types
-            @addable_types ||= addable_roots.flat_map(&:family)
+            @addable_types ||= ::Type.global.where.not(id: active_root_ids).in_family_order
           end
 
-          def addable_roots
-            ::Type.global.roots.where.not(id: active_root_ids).includes(:children)
-          end
-
+          # A family is addable as a whole, so any active member rules out all of it.
           def active_root_ids
             @active_root_ids ||= project.types.pluck(:parent_id, :id).map { |parent_id, id| parent_id || id }
           end

--- a/app/forms/work_package_types/configuration_links/source_form.rb
+++ b/app/forms/work_package_types/configuration_links/source_form.rb
@@ -31,6 +31,8 @@
 module WorkPackageTypes
   module ConfigurationLinks
     class SourceForm < ApplicationForm
+      include WorkPackageTypes::SourceOptions
+
       def initialize(type:, aspect:)
         super()
 
@@ -62,27 +64,10 @@ module WorkPackageTypes
 
       attr_reader :type, :aspect
 
-      # The parent leads the list as the most likely source.
-      def source_options
-        parents, others = Type.global.where.not(id: type.id).order(:name).partition { |source| parent?(source) }
-
-        parents + others
-      end
-
       # When Linked, the current source is preselected so "change source" opens on
-      # it; when Independent, the parent leads as the likely first link.
+      # it; when Independent, the parent is preselected as the likely first link.
       def selected_source
         type.source_for(aspect) || type.parent
-      end
-
-      def label_for(source)
-        return source.name unless parent?(source)
-
-        "#{source.name}#{I18n.t('types.edit.reuse_mode.parent_suffix')}"
-      end
-
-      def parent?(source)
-        source == type.parent
       end
     end
   end

--- a/app/forms/work_package_types/source_options.rb
+++ b/app/forms/work_package_types/source_options.rb
@@ -29,39 +29,25 @@
 #++
 
 module WorkPackageTypes
-  module ConfigurationCopies
-    class SourceForm < ApplicationForm
-      include WorkPackageTypes::SourceOptions
+  # The copy and link dialogs offer the same sources, so they read one list here
+  # and cannot drift apart.
+  module SourceOptions
+    private
 
-      def initialize(type:)
-        super()
+    def source_options
+      Type.global.in_family_order.reject { |source| source == type }
+    end
 
-        @type = type
-      end
+    # Variants carry their parent in the composite name; the current type's own
+    # parent is additionally flagged as the most likely source.
+    def label_for(source)
+      return source.composite_name unless parent?(source)
 
-      form do |source_form|
-        source_form.autocompleter(
-          name: :source_id,
-          label: I18n.t("types.edit.reuse_mode.copy.dialog.source_label"),
-          required: true,
-          autocomplete_options: {
-            placeholder: I18n.t("types.edit.reuse_mode.copy.dialog.source_placeholder"),
-            decorated: true,
-            multiple: false,
-            focusDirectly: false,
-            append_to: "##{DialogComponent::DIALOG_ID}",
-            data: { test_selector: "configuration-copy-source" }
-          }
-        ) do |list|
-          source_options.each do |source|
-            list.option(value: source.id, label: label_for(source))
-          end
-        end
-      end
+      "#{source.composite_name}#{I18n.t('types.edit.reuse_mode.parent_suffix')}"
+    end
 
-      private
-
-      attr_reader :type
+    def parent?(source)
+      source == type.parent
     end
   end
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -113,6 +113,13 @@ class Type < ApplicationRecord
 
   delegate :to_s, to: :name
 
+  # Roots each immediately followed by their own variants. Reads one acts_as_list
+  # list at a time on purpose: positions are numbered per family, so no ORDER BY
+  # over the flat table can keep a family together.
+  def self.in_family_order
+    roots.includes(:children).flat_map(&:family)
+  end
+
   def <=>(other)
     name <=> other.name
   end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -443,6 +443,33 @@ RSpec.describe Type do
       end
     end
 
+    # The types index page and the configuration source pickers both read this,
+    # so the assertions bind to what that page renders rather than to a literal
+    # list, and the two cannot drift apart unnoticed.
+    describe ".in_family_order" do
+      let!(:zeta) { create(:type, name: "Zeta") }
+      let!(:yankee) { create(:type, name: "Yankee", parent: zeta) }
+      let!(:bravo) { create(:type, name: "Bravo", parent: zeta) }
+      # Created last, so the admin's order and an alphabetical one disagree and
+      # the assertions below can tell them apart.
+      let!(:alpha) { create(:type, name: "Alpha") }
+
+      it "keeps the roots in the order the index page lists them" do
+        expect(described_class.in_family_order.reject(&:variant?)).to eq([parent, zeta, alpha])
+      end
+
+      it "orders a family's variants the way the index page renders them" do
+        expect(described_class.in_family_order.select { |member| member.parent == zeta })
+          .to eq([bravo, yankee])
+      end
+
+      it "puts a root ahead of its own variants" do
+        order = described_class.in_family_order
+
+        expect(order.index(zeta)).to be < order.index(bravo)
+      end
+    end
+
     describe "positioning" do
       it "scopes position per parent so each group is numbered independently" do
         parent_a = create(:type)

--- a/spec/requests/work_package_types/configuration_copies_spec.rb
+++ b/spec/requests/work_package_types/configuration_copies_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe "Work package type configuration copies",
       variant = create(:type, parent: source)
       root = create(:type, name: "Bug")
       create(:type, name: "Mobile", parent: root)
+      create(:type, name: "Desktop", parent: root)
 
       get type_configuration_copy_dialog_path(type_id: variant.id, aspect:), as: :turbo_stream
 
@@ -64,6 +65,8 @@ RSpec.describe "Work package type configuration copies",
       expect(response.body).to include("Bug: Mobile")
       # a root is listed before its variant
       expect(response.body.index("Bug")).to be < response.body.index("Bug: Mobile")
+      # variants are alphabetical, not in the order they were added
+      expect(response.body.index("Bug: Desktop")).to be < response.body.index("Bug: Mobile")
     end
 
     it "is not found for aspects without a copy service" do

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -124,13 +124,17 @@ RSpec.describe "Work package type configuration source",
       expect(response.body).to include("Switch")
     end
 
-    it "leads with the parent type for variants" do
+    it "lists every source by composite name, families kept together, the parent flagged" do
       parent = create(:type, name: "Feature")
-      variant = create(:type, parent:)
+      create(:type, name: "Small", parent:)
+      create(:type, name: "Big", parent:)
+      variant = create(:type, name: "Mobile", parent:)
 
       get type_configuration_link_dialog_path(type_id: variant.id, aspect:), as: :turbo_stream
 
-      expect(response.body).to include("Feature (parent)")
+      expect(source_option_labels).to eq(
+        [type.name, source.name, "Feature (parent)", "Feature: Big", "Feature: Small"]
+      )
     end
 
     it "is not found for an unknown aspect" do
@@ -216,5 +220,13 @@ RSpec.describe "Work package type configuration source",
       expect(response).not_to be_successful
       expect(type.reload).not_to be_linked(aspect)
     end
+  end
+
+  # A decorated autocompleter ships its options to the Angular component as a
+  # JSON payload rather than rendering them as markup.
+  def source_option_labels
+    autocompleter = Nokogiri::HTML5.fragment(response.body).at_css("opce-autocompleter")
+
+    JSON.parse(autocompleter["data-items"]).pluck("name")
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/FND-191

# What are you trying to accomplish?

The configuration source picker labelled every variant with its parent's name, so the dropdown contained indistinguishable duplicates — an administrator could silently link a type's configuration to the wrong source.

- `label_for` used `Type#name`, which is `inherited_core_setting(:name)` and resolves to the **root's** name for a variant
- `.order(:name)` was defeated by `Type`'s `default_scope`, so the list came back in raw `position` order, interleaving variants between unrelated root types (see FND-190 for that root cause)
- Neither defect was covered by a spec

Now every entry is labelled with `Type#composite_name` ("Parent: Variant" for a variant, the plain name for a root) and families are kept together.

## Screenshots

Not applicable — labels and ordering are rendered server-side.

# What approach did you choose and why?

- Added `Type.in_family_order`: reads one `acts_as_list` list at a time rather than ordering the flat table. Reuses `Type#family`, which the admin family list also reads, so the screens cannot drift apart.
- Extracted `WorkPackageTypes::SourceOptions` for `source_options` / `label_for`, included by both the link and copy source forms.
- The project add-type picker now reads `Type.in_family_order` too, dropping its own inline copy.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
