### PR TITLE
[FND-198] Switch project’s type variant in background

### DIFF
--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -32,6 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% active_types.each do |type| %>
       <% list.with_item(data: { test_selector: "project-types-row-#{type.id}" }) do |item| %>
         <% item.with_menu do |menu| %>
+          <% switch_action(menu, type) if type.family.many? %>
           <% remove_action(menu, type) %>
         <% end %>
         <%= flex_layout(align_items: :center) do |row| %>

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -43,14 +43,12 @@ See COPYRIGHT and LICENSE files for more details.
             <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { type.root.name } %>
           <% end %>
           <% if type.variant? %>
-            <% row.with_column(mr: 2) do %>
-              <%= render(Primer::Beta::Label.new(scheme: :secondary)) { type.own_name } %>
-            <% end %>
-          <% end %>
-          <% if type.is_in_roadmap? %>
             <% row.with_column do %>
               <%= render(Primer::Beta::Text.new(color: :muted, font_size: :small)) do %>
-                <%= t("projects.settings.types.in_roadmap") %>
+                <%= t("projects.settings.types.variant_prefix") %>
+              <% end %>
+              <%= render(Primer::Beta::Text.new(color: :muted, font_weight: :semibold, font_size: :small)) do %>
+                <%= type.own_name %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -27,13 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= component_wrapper do %>
+<%= component_wrapper(**wrapper_data_attrs) do %>
   <%= render(OpenProject::Common::BorderBoxListComponent.new(container: "project-settings-types")) do |list| %>
     <% active_types.each do |type| %>
       <% list.with_item(data: { test_selector: "project-types-row-#{type.id}" }) do |item| %>
-        <% item.with_menu do |menu| %>
-          <% switch_action(menu, type) if type.family.many? %>
-          <% remove_action(menu, type) %>
+        <% unless switching_from?(type) %>
+          <% item.with_menu do |menu| %>
+            <% switch_action(menu, type) if type.family.many? %>
+            <% remove_action(menu, type) %>
+          <% end %>
         <% end %>
         <%= flex_layout(align_items: :center) do |row| %>
           <% row.with_column(display: :inline_flex, align_items: :center, mr: 2) do %>
@@ -42,7 +44,17 @@ See COPYRIGHT and LICENSE files for more details.
           <% row.with_column(mr: 2) do %>
             <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { type.root.name } %>
           <% end %>
-          <% if type.variant? %>
+          <% if switching_from?(type) %>
+            <% row.with_column(display: :inline_flex, align_items: :center, mr: 2) do %>
+              <%= render(Primer::Beta::Spinner.new(size: :small)) %>
+            <% end %>
+            <% row.with_column do %>
+              <%= render(Primer::Beta::Text.new(color: :muted, font_size: :small)) { switching_to_prefix } %>
+              <%= render(Primer::Beta::Text.new(color: :muted, font_weight: :semibold, font_size: :small)) do %>
+                <%= switching_to_name %>
+              <% end %>
+            <% end %>
+          <% elsif type.variant? %>
             <% row.with_column do %>
               <%= render(Primer::Beta::Text.new(color: :muted, font_size: :small)) do %>
                 <%= t("projects.settings.types.variant_prefix") %>

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -57,6 +57,20 @@ module Projects
                                 .sort_by { |type| type.root.position }
           end
 
+          def switch_path(type)
+            new_project_settings_work_packages_type_switch_path(project, type)
+          end
+
+          def switch_action(menu, type)
+            menu.with_item(
+              label: t("projects.settings.types.switch_type"),
+              href: switch_path(type),
+              content_arguments: { data: { controller: "async-dialog" } }
+            ) do |item|
+              item.with_leading_visual_icon(icon: "list-ordered")
+            end
+          end
+
           def remove_path(type)
             project_settings_work_packages_type_path(project, type)
           end

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -38,15 +38,16 @@ module Projects
           include OpPrimer::ComponentHelpers
           include OpTurbo::Streamable
 
-          def initialize(project:)
+          def initialize(project:, pending_switch: nil)
             super()
 
             @project = project
+            @pending_switch = pending_switch
           end
 
           private
 
-          attr_reader :project
+          attr_reader :project, :pending_switch
 
           # A variant's acts_as_list position is scoped to its parent, so only
           # the family's own position is comparable across rows.
@@ -57,17 +58,63 @@ module Projects
                                 .sort_by { |type| type.root.position }
           end
 
+          def switching? = pending_switch.present?
+
+          def switching_from?(type)
+            switching? && pending_switch.source_id == type.id
+          end
+
+          # Switching to the family parent leaves the project on no variant at
+          # all, so it cannot borrow the wording the mockup gives a variant.
+          def switching_to_prefix
+            key = pending_switch.target.variant? ? "switching_to_variant" : "switching_to_type"
+
+            t("projects.settings.types.#{key}")
+          end
+
+          def switching_to_name
+            pending_switch.target.own_name
+          end
+
+          def wrapper_data_attrs
+            return {} unless switching?
+
+            {
+              data: {
+                controller: "poll-for-changes",
+                poll_for_changes_url_value: status_project_settings_work_packages_types_path(project),
+                poll_for_changes_interval_value: 3000
+              }
+            }
+          end
+
           def switch_path(type)
             new_project_settings_work_packages_type_switch_path(project, type)
           end
 
           def switch_action(menu, type)
+            return blocked_switch_action(menu) if switching?
+
             menu.with_item(
               label: t("projects.settings.types.switch_type"),
               href: switch_path(type),
               content_arguments: { data: { controller: "async-dialog" } }
             ) do |item|
               item.with_leading_visual_icon(icon: "list-ordered")
+            end
+          end
+
+          # Switches are serialised by an advisory lock on the project, so a
+          # second one would queue behind the first. Saying so is kinder than an
+          # action that silently disappears from families nobody is switching.
+          def blocked_switch_action(menu)
+            menu.with_item(
+              label: t("projects.settings.types.switch_type"),
+              disabled: true,
+              description_scheme: :block
+            ) do |item|
+              item.with_leading_visual_icon(icon: "list-ordered")
+              item.with_description { t("projects.settings.types.switch_in_progress") }
             end
           end
 

--- a/app/components/projects/settings/work_packages/types/switch_dialog_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/switch_dialog_component.html.erb
@@ -1,0 +1,40 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(
+      Primer::Alpha::Dialog.new(
+        id: DIALOG_ID,
+        title: t("projects.settings.types.switch_dialog.title", type: source.name),
+        size: :medium_portrait
+      )
+    ) do |dialog| %>
+  <% dialog.with_header(variant: :large) %>
+
+  <%= render(Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(switch: @switch)) %>
+<% end %>

