### PR TITLE
Update description of work package tool with new default

### DIFF
--- a/db/migrate/20260730133700_update_default_work_package_tool_description.rb.rb
+++ b/db/migrate/20260730133700_update_default_work_package_tool_description.rb.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class UpdateDefaultWorkPackageToolDescription < ActiveRecord::Migration[8.0]
+  def up
+    description = ActiveRecord::Base.connection.quote_string McpTools::SearchWorkPackages.default_description
+    exec_query(<<~SQL.squish)
+      UPDATE mcp_configurations SET description = '#{description}' where identifier = 'tools/search_work_packages'
+    SQL
+  end
+end


### PR DESCRIPTION
The new default description contains important information that should be passed along to LLM agents. However, because it's only a default no existing installation would pick it up.

That this migration is necessary is a bad sign for the design around allowing admins to customize tool descriptions. Changing this might be necessary going forward, but for this release we'll simply overwrite existing descriptions.

# Ticket
https://community.openproject.org/wp/AI-112