### PR TITLE
Silence the spurious `vi.mock` hoisting warnings

### DIFF
--- a/frontend/src/common/drag-and-drop/sortable-lists-engine.preview.spec.ts
+++ b/frontend/src/common/drag-and-drop/sortable-lists-engine.preview.spec.ts
@@ -29,21 +29,21 @@
 // The drag preview's `getOffset` decides where the pointer sits on the
 // preview, and Pragmatic only hands it to the real `setCustomNativeDragPreview`
 // — nothing observable from the outside. So this file mocks that module and
-// reads the options back, which the sibling engine spec cannot do: it renders
-// previews for real. Separate file rather than a mock added there, because the
-// suite runs with `isolate: false` and shares one module registry.
+// reads the options back. It stays a separate file from the sibling engine
+// spec because that one renders previews for real, and one file cannot both
+// stub and exercise the same module.
 
 import { vi } from 'vitest';
 import { NativeDragSimulation } from 'core-common/drag-and-drop/testing/native-drag-simulation';
-import { createSortableRoot } from './sortable-lists-engine';
+import type { createSortableRoot as createSortableRootFn } from './sortable-lists-engine';
 
-const { previewCalls } = vi.hoisted(() => ({
-  previewCalls: [] as {
-    getOffset?:(args:{ container:HTMLElement }) => { x:number; y:number };
-  }[],
-}));
+// `doMock` is not hoisted, so this initialises before the factory below runs
+// and a plain const does the job `vi.hoisted()` used to.
+const previewCalls:{
+  getOffset?:(args:{ container:HTMLElement }) => { x:number; y:number };
+}[] = [];
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
   setCustomNativeDragPreview: (options:{
     getOffset?:(args:{ container:HTMLElement }) => { x:number; y:number };
   }) => {
@@ -51,8 +51,14 @@ vi.mock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-previe
   },
 }));
 
+let createSortableRoot:typeof createSortableRootFn;
+
 describe('createSortableRoot drag preview offset', () => {
   let cleanupFns:(() => void)[] = [];
+
+  beforeAll(async () => {
+    ({ createSortableRoot } = await import('./sortable-lists-engine'));
+  });
 
   beforeEach(() => { previewCalls.length = 0; });
 

--- a/frontend/src/common/drag-and-drop/sortable-lists-engine.spec.ts
+++ b/frontend/src/common/drag-and-drop/sortable-lists-engine.spec.ts
@@ -32,23 +32,23 @@ import {
   centerOf,
   towardsEdgeOf,
 } from 'core-common/drag-and-drop/testing/native-drag-simulation';
-import {
-  createSortableRoot,
-  type SortableDropIntent,
-  type SortableDropTransaction,
-  type SortableSource,
+import type {
+  createSortableRoot as createSortableRootFn,
+  SortableDropIntent,
+  SortableDropTransaction,
+  SortableSource,
 } from './sortable-lists-engine';
 
-const { autoScrollRegistrations } = vi.hoisted(() => ({
-  autoScrollRegistrations: [] as {
-    element:Element;
-    getAllowedAxis:() => string;
-    cleanup:() => void;
-    cleaned:boolean;
-  }[],
-}));
+// `doMock` is not hoisted, so this initialises before the factory below runs
+// and a plain const does the job `vi.hoisted()` used to.
+const autoScrollRegistrations:{
+  element:Element;
+  getAllowedAxis:() => string;
+  cleanup:() => void;
+  cleaned:boolean;
+}[] = [];
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
   autoScrollForElements: (args:{ element:Element; getAllowedAxis:() => string }) => {
     const entry = {
       element: args.element,
@@ -61,6 +61,8 @@ vi.mock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
     return entry.cleanup;
   },
 }));
+
+let createSortableRoot:typeof createSortableRootFn;
 
 const liveRegistrations = () => autoScrollRegistrations.filter((r) => !r.cleaned);
 
@@ -144,6 +146,10 @@ function buildCardGrid(items:string[], columns:number):{ root:HTMLElement; cards
 
 describe('createSortableRoot', () => {
   let cleanupFns:(() => void)[] = [];
+
+  beforeAll(async () => {
+    ({ createSortableRoot } = await import('./sortable-lists-engine'));
+  });
 
   beforeEach(() => { autoScrollRegistrations.length = 0; });
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -26,31 +26,32 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+// vi.doMock is not hoisted above imports, unlike vi.mock, so the subject
+// below is imported dynamically further down, after these calls run.
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
   draggable: vi.fn(() => vi.fn()),
   dropTargetForElements: vi.fn(() => vi.fn()),
   monitorForElements: vi.fn(() => vi.fn()),
 }));
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
   autoScrollForElements: vi.fn(() => vi.fn()),
 }));
 
