### PR TITLE
[FND-200] Properly look up active variant in work package creation context

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -206,12 +206,15 @@ module WorkPackages
 
     def assignable_types
       scope = if model.project.nil?
-                Type
+                # Variants are collapsed into their root outside of a project
+                # context, where there is no way to tell which one applies.
+                Type.roots
               else
-                model.project.types.includes(:color)
+                model.project.types
               end
 
-      scope.includes(:color)
+      # A variant reads its name and color off its root, so the parent is preloaded along with them.
+      scope.includes(:color, parent: :color)
     end
 
     def assignable_categories

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -213,8 +213,11 @@ module WorkPackages
                 model.project.types
               end
 
-      # A variant reads its name and color off its root, so the parent is preloaded along with them.
-      scope.includes(:color, parent: :color)
+      # A variant reads its name and color off its root, so the parent is loaded along
+      # with them. Deliberately #preload and not #includes: callers that pluck off this
+      # scope (BCF project extensions) would have Rails self-join types for the parent,
+      # making the unqualified ORDER BY of Type's default scope ambiguous.
+      scope.preload(:color, parent: :color)
     end
 
     def assignable_categories

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -61,14 +61,13 @@ module WorkPackages::Dialogs
           data: { test_selector: "work_package_create_dialog_type" }
         }
       ) do |select|
-        contract
-          .assignable_types
-          .pluck(:id, :name)
-          .map do |value, label|
-          select.option(label:,
-                        value:,
-                        classes: "__hl_inline_type_#{value}",
-                        selected: work_package.type_id == value)
+        # Reads #name off the record rather than plucking the column, so a variant
+        # is labelled with the name of its root.
+        contract.assignable_types.each do |type|
+          select.option(label: type.name,
+                        value: type.id,
+                        classes: "__hl_inline_type_#{type.id}",
+                        selected: work_package.type_id == type.id)
         end
       end
 

--- a/app/models/queries/projects/filters/type_filter.rb
+++ b/app/models/queries/projects/filters/type_filter.rb
@@ -80,8 +80,9 @@ class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
   end
 
   # Reads #name so a value naming a variant is labelled with the name of its root,
-  # which is preloaded for the same reason.
+  # which is loaded along with it. #preload rather than #includes so no caller can
+  # turn this into a self-join of types (see WorkPackages::BaseContract#assignable_types).
   def selected_items
-    Type.where(id: values).includes(:parent).map { |type| { name: type.name, id: type.id } }
+    Type.where(id: values).preload(:parent).map { |type| { name: type.name, id: type.id } }
   end
 end

--- a/app/models/queries/projects/filters/type_filter.rb
+++ b/app/models/queries/projects/filters/type_filter.rb
@@ -29,6 +29,9 @@
 #++
 
 class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
+  # Any family member is a valid value, not just the roots offered by
+  # #autocomplete_options: the project field on the global create form filters by
+  # the root before a project is picked and by the resolved variant afterwards.
   def allowed_values
     @allowed_values ||= Type.pluck(:name, :id)
   end
@@ -37,8 +40,11 @@ class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
     :types
   end
 
+  # A project activates a single member of a type family, which may be a variant
+  # while the value filtered for is its root. Matching the whole family keeps
+  # variants transparent, e.g. for the project field on the global create form.
   def where
-    operator_strategy.sql_for_field(values, Type.table_name, :id)
+    operator_strategy.sql_for_field(expanded_values, Type.table_name, :id)
   end
 
   def type
@@ -46,19 +52,36 @@ class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
   end
 
   def autocomplete_options
-    all_items = allowed_values.map { |name, id| { name:, id: } }
     {
       component: "opce-autocompleter",
       bindValue: "id",
       bindLabel: "name",
       hideSelected: true,
       defaultData: false,
-      items: all_items,
-      model: all_items.select { |item| values.include?(item[:id]) }
+      items: selectable_items,
+      model: selected_items
     }
   end
 
   def self.key
     :type_id
