### PR TITLE
[SPPM-330] Disable PIR for new project attributes by default

### DIFF
--- a/app/controllers/projects/settings/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/creation_wizard_controller.rb
@@ -45,7 +45,16 @@ class Projects::Settings::CreationWizardController < Projects::SettingsControlle
   end
 
   def toggle
-    @project.update(project_creation_wizard_enabled: !@project.project_creation_wizard_enabled)
+    enabling = !@project.project_creation_wizard_enabled
+    @project.update!(project_creation_wizard_enabled: enabling)
+
+    # Enabling PIR will enable all the project's currently active
+    # project attributes for PIR by default.
+    # Note that project attributes that are added to the project *later*
+    # are not enabled in PIR automatically.
+    # They will have to be enabled explicitly on the attributes tab.
+    enable_creation_wizard_for_all_mappings! if enabling
+
     redirect_to project_settings_creation_wizard_path(@project, tab: params[:tab]), status: :see_other
   end
 
@@ -137,6 +146,10 @@ class Projects::Settings::CreationWizardController < Projects::SettingsControlle
     ProjectCustomFieldProjectMapping
       .where(project_id: @project.id, custom_field_id: custom_field_ids)
       .update_all(creation_wizard: true)
+  end
+
+  def enable_creation_wizard_for_all_mappings!
+    @project.project_custom_field_project_mappings.update_all(creation_wizard: true)
   end
 
   def custom_field_toggleable?(custom_field)

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -125,12 +125,10 @@ module Projects
     # This has to run after copy_activated_custom_fields, since that is what
     # actually creates most of the mappings being adjusted here.
     def copy_creation_wizard_flags(project)
-      source_flags = source.project_custom_field_project_mappings.pluck(:custom_field_id, :creation_wizard).to_h
+      enabled_cf_ids = source.project_custom_field_project_mappings.where(creation_wizard: true).pluck(:custom_field_id)
 
-      project.project_custom_field_project_mappings.find_each do |mapping|
-        creation_wizard = source_flags[mapping.custom_field_id]
-        mapping.update_column(:creation_wizard, creation_wizard) unless creation_wizard.nil?
-      end
+      project.project_custom_field_project_mappings.update_all(creation_wizard: false)
+      project.project_custom_field_project_mappings.where(custom_field_id: enabled_cf_ids).update_all(creation_wizard: true)
     end
 
     def retain_attributes(source, target)

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -125,10 +125,12 @@ module Projects
     # This has to run after copy_activated_custom_fields, since that is what
     # actually creates most of the mappings being adjusted here.
     def copy_creation_wizard_flags(project)
-      enabled_cf_ids = source.project_custom_field_project_mappings.where(creation_wizard: true).pluck(:custom_field_id)
+      source_flags = source.project_custom_field_project_mappings.pluck(:custom_field_id, :creation_wizard).to_h
 
-      project.project_custom_field_project_mappings.update_all(creation_wizard: false)
-      project.project_custom_field_project_mappings.where(custom_field_id: enabled_cf_ids).update_all(creation_wizard: true)
+      project.project_custom_field_project_mappings.find_each do |mapping|
+        creation_wizard = source_flags[mapping.custom_field_id]
+        mapping.update_column(:creation_wizard, creation_wizard) unless creation_wizard.nil?
+      end
     end
 
     def retain_attributes(source, target)

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -105,6 +105,7 @@ module Projects
     def after_perform(call)
       super.tap do |super_call|
         copy_activated_custom_fields(super_call)
+        copy_creation_wizard_flags(super_call.result)
         update_calculated_value_custom_fields(super_call.result)
       end
     end
@@ -116,6 +117,20 @@ module Projects
 
     def copy_activated_custom_fields(call)
       call.result.project_custom_field_ids = source.project_custom_field_ids
+    end
+
+    # Activating a custom field on the copy must not silently enable it for
+    # the creation wizard (PIR) - unless the source project already had it
+    # enabled, in which case we want to preserve that setting on the copy.
+    # This has to run after copy_activated_custom_fields, since that is what
+    # actually creates most of the mappings being adjusted here.
+    def copy_creation_wizard_flags(project)
+      source_flags = source.project_custom_field_project_mappings.pluck(:custom_field_id, :creation_wizard).to_h
+
+      project.project_custom_field_project_mappings.find_each do |mapping|
+        creation_wizard = source_flags[mapping.custom_field_id]
+        mapping.update_column(:creation_wizard, creation_wizard) unless creation_wizard.nil?
+      end
     end
 
     def retain_attributes(source, target)
@@ -166,22 +181,6 @@ module Projects
         attributes.except(:parent_id)
       else
         attributes
