### PR TITLE
[COMMS-945] Fix a 500 caused by activities pointing to deleted WPs

### DIFF
--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/polymorphic_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/polymorphic_association.rb
@@ -65,14 +65,25 @@ module JournalFormatter
     end
 
     def associated_object(gid, cache:)
+      global_id = GlobalID.parse(gid)
+      return if global_id.nil?
+
       if cache
-        go = GlobalID.new(gid)
-        cache.fetch(go.model_name, go.model_id) do # rubocop:disable Lint/UselessDefaultValueArgument
-          GlobalID::Locator.locate(gid)
+        cache.fetch(global_id.model_name, global_id.model_id) do # rubocop:disable Lint/UselessDefaultValueArgument
+          locate(global_id)
         end
       else
-        GlobalID::Locator.locate(gid)
+        locate(global_id)
       end
+    end
+
+    # The referenced record may have been destroyed after the journal was written,
+    # e.g. a time entry logged on a work package that has since been deleted.
+    # The detail is then rendered as if the value had been removed.
+    def locate(global_id)
+      GlobalID::Locator.locate(global_id)
+    rescue ActiveRecord::RecordNotFound
+      nil
     end
   end
 end

--- a/spec/lib/open_project/journal_formatter/polymorphic_association_spec.rb
+++ b/spec/lib/open_project/journal_formatter/polymorphic_association_spec.rb
@@ -89,5 +89,59 @@ RSpec.describe JournalFormatter::PolymorphicAssociation do
                         old: old_wp.subject))
       end
     end
+
+    context "when the old value references a record that has since been deleted" do
+      let(:old_value) do
+        create(:work_package).then do |work_package|
+          work_package.to_gid.tap { work_package.destroy }
+        end
+      end
+
+      it "renders only the new value instead of raising" do
+        expect(instance.render("entity_gid", [old_value, new_value]))
+          .to eq(I18n.t(:text_journal_set_to,
+                        label: "<strong>Logged for</strong>",
+                        value: "<i>#{new_wp.subject}</i>"))
+
+        expect(instance.render("entity_gid", [old_value, new_value], html: false))
+          .to eq(I18n.t(:text_journal_set_to,
+                        label: "Logged for",
+                        value: new_wp.subject))
+      end
+
+      it "renders only the new value when a formatter cache is used" do
+        expect(instance.render("entity_gid", [old_value, new_value], html: false, cache: JournalFormatterCache.new))
+          .to eq(I18n.t(:text_journal_set_to,
+                        label: "Logged for",
+                        value: new_wp.subject))
+      end
+    end
+
+    context "when both values reference records that have since been deleted" do
+      let(:old_value) do
+        create(:work_package).then do |work_package|
+          work_package.to_gid.tap { work_package.destroy }
+        end
+      end
+      let(:new_value) do
+        create(:work_package).then do |work_package|
+          work_package.to_gid.tap { work_package.destroy }
+        end
+      end
+
+      it "renders as removed instead of raising" do
+        expect(instance.render("entity_gid", [old_value, new_value], html: false))
+          .to eq(I18n.t(:text_journal_deleted_no_detail, label: "Logged for"))
+      end
+    end
+
+    context "when a value is not a parseable global id" do
+      let(:new_value) { "gid://#{GlobalID.app}//" }
+
+      it "renders as removed instead of raising" do
+        expect(instance.render("entity_gid", [old_value, new_value], html: false))
+          .to eq(I18n.t(:text_journal_deleted, label: "Logged for", old: old_wp.subject))
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-945

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
FIx a glitch caused by attempt to resolve ID of a work package that has been deleted. 

Simply return `nil`, similarly to a case where the global ID isn't parseable.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
