### PR TITLE
Update op-blocknote-extensions to 0.2.2

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.3.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
         "tsx": "^4.22.5"
       },
       "devDependencies": {
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
       "funding": [
         {
           "type": "individual",
@@ -3454,11 +3454,8 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
       "peerDependencies": {
-        "typescript": "^5 || ^6"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4171,14 +4168,14 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.1",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
-      "integrity": "sha512-6o5CKneDMX1WGomdW1waKPzYqTwtisKtJOp8+YMWfuz+oJJxn60x+bd4UiBrdUbPCn+ODiLR/R3CY72Wa6RaWg==",
+      "version": "0.2.2",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
+      "integrity": "sha512-GxVcbHAnxCHszxxirgqTBnRhbStdAu3RYvG5ggY79HfE5og1DFduMJcbP5WO7ItlKiYuzAeXxU+ua6QW+LXrAQ==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
-        "i18next": "^25.6.3",
+        "i18next": "^26.3.5",
         "react-i18next": "^16.3.5",
-        "styled-components": "^6.1.19"
+        "styled-components": "^6.4.3"
       },
       "peerDependencies": {
         "@blocknote/core": ">=0.51.3",
@@ -4857,9 +4854,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
-      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.0.tgz",
+      "integrity": "sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.3.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
     "tsx": "^4.22.5"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -111,7 +111,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^22.0.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
         "openapi-explorer": "^2.4.801",
         "pako": "^2.2.0",
         "qr-creator": "^1.0.0",
@@ -11032,29 +11032,26 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.6.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.6.3.tgz",
-      "integrity": "sha512-AEQvoPDljhp67a1+NsnG/Wb1Nh6YoSvtrmeEd24sfGn3uujCtXCF3cXpr7ulhMywKNFF7p3TX1u2j7y+caLOJg==",
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      },
       "peerDependencies": {
-        "typescript": "^5"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -13075,14 +13072,14 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.1",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
-      "integrity": "sha512-6o5CKneDMX1WGomdW1waKPzYqTwtisKtJOp8+YMWfuz+oJJxn60x+bd4UiBrdUbPCn+ODiLR/R3CY72Wa6RaWg==",
+      "version": "0.2.2",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
+      "integrity": "sha512-GxVcbHAnxCHszxxirgqTBnRhbStdAu3RYvG5ggY79HfE5og1DFduMJcbP5WO7ItlKiYuzAeXxU+ua6QW+LXrAQ==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
-        "i18next": "^25.6.3",
+        "i18next": "^26.3.5",
         "react-i18next": "^16.3.5",
-        "styled-components": "^6.1.19"
+        "styled-components": "^6.4.3"
       },
       "peerDependencies": {
         "@blocknote/core": ">=0.51.3",
@@ -15309,9 +15306,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
-      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.0.tgz",
+      "integrity": "sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^22.0.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.1/op-blocknote-extensions-0.2.1.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
     "openapi-explorer": "^2.4.801",
     "pako": "^2.2.0",
     "qr-creator": "^1.0.0",


### PR DESCRIPTION
This includes:
- [[BNE-121] Cleanup some leftovers ](https://community.openproject.org/wp/BNE-121)
- [[BNE-123] Documents: cursor misplaced after block is created on work package url copy-paste ](https://community.openproject.org/wp/BNE-123)
- [[COMMS-904] Allow copying the link to an unavailable (unauthorized) work package for all inline/block sizes ](https://community.openproject.org/wp/COMMS-904)
- [[COMMS-882] Add proxy URL for work package links in op-blocknote-extensions ](https://community.openproject.org/wp/COMMS-882)

# Tickets

- https://community.openproject.org/wp/BNE-121
- https://community.openproject.org/wp/BNE-123
- https://community.openproject.org/wp/COMMS-904
- https://community.openproject.org/wp/COMMS-882


# Merge checklist

- [ ] Added/updated tests => This was done in the op-blocknote-extensions repository
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