-// This spec mounts the real item controller, which pulls in these modules.
-// Tests share one module registry (the runner does not isolate spec files),
-// so importing the real versions here would leak into the item controller
-// spec and break its spies. Mock them to keep the shared cache inert.
-vi.mock('@atlaskit/pragmatic-drag-and-drop/combine', () => ({
+// This spec mounts the real item controller, which pulls in these three
+// modules. Stub them so its Pragmatic side effects stay inert; nothing
+// here reads them back.
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/combine', () => ({
   combine: vi.fn((...cleanups:(() => void)[]) => vi.fn(() => {
     cleanups.forEach((cleanup) => cleanup());
   })),
 }));
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/prevent-unhandled', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/prevent-unhandled', () => ({
   preventUnhandled: { start: vi.fn(), stop: vi.fn() },
 }));
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
   setCustomNativeDragPreview: vi.fn(),
 }));
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -26,26 +26,28 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/combine', () => ({
+// vi.doMock is not hoisted above imports, unlike vi.mock, so the subject
+// below is imported dynamically further down, after these calls run.
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/combine', () => ({
   combine: vi.fn((...cleanups:(() => void)[]) => vi.fn(() => {
     cleanups.forEach((cleanup) => cleanup());
   })),
 }));
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
   draggable: vi.fn(() => vi.fn()),
   dropTargetForElements: vi.fn(() => vi.fn()),
   monitorForElements: vi.fn(() => vi.fn()),
 }));
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/prevent-unhandled', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/prevent-unhandled', () => ({
   preventUnhandled: {
     start: vi.fn(),
     stop: vi.fn(),
   },
 }));
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
   setCustomNativeDragPreview: vi.fn(),
 }));
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/list.controller.spec.ts
@@ -26,7 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+// vi.doMock is not hoisted above imports, unlike vi.mock, so the subject
+// below is imported dynamically further down, after these calls run.
+vi.doMock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
   draggable: vi.fn(() => vi.fn()),
   dropTargetForElements: vi.fn(() => vi.fn()),
   monitorForElements: vi.fn(() => vi.fn()),

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/scrollable.controller.spec.ts
@@ -31,7 +31,7 @@ import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-
 import type ScrollableControllerType from './scrollable.controller';
 import type { sortableItemData as sortableItemDataFn, SortableListsRoot } from './drag-and-drop';
 
-vi.mock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
+vi.doMock('@atlaskit/pragmatic-drag-and-drop-auto-scroll/element', () => ({
   autoScrollForElements: vi.fn(() => vi.fn()),
 }));
 


### PR DESCRIPTION
# Ticket

No work package — frontend test-output hygiene, noticed while working on AGILE-361.

# What are you trying to accomplish?

A full `npm run test -- --browsers chromium` run passes, but buries that result in warning noise. This PR removes 15 of those warnings; the PR stacked on top removes ~43 more.

```
Warning: A vi.mock("@atlaskit/pragmatic-drag-and-drop/element/adapter") call in
"…/sortable-lists.controller.spec.ts" is not at the top level of the module.
…This will become an error in a future version.
```

They are false positives — every one of those calls is already at the top level of its spec file. The Angular unit-test builder esbuild-bundles each spec before Vitest sees it, wrapping the module body in a lazy `__commonJS` initialiser. `@vitest/mocker` validates hoisting by walking `ast.body`; inside that wrapper the node is not a direct child of `Program`, so it survives the sweep and warns. No source-level placement can satisfy the check.

# What approach did you choose and why?

`vi.mock` → `vi.doMock`. `@vitest/mocker` hoist-checks only `mock`, `unmock` and `hoisted`; `doMock` is excluded, so the wrapper stops mattering. And because `doMock` is not hoisted, `vi.hoisted()` is no longer needed — a plain module-scope `const` initialises before the factory runs.

Four of the six specs needed nothing but the keyword: they already hold `import type` at the top and pull both the mocked packages and the subject under test via `await import(...)` in `beforeAll`, which is exactly the ordering `doMock` requires.

The two engine specs did need restructuring. Both statically imported the value `createSortableRoot`, which transitively imports the mocked `@atlaskit` module — under `doMock` that resolves before the mock registers, so the mock would silently stop applying. Both now use a type-only import plus a lazy binding. That failure mode is quiet, so both were falsification-tested: with the `vi.doMock` block commented out, `sortable-lists-engine.spec.ts` fails 4 `liveRegistrations()` assertions and `…preview.spec.ts` fails 2 `previewCalls` assertions.

## Why `doMock` is safe again

`vi.doMock` was abandoned in these specs because spec files poisoned each other's module registry — a consequence of the builder's `isolate: false` default, which 797894ce8f1 ("Isolate vitest spec files") fixed by setting `isolate: true` in `vitest-base.config.ts`. The reason it was unsafe no longer holds. Three specs also carried comments still describing the pre-`isolate: true` world; those are corrected here.

## Alternatives considered

Suppressing the warning does not work: it is emitted node-side during transform, before the `RUN` banner, so the existing `onConsoleLog` hook in `vitest-base.config.ts` never sees it. Silencing it would need a custom Vite plugin or a patched `console` — and the warning is slated to become a hard error in a future Vitest, so suppression only defers the work.

Worth reporting upstream separately: `@angular/build`'s unit-test builder wrapping each spec in `__commonJS` is what makes Vitest's hoist validator misfire, and that is fixable at source.

# Merge checklist

- [x] Added/updated tests — test-only change; 167 files / 1548 tests pass
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — chromium only

