### PR TITLE
[OP-19846] Fix `bin/setup` failures on first run

### DIFF
--- a/app/models/concerns/has_details_table.rb
+++ b/app/models/concerns/has_details_table.rb
@@ -228,15 +228,30 @@ module HasDetailsTable
     def setup_detail_delegation(detail_class, foreign_key)
       # Try to set up delegation eagerly so that writer methods exist
       # during assign_attributes in new/create. Requires DB + table.
-      if ActiveRecord::Base.connected? && detail_class.table_exists?
-        finalize_detail_delegation!(detail_class, foreign_key)
-      end
+      finalize_detail_delegation!(detail_class, foreign_key)
 
-      # Fallback for when eager setup was skipped (db:create, db:migrate).
+      # Fallbacks for when eager setup was skipped, which happens whenever the
+      # class is loaded before its detail table exists: db:create, db:migrate,
+      # or booting against an empty database (db:prepare loads the app, and
+      # engines reference model classes from their to_prepare blocks, long
+      # before the schema is loaded and seeding starts).
       # finalize_detail_delegation! is idempotent via @_detail_delegation_set_up.
       fk = foreign_key
+      owner = self
+
+      # `new` assigns attributes *before* after_initialize runs, so the writers
+      # have to exist by then. Hooking initialize is the only point early enough.
+      prepend(Module.new do
+        define_method(:initialize) do |*args, &block|
+          owner.send(:finalize_detail_delegation!, detail_class, fk)
+          super(*args, &block)
+        end
+      end)
+
+      # Records loaded from the database are allocated rather than initialized,
+      # so they need the callback to get their readers.
       after_initialize do
-        self.class.send(:finalize_detail_delegation!, detail_class, fk)
+        owner.send(:finalize_detail_delegation!, detail_class, fk)
       end
     end
 
@@ -265,12 +280,25 @@ module HasDetailsTable
       return if @_detail_delegation_set_up
       # The detail table may not yet exist during early migrations on a fresh
       # database. Skip — the next instance will retry once the table is there.
-      return unless ActiveRecord::Base.connected? && detail_class.table_exists?
+      return unless detail_table_exists?(detail_class)
 
       @_detail_delegation_set_up = true
 
       delegate_detail_columns(detail_class, foreign_key)
       delegate_detail_associations(detail_class)
+    end
+
+    # Deliberately queries the database instead of asking the schema cache: a
+    # cache populated before the table existed answers `false` forever, which
+    # would leave the model without its delegated attributes for the rest of
+    # the process.
+    def detail_table_exists?(detail_class)
+      detail_class.connection_pool.with_connection do |connection|
+        connection.data_source_exists?(detail_class.table_name)
+      end
+    rescue ActiveRecord::ActiveRecordError
+      # No database, no connection, or no permission to look — retry later.
+      false
     end
 
     def delegate_detail_columns(detail_class, foreign_key)

--- a/config/constants/open_project/null_db_fallback.rb
+++ b/config/constants/open_project/null_db_fallback.rb
@@ -39,10 +39,17 @@ module OpenProject
         ActiveRecord::Base.establish_connection adapter: :nulldb
       end
 
+      # Reconnects to the real database once it is available, e.g. after
+      # +db:create+ has created the database this process failed to reach when
+      # it booted. Resolving the connection through the environment name rather
+      # than config/database.yml keeps DATABASE_URL working.
       def reset
         return unless applied?
 
-        ActiveRecord::Base.establish_connection(database_config)
+        # Only drop the flag once the reconnect went through: a process that
+        # failed to leave NullDB has to stay eligible for a later retry.
+        ActiveRecord::Base.establish_connection(Rails.env.to_sym)
+        unapplied!
       end
 
       private
@@ -59,10 +66,6 @@ module OpenProject
 
       def applied?
         !!applied
-      end
-
-      def database_config
-        YAML.load_file(Rails.root.join("config/database.yml").to_s)[Rails.env]
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,5 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+# `db:prepare` boots the application *before* it creates the database and loads
+# the schema, which leaves this process holding two kinds of stale state by the
+# time it gets here.
+#
+# When the database did not exist at all, the boot fell back to NullDB and never
+# came back off it, so without this the seeders would write into the void.
+OpenProject::NullDbFallback.reset
+
+# And every model an engine touches from a `to_prepare` block looked up its
+# columns while no table existed yet — memoising that empty answer for the rest
+# of the process, which leaves the model without any attribute methods. Throw
+# that away so the seeders work against the schema that has since been loaded.
+ActiveRecord::Base.connection_pool.schema_cache.clear!
+ActiveRecord::Base.descendants.each(&:reset_column_information)
+Setting.clear_cache
+
 Seeder.log_to_stdout!
 RootSeeder.new(raise_on_unknown_language: true).seed!

