### PR TITLE
Order custom field names in formula validation error

### DIFF
--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -170,7 +170,7 @@ module CustomField::CalculatedValue
       surplus_cfs = formula_cfs - allowed_cfs
 
       if surplus_cfs.any?
-        custom_field_names = CustomField.where(id: surplus_cfs).pluck(:name)
+        custom_field_names = CustomField.where(id: surplus_cfs).order(:id).pluck(:name)
         errors.add(:formula, :not_allowed_custom_fields_referenced, custom_fields: custom_field_names.join(", "))
       end
     end


### PR DESCRIPTION
The names interpolated into the `not_allowed_custom_fields_referenced` error come from an unordered `pluck`, so Postgres returns them in plan-dependent row order. The spec asserting the full message ("The attribute int, float cannot be used...") then fails whenever the rows come back the other way around, which surfaced as a flaky failure of `spec/models/custom_field/calculated_value_spec.rb` on an unrelated PR. Ordering by id makes the message deterministic.