### PR TITLE
[OP-19669] Defer OPCE replacement until morph ends

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.spec.ts
@@ -152,9 +152,14 @@ describe('Date picker preview controller', () => {
   it('replaces an OPCE-* node when scheduling has changed', async () => {
     const currentElement = await morphFrame('/work_packages/123/dialog/preview?schedule_manually=true');
 
-    // The `<div>` sibling is NOT expected to morph here: oldNode.replaceWith()
-    // detaches the OPCE node from the DOM, which breaks idiomorph's sibling walk
-    // for anything that follows it. Pre-existing bug, tracked as OP-19669.
     expect(currentElement.querySelector('opce-test-marker')!.getAttribute('data-marker')).toBe('new');
+  });
+
+  it('keeps morphing siblings that follow a replaced OPCE-* node', async () => {
+    const currentElement = await morphFrame('/work_packages/123/dialog/preview?schedule_manually=true');
+
+    expect(currentElement.querySelectorAll('opce-test-marker')).toHaveLength(1);
+    expect(currentElement.querySelectorAll('div')).toHaveLength(1);
+    expect(currentElement.querySelector('div')!.getAttribute('data-marker')).toBe('new');
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -72,6 +72,13 @@ export abstract class DialogPreviewController extends Controller {
       const schedulingChanged = requestUrl.searchParams.has('schedule_manually');
 
       event.detail.render = (currentElement, newElement) => {
+        // Replacing a node from inside `beforeNodeMorphed` corrupts idiomorph's
+        // walk: it detaches the node it is tracking its position by, and removes
+        // the replacement from the new tree it is iterating. Either one makes it
+        // skip every sibling that follows. Collect the replacements instead and
+        // apply them once the morph has finished.
+        const pendingReplacements:[HTMLElement, Node][] = [];
+
         Idiomorph.morph(currentElement, newElement, {
           ignoreActiveValue: this.ignoreActiveValueWhenMorphing(),
           callbacks: {
@@ -80,7 +87,7 @@ export abstract class DialogPreviewController extends Controller {
               // replace the angular tag with the new version.
               if (isOpenProjectCustomElement(oldNode)) {
                 if (schedulingChanged) {
-                  oldNode.replaceWith(newNode);
+                  pendingReplacements.push([oldNode, newNode.cloneNode(true)]);
                 }
                 return false;
               }
@@ -88,6 +95,9 @@ export abstract class DialogPreviewController extends Controller {
             },
           },
         });
+
+        pendingReplacements.forEach(([oldNode, newNode]) => oldNode.replaceWith(newNode));
+
         this.afterRendering({ shouldFocusBanner: schedulingChanged });
       };
     };


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19669

# What are you trying to accomplish?

> [!IMPORTANT]
> **No user-facing bug is fixed here — this is a latent trap.**

`DialogPreviewController`'s `beforeNodeMorphed` callback replaces `OPCE-*` elements with `oldNode.replaceWith(newNode)` from inside the callback, mutating both trees idiomorph is walking. Detaching `oldNode` leaves `morphChildren` with a `null` insertion point (remaining children get appended, stale ones never removed), and moving `newNode` out of the live `childNodes` `NodeList` makes the index-based iterator skip the next new sibling.

It isn't reachable from the UI today: the only `OPCE-*` element in any dialog this controller serves is `opce-wp-date-picker-instance`, which is the sole child of its own `body.with_row` wrapper and renders its input and flatpickr calendar inside its own host. With no siblings in that parent there is nothing to skip or duplicate. Adding a second element to that row, or flattening the wrapper, would silently corrupt the morph with no error and no failing test.

Found while adding coverage in https://community.openproject.org/wp/OP-19666; the `replaceWith` call itself is unchanged on `dev`.

# What approach did you choose and why?

Replacements are collected during the walk and applied once `Idiomorph.morph()` has returned, so the callback stays side-effect free. `oldNode` stays attached for the whole walk (insertion point remains valid), and the queued node is `newNode.cloneNode(true)` so the new tree never shifts.

Alternatives discarded: re-morphing the container afterwards (papers over the corruption, doubles the work), and letting idiomorph replace via the callback's return value (it has no "replace instead of morph" signal — `false` only skips).

The OP-19666 spec was deliberately narrowed to assert only the OPCE node's own replacement, with a comment pointing here. That narrowing is removed and a dedicated case asserts the sibling morphs and is not duplicated; it fails on `dev` with `expected 'old' to be 'new'`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
