### PR TITLE
[COMMS-933] check for target_versions when archiving projects

### DIFF
--- a/app/contracts/projects/archive_contract.rb
+++ b/app/contracts/projects/archive_contract.rb
@@ -42,7 +42,8 @@ module Projects
 
       exists = WorkPackage
                  .where.not(project_id: model.self_and_descendants.select(:id))
-                 .exists?(version_id: version_ids)
+                 .with_target_version(version_ids)
+                 .exists?
 
       errors.add :base, :foreign_wps_reference_version if exists
     end

--- a/spec/contracts/projects/archive_contract_spec.rb
+++ b/spec/contracts/projects/archive_contract_spec.rb
@@ -106,4 +106,19 @@ RSpec.describe Projects::ArchiveContract do
       include_examples "with archive_project permission on all/some/none of subprojects"
     end
   end
+
+  context "when a work package of another project targets a version of the project" do
+    shared_let(:project) { create(:project) }
+    shared_let(:current_user) { create(:user, member_with_roles: { project => archivist_role }) }
+    shared_let(:version) { create(:version, project:) }
+    shared_let(:other_project) { create(:project) }
+    shared_let(:other_version) { create(:version, project: other_project) }
+
+    before do
+      work_package = create(:work_package, project: other_project)
+      work_package.target_versions = [other_version, version]
+    end
+
+    include_examples "contract is invalid", base: :foreign_wps_reference_version
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-933/activity

# What are you trying to accomplish?
Replace usage of **work package version_id** with **target_versions**

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
