### PR TITLE
[OP-19849] Fix parent and project associations to use visible check in journals

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -72,6 +72,7 @@ class Journal < ApplicationRecord
   register_journal_formatter OpenProject::JournalFormatter::TimeEntryHours
   register_journal_formatter OpenProject::JournalFormatter::TimeEntryNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::Visibility
+  register_journal_formatter OpenProject::JournalFormatter::VisibleNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::WikiDiff
 
   # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -89,7 +89,6 @@ module WorkPackage::Journalized
                   name: JournalizedProcs.event_name,
                   url: JournalizedProcs.event_url
 
-    register_journal_formatted_fields "parent_id", formatter_key: :id
     register_journal_formatted_fields "estimated_hours", "derived_estimated_hours",
                                       "remaining_hours", "derived_remaining_hours",
                                       formatter_key: :chronic_duration
@@ -106,7 +105,8 @@ module WorkPackage::Journalized
 
     # Joined
     register_journal_formatted_fields :parent_id, :project_id,
-                                      :budget_id,
+                                      formatter_key: :visible_named_association
+    register_journal_formatted_fields :budget_id,
                                       :status_id, :type_id,
                                       :assigned_to_id, :priority_id,
                                       :category_id, :version_id,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2964,6 +2964,9 @@ en:
       work_package_parent_deleted: "Parent removed"
 
     changes_retracted: "The changes were retracted."
+    non_visible:
+      project: "a non-visible project"
+      work_package: "a non-visible work package"
   label_accessibility: "Accessibility"
 
   label_account: "Account"

--- a/lib/open_project/journal_formatter/visible_named_association.rb
+++ b/lib/open_project/journal_formatter/visible_named_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,37 +28,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class OpenProject::JournalFormatter::SubprojectNamedAssociation <
-  OpenProject::JournalFormatter::VisibleNamedAssociation
+# References an associated record which includes a visible? check
+class OpenProject::JournalFormatter::VisibleNamedAssociation < JournalFormatter::NamedAssociation
   private
 
-  def format_details(key, values, cache:)
-    label = if values.first.nil?
-              label(key)
-            elsif values.last.nil?
-              I18n.t("activity.item.parent_no_longer")
-            else
-              I18n.t("activity.item.parent_without_of")
-            end
+  def associated_object_name(object)
+    return super if object.nil? || object.visible?
 
-    old_value, value = *format_values(values, key, cache:)
-
-    [label, old_value, value]
-  end
-
-  def format_html_details(label, old_value, value)
-    label = content_tag(:strong, label)
-    old_value = content_tag("i", h(old_value)) if old_value.present?
-    value = content_tag("i", h(value)) if value.present?
-    value ||= ""
-
-    [label, old_value, value]
-  end
-
-  def render_ternary_detail_text(label, value, old_value, options)
-    return I18n.t(:text_journal_deleted_subproject, label:, old: old_value) if value.blank?
-    return I18n.t(:text_journal_of, label:, value:) if old_value.blank?
-
-    super
+    I18n.t("journals.non_visible.#{object.model_name.i18n_key}")
   end
 end

--- a/spec/features/activities/project_attributes_activity_spec.rb
+++ b/spec/features/activities/project_attributes_activity_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Project attributes activity", :js do
         activity_page.expect_activity("Status set to On track")
         activity_page.expect_activity("Status description set (Details)")
         activity_page.expect_activity("Visibility set to public")
-        activity_page.expect_activity("No longer subproject of #{parent_project.name}")
+        activity_page.expect_activity("No longer subproject of a non-visible project")
         activity_page.expect_activity("Project unarchived")
         activity_page.expect_activity("Identifier changed from #{project_was.identifier} " \
                                       "to #{project.identifier}")
@@ -203,7 +203,8 @@ RSpec.describe "Project attributes activity", :js do
         activity_page.expect_activity("Status set to On track")
         activity_page.expect_activity("Status description set (Details)")
         activity_page.expect_activity("Visibility set to public")
-        activity_page.expect_activity("No longer subproject of #{parent_project.name}")
+        # The user is a member of project and project2, but not of their former parent.
+        activity_page.expect_activity("No longer subproject of a non-visible project")
         activity_page.expect_activity("Project unarchived")
         activity_page.expect_activity("Identifier changed from #{project_was.identifier} " \
                                       "to #{project.identifier}")