--- a/app/components/projects/settings/work_packages/types/switch_dialog_component.rb
+++ b/app/components/projects/settings/work_packages/types/switch_dialog_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        # Moves a project from the family member it uses now to another one.
+        class SwitchDialogComponent < ApplicationComponent
+          include OpPrimer::ComponentHelpers
+          include OpTurbo::Streamable
+
+          DIALOG_ID = "project-types-switch-dialog"
+
+          def initialize(switch:)
+            super()
+
+            @switch = switch
+          end
+
+          delegate :source, to: :@switch, private: true
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/work_packages/types/switch_form_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/switch_form_component.html.erb
@@ -1,0 +1,59 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= component_wrapper do %>
+  <%= primer_form_with(model: @switch, scope: :switch, url: submit_path) do |form| %>
+    <%= render(Primer::Alpha::Dialog::Body.new) do %>
+      <%= flex_layout(direction: :column) do |body| %>
+        <% body.with_row(mb: 3) do %>
+          <%= render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert)) do %>
+            <%= t("projects.settings.types.switch_dialog.warning") %>
+          <% end %>
+        <% end %>
+        <% body.with_row(mb: 2) do %>
+          <%= render(Primer::Beta::Text.new(tag: :p)) do %>
+            <%= t("projects.settings.types.switch_dialog.description") %>
+          <% end %>
+        <% end %>
+        <% body.with_row do %>
+          <%= render(Projects::Settings::WorkPackages::Types::SwitchForm.new(form, switch: @switch)) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= render(Primer::Alpha::Dialog::Footer.new) do %>
+      <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) do %>
+        <%= t(:button_cancel) %>
+      <% end %>
+      <%= render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) do %>
+        <%= t("projects.settings.types.switch_dialog.apply") %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/projects/settings/work_packages/types/switch_form_component.rb
+++ b/app/components/projects/settings/work_packages/types/switch_form_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        # The switch dialog's contents. Separate from the dialog so a validation
+        # failure can replace it: replacing the dialog component would swap out
+        # the <dialog> element and close it.
+        class SwitchFormComponent < ApplicationComponent
+          include OpPrimer::ComponentHelpers
+          include OpTurbo::Streamable
+
+          def initialize(switch:)
+            super()
+
+            @switch = switch
+          end
+
+          private
+
+          delegate :project, :source, to: :@switch
+
+          def submit_path
+            project_settings_work_packages_type_switch_path(project, source)
+          end
+
+          def dialog_id
+            SwitchDialogComponent::DIALOG_ID
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -59,8 +59,14 @@ module WorkPackages
           @journal_details ||= journal.details
         end
 
+        # A formatter may render a change as nothing, so what is worth heading is
+        # what comes out of them rather than what went in.
+        def rendered_details
+          @rendered_details ||= journal_details.filter_map { |detail| journal.render_detail(detail).presence }
+        end
+
         def has_details?
-          @has_details ||= journal_details.any?
+          rendered_details.any?
         end
 
         def render_details_header(details_container)
@@ -216,10 +222,7 @@ module WorkPackages
         end
 
         def render_journal_details(details_container_inner)
-          journal_details.each do |detail|
-            rendered_detail = journal.render_detail(detail)
-            render_single_detail(details_container_inner, rendered_detail) if rendered_detail.present?
-          end
+          rendered_details.each { |rendered_detail| render_single_detail(details_container_inner, rendered_detail) }
         end
 
         def render_single_detail(container, rendered_detail)

--- a/app/controllers/concerns/work_package_types/switch_failure_messages.rb
+++ b/app/controllers/concerns/work_package_types/switch_failure_messages.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # A work package that refuses the re-type reports through a dependent result
+  # and leaves the top-level errors empty, which would render a blank message.
+  module SwitchFailureMessages
+    def switch_failure_messages(result)
+      messages = result.errors.full_messages
+      return messages if messages.any?
+
+      result.dependent_results.flat_map { |dependent| dependent.errors.full_messages }.uniq
+    end
+  end
+end

--- a/app/controllers/concerns/work_package_types/switch_feedback.rb
+++ b/app/controllers/concerns/work_package_types/switch_feedback.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # The type list has two states to paint once a switch has been queued: one
+  # still running, or one that has just settled. Both the switch endpoint and
+  # the endpoint the page polls have to paint them the same way.
+  module SwitchFeedback
+    private
+
+    def render_switch_state(project)
+      pending = ::Projects::Types::SwitchStatus.pending_for(project)
+
+      replace_via_turbo_stream(
+        component: Projects::Settings::WorkPackages::Types::ListComponent.new(
+          project: project.reload,
+          pending_switch: pending
+        )
+      )
+      announce_switch_outcome(project) if pending.nil?
+    end
+
+    def announce_switch_outcome(project)
+      outcome = ::Projects::Types::SwitchStatus.latest_for(project)
+      return if outcome.nil?
+
+      if outcome.success?
+        render_success_flash_message_via_turbo_stream(message: outcome.message)
+      else
+        render_error_flash_message_via_turbo_stream(message: outcome.message)
+      end
+    end
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/switches_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/switches_controller.rb
@@ -31,7 +31,13 @@
 class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::SettingsController
   include WorkPackageTypes::TypeVariantsFeature
   include OpTurbo::ComponentStream
-  include FlashMessagesOutputSafetyHelper
+  include WorkPackageTypes::SwitchFeedback
+
+  # A switch that settles inside this window is reported as a finished page, so
+  # a small project reads as a plain refresh rather than a progress dance. The
+  # cost is holding the request for at most this long.
+  DEBOUNCE_SECONDS = 1.0
+  SETTLE_POLL_SECONDS = 0.05
 
   menu_item :settings_work_packages
 
@@ -47,16 +53,14 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
 
     return render_invalid(switch) unless switch.valid?
 
-    result = ::Projects::Types::SwitchVariantService
-               .new(user: current_user, model: @project)
-               .call(source: switch.source, target: switch.target)
+    job = enqueue_switch(switch)
 
-    result.on_success { on_switched(switch) }
-    result.on_failure do
-      render_error_flash_message_via_turbo_stream(message: join_flash_messages(failure_messages(result)))
-    end
+    settled = settled_within_debounce?(job)
 
-    respond_to_with_turbo_streams(status: result)
+    close_dialog_via_turbo_stream("##{Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}")
+    render_switch_state(@project)
+
+    respond_to_with_turbo_streams(status: settled ? :ok : :accepted)
   end
 
   private
@@ -74,15 +78,6 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
     ::Projects::Types::Switch.new(project: @project, source: @source, target_id: params.dig(:switch, :target_id))
   end
 