-      end
-    end
-
-    private
-
-    def build_missing_project_custom_field_project_mappings(project)
-      # Build mappings using the concern's logic
-      super
-
-      # Copy creation_wizard flag from source project's mappings to the newly built mappings
-      source_mappings_by_custom_field_id = source.project_custom_field_project_mappings
-        .index_by(&:custom_field_id)
-
-      project.project_custom_field_project_mappings.each do |mapping|
-        source_mapping = source_mappings_by_custom_field_id[mapping.custom_field_id]
-        mapping.creation_wizard = source_mapping.creation_wizard if source_mapping
       end
     end
   end

--- a/db/migrate/20260805122307_change_creation_wizard_default_on_project_custom_field_project_mappings.rb
+++ b/db/migrate/20260805122307_change_creation_wizard_default_on_project_custom_field_project_mappings.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Newly activating a project attribute for a project must not automatically
+# enable it for the project creation wizard (PIR) anymore. Enabling it has to
+# be a conscious, separate step. Enabling the wizard itself still activates
+# all of a project's currently active attributes, but that is now done
+# explicitly in Projects::Settings::CreationWizardController#toggle instead of
+# relying on this default.
+class ChangeCreationWizardDefaultOnProjectCustomFieldProjectMappings < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :project_custom_field_project_mappings, :creation_wizard, from: true, to: false
+  end
+end

--- a/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
+++ b/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe Projects::Settings::CreationWizardController do
         expect(flash[:error]).to be_nil
         expect(project.reload.project_creation_wizard_enabled).to be true
       end
+
+      context "with a project attribute that was not yet enabled for the creation wizard" do
+        let!(:mapping) do
+          create(:project_custom_field_project_mapping, project:, creation_wizard: false)
+        end
+
+        it "enables all of the project's currently active attributes for the creation wizard" do
+          post :toggle, params: { project_id: project.id }
+
+          expect(mapping.reload.creation_wizard).to be true
+        end
+      end
     end
 
     context "when disabling the wizard without activation conditions met" do

--- a/spec/features/projects/creation_wizard/project_creation_wizard_spec.rb
+++ b/spec/features/projects/creation_wizard/project_creation_wizard_spec.rb
@@ -132,6 +132,13 @@ RSpec.describe "Project creation wizard",
     create(:project_custom_field_project_mapping, project:, project_custom_field: string_custom_field)
     create(:project_custom_field_project_mapping, project:, project_custom_field: list_custom_field)
     create(:project_custom_field_project_mapping, project:, project_custom_field: int_custom_field)
+
+    # Activating a project attribute no longer enables it for the creation
+    # wizard (PIR) automatically. Explicitly enable everything mapped so far
+    # (including user_custom_field, mapped via the project factory above) -
+    # the dedicated "disabled" contexts below turn specific ones back off
+    # afterwards, in their own before/let! hooks, which run after this one.
+    project.project_custom_field_project_mappings.update_all(creation_wizard: true)
   end
 
   it "can visit the wizard path manually and navigate through sections" do

--- a/spec/features/projects/settings/creation_wizard/attributes_spec.rb
+++ b/spec/features/projects/settings/creation_wizard/attributes_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe "Project creation wizard settings - attributes tab",
     end
   end
 
-  it "defaults to true for newly mapped fields" do
+  it "defaults to false for newly mapped fields, even though the wizard is enabled" do
     new_field = create(:string_project_custom_field,
                        name: "New Field",
                        project_custom_field_section: section1)
@@ -301,12 +301,12 @@ RSpec.describe "Project creation wizard settings - attributes tab",
 
     within_custom_field_section_container(section1) do
       within_custom_field_container(new_field) do
-        expect_checked_state
+        expect_unchecked_state
       end
     end
 
     new_mapping.reload
-    expect(new_mapping.creation_wizard).to be true
+    expect(new_mapping.creation_wizard).to be false
   end
 
   it "can enable all fields in a section at once" do

