### PR TITLE
Bug/OP-19819 A `CASE` without default value causes an error on project and projects pages

### DIFF
--- a/app/helpers/calculated_values/errors_helper.rb
+++ b/app/helpers/calculated_values/errors_helper.rb
@@ -43,24 +43,22 @@ module CalculatedValues::ErrorsHelper
     return unless calculated_value_error.is_a?(CalculatedValueError)
 
     error_code = calculated_value_error.error_code
-    missing_custom_field_ids = calculated_value_error.missing_custom_field_ids
-
     translation_key = ERROR_TRANSLATIONS.fetch(error_code, DEFAULT_TRANSLATION)
-    translation_options = {}
 
     if %w[ERROR_MISSING_VALUE ERROR_DISABLED_VALUE].include?(error_code)
       # To keep the error message short, we only show the first custom field with a missing/disabled value.
+      missing_custom_field_id = calculated_value_error.missing_custom_field_ids.first
       # TODO: This is also N+1 problematic.
-      cf = CustomField.find_by(id: missing_custom_field_ids.first)
+      cf = CustomField.find_by(id: missing_custom_field_id) if missing_custom_field_id
 
       if cf
-        translation_options[:custom_field_name] = cf.name
+        I18n.t(translation_key, custom_field_name: cf.name)
       else
-        translation_key = DEFAULT_TRANSLATION
+        I18n.t(DEFAULT_TRANSLATION)
       end
+    else
+      I18n.t(translation_key)
     end
-
-    I18n.t(translation_key, **translation_options)
   end
 
   module_function :calculated_value_error_msg

--- a/app/helpers/calculated_values/errors_helper.rb
+++ b/app/helpers/calculated_values/errors_helper.rb
@@ -51,7 +51,7 @@ module CalculatedValues::ErrorsHelper
     if %w[ERROR_MISSING_VALUE ERROR_DISABLED_VALUE].include?(error_code)
       # To keep the error message short, we only show the first custom field with a missing/disabled value.
       # TODO: This is also N+1 problematic.
-      cf = CustomField.find(missing_custom_field_ids.first)
+      cf = CustomField.find_by(id: missing_custom_field_ids.first)
 
       if cf
         translation_options[:custom_field_name] = cf.name

--- a/app/helpers/calculated_values/errors_helper.rb
+++ b/app/helpers/calculated_values/errors_helper.rb
@@ -48,7 +48,7 @@ module CalculatedValues::ErrorsHelper
     if %w[ERROR_MISSING_VALUE ERROR_DISABLED_VALUE].include?(error_code)
       # To keep the error message short, we only show the first custom field with a missing/disabled value.
       missing_custom_field_id = calculated_value_error.missing_custom_field_ids.first
-      # TODO: This is also N+1 problematic.
+      # One query per distinct missing field due to AR query cache
       cf = CustomField.find_by(id: missing_custom_field_id) if missing_custom_field_id
 
       if cf

--- a/app/models/acts_as_customizable/calculated_value.rb
+++ b/app/models/acts_as_customizable/calculated_value.rb
@@ -75,8 +75,7 @@ module ActsAsCustomizable::CalculatedValue
       errors = {}
 
       calculation.each do |key, value|
-        case value
-        when Numeric, true, false
+        if CustomField::CalculatedValue.computed_value?(value)
           result[key] = value
         else
           result[key] = nil

--- a/app/models/calculated_values/error_handler.rb
+++ b/app/models/calculated_values/error_handler.rb
@@ -83,9 +83,12 @@ module CalculatedValues
       when Dentaku::ZeroDivisionError
         ErrorContext.new(custom_field_id:, error_code: "ERROR_MATHEMATICAL")
       when Dentaku::ArgumentError