--- a/spec/constants/open_project/null_db_fallback_spec.rb
+++ b/spec/constants/open_project/null_db_fallback_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::NullDbFallback do
+  describe ".reset" do
+    # Never let a stubbed run leave the suite believing it is on NullDB.
+    after { described_class.send(:unapplied!) }
+
+    context "when the fallback was never applied" do
+      before { described_class.send(:unapplied!) }
+
+      it "leaves the current connection alone" do
+        allow(ActiveRecord::Base).to receive(:establish_connection)
+
+        described_class.reset
+
+        expect(ActiveRecord::Base).not_to have_received(:establish_connection)
+      end
+    end
+
+    context "when the fallback was applied" do
+      before do
+        described_class.send(:applied!)
+        allow(ActiveRecord::Base).to receive(:establish_connection)
+      end
+
+      # Resolving by environment name rather than reading config/database.yml is
+      # what keeps DATABASE_URL working, so assert on the argument.
+      it "re-establishes the connection for the current environment" do
+        described_class.reset
+
+        expect(ActiveRecord::Base).to have_received(:establish_connection).with(Rails.env.to_sym)
+      end
+
+      it "only reconnects once" do
+        described_class.reset
+        described_class.reset
+
+        expect(ActiveRecord::Base).to have_received(:establish_connection).once
+      end
+
+      it "stays eligible for a retry when reconnecting fails" do
+        allow(ActiveRecord::Base).to receive(:establish_connection).and_raise(ActiveRecord::ConnectionNotEstablished)
+
+        expect { described_class.reset }.to raise_error(ActiveRecord::ConnectionNotEstablished)
+        expect(described_class.send(:applied?)).to be true
+      end
+    end
+  end
+end

--- a/spec/models/concerns/has_details_table_spec.rb
+++ b/spec/models/concerns/has_details_table_spec.rb
@@ -205,6 +205,57 @@ RSpec.describe HasDetailsTable do
     end
   end
 
+  # Mirrors booting against an empty database: `db:prepare` loads the
+  # application (and with it every model an engine references from its
+  # to_prepare block) before it loads the schema and seeds.
+  describe "when the class is loaded before its detail table exists" do
+    before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+      ActiveRecord::Schema.define do
+        drop_table :test_gadget_details, if_exists: true
+
+        create_table :test_gadgets, force: true do |t|
+          t.string :name
+          t.timestamps
+        end
+      end
+
+      klass = Class.new(ApplicationRecord) { self.table_name = "test_gadgets" }
+      Object.const_set(:TestGadget, klass)
+      klass.include(described_class)
+      klass.has_details_table
+
+      ActiveRecord::Schema.define do
+        create_table :test_gadget_details, force: true do |t|
+          t.references :test_gadget, null: false, index: { unique: true }
+          t.boolean :fancy, default: false, null: false
+          t.timestamps
+        end
+      end
+    end
+
+    after(:all) do # rubocop:disable RSpec/BeforeAfterAll
+      Object.send(:remove_const, :TestGadgetDetail) if defined?(TestGadgetDetail) # rubocop:disable RSpec/RemoveConst
+      Object.send(:remove_const, :TestGadget) if defined?(TestGadget) # rubocop:disable RSpec/RemoveConst
+
+      ActiveRecord::Schema.define do
+        drop_table :test_gadget_details, if_exists: true
+        drop_table :test_gadgets, if_exists: true
+      end
+    end
+
+    it "delegates attributes passed to new, which assigns them before after_initialize runs" do
+      gadget = TestGadget.new(name: "Late Schema", fancy: true)
+
+      expect(gadget.fancy).to be true
+    end
+
+    it "persists detail attributes passed to create" do
+      created = TestGadget.create!(name: "Late Schema", fancy: true)
+
+      expect(created.reload.fancy).to be true
+    end
+  end
+
   describe "error promotion" do
     it "promotes detail validation errors onto the owner" do
       I18n.backend.store_translations(:en,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19846

# What are you trying to accomplish?

`./bin/setup` fails on a fresh checkout. There are three distinct failures on that path, each surfacing only once the previous one is fixed:

1. `ActiveModel::UnknownAttributeError: unknown attribute 'organizational_unit' for Group` — the error reported in the ticket.
2. `NoMethodError: super: no superclass method 'start_time=' for an instance of RecurringMeeting`.
3. `Locale  is not supported`, when no database exists at all. The ticket's reproduction steps sidestep this one by creating the databases by hand.

They share a root cause: `db:prepare` boots the application before the database is usable, engines reference models from their `config.to_prepare` blocks during that boot, and each bug is a different piece of state that memoises "no database" and never recovers.

# What approach did you choose and why?

One commit per layer, since each is independently necessary — reverting any one of them reproduces a failure.

`HasDetailsTable` only defined its delegated writers when the detail table existed at class-load time, and its `after_initialize` fallback ran too late: Rails assigns attributes before `_run_initialize_callbacks`, so `Group.create!(organizational_unit: true)` hit a writer that did not exist yet. Delegation is now finalised from a prepended `initialize`. The table probe moved from `connected? && table_exists?` to `connection.data_source_exists?`, because `connected?` is false whenever no connection is leased and `table_exists?` reads the schema cache, which caches the negative answer for the rest of the process.

`OpenProject::NullDbFallback.reset` had no callers anywhere in the repo, so a process that booted without a database stayed on NullDB for its whole run — the seeders wrote into the void and every setting read as nil, which is where the blank locale came from. It now clears its own flag and resolves through the environment name rather than parsing `config/database.yml`, so `DATABASE_URL` keeps working.

`db/seeds.rb` calls that reset and drops stale column information and the settings cache before seeding. That also covers the `RecurringMeeting` failure: `attribute_names` memoises `[]` when `table_exists?` is false, so the model never gets its generated attribute methods and the `super` in `Meeting::VirtualStartTime#start_time=` finds nothing.

Verified with no database present at all: `db:prepare` exits 0 and seeds fully (7 groups, 7 organisational units, 7 projects, 41 work packages, 22 users, 191 settings, 3 admins).

> [!NOTE]
> Each fix is proven necessary, and the combination sufficient, for this seed path only. Whether other models carry the same memoised-empty-schema hazard has not been audited — the two fixed here are the two that happened to blow up. There could be more behind them.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a, no UI changes
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — n/a, no UI changes