--- a/spec/migrations/change_creation_wizard_default_on_project_custom_field_project_mappings_spec.rb
+++ b/spec/migrations/change_creation_wizard_default_on_project_custom_field_project_mappings_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20260805122307_change_creation_wizard_default_on_project_custom_field_project_mappings")
+
+RSpec.describe ChangeCreationWizardDefaultOnProjectCustomFieldProjectMappings, type: :model do
+  let(:conn) { ActiveRecord::Base.connection }
+
+  def creation_wizard_default
+    ProjectCustomFieldProjectMapping.reset_column_information
+    ProjectCustomFieldProjectMapping.column_defaults["creation_wizard"]
+  end
+
+  # The test schema is already migrated (default: false). Reset it back to
+  # the post-migration state after every example so later specs in the same
+  # process don't inherit a stale column cache or a lingering default: true,
+  # regardless of which direction this migration's specs just exercised.
+  after do
+    ActiveRecord::Migration.suppress_messages do
+      conn.change_column_default(:project_custom_field_project_mappings, :creation_wizard, false)
+    end
+    ProjectCustomFieldProjectMapping.reset_column_information
+  end
+
+  describe "up migration" do
+    before do
+      # Put the schema back into the pre-migration state (default: true).
+      ActiveRecord::Migration.suppress_messages do
+        conn.change_column_default(:project_custom_field_project_mappings, :creation_wizard, true)
+      end
+    end
+
+    it "changes the column default from true to false" do
+      expect(creation_wizard_default).to be true
+
+      ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+      expect(creation_wizard_default).to be false
+    end
+
+    it "does not change the creation_wizard value of already existing mappings" do
+      mapping = create(:project_custom_field_project_mapping, creation_wizard: true)
+
+      ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+      expect(mapping.reload.creation_wizard).to be true
+    end
+
+    it "makes newly created mappings default to false" do
+      ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+      mapping = create(:project_custom_field_project_mapping)
+
+      expect(mapping.creation_wizard).to be false
+    end
+  end
+
+  describe "down migration" do
+    it "changes the column default from false back to true" do
+      expect(creation_wizard_default).to be false
+
+      ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) }
+
+      expect(creation_wizard_default).to be true
+    end
+
+    it "does not change the creation_wizard value of already existing mappings" do
+      mapping = create(:project_custom_field_project_mapping, creation_wizard: false)
+
+      ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) }
+
+      expect(mapping.reload.creation_wizard).to be false
+    end
+  end
+end

--- a/spec/models/project/pdf_export/project_initiation_spec.rb
+++ b/spec/models/project/pdf_export/project_initiation_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe Project::PDFExport::ProjectInitiation do
       version_cf.update!(project_custom_field_section: section_b)
 
       disabled_mapping
+
+      # As of SPPM-330, activating a project attribute (e.g. by giving it a value, as the shared context does above)
+      # no longer enables it for the creation wizard (PIR) automatically.
+      # Explicitly enable all project attributes except the deliberately disabled one:
+      project.project_custom_field_project_mappings
+             .where.not(custom_field_id: disabled_custom_field.id)
+             .update_all(creation_wizard: true)
     end
 
     let(:expected_document) do

--- a/spec/services/project_custom_field_project_mappings/toggle_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/toggle_service_spec.rb
@@ -246,6 +246,39 @@ RSpec.describe ProjectCustomFieldProjectMappings::ToggleService do
     end
   end
 
+  describe "creation_wizard flag on newly created mappings" do
+    shared_let(:user) { create(:admin) }
+
+    shared_let(:custom_field) do
+      create(:project_custom_field,
+             name: "Newly activated field",
+             admin_only: false,
+             project_custom_field_section:)
+    end
+
+    context "when the project has the creation wizard (PIR) enabled" do
+      before do
+        project.update!(project_creation_wizard_enabled: true)
+      end
+
+      it "does not enable it for the creation wizard by default" do
+        expect(instance.call(project_id: project.id, custom_field_id: custom_field.id, value: "1")).to be_success
+
+        mapping = ProjectCustomFieldProjectMapping.find_by(project:, custom_field_id: custom_field.id)
+        expect(mapping.creation_wizard).to be false
+      end
+    end
+
+    context "when the project does not have the creation wizard (PIR) enabled" do
+      it "does not enable it for the creation wizard by default" do
+        expect(instance.call(project_id: project.id, custom_field_id: custom_field.id, value: "1")).to be_success
+
+        mapping = ProjectCustomFieldProjectMapping.find_by(project:, custom_field_id: custom_field.id)
+        expect(mapping.creation_wizard).to be false
+      end
+    end
+  end
+
   describe "calculated values", with_ee: %i[calculated_values] do
     using CustomFieldFormulaReferencing
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SPPM-330

# What are you trying to accomplish?
When the creation wizard (PIR) is enabled for a project, all active project attributes for that project should automatically be enabled for PIR.

Before this bugfix, project attributes that are activated later were also automatically enabled for PIR.

With this bugfix, project attributes that are activated later on are no longer automatically enabled for PIR. They have to be explicitly enabled for PIR by the user.

## Screenshots

https://github.com/user-attachments/assets/2ac4c246-8b5e-40c0-894a-b1a6aaf38046

# What approach did you choose and why?
The database default of the `creation_wizard` flag of the custom field mapping is set to false so that new project attributes are no longer implicitly enabled in the creation wizard. Instead, the wizard controller will set the flag for all active project attributes when the user enables PIR.

This has one caveat: the automatic activation for PIR will happen whenever a user enables it. Or, in other words: _each time_ the enable button is clicked. This may have unwanted consequences for admins that carefully curate a great number of project attributes. When they disable PIR for some test and then enable it again, all active project attributes will be enabled within PIR and the curation is lost.

To counter this, we would have to introduce a separate flag, possibly along with a UX concept. At this point, this is overkill, so I went for the simple solution.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