-  # A work package that refuses the re-type reports through a dependent result
-  # and leaves the top-level errors empty, which would render a blank flash.
-  def failure_messages(result)
-    messages = result.errors.full_messages
-    return messages if messages.any?
-
-    result.dependent_results.flat_map { |dependent| dependent.errors.full_messages }.uniq
-  end
-
   def render_invalid(switch)
     update_via_turbo_stream(
       component: Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(switch:)
@@ -91,14 +86,35 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
     respond_to_with_turbo_streams(status: :unprocessable_entity)
   end
 
-  # Reload so the repainted list no longer sees the association's cached types.
-  def on_switched(switch)
-    close_dialog_via_turbo_stream("##{Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}")
-    replace_via_turbo_stream(
-      component: Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project.reload)
+  def enqueue_switch(switch)
+    ::Projects::Types::SwitchVariantJob.perform_later(
+      user: current_user,
+      project: @project,
+      source: switch.source,
+      target: switch.target
     )
-    render_success_flash_message_via_turbo_stream(
-      message: t("projects.settings.types.switch_dialog.success", type: switch.target.composite_name)
-    )
+  end
+
+  # Uncached because the query cache would answer every pass with the row as it
+  # was on the first one, so the worker's progress would never be seen.
+  def settled_within_debounce?(job)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + DEBOUNCE_SECONDS
+
+    ::JobStatus::Status.uncached do
+      loop do
+        return true unless switch_running?(job)
+        return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+        sleep SETTLE_POLL_SECONDS
+      end
+    end
+  end
+
+  # No row yet means the enqueue listener has not written one, which is still a
+  # switch we are waiting on rather than one that has finished.
+  def switch_running?(job)
+    row = ::JobStatus::Status.find_by(job_id: job.job_id)
+
+    row.nil? || ::Projects::Types::SwitchStatus::PENDING.include?(row.status)
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/switches_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/switches_controller.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::SettingsController
+  include WorkPackageTypes::TypeVariantsFeature
+  include OpTurbo::ComponentStream
+  include FlashMessagesOutputSafetyHelper
+
+  menu_item :settings_work_packages
+
+  before_action :require_type_variants_feature
+  before_action :load_source
+
+  def new
+    respond_with_dialog Projects::Settings::WorkPackages::Types::SwitchDialogComponent.new(switch: build_switch)
+  end
+
+  def create
+    switch = build_switch
+
+    return render_invalid(switch) unless switch.valid?
+
+    result = ::Projects::Types::SwitchVariantService
+               .new(user: current_user, model: @project)
+               .call(source: switch.source, target: switch.target)
+
+    result.on_success { on_switched(switch) }
+    result.on_failure do
+      render_error_flash_message_via_turbo_stream(message: join_flash_messages(failure_messages(result)))
+    end
+
+    respond_to_with_turbo_streams(status: result)
+  end
+
+  private
+
+  def load_source
+    @source = @project.types.find_by(id: params[:type_id])
+
+    return if @source
+
+    render_error_flash_message_via_turbo_stream(message: t("projects.settings.types.type_not_found"))
+    respond_to_with_turbo_streams(status: :unprocessable_entity)
+  end
+
+  def build_switch
+    ::Projects::Types::Switch.new(project: @project, source: @source, target_id: params.dig(:switch, :target_id))
+  end
+
+  # A work package that refuses the re-type reports through a dependent result
+  # and leaves the top-level errors empty, which would render a blank flash.
+  def failure_messages(result)
+    messages = result.errors.full_messages
+    return messages if messages.any?
+
+    result.dependent_results.flat_map { |dependent| dependent.errors.full_messages }.uniq
+  end
+
+  def render_invalid(switch)
+    update_via_turbo_stream(
+      component: Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(switch:)
+    )
+
+    respond_to_with_turbo_streams(status: :unprocessable_entity)
+  end
+
+  # Reload so the repainted list no longer sees the association's cached types.
+  def on_switched(switch)
+    close_dialog_via_turbo_stream("##{Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}")
+    replace_via_turbo_stream(
+      component: Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project.reload)
+    )
+    render_success_flash_message_via_turbo_stream(
+      message: t("projects.settings.types.switch_dialog.success", type: switch.target.composite_name)
+    )
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types_controller.rb
@@ -33,13 +33,20 @@ class Projects::Settings::WorkPackages::TypesController < Projects::SettingsCont
   include WorkPackageTypes::TypeVariantsFeature
   include OpTurbo::ComponentStream
   include FlashMessagesOutputSafetyHelper
+  include WorkPackageTypes::SwitchFeedback
 
   menu_item :settings_work_packages
 
-  before_action :require_type_variants_feature, only: %i[new create destroy]
+  before_action :require_type_variants_feature, only: %i[new create destroy status]
 
   def index
     @types = ::Type.all
+  end
+
+  def status
+    render_switch_state(@project)
+
+    respond_to_with_turbo_streams
   end
 
   def new

--- a/app/forms/projects/settings/work_packages/types/switch_form.rb
+++ b/app/forms/projects/settings/work_packages/types/switch_form.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        class SwitchForm < ApplicationForm
+          def initialize(switch:)
+            super()
+
+            @switch = switch
+          end
+
+          form do |switch_form|
+            switch_form.select_list(
+              name: :target_id,
+              label: I18n.t("projects.settings.types.switch_dialog.target_label"),
+              include_blank: false,
+              input_width: :medium,
+              data: { test_selector: "project-types-switch-select" }
+            ) do |list|
+              # Composite rather than own names: repeating the family on every
+              # option is what makes it evident that nothing outside it is on offer.
+              @switch.available_targets.each do |target|
+                list.option(value: target.id, label: target.composite_name, selected: target == @switch.selected_target)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -71,6 +71,7 @@ class Journal < ApplicationRecord
   register_journal_formatter OpenProject::JournalFormatter::Template
   register_journal_formatter OpenProject::JournalFormatter::TimeEntryHours
   register_journal_formatter OpenProject::JournalFormatter::TimeEntryNamedAssociation
+  register_journal_formatter OpenProject::JournalFormatter::TypeNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::Visibility
   register_journal_formatter OpenProject::JournalFormatter::WikiDiff
 

--- a/app/models/projects/types/switch.rb
+++ b/app/models/projects/types/switch.rb
@@ -30,46 +30,46 @@
 
 module Projects
   module Types
-    # Migrates a project from one member of a type family to another, in either
-    # direction. All work packages of the old type are switched to the target
-    # type before the old type is removed and the target type enabled, all
-    # within a single transaction.
-    class SwitchVariantService < BaseService
+    # Which member of a type family a project should use. Backs the switch
+    # dialog: the form binds to it, and it owns the preview of the switch it
+    # describes.
+    class Switch
+      include ActiveModel::Model
+
+      attr_accessor :project, :source
+      attr_writer :target_id
+
+      validate :target_selectable
+
+      def target_id
+        @target_id.presence&.to_i
+      end
+
+      def target
+        return @target if defined?(@target)
+
+        @target = target_id && ::Type.find_by(id: target_id)
+      end
+
+      def available_targets
+        source.family
+      end
+
+      # The dialog opens on the member the project uses now, so applying without
+      # choosing anything is a visible no-op rather than an empty field.
+      def selected_target
+        target || source
+      end
+
       private
 
-      def persist(service_call)
-        source = params[:source]
-        target = params[:target]
-
-        if source == target
-          return failure(:switch_target_identical)
-        elsif source.root != target.root
-          return failure(:switch_target_not_in_family)
-        end
-
-        switch(service_call, source, target)
-      end
-
-      def switch(service_call, source, target)
-        add_type(target)
-        reassign_work_packages(source, target).each { |wp_result| service_call.add_dependent!(wp_result) }
-        return service_call if service_call.failure?
-
-        model.types.delete(source)
-
-        service_call
-      end
-
-      def add_type(target)
-        model.types << target unless model.types.include?(target)
-        enable_work_package_custom_fields(target)
-      end
-
-      def reassign_work_packages(source, target)
-        WorkPackage.where(project: model, type: source).map do |work_package|
-          WorkPackages::UpdateService
-            .new(user:, model: work_package)
-            .call(type: target)
+      def target_selectable
+        if target_id.blank?
+          errors.add(:target_id, :blank)
+        elsif available_targets.exclude?(target)
+          errors.add(:target_id, :not_in_family)
+        elsif target == source
+          errors.add(:target_id, :unchanged)
         end
       end
     end

--- a/app/models/projects/types/switch_status.rb
+++ b/app/models/projects/types/switch_status.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Types
+    # The state of a backgrounded switch as the settings page sees it. Keyed on
+    # the project rather than on the user who started it: a switch changes the
+    # project for everyone, so anyone opening the page while one runs sees it.
+    class SwitchStatus
+      PENDING = %w[in_queue in_process].freeze
+
+      class << self
+        def pending_for(project)
+          wrap(rows(project).where(status: PENDING).last)
+        end
+
+        def latest_for(project)
+          wrap(rows(project).last)
+        end
+
+        private
+
+        # Matched on the payload rather than on the polymorphic reference, which
+        # carries a unique index and so cannot hold a project that is switched
+        # more than once. The kind keeps other jobs' rows out.
+        def rows(project)
+          ::JobStatus::Status
+            .where("payload->>'kind' = ? AND payload->>'project_id' = ?",
+                   SwitchVariantJob::KIND, project.id.to_s)
+            .order(:updated_at, :id)
+        end
+
+        def wrap(row) = row && new(row)
+      end
+
+      delegate :success?, :message, to: :@row
+
+      def initialize(row)
+        @row = row
+      end
+
+      def source_id
+        @row.payload["source_id"]
+      end
+
+      def target
+        return @target if defined?(@target)
+
+        @target = ::Type.find_by(id: @row.payload["target_id"])
+      end
+    end
+  end
+end

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -104,10 +104,12 @@ module WorkPackage::Journalized
     register_journal_formatted_fields "project_phase_definition_id", formatter_key: :project_phase_definition
     register_journal_formatted_fields "target_versions", formatter_key: :target_versions
 
