### PR TITLE
Perform and cache journal visibility check in RequestStore

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -65,6 +65,7 @@ class Journal < ApplicationRecord
   register_journal_formatter OpenProject::JournalFormatter::ProjectPhaseDates
   register_journal_formatter OpenProject::JournalFormatter::ProjectPhaseDefinition
   register_journal_formatter OpenProject::JournalFormatter::ProjectStatusCode
+  register_journal_formatter OpenProject::JournalFormatter::PublicNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::ScheduleManually
   register_journal_formatter OpenProject::JournalFormatter::SubprojectNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::TargetVersions
@@ -72,7 +73,6 @@ class Journal < ApplicationRecord
   register_journal_formatter OpenProject::JournalFormatter::TimeEntryHours
   register_journal_formatter OpenProject::JournalFormatter::TimeEntryNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::Visibility
-  register_journal_formatter OpenProject::JournalFormatter::VisibleNamedAssociation
   register_journal_formatter OpenProject::JournalFormatter::WikiDiff
 
   # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -105,14 +105,16 @@ module WorkPackage::Journalized
 
     # Joined
     register_journal_formatted_fields :parent_id, :project_id,
-                                      formatter_key: :visible_named_association
-    register_journal_formatted_fields :budget_id,
+                                      :budget_id,
                                       :status_id, :type_id,
-                                      :assigned_to_id, :priority_id,
+                                      :priority_id,
                                       :category_id, :version_id,
-                                      :author_id, :responsible_id,
                                       :sprint_id,
                                       formatter_key: :named_association
+    # People are named in the attribute table of the same work package, so the
+    # journal does not withhold them from readers outside their projects.
+    register_journal_formatted_fields :assigned_to_id, :author_id, :responsible_id,
+                                      formatter_key: :public_named_association
     register_journal_formatted_fields :start_date, :due_date, formatter_key: :datetime
     register_journal_formatted_fields :subject, formatter_key: :plaintext
     register_journal_formatted_fields :duration, formatter_key: :day_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3001,7 +3001,14 @@ en:
 
     changes_retracted: "The changes were retracted."
     non_visible:
+      budget: "a non-visible budget"
+      category: "a non-visible category"
+      default: "a non-visible record"
+      issue_priority: "a non-visible priority"
       project: "a non-visible project"
+      sprint: "a non-visible sprint"
+      time_entry_activity: "a non-visible activity"
+      version: "a non-visible version"
       work_package: "a non-visible work package"
   label_accessibility: "Accessibility"
 

--- a/lib/open_project/journal_formatter/public_named_association.rb
+++ b/lib/open_project/journal_formatter/public_named_association.rb
@@ -28,13 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# References an associated record which includes a visible? check
-class OpenProject::JournalFormatter::VisibleNamedAssociation < JournalFormatter::NamedAssociation
+# Opts an association out of the visibility check its superclass applies. Reserved
+# for records the journable already names elsewhere, such as the people in its
+# author, assignee and responsible fields.
+class OpenProject::JournalFormatter::PublicNamedAssociation < JournalFormatter::NamedAssociation
   private
 
-  def associated_object_name(object)
-    return super if object.nil? || object.visible?
-
-    I18n.t("journals.non_visible.#{object.model_name.i18n_key}")
-  end
+  def reachable?(_object) = true
 end

--- a/lib/open_project/journal_formatter/subproject_named_association.rb
+++ b/lib/open_project/journal_formatter/subproject_named_association.rb
@@ -26,8 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class OpenProject::JournalFormatter::SubprojectNamedAssociation <
-  OpenProject::JournalFormatter::VisibleNamedAssociation
+class OpenProject::JournalFormatter::SubprojectNamedAssociation < JournalFormatter::NamedAssociation
   private
 
   def format_details(key, values, cache:)

--- a/lib/open_project/journal_formatter/target_versions.rb
+++ b/lib/open_project/journal_formatter/target_versions.rb
@@ -52,7 +52,7 @@ class OpenProject::JournalFormatter::TargetVersions < JournalFormatter::NamedAss
       next if value.blank? || klass.nil?
 
       value.to_s.split(",")
-           .filter_map { |id| associated_object(klass, id.to_i, cache:)&.name }
+           .filter_map { |id| name_or_placeholder(associated_object(klass, id.to_i, cache:)) }
            .join(", ")
            .presence
     end

