### PR TITLE
[COMMS-937] adjust version scope that was checking work_package.version_id

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -75,7 +75,9 @@ class Version < ApplicationRecord
 
   scope :shared_via_work_packages, ->(*args) {
     user = args.first || User.current
-    where(id: WorkPackage.visible(user).where.not(version_id: nil).distinct.select(:version_id))
+    where(id: WorkPackageVersion.where(kind: "target")
+                                .where(work_package_id: WorkPackage.visible(user).select(:id))
+                                .select(:version_id))
   }
 
   def self.with_status_open

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -602,6 +602,27 @@ RSpec.describe Version do
     end
   end
 
+  describe "shared_via_work_packages scope" do
+    subject { described_class.shared_via_work_packages(user) }
+
+    let(:user) { create(:user) }
+    let(:visible_project) { create(:project, member_with_permissions: { user => [:view_work_packages] }) }
+    let(:invisible_project) { create(:project) }
+    let(:version) { create(:version, project: invisible_project) }
+
+    context "when a visible work package targets the version" do
+      before { create(:work_package, project: visible_project, version:) }
+
+      it { is_expected.to contain_exactly(version) }
+    end
+
+    context "when only an invisible work package targets the version" do
+      before { create(:work_package, project: invisible_project, version:) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe "#visible?" do
     subject { version.visible?(user) }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-937/activity

# What are you trying to accomplish?
Instead of checking version_id column on work_package, go through the correct relation table.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
