### PR TITLE
[AGILE-226] Confine read-only Backlogs cards to their container

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -45,6 +45,7 @@
 @import "work_packages/progress/modal_body_component"
 @import "work_packages/reminder/modal_body_component"
 @import "work_packages/split_view_component"
+@import "work_packages/status_badge_component"
 @import "header/project_select_component"
 @import "homescreen/link_component"
 @import "homescreen/links_component"

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -150,7 +150,7 @@ module OpenProject
       #   # @param drop_target_label [String, nil] when given, renders a
       #   #   drop-zone overlay with this label. The overlay becomes visible
       #   #   while a sortable item hovers the surrounding
-      #   #   `[data-drop-container]` list.
+      #   #   `[data-drop-container="active"]` list.
       #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Blankslate`.
       #   # @return [ViewComponent::Slot]
       #   def with_empty_state(title:, description: nil, icon: nil, drop_target_label: nil, **system_arguments)

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -88,11 +88,16 @@
     border-bottom-right-radius: 0
 
   // Drop container: the whole list outlines while a sortable item hovers it,
-  // signalling the item will land inside this list.
+  // signalling the item will land inside this list. A refused container (a
+  // confined item hovering a foreign list) mutes the outline to a danger tone
+  // instead, signalling the item will not land here.
   &[data-drop-container]
     outline: var(--borderWidth-thick) solid var(--fgColor-accent)
     outline-offset: calc(var(--borderWidth-thick) * -1)
     border-radius: var(--borderRadius-medium)
+
+  &[data-drop-container="refused"]
+    outline-color: var(--borderColor-danger-muted)
 
   // The empty-state row only makes sense while it is alone in the list. Hiding
   // it as soon as a sibling row appears (e.g. dropped by drag and drop) avoids
@@ -250,7 +255,7 @@
     @media (prefers-reduced-motion: no-preference)
       transition: opacity 0.1s ease-in-out, visibility 0s linear 0.1s
 
-.op-border-box-list[data-drop-container] .op-border-box-list-empty-state--drop-overlay
+.op-border-box-list[data-drop-container="active"] .op-border-box-list-empty-state--drop-overlay
   opacity: 1
   visibility: visible
   pointer-events: auto

--- a/app/components/open_project/common/border_box_list_component/empty_state.rb
+++ b/app/components/open_project/common/border_box_list_component/empty_state.rb
@@ -47,7 +47,8 @@ module OpenProject
         #   announced politely to assistive technology.
         # @param drop_target_label [String, nil] when given, renders a drop-zone
         #   overlay with this label. The overlay becomes visible while a
-        #   sortable item hovers the surrounding `[data-drop-container]` list.
+        #   sortable item hovers the surrounding `[data-drop-container="active"]`
+        #   list.
         # @param system_arguments [Hash] forwarded to `Primer::Beta::Blankslate`.
         def initialize(
           title:,

--- a/app/components/work_packages/status_badge_component.html.erb
+++ b/app/components/work_packages/status_badge_component.html.erb
@@ -1,3 +1,14 @@
-<%=
-  render(Primer::Beta::Label.new(size: :medium, inline: true, **@system_arguments)) { @status.name }
-%>
+<%= render(Primer::Beta::Label.new(size: :medium, inline: true, **@system_arguments)) do -%>
+  <%- if readonly? -%>
+    <%= render(
+          Primer::Beta::Octicon.new(
+            icon: :lock,
+            size: :xsmall,
+            classes: "op-status-badge--icon",
+            aria: { label: t("activerecord.attributes.status.is_readonly") }
+          )
+        ) -%>
+  <%- end -%>
+  <%# The name carries its own element so that truncation applies to it alone and cannot swallow the lock %>
+  <%= render(Primer::Beta::Text.new(classes: "op-status-badge--name")) { @status.name } -%>
+<% end %>

--- a/app/components/work_packages/status_badge_component.html.erb
+++ b/app/components/work_packages/status_badge_component.html.erb
@@ -5,7 +5,7 @@
             icon: :lock,
             size: :xsmall,
             classes: "op-status-badge--icon",
-            aria: { label: t("activerecord.attributes.status.is_readonly") }
+            aria: { label: Status.human_attribute_name(:is_readonly) }
           )
         ) -%>
   <%- end -%>

--- a/app/components/work_packages/status_badge_component.rb
+++ b/app/components/work_packages/status_badge_component.rb
@@ -43,5 +43,29 @@ class WorkPackages::StatusBadgeComponent < ApplicationComponent
         "__hl_background_status_#{@status.id}"
       )
     end
+
+    # Applied for every scheme: the `:secondary` badge skips the block above and
+    # still needs the hook the read-only layout is scoped to.
+    @system_arguments[:classes] = class_names(
+      @system_arguments[:classes],
+      "op-status-badge",
+      "op-status-badge_readonly" => readonly?
+    )
+  end
+
+  private
+
+  # A read-only status forbids every attribute write except the status itself
+  # ({WorkPackages::BaseContract#readonly_attributes_unchanged}), which is not
+  # something the badge's colour and name convey on their own. The lock says so,
+  # matching the leading visual {WorkPackages::StatusButtonComponent} already
+  # gives read-only options in the status dropdown.
+  #
+  # Read-only statuses are an Enterprise feature, and {Status#is_readonly}
+  # answers `false` without the token, so no further gate is needed here.
+  #
+  # @return [Boolean] whether the status locks the work package.
+  def readonly?
+    @status.is_readonly?
   end
 end

--- a/app/components/work_packages/status_badge_component.sass
+++ b/app/components/work_packages/status_badge_component.sass
@@ -1,0 +1,14 @@
+// Scoped to `.Label` so it outweighs Primer's `.Label--inline { display: inline }`
+// whatever order the stylesheets load in. An inline box gives the lock no
+// alignment context, so only the read-only badge becomes a flex container.
+.Label.op-status-badge
+  &_readonly
+    display: inline-flex
+    align-items: center
+    gap: 0.25rem
+
+  .op-status-badge--icon
+    flex-shrink: 0
+
+  .op-status-badge--name
+    @include text-shortener

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -902,4 +902,13 @@ describe('Sortable lists controller', () => {
 
     expect(controller.moveAvailability(document.createElement('li'))).toBeNull();
   });
+
+  it('resolves the owning list element of an item for the drag payload', async () => {
+    const { root, sourceList, firstSourceItem } = renderFixture();
+    await ctx.nextFrame();
+    const controller = ctx.application.getControllerForElementAndIdentifier(root, 'sortable-lists') as SortableListsControllerType;
+
+    expect(controller.ownerListElementOf(firstSourceItem)).toBe(sourceList);
+    expect(controller.ownerListElementOf(document.createElement('li'))).toBeNull();
+  });
 });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -215,6 +215,12 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     });
   }
 
+  // The list element an item currently belongs to, for the confinement field
+  // on the drag payload; null outside any registered list.
+  ownerListElementOf(itemElement:HTMLElement):HTMLElement|null {
+    return this.ownerListOf(itemElement)?.element ?? null;
+  }
+
   private ownerListOf(itemElement:HTMLElement) {
     return this.sortableListsListOutlets.find((list) => list.element.contains(itemElement)) ?? null;
   }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.spec.ts
@@ -403,6 +403,59 @@ describe('sortable lists drag and drop helpers', () => {
       expect(intent?.previousItemId).toEqual('5');
     });
 
