### PR TITLE
[FND-186] Change project attributes screen to hide the ones that are deactivated in the source when in linked mode  

### DIFF
--- a/app/components/work_package_types/project_attributes/index_component.html.erb
+++ b/app/components/work_package_types/project_attributes/index_component.html.erb
@@ -28,7 +28,7 @@
         end
       end
 
-      @project_custom_field_sections.each do |project_custom_field_section, project_custom_fields|
+      visible_sections.each do |project_custom_field_section, project_custom_fields|
         flex.with_row do
           render(
             WorkPackageTypes::ProjectAttributes::SectionComponent.new(

--- a/app/components/work_package_types/project_attributes/index_component.rb
+++ b/app/components/work_package_types/project_attributes/index_component.rb
@@ -27,6 +27,27 @@ module WorkPackageTypes
 
       private
 
+      def visible_sections
+        return @project_custom_field_sections unless @readonly
+
+        sections_with_active_fields
+      end
+
+      def sections_with_active_fields
+        result = []
+
+        @project_custom_field_sections.each do |section, custom_fields|
+          active_fields = custom_fields.select { |cf| active_field_ids.include?(cf.id) }
+          result << [section, active_fields] if active_fields.any?
+        end
+
+        result
+      end
+
+      def active_field_ids
+        @active_field_ids ||= @type.project_custom_field_type_mappings.to_set(&:custom_field_id)
+      end
+
       def wrapper_data_attributes
         {
           controller: "filter--filter-list",

--- a/spec/features/types/project_attributes_spec.rb
+++ b/spec/features/types/project_attributes_spec.rb
@@ -200,4 +200,35 @@ RSpec.describe "Work package type project attributes", :js do
       expect(custom_fields[1].text).to include("Boolean field")
     end
   end
+
+  describe "in linked mode", with_flag: { type_variants: true } do
+    let(:aspect) { Type::ConfigurationLink::PROJECT_ATTRIBUTES }
+    let(:source_type) { create(:type, name: "Source type") }
+    let(:linked_type) { create(:type, name: "Linked type") }
+    let(:linked_type_page) { Pages::Types::ProjectAttributes.new(linked_type) }
+
+    before do
+      # Source activates only the Boolean field
+      source_type.project_custom_fields << boolean_project_custom_field
+      linked_type.link!(aspect, source: source_type)
+    end
+
+    it "hides the attributes deactivated in the source and only lists the active ones" do
+      linked_type_page.visit!
+
+      expect(page).to have_text("Boolean field")
+      expect(page).to have_no_text("String field")
+      expect(page).to have_no_text("List field")
+      # Also hides empty sections
+      expect(page).to have_no_css("[data-test-selector='type-project-attribute-section-#{select_section.id}']")
+    end
+
+    it "still lists all attributes for the independent source type" do
+      Pages::Types::ProjectAttributes.new(source_type).visit!
+
+      expect(page).to have_text("Boolean field")
+      expect(page).to have_text("String field")
+      expect(page).to have_text("List field")
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/FND-186

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
