### PR TITLE
Run bundle clean --force on dockerization step

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -80,7 +80,9 @@ COPY vendor ./vendor
 # Add lib in case a plugin tries to load VERSION file under lib
 COPY lib ./lib
 
-COPY ./docker/prod/setup/bundle-install.sh ./vendor/bundle* ./vendor/
+# The restored vendor/bundle cache already arrives with `COPY vendor` above. Naming
+# it again here copied its *contents* into vendor/, leaving a stale second gem tree.
+COPY ./docker/prod/setup/bundle-install.sh ./vendor/
 RUN bash vendor/bundle-install.sh && rm vendor/bundle-install.sh
 
 COPY . .

--- a/docker/prod/setup/bundle-install.sh
+++ b/docker/prod/setup/bundle-install.sh
@@ -5,6 +5,8 @@ set -e
 bundle config set --local path 'vendor/bundle'
 bundle config set --local without 'test development'
 bundle install --jobs=8 --retry=3
+# Use bundle clean to force remove gem versions the Gemfile.lock does not depend on
+bundle clean --force
 bundle config set deployment 'true'
 cp Gemfile.lock Gemfile.lock.bak
 rm -rf vendor/bundle/ruby/*/cache


### PR DESCRIPTION
run bundle clean --force after bundle install, before bundle config set deployment 'true' and before the existing rm -rf pruning. This ensures we drop gem versions that our Gemfile.lock does not require. They accumulate because installing into a restored vendor/bundle adds new versions without removing superseded ones.

Also removed ./vendor/bundle* from the COPY, leaving just COPY ./docker/prod/setup/bundle-install.sh ./vendor/. With a directory source, COPY writes the directory's contents, so naming vendor/bundle there dumped its gem tree a second time as /app/vendor/ruby/.