### PR TITLE
[COMMS-943] clarify that project identifiers are non confidential when project based semantic work package identifiers are used

### DIFF
--- a/app/components/projects/settings/change_identifier_dialog_component.html.erb
+++ b/app/components/projects/settings/change_identifier_dialog_component.html.erb
@@ -27,19 +27,24 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(Primer::Alpha::Dialog.new(
-      id: "change-identifier-dialog",
-      title: t("projects.settings.change_identifier_dialog_title")
-    )) do |dialog| %>
+<%= render(
+      Primer::Alpha::Dialog.new(
+        id: "change-identifier-dialog",
+        title: t("projects.settings.change_identifier_dialog_title"),
+        size: :medium_portrait
+      )
+    ) do |dialog| %>
   <% dialog.with_body do %>
     <%= render(Primer::Alpha::Banner.new(scheme: :warning, mb: 3)) do %>
       <%= t("projects.settings.change_identifier_warning") %>
     <% end %>
 
-    <%= settings_primer_form_with(model: project,
-                                  url: project_identifier_path(project),
-                                  id: "change-identifier-form",
-                                  mt: 4) do |f| %>
+    <%= settings_primer_form_with(
+          model: project,
+          url: project_identifier_path(project),
+          id: "change-identifier-form",
+          mt: 4
+        ) do |f| %>
       <%= render(Primer::Forms::FormList.new(Projects::Settings::EditableIdentifierForm.new(f))) %>
     <% end %>
   <% end %>

--- a/app/forms/projects/settings/editable_identifier_form.rb
+++ b/app/forms/projects/settings/editable_identifier_form.rb
@@ -35,7 +35,7 @@ module Projects
           f.text_field(
             name: :identifier,
             label: attribute_name(:identifier),
-            caption: I18n.t("projects.settings.change_identifier_format_hint_semantic"),
+            caption: semantic_identifier_caption,
             required: true,
             validation_message: validation_message_for(:identifier),
             data: { "projects--identifier-suggestion-target": "identifier" }
@@ -53,6 +53,18 @@ module Projects
       end
 
       private
+
+      def semantic_identifier_caption
+        helpers.safe_join(
+          [
+            I18n.t("projects.settings.change_identifier_format_hint_semantic"),
+            render(Primer::OpenProject::InlineMessage.new(scheme: :warning, tag: :span, mt: 1)) do
+              I18n.t("projects.settings.identifier_visibility_warning")
+            end
+          ],
+          helpers.tag.br
+        )
+      end
 
       def validation_message_for(attribute)
         model.errors.full_messages_for(attribute).to_sentence.presence

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4966,6 +4966,7 @@ en:
       header_identifier: Identifier
       header_relations: Project relations
       header_status: Status
+      identifier_visibility_warning: "Project identifiers aren't private. If your project is confidential, choose a nondescript identifier."
       life_cycle:
         filter:
           label: "Search project phase"

--- a/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
@@ -85,7 +85,7 @@ Existing work package identifiers remain valid after the change. Previously assi
 > A project's identifier is not restricted to its members and should not be treated as
 > confidential, even if the project itself is private.
 
-Work packages can be referenced from rich text anywhere in OpenProject — for example wiki pages,
+Work packages can be referenced in rich text editors anywhere in OpenProject — for example wiki pages,
 documents, forum posts, meeting agendas, or work package descriptions and comments — using the work
 package's identifier (e.g. `PROJ-123`) or a rich link inserted via the editor. If such content
 becomes visible to users outside the project, the project identifier is exposed along with it. No

--- a/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-identifiers/README.md
@@ -79,6 +79,37 @@ Existing work package identifiers remain valid after the change. Previously assi
 > Before enabling project-based identifiers in a production environment, inform users about the change so they understand the new identifier format they will encounter.
 > We also recommend implementing the switch outside of main working hours, to avoid any possible conflicts with ongoing user activity.
 
+## Project identifier visibility
+
+> [!WARNING]
+> A project's identifier is not restricted to its members and should not be treated as
+> confidential, even if the project itself is private.
+
+Work packages can be referenced from rich text anywhere in OpenProject — for example wiki pages,
+documents, forum posts, meeting agendas, or work package descriptions and comments — using the work
+package's identifier (e.g. `PROJ-123`) or a rich link inserted via the editor. If such content
+becomes visible to users outside the project, the project identifier is exposed along with it. No
+other information about the referenced work package is exposed to users who lack permission to view
+it.
+
+This can happen in a few ways:
+
+- **Public projects**: If a project is set to public, its enabled modules (such as Documents, Wiki,
+  or Forums) are visible to other users of the instance according to their **Non member** role
+  permissions, without requiring project membership.
+- **Anonymous access**: If the instance permits access without authentication, a public project's
+  content may additionally be visible to unauthenticated visitors, governed by the **Anonymous**
+  role.
+- **Cross-project references**: Rich text in one project can reference a work package from another
+  project. If that content's own project is public (or otherwise accessible to a wider audience),
+  the identifier of the referenced project becomes visible too — even if the referenced project
+  itself is private.
+
+Because of these paths, a project identifier should be treated as potentially visible to any user
+of the instance, and in some configurations, the general public. If the identifier itself could
+reveal sensitive information (e.g. a client name or project codename), choose a nondescript
+identifier when creating the project.
+
 ## Reserved project identifiers
 
 When project identifiers are changed, OpenProject reserves previous identifiers to prevent conflicts and preserve existing references.

--- a/spec/forms/projects/settings/editable_identifier_form_spec.rb
+++ b/spec/forms/projects/settings/editable_identifier_form_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Projects::Settings::EditableIdentifierForm, type: :forms do
     it "renders an editable field with the legacy caption" do
       expect(page).to have_field "Identifier", with: "my-project", disabled: false
       expect(page).to have_text "Only lowercase letters (a–z), numbers, dashes or underscores."
+      expect(page).to have_no_text "Project identifiers aren't private"
     end
   end
 
@@ -55,6 +56,8 @@ RSpec.describe Projects::Settings::EditableIdentifierForm, type: :forms do
       expect(page).to have_field "Identifier", with: "my-project", disabled: false
       expect(page).to have_text "Only uppercase letters (A–Z), numbers or underscores. " \
                                 "Max 10 characters. Must start with a letter."
+      expect(page).to have_css ".InlineMessage", text: "Project identifiers aren't private. " \
+                                                       "If your project is confidential, choose a nondescript identifier."
     end
   end
 


### PR DESCRIPTION
when project-based semantic work package identifiers are used

# Ticket
https://community.openproject.org/wp/COMMS-943

# What are you trying to accomplish?
Make it crystal clear to users that project identifiers are not treated as confidential and that they should be chosen carefully if the project itself is confidential.

## Screenshots
<img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/2a3307e6-4ff8-4b93-a9cd-5be605d78878" />

<img width="489" height="376" alt="image" src="https://github.com/user-attachments/assets/c50c79f0-0097-4d7c-b0fe-005fd7d9dfff" />


# What approach did you choose and why?
- Add a Primer::OpenProject::InlineMessage with the warning to the help text of the identifier form field
- Updated documentation
- Increased size of indentifier change modal to avoid having a scrollbar in a tiny modal
- Fixed rubocop issues in app/components/projects/settings/change_identifier_dialog_component.html.erb after doing the modal size changes

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