--- a/spec/lib/open_project/journal_formatter/visible_named_association_spec.rb
+++ b/spec/lib/open_project/journal_formatter/visible_named_association_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::JournalFormatter::VisibleNamedAssociation do
+  shared_let(:permitted_project) { create(:private_project, name: "Permitted project") }
+  shared_let(:other_project) { create(:private_project, name: "Other project") }
+
+  shared_let(:permitted_parent) do
+    create(:work_package, project: permitted_project, subject: "Parent in permitted project")
+  end
+  shared_let(:other_parent) do
+    create(:work_package, project: other_project, subject: "Parent in other project")
+  end
+
+  shared_let(:reader) do
+    create(:user, member_with_permissions: { permitted_project => %i[view_work_packages view_project_activity] })
+  end
+  shared_let(:reader_of_both) do
+    create(:user, member_with_permissions: {
+             permitted_project => %i[view_work_packages view_project_activity],
+             other_project => %i[view_work_packages view_project_activity]
+           })
+  end
+
+  describe "the parent of a work package" do
+    shared_let(:work_package) { create(:work_package, project: permitted_project, subject: "Child") }
+
+    let(:journal) { work_package.journals.last }
+
+    def render(values)
+      journal.render_detail(["parent_id", values])
+    end
+
+    context "with a reader permitted in one project only" do
+      current_user { reader }
+
+      it "names the parent it may see" do
+        expect(render([nil, permitted_parent.id])).to include(permitted_parent.subject)
+        expect(render([permitted_parent.id, nil])).to include(permitted_parent.subject)
+      end
+
+      it "withholds the subject of the parent it may not see" do
+        expect(render([nil, other_parent.id]))
+          .to eq("<strong>Parent</strong> set to <i>a non-visible work package</i>")
+        expect(render([other_parent.id, nil])).not_to include(other_parent.subject)
+        expect(render([other_parent.id, permitted_parent.id])).not_to include(other_parent.subject)
+        expect(render([permitted_parent.id, other_parent.id])).not_to include(other_parent.subject)
+      end
+    end
+
+    context "with a reader permitted in both projects" do
+      current_user { reader_of_both }
+
+      it "names both parents" do
+        expect(render([permitted_parent.id, other_parent.id]))
+          .to include(permitted_parent.subject)
+          .and include(other_parent.subject)
+      end
+    end
+
+    context "with a journal written by an actual parent change",
+            with_settings: { journal_aggregation_time_minutes: 0 } do
+      shared_let(:child) { create(:work_package, project: permitted_project, subject: "Reparented") }
+
+      shared_let(:parent_change_journal) do
+        User.execute_as(create(:admin)) do
+          WorkPackages::UpdateService.new(user: User.current, model: child).call(parent: other_parent)
+        end
+
+        child.reload.journals.last
+      end
+
+      current_user { reader }
+
+      it "withholds the subject across every detail of the journal" do
+        expect(parent_change_journal.details).to include("parent_id")
+
+        rendered = parent_change_journal.details.keys.filter_map { parent_change_journal.render_detail(it) }
+
+        expect(rendered).to be_present
+        expect(rendered.join(" ")).not_to include(other_parent.subject)
+      end
+    end
+  end
+
+  describe "the project of a work package" do
+    shared_let(:work_package) { create(:work_package, project: permitted_project, subject: "Moved") }
+
+    let(:journal) { work_package.journals.last }
+
+    def render(values)
+      journal.render_detail(["project_id", values])
+    end
+
+    context "with a reader permitted in one project only" do
+      current_user { reader }
+
+      it "withholds the name of the project it may not see" do
+        expect(render([other_project.id, permitted_project.id]))
+          .to eq("<strong>Project</strong> changed from <i>a non-visible project</i> " \
+                 "to <i>#{permitted_project.name}</i>")
+      end
+    end
+
+    context "with a reader permitted in both projects" do
+      current_user { reader_of_both }
+
+      it "names both projects" do
+        expect(render([other_project.id, permitted_project.id]))
+          .to include(other_project.name)
+          .and include(permitted_project.name)
+      end
+    end
+  end
+
+  describe "the parent of a project" do
+    let(:journal) { permitted_project.journals.last }
+
+    def render(values)
+      journal.render_detail(["parent_id", values])
+    end
+
+    context "with a reader permitted in one project only" do
+      current_user { reader }
+
+      it "withholds the name of the parent project it may not see" do
+        expect(render([nil, other_project.id])).not_to include(other_project.name)
+      end
+
+      # The wording the project activity page shows when a subproject is detached
+      # from a parent the reader has no access to.
+      it "withholds the name of a parent it no longer belongs to" do
+        expect(render([other_project.id, nil]))
+          .to eq("<strong>No longer subproject of</strong> <i>a non-visible project</i>")
+      end
+    end
+
+    context "with a reader permitted in both projects" do
+      current_user { reader_of_both }
+
+      it "names the parent project" do
+        expect(render([nil, other_project.id])).to include(other_project.name)
+      end
+    end
+  end
+end

--- a/spec/models/journal/project_journal_spec.rb
+++ b/spec/models/journal/project_journal_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe Journal::ProjectJournal do
     let(:project) { build(:project) }
     let(:journal) { build(:project_journal, journable: project) }
 
+    # The parent of a project is only named to readers who may see it.
+    current_user { build_stubbed(:admin) }
+
     it "renders identifier field correctly" do
       html = journal.render_detail(["identifier", [nil, "my-project"]], html: true)
       expect(html).to eq("<strong>Identifier</strong> set to " \


### PR DESCRIPTION
NamedAssociation is not correctly testing for visibility, which allowed to leak project and parent changes in some cases.

https://community.openproject.org/work_packages/OP-19849