+  end
+
+  private
+
+  def expanded_values
+    Type.family_ids(values).presence || values
+  end
+
+  # Only roots are offered as variants are collapsed into them, and filtering for
+  # a root matches its variants anyway.
+  def selectable_items
+    Type.roots.pluck(:name, :id).map { |name, id| { name:, id: } }
+  end
+
+  # Reads #name so a value naming a variant is labelled with the name of its root,
+  # which is preloaded for the same reason.
+  def selected_items
+    Type.where(id: values).includes(:parent).map { |type| { name: type.name, id: type.id } }
   end
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -122,6 +122,14 @@ class Type < ApplicationRecord
     roots.includes(:children).flat_map(&:family)
   end
 
+  # Ids of every member of the families the given ids belong to. Variants are
+  # transparent to users, so a filter naming one member has to match them all.
+  def self.family_ids(ids)
+    root_ids = where(id: ids).pluck(Arel.sql("COALESCE(parent_id, id)")).uniq
+
+    where(id: root_ids).or(where(parent_id: root_ids)).pluck(:id)
+  end
+
   def <=>(other)
     name <=> other.name
   end
@@ -195,6 +203,10 @@ class Type < ApplicationRecord
 
   def root
     parent || self
+  end
+
+  def root_id
+    parent_id || id
   end
 
   def variant?

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -94,6 +94,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     update_derivable_date_attribute
     update_progress_attributes
     update_project_dependent_attributes
+    resolve_type_within_family
     reassign_invalid_status_if_type_changed
     set_templated_description
     set_cause_for_readonly_attributes
@@ -282,6 +283,32 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
       assign_default_type unless work_package.type
     end
+  end
+
+  # Outside of a project only root types are offered (see the types API), while a
+  # project runs a single member of a family, possibly a variant. Following that
+  # member keeps variants transparent when the type is picked before the project,
+  # as on the global create form, and when moving between projects.
+  def resolve_type_within_family
+    return unless work_package.type_id_changed? || work_package.project_id_changed?
+
+    family_member = enabled_family_member
+    return if family_member.nil?
+
+    model.change_by_system { work_package.type = family_member }
+  end
+
+  # The member of the type's family the project has enabled, or nil if that is the
+  # type itself or no member of the family is enabled at all.
+  def enabled_family_member
+    type = work_package.type
+    project = work_package.project
+    return if type.nil? || project.nil?
+
+    enabled_types = project.types.to_a
+    return if enabled_types.include?(type)
+
+    enabled_types.detect { |enabled| enabled.root_id == type.root_id }
   end
 
   # The identifier belongs to the source project; a fresh one is allocated

--- a/spec/components/work_packages/dialogs/create_form_component_spec.rb
+++ b/spec/components/work_packages/dialogs/create_form_component_spec.rb
@@ -63,4 +63,18 @@ RSpec.describe WorkPackages::Dialogs::CreateFormComponent, type: :component do
       expect(page.find('input[name="work_package[subject]"]')).to be_disabled
     end
   end
+
+  context "when the project runs a variant", with_flag: { type_variants: true } do
+    let(:root_type) { create(:type, name: "Bug") }
+    let(:variant) { create(:type, name: "Mobile Bug", parent: root_type) }
+    let(:work_package) { create(:work_package, type: variant, project: create(:project, types: [variant])) }
+
+    it "labels the type with the name of its root" do
+      render_component
+
+      items = JSON.parse(page.find("opce-autocompleter[data-test-selector='work_package_create_dialog_type']")["data-items"])
+
+      expect(items).to contain_exactly(a_hash_including("id" => variant.id, "name" => "Bug"))
+    end
+  end
 end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1930,9 +1930,9 @@ RSpec.describe WorkPackages::BaseContract do
         work_package.project = nil
       end
 
