### PR TITLE
[OP-19787] Meeting invitation email shows event shifted by +1 hour for dates between 2026-09-29 and 2026-10-24

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -276,9 +276,8 @@ module Meetings
       all_times.each do |timezone, times|
         calendar.timezone do |tz|
           tz.tzid = timezone.tzinfo.canonical_identifier
-          transitions = timezone.tzinfo.transitions_up_to(times.max + 6.months, times.min - 6.months)
 
-          transitions.each do |tr|
+          relevant_transitions(timezone.tzinfo, times).each do |tr|
             if tr.offset.dst?
               tz.daylight { |d| transition_to_component(d, tr) }
             else
@@ -287,6 +286,17 @@ module Meetings
           end
         end
       end
+    end
+
+    # `transitions_up_to(to, from)` only returns transitions at or after `from`, so a
+    # fixed lookback (e.g. `times.min - 6.months`) can skip past the transition that
+    # established the offset currently in effect. When that happens the VTIMEZONE has
+    # no observance preceding the event and clients fall back to the wrong offset
+    def relevant_transitions(tzinfo, times)
+      transitions = tzinfo.transitions_up_to(times.max + 6.months, times.min)
+      active = tzinfo.transitions_up_to(times.min).last
+      transitions.unshift(active) if active
+      transitions
     end
 
     def transition_to_component(component, transition)

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -645,7 +645,7 @@ RSpec.describe Meetings::IcalendarBuilder,
       expect(vtimezone_block).to be_present
       standard_count = vtimezone_block.scan("BEGIN:STANDARD").size
       daylight_count = vtimezone_block.scan("BEGIN:DAYLIGHT").size
-      expect(standard_count).to eq(4)
+      expect(standard_count).to eq(3)
       expect(daylight_count).to eq(4)
     end
 
@@ -657,7 +657,30 @@ RSpec.describe Meetings::IcalendarBuilder,
     end
   end
 
-  context "with mutlipple recurring meetings in different timezones" do
+  context "for a meeting shortly before a DST change (Bug OP-19787)" do
+    subject(:builder) { described_class.new(timezone:) }
+
+    let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+    # Europe/Berlin switches from CEST (+02:00) to CET (+01:00) on 2026-10-25
+    let(:meeting) { create(:meeting, :author_participates, start_time: Time.zone.parse("2026-09-30 09:00"), duration: 1.0) }
+
+    it "emits a VTIMEZONE observance in effect at the meeting start, resolving to summer time (+0200)" do
+      builder.add_single_meeting_event(meeting:)
+
+      tz = parsed_calendar.timezones.first
+      event_start = ActiveSupport::TimeZone["Europe/Berlin"].parse("2026-09-30 09:00")
+
+      observances = (tz.standards + tz.daylights)
+      preceding = observances
+                    .select { |o| o.dtstart.to_time <= event_start }
+                    .max_by { |o| o.dtstart.to_time }
+
+      expect(preceding).to be_present
+      expect(preceding.tzoffsetto.value_ical).to eq("+0200")
+    end
+  end
+
+  context "with multiple recurring meetings in different timezones" do
     let(:project) { create(:project) }
     let(:user) do
       create(:user, firstname: "John", lastname: "Doe", member_with_permissions: { project => [:view_meetings] })


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-19787

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What?
Limiting transitions to -6 months meant that the last relevant transition could be excluded when the transition happened more than 6 months ago, so anything after 2026-03-29 (when Europe/Berlin goes to summer time) + 6 months ends up without the transition.

When this transition isn't present, I think clients use different defaults, and perhaps that's why for the bug reporter downloaded ics events directly from OP work but email attachments don't (even though they are generated the exact same way). This I am not 100% sure about though...

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
