### PR TITLE
[COMMS-934] Adjust WorkPackageAtTimestampRepresenter with target_versions

### DIFF
--- a/app/models/journable/timestamps.rb
+++ b/app/models/journable/timestamps.rb
@@ -106,7 +106,7 @@ module Journable::Timestamps
       attributes[missing_column_name] = nil
     end
     journable = self.class.instantiate(attributes)
-    ::Journable::WithHistoricAttributes.load_custom_values(journable)
+    ::Journable::WithHistoricAttributes.load_journal_associations(journable)
     journable.readonly!
     journable
   end

--- a/app/models/journable/timestamps.rb
+++ b/app/models/journable/timestamps.rb
@@ -93,19 +93,7 @@ module Journable::Timestamps
   def at_timestamp(timestamp)
     return unless journal = journals.at_timestamp(timestamp).first
 
-    attributes = journal.data.attributes.merge(
-      {
-        "id" => id,
-        "created_at" => created_at,
-        "updated_at" => journal.updated_at,
-        "timestamp" => timestamp,
-        "journal_id" => journal.id
-      }
-    )
-    self.class.column_names_missing_in_journal.each do |missing_column_name|
-      attributes[missing_column_name] = nil
-    end
-    journable = self.class.instantiate(attributes)
+    journable = self.class.instantiate(historic_attributes(journal, timestamp))
     ::Journable::WithHistoricAttributes.load_journal_associations(journable)
     journable.readonly!
     journable
@@ -127,5 +115,21 @@ module Journable::Timestamps
     raise ActiveRecord::RecordNotSaved, "This is no historic data. You can only revert to historic data." unless historic?
 
     self.class.find(id).update! attributes.except("id", "timestamp", "journal_id", "created_at", "updated_at")
+  end
+
+  private
+
+  def historic_attributes(journal, timestamp)
+    attributes = journal.data.attributes.merge(
+      "id" => id,
+      "created_at" => created_at,
+      "updated_at" => journal.updated_at,
+      "timestamp" => timestamp,
+      "journal_id" => journal.id
+    )
+    self.class.column_names_missing_in_journal.each do |missing_column_name|
+      attributes[missing_column_name] = nil
+    end
+    attributes
   end
 end

--- a/app/models/journable/with_historic_attributes.rb
+++ b/app/models/journable/with_historic_attributes.rb
@@ -120,8 +120,8 @@ class Journable::WithHistoricAttributes < SimpleDelegator
       end
     end
 
-    def load_custom_values(journalized)
-      Loader.new(journalized).load_custom_values
+    def load_journal_associations(journalized)
+      Loader.new(journalized).load_journal_associations
     end
 
     private
@@ -262,7 +262,37 @@ class Journable::WithHistoricAttributes < SimpleDelegator
       )
     )
 
+    merge_target_versions_changes!(changes, historic_journable)
+
     changes
+  end
+
+  # Version changes are derived from the target_versions sets: the version_id
+  # column is a deprecated mirror of the primary target version (the lowest
+  # version id), so its diff is replaced by one inferred from the sets.
+  def merge_target_versions_changes!(changes, historic_journable)
+    return unless __getobj__.respond_to?(:target_versions)
+
+    changes.delete("version_id")
+    changes.merge!(target_versions_changes(historic_journable))
+  end
+
+  def target_versions_changes(historic_journable)
+    old_ids = sorted_target_version_ids(historic_journable)
+    new_ids = sorted_target_version_ids(__getobj__)
+
+    {}.tap do |changes|
+      changes["version_id"] = [old_ids.first, new_ids.first] if old_ids.first != new_ids.first
+      changes["target_versions"] = [old_ids, new_ids].map { joined_version_ids(it) } if old_ids != new_ids
+    end
+  end
+
+  def sorted_target_version_ids(work_package)
+    work_package.target_versions.map(&:id).sort
+  end
+
+  def joined_version_ids(ids)
+    ids.join(",").presence
   end
 
   def changed_attributes_at_timestamp(timestamp)