-      it "is all types" do
+      it "is the root types as there is no project telling which variant applies" do
         allow(Type)
-          .to receive(:includes)
+          .to receive(:roots)
           .and_return(scope)
 
         expect(contract.assignable_types)
@@ -1948,6 +1948,22 @@ RSpec.describe WorkPackages::BaseContract do
 
         expect(contract.assignable_types)
           .to eql(scope)
+      end
+    end
+
+    context "when the project runs variants", with_flag: { type_variants: true } do
+      # One variant per family, as a project runs a single member of each.
+      let(:variants) { create_list(:type, 5).map { |root| create(:type, parent: root) } }
+
+      before do
+        work_package.project = create(:project, types: variants)
+      end
+
+      # A variant reads its name and color off its root, so the query count has to
+      # stay independent of the number of types.
+      it "preloads the roots the names and colors are read from" do
+        expect { contract.assignable_types.each { |type| [type.name, type.color] } }
+          .to have_a_query_limit(3)
       end
     end
   end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1920,7 +1920,7 @@ RSpec.describe WorkPackages::BaseContract do
     let(:scope) do
       instance_double(ActiveRecord::Querying).tap do |s|
         allow(s)
-          .to receive(:includes)
+          .to receive(:preload)
           .and_return(s)
       end
     end

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -414,6 +414,28 @@ RSpec.describe "new work package", :js do
         expect(page).to have_no_css(".ng-dropdown-panel .ng-option", text: project_without_bug.name)
       end
     end
+
+    # Only root types are offered here, so a project running a variant of the
+    # picked type has to be offered and create a work package of that variant,
+    # variants being transparent to users (FND-200).
+    context "with a project running a variant of type_bug", with_flag: { type_variants: true } do
+      let!(:variant) { create(:type, name: "Mobile Bug", parent: type_bug) }
+      let!(:variant_project) do
+        create(:project, name: "Variant project", types: [variant])
+      end
+      let(:user) do
+        create(:user, member_with_permissions: { project => permissions, variant_project => permissions })
+      end
+
+      it "shows the project and creates the work package with the variant" do
+        create_work_package_globally(type_bug, variant_project.name)
+        expect(page).to have_selector(safeguard_selector, wait: 10)
+
+        save_work_package!
+
+        expect(WorkPackage.last.type).to eq variant
+      end
+    end
   end
 
   context "as a user with no permissions" do

--- a/spec/models/queries/projects/filters/type_filter_spec.rb
+++ b/spec/models/queries/projects/filters/type_filter_spec.rb
@@ -50,4 +50,66 @@ RSpec.describe Queries::Projects::Filters::TypeFilter do
       end
     end
   end
+
+  describe "filtering" do
+    shared_let(:root_type) { create(:type, name: "Bug") }
+    shared_let(:variant) { create(:type, name: "Mobile Bug", parent: root_type) }
+    shared_let(:other_type) { create(:type, name: "Task") }
+
+    shared_let(:project_with_root) { create(:project, types: [root_type]) }
+    shared_let(:project_with_variant) { create(:project, types: [variant]) }
+    shared_let(:project_with_other_type) { create(:project, types: [other_type]) }
+
+    current_user { create(:admin) }
+
+    def results_for(*types)
+      ProjectQuery
+        .new
+        .tap { |query| query.where(:type_id, "=", types.map { |type| type.id.to_s }) }
+        .results
+    end
+
+    it "finds projects running any member of the family of the filtered type" do
+      expect(results_for(root_type)).to contain_exactly(project_with_root, project_with_variant)
+      expect(results_for(variant)).to contain_exactly(project_with_root, project_with_variant)
+    end
+
+    it "keeps types of other families out" do
+      expect(results_for(other_type)).to contain_exactly(project_with_other_type)
+    end
+
+    it "finds no projects for a type that does not exist" do
+      query = ProjectQuery.new
+      query.where(:type_id, "=", [(Type.maximum(:id) + 1).to_s])
+
+      expect(query.results).to be_empty
+    end
+  end
+
+  describe "#autocomplete_options" do
+    shared_let(:root_type) { create(:type, name: "Bug") }
+    shared_let(:variant) { create(:type, name: "Mobile Bug", parent: root_type) }
+
+    subject(:options) { described_class.create!(name: :type_id, operator: "=", values:).autocomplete_options }
+
+    context "with a root type selected" do
+      let(:values) { [root_type.id.to_s] }
+
+      it "offers roots only, variants being collapsed into them" do
+        expect(options[:items]).to contain_exactly({ name: "Bug", id: root_type.id })
+      end
+
+      it "has the selected type as its model" do
+        expect(options[:model]).to contain_exactly({ name: "Bug", id: root_type.id })
+      end
+    end
+
+    context "with a variant selected" do
+      let(:values) { [variant.id.to_s] }
+
+      it "labels it with the name of its root" do
+        expect(options[:model]).to contain_exactly({ name: "Bug", id: variant.id })
+      end
+    end
+  end
 end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -411,6 +411,41 @@ RSpec.describe Type do
       end
     end
 
