### PR TITLE
[op-19850] very long loading times for project timeline widget

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -102,6 +102,8 @@ describe('ProjectTimelineGraphComponent', () => {
   let buildData:(phases:unknown[]) => { items:ProjectTimelineItem[]; groups:{ id:string; content:string }[] };
   let tooltipTemplate:(item:ProjectTimelineItem) => HTMLElement|string;
   let buildAccessibleItems:(phases:unknown[]) => { id:string; text:string }[];
+  let revealTimeline:() => void;
+  let ready:() => boolean;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -125,6 +127,31 @@ describe('ProjectTimelineGraphComponent', () => {
     tooltipTemplate = (component as any).tooltipTemplate.bind(component);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
     buildAccessibleItems = (component as any).buildAccessibleItems.bind(component);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
+    revealTimeline = (component as any).revealTimeline.bind(component);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
+    ready = (component as any).ready;
+  });
+
+  describe('revealTimeline', () => {
+    it('reveals the timeline immediately after the initial draw completes', () => {
+      const setOptions = vi.fn((_options:{
+        showCurrentTime:boolean;
+        cluster:{ maxItems:number; clusterCriteria:(a:ProjectTimelineItem, b:ProjectTimelineItem) => boolean };
+      }) => undefined);
+      const timeline = { setOptions, destroy: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (component as any).timeline = timeline;
+
+      revealTimeline();
+
+      expect(setOptions).toHaveBeenCalledOnce();
+      const options = setOptions.mock.calls[0][0];
+      expect(options.showCurrentTime).toBe(true);
+      expect(options.cluster.maxItems).toBe(1);
+      expect(options.cluster.clusterCriteria).toBeTypeOf('function');
+      expect(ready()).toBe(true);
+    });
   });
 
   describe('buildData', () => {

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -102,8 +102,6 @@ describe('ProjectTimelineGraphComponent', () => {
   let buildData:(phases:unknown[]) => { items:ProjectTimelineItem[]; groups:{ id:string; content:string }[] };
   let tooltipTemplate:(item:ProjectTimelineItem) => HTMLElement|string;
   let buildAccessibleItems:(phases:unknown[]) => { id:string; text:string }[];
-  let revealTimeline:() => void;
-  let ready:() => boolean;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -127,31 +125,6 @@ describe('ProjectTimelineGraphComponent', () => {
     tooltipTemplate = (component as any).tooltipTemplate.bind(component);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
     buildAccessibleItems = (component as any).buildAccessibleItems.bind(component);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
-    revealTimeline = (component as any).revealTimeline.bind(component);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
-    ready = (component as any).ready;
-  });
-
-  describe('revealTimeline', () => {
-    it('reveals the timeline immediately after the initial draw completes', () => {
-      const setOptions = vi.fn((_options:{
-        showCurrentTime:boolean;
-        cluster:{ maxItems:number; clusterCriteria:(a:ProjectTimelineItem, b:ProjectTimelineItem) => boolean };
-      }) => undefined);
-      const timeline = { setOptions, destroy: vi.fn() };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (component as any).timeline = timeline;
-
-      revealTimeline();
-
-      expect(setOptions).toHaveBeenCalledOnce();
-      const options = setOptions.mock.calls[0][0];
-      expect(options.showCurrentTime).toBe(true);
-      expect(options.cluster.maxItems).toBe(1);
-      expect(options.cluster.clusterCriteria).toBeTypeOf('function');
-      expect(ready()).toBe(true);
-    });
   });
 
   describe('buildData', () => {
@@ -433,6 +406,17 @@ describe('ProjectTimelineGraphComponent', () => {
       expect(element.querySelector('ul.sr-only')?.textContent).toContain('Phase Build: 2024-04-01 to 2024-06-30');
       expect(element.querySelector('ul.sr-only')?.textContent).toContain('Phase gate Build Start: 2024-04-01');
       expect(element.querySelector('ul.sr-only')?.textContent).toContain('Phase gate Build End: 2024-06-30');
+    });
+
+    it('hides the loading skeleton once the initial draw completes', async () => {
+      const element = fixture.nativeElement as HTMLElement;
+
+      await vi.waitUntil(() => {
+        fixture.detectChanges();
+        return element.querySelector('.op-project-timeline-graph--wrapper_loading') === null;
+      });
+
+      expect(element.querySelector('.op-project-timeline-graph--wrapper_loading')).toBeNull();
     });
   });
 });

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -27,13 +27,13 @@
 //++
 
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
-  OnDestroy,
   ViewChild,
   ViewEncapsulation,
+  afterNextRender,
   computed,
   effect,
   inject,
@@ -91,7 +91,7 @@ const GROUP_LIFECYCLE = 'lifecycle';
   encapsulation: ViewEncapsulation.None,
   imports: [OpenprojectContentLoaderModule],
 })
-export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
+export class ProjectTimelineGraphComponent {
   @ViewChild('container') containerRef!:ElementRef<HTMLDivElement>;
 
   readonly phasesData = input.required<string>();
@@ -110,29 +110,20 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
   protected readonly ready = signal(false);
 
   private timeline:Timeline | null = null;
-  private destroyed = false;
 
   constructor() {
+    afterNextRender(() => this.initTimeline(this.phases()));
+    inject(DestroyRef).onDestroy(() => {
+      this.timeline?.destroy();
+      this.timeline = null;
+    });
+
     effect(() => {
       const phases = this.phases();
       if (this.timeline) {
         this.updateTimeline(phases);
       }
     });
-  }
-
-  ngAfterViewInit():void {
-    requestAnimationFrame(() => {
-      if (!this.destroyed) {
-        this.initTimeline(this.phases());
-      }
-    });
-  }
-
-  ngOnDestroy():void {
-    this.destroyed = true;
-    this.timeline?.destroy();
-    this.timeline = null;
   }
 
   private buildData(phases:ProjectPhaseData[]) {
@@ -262,7 +253,7 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
   }
 
   private revealTimeline():void {
-    if (!this.timeline || this.destroyed) return;
+    if (!this.timeline) return;
 
     this.timeline.setOptions({
       showCurrentTime: true,

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -40,8 +40,6 @@ import {
   input,
   signal,
 } from '@angular/core';
-import { Subject } from 'rxjs';
-import { debounceTime, take, takeUntil } from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
@@ -113,8 +111,6 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
   private timeline:Timeline | null = null;
   private destroyed = false;
-  private readyHandler:(() => void) | null = null;
-  private readonly destroyed$ = new Subject<void>();
 
   constructor() {
     effect(() => {
@@ -135,9 +131,6 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy():void {
     this.destroyed = true;
-    this.destroyed$.next();
-    this.destroyed$.complete();
-    if (this.readyHandler) this.timeline?.off('changed', this.readyHandler);
     this.timeline?.destroy();
     this.timeline = null;
   }
@@ -258,37 +251,24 @@ export class ProjectTimelineGraphComponent implements AfterViewInit, OnDestroy {
         showMajorLabels: true,
         showMinorLabels: true,
         margin: { item: { horizontal: 0, vertical: 16 } },
-        showCurrentTime: false, // enabled after reveal; avoids periodic changed events interfering with the ready debounce
+        showCurrentTime: false, // enabled after the initial draw to avoid unnecessary redraws while loading
         zoomMin: 7 * 24 * 60 * 60 * 1000, // 7 days minimum zoom
         zoomMax: 50 * 365 * 24 * 60 * 60 * 1000, // 50 years days maximum zoom
+        onInitialDrawComplete: () => this.revealTimeline(),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
         tooltip: { template: this.tooltipTemplate.bind(this) } as any,
       },
     );
-    this.revealWhenReady();
   }
 
-  // Hides the skeleton once vis-timeline has stopped firing 'changed' events.
-  // Multiple render passes occur on an initial load, so we debounce
-  private revealWhenReady():void {
-    const changed$ = new Subject<void>();
+  private revealTimeline():void {
+    if (!this.timeline || this.destroyed) return;
 
-    this.readyHandler = () => changed$.next();
-    this.timeline!.on('changed', this.readyHandler);
-
-    changed$.pipe(
-      debounceTime(1000),
-      take(1),
-      takeUntil(this.destroyed$),
-    ).subscribe(() => {
-      this.timeline!.off('changed', this.readyHandler!);
-      this.readyHandler = null;
-      this.timeline!.setOptions({
-        showCurrentTime: true,
-        cluster: { maxItems: 1, clusterCriteria: this.shouldCluster.bind(this) },
-      });
-      this.ready.set(true);
+    this.timeline.setOptions({
+      showCurrentTime: true,
+      cluster: { maxItems: 1, clusterCriteria: this.shouldCluster.bind(this) },
     });
+    this.ready.set(true);
   }
 
   private tooltipTemplate(item:ProjectTimelineItem):HTMLElement | string {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19850

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The widget previously waited until no `changed` event had been emitted for one second. Since vis-timeline performs periodic resize checks, the debounce could restart repeatedly and leave the loading skeleton visible after the timeline had already finished rendering.

# What approach did you choose and why?
- Uses `onInitialDrawComplete` to reveal the timeline after its initial render.
- Keeps clustering and the current-time marker deferred until rendering completes.
- Removes the obsolete RxJS event and cleanup.