+    register_journal_formatted_fields "type_id", formatter_key: :type_named_association
+
     # Joined
     register_journal_formatted_fields :parent_id, :project_id,
                                       :budget_id,
-                                      :status_id, :type_id,
+                                      :status_id,
                                       :assigned_to_id, :priority_id,
                                       :category_id, :version_id,
                                       :author_id, :responsible_id,

--- a/app/views/projects/settings/work_packages/types/index.html.erb
+++ b/app/views/projects/settings/work_packages/types/index.html.erb
@@ -42,7 +42,12 @@ See COPYRIGHT and LICENSE files for more details.
        ) { t("activerecord.attributes.work_package.type") } %>
   <% end %>
 
-  <%= render(Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project)) %>
+  <%= render(
+        Projects::Settings::WorkPackages::Types::ListComponent.new(
+          project: @project,
+          pending_switch: ::Projects::Types::SwitchStatus.pending_for(@project)
+        )
+      ) %>
 <% elsif Type.any? %>
   <%= form_for @project,
                url: bulk_update_project_settings_work_packages_types_path(@project),

--- a/app/workers/projects/types/switch_variant_job.rb
+++ b/app/workers/projects/types/switch_variant_job.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Types
+    # Runs a type switch off-request. The service re-types every work package
+    # through WorkPackages::UpdateService, which journals and notifies per
+    # record, so a large family takes far longer than a request may last.
+    class SwitchVariantJob < ApplicationJob
+      include WorkPackageTypes::SwitchFailureMessages
+
+      # Discriminates our status rows from those of any other job that comes to
+      # reference a project.
+      KIND = "type_switch"
+
+      queue_with_priority :above_normal
+
+      def perform(user:, project:, source:, target:)
+        result = SwitchVariantService.new(user:, model: project).call(source:, target:)
+
+        if result.success?
+          upsert_status status: :success,
+                        message: I18n.t("projects.settings.types.switch_dialog.success",
+                                        type: target.composite_name)
+        else
+          upsert_status status: :failure, message: switch_failure_messages(result).join(", ")
+        end
+
+        result
+      end
+
+      def store_status? = true
+
+      def updates_own_status? = true
+
+      protected
+
+      # Stamped on every status update, including the in_queue row the enqueue
+      # listener writes, so the row is self-describing from the moment it exists.
+      #
+      # The project lives in the payload rather than in status_reference because
+      # job_statuses holds a unique index on its polymorphic reference: a project
+      # is switched repeatedly, so the second switch would collide there — and
+      # upsert_status retries RecordNotUnique without bound.
+      def build_status_attributes(attributes)
+        payload = (attributes[:payload] || {}).merge(
+          kind: KIND,
+          project_id: params[:project].id,
+          source_id: params[:source].id,
+          target_id: params[:target].id
+        )
+
+        super(attributes.merge(payload:))
+      end
+
+      private
+
+      def params
+        arguments.is_a?(Array) ? Hash(arguments.first) : {}
+      end
+    end
+  end
+end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -239,7 +239,7 @@ Rails.application.reloader.to_prepare do
 
       map.permission :manage_types,
                      {
-                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update],
+                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update status],
                        "projects/settings/work_packages/types/switches": %i[new create]
                      },
                      permissible_on: :project,

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -239,7 +239,8 @@ Rails.application.reloader.to_prepare do
 
       map.permission :manage_types,
                      {
-                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update]
+                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update],
+                       "projects/settings/work_packages/types/switches": %i[new create]
                      },
                      permissible_on: :project,
                      require: :member

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5059,7 +5059,11 @@ en:
           target_label: "Variant"
           title: "%{type}: Switch variant"
           warning: "If you switch variants, you might lose information associated with custom fields that might not be present in the new one."
+        switch_in_progress: "Another variant switch is in progress."
         switch_type: "Switch variant"
+        # Both carry their own punctuation so locales can set their own spacing.
+        switching_to_type: "Switching to:"
+        switching_to_variant: "Switching to variant:"
         type_not_found: "The selected type could not be found."
         # Carries its own punctuation so locales can set their own spacing.
         variant_prefix: "Variant:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,15 @@ en:
     attributes:
       projects/copy_options:
         dependencies: "Dependencies"
+      projects/types/switch:
+        target_id: "Variant"
+    errors:
+      models:
+        projects/types/switch:
+          attributes:
+            target_id:
+              not_in_family: "must belong to the same type family"
+              unchanged: "must be different from the one the project uses now"
 
   activerecord:
     attributes:
@@ -708,9 +717,8 @@ en:
               cannot_assign_variant_and_parent: "Cannot assign a variant and its parent "
               cannot_assign_variants_yet: "Variants cannot be enabled on a project yet. Enable the feature flag to try out variants"
               in_use_by_work_packages: "still in use by work packages: %{types}"
-              switch_source_not_a_variant: "Can only switch away from a variant"
-              switch_target_identical: "The target Type must be different from the current variant"
-              switch_target_not_in_family: "Can only switch to another variant of the same Type or to its parent Type"
+              switch_target_identical: "The target type must be different from the type the project uses now"
+              switch_target_not_in_family: "Can only switch to another type of the same family"
           cannot_be_assigned_to_artifact_work_package: "The chosen user is not allowed to be assigned to work packages."
           foreign_wps_reference_version: "Work packages in non descendant projects reference versions of the project or its descendants."
         project/phase:
@@ -5045,6 +5053,14 @@ en:
         in_roadmap: "In roadmap"
         no_results_title_text: There are currently no types available.
         remove_from_project: "Remove from project"
+        switch_dialog:
+          apply: "Apply"
+          description: "Select a different variant of this type to use in this project."
+          success: "The project now uses %{type}."
+          target_label: "Variant"
+          title: "%{type}: Switch variant"
+          warning: "If you switch variants, you might lose information associated with custom fields that might not be present in the new one."
+        switch_type: "Switch variant"
         type_not_found: "The selected type could not be found."
       versions:
         no_results_content_text: Create a new version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5050,7 +5050,6 @@ en:
           title: "No types are active in this project"
         form:
           enable_type_in_project: 'Enable type "%{type}"'
-        in_roadmap: "In roadmap"
         no_results_title_text: There are currently no types available.
         remove_from_project: "Remove from project"
         switch_dialog:
@@ -5062,6 +5061,8 @@ en:
           warning: "If you switch variants, you might lose information associated with custom fields that might not be present in the new one."
         switch_type: "Switch variant"
         type_not_found: "The selected type could not be found."
+        # Carries its own punctuation so locales can set their own spacing.
+        variant_prefix: "Variant:"
       versions:
         no_results_content_text: Create a new version
         no_results_title_text: There are currently no versions for the project.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -428,6 +428,8 @@ Rails.application.routes.draw do
           resource :internal_comments, only: %i[show update]
           resources :types, only: %i[index new create destroy] do
             patch :bulk_update, on: :collection
