### PR TITLE
[SPPM-326] Footer link to Gantt chart is visible even if Gantt module is disabled

### DIFF
--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -86,6 +86,7 @@ module Grids
 
       def gantt_link
         return unless view_work_packages_allowed?
+        return unless project.module_enabled?(:gantt)
 
         result = ::Gantt::DefaultQueryGeneratorService.new(with_project: project).call(query_key: :milestones)
         return unless result


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-326

# What are you trying to accomplish?
Do not link to Gantt module if it is not activated

