### PR TITLE
Use after_validation not before in meeting schema

### DIFF
--- a/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_api.rb
+++ b/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_api.rb
@@ -34,7 +34,7 @@ module API
       module Schemas
         class MeetingSchemaAPI < ::API::OpenProjectAPI
           resources :schema do
-            before do
+            after_validation do
               authorize_in_any_project(:view_meetings)
             end
 


### PR DESCRIPTION
The problem in specs is that we stub current user, so this error cannot be reliably tested.

But we need after_validation to have the user set up correctly

https://community.openproject.org/work_packages/MEET-586