+
+            resource :switch, only: %i[new create], controller: "types/switches"
           end
           resource :custom_fields, only: %i[show update]
           resource :categories, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -428,6 +428,7 @@ Rails.application.routes.draw do
           resource :internal_comments, only: %i[show update]
           resources :types, only: %i[index new create destroy] do
             patch :bulk_update, on: :collection
+            get :status, on: :collection
 
             resource :switch, only: %i[new create], controller: "types/switches"
           end

--- a/lib/open_project/journal_formatter/type_named_association.rb
+++ b/lib/open_project/journal_formatter/type_named_association.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class OpenProject::JournalFormatter::TypeNamedAssociation < JournalFormatter::NamedAssociation
+  # Variants answer the name of the type they present as, so a switch within one
+  # family would read "Type changed from Epic to Epic". How to word it instead is
+  # still open: the change stays journaled, it is only left unrendered until then.
+  def render(key_with_id, values, options = { html: true })
+    return if within_one_family?(values, cache: options[:cache])
+
+    super
+  end
+
+  private
+
+  def within_one_family?(values, cache:)
+    types = values.map { |value| value && associated_object(::Type, value.to_i, cache:) }
+
+    types.all? && types.map(&:root).uniq.one?
+  end
+end

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -64,6 +64,67 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
+  context "when a switch is running in the background" do
+    shared_let(:blueprint) { create(:type, name: "Blueprint", parent: epic) }
+
+    # A second family with variants of its own, so the effect of a switch on the
+    # rows that are not switching is visible.
+    shared_let(:feature) { create(:type, name: "Feature").tap { |type| type.update_column(:position, 3) } }
+    shared_let(:research) { create(:type, name: "Research", parent: feature) }
+
+    subject(:component) { described_class.new(project:, pending_switch:) }
+
+    let(:project) { create(:project, types: [design, research]) }
+    let(:pending_switch) do
+      instance_double(Projects::Types::SwitchStatus, source_id: design.id, target: blueprint)
+    end
+
+    before { render_inline(component) }
+
+    # Its own name, not the composite one: the parent already labels the row.
+    it "says where the switching family is heading" do
+      expect(page).to have_text("Switching to variant: Blueprint", normalize_ws: true)
+    end
+
+    context "when the target is the family parent rather than a variant" do
+      let(:pending_switch) do
+        instance_double(Projects::Types::SwitchStatus, source_id: design.id, target: epic)
+      end
+
+      it "drops the word variant, because the project will be left on none" do
+        expect(page).to have_text("Switching to: Epic", normalize_ws: true)
+      end
+    end
+
+    it "polls, so the row settles without the user reloading" do
+      expect(page).to have_css("[data-controller='poll-for-changes']")
+    end
+
+    it "offers no actions on the switching row" do
+      expect(switching_row).to have_no_button("Remove from project", visible: :all)
+    end
+
+    # The service takes an advisory lock on the project, so a second switch would
+    # queue behind the first. Disabling says so; hiding used to leave families
+    # nobody is switching looking broken.
+    it "keeps the switch action on the other family, disabled and explained" do
+      expect(other_family_row).to have_text("Switch variant")
+      expect(other_family_row).to have_text("Another variant switch is in progress.")
+      expect(other_family_row).to have_no_css(
+        "a[href='#{new_project_settings_work_packages_type_switch_path(project, research)}']",
+        visible: :all
+      )
+    end
+
+    def switching_row
+      page.find("[data-test-selector='project-types-row-#{design.id}']", visible: :all)
+    end
+
+    def other_family_row
+      page.find("[data-test-selector='project-types-row-#{research.id}']", visible: :all)
+    end
+  end
+
   context "when a family is active through a variant" do
     let(:project) { create(:project, types: [design]) }
 

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -74,8 +74,10 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_no_text("Epic: Design")
     end
 
-    it "labels the active variant" do
-      expect(page).to have_css(".Label", text: "Design")
+    # normalize_ws because render_inline keeps the newline between the two Text
+    # components that a browser lays out on one line.
+    it "names the active variant after the parent it presents as" do
+      expect(page).to have_text("Variant: Design", normalize_ws: true)
     end
 
     it "points the remove action at the variant" do
@@ -83,26 +85,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
         "form[action='#{project_settings_work_packages_type_path(project, design)}']",
         visible: :all
       )
-    end
-  end
-
-  describe "the roadmap indicator" do
-    let(:project) { create(:project, types: [bug]) }
-
-    it "marks a type that is shown in the roadmap by default" do
-      render_inline(component)
-
-      expect(page).to have_text("In roadmap")
-    end
-
-    context "when the type is not shown in the roadmap" do
-      before { bug.update!(is_in_roadmap: false) }
-
-      it "says nothing rather than stating the negative" do
-        render_inline(component)
-
-        expect(page).to have_no_text("In roadmap")
-      end
     end
   end
 

--- a/spec/components/work_packages/activities_tab/journals/item_component/details_spec.rb
+++ b/spec/components/work_packages/activities_tab/journals/item_component/details_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::ActivitiesTab::Journals::ItemComponent::Details, type: :component do
+  shared_let(:user) { create(:user) }
+  shared_let(:work_package) { create(:work_package) }
+
+  let(:journal) { build_stubbed(:work_package_journal, journable: work_package, user:, version: 2) }
+
+  subject(:component) do
+    described_class.new(journal:, filter: WorkPackages::ActivitiesTab::Filters::ALL)
+  end
+
+  before do
+    login_as(user)
+
+    allow(journal).to receive(:details).and_return(details)
+    rendered.each { |detail, text| allow(journal).to receive(:render_detail).with(detail).and_return(text) }
+
+    render_inline(component)
+  end
+
+  context "with a detail that renders" do
+    let(:details) { { "subject" => ["Old", "New"] } }
+    let(:rendered) { { ["subject", ["Old", "New"]] => "Subject changed from Old to New" } }
+
+    it "renders the change" do
+      expect(page).to have_text("Subject changed from Old to New")
+    end
+
+    it "heads the change with its author and time" do
+      expect(page).to have_css("[data-test-selector='op-journal-details-header']")
+    end
+  end
+
+  # A formatter that renders nothing leaves the entry with no change to show, so
+  # a header would announce an author and a time above an empty entry.
+  context "when every detail renders blank" do
+    let(:details) { { "type_id" => [1, 2] } }
+    let(:rendered) { { ["type_id", [1, 2]] => nil } }
+
+    it "renders no header" do
+      expect(page).to have_no_css("[data-test-selector='op-journal-details-header']")
+    end
+
+    it "renders no change" do
+      expect(page).to have_no_css("[data-test-selector='op-journal-detail-description']")
+    end
+  end
+end

--- a/spec/features/projects/settings/work_package_types_spec.rb
+++ b/spec/features/projects/settings/work_package_types_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
     work_package = create(:work_package, project:, type: design)
 
     settings_page.switch_type(design, target: "Epic: Blueprint")
+    settings_page.await_switch_queued(design)
+    perform_enqueued_jobs
 
     expect_flash(message: "The project now uses Epic: Blueprint.")
     settings_page.expect_type_row(blueprint, variant: "Blueprint")
@@ -105,6 +107,8 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
 
   it "switches the project from a variant to the family parent" do
     settings_page.switch_type(design, target: "Epic")
+    settings_page.await_switch_queued(design)
+    perform_enqueued_jobs
 
     settings_page.expect_type_row(epic)
     expect(project.reload.types).to include(epic)
@@ -134,6 +138,45 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
   # would open a dialog whose only option is the current one.
   it "offers no switch action for a family without variants" do
     settings_page.expect_no_switch_action(bug)