+    describe "#root_id" do
+      it "returns the parent's id for a child" do
+        expect(child.root_id).to eq(parent.id)
+      end
+
+      it "returns its own id for a root" do
+        expect(parent.root_id).to eq(parent.id)
+      end
+    end
+
+    describe ".family_ids" do
+      let!(:other) { create(:type) }
+
+      it "returns every member of the family of a root" do
+        expect(described_class.family_ids([parent.id])).to contain_exactly(parent.id, child.id)
+      end
+
+      it "returns every member of the family of a variant" do
+        expect(described_class.family_ids([child.id])).to contain_exactly(parent.id, child.id)
+      end
+
+      it "accepts ids as strings, as filters hold them" do
+        expect(described_class.family_ids([child.id.to_s])).to contain_exactly(parent.id, child.id)
+      end
+
+      it "combines the families of all given ids without duplicates" do
+        expect(described_class.family_ids([parent.id, child.id, other.id]))
+          .to contain_exactly(parent.id, child.id, other.id)
+      end
+
+      it "is empty for ids that do not exist" do
+        expect(described_class.family_ids([described_class.maximum(:id) + 1])).to be_empty
+      end
+    end
+
     # Isolated from the shared parent/child so the factory's generated names
     # cannot land between the names under test.
     describe "#sorted_variants" do

--- a/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
@@ -67,6 +67,17 @@ RSpec.describe API::V3::WorkPackages::AvailableProjectsOnCreateAPI do
     it_behaves_like "API V3 collection response", 1, 1, "Project" do
       let(:elements) { [project_with_type] }
     end
+
+    # Types are picked as roots outside of a project context, so a project running
+    # a variant of the filtered type has to be offered as well.
+    context "when the project runs a variant of the filtered type" do
+      let(:variant) { create(:type, parent: type) }
+      let(:project_with_type) { create(:project, types: [variant]) }
+
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [project_with_type] }
+      end
+    end
   end
 
   describe "with a single project" do

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -110,6 +110,39 @@ RSpec.describe "POST api/v3/workspaces/:id/work_packages/form" do
     end
   end
 
