### PR TITLE
[MEET-546] Double clicking remove button in meeting participants result in 404  

### DIFF
--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -36,7 +36,7 @@ class MeetingParticipantsController < ApplicationController
   load_and_authorize_with_permission_in_project :edit_meetings
 
   before_action :set_meeting
-  before_action :set_participant, only: %i[toggle_attendance destroy]
+  before_action :set_participant, only: %i[toggle_attendance]
 
   def create
     user_ids = Array(params.dig(:meeting_participant, :user_id)).compact_blank
@@ -73,22 +73,26 @@ class MeetingParticipantsController < ApplicationController
   end
 
   def destroy
-    user_id = @participant.user_id
-    call = MeetingParticipants::DeleteService
-      .new(user: User.current, model: @participant)
-      .call
+    participant = @meeting.participants.find_by(id: params[:id])
 
-    if call.success?
-      if @meeting.series_template? && params[:apply_to_upcoming] == "1"
-        remove_from_upcoming_occurrences(user_id)
+    if participant
+      call = MeetingParticipants::DeleteService
+        .new(user: User.current, model: participant)
+        .call
+
+      unless call.success?
+        render_error_flash_message_via_turbo_stream(message: join_flash_messages(call.errors))
+        return respond_with_turbo_streams
       end
 
-      update_add_user_form_component_via_turbo_stream
-      update_list_component_via_turbo_stream
-      update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
-    else
-      render_error_flash_message_via_turbo_stream(message: join_flash_messages(call.errors))
+      if @meeting.series_template? && params[:apply_to_upcoming] == "1"
+        remove_from_upcoming_occurrences(participant.user_id)
+      end
     end
+
+    update_add_user_form_component_via_turbo_stream
+    update_list_component_via_turbo_stream
+    update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
 
     respond_with_turbo_streams
   end

--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -56,9 +56,7 @@ class MeetingParticipantsController < ApplicationController
       participant.update!(attended: true)
     end
 
-    update_add_user_form_component_via_turbo_stream
-    update_list_component_via_turbo_stream
-    update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
+    update_participants_via_turbo_stream
 
     respond_with_turbo_streams
   end
@@ -76,23 +74,15 @@ class MeetingParticipantsController < ApplicationController
     participant = @meeting.participants.find_by(id: params[:id])
 
     if participant
-      call = MeetingParticipants::DeleteService
-        .new(user: User.current, model: participant)
-        .call
+      call = remove_participant(participant)
 
       unless call.success?
         render_error_flash_message_via_turbo_stream(message: join_flash_messages(call.errors))
         return respond_with_turbo_streams
       end
-
-      if @meeting.series_template? && params[:apply_to_upcoming] == "1"
-        remove_from_upcoming_occurrences(participant.user_id)
-      end
     end
 
-    update_add_user_form_component_via_turbo_stream
-    update_list_component_via_turbo_stream
-    update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
+    update_participants_via_turbo_stream
 
     respond_with_turbo_streams
   end
@@ -109,6 +99,24 @@ class MeetingParticipantsController < ApplicationController
 
   def set_participant
     @participant = @meeting.participants.find(params[:id])
+  end
+
+  def remove_participant(participant)
+    call = MeetingParticipants::DeleteService
+      .new(user: User.current, model: participant)
+      .call
+
+    if call.success? && @meeting.series_template? && params[:apply_to_upcoming] == "1"
+      remove_from_upcoming_occurrences(participant.user_id)
+    end
+
+    call
+  end
+
+  def update_participants_via_turbo_stream
+    update_add_user_form_component_via_turbo_stream
+    update_list_component_via_turbo_stream
+    update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
   end
 
   def create_new_participants(user_ids)

--- a/modules/meeting/spec/requests/meeting_participants_spec.rb
+++ b/modules/meeting/spec/requests/meeting_participants_spec.rb
@@ -268,6 +268,18 @@ RSpec.describe "MeetingParticipants requests",
 
       expect(response).to have_http_status(:ok)
     end
+
+    context "when the participant was already removed (e.g. rapid double-click)" do
+      before { participant.destroy }
+
+      it "responds gracefully instead of a 404" do
+        expect do
+          delete project_meeting_participant_path(project, meeting, participant), as: :turbo_stream
+        end.not_to change { meeting.participants.count }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "GET /meetings/:meeting_id/participants/manage_participants_dialog" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-546

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
`.find` -> `.find_by`

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