--- a/lib/open_project/journal_formatter/time_entry_named_association.rb
+++ b/lib/open_project/journal_formatter/time_entry_named_association.rb
@@ -26,7 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class OpenProject::JournalFormatter::TimeEntryNamedAssociation < JournalFormatter::NamedAssociation
+class OpenProject::JournalFormatter::TimeEntryNamedAssociation <
+  OpenProject::JournalFormatter::PublicNamedAssociation
   private
 
   def format_details(key, values, cache:)

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -57,9 +57,34 @@ module JournalFormatter
       values.map do |value|
         next unless klass && value
 
-        record = associated_object(klass, value.to_i, cache:)
-        associated_object_name(record)
+        name_or_placeholder(associated_object(klass, value.to_i, cache:))
       end
+    end
+
+    def name_or_placeholder(object)
+      return associated_object_name(object) if object.nil? || reachable?(object)
+
+      I18n.t("journals.non_visible.#{object.model_name.i18n_key}",
+             default: I18n.t("journals.non_visible.default"))
+    end
+
+    # A journal outlives the reader's access to what it references: a work package
+    # moved between projects keeps journal entries naming the parent, version,
+    # category and budget it had in a project the reader cannot open.
+    #
+    # The reader is part of the key, so a verdict left behind in a thread that
+    # outlives a single request cannot be read back for somebody else.
+    def reachable?(object)
+      RequestStore.fetch("journal_reachable/#{User.current.id}/#{object.class.name}/#{object.id}") do
+        reader_may_see?(object)
+      end
+    end
+
+    def reader_may_see?(object)
+      return object.visible? if object.respond_to?(:visible?)
+
+      project = object.try(:project)
+      project.nil? || project.visible?
     end
 
     def associated_object_name(object)

--- a/modules/backlogs/spec/models/work_packages/sprint_journaling_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/sprint_journaling_spec.rb
@@ -73,6 +73,9 @@ RSpec.describe "WorkPackage sprint association journaling", # rubocop:disable RS
   it "formats the sprint change in the journal" do
     work_package_with_sprint.update!(sprint: sprint2)
 
+    # A sprint is only named to readers who may see its project.
+    login_as(create(:user, member_with_permissions: { project => %i[view_work_packages] }))
+
     last_journal = work_package_with_sprint.journals.last
     formatted = last_journal.render_detail("sprint_id", no_html: true)
 

--- a/modules/resource_management/app/models/resource_allocation.rb
+++ b/modules/resource_management/app/models/resource_allocation.rb
@@ -59,8 +59,10 @@ class ResourceAllocation < ApplicationRecord
   register_journal_formatted_fields "state", formatter_key: :plaintext
   register_journal_formatted_fields "start_date", "end_date", formatter_key: :datetime
   register_journal_formatted_fields "allocated_time", formatter_key: :allocated_time
+  # An allocation is about these people, so naming them does not depend on the
+  # reader sharing a project with them.
   register_journal_formatted_fields "principal_id", "requested_by_id", "reviewed_by_id", "principal_assigned_by_id",
-                                    formatter_key: :named_association
+                                    formatter_key: :public_named_association
   register_journal_formatted_fields "entity_gid", formatter_key: :polymorphic_association
   register_journal_formatted_fields "filter_name", formatter_key: :plaintext
 

--- a/spec/lib/acts_as_journalized/journal_formatter/named_association_spec.rb
+++ b/spec/lib/acts_as_journalized/journal_formatter/named_association_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe OpenProject::JournalFormatter::VisibleNamedAssociation do
+RSpec.describe JournalFormatter::NamedAssociation do
   shared_let(:permitted_project) { create(:private_project, name: "Permitted project") }
   shared_let(:other_project) { create(:private_project, name: "Other project") }
 
@@ -75,6 +75,19 @@ RSpec.describe OpenProject::JournalFormatter::VisibleNamedAssociation do
         expect(render([other_parent.id, permitted_parent.id])).not_to include(other_parent.subject)
         expect(render([permitted_parent.id, other_parent.id])).not_to include(other_parent.subject)
       end
+    end
+
+    # Verdicts are memoized per request. Should a thread ever outlive one, the next
+    # reader must still be judged on their own access.
+    it "does not carry one reader's verdict over to the next" do
+      login_as(reader)
+      withheld = render([nil, other_parent.id])
+
+      login_as(reader_of_both)
+      disclosed = render([nil, other_parent.id])
+
+      expect(withheld).not_to include(other_parent.subject)
+      expect(disclosed).to include(other_parent.subject)
     end
 
     context "with a reader permitted in both projects" do