-        ErrorContext.new(custom_field_id:,
-                         error_code: "ERROR_MISSING_VALUE",
-                         missing_custom_field_ids: find_missing_values_for_field(custom_field_id))
+        missing_custom_field_ids = find_missing_values_for_field(custom_field_id)
+        if missing_custom_field_ids.present?
+          ErrorContext.new(custom_field_id:, error_code: "ERROR_MISSING_VALUE", missing_custom_field_ids:)
+        else
+          ErrorContext.new(custom_field_id:, error_code: "ERROR_UNKNOWN")
+        end
       when Dentaku::UnboundVariableError
         ErrorContext.new(custom_field_id:,
                          error_code: "ERROR_DISABLED_VALUE",

--- a/app/models/calculated_values/error_handler.rb
+++ b/app/models/calculated_values/error_handler.rb
@@ -104,8 +104,9 @@ module CalculatedValues
 
     # Returns a list of all custom field ids that could not compute a value.
     def cf_ids_with_missing_values
-      @cf_ids_with_missing_values ||= given_values.merge(calculation_errors)
-                                                  .filter_map { |k, v| to_id(k) unless v.is_a?(Numeric) }
+      @cf_ids_with_missing_values ||= given_values.merge(calculation_errors).filter_map do |k, v|
+        to_id(k) unless CustomField::CalculatedValue.computed_value?(v)
+      end
     end
 
     def create_error_records!(error_contexts)

--- a/app/models/calculated_values/error_handler.rb
+++ b/app/models/calculated_values/error_handler.rb
@@ -83,7 +83,9 @@ module CalculatedValues
       when Dentaku::ZeroDivisionError
         ErrorContext.new(custom_field_id:, error_code: "ERROR_MATHEMATICAL")
       when Dentaku::ArgumentError
-        build_missing_value_error_context(custom_field_id)
+        ErrorContext.new(custom_field_id:,
+                         error_code: "ERROR_MISSING_VALUE",
+                         missing_custom_field_ids: find_missing_values_for_field(custom_field_id))
       when Dentaku::UnboundVariableError
         ErrorContext.new(custom_field_id:,
                          error_code: "ERROR_DISABLED_VALUE",
@@ -91,11 +93,6 @@ module CalculatedValues
       else
         ErrorContext.new(custom_field_id:, error_code: "ERROR_UNKNOWN")
       end
-    end
-
-    def build_missing_value_error_context(custom_field_id)
-      missing_values = find_missing_values_for_field(custom_field_id)
-      ErrorContext.new(custom_field_id:, error_code: "ERROR_MISSING_VALUE", missing_custom_field_ids: missing_values)
     end
 
     def find_missing_values_for_field(custom_field_id)

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -82,6 +82,10 @@ module CustomField::CalculatedValue
     Dentaku::Calculator.new(case_sensitive: true, raw_date_literals: false)
   end
 
+  def self.computed_value?(value)
+    value in Numeric | true | false
+  end
+
   class_methods do
     def with_formula_referencing(id)
       where("(formula -> 'referenced_custom_fields') @> ?", id)

--- a/modules/overviews/app/components/overviews/project_custom_fields/show_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/show_component.html.erb
@@ -1,8 +1,10 @@
-<%= render OpenProject::Common::InplaceEditFieldComponent.new(
-      model: @project,
-      attribute: @project_custom_field.attribute_name.to_sym,
-      open_in_dialog: limited_space?,
-      truncated: limited_space?,
-      test_selector: "project-custom-field-#{@project_custom_field.id}",
-      display_classes: "op-project-custom-field-container"
-    ) %>
+<%=
+  render OpenProject::Common::InplaceEditFieldComponent.new(
+    model: @project,
+    attribute: @project_custom_field.attribute_name.to_sym,
+    open_in_dialog: limited_space?,
+    truncated: limited_space?,
+    test_selector: "project-custom-field-#{@project_custom_field.id}",
+    display_classes: "op-project-custom-field-container"
+  )
+%>

--- a/spec/helpers/calculated_values/errors_helper_spec.rb
+++ b/spec/helpers/calculated_values/errors_helper_spec.rb
@@ -69,6 +69,27 @@ RSpec.describe CalculatedValues::ErrorsHelper do
         expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.missing_value",
                                                                        custom_field_name: other_custom_field.name))
       end
+
+      it "when there are no missing values, it fallbacks to unknown error" do
+        error.missing_custom_field_ids = []
+
+        error.error_code = "ERROR_MISSING_VALUE"
+        expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.unknown"))
+      end
+
+      it "when missing value can't be found, it fallbacks to unknown error" do
+        error.missing_custom_field_ids = [0]
+
+        error.error_code = "ERROR_MISSING_VALUE"
+        expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.unknown"))
+      end
+
+      it "with unexpected missing value, it fallbacks to unknown error" do
+        error.missing_custom_field_ids = [nil]
+
+        error.error_code = "ERROR_MISSING_VALUE"
+        expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.unknown"))
+      end
     end
 
     describe "disabled values" do
@@ -86,6 +107,27 @@ RSpec.describe CalculatedValues::ErrorsHelper do
         error.error_code = "ERROR_DISABLED_VALUE"
         expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.disabled_value",
                                                                        custom_field_name: other_custom_field.name))
