### PR TITLE
[JIM-150] Custom fields of type Select List (single choice) are not migrated correctly

### DIFF
--- a/app/workers/import/jira_import_projects_job.rb
+++ b/app/workers/import/jira_import_projects_job.rb
@@ -151,15 +151,7 @@ module Import
 
     def new_custom_fields_in_type(jira_issue, type, custom_field_registry)
       existing_cf_ids = type.custom_field_ids
-      cfs = custom_field_registry.filter_map do |entry|
-        field_key = entry[:jira_field].jira_field_id
-        raw_value = jira_issue.payload["fields"][field_key]
-        next if raw_value.blank?
-
-        context = find_context_for_issue(entry, jira_issue)
-        context&.dig(:custom_field)
-      end
-      cfs.uniq.reject { |cf| existing_cf_ids.include?(cf.id) }
+      custom_fields_for_issue(custom_field_registry, jira_issue).reject { |cf| existing_cf_ids.include?(cf.id) }
     end
 
     def update_custom_fields_in_type(type, new_custom_fields)
@@ -193,12 +185,9 @@ module Import
     end
 
     def update_custom_fields_in_project(project, jira_project, custom_field_registry)
-      project_key = jira_project.payload["key"]
-      applicable_cfs = custom_field_registry.flat_map do |entry|
-        entry[:contexts]
-          .select { |ctx| context_applies_to_project?(ctx, project_key) }
-          .map { |ctx| ctx[:custom_field] }
-      end
+      applicable_cfs = Import::JiraIssue
+                         .where(jira_import_id: @jira_import.id, jira_project_id: jira_project.id)
+                         .flat_map { |jira_issue| custom_fields_for_issue(custom_field_registry, jira_issue) }
       existing_cf_ids = project.work_package_custom_fields.pluck(:id).to_set
       new_cfs = applicable_cfs.uniq.reject { |cf| existing_cf_ids.include?(cf.id) }
       project.work_package_custom_fields << new_cfs if new_cfs.any?

--- a/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
+++ b/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
@@ -250,8 +250,12 @@ module Import
         if cascading_select_as_list?
           flatten_cascading_allowed_values(allowed)
         else
-          allowed.pluck("value").compact.uniq
+          allowed.pluck("value").compact.map { |value| option_label(value) }.compact_blank.uniq
         end
+      end
+
+      def option_label(value)
+        value.to_s.strip
       end
 
       def cascading_select_as_list?
@@ -264,7 +268,7 @@ module Import
       # E.g. Animals -> ["Animals"], Animals / Cat -> ["Animals", "Animals / Cat"]
       def flatten_cascading_allowed_values(allowed_values, parent_path: nil)
         allowed_values.flat_map do |av|
-          label = av["value"]
+          label = option_label(av["value"])
           next [] if label.blank?
 
           full_path = parent_path ? "#{parent_path} / #{label}" : label
@@ -303,7 +307,7 @@ module Import
       def convert_multicheckbox_bool_value(raw_value)
         return false unless raw_value.is_a?(Array)
 
-        raw_value.any? { |v| v["value"] == @option_value }
+        raw_value.any? { |v| option_label(v["value"]) == @option_value }
       end
 
       def convert_user_value(raw_value)
@@ -341,7 +345,7 @@ module Import
       end
 
       def extract_list_label(value)
-        value.is_a?(Hash) ? value["value"] : value.to_s
+        option_label(value.is_a?(Hash) ? value["value"] : value)
       end
 
       # Walks the parent -> child chain of a cascading select value, returning
@@ -350,7 +354,7 @@ module Import
       def extract_cascading_chain(value, parent_path: nil)
         return [] unless value.is_a?(Hash) && value["value"].present?
 
-        label = value["value"]
+        label = option_label(value["value"])
         full_path = parent_path ? "#{parent_path} / #{label}" : label
         [full_path] + extract_cascading_chain(value["child"], parent_path: full_path)
       end
@@ -369,7 +373,7 @@ module Import
       end
 
       def insert_hierarchy_option(service, contract, parent, option)
