### PR TITLE
[FND-185] Variants can disable fields in the project attributes configuration screen (when using linked mode)  

### DIFF
--- a/app/components/work_package_types/exclusion_toggle_component.rb
+++ b/app/components/work_package_types/exclusion_toggle_component.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # The switch each linked attribute row renders to control exclusion of one element.
+  #
+  # +element_key+ the attribute or query key ("assignee", "custom_field_3", "query_7");
+  # +label+ Readable attribute label for the aria-label of the toggle
+  class ExclusionToggleComponent < ApplicationComponent
+    def initialize(exclusions:, element_key:, label:, aspect:, off_label:, test_selector:)
+      super()
+
+      @exclusions = exclusions
+      @element_key = element_key
+      @label = label
+      @aspect = aspect
+      @off_label = off_label
+      @test_selector = test_selector
+    end
+
+    # Exclusions or element_key being empty means the type owns its configuration, so there is
+    # nothing to render.
+    def render?
+      @exclusions.present? && @element_key.present?
+    end
+
+    def call
+      render(Primer::Alpha::ToggleSwitch.new(**toggle_arguments))
+    end
+
+    private
+
+    def toggle_arguments
+      {
+        src: toggle_path,
+        csrf_token: helpers.form_authenticity_token,
+        checked: !excluded?,
+        on_label: "",
+        off_label: @off_label,
+        size: :small,
+        status_label_position: :start,
+        aria: { label: @label },
+        classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator",
+        data: { test_selector: @test_selector }
+      }
+    end
+
+    def excluded?
+      @exclusions.excluded?(@element_key)
+    end
+
+    def toggle_path
+      type_excluded_element_toggle_path(type_id: @exclusions.type.id, aspect: @aspect, element: @element_key)
+    end
+  end
+end

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -35,22 +35,6 @@ module WorkPackageTypes
 
     ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
 
-    # The elements this type does not show.
-    #  - own: this type's own link
-    #  - effective: the union over the whole link chain
-    #
-    # An element in effective but not in own was excluded by a link above this type, which is
-    # what #excluded_by_source? answers: this type cannot reach that link to undo it.
-    ExclusionState = Data.define(:type, :own, :effective) do
-      def excluded?(key)
-        effective.include?(key.to_s)
-      end
-
-      def excluded_by_source?(key)
-        excluded?(key) && own.exclude?(key.to_s)
-      end
-    end
-
     def initialize(type:, form_attributes:, no_filter_query:)
       super(type)
       @type = type
@@ -70,7 +54,7 @@ module WorkPackageTypes
     def exclusion_state
       return @exclusion_state if defined?(@exclusion_state)
 
-      @exclusion_state = readonly? ? build_exclusion_state : nil
+      @exclusion_state = readonly? ? WorkPackageTypes::ExclusionState.for(@type, ASPECT) : nil
     end
 
     def ee_available?
@@ -163,17 +147,6 @@ module WorkPackageTypes
     # A query group is a single entry in the section, so a source exclusion drops the whole section.
     def retained_query_group(group)
       group unless group[:element_key].present? && exclusion_state.excluded_by_source?(group[:element_key])
-    end
-
-    def build_exclusion_state
-      link = @type.configuration_links.find_by(aspect: ASPECT)
-      return nil unless link
-
-      ExclusionState.new(
-        type: @type,
-        own: link.excluded_elements.map(&:to_s),
-        effective: @type.effective_excluded_elements(ASPECT).map(&:to_s)
-      )
     end
   end
 end

--- a/app/components/work_package_types/project_attributes/index_component.html.erb
+++ b/app/components/work_package_types/project_attributes/index_component.html.erb
@@ -35,7 +35,8 @@
               type: @type,
               project_custom_field_section:,
               project_custom_fields:,
-              readonly: @readonly
+              linked: linked?,
+              exclusion_state:
             )
           )
         end

--- a/app/components/work_package_types/project_attributes/index_component.rb
+++ b/app/components/work_package_types/project_attributes/index_component.rb
@@ -17,35 +17,46 @@ module WorkPackageTypes
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 
-      def initialize(type:, project_custom_field_sections:, readonly: false)
-        super
+      ASPECT = Type::ConfigurationLink::PROJECT_ATTRIBUTES
+
+      def initialize(type:, project_custom_field_sections:)
+        super()
 
         @type = type
         @project_custom_field_sections = project_custom_field_sections
-        @readonly = readonly
       end
 
       private
 
