### PR TITLE
Skip version check for automation PRs

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -14,7 +14,12 @@ permissions:
 
 jobs:
   version-check:
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    # Skip automation PRs (dependabot, copilot, the release merge PRs opened by
+    # openprojectci) as they never link a work package.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.user.type != 'Bot'
+      && github.event.pull_request.user.login != 'openprojectci'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Ticket

No work package — CI housekeeping.

# What are you trying to accomplish?

The work package version check runs on PRs opened by automation, which never link a work package. Every release merge PR (e.g. https://github.com/opf/openproject/pull/24592) therefore gets a "does not link an OpenProject work package" warning comment that nobody can act on.

This skips the job for PRs authored by bots or by `openprojectci`.

# What approach did you choose and why?

Two changes to the job condition:

- Keyed on `github.event.pull_request.user` (the PR author) instead of `github.actor`. On `synchronize`, `github.actor` is whoever pushed last, so a human pushing to a bot's branch would re-trigger the check.
- Replaced the `dependabot[bot]` string comparison with `user.type != 'Bot'`, which also covers `copilot[bot]` and `copilot-swe-agent[bot]`. `openprojectci` is a regular user account holding the PAT used by `create-merge-release-into-dev-pr.yml`, so it needs an explicit login check on top.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