-        label = option["value"]
+        label = option_label(option["value"])
         return if label.blank?
 
         result = service.insert_item(contract_class: contract, parent:, label:)
@@ -398,7 +402,7 @@ module Import
         root = custom_field.hierarchy_root
         return unless root
 
-        parent_item = root.children.find_by(label: raw_value["value"])
+        parent_item = root.children.find_by(label: option_label(raw_value["value"]))
         return unless parent_item
 
         find_hierarchy_child(parent_item, raw_value["child"])&.id || parent_item.id
@@ -407,7 +411,7 @@ module Import
       def find_hierarchy_child(parent_item, child_data)
         return unless child_data.is_a?(Hash) && child_data["value"].present?
 
-        parent_item.children.find_by(label: child_data["value"])
+        parent_item.children.find_by(label: option_label(child_data["value"]))
       end
 
       def find_field_user(jira_user_key)

--- a/app/workers/import/jira_import_projects_job/jira_import_custom_fields.rb
+++ b/app/workers/import/jira_import_projects_job/jira_import_custom_fields.rb
@@ -47,6 +47,15 @@ module Import
         end
       end
 
+      def custom_fields_for_issue(custom_field_registry, jira_issue)
+        custom_field_registry.filter_map do |entry|
+          raw_value = jira_issue.payload["fields"][entry[:jira_field].jira_field_id]
+          next if raw_value.blank?
+
+          find_context_for_issue(entry, jira_issue)&.dig(:custom_field)
+        end.uniq
+      end
+
       # Builds one OP custom field per (Jira field, context group) combination, before any
       # per-project import begins. Context groups describe which (project_key, issuetype_id)
       # tuples share an allowedValues set.
@@ -98,57 +107,28 @@ module Import
         schema["type"] == "array" && schema["items"] == "string"
       end
 
-      def build_string_array_registry_entries(jira_field)
-        string_values = collect_string_values_from_issues(jira_field)
-        allowed_values = string_values.map { |v| { "value" => v } }
-        groups = jira_field.payload["contextGroups"]
+      def option_field?(jira_field)
+        schema = jira_field.payload["schema"] || {}
+        %w[option option-with-child].include?(schema["type"]) ||
+          (schema["type"] == "array" && schema["items"] == "option")
+      end
 
-        contexts = if groups.present?
-                     groups.map { |g| build_context_entry(jira_field, g.merge("allowedValues" => allowed_values)) }
-                   else
-                     [
-                       build_context_entry(
-                         jira_field,
-                         {
-                           "projects" => [],
-                           "issuetypes" => [],
-                           "allowedValues" => allowed_values
-                         }
-                       )
-                     ]
-                   end
+      def build_string_array_registry_entries(jira_field)
+        allowed_values = Array(jira_field.payload["contextGroups"]).flat_map { |group| Array(group["allowedValues"]) }
+        allowed_values = issue_string_values(jira_field).reduce(allowed_values) do |values, string_value|
+          merge_allowed_value(values, { "value" => string_value })
+        end
+        contexts = [
+          build_context_entry(jira_field, { "projects" => [], "issuetypes" => [], "allowedValues" => allowed_values })
+        ]
         [{ jira_field:, contexts: }]
       end
 
-      def collect_string_values_from_issues(jira_field)
-        field_key = jira_field.jira_field_id
-        values = Set.new
-        Import::JiraIssue.where(jira_id: @jira_id, jira_project_id: all_jira_import_project_ids).find_each do |issue|
-          raw = issue.payload["fields"][field_key]
-          next unless raw.is_a?(Array)
-
-          raw.each { |v| values << v.to_s if v.present? }
-        end
-        values.to_a.sort
-      end
-
       def build_multicheckbox_registry_entries(jira_field)
-        groups = jira_field.payload["contextGroups"]
-
-        return build_multicheckbox_entries_without_context_groups(jira_field) if groups.blank?
+        groups = augmented_context_groups(jira_field)
+        return [] if groups.blank?
 
         build_multicheckbox_entries_with_context_groups(jira_field, groups)