+  end
+
+  # Nothing performs the job, so it is still queued when the debounce window
+  # closes: the case where the switch outlives it and the indicators appear.
+  context "when the switch outlives the debounce window" do
+    before { create(:work_package, project:, type: design) }
+
+    it "hands the switch to a background job instead of holding the request" do
+      settings_page.switch_type(design, target: "Epic: Blueprint")
+
+      settings_page.expect_switching_row(design, target: "Blueprint")
+      # Nothing has run yet: the request only queued it.
+      expect(project.reload.types).to contain_exactly(design, bug)
+
+      perform_enqueued_jobs
+
+      expect(project.reload.types).to contain_exactly(blueprint, bug)
+    end
+
+    it "settles the row without a reload, and never opens a dialog" do
+      settings_page.switch_type(design, target: "Epic: Blueprint")
+
+      settings_page.expect_switching_row(design, target: "Blueprint")
+      settings_page.expect_no_dialog
+
+      perform_enqueued_jobs
+
+      settings_page.expect_type_row(blueprint, variant: "Blueprint")
+      expect_flash(message: "The project now uses Epic: Blueprint.")
+    end
+
+    # Keyed on the project, so a colleague who did not start it still sees it.
+    it "shows a switch started by somebody else" do
+      Projects::Types::SwitchVariantJob.perform_later(user: current_user, project:, source: design, target: blueprint)
+
+      settings_page.visit!
+
+      settings_page.expect_switching_row(design, target: "Blueprint")
+    end
   end
 
   # Located by test selector because the tab nav above renders a "Types" link,

--- a/spec/features/projects/settings/work_package_types_spec.rb
+++ b/spec/features/projects/settings/work_package_types_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
 
   shared_let(:epic) { create(:type, name: "Epic") }
   shared_let(:design) { create(:type, name: "Design", parent: epic) }
+  shared_let(:blueprint) { create(:type, name: "Blueprint", parent: epic) }
   shared_let(:bug) { create(:type, name: "Bug") }
   shared_let(:milestone) { create(:type, name: "Milestone") }
   shared_let(:feature) { create(:type, name: "Feature") }
@@ -44,8 +45,11 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
   let(:project) { create(:project, types: [design, bug]) }
   let(:settings_page) { Pages::Projects::Settings::WorkPackageTypes.new(project) }
 
+  # edit_work_packages is needed on top of manage_types: switching re-types the
+  # project's work packages through WorkPackages::UpdateService as this user.
   current_user do
-    create(:user, member_with_permissions: { project => %i[edit_project manage_types view_work_packages] })
+    create(:user, member_with_permissions: { project => %i[edit_project manage_types view_work_packages
+                                                           edit_work_packages] })
   end
 
   before { settings_page.visit! }
@@ -86,6 +90,50 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
       settings_page.expect_type_row(bug)
       expect(project.reload.types).to include(bug)
     end
+  end
+
+  it "switches the project to a sibling variant and re-types its work packages" do
+    work_package = create(:work_package, project:, type: design)
+
+    settings_page.switch_type(design, target: "Epic: Blueprint")
+
+    expect_flash(message: "The project now uses Epic: Blueprint.")
+    settings_page.expect_type_row(blueprint, variant: "Blueprint")
+    settings_page.expect_no_type_row(design)
+    expect(work_package.reload.type).to eq(blueprint)
+  end
+
+  it "switches the project from a variant to the family parent" do
+    settings_page.switch_type(design, target: "Epic")
+
+    settings_page.expect_type_row(epic)
+    expect(project.reload.types).to include(epic)
+  end
+
+  it "warns about hidden custom field data and opens on the variant in use" do
+    settings_page.open_switch_dialog(design)
+
+    within(settings_page.switch_dialog) do
+      expect(page).to have_text("Epic: Switch variant")
+      expect(page).to have_text("you might lose information associated with custom fields")
+      expect(page).to have_select("Variant", selected: "Epic: Design")
+    end
+  end
+
+  it "refuses to apply the variant the project already uses" do
+    settings_page.open_switch_dialog(design)
+    settings_page.apply_switch
+
+    within(settings_page.switch_dialog) do
+      expect(page).to have_text("must be different from the one the project uses now")
+    end
+    expect(project.reload.types).to include(design)
+  end
+
+  # A family with no variants has nothing to switch to, so offering the action
+  # would open a dialog whose only option is the current one.
+  it "offers no switch action for a family without variants" do
+    settings_page.expect_no_switch_action(bug)
   end
 
   # Located by test selector because the tab nav above renders a "Types" link,

--- a/spec/lib/open_project/journal_formatter/type_named_association_spec.rb
+++ b/spec/lib/open_project/journal_formatter/type_named_association_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::JournalFormatter::TypeNamedAssociation do
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+  shared_let(:research) { create(:type, name: "Research", parent: epic) }
+  shared_let(:bug) { create(:type, name: "Bug") }
+
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:journal) { build_stubbed(:work_package_journal, journable: work_package) }
+
+  subject(:formatter) { described_class.new(journal) }
+
+  describe "#render" do
+    it "renders a change between two families" do
+      expect(formatter.render(:type_id, [bug.id.to_s, epic.id.to_s]))
+        .to eq(I18n.t(:text_journal_changed_plain,
+                      label: "<strong>Type</strong>",
+                      linebreak: nil,
+                      old: "<i>Bug</i>",
+                      new: "<i>Epic</i>"))
+    end
+
+    # Every member of a family answers the root's name, so these would all read
+    # "Type changed from Epic to Epic".
+    it "renders nothing when switching between two variants of one family" do
+      expect(formatter.render(:type_id, [design.id.to_s, research.id.to_s])).to be_nil
+    end
+
+    it "renders nothing when switching from a variant to the parent it presents as" do
+      expect(formatter.render(:type_id, [design.id.to_s, epic.id.to_s])).to be_nil
+    end
+
+    it "renders nothing when switching from the parent to one of its variants" do
+      expect(formatter.render(:type_id, [epic.id.to_s, design.id.to_s])).to be_nil
+    end
+
+    it "renders the initial type of a work package" do
+      expect(formatter.render(:type_id, [nil, epic.id.to_s]))
+        .to eq(I18n.t(:text_journal_set_to, label: "<strong>Type</strong>", value: "<i>Epic</i>"))
+    end
+
+    # A deleted type leaves an id that resolves to nothing, so there is no
+    # family to compare against.
+    it "renders a change away from a type that no longer exists" do
+      expect(formatter.render(:type_id, ["#{epic.id}0000", bug.id.to_s]))
+        .to eq(I18n.t(:text_journal_set_to, label: "<strong>Type</strong>", value: "<i>Bug</i>"))
+    end
+  end
+end

