### PR TITLE
Adding mobile app documentation for Login Troubleshooting on Certificate Chain

### DIFF
--- a/docs/mobile-app-guide/first-steps/login-troubleshooting/README.md
+++ b/docs/mobile-app-guide/first-steps/login-troubleshooting/README.md
@@ -15,7 +15,7 @@ If you’re having trouble logging into the **OpenProject Mobile App**, the foll
 **Symptom:**  
 You see a browser error such as _“The site can't be reached. The server address could not be found”_.
 
-**Cause:**  
+**Possible cause:**  
 The URL you entered may be incorrect, inaccessible, or not using HTTPS.
 
 **Possible Solution:**
@@ -29,7 +29,7 @@ The URL you entered may be incorrect, inaccessible, or not using HTTPS.
 **Symptom:**  
 Login fails with a browser error such as _“An authorization error has occurred. The client is not authorized to perform this request using this method.”, or you are redirected back to the login screen without authentication.
 
-**Cause:**  
+**Possible cause:**  
 The mobile app uses OAuth 2.0 for secure authentication. If the built-in OAuth applications are not enabled in your instance, the app cannot log you in.
 
 **Possible Solution:**
@@ -39,12 +39,36 @@ The mobile app uses OAuth 2.0 for secure authentication. If the built-in OAuth a
 2. Make sure that **Built-in OAuth applications** are enabled.
 3. If you don’t have admin rights, contact your OpenProject administrator.
 
+## TLS error in the app but the site opens in a browser (incomplete certificate chain)
+
+**Symptom:**  
+You cannot sign in to the mobile app against a self-hosted OpenProject instance. The app reports a TLS/certificate verification error or a generic “Unable to sign in” message, even though the OpenProject URL opens normally in a web browser.
+
+**Possible cause:**  
+Your server is serving an **incomplete TLS certificate chain**, only the server (leaf) certificate, without the intermediate CA certificate(s) needed to link it to a trusted root.
+
+Browsers often *hide* this issue because they can download missing intermediate certificates automatically (AIA fetching) or reuse cached intermediates. **Mobile app HTTP clients typically require the server to present the full chain during the TLS handshake**, so the same server can work in a browser but fail in the app. This is a **server configuration issue**.
+
+**How to confirm:**
+- **Online:** Run the SSL Labs Server Test: https://www.ssllabs.com/ssltest/analyze.html?d=YOUR_INSTANCE_DOMAIN. If you see **“Chain issues: Incomplete”**, this is likely the cause.
+- **Command line:**
+```openssl s_client -connect your-server.com:443 -servername your-server.com </dev/null```. In the output, check the Certificate chain section. If it lists only entry `0` (the leaf certificate) with no intermediate entries (`1`, `2`, …), or you see: `Verify return code: 21 (unable to verify the first certificate)`, then the **chain is incomplete**.
+
+**Possible Solution:**
+Configure your web server/proxy to serve the **full certificate chain** (leaf certificate **followed** by the intermediate certificate(s)):
+- **nginx**: ensure `ssl_certificate` points to a full-chain bundle, not a leaf-only file. For example: ```cat your_domain.crt intermediate.crt > fullchain.crt```
+- **Let’s Encrypt/Certbot**: use `fullchain.pem`, not `cert.pem`.
+- **Apache**: provide the intermediate certificate(s) via `SSLCertificateFile` (bundle) or `SSLCertificateChainFile` (older setups).
+- **Load balancer/reverse proxy/CDN (AWS ALB, HAProxy, Cloudflare, IIS, …)**: make sure the **intermediate certificate** field is not empty.
+
+After updating the configuration, re-run the SSL Labs test to confirm the chain issue is resolved, then try signing in again from the app.
+
 ## Instance Not on Minimum Supported Version
 
 **Symptom:**  
 You know that your instance is running not on the minimum supported version, OpenProject 17.0.0, and the login fails with a browser error such as _“An authorization error has occurred. The client is not authorized to perform this request using this method.”_.
 
-**Cause:**  
+**Possible cause:**  
 The OpenProject Mobile App requires your instance to be on **OpenProject version 17.0.0 or higher**.  
 If your instance is running an older version, OAuth authentication may be disabled by default.
 
@@ -63,7 +87,7 @@ If your instance is running an older version, OAuth authentication may be disabl
 **Symptom:**  
 You receive a browser error message such as _“Secure connection failed. Untrusted certificate”_.
 
-**Cause:**  
+**Possible cause:**  
 Your OpenProject instance must use a **valid, signed SSL certificate** (HTTPS). Self-signed certificates or expired certificates are not supported.
 
 **Possible Solution:**
@@ -76,7 +100,7 @@ Your OpenProject instance must use a **valid, signed SSL certificate** (HTTPS). 
 **Symptom:**  
 You see _“Invalid username or password”_ when logging in.
 
-**Cause:**  
+**Possible cause:**  
 Your login credentials are incorrect or have been changed.
 
 **Possible Solution:**
@@ -90,7 +114,7 @@ Your login credentials are incorrect or have been changed.
 **Symptom:**  
 Login attempts fail with no clear error message.
 
-**Cause:**  
+**Possible cause:**  
 Your on-premises OpenProject instance may have **API access disabled**, preventing the mobile app from connecting.
 
 **Possible Solution:**
@@ -105,7 +129,7 @@ Your on-premises OpenProject instance may have **API access disabled**, preventi
 **Symptom:**  
 You receive a browser error message such as _“Secure connection failed. Untrusted certificate”_.
 
-**Cause:**  
+**Possible cause:**  
 The mobile app only supports secure connections via **HTTPS**.
 
 **Possible Solution:**
@@ -118,7 +142,7 @@ The mobile app only supports secure connections via **HTTPS**.
 **Symptom:**  
 Login attempts time out or fail when using certain networks with an error such as “Login time out. Check your network”.
 
-**Cause:**  
+**Possible cause:**  
 Corporate or restricted networks may block outbound requests to your OpenProject instance or authentication endpoints.
 
 **Possible Solution:**


### PR DESCRIPTION
After detecting a common error on the OAuth we added the documentation for the possible error cause, how to verify it and how to fix into the Troubleshooting page.

# Ticket
https://community.openproject.org/wp/MAF-112

# What are you trying to accomplish?
Changing the documentation to add a missing Login error case

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