-      end
-
-      def build_multicheckbox_entries_without_context_groups(jira_field)
-        option_values = collect_option_values_from_issues(jira_field)
-        return [] if option_values.empty?
-
-        if option_values.size == 1
-          [{ jira_field:, contexts: [build_context_entry(jira_field, nil, option_value: option_values.first)] }]
-        else
-          [{ jira_field:, contexts: [build_context_entry(jira_field, nil)] }]
-        end
       end
 
       def build_multicheckbox_entries_with_context_groups(jira_field, groups)
@@ -162,7 +142,7 @@ module Import
         list_groups = []
 
         groups.each do |group|
-          option_values = Array(group["allowedValues"]).pluck("value").compact.uniq
+          option_values = option_labels(group["allowedValues"])
           if option_values.size == 1
             boolean_groups << { group:, option_value: option_values.first }
           elsif option_values.size > 1
@@ -197,25 +177,129 @@ module Import
           .pluck(:id)
       end
 
-      def collect_option_values_from_issues(jira_field)
-        values = Set.new
-        Import::JiraIssue.where(jira_id: @jira_id, jira_project_id: all_jira_import_project_ids).find_each do |issue|
-          raw = issue.payload["fields"][jira_field.jira_field_id]
-          next unless raw.is_a?(Array)
-
-          raw.each { |v| values << v["value"] if v["value"].present? }
-        end
-        values.to_a.sort
-      end
-
       def build_contexts_for_field(jira_field)
-        groups = jira_field.payload["contextGroups"]
+        groups = augmented_context_groups(jira_field)
         if groups.present?
           needs_disambiguation = groups.size > 1
           groups.map { |group| build_context_entry(jira_field, group, needs_disambiguation:) }
         else
           [build_context_entry(jira_field, nil)]
         end
+      end
+
+      def augmented_context_groups(jira_field)
+        groups = dup_context_groups(jira_field)
+        return groups unless option_field?(jira_field)
+
+        issue_options = issue_option_values(jira_field)
+        return groups if issue_options.empty?
+
+        groups << global_context_group if groups.empty?
+        issue_options.each { |option, *scope| add_option_to_context_group(groups, option, scope) }
+        groups
+      end
+
+      def dup_context_groups(jira_field)
+        Array(jira_field.payload["contextGroups"]).map do |group|
+          group.merge("allowedValues" => Array(group["allowedValues"]))
+        end
+      end
+
+      def global_context_group
+        { "projects" => [], "issuetypes" => [], "allowedValues" => [] }
+      end
+
+      def add_option_to_context_group(groups, option, scope)
+        group = groups[matching_context_group_index(groups, *scope)]
+        group["allowedValues"] = merge_allowed_value(group["allowedValues"], option)
+      end
+
+      def merge_allowed_value(allowed_values, option)
+        label = option["value"].to_s.strip
+        return allowed_values if label.blank?
+
+        existing = allowed_values.find { |av| av["value"].to_s.strip == label }
+        return allowed_values + [build_allowed_value(label, option["child"])] if existing.nil?
+
+        merge_allowed_child(allowed_values, existing, option["child"])
+      end
+
+      def merge_allowed_child(allowed_values, existing, child)
+        return allowed_values if child.blank?
+
+        merged = existing.merge("children" => merge_allowed_value(Array(existing["children"]), child))
+        allowed_values.map { |av| av.equal?(existing) ? merged : av }
+      end
+
+      def build_allowed_value(label, child)
+        entry = { "value" => label }
+        entry["children"] = merge_allowed_value([], child) if child.present?
+        entry
+      end
+
+      def matching_context_group_index(groups, project_key, issuetype_id)
+        groups.index do |group|
+          scope_applies?(group["projects"], project_key) && scope_applies?(group["issuetypes"], issuetype_id)
+        end || 0
+      end
+
+      def option_labels(allowed_values)
+        Array(allowed_values).pluck("value").compact.map { |value| value.to_s.strip }.compact_blank.uniq
+      end
+
+      def issue_option_values(jira_field)
+        issue_field_values_index[:options][jira_field.jira_field_id].values
+      end
+
+      def issue_string_values(jira_field)
+        issue_field_values_index[:strings][jira_field.jira_field_id].to_a.sort
+      end
+
+      def issue_field_values_index
+        @issue_field_values_index ||= build_issue_field_values_index
+      end
+
+      def build_issue_field_values_index
+        index = { options: Hash.new { |h, k| h[k] = {} }, strings: Hash.new { |h, k| h[k] = Set.new } }
+        Import::JiraIssue.where(jira_id: @jira_id, jira_project_id: all_jira_import_project_ids).find_each do |issue|
+          scope = issue_context_scope(issue)
+          used_custom_field_values(issue).each { |field_key, raw| record_issue_field_values(index, field_key, raw, scope) }
+        end
+        index
+      end
+
+      def issue_context_scope(issue)
+        [issue.payload.dig("fields", "project", "key"), issue.payload.dig("fields", "issuetype", "id")]
+      end
+
+      def used_custom_field_values(issue)
+        issue.payload["fields"].select { |field_key, raw| field_key.start_with?("customfield_") && raw.present? }
+      end
+
+      def record_issue_field_values(index, field_key, raw, scope)
+        Array.wrap(raw).each do |value|
+          if value.is_a?(Hash)
+            record_issue_option_value(index[:options][field_key], value, scope)
+          elsif raw.is_a?(Array) && value.is_a?(String)
+            index[:strings][field_key] << value.strip if value.strip.present?
+          end
+        end
+      end
+
+      def record_issue_option_value(field_options, option, scope)
+        return if option["value"].blank?
+
+        field_options[scope + [option_chain_signature(option)]] ||= [option, *scope]
+      end
+
+      def option_chain_signature(option)
+        labels = []
+        node = option
+        while node.is_a?(Hash) && node["value"].present?
+          labels << node["value"].to_s.strip
+          node = node["child"]
+        end
+        labels.join(" / ")
       end
 
       def build_context_entry(jira_field, context_group, option_value: nil, needs_disambiguation: false)