--- a/app/models/journable/with_historic_attributes.rb
+++ b/app/models/journable/with_historic_attributes.rb
@@ -267,9 +267,6 @@ class Journable::WithHistoricAttributes < SimpleDelegator
     changes
   end
 
-  # Version changes are derived from the target_versions sets: the version_id
-  # column is a deprecated mirror of the primary target version (the lowest
-  # version id), so its diff is replaced by one inferred from the sets.
   def merge_target_versions_changes!(changes, historic_journable)
     return unless __getobj__.respond_to?(:target_versions)
 

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -149,8 +149,10 @@ class Journable::WithHistoricAttributes
     # Marks the target_versions association as loaded with the versions
     # snapshotted for the journal, so the historic work package exposes the
     # versions of its time instead of querying the current join rows.
+    # Snapshots outlive deleted versions (no foreign key); those resolve to
+    # nil and are dropped, as in the journal formatter.
     def set_target_versions_association_from_journal!(work_package:, version_journals:)
-      historic_versions = version_journals.map(&:version).sort_by(&:id)
+      historic_versions = version_journals.filter_map(&:version).sort_by(&:id)
 
       work_package.association(:target_versions).loaded!
       work_package.association(:target_versions).target = historic_versions

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -66,22 +66,33 @@ class Journable::WithHistoricAttributes
               "ie: WorkPackage.at_timestamp(1.day.ago) or WorkPackage.find(1).at_timestamp(1.day.ago)"
       end
 
-      customizable_journals_by_journal_id = load_customizable_journals_by_journal_id(journal_ids)
-      version_journals_by_journal_id = load_version_journals_by_journal_id(journal_ids)
+      load_custom_value_associations(journalized, journal_ids)
+      load_target_versions_associations(journalized, journal_ids)
 
-      journalized.each do |work_package|
-        customizable_journals = Array(customizable_journals_by_journal_id[work_package.journal_id])
-        set_custom_value_association_from_journal!(work_package:, customizable_journals:)
-
-        if version_journals_by_journal_id
-          version_journals = Array(version_journals_by_journal_id[work_package.journal_id])
-          set_target_versions_association_from_journal!(work_package:, version_journals:)
-        end
-      end
       journalized
     end
 
     private
+
+    def load_custom_value_associations(journalized, journal_ids)
+      customizable_journals_by_journal_id = load_customizable_journals_by_journal_id(journal_ids)
+
+      journalized.each do |work_package|
+        customizable_journals = Array(customizable_journals_by_journal_id[work_package.journal_id])
+        set_custom_value_association_from_journal!(work_package:, customizable_journals:)
+      end
+    end
+
+    def load_target_versions_associations(journalized, journal_ids)
+      return unless journalized_class.method_defined?(:target_versions)
+
+      version_journals_by_journal_id = load_version_journals_by_journal_id(journal_ids)
+
+      journalized.each do |work_package|
+        version_journals = Array(version_journals_by_journal_id[work_package.journal_id])
+        set_target_versions_association_from_journal!(work_package:, version_journals:)
+      end
+    end
 
     def work_package_ids_of_query_at_timestamp_calculation(query, timestamp)
       query = query.dup
@@ -126,8 +137,6 @@ class Journable::WithHistoricAttributes
     end
 
     def load_version_journals_by_journal_id(journal_ids)
-      return unless journalized_class.method_defined?(:target_versions)
-
       Journal::WorkPackageVersionJournal
         .where(journal_id: journal_ids, kind: "target")
         .includes(:version)

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -155,11 +155,6 @@ class Journable::WithHistoricAttributes
       work_package.association(:custom_values).target = historic_custom_values
     end
 
-    # Marks the target_versions association as loaded with the versions
-    # snapshotted for the journal, so the historic work package exposes the
-    # versions of its time instead of querying the current join rows.
-    # Snapshots outlive deleted versions (no foreign key); those resolve to
-    # nil and are dropped, as in the journal formatter.
     def set_target_versions_association_from_journal!(work_package:, version_journals:)
       historic_versions = version_journals.filter_map(&:version).sort_by(&:id)
 

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -56,7 +56,7 @@ class Journable::WithHistoricAttributes
       @work_package_ids_of_query_at_timestamp[query][timestamp]
     end
 
