### PR TITLE
[SPPM-327] Widget doesn't display milestones in a particular case

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -94,7 +94,7 @@
       transform: translateX(-100%)
 
   // Gates group row: we override the height so that the gates appear visually closer to the phases
-  .vis-group.op-timeline-group--gates
+  .vis-group.op-timeline-group--gates:has(.vis-item)
     border-bottom-color: transparent
     height: 2.25rem !important
     overflow: visible


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-327
https://community.openproject.org/wp/SPPM-328

# What are you trying to accomplish?
This happens when you have only sprints or only milestones to be displayed in the timeline widget. The PR now only changes the gates row height if is actually has data to show. Otherwise the gates row is forced to its min-height causing the row below (either milestones or sprints) to be pushed out of view. 🤦🏼‍♀️
