### PR TITLE
Improve efficiency of MCP request handling

### DIFF
--- a/app/services/mcp_resources.rb
+++ b/app/services/mcp_resources.rb
@@ -46,12 +46,22 @@ module McpResources
       @resources_by_name ||= all.index_by(&:qualified_name)
     end
 
-    def enabled_resources
-      enabled.select(&:uri)
+    def enabled_mcp_resources
+      McpConfiguration.where(enabled: true).filter_map do |config|
+        res = resources_by_name[config.identifier]
+        next nil if res.nil? || res.uri.nil?
+
+        res.resource(title: config.title, description: config.description)
+      end
     end
 
-    def enabled_resource_templates
-      enabled.select(&:uri_template)
+    def enabled_mcp_resource_templates
+      McpConfiguration.where(enabled: true).filter_map do |config|
+        res = resources_by_name[config.identifier]
+        next nil if res.nil? || res.uri_template.nil?
+
+        res.resource_template(title: config.title, description: config.description)
+      end
     end
 
     def read_resource(uri)

--- a/app/services/mcp_resources.rb
+++ b/app/services/mcp_resources.rb
@@ -49,7 +49,7 @@ module McpResources
     def enabled_mcp_resources
       McpConfiguration.where(enabled: true).filter_map do |config|
         res = resources_by_name[config.identifier]
-        next nil if res.nil? || res.uri.nil?
+        next unless res&.uri
 
         res.resource(title: config.title, description: config.description)
       end
@@ -58,7 +58,7 @@ module McpResources
     def enabled_mcp_resource_templates
       McpConfiguration.where(enabled: true).filter_map do |config|
         res = resources_by_name[config.identifier]
-        next nil if res.nil? || res.uri_template.nil?
+        next unless res&.uri_template
 
         res.resource_template(title: config.title, description: config.description)
       end

--- a/app/services/mcp_resources/base.rb
+++ b/app/services/mcp_resources/base.rb
@@ -69,32 +69,26 @@ module McpResources
         UriTemplate.new("#{Setting.protocol}://#{Setting.host_name}#{@template_suffix}")
       end
 
-      def resource
+      def resource(title:, description:)
         raise ArgumentError, "#{self.class.name} can't be used as resource, uri is blank" if uri.blank?
-
-        config = McpConfiguration.find_by(identifier: qualified_name)
-        return nil if config.nil?
 
         MCP::Resource.new(
           uri:,
           name:,
-          title: config.title,
-          description: config.description,
+          title:,
+          description:,
           mime_type: "application/json"
         )
       end
 
-      def resource_template
+      def resource_template(title:, description:)
         raise ArgumentError, "#{self.class.name} can't be used as resource_template, uri_template is blank" if uri_template.blank?
-
-        config = McpConfiguration.find_by(identifier: qualified_name)
-        return nil if config.nil?
 
         MCP::ResourceTemplate.new(
           uri_template:,
           name:,
-          title: config.title,
-          description: config.description,
+          title:,
+          description:,
           mime_type: "application/json"
         )
       end

--- a/app/services/mcp_tools.rb
+++ b/app/services/mcp_tools.rb
@@ -38,8 +38,10 @@ module McpTools
       @all ||= []
     end
 
-    def enabled
-      McpConfiguration.where(enabled: true).pluck(:identifier).filter_map { |name| tools_by_name[name] }
+    def enabled_mcp_tools
+      McpConfiguration.where(enabled: true).filter_map do |config|
+        tools_by_name[config.identifier]&.tool(title: config.title, description: config.description)
+      end
     end
 
     def tools_by_name

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -148,15 +148,12 @@ module McpTools
         @annotations
       end
 
-      def tool
-        config = McpConfiguration.find_by(identifier: qualified_name)
-        return nil if config.nil?
-
+      def tool(title:, description:)
         implementation = self
         MCP::Tool.define(
           name:,
-          title: config.title,
-          description: config.description,
+          title:,
+          description:,
           input_schema:,
           annotations: read_annotations
         ) do |server_context: {}, **opts|

--- a/lib/api/mcp.rb
+++ b/lib/api/mcp.rb
@@ -54,9 +54,9 @@ module API
         title: server_config.title,
         # description: server_config.description, # not yet supported by mcp gem
         version: "1.0.0",
-        tools: McpTools.enabled.map(&:tool),
-        resources: McpResources.enabled_resources.map(&:resource),
-        resource_templates: McpResources.enabled_resource_templates.map(&:resource_template),
+        tools: McpTools.enabled_mcp_tools,
+        resources: McpResources.enabled_mcp_resources,
+        resource_templates: McpResources.enabled_mcp_resource_templates,
         server_context: { current_user: User.current }
       )
 


### PR DESCRIPTION
Previously we performed one SQL query per defined MCP tool and resource on each request, due to the way how MCP tools and resources have been connected to their database entities. Those N+1 queries have now been resolved, so the number of registered tools has no influence on the number of SQL requests.

# Review note

The one caveat that becomes even more visible now (but was already a problem before), is naming. On the example of tools:

Each implementation of `McpTools::Base` implements a method called `tool` and it returns an `MCP::Tool`. What happens here is that we built an interface between OpenProject (which defines `McpTools`) and a gem handling MCP (which defines `MCP::Tool`). This is a name conflict that's not easy to resolve, because what we define on the OpenProject side is the _implementation_ of the various MCP tools, but `MCP::Tool` carries it towards the gem via `MCP::Server`.

The methods that were touched in this PR (e.g. `McpTools.enabled`) used to return instances of `McpTools::Base` and were used to map towards an array of `MCP::Tool`. They have now been renamed to have `mcp_` in their name, to indicate that they return objects of the `mcp` gem directly. But I think there's no way to really make this clear. I am open to suggestions beyond "this is confusing" :D