+  # The global create form offers root types only, so picking a project that runs a
+  # variant of the chosen type has to resolve to that variant (FND-200).
+  describe "with a project running a variant of the provided type" do
+    shared_let(:root_type) { create(:type, name: "Bug") }
+    shared_let(:variant) { create(:type, name: "Mobile Bug", parent: root_type) }
+    shared_let(:variant_project) { create(:project, types: [variant]) }
+
+    let(:parameters) do
+      {
+        _links: {
+          project: { href: api_v3_paths.project(variant_project.id) },
+          type: { href: api_v3_paths.type(root_type.id) }
+        },
+        subject: "lorem ipsum"
+      }
+    end
+
+    it "has 0 validation errors" do
+      expect(subject.body).to have_json_size(0).at_path("_embedded/validationErrors")
+    end
+
+    it "resolves the type to the variant while keeping the name of its root" do
+      type_link = {
+        href: api_v3_paths.type(variant.id),
+        title: root_type.name
+      }
+
+      expect(subject.body)
+        .to be_json_eql(type_link.to_json)
+        .at_path("_embedded/payload/_links/type")
+    end
+  end
+
   describe "with targetVersions (e.g. when duplicating a work package)" do
     shared_let(:version) { create(:version, project:) }
 

--- a/spec/services/work_packages/create_service_integration_spec.rb
+++ b/spec/services/work_packages/create_service_integration_spec.rb
@@ -117,6 +117,22 @@ RSpec.describe WorkPackages::CreateService, "integration", type: :model do
     end
   end
 
+  # The type is picked before the project on the global create form, where only
+  # root types are offered (FND-200).
+  context "when the project runs a variant of the provided type", with_flag: { type_variants: true } do
+    let(:variant) { create(:type, parent: default_type) }
+    let(:project) { create(:project, types: [variant]) }
+    let(:attributes) do
+      { subject: "blubs", project:, type: default_type }
+    end
+
+    it "creates the work package with the variant" do
+      expect(service_result).to be_success
+      expect(service_result.errors).to be_empty
+      expect(new_work_package.type).to eql variant
+    end
+  end
+
   describe "#call" do
     let(:attributes) do
       { subject: "blubs",

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -385,6 +385,25 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
         end
       end
 
+      # Variants are transparent to users, so the type follows the member of its
+      # family the target project runs (FND-200).
+      context "with a variant of the type existing in the target project",
+              with_flag: { type_variants: true } do
+        shared_let(:variant) { create(:type, parent: default_type) }
+
+        before do
+          target_project.types << variant
+        end
+
+        it "switches to the variant" do
+          expect(subject)
+            .to be_success
+
+          expect(subject.result.type)
+            .to eql variant
+        end
+      end
+
       context "with only non default types" do
         before do
           target_project.types << other_type


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/FND-200

# What was wrong

Two independent breakages on the same path:

1. `Queries::Projects::Filters::TypeFilter` matched `projects_types.type_id` literally, so a project running a variant was invisible to a filter for the root.
2. Even with the project selectable, creation failed: "Type is not set to one of the allowed values.", because the WP would have been created with the root type in a project that doesn't have it enabled but only a variant.

# Changes

`app/models/type.rb` — `#root_id` next to the existing `#root`, and `.family_ids(ids)` returning every member of the families the given ids belong to.

`app/models/queries/projects/filters/type_filter.rb` — `#where` filters on the expanded family. `allowed_values` deliberately stays all types (the List strategy validates values against it, and the form legitimately filters by a variant id once resolution has happened); the roots-only restriction moved to `autocomplete_options`, whose items are now roots and whose model reads `Type#name`, so a value naming a variant is labelled with its root instead of leaking the variant's own name.

`app/services/work_packages/set_attributes_service.rb` — `resolve_type_within_family` follows the family member the project is using, inside `change_by_system`, on any type/project change. Placed before `reassign_invalid_status_if_type_changed` so the status is re-validated against the resolved type. It also fixes moving a WP into a project running a different family member, which previously just errored.

`app/contracts/work_packages/base_contract.rb` — Assignable types default to `Type.roots` when there's no project, so the global form's type dropdown no longer lists variants as duplicate root names. Preloads `:color, parent: :color` since a variant reads both off its root — this feeds both the API schema representer and the create dialog.

`app/forms/work_packages/dialogs/create_form.rb` — reads `type.name` off the record instead of `pluck(:id, :name)`, which bypassed the `#name` override and showed the variant's own name in the project-scoped dialog.