+    // A confined item's foreign-list targets stay registered (they express
+    // refusal through a 'none' drop effect), so the browser should never fire
+    // a drop over them — but if one slips through, the intent must resolve to
+    // nothing rather than to a move the server will reject.
+    it('resolves no intent for a confined item over a foreign list', () => {
+      const { root, list } = buildList();
+      const sourceList = document.createElement('ul');
+      const source = itemRow('1');
+
+      sourceList.setAttribute('data-controller', 'sortable-lists--list');
+      sourceList.append(source);
+      list.append(itemRow('4'), itemRow('5'));
+      root.append(sourceList);
+
+      const intent = resolveDropIntent({
+        location: dropLocation({
+          dropTargets: [{ data: sortableListData({ type: 'backlog_bucket', listId: '7' }), element: list }],
+        }),
+        root,
+        sourceData: sortableItemData({
+          type: 'work_package',
+          itemId: '1',
+          sourceListElement: sourceList,
+          confined: true,
+        }),
+      });
+
+      expect(intent).toBeNull();
+    });
+
+    it('resolves a confined item dropped on its own source list', () => {
+      const { root, list } = buildList();
+      const source = itemRow('1');
+
+      list.append(source, itemRow('2'));
+
+      const intent = resolveDropIntent({
+        location: dropLocation({
+          dropTargets: [{ data: sortableListData({ type: 'sprint', listId: '7' }), element: list }],
+        }),
+        root,
+        sourceData: sortableItemData({
+          type: 'work_package',
+          itemId: '1',
+          sourceListElement: list,
+          confined: true,
+        }),
+      });
+
+      expect(intent?.listElement).toBe(list);
+      expect(intent?.previousItemId).toEqual('2');
+    });
+
     it('prepends to the list when its drop position is start', () => {
       const { root, list } = buildList();
       const sourceList = document.createElement('ul');

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -192,13 +192,20 @@ export function isItemFromRoot(
     && data.rootElement === rootElement;
 }
 
-// Whether a drop target may accept the dragged item under its confinement.
-// contains() includes the element itself, so one predicate passes both the
-// source list element and every row inside it while refusing every foreign
-// container. The source list keeping its acceptance is load-bearing: a drop
-// resolves through the list target (resolveDropIntent returns null without
-// one), so refusing it would kill within-list reorder, not just cross-list
-// moves.
+// Whether a drop on the given target may amount to a move under the source's
+// confinement. contains() includes the element itself, so one predicate passes
+// both the source list element and every row inside it while failing every
+// foreign container. The source list passing is load-bearing: a drop resolves
+// through the list target (resolveDropIntent returns null without one), so
+// failing it would kill within-list reorder, not just cross-list moves.
+//
+// Item drop targets consult this in canDrop and refuse outright; list drop
+// targets stay accepted regardless (an accepted target is what keeps the
+// standard 'move' cursor on the dragover — refused, Chrome falls back to a
+// copy cursor) and the refusal is enforced here in resolveDropIntent: a
+// release over a container this fails for resolves to no move at all, and
+// the drop-indicator layers consult it too, so such a container never shows
+// a drop position.
 export function confinementAllowsDrop(
   data:SortableItemData,
   targetElement:Element,
@@ -283,11 +290,13 @@ export function resolveDropIntent({
   const targetItem = location.current.dropTargets.find(
     (target):target is typeof target & { data:SortableItemData; element:HTMLElement } => (
       isSortableItemData(target.data) && target.element instanceof HTMLElement && root.contains(target.element)
+        && confinementAllowsDrop(sourceData, target.element)
     ),
   );
   const targetList = location.current.dropTargets.find(
     (target):target is typeof target & { data:SortableListData; element:HTMLElement } => (
       isSortableListData(target.data) && target.element instanceof HTMLElement && root.contains(target.element)
+        && confinementAllowsDrop(sourceData, target.element)
     ),
   );
   if (!targetList) {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -51,6 +51,14 @@ export interface SortableItemData extends Record<string|symbol, unknown> {
   type:string;
   itemId:string;
   rootElement:HTMLElement|null;
+  // The list element the drag started in, resolved by the root at drag start
+  // (items hold no list reference themselves). Null when the item is not in a
+  // registered list. Mirrors the rootElement pattern: identity is carried on
+  // the payload so drop targets can decide without walking the DOM.
+  sourceListElement:HTMLElement|null;
+  // A confined item may only land in sourceListElement or one of its rows;
+  // every other container refuses it. See confinementAllowsDrop.
+  confined:boolean;
 }
 
 export type SortableListDropPosition = 'start'|'end';
@@ -78,6 +86,9 @@ export interface SortableListsRoot {
   moveInDirection(itemElement:HTMLElement, direction:MoveDirection):void;
   // A snapshot for menu gating; the click path re-resolves against the live DOM.
   moveAvailability(itemElement:HTMLElement):MoveAvailability|null;
+  // The element of the list an item currently belongs to; null outside any
+  // registered list. Items carry no list reference, so the root resolves it.
+  ownerListElementOf(itemElement:HTMLElement):HTMLElement|null;
 }
 
 // Implemented by the list, item and scrollable controllers so the root can
@@ -109,16 +120,22 @@ export function sortableItemData({
   type,
   itemId,
   rootElement = null,
+  sourceListElement = null,
+  confined = false,
 }:{
   type:string;
   itemId:string;
   rootElement?:HTMLElement|null;
+  sourceListElement?:HTMLElement|null;
+  confined?:boolean;
 }):SortableItemData {
   return {
     [sortableItemDataKey]: true,
     type,
     itemId,
     rootElement,
+    sourceListElement,
+    confined,
   };
 }
 
@@ -173,6 +190,20 @@ export function isItemFromRoot(
   return rootElement != null
     && isSortableItemData(data)
     && data.rootElement === rootElement;
+}
+
+// Whether a drop target may accept the dragged item under its confinement.
+// contains() includes the element itself, so one predicate passes both the
+// source list element and every row inside it while refusing every foreign
+// container. The source list keeping its acceptance is load-bearing: a drop
+// resolves through the list target (resolveDropIntent returns null without
+// one), so refusing it would kill within-list reorder, not just cross-list
+// moves.
+export function confinementAllowsDrop(
+  data:SortableItemData,
+  targetElement:Element,
+):boolean {
+  return !data.confined || (data.sourceListElement?.contains(targetElement) ?? false);
 }
 
 export function resolvePreviousSortableItemId({

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/drag-and-drop.ts
@@ -204,8 +204,8 @@ export function isItemFromRoot(
 // standard 'move' cursor on the dragover — refused, Chrome falls back to a
 // copy cursor) and the refusal is enforced here in resolveDropIntent: a
 // release over a container this fails for resolves to no move at all, and
-// the drop-indicator layers consult it too, so such a container never shows
-// a drop position.
+// the drop-indicator layers consult it too — rows never show a drop position
+// for it, and the list marks its container refused instead of active.
 export function confinementAllowsDrop(
   data:SortableItemData,
   targetElement:Element,

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -91,7 +91,7 @@ describe('Sortable lists item controller', () => {
 
   function fakeRoot(
     element = document.createElement('div'),
-    { busy = false } = {},
+    { busy = false, ownerListElement = null }:{ busy?:boolean; ownerListElement?:HTMLElement|null } = {},
   ):SortableListsRoot {
     Object.defineProperty(element, 'isConnected', { value: true, configurable: true });
     return {
@@ -99,12 +99,17 @@ describe('Sortable lists item controller', () => {
       busy,
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
+      ownerListElementOf: vi.fn(() => ownerListElement),
     };
   }
 
   function connectedControllerFor(
     element:HTMLElement,
-    { handle = null, root = fakeRoot() }:{ handle?:HTMLElement|null; root?:SortableListsRoot|null } = {},
+    { handle = null, root = fakeRoot(), confinedValue = false }:{
+      handle?:HTMLElement|null;
+      root?:SortableListsRoot|null;
+      confinedValue?:boolean;
+    } = {},
   ) {
     const controller = Object.create(ItemController.prototype) as InstanceType<typeof ItemControllerType>;
 
@@ -113,6 +118,7 @@ describe('Sortable lists item controller', () => {
     Object.defineProperty(controller, 'hasIdValue', { value: true });
     Object.defineProperty(controller, 'typeValue', { value: 'item' });
     Object.defineProperty(controller, 'hasTypeValue', { value: true });
+    Object.defineProperty(controller, 'confinedValue', { value: confinedValue });
     Object.defineProperty(controller, 'hasHandleTarget', { value: handle !== null });
     if (handle) {
       Object.defineProperty(controller, 'handleTarget', { value: handle });
@@ -165,12 +171,21 @@ describe('Sortable lists item controller', () => {
     Object.defineProperty(controller, 'hasIdValue', { value: id !== '' });
     Object.defineProperty(controller, 'typeValue', { value: type });
     Object.defineProperty(controller, 'hasTypeValue', { value: type !== '' });
+    Object.defineProperty(controller, 'confinedValue', { value: false });
     Object.defineProperty(controller, 'hasHandleTarget', { value: false });
 
     controller.connect();
 
     return warn;
   }
+
+  it('registers a drag source', () => {
+    const element = document.createElement('li');
+
+    connectedControllerFor(element);
+
+    expect(draggable).toHaveBeenCalledWith(expect.objectContaining({ element }));
+  });
 
   it('warns when connected without an item id', () => {
     const warn = connectItem({ id: '', type: 'work_package' });
@@ -424,6 +439,88 @@ describe('Sortable lists item controller', () => {
     })).toBe(true);
   });
 
+  // A confined item may only land in its source list. Rows of that list keep
+  // accepting it (within-list reorder), rows of any other list refuse it, and
+  // with no payload list there is nothing it may land on.
+  describe('a confined drag source', () => {
+    function canDropOnto(targetElement:HTMLElement, root:HTMLElement, sourceListElement:HTMLElement|null) {
+      return vi.mocked(dropTargetForElements).mock.lastCall?.[0].canDrop?.({
+        element: targetElement,
+        input: {} as never,
+        source: {
+          data: sortableItemData({
+            type: 'item',
+            itemId: '456',
+            rootElement: root,
+            sourceListElement,
+            confined: true,
+          }),
+          element: document.createElement('article'),
+        } as never,
+      });
+    }
+
+    it('still registers a drag source', () => {
+      const element = document.createElement('li');
+
+      connectedControllerFor(element, { confinedValue: true });
+
+      expect(draggable).toHaveBeenCalledWith(expect.objectContaining({ element }));
+    });
+
+    it('is accepted by a row inside its source list', () => {
+      const root = document.createElement('div');
+      const sourceList = document.createElement('div');
+      const targetElement = document.createElement('article');
+      sourceList.appendChild(targetElement);
+
+      connectedControllerFor(targetElement, { root: fakeRoot(root) });
+
+      expect(canDropOnto(targetElement, root, sourceList)).toBe(true);
+    });
+
+    it('is refused by a row of a foreign list', () => {
+      const root = document.createElement('div');
+      const sourceList = document.createElement('div');
+      const targetElement = document.createElement('article');
+
+      connectedControllerFor(targetElement, { root: fakeRoot(root) });
+
+      expect(canDropOnto(targetElement, root, sourceList)).toBe(false);
+    });
+
+    it('is refused everywhere when its payload carries no source list', () => {
+      const root = document.createElement('div');
+      const targetElement = document.createElement('article');
+
+      connectedControllerFor(targetElement, { root: fakeRoot(root) });
+
+      expect(canDropOnto(targetElement, root, null)).toBe(false);
+    });
+  });
+
+  it('accepts an unconfined drop from a row of another list', () => {
+    const root = document.createElement('div');
+    const foreignList = document.createElement('div');
+    const targetElement = document.createElement('article');
+
+    connectedControllerFor(targetElement, { root: fakeRoot(root) });
+
+    expect(vi.mocked(dropTargetForElements).mock.lastCall?.[0].canDrop?.({
+      element: targetElement,
+      input: {} as never,
+      source: {
+        data: sortableItemData({
+          type: 'item',
+          itemId: '456',
+          rootElement: root,
+          sourceListElement: foreignList,
+        }),
+        element: document.createElement('article'),
+      } as never,
+    })).toBe(true);
+  });
+
   it('does not accept drops while the root is busy moving another item', () => {
     const root = document.createElement('div');
     const targetElement = document.createElement('article');
@@ -544,6 +641,27 @@ describe('Sortable lists item controller', () => {
 
     expect(vi.mocked(draggable).mock.lastCall?.[0].getInitialData?.(draggableArgs(element)))
       .toEqual(expect.objectContaining({ itemId: '123', type: 'item', rootElement: root }));
+  });
+
+  it('includes the root-resolved source list and confinement in the drag payload', () => {
+    const root = document.createElement('div');
+    const sourceList = document.createElement('div');
+    const element = document.createElement('article');
+    connectedControllerFor(element, {
+      root: fakeRoot(root, { ownerListElement: sourceList }),
+      confinedValue: true,
+    });
+
+    expect(vi.mocked(draggable).mock.lastCall?.[0].getInitialData?.(draggableArgs(element)))
+      .toEqual(expect.objectContaining({ sourceListElement: sourceList, confined: true }));
+  });
+
+  it('defaults the payload to unconfined with no source list', () => {
+    const element = document.createElement('article');
+    connectedControllerFor(element);
+
+    expect(vi.mocked(draggable).mock.lastCall?.[0].getInitialData?.(draggableArgs(element)))
+      .toEqual(expect.objectContaining({ sourceListElement: null, confined: false }));
   });
 
   describe('Stimulus application wiring', () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.ts
@@ -41,6 +41,7 @@ import { Controller, type ActionEvent } from '@hotwired/stimulus';
 import type { ActionMenuElement } from '@openproject/primer-view-components/app/components/primer/alpha/action_menu/action_menu_element';
 import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 import {
+  confinementAllowsDrop,
   isItemFromRoot,
   sortableItemData,
   type RootAwareChild,
@@ -60,6 +61,12 @@ export default class ItemController extends Controller<HTMLElement> implements R
     id: String,
     type: String,
     hideUnavailable: { type: Boolean, default: true },
+    // A confined item is still a full drag source, but only its own list and
+    // that list's rows accept it as a drop target; foreign containers refuse
+    // it, so a release there lands nowhere and the item stays put. Consumers
+    // use this for items the server allows to reorder in place but refuses to
+    // relocate to another container.
+    confined: { type: Boolean, default: false },
     label: String,
   };
 
@@ -68,6 +75,7 @@ export default class ItemController extends Controller<HTMLElement> implements R
   declare readonly typeValue:string;
   declare readonly hasTypeValue:boolean;
   declare readonly hideUnavailableValue:boolean;
+  declare readonly confinedValue:boolean;
   declare readonly labelValue:string;
   declare readonly hasLabelValue:boolean;
 
@@ -248,7 +256,8 @@ export default class ItemController extends Controller<HTMLElement> implements R
         // resolving to a silent no-op. Holds today (one type per list).
         return isItemFromRoot(root.element, source.data)
           && source.data.itemId !== this.idValue
-          && source.data.type === this.typeValue;
+          && source.data.type === this.typeValue
+          && confinementAllowsDrop(source.data, this.element);
       },
       getData: ({ input }) => {
         return attachClosestEdge(this.getItemData(), {
@@ -311,6 +320,8 @@ export default class ItemController extends Controller<HTMLElement> implements R
       itemId: this.idValue,
       type: this.typeValue,
       rootElement: this.root?.element ?? null,
+      sourceListElement: this.root?.ownerListElementOf(this.element) ?? null,
+      confined: this.confinedValue,
     });
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -226,18 +226,12 @@ describe('Sortable lists list controller', () => {
       .toBe(true);
   });
 
-  it('accepts a confined item when it is that item source list', async () => {
-    const root = document.createElement('div');
-    const { list } = await connectedListFor({ acceptedType: 'work_package', root: fakeRoot(root) });
-
-    expect(dropTargetOptionsFor(list)?.canDrop?.({
-      element: list,
-      input: {} as never,
-      source: source(root, 'work_package', { confined: true, sourceListElement: list }),
-    })).toBe(true);
-  });
-
-  it('rejects a confined item from another list', async () => {
+  // A confined item stays accepted by a foreign list on purpose: only an
+  // accepted target keeps the standard 'move' cursor on the dragover (refused,
+  // Chrome falls back to a copy cursor), and Pragmatic's getDropEffect cannot
+  // express 'none'. The refusal lives in resolveDropIntent and in the
+  // suppressed drop indicators instead.
+  it('still accepts a confined item from another list', async () => {
     const root = document.createElement('div');
     const { list } = await connectedListFor({ acceptedType: 'work_package', root: fakeRoot(root) });
 
@@ -245,18 +239,7 @@ describe('Sortable lists list controller', () => {
       element: list,
       input: {} as never,
       source: source(root, 'work_package', { confined: true, sourceListElement: document.createElement('ul') }),
-    })).toBe(false);
-  });
-
-  it('rejects a confined item whose payload carries no source list', async () => {
-    const root = document.createElement('div');
-    const { list } = await connectedListFor({ acceptedType: 'work_package', root: fakeRoot(root) });
-
-    expect(dropTargetOptionsFor(list)?.canDrop?.({
-      element: list,
-      input: {} as never,
-      source: source(root, 'work_package', { confined: true }),
-    })).toBe(false);
+    })).toBe(true);
   });
 
   it('rejects an item whose type is not accepted', async () => {
@@ -289,39 +272,62 @@ describe('Sortable lists list controller', () => {
   });
 
   it('outlines the container for a list-only drop', async () => {
-    const { list } = await connectedListFor();
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
     const options = dropTargetOptionsFor(list);
 
-    options?.onDragEnter?.({ location: locationOver() } as never);
+    options?.onDragEnter?.({ location: locationOver(), source: source(rootElement) } as never);
 
     expect(list.dataset.dropContainer).toEqual('active');
   });
 
   it('does not outline the container while the pointer is over an item row', async () => {
-    const { list } = await connectedListFor();
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
     const options = dropTargetOptionsFor(list);
 
-    options?.onDrag?.({ location: locationOver({ data: sortableItemData({ itemId: '1', type: 'work_package', rootElement: null }) }) } as never);
+    options?.onDrag?.({
+      location: locationOver({ data: sortableItemData({ itemId: '1', type: 'work_package', rootElement: null }) }),
+      source: source(rootElement),
+    } as never);
+
+    expect(list.dataset.dropContainer).toBeUndefined();
+  });
+
+  it('does not outline the container for a confined item from another list', async () => {
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
+    const options = dropTargetOptionsFor(list);
+
+    options?.onDragEnter?.({
+      location: locationOver(),
+      source: source(rootElement, 'work_package', { confined: true, sourceListElement: document.createElement('ul') }),
+    } as never);
 
     expect(list.dataset.dropContainer).toBeUndefined();
   });
 
   it('clears the container outline when the pointer moves from the list onto an item row', async () => {
-    const { list } = await connectedListFor();
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
     const options = dropTargetOptionsFor(list);
 
-    options?.onDragEnter?.({ location: locationOver() } as never);
+    options?.onDragEnter?.({ location: locationOver(), source: source(rootElement) } as never);
     expect(list.dataset.dropContainer).toEqual('active');
 
-    options?.onDrag?.({ location: locationOver({ data: sortableItemData({ itemId: '1', type: 'work_package', rootElement: null }) }) } as never);
+    options?.onDrag?.({
+      location: locationOver({ data: sortableItemData({ itemId: '1', type: 'work_package', rootElement: null }) }),
+      source: source(rootElement),
+    } as never);
     expect(list.dataset.dropContainer).toBeUndefined();
   });
 
   it('clears the container outline on drag leave', async () => {
-    const { list } = await connectedListFor();
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
     const options = dropTargetOptionsFor(list);
 
-    options?.onDragEnter?.({ location: locationOver() } as never);
+    options?.onDragEnter?.({ location: locationOver(), source: source(rootElement) } as never);
     expect(list.dataset.dropContainer).toEqual('active');
 
     options?.onDragLeave?.({} as never);

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -76,6 +76,7 @@ describe('Sortable lists list controller', () => {
       busy,
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
+      ownerListElementOf: vi.fn(() => null),
     };
   }
 
@@ -114,9 +115,13 @@ describe('Sortable lists list controller', () => {
     return vi.mocked(dropTargetForElements).mock.calls.find(([options]) => options.element === element)?.[0];
   }
 
-  function source(rootElement:HTMLElement|null, type = 'work_package') {
+  function source(
+    rootElement:HTMLElement|null,
+    type = 'work_package',
+    { confined = false, sourceListElement = null }:{ confined?:boolean; sourceListElement?:HTMLElement|null } = {},
+  ) {
     return {
-      data: sortableItemData({ itemId: '1', type, rootElement }),
+      data: sortableItemData({ itemId: '1', type, rootElement, confined, sourceListElement }),
       element: document.createElement('li'),
     } as never;
   }
@@ -219,6 +224,39 @@ describe('Sortable lists list controller', () => {
 
     expect(dropTargetOptionsFor(list)?.canDrop?.({ element: list, input: {} as never, source: source(root, 'work_package') }))
       .toBe(true);
+  });
+
+  it('accepts a confined item when it is that item source list', async () => {
+    const root = document.createElement('div');
+    const { list } = await connectedListFor({ acceptedType: 'work_package', root: fakeRoot(root) });
+
+    expect(dropTargetOptionsFor(list)?.canDrop?.({
+      element: list,
+      input: {} as never,
+      source: source(root, 'work_package', { confined: true, sourceListElement: list }),
+    })).toBe(true);
+  });
+
+  it('rejects a confined item from another list', async () => {
+    const root = document.createElement('div');
+    const { list } = await connectedListFor({ acceptedType: 'work_package', root: fakeRoot(root) });
+
+    expect(dropTargetOptionsFor(list)?.canDrop?.({
+      element: list,
+      input: {} as never,
+      source: source(root, 'work_package', { confined: true, sourceListElement: document.createElement('ul') }),
+    })).toBe(false);
+  });
+
+  it('rejects a confined item whose payload carries no source list', async () => {
+    const root = document.createElement('div');
+    const { list } = await connectedListFor({ acceptedType: 'work_package', root: fakeRoot(root) });
+
+    expect(dropTargetOptionsFor(list)?.canDrop?.({
+      element: list,
+      input: {} as never,
+      source: source(root, 'work_package', { confined: true }),
+    })).toBe(false);
   });
 
   it('rejects an item whose type is not accepted', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -294,7 +294,7 @@ describe('Sortable lists list controller', () => {
     expect(list.dataset.dropContainer).toBeUndefined();
   });
 
-  it('does not outline the container for a confined item from another list', async () => {
+  it('marks the container refused for a confined item from another list', async () => {
     const rootElement = document.createElement('div');
     const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
     const options = dropTargetOptionsFor(list);
@@ -304,6 +304,34 @@ describe('Sortable lists list controller', () => {
       source: source(rootElement, 'work_package', { confined: true, sourceListElement: document.createElement('ul') }),
     } as never);
 
+    expect(list.dataset.dropContainer).toEqual('refused');
+  });
+
+  it('outlines the container for a confined item over its own list', async () => {
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
+    const options = dropTargetOptionsFor(list);
+
+    options?.onDragEnter?.({
+      location: locationOver(),
+      source: source(rootElement, 'work_package', { confined: true, sourceListElement: list }),
+    } as never);
+
+    expect(list.dataset.dropContainer).toEqual('active');
+  });
+
+  it('clears the refused mark on drag leave', async () => {
+    const rootElement = document.createElement('div');
+    const { list } = await connectedListFor({ root: fakeRoot(rootElement) });
+    const options = dropTargetOptionsFor(list);
+
+    options?.onDragEnter?.({
+      location: locationOver(),
+      source: source(rootElement, 'work_package', { confined: true, sourceListElement: document.createElement('ul') }),
+    } as never);
+    expect(list.dataset.dropContainer).toEqual('refused');
+
+    options?.onDragLeave?.({} as never);
     expect(list.dataset.dropContainer).toBeUndefined();
   });
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
@@ -96,14 +96,22 @@ export default class ListController extends Controller<HTMLElement> implements R
 
     this.cleanupFn = dropTargetForElements({
       element: this.element,
+      // A confined item from another list stays accepted here on purpose,
+      // even though releasing it resolves to nothing (see acceptsDrop): only
+      // an accepted target lets Pragmatic keep the standard 'move' drop
+      // effect on the dragover, and with it the standard cursor. Refused, the
+      // container falls through to the browser default, which Chrome renders
+      // as a copy cursor — promising an "add" that will never happen.
+      // Pragmatic's getDropEffect cannot express 'none', so acceptance is the
+      // only supported way to control the cursor over these containers.
       canDrop: ({ source }) => this.canDrop(source.data),
       getData: () => this.listData,
       getIsSticky: () => false,
-      onDragEnter: ({ location }) => {
-        this.syncDropIndicator(location);
+      onDragEnter: ({ location, source }) => {
+        this.syncDropIndicator(location, source.data);
       },
-      onDrag: ({ location }) => {
-        this.syncDropIndicator(location);
+      onDrag: ({ location, source }) => {
+        this.syncDropIndicator(location, source.data);
       },
       onDragLeave: () => {
         this.clearDropIndicator();
@@ -164,19 +172,26 @@ export default class ListController extends Controller<HTMLElement> implements R
       return false;
     }
 
-    // A confined item's source list always passes the confinement check
-    // (containment includes the list element itself), keeping within-list
-    // reorder alive; only foreign containers refuse.
-    return isItemFromRoot(root.element, data)
-      && data.type === this.acceptedTypeValue
-      && confinementAllowsDrop(data, this.element);
+    return isItemFromRoot(root.element, data) && data.type === this.acceptedTypeValue;
+  }
+
+  // Whether a drop released here would amount to a move. A confined item's
+  // source list always passes (containment includes the list element itself),
+  // keeping within-list reorder alive; foreign containers stay accepted drop
+  // targets (see canDrop above) but a release on them resolves to nothing —
+  // resolveDropIntent applies the same confinement filter.
+  private acceptsDrop(data:Record<string|symbol, unknown>):boolean {
+    return isItemFromRoot(this.root?.element ?? null, data) && confinementAllowsDrop(data, this.element);
   }
 
   // The list is the item targets' parent drop target, so its onDrag keeps firing
   // while the pointer is over a row. Outline the container only for a list-only
-  // drop (no item target in play), so the row gap indicator owns that case.
-  private syncDropIndicator(location:DragLocationHistory):void {
-    if (location.current.dropTargets.some(({ data }) => isSortableItemData(data))) {
+  // drop (no item target in play) by a source that may actually land here, so
+  // the row gap indicator owns the over-a-row case and a confined foreign item
+  // draws nothing at all.
+  private syncDropIndicator(location:DragLocationHistory, sourceData:Record<string|symbol, unknown>):void {
+    if (!this.acceptsDrop(sourceData)
+      || location.current.dropTargets.some(({ data }) => isSortableItemData(data))) {
       this.clearDropIndicator();
     } else {
       this.renderDropIndicator();

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
@@ -175,31 +175,28 @@ export default class ListController extends Controller<HTMLElement> implements R
     return isItemFromRoot(root.element, data) && data.type === this.acceptedTypeValue;
   }
 
-  // Whether a drop released here would amount to a move. A confined item's
-  // source list always passes (containment includes the list element itself),
-  // keeping within-list reorder alive; foreign containers stay accepted drop
-  // targets (see canDrop above) but a release on them resolves to nothing —
-  // resolveDropIntent applies the same confinement filter.
-  private acceptsDrop(data:Record<string|symbol, unknown>):boolean {
-    return isItemFromRoot(this.root?.element ?? null, data) && confinementAllowsDrop(data, this.element);
-  }
-
   // The list is the item targets' parent drop target, so its onDrag keeps firing
-  // while the pointer is over a row. Outline the container only for a list-only
-  // drop (no item target in play) by a source that may actually land here, so
-  // the row gap indicator owns the over-a-row case and a confined foreign item
-  // draws nothing at all.
+  // while the pointer is over a row. Indicate only for a list-only drop (no item
+  // target in play), so the row gap indicator owns the over-a-row case. Whether
+  // a release would amount to a move decides the indicator's state: a confined
+  // item's source list counts as a move (containment includes the list element
+  // itself, keeping within-list reorder alive), while a foreign container stays
+  // an accepted drop target (see canDrop above) whose release resolves to
+  // nothing — resolveDropIntent applies the same confinement filter — and is
+  // marked refused so it can signal that a drop will not land here.
   private syncDropIndicator(location:DragLocationHistory, sourceData:Record<string|symbol, unknown>):void {
-    if (!this.acceptsDrop(sourceData)
+    if (!isItemFromRoot(this.root?.element ?? null, sourceData)
       || location.current.dropTargets.some(({ data }) => isSortableItemData(data))) {
       this.clearDropIndicator();
+    } else if (confinementAllowsDrop(sourceData, this.element)) {
+      this.renderDropIndicator('active');
     } else {
-      this.renderDropIndicator();
+      this.renderDropIndicator('refused');
     }
   }
 
-  private renderDropIndicator():void {
-    this.element.dataset.dropContainer = 'active';
+  private renderDropIndicator(state:'active'|'refused'):void {
+    this.element.dataset.dropContainer = state;
   }
 
   private clearDropIndicator():void {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.ts
@@ -30,6 +30,7 @@ import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element
 import { type DragLocationHistory } from '@atlaskit/pragmatic-drag-and-drop/types';
 import { Controller } from '@hotwired/stimulus';
 import {
+  confinementAllowsDrop,
   isItemFromRoot,
   isSortableItemData,
   sortableListData,
@@ -163,7 +164,12 @@ export default class ListController extends Controller<HTMLElement> implements R
       return false;
     }
 
-    return isItemFromRoot(root.element, data) && data.type === this.acceptedTypeValue;
+    // A confined item's source list always passes the confinement check
+    // (containment includes the list element itself), keeping within-list
+    // reorder alive; only foreign containers refuse.
+    return isItemFromRoot(root.element, data)
+      && data.type === this.acceptedTypeValue
+      && confinementAllowsDrop(data, this.element);
   }
 
   // The list is the item targets' parent drop target, so its onDrag keeps firing

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -72,6 +72,7 @@ describe('Sortable lists scrollable controller', () => {
       busy: false,
       moveInDirection: vi.fn(),
       moveAvailability: vi.fn(() => null),
+      ownerListElementOf: vi.fn(() => null),
     };
   }
 

--- a/lookbook/previews/open_project/work_packages/status_badge_component_preview.rb
+++ b/lookbook/previews/open_project/work_packages/status_badge_component_preview.rb
@@ -34,9 +34,14 @@ module OpenProject::WorkPackages
     # @label Playground
     # @param size [Symbol] select [ medium, large]
     # @param inline [Boolean]
-    def playground(size: :medium, inline: false)
+    # @param readonly [Boolean]
+    def playground(size: :medium, inline: false, readonly: false)
       # Colors will be applied in code as well but there are not loaded in the lookbook
-      render(WorkPackages::StatusBadgeComponent.new(status: Status.first, size:, inline:))
+      # The lock is only drawn where the readonly work packages Enterprise feature is available
+      status = Status.first
+      status.is_readonly = readonly
+
+      render(WorkPackages::StatusBadgeComponent.new(status:, size:, inline:))
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/concerns/work_package_movability.rb
+++ b/modules/backlogs/app/components/backlogs/concerns/work_package_movability.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs::Concerns
+  # Decides whether a card may offer to move its work package.
+  #
+  # The card row and the card menu are separate components that each render a
+  # way to move it, so the decision lives here and both consume it: a
+  # surface that answered the question for itself would be free to drift out of
+  # step with the other, which is the defect this exists to prevent.
+  #
+  # Requires `work_package`, `project` and `current_user` in the including
+  # component; `project` and `current_user` are what {#sortable?} resolves the
+  # permission against.
+  module WorkPackageMovability
+    include Backlogs::CommonHelper
+
+    private
+
+    # Whether the card takes part in its list's ordering at all. This is the
+    # page-level factor: `manage_sprint_items` resolves against the page's
+    # project, so it answers the same way for every card on the page.
+    #
+    # @return [Boolean] whether the card belongs to the list's ordering model.
+    def sortable?
+      user_allowed?(:manage_sprint_items)
+    end
+
+    # Whether this particular work package may leave its container. A read-only
+    # status blocks every attribute write
+    # ({WorkPackages::BaseContract#readonly_attributes_unchanged}), and a move
+    # to another sprint, backlog bucket or the inbox writes `sprint_id` or
+    # `backlog_bucket_id`, so the server refuses it no matter which surface
+    # asked. A reorder within the card's own list writes no attribute at all —
+    # position is applied by `move_after` once the contract has passed — so it
+    # stays allowed and keeps gating on {#sortable?} alone.
+    #
+    # A card can be sortable without being movable, and that distinction
+    # matters: an unmovable card is frozen in its container, not in its order.
+    # It keeps its drag (confined to its own list) and its positional move
+    # actions; only the cross-container moves go.
+    #
+    # Read-only statuses are an Enterprise feature ({Status.can_readonly?}), so
+    # in Community this reduces to {#sortable?}.
+    #
+    # @return [Boolean] whether a move to another container may be offered for
+    #   this work package.
+    def movable?
+      sortable? && !work_package.readonly_status?
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_item_component.rb
@@ -31,6 +31,7 @@
 module Backlogs
   class WorkPackageCardListItemComponent < OpenProject::Common::BorderBoxListComponent::WorkPackageItem
     include CommonHelper
+    include Concerns::WorkPackageMovability
 
     private
 
@@ -42,8 +43,10 @@ module Backlogs
       )
     end
 
+    # Every sortable card drags: a read-only one stays a drag source too, only
+    # confined to its own list (see {#confined?}).
     def draggable?
-      user_allowed?(:manage_sprint_items)
+      sortable?
     end
 
     def split_url
@@ -97,13 +100,27 @@ module Backlogs
       }
     end
 
-    def draggable_data
+    # An unmovable card registers as a sortable item like any other: it keeps
+    # its drag and its positional moves, stays a drop target and keeps counting
+    # as a row of its list. The confined value is what pins it to that list.
+    def row_data
+      sortable? ? sortable_item_data : {}
+    end
+
+    def sortable_item_data
       {
         controller: "sortable-lists--item",
         sortable_lists__item_id_value: work_package.id,
         sortable_lists__item_label_value: work_package.to_fs(:caption),
-        sortable_lists__item_type_value: "work_package"
+        sortable_lists__item_type_value: "work_package",
+        sortable_lists__item_confined_value: confined?
       }
+    end
+
+    # Whether the card's drag is pinned to its own list: it may reorder in
+    # place, but no other container accepts it.
+    def confined?
+      sortable? && !movable?
     end
 
     public

--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
@@ -34,6 +34,7 @@ module Backlogs
   class WorkPackageCardMenuComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
     include CommonHelper
+    include Concerns::WorkPackageMovability
 
     attr_reader :work_package, :project, :open_sprints_exist, :other_buckets_exist, :current_user
 
@@ -53,28 +54,27 @@ module Backlogs
 
     private
 
+    # Positional moves reorder within the card's own list, which the server
+    # allows even for a read-only work package, so they gate on the page-level
+    # permission alone. Only the cross-container moves below require movable?.
     def show_move_items?
-      allowed_to_manage_sprint_items?
+      sortable?
     end
 
     def show_move_to_inbox?
-      allowed_to_manage_sprint_items? && (work_package.sprint_id? || work_package.backlog_bucket_id?)
+      movable? && (work_package.sprint_id? || work_package.backlog_bucket_id?)
     end
 
     def show_move_to_backlog_bucket?
-      allowed_to_manage_sprint_items? && other_buckets_exist
+      movable? && other_buckets_exist
     end
 
     def show_move_to_sprint?
-      allowed_to_manage_sprint_items? && open_sprints_exist
+      movable? && open_sprints_exist
     end
 
     def show_move_submenu?
       show_move_items? || show_move_to_sprint? || show_move_to_inbox? || show_move_to_backlog_bucket?
-    end
-
-    def allowed_to_manage_sprint_items?
-      user_allowed?(:manage_sprint_items)
     end
 
     def build_move_menu(menu)

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_item_component_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
 
   shared_let(:type_feature) { create(:type_feature) }
   shared_let(:default_status) { create(:default_status) }
+  shared_let(:readonly_status) { create(:status, :readonly) }
   shared_let(:default_priority) { create(:default_priority) }
   shared_let(:user) { create(:admin) }
   current_user { user }
@@ -59,6 +60,16 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
            position: 1,
            sprint:)
   end
+  let(:readonly_work_package) do
+    create(:work_package,
+           project:,
+           type: type_feature,
+           status: readonly_status,
+           priority: default_priority,
+           subject: "Rejected card",
+           position: 1,
+           sprint:)
+  end
   let(:item) do
     described_class.new(work_package:, project:, container:, params:, current_user: user)
   end
@@ -69,7 +80,8 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
       expect(item.row_args[:data]).to include(
         controller: "sortable-lists--item",
         sortable_lists__item_id_value: work_package.id,
-        sortable_lists__item_type_value: "work_package"
+        sortable_lists__item_type_value: "work_package",
+        sortable_lists__item_confined_value: false
       )
       expect(item.row_args[:draggable]).to be(true)
       expect(item.row_args).not_to include(:tabindex)
@@ -95,6 +107,48 @@ RSpec.describe Backlogs::WorkPackageCardListItemComponent, type: :component do
       it "does not mark the card as draggable" do
         expect(render_inline(item.card)).to have_css(".op-work-package-card.Box-card--clickable")
         expect(page).to have_no_css(".Box-card--draggable")
+      end
+    end
+
+    # A read-only status blocks every attribute write, so the server refuses
+    # the sprint_id/backlog_bucket_id change a cross-container move performs —
+    # but a reorder within the card's own list writes no attribute and stays
+    # allowed. The row keeps its drag, confined to that list.
+    context "when the work package is in a read-only status", with_ee: %i[readonly_work_packages] do
+      let(:work_package) { readonly_work_package }
+
+      it "still marks the row as draggable" do
+        expect(item.row_args[:draggable]).to be(true)
+      end
+
+      it "registers the row as a sortable item confined to its list" do
+        expect(item.row_args[:data]).to include(
+          controller: "sortable-lists--item",
+          sortable_lists__item_id_value: work_package.id,
+          sortable_lists__item_confined_value: true
+        )
+      end
+
+      it "keeps the card focusable so keyboard users can still open it" do
+        expect(render_inline(item.card)).to have_css(".op-work-package-card[tabindex='0']")
+      end
+
+      it "still offers the card as a drag handle", :aggregate_failures do
+        render_inline(item.card)
+
+        expect(page).to have_css(".op-work-package-card[data-sortable-lists--item-target='preview handle']")
+        expect(page).to have_css(".Box-card--draggable")
+      end
+    end
+
+    # Status#is_readonly always returns false without the token, so the same
+    # work package is movable in Community and the bug cannot occur there.
+    context "when the work package is in a read-only status without an Enterprise token" do
+      let(:work_package) { readonly_work_package }
+
+      it "does not confine the row" do
+        expect(item.row_args[:draggable]).to be(true)
+        expect(item.row_args[:data]).to include(sortable_lists__item_confined_value: false)
       end
     end
   end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
   shared_let(:type_feature) { create(:type_feature) }
   shared_let(:type_task) { create(:type_task) }
   shared_let(:default_status) { create(:default_status) }
+  shared_let(:readonly_status) { create(:status, :readonly) }
   shared_let(:default_priority) { create(:default_priority) }
   shared_let(:user) { create(:admin) }
   current_user { user }
@@ -46,6 +47,17 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
   let!(:third_story) { create_story(position: 3) }
   let!(:fourth_story) { create_story(position: 4) }
   let(:work_package) { second_story }
+  let(:readonly_story) do
+    create(:work_package,
+           subject: "Rejected Story",
+           project:,
+           type: type_feature,
+           status: readonly_status,
+           priority: default_priority,
+           position: 5,
+           sprint:,
+           backlog_bucket: bucket)
+  end
 
   def create_story(position:, subject: "Test Story", story_points: 5)
     create(:work_package,
@@ -363,6 +375,62 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       render_component(other_buckets_exist: false)
 
       expect(page).to have_no_element(:a, id: /\Awork_package_#{work_package.id}_menu_move_to_backlog_bucket\z/)
+    end
+  end
+
+  # A read-only status blocks every attribute write, so the server refuses the
+  # sprint_id/backlog_bucket_id change a cross-container move performs — the
+  # menu must not offer those. A reorder within the card's own list writes no
+  # attribute and stays allowed, so the positional moves survive.
+  describe "a work package in a read-only status" do
+    let(:work_package) { readonly_story }
+
+    context "with an Enterprise token", with_ee: %i[readonly_work_packages] do
+      it "offers no move to another container", :aggregate_failures do
+        render_component
+
+        expect(page).to have_no_element(:a, id: /\Awork_package_#{work_package.id}_menu_move_to_sprint\z/)
+        expect(page).to have_no_element(:a, id: /\Awork_package_#{work_package.id}_menu_move_to_backlog_bucket\z/)
+        expect(page).to have_no_element(:button, id: /\Awork_package_#{work_package.id}_menu_move_to_inbox\z/)
+      end
+
+      it "keeps the positional moves within its own list", :aggregate_failures do
+        render_component
+
+        expect(page).to have_selector(:menuitem, text: "Move to position")
+        expect(page).to have_text(I18n.t(:label_sort_highest))
+        expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_text(I18n.t(:label_sort_lower))
+        expect(page).to have_text(I18n.t(:label_sort_lowest))
+      end
+
+      it "keeps the divider that separates the move group" do
+        render_component
+
+        expect(page).to have_css(".ActionList-sectionDivider")
+      end
+
+      it "still offers the actions that do not write to it", :aggregate_failures do
+        render_component
+
+        expect(page).to have_element(:button, id: /\Awork_package_#{work_package.id}_menu_open_details\z/)
+        expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_fullscreen\z/)
+        expect(page).to have_element(:"clipboard-copy",
+                                     id: /\Awork_package_#{work_package.id}_menu_copy_url_to_clipboard\z/)
+        expect(page).to have_element(:"clipboard-copy",
+                                     id: /\Awork_package_#{work_package.id}_menu_copy_work_package_id\z/)
+      end
+    end
+
+    # Status#is_readonly always returns false without the token, so the same
+    # work package is movable in Community and the bug cannot occur there.
+    context "without an Enterprise token" do
+      it "still offers the move actions" do
+        render_component
+
+        expect(page).to have_selector(:menuitem, text: "Move to position")
+        expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_move_to_sprint\z/)
+      end
     end
   end
 end

--- a/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe "A read-only work package card in Backlogs",
     backlogs_page.visit!
   end
 
+  it "wears a lock the movable card beside it does not", :aggregate_failures do
+    backlogs_page.expect_work_package_locked(rejected_wp)
+    backlogs_page.expect_work_package_not_locked(movable_wp)
+  end
+
   it "can be reordered within its own list, and stays a drop target", :aggregate_failures do
     backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
 

--- a/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "A read-only work package card in Backlogs",
+               :js, :selenium, with_ee: %i[readonly_work_packages] do
+  let!(:default_status) { create(:default_status) }
+  let!(:rejected_status) { create(:status, :readonly, name: "Rejected") }
+
+  let(:type) { create(:type) }
+  let!(:project) do
+    create(:project,
+           types: [type],
+           enabled_module_names: %w(work_package_tracking backlogs))
+  end
+
+  let(:manage_sprint_items_role) do
+    create(:project_role,
+           permissions: %i(view_sprints
+                           manage_sprint_items
+                           view_work_packages
+                           edit_work_packages))
+  end
+
+  let!(:sprint) { create(:sprint, project:) }
+  let!(:other_sprint) { create(:sprint, project:) }
+
+  let!(:movable_wp) { create(:work_package, sprint:, type:, project:, status: default_status) }
+  let!(:rejected_wp) { create(:work_package, sprint:, type:, project:, status: rejected_status) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user, member_with_roles: { project => manage_sprint_items_role })
+  end
+
+  before do
+    backlogs_page.visit!
+  end
+
+  it "can be reordered within its own list, and stays a drop target", :aggregate_failures do
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+
+    backlogs_page.expect_work_package_confined(rejected_wp)
+
+    # The server allows a within-list reorder for a read-only work package —
+    # position is not one of its attributes — so the card keeps its drag
+    # inside its own list.
+    backlogs_page.drag_work_package(rejected_wp, before: movable_wp)
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [rejected_wp, movable_wp])
+
+    # Dropping a movable neighbour against it proves the read-only card is
+    # also still a drop target: confining its drag must not carve a dead zone
+    # out of the list.
+    backlogs_page.drag_work_package(movable_wp, before: rejected_wp)
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+  end
+
+  it "refuses to leave its sprint by drag", :aggregate_failures do
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+
+    backlogs_page.drag_work_package_without_move(rejected_wp, into: other_sprint)
+
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    expect(rejected_wp.reload.sprint_id).to eq(sprint.id)
+  end
+
+  it "offers no move to another container in its menu, but keeps the rest", :aggregate_failures do
+    backlogs_page.within_work_package_menu(rejected_wp) do |menu|
+      expect(menu).to have_no_selector(:menuitem, text: "Move to sprint")
+      expect(menu).to have_no_selector(:menuitem, text: "Move to backlog bucket")
+      expect(menu).to have_no_selector(:menuitem, text: "Move to inbox")
+
+      expect(menu).to have_selector(:menuitem, text: "Move to position")
+      expect(menu).to have_selector(:menuitem, text: I18n.t(:"js.button_open_details"))
+      expect(menu).to have_selector(:menuitem, text: I18n.t(:"js.button_open_fullscreen"))
+    end
+  end
+
+  # End to end through the same endpoint the drag uses: the UI offers the
+  # positional move and the server accepts it, proving the two agree on what a
+  # read-only work package may do.
+  it "moves within its list through the positional menu actions" do
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+
+    backlogs_page.click_in_work_package_move_submenu(rejected_wp, I18n.t(:label_sort_highest))
+
+    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [rejected_wp, movable_wp])
+  end
+
+  it "keeps the movement actions on a movable card in the same sprint" do
+    backlogs_page.within_work_package_menu(movable_wp) do |menu|
+      expect(menu).to have_selector(:menuitem, text: "Move to position")
+      expect(menu).to have_selector(:menuitem, text: "Move to sprint")
+    end
+  end
+end

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_readonly_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_readonly_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Pins the server behaviour that Backlogs::Concerns::WorkPackageMovability
+# renders decisions from. The card surfaces hide every movement action for a
+# read-only work package; these examples record what the server would actually
+# have done, so a change on either side is visible against the other.
+RSpec.describe Backlogs::WorkPackages::UpdateService,
+               "with a read-only work package",
+               type: :model,
+               with_ee: %i[readonly_work_packages] do
+  shared_let(:readonly_status) { create(:status, :readonly) }
+  shared_let(:default_status) { create(:status, is_default: true) }
+  shared_let(:project) { create(:project) }
+  shared_let(:sprint) { create(:sprint, project:) }
+  shared_let(:other_sprint) { create(:sprint, project:) }
+  shared_let(:bucket) { create(:backlog_bucket, project:) }
+
+  shared_let(:role) do
+    create(:project_role, permissions: %i[view_work_packages edit_work_packages manage_sprint_items])
+  end
+  shared_let(:user) { create(:user, member_with_roles: { project => role }) }
+
+  let!(:work_package) { create(:work_package, status: readonly_status, sprint:, project:) }
+
+  def move(**) = described_class.new(user:, work_package:).call(**)
+
+  # Every cross-list move writes sprint_id or backlog_bucket_id, and a read-only
+  # status makes those unwritable, so the contract refuses the whole move. This
+  # is the rejection users hit as an error toast before the drag and the move
+  # actions were gated on movability.
+  describe "moving it to another list" do
+    it "refuses a move to another sprint", :aggregate_failures do
+      call = move(list_type: "sprint", list_id: other_sprint.id, prev_id: "")
+
+      expect(call).to be_failure
+      expect(call.errors).to be_of_kind(:sprint_id, :error_readonly)
+      expect(call.errors).to be_of_kind(:base, :readonly_status)
+      expect(work_package.reload.sprint_id).to eq(sprint.id)
+    end
+
+    it "refuses a move to a backlog bucket", :aggregate_failures do
+      call = move(list_type: "backlog_bucket", list_id: bucket.id, prev_id: "")
+
+      expect(call).to be_failure
+      expect(work_package.reload.backlog_bucket_id).to be_nil
+    end
+
+    it "refuses a move to the inbox", :aggregate_failures do
+      call = move(list_type: "inbox", list_id: project.id, prev_id: "")
+
+      expect(call).to be_failure
+      expect(work_package.reload.sprint_id).to eq(sprint.id)
+    end
+  end
+
+  # A same-list move resolves to the attributes the work package already has, so
+  # nothing changes and the contract passes; move_after then writes position
+  # afterwards, outside contract scope. Position is not a work package attribute
+  # -- it is absent from the permitted params, the API schema and the journal --
+  # so nothing rejects it.
+  #
+  # The cards rely on this: a read-only card keeps its within-list reorder (drag
+  # and positional menu moves), per AGILE-226 — frozen in its container, not in
+  # its order. If this example ever goes red because the server started refusing
+  # the reorder, the UI has begun offering an action the server rejects and must
+  # be re-gated to match.
+  describe "reordering it within its own list" do
+    let!(:other_work_package) { create(:work_package, status: default_status, sprint:, project:) }
+
+    it "still succeeds, because position is not a work package attribute", :aggregate_failures do
+      expect(work_package.reload.position).to eq(1)
+
+      call = move(list_type: "sprint", list_id: sprint.id, prev_id: other_work_package.id)
+
+      expect(call).to be_success
+      expect(work_package.reload.position).to eq(2)
+    end
+
+    it "records no journal entry for the reorder" do
+      expect { move(list_type: "sprint", list_id: sprint.id, prev_id: other_work_package.id) }
+        .not_to change { work_package.reload.journals.count }
+    end
+  end
+end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -664,8 +664,9 @@ module Pages
     # the foreign container stays an accepted drop target so the drag keeps
     # the standard cursor, so it may appear in the drop's target list, but no
     # row of it may — and the final dragover, the one over the foreign
-    # container, must show no drop indicator of either kind. Earlier dragovers
-    # may legitimately show indicators while the pointer is still crossing the
+    # container, must show no drop position and mark that container refused
+    # (the muted danger outline) rather than active. Earlier dragovers may
+    # legitimately show indicators while the pointer is still crossing the
     # card's own list, which keeps accepting it for real.
     def expect_backlogs_drag_refused
       refusal = page.evaluate_script(<<~JS)
@@ -690,7 +691,7 @@ module Pages
       expect(refusal.fetch("dropTargetTypes")).not_to include("work_package")
       expect(refusal.fetch("observedDragover")).to be(true)
       expect(refusal.fetch("dropPositions")).to be_empty
-      expect(refusal.fetch("dropContainers")).to eq(0)
+      expect(refusal.fetch("dropContainers")).to eq(["refused"])
     end
 
     def drag_work_package_to_backlog_inbox(work_package)
@@ -1145,7 +1146,9 @@ module Pages
             label,
             draggingCount: document.querySelectorAll('[data-dragging]').length,
             honeyPotCount: document.querySelectorAll('[data-pdnd-honey-pot]').length,
-            dropContainers: document.querySelectorAll('[data-drop-container]').length,
+            dropContainers: Array
+              .from(document.querySelectorAll('[data-drop-container]'))
+              .map((element) => element.getAttribute('data-drop-container')),
             dropTargets: document.querySelectorAll('[data-drop-target-for-element]').length,
             dropPositions: Array
               .from(document.querySelectorAll('[data-drop-position]'))
@@ -1177,7 +1180,9 @@ module Pages
             effectAllowed: event.dataTransfer?.effectAllowed ?? null,
             draggingCount: document.querySelectorAll('[data-dragging]').length,
             honeyPotCount: document.querySelectorAll('[data-pdnd-honey-pot]').length,
-            dropContainers: document.querySelectorAll('[data-drop-container]').length,
+            dropContainers: Array
+              .from(document.querySelectorAll('[data-drop-container]'))
+              .map((element) => element.getAttribute('data-drop-container')),
             dropPositions: Array
               .from(document.querySelectorAll('[data-drop-position]'))
               .map((element) => ({

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -484,6 +484,17 @@ module Pages
         .to have_no_css(draggable_work_package_selector(work_package))
     end
 
+    # A read-only card keeps its drag but is confined to its own list: it can
+    # be reordered in place, while every other container refuses it. The
+    # confined value is what the foreign drop targets read.
+    def expect_work_package_confined(work_package)
+      expect(page)
+        .to have_css("#{draggable_work_package_selector(work_package)}" \
+                     "[data-sortable-lists--item-confined-value='true']")
+      expect(page)
+        .to have_css("#{work_package_selector(work_package)}[draggable]")
+    end
+
     def pick_up_and_release_work_package(work_package)
       # A mid-drag list refresh can detach the grabbed row, so retry a bounded
       # number of times on a stale node. retry_block no-ops under
@@ -602,6 +613,68 @@ module Pages
       end
     rescue Capybara::Cuprite::ObsoleteNode, Selenium::WebDriver::Error::StaleElementReferenceError
       retry
+    end
+
+    # Drags a confined card over another sprint's list body and releases it
+    # there. No foreign container accepts it, so the release must resolve to
+    # nothing: no drop indicator over the target, no accepted drop target at
+    # release, no move request. The card's unchanged position is the caller's
+    # assertion.
+    def drag_work_package_without_move(moved, into:)
+      # See pick_up_and_release_work_package for the retry rationale.
+      retry_block(
+        args: {
+          tries: 3,
+          on: [
+            Capybara::Cuprite::ObsoleteNode,
+            Selenium::WebDriver::Error::StaleElementReferenceError
+          ]
+        }
+      ) do
+        moved_element = find(draggable_work_package_selector(moved))
+        target_element = find(list_body_selector(sprint_selector(into)))
+        install_backlogs_move_request_probe
+        begin
+          drag_backlogs_item(source: moved_element, target: target_element)
+        ensure
+          stop_backlogs_move_request_probe
+        end
+      end
+
+      expect_backlogs_drag_refused
+      expect_no_backlogs_move_request
+    end
+
+    # The refusal must be observable, or the assertions above would also pass
+    # for a drag that never engaged. The drop has to reach the controller with
+    # no accepted target, and the final dragover — the one over the foreign
+    # container — must show no drop indicator of either kind. Earlier dragovers
+    # may legitimately show indicators while the pointer is still crossing the
+    # card's own list, which keeps accepting it.
+    def expect_backlogs_drag_refused
+      refusal = page.evaluate_script(<<~JS)
+        (() => {
+          const state = window.__opBacklogsDndProbeState;
+          const call = state?.handleDropCalls?.at(-1);
+          const lastDragover = (state?.events ?? [])
+            .filter((event) => event.type === 'dragover')
+            .at(-1);
+
+          return {
+            handled: Boolean(call),
+            dropTargetCount: call?.dropTargets?.length ?? 0,
+            observedDragover: Boolean(lastDragover),
+            dropPositions: lastDragover?.dropPositions ?? null,
+            dropContainers: lastDragover?.dropContainers ?? null
+          };
+        })()
+      JS
+
+      expect(refusal.fetch("handled")).to be(true)
+      expect(refusal.fetch("dropTargetCount")).to eq(0)
+      expect(refusal.fetch("observedDragover")).to be(true)
+      expect(refusal.fetch("dropPositions")).to be_empty
+      expect(refusal.fetch("dropContainers")).to eq(0)
     end
 
     def drag_work_package_to_backlog_inbox(work_package)
@@ -1050,6 +1123,7 @@ module Pages
             label,
             draggingCount: document.querySelectorAll('[data-dragging]').length,
             honeyPotCount: document.querySelectorAll('[data-pdnd-honey-pot]').length,
+            dropContainers: document.querySelectorAll('[data-drop-container]').length,
             dropTargets: document.querySelectorAll('[data-drop-target-for-element]').length,
             dropPositions: Array
               .from(document.querySelectorAll('[data-drop-position]'))
@@ -1081,6 +1155,7 @@ module Pages
             effectAllowed: event.dataTransfer?.effectAllowed ?? null,
             draggingCount: document.querySelectorAll('[data-dragging]').length,
             honeyPotCount: document.querySelectorAll('[data-pdnd-honey-pot]').length,
+            dropContainers: document.querySelectorAll('[data-drop-container]').length,
             dropPositions: Array
               .from(document.querySelectorAll('[data-drop-position]'))
               .map((element) => ({

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -495,6 +495,21 @@ module Pages
         .to have_css("#{work_package_selector(work_package)}[draggable]")
     end
 
+    # The lock on the status badge is what tells the user why the cross-container
+    # moves are gone. Without it a read-only card is indistinguishable from a
+    # movable one until they try to move it and nothing happens.
+    def expect_work_package_locked(work_package)
+      within_work_package(work_package) do
+        expect(page).to have_css(readonly_lock_selector)
+      end
+    end
+
+    def expect_work_package_not_locked(work_package)
+      within_work_package(work_package) do
+        expect(page).to have_no_css(readonly_lock_selector)
+      end
+    end
+
     def pick_up_and_release_work_package(work_package)
       # A mid-drag list refresh can detach the grabbed row, so retry a bounded
       # number of times on a stale node. retry_block no-ops under
@@ -838,6 +853,12 @@ module Pages
 
     def draggable_work_package_selector(work_package)
       "#{work_package_selector(work_package)}[data-sortable-lists--item-id-value]"
+    end
+
+    # Located by the lock's accessible name so the expectation fails if the
+    # icon ever loses the text that explains it.
+    def readonly_lock_selector
+      "[aria-label='#{I18n.t('activerecord.attributes.status.is_readonly')}']"
     end
 
     def drag_backlogs_item(source:, target:, edge: nil)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -858,7 +858,7 @@ module Pages
     # Located by the lock's accessible name so the expectation fails if the
     # icon ever loses the text that explains it.
     def readonly_lock_selector
-      "[aria-label='#{I18n.t('activerecord.attributes.status.is_readonly')}']"
+      "[aria-label='#{Status.human_attribute_name(:is_readonly)}']"
     end
 
     def drag_backlogs_item(source:, target:, edge: nil)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -631,10 +631,9 @@ module Pages
     end
 
     # Drags a confined card over another sprint's list body and releases it
-    # there. No foreign container accepts it, so the release must resolve to
-    # nothing: no drop indicator over the target, no accepted drop target at
-    # release, no move request. The card's unchanged position is the caller's
-    # assertion.
+    # there. The release must resolve to nothing: no drop indicator over the
+    # target, no row of it accepting, no move request. The card's unchanged
+    # position is the caller's assertion.
     def drag_work_package_without_move(moved, into:)
       # See pick_up_and_release_work_package for the retry rationale.
       retry_block(
@@ -661,11 +660,13 @@ module Pages
     end
 
     # The refusal must be observable, or the assertions above would also pass
-    # for a drag that never engaged. The drop has to reach the controller with
-    # no accepted target, and the final dragover — the one over the foreign
-    # container — must show no drop indicator of either kind. Earlier dragovers
+    # for a drag that never engaged. The drop has to reach the controller —
+    # the foreign container stays an accepted drop target so the drag keeps
+    # the standard cursor, so it may appear in the drop's target list, but no
+    # row of it may — and the final dragover, the one over the foreign
+    # container, must show no drop indicator of either kind. Earlier dragovers
     # may legitimately show indicators while the pointer is still crossing the
-    # card's own list, which keeps accepting it.
+    # card's own list, which keeps accepting it for real.
     def expect_backlogs_drag_refused
       refusal = page.evaluate_script(<<~JS)
         (() => {
@@ -677,7 +678,7 @@ module Pages
 
           return {
             handled: Boolean(call),
-            dropTargetCount: call?.dropTargets?.length ?? 0,
+            dropTargetTypes: call?.dropTargets?.map((target) => target.data?.entries?.type) ?? [],
             observedDragover: Boolean(lastDragover),
             dropPositions: lastDragover?.dropPositions ?? null,
             dropContainers: lastDragover?.dropContainers ?? null
@@ -686,7 +687,7 @@ module Pages
       JS
 
       expect(refusal.fetch("handled")).to be(true)
-      expect(refusal.fetch("dropTargetCount")).to eq(0)
+      expect(refusal.fetch("dropTargetTypes")).not_to include("work_package")
       expect(refusal.fetch("observedDragover")).to be(true)
       expect(refusal.fetch("dropPositions")).to be_empty
       expect(refusal.fetch("dropContainers")).to eq(0)

--- a/spec/components/work_packages/status_badge_component_spec.rb
+++ b/spec/components/work_packages/status_badge_component_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::StatusBadgeComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:lock) { "[aria-label='#{I18n.t('activerecord.attributes.status.is_readonly')}']" }
+  let(:status) { build_stubbed(:status, name: "In progress") }
+
+  subject(:rendered_component) do
+    render_component(status:)
+  end
+
+  it "renders the status name" do
+    expect(rendered_component).to have_primer_label "In progress"
+  end
+
+  it "does not lock a status that permits changes" do
+    expect(rendered_component).to have_no_css lock
+  end
+
+  context "with a read-only status", with_ee: %i[readonly_work_packages] do
+    let(:status) { build_stubbed(:status, :readonly, name: "Rejected") }
+
+    it "renders the status name" do
+      expect(rendered_component).to have_primer_label "Rejected"
+    end
+
+    it "locks the badge, naming what the lock means" do
+      expect(rendered_component).to have_css lock
+    end
+
+    context "when rendered in the secondary scheme" do
+      subject(:rendered_component) do
+        render_component(status:, scheme: :secondary)
+      end
+
+      it "still locks the badge" do
+        expect(rendered_component).to have_css lock
+      end
+    end
+  end
+
+  context "with a read-only status and no Enterprise token" do
+    let(:status) { build_stubbed(:status, :readonly, name: "Rejected") }
+
+    it "does not lock the badge, matching what the contract allows" do
+      expect(rendered_component).to have_no_css lock
+    end
+  end
+end

--- a/spec/components/work_packages/status_badge_component_spec.rb
+++ b/spec/components/work_packages/status_badge_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe WorkPackages::StatusBadgeComponent, type: :component do
     render_inline(described_class.new(...))
   end
 
-  let(:lock) { "[aria-label='#{I18n.t('activerecord.attributes.status.is_readonly')}']" }
+  let(:lock) { "[aria-label='#{Status.human_attribute_name(:is_readonly)}']" }
   let(:status) { build_stubbed(:status, name: "In progress") }
 
   subject(:rendered_component) do


### PR DESCRIPTION
> [!NOTE]
> Until #24503 ([AGILE-358](https://community.openproject.org/wp/AGILE-358)) lands, dropping an item in its original position will end up reordering the list – potentially confusing when manually testing.

# Ticket

https://community.openproject.org/wp/AGILE-226

# What are you trying to accomplish?

A work package in a read-only status rendered as a fully draggable card. Dragging it to another sprint appeared to work, then the server rejected the move and an error toast appeared.

A read-only card now offers exactly what the server accepts: it can still be reordered within its own list — by drag and via Move to position — but no other container accepts it, and Move to sprint, Move to backlog bucket and Move to backlog inbox are gone from its menu. A lock on the status badge marks the card. The rest of the menu is untouched and the card stays focusable and openable by keyboard. Read-only statuses are Enterprise-only, so nothing changes in Community.

## Screen recording

https://github.com/user-attachments/assets/66ddf452-fe4b-4bf8-ae27-0491519e0068

# What approach did you choose and why?

The server refuses any move that writes `sprint_id` or `backlog_bucket_id`; a within-list reorder writes no attribute at all (position is applied by `move_after` after contract validation), so it succeeds. Both gating factors live in `Backlogs::Concerns::WorkPackageMovability` — `sortable?` (page-level permission) gates everything positional, `movable?` additionally gates leaving the container — consumed by row and menu alike so the surfaces cannot drift apart.

On the frontend the card stays a full drag source, but its payload carries its origin list and a `confined` flag; list- and row-level drop targets refuse a confined item from another list in `canDrop`, which also suppresses their drop indicators. The origin list keeps accepting — refusing it would kill within-list reorder, the regression `eff6cc4b0b5` reverted.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