-    def load_custom_values(journalized = journables)
+    def load_journal_associations(journalized = journables)
       journal_ids = begin
         journalized.map(&:journal_id)
       rescue NoMethodError
@@ -67,10 +67,16 @@ class Journable::WithHistoricAttributes
       end
 
       customizable_journals_by_journal_id = load_customizable_journals_by_journal_id(journal_ids)
+      version_journals_by_journal_id = load_version_journals_by_journal_id(journal_ids)
 
       journalized.each do |work_package|
         customizable_journals = Array(customizable_journals_by_journal_id[work_package.journal_id])
         set_custom_value_association_from_journal!(work_package:, customizable_journals:)
+
+        if version_journals_by_journal_id
+          version_journals = Array(version_journals_by_journal_id[work_package.journal_id])
+          set_target_versions_association_from_journal!(work_package:, version_journals:)
+        end
       end
       journalized
     end
@@ -97,7 +103,7 @@ class Journable::WithHistoricAttributes
 
     def journalized_at_timestamp(tms)
       journalized = (currently_invisible_journalized_at_timestamp(tms) + currently_visible_journalized_at_timestamp(tms))
-      load_custom_values(journalized)
+      load_journal_associations(journalized)
     end
 
     def currently_invisible_journalized_at_timestamp(timestamp)
@@ -119,6 +125,15 @@ class Journable::WithHistoricAttributes
         .group_by(&:journal_id)
     end
 
+    def load_version_journals_by_journal_id(journal_ids)
+      return unless journalized_class.method_defined?(:target_versions)
+
+      Journal::WorkPackageVersionJournal
+        .where(journal_id: journal_ids, kind: "target")
+        .includes(:version)
+        .group_by(&:journal_id)
+    end
+
     def set_custom_value_association_from_journal!(work_package:, customizable_journals:)
       # Build the associated customizable_journals as custom values, this way the historic work packages
       # will behave just as the normal ones. Additionally set the reverse customized association
@@ -129,6 +144,16 @@ class Journable::WithHistoricAttributes
 
       work_package.association(:custom_values).loaded!
       work_package.association(:custom_values).target = historic_custom_values
+    end
+
+    # Marks the target_versions association as loaded with the versions
+    # snapshotted for the journal, so the historic work package exposes the
+    # versions of its time instead of querying the current join rows.
+    def set_target_versions_association_from_journal!(work_package:, version_journals:)
+      historic_versions = version_journals.map(&:version).sort_by(&:id)
+
+      work_package.association(:target_versions).loaded!
+      work_package.association(:target_versions).target = historic_versions
     end
 
     attr_accessor :journables

--- a/lib/api/v3/work_packages/eager_loading/historic_attributes.rb
+++ b/lib/api/v3/work_packages/eager_loading/historic_attributes.rb
@@ -111,8 +111,6 @@ module API::V3::WorkPackages::EagerLoading
       work_package.readonly!
     end
 
-    # The target_versions association would otherwise read the current join
-    # rows, showing today's versions next to historic attributes.
     def override_target_versions(work_package, source)
       return unless work_package.respond_to?(:target_versions)
 

--- a/lib/api/v3/work_packages/eager_loading/historic_attributes.rb
+++ b/lib/api/v3/work_packages/eager_loading/historic_attributes.rb
@@ -106,8 +106,18 @@ module API::V3::WorkPackages::EagerLoading
 
     def override_attributes(work_package, source)
       work_package.attributes = source.attributes.except("timestamp", "journal_id")
+      override_target_versions(work_package, source)
       work_package.clear_changes_information
       work_package.readonly!