-      def visible_sections
-        return @project_custom_field_sections unless @readonly
-
-        sections_with_active_fields
+      def linked?
+        OpenProject::FeatureDecisions.type_variants_active? && @type.linked?(ASPECT)
       end
 
-      def sections_with_active_fields
+      def exclusion_state
+        return @exclusion_state if defined?(@exclusion_state)
+
+        @exclusion_state = linked? ? WorkPackageTypes::ExclusionState.for(@type, ASPECT) : nil
+      end
+
+      def visible_sections
+        return @project_custom_field_sections unless linked?
+
         result = []
-
         @project_custom_field_sections.each do |section, custom_fields|
-          active_fields = custom_fields.select { |cf| active_field_ids.include?(cf.id) }
-          result << [section, active_fields] if active_fields.any?
+          shown = custom_fields.select { |cf| show_in_linked_mode?(cf) }
+          result << [section, shown] if shown.any?
         end
-
         result
       end
 
-      def active_field_ids
-        @active_field_ids ||= @type.project_custom_field_type_mappings.to_set(&:custom_field_id)
+      def show_in_linked_mode?(custom_field)
+        source_active_field_ids.include?(custom_field.id) &&
+          !exclusion_state&.excluded_by_source?(custom_field.attribute_name)
+      end
+
+      def source_active_field_ids
+        @source_active_field_ids ||=
+          @type.effective_source_for(ASPECT).own_project_custom_field_type_mappings.to_set(&:custom_field_id)
       end
 
       def wrapper_data_attributes

--- a/app/components/work_package_types/project_attributes/row_component.html.erb
+++ b/app/components/work_package_types/project_attributes/row_component.html.erb
@@ -26,18 +26,23 @@
       end
 
       custom_field_container.with_column(py: 1, mr: 2) do
-        render(
-          Primer::Alpha::ToggleSwitch.new(
-            src: readonly ? nil : toggle_path,
-            csrf_token: form_authenticity_token,
-            data: toggle_data_attributes,
-            checked: active_for_type?,
-            enabled: !readonly,
-            size: :small,
-            status_label_position: :start,
-            classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"
+        if linked
+          render(exclusion_toggle)
+        else
+          render(
+            Primer::Alpha::ToggleSwitch.new(
+              src: toggle_path,
+              csrf_token: form_authenticity_token,
+              data: toggle_data_attributes,
+              checked: active_for_type?,
+              on_label: "",
+              off_label: t("types.edit.project_attributes.disabled"),
+              size: :small,
+              status_label_position: :start,
+              classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"
+            )
           )
-        )
+        end
       end
     end
   end

--- a/app/components/work_package_types/project_attributes/row_component.rb
+++ b/app/components/work_package_types/project_attributes/row_component.rb
@@ -17,25 +17,40 @@ module WorkPackageTypes
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 
-      def initialize(type:, project_custom_field:, readonly: false)
-        super
+      ASPECT = Type::ConfigurationLink::PROJECT_ATTRIBUTES
+
+      def initialize(type:, project_custom_field:, linked: false, exclusion_state: nil)
+        super()
 
         @type = type
         @project_custom_field = project_custom_field
-        @readonly = readonly
-        @project_custom_field_type_mappings = type.project_custom_field_type_mappings
+        @linked = linked
+        @exclusion_state = exclusion_state
       end
 
       private
 
-      attr_reader :readonly
+      attr_reader :linked
 
       def wrapper_uniq_by
         @project_custom_field.id
       end
 
+      # Linked mode disables an inherited attribute by excluding it
+      # Independent mode toggles the type's own mapping directly
+      def exclusion_toggle
+        WorkPackageTypes::ExclusionToggleComponent.new(
+          exclusions: @exclusion_state,
+          element_key: @project_custom_field.attribute_name,
+          label: t("types.edit.project_attributes.exclusions.attribute_label", attribute: @project_custom_field.name),
+          aspect: ASPECT,
+          off_label: t("types.edit.project_attributes.disabled"),
+          test_selector: "toggle-type-project-attribute-#{@project_custom_field.id}"
+        )
+      end
+
       def active_for_type?
-        @project_custom_field_type_mappings.any? do |mapping|
+        @type.project_custom_field_type_mappings.any? do |mapping|
           mapping.custom_field_id == @project_custom_field.id
         end
       end

--- a/app/components/work_package_types/project_attributes/section_component.html.erb
+++ b/app/components/work_package_types/project_attributes/section_component.html.erb
@@ -12,40 +12,38 @@
         title: @project_custom_field_section.name,
         title_arguments: { font_weight: :bold }
       ) do |header|
