### PR TITLE
[Dream-780] Change action_label slot of BorderBoxList to a semantically more fitting one

### DIFF
--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -56,13 +56,10 @@ module OpenProject
       #   # @param title [String] header title.
       #   # @param show_drag_handle [Boolean] whether the header renders a
       #   #   leading drag handle.
-      #   # @param multi_line [Boolean] for collapsible headers, whether the
-      #   #   description renders on its own line. Pass `false` to render it
-      #   #   inline on the title row.
       #   # @param system_arguments [Hash] forwarded to {Header}. List wiring
       #   #   arguments are supplied internally.
       #   # @return [ViewComponent::Slot]
-      #   def with_header(title: nil, show_drag_handle: false, multi_line: true, **system_arguments, &block)
+      #   def with_header(title: nil, show_drag_handle: false, **system_arguments, &block)
       #   end
       renders_one :header, ->(**system_arguments) {
         system_arguments = system_arguments.except(:id, :list_id)

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -137,6 +137,9 @@
   &--actions,
   &--menu
     margin-left: var(--stack-gap-normal)
+
+  &--actions,
+  &--menu
     align-self: flex-start
 
   &--actions
@@ -144,9 +147,15 @@
     align-items: center
     gap: var(--stack-gap-condensed)
 
-  // An informational label has no room next to the title on a phone, so it
-  // is dropped there. Action buttons stay, as they are functional.
   &--label
+    display: flex
+    align-items: center
+    // A label's text is not length-constrained,
+    // so cap it (roughly 35 characters' worth)
+    .Label
+      max-width: 200px
+      @include text-shortener
+
     @media screen and (max-width: $breakpoint-sm)
       display: none
 

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -110,19 +110,19 @@
 
 .op-border-box-list-header
   display: grid
-  grid-template-columns: minmax(0, 1fr) minmax(5rem, max-content) auto
-  grid-template-areas: "heading actions menu" "description description description"
+  grid-template-columns: minmax(0, 1fr) auto auto auto
+  grid-template-areas: "heading label actions menu" "description description description description"
   align-items: center
 
   &_collapsible
-    grid-template-areas: "heading actions menu"
+    grid-template-areas: "heading label actions menu"
 
   &_with-drag-handle
-    grid-template-columns: 2rem minmax(0, 1fr) minmax(5rem, max-content) auto
-    grid-template-areas: "drag_handle heading actions menu" ". description description description"
+    grid-template-columns: 2rem minmax(0, 1fr) auto auto auto
+    grid-template-areas: "drag_handle heading label actions menu" ". description description description description"
     margin-left: calc(-1 * var(--stack-padding-normal))
     &.op-border-box-list-header_collapsible
-      grid-template-areas: "drag_handle heading actions menu"
+      grid-template-areas: "drag_handle heading label actions menu"
 
   &--drag_handle
     align-self: center
@@ -133,6 +133,7 @@
   &--heading
     min-width: 0
 
+  &--label,
   &--actions,
   &--menu
     margin-left: var(--stack-gap-normal)
@@ -143,17 +144,11 @@
     align-items: center
     gap: var(--stack-gap-condensed)
 
-    // A label-only area pins to the track end. It keeps the base flex-start
-    // anchor (not the -6px button nudge) so the label's centre lands on the
-    // same line as the adjacent kebab glyph, independent of the row height.
-    &:not(:has(.Button))
-      justify-self: end
-      margin-top: 0
-
-      // An informational label has no room next to the title on a phone, so it
-      // is dropped there. Action buttons stay, as they are functional.
-      @media screen and (max-width: $breakpoint-sm)
-        display: none
+  // An informational label has no room next to the title on a phone, so it
+  // is dropped there. Action buttons stay, as they are functional.
+  &--label
+    @media screen and (max-width: $breakpoint-sm)
+      display: none
 
   &--heading-line
     display: flex

--- a/app/components/open_project/common/border_box_list_component/header.html.erb
+++ b/app/components/open_project/common/border_box_list_component/header.html.erb
@@ -77,6 +77,12 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   <% end %>
 
+  <% if description? && !collapsible? %>
+    <% grid.with_area(:description) do %>
+      <%= description %>
+    <% end %>
+  <% end %>
+
   <% if label? %>
     <% grid.with_area(:label) do %>
       <%= label %>
@@ -94,12 +100,6 @@ See COPYRIGHT and LICENSE files for more details.
   <% if menu? %>
     <% grid.with_area(:menu) do %>
       <%= menu %>
-    <% end %>
-  <% end %>
-
-  <% if description? && !collapsible? %>
-    <% grid.with_area(:description) do %>
-      <%= description %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/open_project/common/border_box_list_component/header.html.erb
+++ b/app/components/open_project/common/border_box_list_component/header.html.erb
@@ -47,8 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
         render(
           Primer::OpenProject::BorderBox::CollapsibleHeader.new(
             collapsible_id:,
-            collapsed:,
-            multi_line:
+            collapsed:
           )
         ) do |collapsible|
       %>
@@ -78,9 +77,9 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   <% end %>
 
-  <% if description? && !collapsible? %>
-    <% grid.with_area(:description) do %>
-      <%= description %>
+  <% if label? %>
+    <% grid.with_area(:label) do %>
+      <%= label %>
     <% end %>
   <% end %>
 
@@ -95,6 +94,12 @@ See COPYRIGHT and LICENSE files for more details.
   <% if menu? %>
     <% grid.with_area(:menu) do %>
       <%= menu %>
+    <% end %>
+  <% end %>
+
+  <% if description? && !collapsible? %>
+    <% grid.with_area(:description) do %>
+      <%= description %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -89,21 +89,26 @@ module OpenProject
         #   # @return [ViewComponent::Slot]
         #   def with_action_button(**system_arguments, &block)
         #   end
-        #
-        #   # Adds a label to the header actions area.
-        #   #
-        #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Label`.
-        #   # @return [ViewComponent::Slot]
-        #   def with_action_label(**system_arguments, &block)
-        #   end
         renders_many :actions, types: {
           button: ->(scheme: DEFAULT_ACTION_SCHEME, **system_arguments) do
             Primer::Beta::Button.new(scheme:, **system_arguments)
-          end,
-          label: ->(**system_arguments) do
-            Primer::Beta::Label.new(**system_arguments)
           end
         }
+
+        # @!parse
+        #   # Adds an informational status label to the header.
+        #   #
+        #   # The label is right-aligned in the header and hidden on small
+        #   # screens, so it must only carry supplementary status and never be
+        #   # the sole affordance for an action.
+        #   #
+        #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Label`.
+        #   # @return [ViewComponent::Slot]
+        #   def with_label(**system_arguments, &block)
+        #   end
+        renders_one :label, ->(**system_arguments) do
+          Primer::Beta::Label.new(**system_arguments)
+        end
 
         attr_reader :count,
                     :count_label,
@@ -114,11 +119,9 @@ module OpenProject
                     :interactive,
                     :collapsed,
                     :collapsible,
-                    :show_drag_handle,
-                    :multi_line
+                    :show_drag_handle
 
         alias_method :show_drag_handle?, :show_drag_handle
-        alias_method :multi_line?, :multi_line
 
         attr_writer :collapsible_id
 
@@ -142,9 +145,6 @@ module OpenProject
         #   with a toggle button.
         # @param show_drag_handle [Boolean] whether the header renders a leading
         #   drag handle. Defaults to `false`.
-        # @param multi_line [Boolean] for collapsible headers, whether the
-        #   description renders on its own line and may wrap. Pass `false` to
-        #   render the description inline on the title row. Defaults to `true`.
         # @param system_arguments [Hash] forwarded to `Primer::Beta::BorderBox#with_header`.
         def initialize(
           title: nil,
@@ -158,7 +158,6 @@ module OpenProject
           collapsed: false,
           collapsible: false,
           show_drag_handle: false,
-          multi_line: true,
           **system_arguments
         )
           super()
@@ -175,7 +174,6 @@ module OpenProject
           @collapsed = collapsed
           @collapsible = collapsible
           @show_drag_handle = show_drag_handle
-          @multi_line = multi_line
           @system_arguments = system_arguments
         end
 

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -57,9 +57,9 @@ module WorkPackageTypes
       # collapsed header names it instead.
       def add_default_label(header, root)
         if root.is_default?
-          header.with_action_label { t("types.index.enabled_in_new_projects") }
+          header.with_label { t("types.index.enabled_in_new_projects") }
         elsif (variant = default_variant(root))
-          header.with_action_label(scheme: :secondary) do
+          header.with_label(scheme: :secondary) do
             t("types.index.variant_enabled_in_new_projects", name: variant.own_name)
           end
         end

--- a/lookbook/docs/components/border-box-list.md.erb
+++ b/lookbook/docs/components/border-box-list.md.erb
@@ -69,6 +69,7 @@ comparable lists should use headers.
 |---|---|
 | `with_title` | Block-based alternative to `title:`, for titles that need more than plain text. Takes precedence over `title:` |
 | `with_description` | Secondary content below the title, wrapped in `Primer::Beta::Text` with muted color by default. Accepts Primer system arguments |
+| `with_label` | Informational status label (`Primer::Beta::Label`) shown on the title row. Right-aligned, truncated when long, and hidden on small screens, so use it only for supplementary status, never as the sole affordance for an action |
 | `with_action_button` | Button rendered in the header actions area |
 | `with_menu` | Action menu rendered in the header actions area. Pass `button_aria_label:` for the trigger button |
 

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -154,7 +154,6 @@ module OpenProject
       # @param description text
       # @param interactive toggle
       # @param collapsible toggle
-      # @param multi_line toggle
       def playground(
         title_tag: :h4,
         count: :inferred,
@@ -164,8 +163,7 @@ module OpenProject
         header_padding: :inherit,
         description: PLAYGROUND_DESCRIPTION,
         interactive: false,
-        collapsible: false,
-        multi_line: true
+        collapsible: false
       )
         render OpenProject::Common::BorderBoxListComponent.new(
           container: "border-box-list-playground-preview",
@@ -178,7 +176,6 @@ module OpenProject
             title: "Playground list",
             title_tag: title_tag.to_sym,
             count: preview_count(count),
-            multi_line: boolean_preview_param(multi_line),
             count_arguments: {
               scheme: count_scheme.to_sym,
               hide_if_zero: boolean_preview_param(hide_zero_count),
@@ -216,20 +213,20 @@ module OpenProject
         end
       end
 
-      # @label With header action label
-      # Header action area holding a status label, optionally next to an action button.
+      # @label With header label
+      # Header holding a status label, optionally next to an action button.
       # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
       # @param with_action_button toggle
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
-      def with_header_action_label(
+      def with_header_label(
         label_scheme: :default,
         with_action_button: false,
         padding: :default,
         header_padding: :inherit
       )
-        render_action_label_list(
-          container: "border-box-list-header-action-label-preview",
+        render_label_list(
+          container: "border-box-list-header-label-preview",
           label_scheme:,
           with_action_button:,
           padding:,
@@ -238,21 +235,21 @@ module OpenProject
         )
       end
 
-      # @label With collapsible header action label
-      # The collapsible header renders through its own heading markup, so the action
+      # @label With collapsible header label
+      # The collapsible header renders through its own heading markup, so the
       # label alignment is worth checking separately.
       # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
       # @param with_action_button toggle
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
-      def with_collapsible_header_action_label(
+      def with_collapsible_header_label(
         label_scheme: :default,
         with_action_button: false,
         padding: :default,
         header_padding: :inherit
       )
-        render_action_label_list(
-          container: "border-box-list-collapsible-header-action-label-preview",
+        render_label_list(
+          container: "border-box-list-collapsible-header-label-preview",
           label_scheme:,
           with_action_button:,
           padding:,
@@ -281,8 +278,8 @@ module OpenProject
 
       private
 
-      def render_action_label_list(container:, label_scheme:, with_action_button:, padding:, header_padding:,
-                                   collapsible:)
+      def render_label_list(container:, label_scheme:, with_action_button:, padding:, header_padding:,
+                            collapsible:)
         render OpenProject::Common::BorderBoxListComponent.new(
           container:,
           padding:,
@@ -290,7 +287,7 @@ module OpenProject
           collapsible:
         ) do |list|
           list.with_header(title: "Bug", count: true) do |header|
-            header.with_action_label(scheme: label_scheme) { "Default" }
+            header.with_label(scheme: label_scheme) { "Default" }
             if boolean_preview_param(with_action_button)
               header.with_action_button do |button|
                 button.with_leading_visual_icon(icon: :pencil)

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -215,11 +215,13 @@ module OpenProject
 
       # @label With header label
       # Header holding a status label, optionally next to an action button.
+      # @param label text
       # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
       # @param with_action_button toggle
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
       def with_header_label(
+        label: "Default",
         label_scheme: :default,
         with_action_button: false,
         padding: :default,
@@ -227,6 +229,7 @@ module OpenProject
       )
         render_label_list(
           container: "border-box-list-header-label-preview",
+          label:,
           label_scheme:,
           with_action_button:,
           padding:,
@@ -238,11 +241,13 @@ module OpenProject
       # @label With collapsible header label
       # The collapsible header renders through its own heading markup, so the
       # label alignment is worth checking separately.
+      # @param label text
       # @param label_scheme [Symbol] select [default, primary, secondary, accent, success, attention, severe, danger]
       # @param with_action_button toggle
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
       def with_collapsible_header_label(
+        label: "Default",
         label_scheme: :default,
         with_action_button: false,
         padding: :default,
@@ -250,6 +255,7 @@ module OpenProject
       )
         render_label_list(
           container: "border-box-list-collapsible-header-label-preview",
+          label:,
           label_scheme:,
           with_action_button:,
           padding:,
@@ -278,7 +284,7 @@ module OpenProject
 
       private
 
-      def render_label_list(container:, label_scheme:, with_action_button:, padding:, header_padding:,
+      def render_label_list(container:, label:, label_scheme:, with_action_button:, padding:, header_padding:,
                             collapsible:)
         render OpenProject::Common::BorderBoxListComponent.new(
           container:,
@@ -287,7 +293,7 @@ module OpenProject
           collapsible:
         ) do |list|
           list.with_header(title: "Bug", count: true) do |header|
-            header.with_label(scheme: label_scheme) { "Default" }
+            header.with_label(scheme: label_scheme) { label }
             if boolean_preview_param(with_action_button)
               header.with_action_button do |button|
                 button.with_leading_visual_icon(icon: :pencil)

--- a/spec/components/open_project/common/border_box_list_component_preview_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_preview_spec.rb
@@ -99,28 +99,28 @@ RSpec.describe OpenProject::Common::BorderBoxListComponentPreview, type: :compon
     expect(page).to have_css(".Box.Box--condensed.op-border-box-list_header-padding-default")
   end
 
-  it "renders the header action label preview" do
-    render_preview(:with_header_action_label, from: described_class)
+  it "renders the header label preview" do
+    render_preview(:with_header_label, from: described_class)
 
-    expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
+    expect(page).to have_css(".op-border-box-list-header--label .Label", text: "Default")
     expect(page).to have_no_css(".op-border-box-list-header--actions .Button")
   end
 
-  it "renders the header action label preview alongside an action button" do
+  it "renders the header label preview alongside an action button" do
     render_preview(
-      :with_header_action_label,
+      :with_header_label,
       from: described_class,
       params: { with_action_button: true }
     )
 
-    expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
+    expect(page).to have_css(".op-border-box-list-header--label .Label", text: "Default")
     expect(page).to have_css(".op-border-box-list-header--actions .Button", text: "Edit")
   end
 
-  it "renders the collapsible header action label preview" do
-    render_preview(:with_collapsible_header_action_label, from: described_class)
+  it "renders the collapsible header label preview" do
+    render_preview(:with_collapsible_header_label, from: described_class)
 
     expect(page).to have_css(".op-border-box-list-header_collapsible")
-    expect(page).to have_css(".op-border-box-list-header--actions .Label", text: "Default")
+    expect(page).to have_css(".op-border-box-list-header--label .Label", text: "Default")
   end
 end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -230,6 +230,23 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_button("Edit")
     end
 
+    it "renders a status label in its own header area" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-label")
+      ) do |list|
+        list.with_header(title: "Bug") do |header|
+          header.with_label(scheme: :success) { "Enabled" }
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css(
+        ".op-border-box-list-header--label .Label.Label--success",
+        text: "Enabled"
+      )
+      expect(rendered).to have_no_css(".op-border-box-list-header--actions .Label")
+    end
+
     it "renders a menu in the header" do
       rendered = render_inline(
         described_class.new(container: "hdr-menu")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-780

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

- [X] Add a dedicated with_label slot to the BorderBoxListComponent header.
- [X] Remove multi_line description support from the header.