@@ -287,11 +371,17 @@ module Import
       end
 
       def context_applies_to_project?(context, project_key)
-        context[:projects].empty? || context[:projects].include?(project_key)
+        scope_applies?(context[:projects], project_key)
       end
 
       def context_applies_to_issuetype?(context, issuetype_id)
-        context[:issuetypes].empty? || context[:issuetypes].include?(issuetype_id)
+        scope_applies?(context[:issuetypes], issuetype_id)
+      end
+
+      # An empty scope means "applies to all projects" / "applies to all issue types".
+      def scope_applies?(scope, value)
+        scope = Array(scope)
+        scope.empty? || scope.include?(value)
       end
     end
   end

--- a/docs/installation-and-operations/jira-migration/custom-fields/README.md
+++ b/docs/installation-and-operations/jira-migration/custom-fields/README.md
@@ -76,9 +76,19 @@ Jira cascading select fields have two import modes depending on your OpenProject
 
 Jira Labels fields and any String list custom fields do not expose all their allowed values within [Field contexts](#field-contexts) through the Jira API. 
 Instead, the migrator scans all imported issues and collects every distinct string value actually used. 
-These collected values become the option list for a multi-value List custom field in OpenProject.
+These collected values become the option list for a single multi-value List custom field in OpenProject.
 
 Values that do not appear in any issue are not added to the option list.
+
+### Option lists with incomplete allowed values
+
+The Jira API only reports the options a field currently offers on an issue's edit screen. Options removed from a field 
+context after issues were set - and fields that sit on no edit screen at all - therefore report no allowed values, or 
+fewer than the imported issues actually use.
+
+To avoid losing those values, the migrator also collects the options found on the imported issues themselves and adds 
+any that the API did not report to the option list of the custom field the issue is imported into. This applies to 
+single select, radio button, multi-select, checkbox and cascading select fields.
 
 ### Text areas and wiki markup
 
@@ -102,7 +112,8 @@ The migrator handles this as follows:
   The migrator uses project keys as suffixes to disambiguate contexts, but the original context names are not preserved.
 
 During issue import, each issue is matched to the context whose projects and issue types fit. 
-If no context matches (for example, the field was removed from a screen after values were set), the first available context is used as a fallback so no data is silently lost.
+If no context matches (for example, the field was removed from a screen after values were set), the first available context is used as a fallback so no data is silently lost. 
+The custom field an issue resolves to is activated in that issue's project, whether it was matched or used as a fallback.
 
 ### Deduplication with existing custom fields
 

--- a/spec/workers/import/jira_import_projects_job_custom_fields_spec.rb
+++ b/spec/workers/import/jira_import_projects_job_custom_fields_spec.rb
@@ -903,6 +903,172 @@ RSpec.describe Import::JiraImportProjectsJob,
     end
   end
 
+  describe "option lists whose allowed values are missing from the Jira field contexts" do
+    # editmeta only reports the options an issue's edit screen currently offers, so contextGroups
+    # can be absent altogether or lack options that issues still carry. The options actually used
+    # by the imported issues must be recovered so their values survive the import.
+    let!(:jira_issue) do
+      create(:jira_issue, jira:, jira_import:,
+                          jira_issue_id: "10200",
+                          jira_project_id: jira_project.id,
+                          payload: issue_payload)
+    end
+
+    def jira_list_field(id:, name:, schema:, context_groups: nil)
+      payload = { "id" => id, "name" => name, "schema" => schema }
+      payload["contextGroups"] = context_groups if context_groups
+      create(:jira_field, jira:, jira_import:, jira_field_id: id, payload:)
+    end
+
+    context "with a single-select field and no contextGroups at all" do
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10264", name: "CF List",
+                        schema: { "type" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select" })
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "collects the option from the imported issues and sets the value" do
+        cf = WorkPackageCustomField.find_by!(name: "CF List")
+        expect(cf.custom_options.pluck(:value)).to contain_exactly("Cat")
+        expect(cf.multi_value).to be false
+        expect(cf_value("CF List")).to eq("Cat")
+      end
+    end
+
+    context "with a multi-select field and no contextGroups at all" do
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10265", name: "CF Multi-List",
+                        schema: { "type" => "array", "items" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:multiselect" })
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "collects all options from the imported issues and sets both values" do
+        cf = WorkPackageCustomField.find_by!(name: "CF Multi-List")
+        expect(cf.custom_options.pluck(:value)).to contain_exactly("Mouse", "Turtle")
+        expect(cf.multi_value).to be true
+        expect(cf_value("CF Multi-List")).to contain_exactly("Mouse", "Turtle")
+      end
+    end
+
+    context "with a multicheckboxes field and no contextGroups at all" do
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10260", name: "CF Booleans",
+                        schema: { "type" => "array", "items" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes" })
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "becomes a boolean because the issues only use one option" do
+        cf = WorkPackageCustomField.find_by!(name: "CF Booleans - Check 1")
+        expect(cf.field_format).to eq("bool")
+        expect(cf_value("CF Booleans - Check 1")).to be true
+      end
+    end
+
+    context "when the value on the issue is no longer an allowed value of its context" do
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10264", name: "CF List",
+                        schema: { "type" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select" },
+                        context_groups: [global_context.merge(
+                          "allowedValues" => [{ "id" => "10142", "value" => "Dog" }]
+                        )])
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "adds the missing option next to the reported ones and sets the value" do
+        cf = WorkPackageCustomField.find_by!(name: "CF List")
+        expect(cf.custom_options.pluck(:value)).to contain_exactly("Dog", "Cat")
+        expect(cf_value("CF List")).to eq("Cat")
+      end
+    end
+
+    context "when the option label carries surrounding whitespace" do
+      let(:issue_payload) do
+        payload = JSON.parse(Rails.root.join("spec/fixtures/import/jira/issue_with_custom_fields.json").read)
+        payload["fields"]["customfield_10264"] = { "id" => "10141", "value" => " Cat " }
+        payload
+      end
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10264", name: "CF List",
+                        schema: { "type" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select" },
+                        context_groups: [global_context.merge(
+                          "allowedValues" => [{ "id" => "10141", "value" => " Cat " }]
+                        )])
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "matches the stripped option instead of dropping the value" do
+        cf = WorkPackageCustomField.find_by!(name: "CF List")
+        expect(cf.custom_options.pluck(:value)).to contain_exactly("Cat")
+        expect(cf_value("CF List")).to eq("Cat")
+      end
+    end
+
+    context "when no context group covers the issue's project key" do
+      # The issue fixture reports project key DYX while the imported project's key is DPPP, so the
+      # issue falls back to the first context. The resolved custom field still has to be activated
+      # in the project or the work package would silently discard its value.
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10264", name: "CF List",
+                        schema: { "type" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select" },
+                        context_groups: [{ "projects" => ["OTHER"], "issuetypes" => ["10100"],
+                                           "allowedValues" => [{ "id" => "10141", "value" => "Cat" }] }])
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "activates the fallback custom field in the project and keeps the value" do
+        cf = WorkPackageCustomField.find_by!(name: "CF List")
+        expect(imported_wp.project.work_package_custom_fields).to include(cf)
+        expect(imported_wp.type.custom_fields).to include(cf)
+        expect(cf_value("CF List")).to eq("Cat")
+      end
+    end
+
+    context "when a context group covers a project without any issue using the field" do
+      let!(:jira_field) do
+        jira_list_field(id: "customfield_10264", name: "CF List",
+                        schema: { "type" => "option",
+                                  "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select" },
+                        context_groups: [global_context.merge(
+                          "allowedValues" => [{ "id" => "10141", "value" => "Cat" }]
+                        )])
+      end
+      let!(:jira_issue_without_value) do
+        create(:jira_issue, jira:, jira_import:,
+                            jira_issue_id: "10201",
+                            jira_project_id: jira_project.id,
+                            payload: issue_payload.deep_dup.tap do |p|
+                              p["key"] = "DYX-3"
+                              p["fields"]["summary"] = "Issue without the list value"
+                              p["fields"].delete("customfield_10264")
+                            end)
+      end
+
+      before { described_class.new.perform(jira_import.id) }
+
+      it "still sets the value on the issue that has one" do
+        expect(cf_value("CF List")).to eq("Cat")
+      end
+
+      it "leaves the other work package without a value" do
+        cf = WorkPackageCustomField.find_by!(name: "CF List")
+        other_wp = WorkPackage.find_by!(subject: "Issue without the list value")
+        expect(other_wp.send(cf.attribute_getter)).to be_nil
+      end
+    end
+  end
+
   describe "all custom field types in a single import run", with_ee: [:custom_field_hierarchies] do
     # Registers all field types at once and verifies the correct number of
     # OP custom fields are created:


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-150

# What are you trying to achieve?

Sometimes values of Jira option based custom fields (single select, multi select) were
silently dropped during the Jira migration.

The root cause is that 
- the Jira API only reports the options a field currently offers on an issue's *edit screen*. So
`allowedValues` in the field context is not a complete list of the values actually stored on issues
- a field that sits on no edit screen at all reports no context groups and no allowed values,
- options removed from a context after issues were already set are not reported anymore,
- labels can differ from the stored values by surrounding whitespace.

Two follow-up problems came out of the same area:

- issues whose project/issue type matched no context group fell back to the first context, but the custom field of that
  fallback context was never activated in the issue's project, so the value could not be written,
- projects got custom fields activated based on context groups rather than on what the imported issues actually use,
  which both missed fallback cases and activated unused fields.
  
# What approach did you choose and why?

- Collect the options from the imported issues, not only from the field metadata
  Those collected options are merged into the field context groups (`augmented_context_groups`) before any OpenProject
custom field is built: each option is added to the context group that matches its scope (falling back to the first
group), and a global group is created if the field reports no context groups at all.
- Normalize option labels in one place
- Activate custom fields based on the issues

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
- [x] Added a note in the documentation 