-        unless readonly
-          header.with_action_button(
-            tag: :a,
-            href: enable_all_path,
-            scheme: :invisible,
-            font_weight: :bold,
-            color: :subtle,
-            "aria-label": t("types.edit.project_attributes.actions.label_enable_all"),
-            data: {
-              "turbo-method": :put,
-              "turbo-stream": true,
-              test_selector: "enable-all-type-project-attributes-#{@project_custom_field_section.id}"
-            }
-          ) do |button|
-            button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-            t("types.edit.project_attributes.actions.label_enable_all")
-          end
+        header.with_action_button(
+          tag: :a,
+          href: enable_all_path,
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("types.edit.project_attributes.actions.label_enable_all"),
+          data: {
+            "turbo-method": :put,
+            "turbo-stream": true,
+            test_selector: "enable-all-type-project-attributes-#{@project_custom_field_section.id}"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+          t("types.edit.project_attributes.actions.label_enable_all")
+        end
 
-          header.with_action_button(
-            tag: :a,
-            href: disable_all_path,
-            scheme: :invisible,
-            font_weight: :bold,
-            color: :subtle,
-            "aria-label": t("types.edit.project_attributes.actions.label_disable_all"),
-            data: {
-              "turbo-method": :put,
-              "turbo-stream": true,
-              test_selector: "disable-all-type-project-attributes-#{@project_custom_field_section.id}"
-            }
-          ) do |button|
-            button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-            t("types.edit.project_attributes.actions.label_disable_all")
-          end
+        header.with_action_button(
+          tag: :a,
+          href: disable_all_path,
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          "aria-label": t("types.edit.project_attributes.actions.label_disable_all"),
+          data: {
+            "turbo-method": :put,
+            "turbo-stream": true,
+            test_selector: "disable-all-type-project-attributes-#{@project_custom_field_section.id}"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+          t("types.edit.project_attributes.actions.label_disable_all")
         end
       end
 
@@ -62,7 +60,8 @@
               WorkPackageTypes::ProjectAttributes::RowComponent.new(
                 type: @type,
                 project_custom_field:,
-                readonly: @readonly
+                linked:,
+                exclusion_state:
               )
             )
           end

--- a/app/components/work_package_types/project_attributes/section_component.rb
+++ b/app/components/work_package_types/project_attributes/section_component.rb
@@ -17,38 +17,34 @@ module WorkPackageTypes
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 
-      def initialize(type:, project_custom_field_section:, project_custom_fields:, readonly: false)
-        super
+      def initialize(type:, project_custom_field_section:, project_custom_fields:, linked: false, exclusion_state: nil)
+        super()
 
         @type = type
         @project_custom_field_section = project_custom_field_section
         @project_custom_fields = project_custom_fields
-        @readonly = readonly
+        @linked = linked
+        @exclusion_state = exclusion_state
       end
 
       private
 
-      attr_reader :readonly
+      attr_reader :linked, :exclusion_state
 
       def enable_all_path
-        enable_all_of_section_type_project_attributes_path(
-          @type,
-          project_custom_field_type_mapping: bulk_action_params
-        )
+        bulk_path(:enable_all_of_section)
       end
 
       def disable_all_path
-        disable_all_of_section_type_project_attributes_path(
-          @type,
-          project_custom_field_type_mapping: bulk_action_params
-        )
+        bulk_path(:disable_all_of_section)
       end
 
-      def bulk_action_params
-        {
-          type_id: @type.id,
-          custom_field_section_id: @project_custom_field_section.id
-        }
+      def bulk_path(action)
+        send(
+          :"#{action}_type_project_attributes_path",
+          @type,
+          project_custom_field_type_mapping: { type_id: @type.id, custom_field_section_id: @project_custom_field_section.id }
+        )
       end
 
       def wrapper_uniq_by

--- a/app/components/work_package_types/wizard/project_attributes_step_component.rb
+++ b/app/components/work_package_types/wizard/project_attributes_step_component.rb
@@ -30,9 +30,6 @@
 
 module WorkPackageTypes
   module Wizard
-    # The project attributes wizard step: the reuse-mode banner over the project
-    # attribute toggles, shown read-only while the aspect is Linked. Mirrors the
-    # project attributes tab and PdfStepComponent.
     class ProjectAttributesStepComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
@@ -48,8 +45,7 @@ module WorkPackageTypes
                  )) +
             render(WorkPackageTypes::ProjectAttributes::IndexComponent.new(
                      type: model,
-                     project_custom_field_sections:,
-                     readonly: model.linked?(Type::ConfigurationLink::PROJECT_ATTRIBUTES)
+                     project_custom_field_sections:
                    ))
         end
       end

--- a/app/controllers/work_package_types/project_attributes_tab_controller.rb
+++ b/app/controllers/work_package_types/project_attributes_tab_controller.rb
@@ -15,6 +15,8 @@ module WorkPackageTypes
     include OpTurbo::ComponentStream
     include WorkPackageTypes::ProjectAttributesComponentStreams
 
+    ASPECT = Type::ConfigurationLink::PROJECT_ATTRIBUTES
+
     current_menu_item [:edit, :toggle, :enable_all_of_section, :disable_all_of_section] do
       :types
     end
@@ -36,15 +38,21 @@ module WorkPackageTypes
       end
     end
 
+    # Linked types have no own mappings to toggle, so a section's bulk enable/disable narrows the
+    # link's excluded_elements instead; independent types toggle their own mappings as before.
     def enable_all_of_section
-      bulk_update_section(:enable)
+      linked? ? bulk_exclusion(ExcludedElements::RemoveService) : bulk_update_section(:enable)
     end
 
     def disable_all_of_section
-      bulk_update_section(:disable)
+      linked? ? bulk_exclusion(ExcludedElements::AddService) : bulk_update_section(:disable)
     end
 
     private
+
+    def linked?
+      @type.linked?(ASPECT)
+    end
 
     def eager_load_project_custom_field_data
       @project_custom_field_sections =
@@ -66,6 +74,25 @@ module WorkPackageTypes
         )
         .call(action:)
 
