### PR TITLE
Reduce amount of unescaping in storages module

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/queries/internal/children_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/queries/internal/children_query.rb
@@ -157,7 +157,7 @@ module Storages
                     ancestors.push(drive_root(drive_name))
                   else
                     ancestors.push(
-                      @transformer.build_ancestor(component, "#{CGI.unescape(ancestors.last.location)}/#{component}")
+                      @transformer.build_ancestor(component, "#{ancestors.last.location}/#{CGI.unescape(component)}")
                     )
                   end
                 end

--- a/modules/storages/app/common/storages/adapters/results/storage_file_info.rb
+++ b/modules/storages/app/common/storages/adapters/results/storage_file_info.rb
@@ -74,13 +74,10 @@ module Storages
         def to_storage_file = StorageFile.build(**to_h, created_by_name: owner_name)
 
         def clean_location
-          return if location.nil?
+          return nil if location.nil?
+          return location if location.starts_with? "/"
 
-          if location.starts_with? "/"
-            CGI.unescape(location)
-          else
-            CGI.unescape("/#{location}")
-          end
+          "/#{location}"
         end
 
         def self.from_id(file_id)


### PR DESCRIPTION
Those are possible cases of double-unescaping. Though I have to admit, that in both cases I know too little about the source data to be really sure.

In the case of the children query the unescaping looked misplaced at least and I am still not sure whether it can be removed entirely. But the way it was placed would've only unescaped the "parent" segment of the location (multiple times depending on depth) and never the current (i.e. "component") segment of the location, which would be weird. This might still indicate that the entire unescaping was superfluous.

**Update:** According to [Microsoft docs](https://learn.microsoft.com/en-us/graph/api/resources/itemreference?view=graph-rest-1.0#properties) the `path` of the parent reference is "percent encoded", so the unescaping makes sense.

In case of the StorageFileInfo, by now the contract should be that the stored location is not escaped, so unescaping should be unnecessary. Here's hoping that specs would uncover me being wrong...

# Ticket
https://community.openproject.org/wp/SSI-467