+    end
+
+    # The target_versions association would otherwise read the current join
+    # rows, showing today's versions next to historic attributes.
+    def override_target_versions(work_package, source)
+      return unless work_package.respond_to?(:target_versions)
+
+      work_package.association(:target_versions).loaded!
+      work_package.association(:target_versions).target = source.target_versions.to_a
     end
 
     def set_timestamp_attributes(work_package, source, timestamp)

--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -51,6 +51,7 @@ module API
           priority
           type
           version
+          target_versions
           parent
         ].freeze
 
@@ -101,7 +102,7 @@ module API
         # contains the lower camel-cased names.
         def rendered_properties_for_links
           @rendered_properties_for_links ||= rendered_properties.map do |property|
-            if property.starts_with?("custom_field_")
+            if property.starts_with?("custom_field_") || property == "target_versions"
               API::Utilities::PropertyNameConverter.from_ar_name(property)
             else
               property

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
   let(:type) { build_stubbed(:type) }
   let(:priority) { build_stubbed(:priority) }
   let(:version) { build_stubbed(:version) }
+  let(:target_versions) { [version] }
   let(:parent) do
     build_stubbed(:work_package).tap do |wp|
       allow(wp)
@@ -97,12 +98,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
               .with(:wrapped?)
               .and_return(true)
       allow(wp)
-        .to receive_messages(available_custom_fields:, custom_field_values: [custom_value])
+        .to receive_messages(available_custom_fields:,
+                             custom_field_values: [custom_value],
+                             effective_target_versions: target_versions)
     end
   end
   let(:timestamp) { Timestamp.new(1.day.ago) }
 
-  let(:attributes_changed_to_baseline) { work_package.attributes.keys + ["custom_field_#{custom_field.id}"] }
+  let(:attributes_changed_to_baseline) { work_package.attributes.keys + ["custom_field_#{custom_field.id}", "target_versions"] }
   let(:exists_at_timestamp) { true }
   let(:with_query) { true }
   let(:matches_filters_at_timestamp) { true }
@@ -169,6 +172,12 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
             "href" => api_v3_paths.version(version.id),
             "title" => version.name
           },
+          "targetVersions" => [
+            {
+              "href" => api_v3_paths.version(version.id),
+              "title" => version.name
+            }
+          ],
           "parent" => {
             "displayId" => parent.display_id.to_s,
             "href" => api_v3_paths.work_package(parent.id),
@@ -211,6 +220,90 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
             "href" => api_v3_paths.version(version.id),
             "title" => version.name
           },