+      respond_to_bulk(call)
+    end
+
+    def bulk_exclusion(service_class)
+      call = service_class
+        .new(user: current_user, type: @type)
+        .call(aspect: ASPECT, elements: section_element_keys)
+
+      respond_to_bulk(call)
+    end
+
+    # The section's attributes that the type actually inherits, keyed as the link stores them.
+    def section_element_keys
+      source_active_ids = @type.effective_source_for(ASPECT)
+                               .own_project_custom_field_type_mappings.pluck(:custom_field_id)
+      @project_custom_field_section.custom_fields.where(id: source_active_ids).map(&:attribute_name)
+    end
+
+    def respond_to_bulk(call)
       if call.success?
         eager_load_project_custom_field_data
         update_project_attribute_sections_via_turbo_stream

--- a/app/models/work_package_types/exclusion_state.rb
+++ b/app/models/work_package_types/exclusion_state.rb
@@ -29,21 +29,30 @@
 #++
 
 module WorkPackageTypes
-  module FormConfiguration
-    # Form-configuration binding of WorkPackageTypes::ExclusionToggleComponent.
-    class ExclusionToggleComponent < WorkPackageTypes::ExclusionToggleComponent
-      ASPECT = Type::ConfigurationLink::FORM_CONFIGURATION
+  # The elements this type does not show.
+  #  - own: this type's own link
+  #  - effective: the union over the whole link chain
+  #
+  # An element in effective but not in own was excluded by a link above this type, which is
+  # what #excluded_by_source? answers: this type cannot reach that link to undo it.
+  ExclusionState = Data.define(:type, :own, :effective) do
+    def self.for(type, aspect)
+      link = type.configuration_links.find_by(aspect:)
+      return unless link
 
-      def initialize(exclusions:, element_key:, label:)
-        super(
-          exclusions:,
-          element_key:,
-          label:,
-          aspect: ASPECT,
-          off_label: I18n.t("types.edit.form_configuration.exclusions.excluded"),
-          test_selector: "toggle-form-config-exclusion-#{element_key}"
-        )
-      end
+      new(
+        type:,
+        own: link.excluded_elements.map(&:to_s),
+        effective: type.effective_excluded_elements(aspect).map(&:to_s)
+      )
+    end
+
+    def excluded?(key)
+      effective.include?(key.to_s)
+    end
+
+    def excluded_by_source?(key)
+      excluded?(key) && own.exclude?(key.to_s)
     end
   end
 end

