### PR TITLE
[JIM-158] Jira attachment authors are not created as users

### DIFF
--- a/app/workers/import/jira_fetch_and_import_projects_job.rb
+++ b/app/workers/import/jira_fetch_and_import_projects_job.rb
@@ -73,6 +73,7 @@ module Import
       payload = issue.payload["fields"]
       collect_field_user_keys(user_keys, mention_usernames, payload)
       collect_comment_user_keys(user_keys, mention_usernames, payload)
+      collect_attachment_user_keys(user_keys, payload)
       collect_changelog_user_keys(user_keys, issue)
     end
 
@@ -87,6 +88,13 @@ module Import
       payload.dig("comment", "comments").each do |c|
         user_keys << c.dig("author", "key")
         collect_markup_mentions(c["body"], mention_usernames)
+      end
+    end
+
+    def collect_attachment_user_keys(user_keys, payload)
+      (payload["attachment"] || []).each do |attachment|
+        key = attachment.dig("author", "key")
+        user_keys << key if key.present?
       end
     end
 

--- a/app/workers/import/jira_import_projects_job.rb
+++ b/app/workers/import/jira_import_projects_job.rb
@@ -332,18 +332,20 @@ module Import
 
       comments = jira_issue.payload.dig("fields", "comment", "comments") || []
       comments.each do |comment|
-        author = find_user(comment["author"]["key"])
-        import_member(project, author)
-        journal_service.add_comment(comment:, user: author)
+        key = comment.dig("author", "key")
+        author = find_user(key)
+        import_member(project, author) if author.present?
+        journal_service.add_comment(comment:, user: author || User.system)
       end
 
       journal_service.call
 
       attachments = jira_issue.payload.dig("fields", "attachment") || []
       attachments.each do |attachment|
-        author = find_user(attachment["author"]["key"])
-        import_member(project, author)
-        import_attachment(work_package, attachment, author)
+        key = attachment.dig("author", "key")
+        author = find_user(key)
+        import_member(project, author) if author.present?
+        import_attachment(work_package, attachment, author || User.system)
       end
     end
 

--- a/spec/workers/import/jira_fetch_and_import_projects_job_spec.rb
+++ b/spec/workers/import/jira_fetch_and_import_projects_job_spec.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -34,6 +34,88 @@ RSpec.describe Import::JiraFetchAndImportProjectsJob do
   let(:job) { described_class.new }
   let(:jira_client) { instance_double(Import::JiraClient) }
   let(:user_keys) { Set.new }
+
+  describe "#collect_attachment_user_keys" do
+    it "adds the author key of every attachment" do
+      payload = {
+        "attachment" => [
+          { "filename" => "a.png", "author" => { "key" => "JIRAUSER100" } },
+          { "filename" => "b.png", "author" => { "key" => "JIRAUSER200" } }
+        ]
+      }
+
+      job.send(:collect_attachment_user_keys, user_keys, payload)
+      expect(user_keys).to contain_exactly("JIRAUSER100", "JIRAUSER200")
+    end
+
+    it "does not add duplicates" do
+      payload = {
+        "attachment" => [
+          { "filename" => "a.png", "author" => { "key" => "JIRAUSER100" } },
+          { "filename" => "b.png", "author" => { "key" => "JIRAUSER100" } }
+        ]
+      }
+
+      job.send(:collect_attachment_user_keys, user_keys, payload)
+      expect(user_keys).to contain_exactly("JIRAUSER100")
+    end
+
+    it "skips attachments without an author" do
+      payload = {
+        "attachment" => [
+          { "filename" => "a.png" },
+          { "filename" => "b.png", "author" => nil },
+          { "filename" => "c.png", "author" => { "key" => nil } },
+          { "filename" => "d.png", "author" => { "key" => "JIRAUSER100" } }
+        ]
+      }
+
+      job.send(:collect_attachment_user_keys, user_keys, payload)
+      expect(user_keys).to contain_exactly("JIRAUSER100")
+    end
+
+    it "handles issues without attachments" do
+      expect { job.send(:collect_attachment_user_keys, user_keys, {}) }.not_to raise_error
+      expect(user_keys).to be_empty
+    end
+  end
+
+  describe "#collect_user_keys_from_issue" do
+    let(:mention_usernames) { Set.new }
+    let(:issue) do
+      instance_double(Import::JiraIssue, payload: {
+                        "fields" => {
+                          "description" => "no mentions here",
+                          "creator" => { "key" => "JIRAUSER_CREATOR" },
+                          "reporter" => { "key" => "JIRAUSER_REPORTER" },
+                          "assignee" => { "key" => "JIRAUSER_ASSIGNEE" },
+                          "comment" => {
+                            "comments" => [{ "author" => { "key" => "JIRAUSER_COMMENTER" }, "body" => "a comment" }]
+                          },
+                          "attachment" => [
+                            { "filename" => "a.png", "author" => { "key" => "JIRAUSER_UPLOADER" } }
+                          ]
+                        },
+                        "changelog" => {
+                          "histories" => [{ "author" => { "key" => "JIRAUSER_EDITOR" }, "items" => [] }]
+                        }
+                      })
+    end
+
+    it "collects attachment authors alongside the other involved users" do
+      job.send(:collect_user_keys_from_issue, user_keys, mention_usernames, issue)
+
+      expect(user_keys).to include("JIRAUSER_UPLOADER")
+      expect(user_keys).to contain_exactly(
+        "JIRAUSER_CREATOR",
+        "JIRAUSER_REPORTER",
+        "JIRAUSER_ASSIGNEE",
+        "JIRAUSER_COMMENTER",
+        "JIRAUSER_UPLOADER",
+        "JIRAUSER_EDITOR"
+      )
+    end
+  end
 
   describe "#resolve_mention_user_keys" do
     context "when all mentioned users exist" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-158

# What are you trying to achieve?

Attachment authors have not been collected for the import users phase

# What approach did you choose and why?

- Collect attachment authors
- If there is no author is set, we import it as system user

# Merge checklist

- [x] Added/updated tests
