### PR TITLE
[DB-904] Adds apply method to the inexistent action

### DIFF
--- a/app/models/custom_actions/actions/inexistent.rb
+++ b/app/models/custom_actions/actions/inexistent.rb
@@ -33,6 +33,8 @@ class CustomActions::Actions::Inexistent < CustomActions::Actions::Base
     :inexistent
   end
 
+  def apply(*); end
+
   def validate(errors)
     errors.add :actions, :does_not_exist
   end


### PR DESCRIPTION
:warning: Related Work Package: [OP#DB-904](https://community.openproject.org/work_packages/DB-904)

The issue happens when `Actions::Inexistent#apply` is called, which happens when a CustomAction is executed.

Why would we end up with an inexistent action? This can happen in a multitude of ways, in this case was deleting a Custom Field that was used in some actions.