--- a/app/views/work_package_types/project_attributes_tab/edit.html.erb
+++ b/app/views/work_package_types/project_attributes_tab/edit.html.erb
@@ -22,7 +22,6 @@ See COPYRIGHT and LICENSE files for more details.
 
   <%= render WorkPackageTypes::ProjectAttributes::IndexComponent.new(
         type: @type,
-        project_custom_field_sections: @project_custom_field_sections,
-        readonly: @type.linked?(Type::ConfigurationLink::PROJECT_ATTRIBUTES)
+        project_custom_field_sections: @project_custom_field_sections
       ) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6174,6 +6174,9 @@ en:
           label_disable_all: "Disable all"
           label_enable_all: "Enable all"
         description: "Select the project attributes that you want to enable for this work package type. Enabled project attributes are displayed in a separate tab in work packages of this type. Users with the necessary permissions can view and edit these attributes there."
+        disabled: "Disabled"
+        exclusions:
+          attribute_label: "Inherit %{attribute}"
         filter: "Search by section or name"
         tab: "Project attributes"
       projects:

--- a/spec/components/work_package_types/form_configuration/exclusion_toggle_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/exclusion_toggle_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::ExclusionToggleComponent, ty
   let(:type) { create(:type) }
 
   def exclusion_state(effective: [])
-    WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(type:, own: effective, effective:)
+    WorkPackageTypes::ExclusionState.new(type:, own: effective, effective:)
   end
 
   def component(exclusions: exclusion_state, element_key: "assignee", label: "Inherit Assignee")

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
     end
 
     it "is keyed on the attribute and labelled with its translation", :aggregate_failures do
