### PR TITLE
[sppm-324] Milestone tooltip is off screen if milestone name is long

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -150,7 +150,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
         zoomMin: 7 * 24 * 60 * 60 * 1000, // 7 days minimum zoom
         zoomMax: 50 * 365 * 24 * 60 * 60 * 1000, // 50 years maximum zoom
         // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
-        tooltip: { template: this.tooltip.tooltipTemplate.bind(this.tooltip) } as any,
+        tooltip: { template: this.tooltip.tooltipTemplate.bind(this.tooltip), overflowMethod: 'cap' } as any,
       },
     );
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-324

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Set vis-timeline's tooltip overflowMethod to `cap` so long milestone tooltips are clamped within the timeline container instead of being flipped beyond its bounds.