+      end
+
+      it "when there are no disabled values, it fallbacks to unknown error" do
+        error.missing_custom_field_ids = []
+
+        error.error_code = "ERROR_DISABLED_VALUE"
+        expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.unknown"))
+      end
+
+      it "when disabled value can't be found, it fallbacks to unknown error" do
+        error.missing_custom_field_ids = [0]
+
+        error.error_code = "ERROR_DISABLED_VALUE"
+        expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.unknown"))
+      end
+
+      it "with unexpected disabled value, it fallbacks to unknown error" do
+        error.missing_custom_field_ids = [nil]
+
+        error.error_code = "ERROR_DISABLED_VALUE"
+        expect(subject.calculated_value_error_msg(error)).to eq(I18n.t("calculated_values.errors.unknown"))
       end
     end
   end

--- a/spec/models/acts_as_customizable/calculated_value_spec.rb
+++ b/spec/models/acts_as_customizable/calculated_value_spec.rb
@@ -597,6 +597,78 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_ee: %i[calculated_value
       end
     end
 
+    context "when Dentaku::ArgumentError is not caused by a missing value" do
+      context "when wrong value is boolean" do
+        let(:cf_bool) { create(:boolean_project_custom_field, projects: [project]) }
+        let(:cv) do
+          create(:calculated_value_project_custom_field, :skip_validations, projects: [project],
+                                                                            formula: "#{cf_bool} + 1")
+        end
+
+        let(:custom_field_values) do
+          { cf_bool => cf_bool_value, cv => nil }
+        end
+
+        context "when value is true" do
+          let(:cf_bool_value) { true }
+
+          it "creates an unknown error and reports no missing values" do
+            project.calculate_custom_fields([cv])
+
+            expect(cv.first_calculation_error(project))
+              .to have_attributes(error_code: "ERROR_UNKNOWN", missing_custom_field_ids: [])
+          end
+        end
+
+        context "when value is false" do
+          let(:cf_bool_value) { false }
+
+          it "creates an unknown error and reports no missing values" do
+            project.calculate_custom_fields([cv])
+
+            expect(cv.first_calculation_error(project))
+              .to have_attributes(error_code: "ERROR_UNKNOWN", missing_custom_field_ids: [])
+          end
+        end
+      end
+
+      context "when case expression falls through without default branch (regression #OP-19819)" do
+        let(:cv) do
+          create(:calculated_value_project_custom_field, :skip_validations, projects: [project],
+                                                                            formula: "CASE 0 WHEN 1 THEN 2 END")
+        end
+
+        let(:custom_field_values) { {} }
+
+        it "creates an unknown error and reports no missing values" do
+          project.calculate_custom_fields([cv])
+
+          expect(cv.first_calculation_error(project))
+            .to have_attributes(error_code: "ERROR_UNKNOWN", missing_custom_field_ids: [])
+        end
+      end
+    end
+
+    describe "missing value alongside a set boolean reference" do
+      let(:cf_int) { create(:integer_project_custom_field, projects: [project]) }
+      let(:cf_bool) { create(:boolean_project_custom_field, projects: [project]) }
+      let(:cv) do
+        create(:calculated_value_project_custom_field, :skip_validations, projects: [project],
+                                                                          formula: "#{cf_int} + #{cf_bool}")
+      end
+
+      let(:custom_field_values) do
+        { cf_int => nil, cf_bool => true, cv => nil }
+      end
+
+      it "reports only the missing field" do
+        project.calculate_custom_fields([cv])
+
+        expect(cv.first_calculation_error(project))
+          .to have_attributes(error_code: "ERROR_MISSING_VALUE", missing_custom_field_ids: [cf_int.id])
+      end
+    end
+
     describe "disabled value" do
       let(:cf_int) { create(:integer_project_custom_field, projects: []) }
       let(:cv1) do

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -213,6 +213,31 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
     end
   end
 
+  describe ".computed_value?" do
+    {
+      true => [
+        1,
+        2.0,
+        BigDecimal("3"),
+        true,
+        false
+      ],
+      false => [
+        nil,
+        "3",
+        "foo",
+        [1],
+        Dentaku::ArgumentError.for(:invalid_value)
+      ]
+    }.each do |is_computed, values|
+      values.each do |value|
+        context "for #{value.inspect}" do
+          it { expect(described_class.computed_value?(value)).to be(is_computed) }
+        end
+      end
+    end
+  end
+
   describe "#usable_custom_field_references_for_formula" do
     let!(:int) { create(:project_custom_field, :integer, default_value: 4, is_for_all: true) }
     let!(:float) { create(:project_custom_field, :float, default_value: 5.5, is_for_all: true) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19819

# What are you trying to accomplish?
Don't allow a problem during formula calculation or when displaying calculated value error message cause project overview or projects table to fail to display.

# What approach did you choose and why?
Rework error message helper
Use query method that can't cause 404 to replace the page
Create single place to determine correctly calculated values
Improve detection of missing values instead of considering all Dentaku::ArgumentError to be that

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