-      render_row(exclusions: WorkPackageTypes::FormConfigurationComponent::ExclusionState
+      render_row(exclusions: WorkPackageTypes::ExclusionState
                                .new(type:, own: [], effective: []))
 
       toggle = page.find("[data-test-selector='toggle-form-config-exclusion-assignee']")

--- a/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_query_row_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupQueryRowComponent, type
   describe "the exclusion toggle" do
     let(:type) { create(:type) }
     let(:exclusions) do
-      WorkPackageTypes::FormConfigurationComponent::ExclusionState.new(
+      WorkPackageTypes::ExclusionState.new(
         type:, own: [], effective: []
       )
     end

--- a/spec/controllers/work_package_types/project_attributes_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/project_attributes_tab_controller_spec.rb
@@ -153,5 +153,50 @@ RSpec.describe WorkPackageTypes::ProjectAttributesTabController do
         expect(response.body).to include("Project attributes could not be updated.")
       end
     end
+
+    context "when the type is linked", with_flag: { type_variants: true } do
+      let(:aspect) { Type::ConfigurationLink::PROJECT_ATTRIBUTES }
+      let(:source) { create(:type) }
+      let(:link) { type.configuration_links.find_by(aspect:) }
+      let(:params) do
+        {
+          type_id: type.id,
+          project_custom_field_type_mapping: {
+            type_id: type.id,
+            custom_field_section_id: project_custom_field_section.id
+          }
+        }
+      end
+
+      before do
+        source.project_custom_fields << project_custom_field
+        type.link!(aspect, source:)
+      end
+
+      describe "PUT disable_all_of_section" do
+        it "excludes the section's inherited attributes on the link" do
+          expect(link.excluded_elements).to be_empty
+
+          put :disable_all_of_section, params: params, format: :turbo_stream
+
+          expect(response).to have_http_status(:ok)
+          expect(link.reload.excluded_elements).to contain_exactly(project_custom_field.attribute_name)
+          expect(type.project_custom_field_type_mappings.map(&:custom_field_id)).to be_empty
+        end
+      end
+
+      describe "PUT enable_all_of_section" do
+        before { link.update!(excluded_elements: [project_custom_field.attribute_name]) }
+
+        it "re-inherits the section's attributes" do
+          put :enable_all_of_section, params: params, format: :turbo_stream
+
+          expect(response).to have_http_status(:ok)
+          expect(link.reload.excluded_elements).to be_empty
+          expect(type.project_custom_field_type_mappings.map(&:custom_field_id))
+            .to contain_exactly(project_custom_field.id)
+        end
+      end
+    end
   end
 end

--- a/spec/features/types/project_attributes_spec.rb
+++ b/spec/features/types/project_attributes_spec.rb
@@ -206,21 +206,64 @@ RSpec.describe "Work package type project attributes", :js do
     let(:source_type) { create(:type, name: "Source type") }
     let(:linked_type) { create(:type, name: "Linked type") }
     let(:linked_type_page) { Pages::Types::ProjectAttributes.new(linked_type) }
+    let(:link) { linked_type.configuration_links.find_by(aspect:) }
 
-    before do
-      # Source activates only the Boolean field
-      source_type.project_custom_fields << boolean_project_custom_field
-      linked_type.link!(aspect, source: source_type)
+    def active_custom_field_ids
+      linked_type.project_custom_field_type_mappings.map(&:custom_field_id)
     end
 
-    it "hides the attributes deactivated in the source and only lists the active ones" do
+    before do
+      # Source activates Boolean + String, List stays deactivated
+      source_type.project_custom_fields << [boolean_project_custom_field, string_project_custom_field]
+      linked_type.link!(aspect, source: source_type)
       linked_type_page.visit!
+    end
 
-      expect(page).to have_text("Boolean field")
-      expect(page).to have_no_text("String field")
+    it "shows the source-active attributes as toggles and hides the source-deactivated ones" do
+      linked_type_page.within_attribute(boolean_project_custom_field) do
+        linked_type_page.expect_checked_state
+      end
+      linked_type_page.within_attribute(string_project_custom_field) do
+        linked_type_page.expect_checked_state
+      end
+
       expect(page).to have_no_text("List field")
-      # Also hides empty sections
       expect(page).to have_no_css("[data-test-selector='type-project-attribute-section-#{select_section.id}']")
+    end
+
+    it "disables an inherited attribute for the variant via its toggle" do
+      expect(active_custom_field_ids)
+        .to contain_exactly(boolean_project_custom_field.id, string_project_custom_field.id)
+
+      linked_type_page.toggle(string_project_custom_field)
+
+      linked_type_page.within_attribute(string_project_custom_field) do
+        linked_type_page.expect_unchecked_state
+      end
+
+      linked_type_page.visit!
+      linked_type_page.within_attribute(string_project_custom_field) do
+        linked_type_page.expect_unchecked_state
+      end
+
+      expect(link.reload.excluded_elements).to eq([string_project_custom_field.attribute_name])
+      expect(active_custom_field_ids).to contain_exactly(boolean_project_custom_field.id)
+    end
+
+    it "hides attributes an ancestor variant disabled" do
+      # A -> B -> C
+      type_b = create(:type, name: "Type B")
+      type_b.link!(aspect, source: source_type)
+      type_b.configuration_links.find_by(aspect:).update!(excluded_elements: [boolean_project_custom_field.attribute_name])
+      type_c = create(:type, name: "Type C")
+      type_c.link!(aspect, source: type_b)
+
+      Pages::Types::ProjectAttributes.new(type_c).visit!
+
+      # Boolean was disabled by B and is hidden on C
+      expect(page).to have_no_text("Boolean field")
+      # String is still inherited and controllable on C
+      expect(page).to have_text("String field")
     end
 
     it "still lists all attributes for the independent source type" do

--- a/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
+++ b/spec/services/work_package_types/switch_to_independent_mode_service_spec.rb
@@ -170,6 +170,22 @@ RSpec.describe WorkPackageTypes::SwitchToIndependentModeService do
         expect(type.reload).not_to be_linked(aspect)
         expect(type.own_project_custom_field_type_mappings.map(&:custom_field_id)).to contain_exactly(field.id)
       end
+
+      it "copies only the attributes the variant kept active, dropping the ones it disabled",
+         with_flag: { type_variants: true } do
+        source = create(:type)
+        kept = create(:project_custom_field)
+        disabled = create(:project_custom_field)
+        ProjectCustomFieldTypeMapping.create!(type: source, project_custom_field: kept)
+        ProjectCustomFieldTypeMapping.create!(type: source, project_custom_field: disabled)
+        type.link!(aspect, source:)
+        type.configuration_links.find_by(aspect:).update!(excluded_elements: [disabled.attribute_name])
+
+        result = service.call(mode: WorkPackageTypes::IndependentMode::COPY)
+
+        expect(result).to be_success
+        expect(type.own_project_custom_field_type_mappings.map(&:custom_field_id)).to contain_exactly(kept.id)
+      end
     end
 
     context "with the empty mode (project attributes)" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/FND-185

Follows https://github.com/opf/openproject/pull/24541 

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Mainly reuse and refactor what was already done for the form attributes screen by extracting common logic out and then using it in both places where possible

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