--- a/spec/models/projects/types/switch_spec.rb
+++ b/spec/models/projects/types/switch_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::Types::Switch do
+  subject(:switch) { described_class.new(project:, source:, target_id:) }
+
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+  shared_let(:research) { create(:type, name: "Research", parent: epic) }
+  shared_let(:bug) { create(:type, name: "Bug") }
+
+  let(:project) { create(:project, types: [design]) }
+  let(:source) { design }
+  let(:target_id) { research.id }
+
+  describe "#available_targets" do
+    it "offers the whole family, the current member included, so the select can open on it" do
+      expect(switch.available_targets).to contain_exactly(epic, design, research)
+    end
+
+    context "when the project uses the family parent" do
+      let(:source) { epic }
+
+      it "still offers the whole family" do
+        expect(switch.available_targets).to contain_exactly(epic, design, research)
+      end
+    end
+  end
+
+  describe "#selected_target" do
+    it "is the chosen target once one is submitted" do
+      expect(switch.selected_target).to eq(research)
+    end
+
+    context "when nothing has been chosen yet" do
+      let(:target_id) { nil }
+
+      # The dialog opens on the member in use rather than on an empty field.
+      it "falls back to the source" do
+        expect(switch.selected_target).to eq(design)
+      end
+    end
+  end
+
+  describe "#target" do
+    it "resolves the id" do
+      expect(switch.target).to eq(research)
+    end
+
+    context "when no id was given" do
+      let(:target_id) { nil }
+
+      it "is nil rather than raising" do
+        expect(switch.target).to be_nil
+      end
+    end
+  end
+
+  describe "validation" do
+    it "accepts a sibling variant" do
+      expect(switch).to be_valid
+    end
+
+    context "when the target is the family parent" do
+      let(:target_id) { epic.id }
+
+      it "is accepted, because adopting the parent is a legitimate switch" do
+        expect(switch).to be_valid
+      end
+    end
+
+    context "when nothing was chosen" do
+      let(:target_id) { nil }
+
+      it "reports a blank target" do
+        expect(switch).not_to be_valid
+        expect(switch.errors[:target_id]).to include("can't be blank")
+      end
+    end
+
+    context "when the target is the member already in use" do
+      let(:target_id) { design.id }
+
+      it "is rejected with its own message, since applying it would change nothing" do
+        expect(switch).not_to be_valid
+        expect(switch.errors[:target_id]).to include("must be different from the one the project uses now")
+      end
+    end
+
+    context "when the target belongs to another family" do
+      let(:target_id) { bug.id }
+
+      it "is rejected" do
+        expect(switch).not_to be_valid
+        expect(switch.errors[:target_id]).to include("must belong to the same type family")
+      end
+    end
+
+    context "when the target does not exist" do
+      let(:target_id) { 0 }
+
+      it "is rejected without raising" do
+        expect(switch).not_to be_valid
+        expect(switch.errors[:target_id]).to include("must belong to the same type family")
+      end
+    end
+  end
+end

--- a/spec/models/projects/types/switch_status_spec.rb
+++ b/spec/models/projects/types/switch_status_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::Types::SwitchStatus do
+  shared_let(:user) { create(:admin) }
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+
+  let(:project) { create(:project, types: [epic]) }
+
+  def create_status(status:, kind: "type_switch", for_project: project)
+    JobStatus::Status.create!(
+      job_id: SecureRandom.uuid,
+      user:,
+      status:,
+      message: "The project now uses Epic: Design.",
+      payload: { "kind" => kind, "project_id" => for_project.id, "source_id" => epic.id, "target_id" => design.id }
+    )
+  end
+
+  describe ".pending_for" do
+    it "finds a queued switch" do
+      create_status(status: :in_queue)
+
+      expect(described_class.pending_for(project).target).to eq(design)
+    end
+
+    it "finds a running switch" do
+      create_status(status: :in_process)
+
+      expect(described_class.pending_for(project)).to be_present
+    end
+
+    it "ignores a settled switch" do
+      create_status(status: :success)
+
+      expect(described_class.pending_for(project)).to be_nil
+    end
+
+    it "ignores another project's switch" do
+      create_status(status: :in_process, for_project: create(:project))
+
+      expect(described_class.pending_for(project)).to be_nil
+    end
+
+    # A project is switched repeatedly, so its rows accumulate.
+    it "finds the running switch even when earlier ones have settled" do
+      create_status(status: :success)
+      create_status(status: :in_process)
+
+      expect(described_class.pending_for(project)).to be_present
+    end
+
+    # A status row referencing a project need not be ours: the discriminator is
+    # what keeps another job's row from painting the type list.
+    it "ignores a row from a different kind of job" do
+      create_status(status: :in_process, kind: "something_else")
+
+      expect(described_class.pending_for(project)).to be_nil
+    end
+  end
+
+  describe ".latest_for" do
+    it "reports the outcome of the switch that just settled" do
+      create_status(status: :success)
+
+      expect(described_class.latest_for(project)).to be_success
+    end
+
+    it "reports a failure as such" do
+      create_status(status: :failure)
+
+      expect(described_class.latest_for(project)).not_to be_success
+    end
+
+    it "is nil when the project has never had one" do
+      expect(described_class.latest_for(project)).to be_nil
+    end
+  end
+
+  describe "#source_id" do
+    it "names the row the switch belongs to" do
+      create_status(status: :in_process)
+
+      expect(described_class.pending_for(project).source_id).to eq(epic.id)
+    end
+  end
+
+  describe "#message" do
+    it "carries what the job reported, for the page to announce" do
+      create_status(status: :success)
+
+      expect(described_class.latest_for(project).message).to eq("The project now uses Epic: Design.")
+    end
+  end
+end

--- a/spec/requests/projects/settings/work_packages/types/switches_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/switches_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Projects::Settings::WorkPackages::Types::Switches",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+  shared_let(:blueprint) { create(:type, name: "Blueprint", parent: epic) }
+  shared_let(:project) { create(:project, types: [design]) }
+  shared_let(:user) do
+    create(:user, member_with_permissions: { project => %i[edit_project manage_types view_work_packages] })
+  end
+
+  subject(:switch!) do
+    post project_settings_work_packages_type_switch_path(project, design),
+         params: { switch: { target_id: blueprint.id } },
+         as: :turbo_stream
+  end
+
+  let(:status_when_checked) { :in_queue }
+  let(:message_when_checked) { "The project now uses Epic: Blueprint." }
+
+  # The job is never really run. What the branch depends on is only what the
+  # status row says by the time the debounce window is checked, so the spec sets
+  # that directly instead of racing a worker.
+  before do
+    login_as user
+    stub_const("Projects::Settings::WorkPackages::Types::SwitchesController::DEBOUNCE_SECONDS", 0.1)
+
+    allow(Projects::Types::SwitchVariantJob).to receive(:perform_later) do
+      job_id = SecureRandom.uuid
+
+      JobStatus::Status.create!(
+        job_id:,
+        user:,
+        status: status_when_checked,
+        message: message_when_checked,
+        payload: { "kind" => "type_switch", "project_id" => project.id,
+                   "source_id" => design.id, "target_id" => blueprint.id }
+      )
+
+      instance_double(Projects::Types::SwitchVariantJob, job_id:)
+    end
+  end
+
+  context "when the switch settles inside the debounce window" do
+    let(:status_when_checked) { :success }
+
+    it "reports the outcome and shows no spinner" do
+      switch!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("The project now uses Epic: Blueprint.")
+      expect(response.body).not_to include("Switching to variant:")
+    end
+  end
+
+  context "when the switch outlives the debounce window" do
+    it "marks the switching row as running" do
+      switch!
+
+      expect(response).to have_http_status(:accepted)
+      expect(response.body).to include("Switching to variant:")
+    end
+  end
+
+  context "when the switch fails inside the debounce window" do
+    let(:status_when_checked) { :failure }
+    let(:message_when_checked) { "Type is not writable." }
+
+    it "reports the failure rather than staying silent" do
+      switch!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Type is not writable.")
+      expect(response.body).not_to include("Switching to variant:")
+    end
+  end
+end