@@ -170,6 +183,76 @@ RSpec.describe OpenProject::JournalFormatter::VisibleNamedAssociation do
       it "names the parent project" do
         expect(render([nil, other_project.id])).to include(other_project.name)
       end
+    end
+  end
+
+  # Moving a work package between projects nulls its version, category and budget
+  # and reassigns its category, so one journal entry can name several records that
+  # belong to the project it came from.
+  describe "records left behind by a move between projects" do
+    shared_let(:work_package) { create(:work_package, project: permitted_project, subject: "Moved") }
+
+    shared_let(:other_version) { create(:version, project: other_project, name: "Version in other project") }
+    shared_let(:other_category) { create(:category, project: other_project, name: "Category in other project") }
+    shared_let(:other_budget) { create(:budget, project: other_project, subject: "Budget in other project") }
+
+    let(:journal) { work_package.journals.last }
+
+    context "with a reader permitted in one project only" do
+      current_user { reader }
+
+      it "withholds the version name" do
+        expect(journal.render_detail(["version_id", [other_version.id, nil]]))
+          .to eq("<strong>Version</strong> deleted (<strike><i>a non-visible version</i></strike>)")
+      end
+
+      it "withholds the category name" do
+        expect(journal.render_detail(["category_id", [other_category.id, nil]]))
+          .not_to include(other_category.name)
+      end
+
+      it "withholds the budget name" do
+        expect(journal.render_detail(["budget_id", [other_budget.id, nil]]))
+          .not_to include(other_budget.subject)
+      end
+
+      it "withholds names among the target versions" do
+        permitted_version = create(:version, project: permitted_project, name: "Version in permitted project")
+        rendered = journal.render_detail(["target_versions", [nil, "#{permitted_version.id},#{other_version.id}"]])
+
+        expect(rendered).to include(permitted_version.name)
+        expect(rendered).not_to include(other_version.name)
+      end
+    end
+
+    context "with a reader permitted in both projects" do
+      current_user { reader_of_both }
+
+      it "names all of them" do
+        expect(journal.render_detail(["version_id", [other_version.id, nil]])).to include(other_version.name)
+        expect(journal.render_detail(["category_id", [other_category.id, nil]])).to include(other_category.name)
+        expect(journal.render_detail(["budget_id", [other_budget.id, nil]])).to include(other_budget.subject)
+      end
+    end
+  end
+
+  describe "people, which the journable names anyway" do
+    shared_let(:work_package) { create(:work_package, project: permitted_project, subject: "Assigned") }
+    shared_let(:stranger) do
+      create(:user, firstname: "Stranger", lastname: "Person",
+                    member_with_permissions: { other_project => %i[view_work_packages] })
+    end
+
+    let(:journal) { work_package.journals.last }
+
+    current_user { reader }
+
+    it "names them even though the reader shares no project with them" do
+      expect(stranger.visible?(reader)).to be(false)
+
+      expect(journal.render_detail(["assigned_to_id", [nil, stranger.id]])).to include(stranger.name)
+      expect(journal.render_detail(["responsible_id", [nil, stranger.id]])).to include(stranger.name)
+      expect(journal.render_detail(["author_id", [nil, stranger.id]])).to include(stranger.name)
     end
   end
 end

--- a/spec/lib/open_project/journal_formatter/target_versions_spec.rb
+++ b/spec/lib/open_project/journal_formatter/target_versions_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe OpenProject::JournalFormatter::TargetVersions do
 
       [version, other_version].each do |v|
         allow(Version).to receive(:find_by).with(id: v.id).and_return(v)
+        # Withholding names from readers outside the project is covered in the
+        # JournalFormatter::NamedAssociation spec.
+        allow(v).to receive(:visible?).and_return(true)
       end
     end
 


### PR DESCRIPTION
JournalFormatter::NamedAssociation resolved every association with a bare find_by and printed its name, so a journal could name a record from a project the reader has no access to.

We replace these checks with a visible? check by default IF the association responds to it.

These checks add more computational time, so we cache them in RequestStore.

# Ticket
https://community.openproject.org/work_packages/OP-19853