### PR TITLE
[OP-19856] Replace gosu with setpriv

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -141,9 +141,6 @@ ENV OPENPROJECT_RAILS__CACHE__STORE=memcache
 ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject
 ENV PGDATA=/var/openproject/pgdata
 
-COPY --from=openproject/gosu /go/bin/gosu /usr/local/bin/gosu
-RUN chmod +x /usr/local/bin/gosu && gosu nobody true
-
 COPY --from=openproject/hocuspocus:17.6.0 --chown=$APP_USER:$APP_USER /app /opt/hocuspocus
 # Keep node/npm in all-in-one for bundled hocuspocus even when BIM support is disabled.
 COPY --from=build-base /usr/local/bin/node /usr/local/bin/node

--- a/docker/prod/entrypoint.sh
+++ b/docker/prod/entrypoint.sh
@@ -106,7 +106,11 @@ if [ "$(id -u)" = '0' ]; then
 		exec "$@"
 	fi
 
-	exec gosu $APP_USER "$BASH_SOURCE" "$@"
+	# setpriv keeps the current environment, so we need to update HOME to the APP_USER
+	HOME="$(getent passwd "$APP_USER" | cut -d: -f6)"
+	export HOME
+
+	exec setpriv --reuid "$APP_USER" --regid "$(id -g "$APP_USER")" --init-groups "$BASH_SOURCE" "$@"
 fi
 
 exec "$@"

--- a/script/ci/docker_validate_image.sh
+++ b/script/ci/docker_validate_image.sh
@@ -267,8 +267,8 @@ validate_all_in_one() {
 
   docker exec "${VALIDATION_CONTAINER_NAME}" sh -lc '
 set -eu
-command -v -- gosu >/dev/null 2>&1
-gosu nobody true
+command -v -- setpriv >/dev/null 2>&1
+setpriv --reuid nobody --regid nogroup --init-groups true
 [ -d /opt/hocuspocus ]
 [ -x /usr/lib/postgresql/17/bin/psql ]
 command -v -- node >/dev/null 2>&1


### PR DESCRIPTION
https://community.openproject.org/work_packages/OP-19856

Removed gosu from AIO dockerfile, as our own build is outdated.

Changes:

We need to manually set HOME for setpriv.
This is the one place setpriv isn't a full replacement. gosu's main.go does os.Unsetenv("HOME") and then SetupUser sets HOME from the passwd entry. setpriv deliberately doesn't touch the environment, so without this the app user would inherit root's HOME=/root — unwritable, and it would miss the .irbrc that Dockerfile:99 symlinks into /home/app for docker/prod/console. getent passwd | cut -d: -f6 reproduces the env exactly now with gosu

--regid "$(id -g "$APP_USER")" uses the numeric primary GID rather than the group name, matching gosu's use of the passwd GID instead of assuming a group named app exists.

Confirmed tests:
- setpriv is /usr/bin/setpriv in util-linux (Priority: required), not util-linux-extra — present in ruby:slim-trixie with no new package.
- Privilege drop is final: setpriv.c does setresuid(ruid, euid, euid) and setresgid(rgid, egid, egid), so root access can't be re-entered.
- --init-groups calls initgroups(3), matching gosu's unix.Setgroups(execUser.Sgids). The manpage requires one of --clear-groups/--groups/--keep-groups/--init-groups alongside --regid, which is satisfied.

This makes the gosu dependency bump unnecessary, so nothing to push there. Fixes CVE-2025-68121