+          "self" => {
+            "href" => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
+            "title" => work_package.subject
+          },
+          "schema" => {
+            "href" => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
+          }
+        }
+      }.to_json
+    end
+
+    it "renders as expected" do
+      expect(subject)
+        .to be_json_eql(expected_json)
+    end
+  end
+
+  context "with the target versions changed together with the primary version" do
+    let(:version_b) { build_stubbed(:version) }
+    let(:target_versions) { [version, version_b] }
+    let(:attributes_changed_to_baseline) { %w[version_id target_versions] }
+
+    let(:expected_json) do
+      {
+        "_meta" => {
+          "matchesFilters" => true,
+          "exists" => true,
+          "timestamp" => timestamp.to_s
+        },
+        "_links" => {
+          "version" => {
+            "href" => api_v3_paths.version(version.id),
+            "title" => version.name
+          },
+          "targetVersions" => [
+            {
+              "href" => api_v3_paths.version(version.id),
+              "title" => version.name
+            },
+            {
+              "href" => api_v3_paths.version(version_b.id),
+              "title" => version_b.name
+            }
+          ],
+          "self" => {
+            "href" => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
+            "title" => work_package.subject
+          },
+          "schema" => {
+            "href" => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
+          }
+        }
+      }.to_json
+    end
+
+    it "renders as expected" do
+      expect(subject)
+        .to be_json_eql(expected_json)
+    end
+  end
+
+  context "with only the target versions changed" do
+    let(:version_b) { build_stubbed(:version) }
+    let(:target_versions) { [version, version_b] }
+    let(:attributes_changed_to_baseline) { %w[target_versions] }
+
+    let(:expected_json) do
+      {
+        "_meta" => {
+          "matchesFilters" => true,
+          "exists" => true,
+          "timestamp" => timestamp.to_s
+        },
+        "_links" => {
+          "targetVersions" => [
+            {
+              "href" => api_v3_paths.version(version.id),
+              "title" => version.name
+            },
+            {
+              "href" => api_v3_paths.version(version_b.id),
+              "title" => version_b.name
+            }
+          ],
           "self" => {
             "href" => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             "title" => work_package.subject
@@ -431,6 +524,12 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
             "href" => api_v3_paths.version(version.id),
             "title" => version.name
           },
+          "targetVersions" => [
+            {
+              "href" => api_v3_paths.version(version.id),
+              "title" => version.name
+            }
+          ],
           "parent" => {
             "displayId" => parent.display_id.to_s,
             "href" => api_v3_paths.work_package(parent.id),

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -321,6 +321,40 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
     end
   end
 
+  context "with all target versions removed" do
+    let(:version) { nil }
+    let(:target_versions) { [] }
+    let(:attributes_changed_to_baseline) { %w[version_id target_versions] }
+
+    let(:expected_json) do
+      {
+        "_meta" => {
+          "matchesFilters" => true,
+          "exists" => true,
+          "timestamp" => timestamp.to_s
+        },
+        "_links" => {
+          "version" => {
+            "href" => nil
+          },
+          "targetVersions" => [],
+          "self" => {
+            "href" => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
+            "title" => work_package.subject
+          },
+          "schema" => {
+            "href" => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
+          }
+        }
+      }.to_json
+    end
+
+    it "renders as expected" do
+      expect(subject)
+        .to be_json_eql(expected_json)
+    end
+  end
+
   context "without a linked property" do
     let(:attributes_changed_to_baseline) { %w[subject start_date] }
 

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
     end
   end
 
-  context "with the target versions changed together with the primary version" do
+  context "with the target versions changed together with the single-value version" do
     let(:version_b) { build_stubbed(:version) }
     let(:target_versions) { [version, version_b] }
     let(:attributes_changed_to_baseline) { %w[version_id target_versions] }

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -664,6 +664,16 @@ RSpec.describe Journable::WithHistoricAttributes,
         expect(work_package.reload.target_versions)
           .to contain_exactly(version_a, version_b)
       end
+
+      it "omits snapshotted target versions that were deleted since" do
+        update_target_versions(version_a, version_b)
+        version_b.destroy!
+
+        # 1 hour in the future so the journal written by the update above is
+        # unambiguously in the past, regardless of sub-second timing.
+        expect(subject.at_timestamp(Timestamp.parse(1.hour.from_now.iso8601)).target_versions)
+          .to contain_exactly(version_a)
+      end
     end
 
     describe "#changed_at_timestamp" do

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -677,7 +677,7 @@ RSpec.describe Journable::WithHistoricAttributes,
     end
 
     describe "#changed_at_timestamp" do
-      context "when the primary target version was swapped" do
+      context "when the target version was swapped" do
         it "marks both the version and the target versions as changed" do
           update_target_versions(version_b)
 
@@ -686,7 +686,7 @@ RSpec.describe Journable::WithHistoricAttributes,
         end
       end
 
-      context "when a secondary target version was added" do
+      context "when a target version was added alongside the existing one" do
         it "marks only the target versions as changed" do
           update_target_versions(version_a, version_b)
 
@@ -695,7 +695,7 @@ RSpec.describe Journable::WithHistoricAttributes,
         end
       end
 
-      context "when a secondary target version was removed" do
+      context "when one of several target versions was removed" do
         it "marks only the target versions as changed" do
           # Journal rows are stamped by the database clock, so a past removal
           # can't be journalled directly; seed the baseline snapshot instead.

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -695,6 +695,29 @@ RSpec.describe Journable::WithHistoricAttributes,
         end
       end
 
+      context "when a secondary target version was removed" do
+        it "marks only the target versions as changed" do
+          # Journal rows are stamped by the database clock, so a past removal
+          # can't be journalled directly; seed the baseline snapshot instead.
+          create(:journal_work_package_version_journal,
+                 journal: work_package.journals.first,
+                 version: version_b,
+                 kind: "target")
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("target_versions")
+        end
+      end
+
+      context "when all target versions were removed" do
+        it "marks both the version and the target versions as changed" do
+          update_target_versions
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("target_versions", "version_id")
+        end
+      end
+
       context "when the target versions are unchanged" do
         it "reports no version change" do
           expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -632,4 +632,65 @@ RSpec.describe Journable::WithHistoricAttributes,
       end
     end
   end
+
+  describe "target versions" do
+    shared_let(:version_a) { create(:version, project:, name: "Version A") }
+    shared_let(:version_b) { create(:version, project:, name: "Version B") }
+
+    let(:work_package) do
+      create(:work_package,
+             subject: "The versioned work package",
+             project:,
+             version: version_a,
+             journals: {
+               created_at => {},
+               1.day.ago => {}
+             })
+    end
+
+    subject { described_class.wrap(work_package, timestamps:) }
+
+    def update_target_versions(*versions)
+      work_package.target_version_ids_replacements = versions.map(&:id)
+      work_package.save!
+    end
+
+    describe "#at_timestamp" do
+      it "returns the target versions from the journal snapshot, not the current ones" do
+        update_target_versions(version_a, version_b)
+
+        expect(subject.at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")).target_versions)
+          .to contain_exactly(version_a)
+        expect(work_package.reload.target_versions)
+          .to contain_exactly(version_a, version_b)
+      end
+    end
+
+    describe "#changed_at_timestamp" do
+      context "when the primary target version was swapped" do
+        it "marks both the version and the target versions as changed" do
+          update_target_versions(version_b)
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("target_versions", "version_id")
+        end
+      end
+
+      context "when a secondary target version was added" do
+        it "marks only the target versions as changed" do
+          update_target_versions(version_a, version_b)
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("target_versions")
+        end
+      end
+
+      context "when the target versions are unchanged" do
+        it "reports no version change" do
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -329,6 +329,34 @@ RSpec.describe "API v3 Work package resource",
             end
           end
 
+          describe "when requesting only a historic timestamp with since-changed target versions" do
+            let(:timestamps) { [Timestamp.parse("2015-01-01T00:00:00Z")] }
+
+            let(:version_a) { create(:version, project:, name: "Version A") }
+            let(:version_b) { create(:version, project:, name: "Version B") }
+
+            let(:work_package) do
+              create(:work_package,
+                     subject: "The current work package",
+                     project:,
+                     version: version_a,
+                     journals: {
+                       created_at => { subject: "The original work package" },
+                       1.day.ago + 1 => {}
+                     }).tap do |wp|
+                wp.target_version_ids_replacements = [version_a.id, version_b.id]
+                wp.save!
+              end
+            end
+
+            it "renders the target versions of the requested time, not the current ones" do
+              expect(subject)
+                .to be_json_eql(
+                  [{ href: api_v3_paths.version(version_a.id), title: version_a.name }].to_json
+                ).at_path("_links/targetVersions")
+            end
+          end
+
           describe "when the work package has not been present at the baseline time" do
             let(:timestamps) { [Timestamp.parse("2015-01-01T00:00:00Z"), Timestamp.now] }
             let(:created_at) { 10.days.ago }


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-934

Introduce _targetVersions_ to WorkPackageAtTimestampRepresenter which is primarily used for the Baseline comparison feature. It only adds a multi-value `targetVersions` node and retains the backwards compatible single-value `versions` as per agreed convention to avoid breaking existing consumers.

> 📸  _Baseline "since yesterday" with a single version swap (Sprint 1 to Sprint 2) and a multiple target version addition (Sprint 1 to Sprint 1 + Sprint 2):_

<img width="1680" height="940" alt="baseline_target_versions" src="https://github.com/user-attachments/assets/7525246b-ea44-447b-81bd-ca0a87d6db3f" />