--- a/spec/services/projects/types/switch_variant_service_spec.rb
+++ b/spec/services/projects/types/switch_variant_service_spec.rb
@@ -60,13 +60,14 @@ RSpec.describe Projects::Types::SwitchVariantService, with_flag: { type_variants
     end
   end
 
-  context "when the source is not a variant" do
+  context "when switching from the parent type to one of its variants" do
+    let(:project) { create(:project, types: [parent_type]) }
+    let!(:work_package) { create(:work_package, project:, type: parent_type) }
     let(:source) { parent_type }
     let(:target) { variant }
 
-    it "fails without changing anything" do
-      expect(service_call).to be_failure
-      expect(service_call.errors.symbols_for(:types)).to contain_exactly(:switch_source_not_a_variant)
+    it "moves the work packages to the variant and swaps the enabled types" do
+      expect(service_call).to be_success
       expect(work_package.reload.type).to eq(variant)
       expect(project.reload.types).to contain_exactly(variant)
     end

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -52,7 +52,7 @@ module Pages
           row = find_row(type)
 
           expect(row).to have_text(type.root.name)
-          expect(row).to have_css(".Label", text: variant) if variant
+          expect(row).to have_text("Variant: #{variant}") if variant
         end
 
         def expect_no_type_row(type)

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -89,6 +89,24 @@ module Pages
           page.find_by_id("project-types-switch-dialog")
         end
 
+        # The spinner is the only sign the request came back, so waiting on it is
+        # what guarantees the job is queued before an example performs it. Kept
+        # target-agnostic because switching to the family parent is worded
+        # differently from switching to a variant.
+        def await_switch_queued(type)
+          expect(find_row(type)).to have_text("Switching to")
+        end
+
+        def expect_switching_row(type, target:)
+          expect(find_row(type)).to have_text("Switching to variant: #{target}", normalize_ws: true)
+        end
+
+        # The designer settled on the row spinner alone, so a backgrounded switch
+        # must not raise a modal of any kind.
+        def expect_no_dialog
+          expect(page).to have_no_css("dialog[open]")
+        end
+
         def expect_no_switch_action(type)
           within(find_row(type)) { find("action-menu > button").click }
 

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -34,6 +34,8 @@ module Pages
   module Projects
     module Settings
       class WorkPackageTypes < Pages::Page
+        include ::Components::Autocompleter::NgSelectAutocompleteHelpers
+
         attr_accessor :project
 
         def initialize(project)
@@ -60,6 +62,37 @@ module Pages
         def remove_type(type)
           within(find_row(type)) { find("action-menu > button").click }
           click_on "Remove from project"
+        end
+
+        def switch_type(type, target:)
+          open_switch_dialog(type)
+          choose_switch_target(target)
+          apply_switch
+        end
+
+        def open_switch_dialog(type)
+          within(find_row(type)) { find("action-menu > button").click }
+          click_on "Switch variant"
+
+          expect(switch_dialog).to have_select("Variant")
+        end
+
+        def choose_switch_target(target)
+          within(switch_dialog) { select target, from: "Variant" }
+        end
+
+        def apply_switch
+          within(switch_dialog) { click_on "Apply" }
+        end
+
+        def switch_dialog
+          page.find_by_id("project-types-switch-dialog")
+        end
+
+        def expect_no_switch_action(type)
+          within(find_row(type)) { find("action-menu > button").click }
+
+          expect(page).to have_no_text("Switch variant")
         end
 
         def find_row(type)

--- a/spec/workers/projects/types/switch_variant_job_spec.rb
+++ b/spec/workers/projects/types/switch_variant_job_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::Types::SwitchVariantJob, with_flag: { type_variants: true } do
+  shared_let(:user) { create(:admin) }
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:design) { create(:type, name: "Design", parent: epic) }
+
+  let(:project) { create(:project, types: [epic]) }
+  let!(:work_package) { create(:work_package, project:, type: epic) }
+  let(:source) { epic }
+  let(:target) { design }
+  # Instantiated rather than called through .perform_now so the spec can read
+  # back the job_id the status row is keyed on.
+  let(:job) { described_class.new(user:, project:, source:, target:) }
+
+  def job_status = JobStatus::Status.find_by(job_id: job.job_id)
+
+  describe "#perform" do
+    subject(:perform_job) { job.perform_now }
+
+    it "re-types the work packages and swaps the enabled types" do
+      perform_job
+
+      expect(work_package.reload.type).to eq(design)
+      expect(project.reload.types).to contain_exactly(design)
+    end
+
+    it "records a success both surfaces can read" do
+      perform_job
+
+      expect(job_status).to be_success
+      expect(job_status.message).to eq("The project now uses Epic: Design.")
+    end
+
+    context "when the target is outside the family" do
+      let(:target) { create(:type, name: "Unrelated") }
+
+      it "records the failure rather than raising" do
+        perform_job
+
+        expect(job_status).to be_failure
+        expect(work_package.reload.type).to eq(epic)
+      end
+    end
+
+    context "when a work package refuses the re-type" do
+      before do
+        errors = ActiveModel::Errors.new(work_package)
+        errors.add(:base, "Type is not writable.")
+
+        allow(WorkPackages::UpdateService)
+          .to receive(:new).and_return(instance_double(WorkPackages::UpdateService,
+                                                       call: ServiceResult.failure(errors:)))
+      end
+
+      # The service reports that through a dependent result, leaving its own
+      # errors empty, so a naive message would be blank.
+      it "reports the work package's own complaint" do
+        perform_job
+
+        expect(job_status).to be_failure
+        expect(job_status.message).to include("Type is not writable.")
+      end
+    end
+  end
+
+  describe "the status row" do
+    subject(:status) { JobStatus::Status.find_by(job_id: enqueued_job.job_id) }
+
+    let(:enqueued_job) do
+      User.execute_as(user) { described_class.perform_later(user:, project:, source:, target:) }
+    end
+
+    # Stamped at enqueue rather than at start, so a settings page opened while
+    # the job is still queued can already name the switch.
+    it "names the project, the source and the target as soon as it is queued" do
+      expect(status.payload).to include("kind" => "type_switch",
+                                        "project_id" => project.id,
+                                        "source_id" => source.id,
+                                        "target_id" => target.id)
+    end
+
+    # Guards the same constraint as the example below, but fails fast: putting
+    # the project back here makes that one hang rather than fail.
+    it "leaves the uniquely indexed reference empty" do
+      expect(status.reference).to be_nil
+    end
+
+    # job_statuses has a unique index on (reference_type, reference_id), so
+    # carrying the project there made the second switch of a project raise
+    # RecordNotUnique — which upsert_status retries without bound.
+    it "can be queued again for the same project" do
+      status
+
+      expect { User.execute_as(user) { described_class.perform_later(user:, project:, source: target, target: source) } }
+        .to change(JobStatus::Status, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/FND-198

**Stacked on #24540 (FND-109)** — the base of this PR is that branch, so it needs to merge first. The diff here is the background execution only.

# What are you trying to accomplish?

- Run a project's type-variant switch in a background job rather than in the request.

Feedback is in-place state on the type row — a spinner plus "Switching to variant: …", keyed on the **project** rather than the user, so a colleague who did not start it sees it too.

A job-status dialog was built as the alternative so the two could be compared. **The designer chose the row indicator**, so the last commit removes the dialog.

## Screenshots

<img width="1116" height="510" alt="Screenshot of the spinner" src="https://github.com/user-attachments/assets/738bae7a-f69f-478a-867e-1a9861daede1" />

# What approach did you choose and why?

- **Debounce instead of WP count**:
   - Relies on perceived user-time: the request waits up to a second for the job's status row to settle. That duration is arbitrary and the constant can be easily changed.
   - A first commit gated on a work package count (`BACKGROUND_THRESHOLD`); the debounce replaces it, since process time per WP can’t be steadily guessed.
- **The row names the target variant on its own** ("Switching to variant: Blueprint"), reusing the wording the settled row already uses rather than the composite name. Switching to the family parent leaves the project on no variant at all, so that case reads "Switching to:" instead.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) — Chrome only so far


