### PR TITLE
[DREAM-801] Extend BorderBoxList header API

### DIFF
--- a/app/components/open_project/common/border_box_list_component.html.erb
+++ b/app/components/open_project/common/border_box_list_component.html.erb
@@ -34,13 +34,13 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   <% end %>
 
-  <% items.each do |item| %>
-    <% border_box.with_row(**item.row_args) do %>
-      <%= item %>
+  <% if items.any? %>
+    <% items.each do |item| %>
+      <% border_box.with_row(**item.row_args) do %>
+        <%= item %>
+      <% end %>
     <% end %>
-  <% end %>
-
-  <% if empty_state? %>
+  <% elsif empty_state? %>
     <% border_box.with_row(data: { empty_list_item: true }) do %>
       <%= empty_state %>
     <% end %>

--- a/app/components/open_project/common/border_box_list_component.html.erb
+++ b/app/components/open_project/common/border_box_list_component.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
         <%= item %>
       <% end %>
     <% end %>
-  <% elsif empty_state? %>
+  <% elsif empty_state? && !empty_state_behavior.none? %>
     <% border_box.with_row(data: { empty_list_item: true }) do %>
       <%= empty_state %>
     <% end %>

--- a/app/components/open_project/common/border_box_list_component.html.erb
+++ b/app/components/open_project/common/border_box_list_component.html.erb
@@ -27,8 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
 
-<% empty_row_content = capture { empty_state.to_s } if empty_state? %>
-<% box = capture do %>
+<%=
+  render(
+    Primer::ConditionalWrapper.new(
+      condition: empty_state_behavior.dynamic?,
+      tag: :div,
+      data: { controller: "border-box-list" }
+    )
+  ) do
+%>
   <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
     <% if header? %>
       <% border_box.with_header(**header.row_args) do %>
@@ -44,7 +51,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     <% elsif empty_state? && !empty_state_behavior.none? %>
       <% border_box.with_row(data: { empty_list_item: true }) do %>
-        <%= empty_row_content %>
+        <%= empty_state %>
       <% end %>
     <% end %>
 
@@ -54,15 +61,9 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     <% end %>
   <% end %>
-<% end %>
-
-<% if empty_state_behavior.dynamic? %>
-  <%= tag.div(data: { controller: "border-box-list" }) do %>
-    <%= box %>
+  <% if empty_state_behavior.dynamic? %>
     <template data-border-box-list-target="emptyStateTemplate">
-      <li class="Box-row" data-empty-list-item="true"><%= empty_row_content %></li>
+      <li class="Box-row" data-empty-list-item="true"><%= empty_state %></li>
     </template>
   <% end %>
-<% else %>
-  <%= box %>
 <% end %>

--- a/app/components/open_project/common/border_box_list_component.html.erb
+++ b/app/components/open_project/common/border_box_list_component.html.erb
@@ -27,28 +27,42 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
 
-<%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
-  <% if header? %>
-    <% border_box.with_header(**header.row_args) do %>
-      <%= header %>
-    <% end %>
-  <% end %>
-
-  <% if items.any? %>
-    <% items.each do |item| %>
-      <% border_box.with_row(**item.row_args) do %>
-        <%= item %>
+<% empty_row_content = capture { empty_state.to_s } if empty_state? %>
+<% box = capture do %>
+  <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
+    <% if header? %>
+      <% border_box.with_header(**header.row_args) do %>
+        <%= header %>
       <% end %>
     <% end %>
-  <% elsif empty_state? && !empty_state_behavior.none? %>
-    <% border_box.with_row(data: { empty_list_item: true }) do %>
-      <%= empty_state %>
-    <% end %>
-  <% end %>
 
-  <% if footer? %>
-    <% border_box.with_footer(**footer.footer_args) do %>
-      <%= footer %>
+    <% if items.any? %>
+      <% items.each do |item| %>
+        <% border_box.with_row(**item.row_args) do %>
+          <%= item %>
+        <% end %>
+      <% end %>
+    <% elsif empty_state? && !empty_state_behavior.none? %>
+      <% border_box.with_row(data: { empty_list_item: true }) do %>
+        <%= empty_row_content %>
+      <% end %>
+    <% end %>
+
+    <% if footer? %>
+      <% border_box.with_footer(**footer.footer_args) do %>
+        <%= footer %>
+      <% end %>
     <% end %>
   <% end %>
+<% end %>
+
+<% if empty_state_behavior.dynamic? %>
+  <%= tag.div(data: { controller: "border-box-list" }) do %>
+    <%= box %>
+    <template data-border-box-list-target="emptyStateTemplate">
+      <li class="Box-row" data-empty-list-item="true"><%= empty_row_content %></li>
+    </template>
+  <% end %>
+<% else %>
+  <%= box %>
 <% end %>

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -134,12 +134,10 @@ module OpenProject
       }
 
       # Optional empty-state content rendered when no items are present.
+      # When omitted, the component renders a generic default empty state.
       #
       # @!parse
-      #   # Adds empty-state content.
-      #   #
-      #   # Interactive lists announce this empty state only when the slot is
-      #   # configured explicitly.
+      #   # Adds custom empty-state content.
       #   #
       #   # @param title [String] empty-state title.
       #   # @param description [String, nil] optional supporting text.
@@ -148,17 +146,28 @@ module OpenProject
       #   #   drop-zone overlay with this label. The overlay becomes visible
       #   #   while a sortable item hovers the surrounding
       #   #   `[data-drop-container="active"]` list.
+      #   # @param action_label [String, nil] optional call-to-action rendered
+      #   #   as the blankslate's primary action.
+      #   # @param action_icon [Symbol, nil] optional leading icon for the
+      #   #   call-to-action.
+      #   # @param action_arguments [Hash] forwarded to the primary-action
+      #   #   button (e.g. `href:`, `scheme:`, `data:`).
       #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Blankslate`.
       #   # @return [ViewComponent::Slot]
-      #   def with_empty_state(title:, description: nil, icon: nil, drop_target_label: nil, **system_arguments)
+      #   def with_empty_state(title:, description: nil, icon: nil, drop_target_label: nil,
+      #                        action_label: nil, action_icon: nil, action_arguments: {}, **system_arguments)
       #   end
-      renders_one :empty_state, ->(title:, description: nil, icon: nil, drop_target_label: nil, **system_arguments) {
+      renders_one :empty_state, ->(title:, description: nil, icon: nil, drop_target_label: nil,
+                                   action_label: nil, action_icon: nil, action_arguments: {}, **system_arguments) {
         EmptyState.new(
           title:,
           description:,
           icon:,
           interactive: interactive?,
           drop_target_label:,
+          action_label:,
+          action_icon:,
+          action_arguments:,
           **system_arguments
         )
       }
@@ -192,8 +201,7 @@ module OpenProject
       #   the header's block padding.
       # @param interactive [Boolean] whether dynamic list updates should be
       #   announced politely to assistive technology. This affects the counter
-      #   and an explicitly configured empty state; it does not create default
-      #   empty-state content for manually composed lists.
+      #   and empty-state content.
       # @param collapsible [Boolean] whether the header renders a collapsible
       #   toggle. Defaults to `false`.
       # @param current_user [User] user context passed to work-package items.
@@ -240,6 +248,7 @@ module OpenProject
 
       def before_render
         content
+        configure_empty_state!
         configure_header!
       end
 
@@ -260,6 +269,15 @@ module OpenProject
         return unless collapsible? && footer?
 
         header.collapsible_id = [list_id, footer_id].compact.join(" ")
+      end
+
+      def configure_empty_state!
+        return if items.any? || empty_state?
+
+        with_empty_state(
+          title: I18n.t(:label_nothing_display),
+          description: I18n.t(:no_results_title_text)
+        )
       end
     end
   end

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -245,7 +245,12 @@ module OpenProject
 
         @system_arguments[:id] ||= dom_target(container)
         @list_id = dom_target(@system_arguments[:id], :list)
-        @system_arguments[:list_arguments] = { id: @list_id }
+        @system_arguments[:list_arguments] =
+          if @empty_state_behavior.dynamic?
+            { id: @list_id, data: { "border-box-list-target": "list" } }
+          else
+            { id: @list_id }
+          end
         @system_arguments[:classes] = class_names(
           @system_arguments[:classes],
           "op-border-box-list",

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -43,8 +43,11 @@ module OpenProject
       SCHEME_OPTIONS = [SCHEME_DEFAULT, :transparent].freeze
       HEADER_PADDING_DEFAULT = :inherit
       HEADER_PADDING_OPTIONS = [HEADER_PADDING_DEFAULT, :condensed, :default, :spacious].freeze
+      EMPTY_STATE_BEHAVIOR_DEFAULT = :static
+      EMPTY_STATE_BEHAVIOR_OPTIONS = [EMPTY_STATE_BEHAVIOR_DEFAULT, :none, :dynamic].freeze
 
-      attr_reader :container, :scheme, :header_padding, :collapsible, :current_user, :header_id, :footer_id, :list_id
+      attr_reader :container, :scheme, :header_padding, :empty_state_behavior, :collapsible, :current_user,
+                  :header_id, :footer_id, :list_id
 
       alias_method :collapsible?, :collapsible
 
@@ -199,6 +202,12 @@ module OpenProject
       #   the header. `:inherit` keeps Primer's padding from the underlying
       #   BorderBox. `:condensed`, `:default`, and `:spacious` override only
       #   the header's block padding.
+      # @param empty_state_behavior [Symbol] policy for the empty state shown
+      #   when the list has no items. `:static` (default) renders the generic
+      #   empty state unless a custom one is declared via `with_empty_state`.
+      #   `:none` suppresses the empty state entirely, including any declared
+      #   slot. `:dynamic` reserves client-side lifecycle handling for
+      #   sortable and filtered lists; no markup is added by this param yet.
       # @param interactive [Boolean] whether dynamic list updates should be
       #   announced politely to assistive technology. This affects the counter
       #   and empty-state content.
@@ -211,6 +220,7 @@ module OpenProject
         container:,
         scheme: SCHEME_DEFAULT,
         header_padding: HEADER_PADDING_DEFAULT,
+        empty_state_behavior: EMPTY_STATE_BEHAVIOR_DEFAULT,
         interactive: false,
         collapsible: false,
         current_user: User.current,
@@ -224,6 +234,9 @@ module OpenProject
         )
         @header_padding = ActiveSupport::StringInquirer.new(
           fetch_or_fallback(HEADER_PADDING_OPTIONS, header_padding, HEADER_PADDING_DEFAULT).to_s
+        )
+        @empty_state_behavior = ActiveSupport::StringInquirer.new(
+          fetch_or_fallback(EMPTY_STATE_BEHAVIOR_OPTIONS, empty_state_behavior, EMPTY_STATE_BEHAVIOR_DEFAULT).to_s
         )
         @interactive = interactive
         @collapsible = collapsible
@@ -253,7 +266,9 @@ module OpenProject
       end
 
       def render?
-        header? || items.any? || empty_state? || footer?
+        # rubocop:disable Style/InverseMethods -- `none?` is StringInquirer#none?, not Enumerable#none?
+        header? || items.any? || (empty_state? && !empty_state_behavior.none?) || footer?
+        # rubocop:enable Style/InverseMethods
       end
 
       private
@@ -272,6 +287,7 @@ module OpenProject
       end
 
       def configure_empty_state!
+        return unless empty_state_behavior.static? || empty_state_behavior.dynamic?
         return if items.any? || empty_state?
 
         with_empty_state(

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -293,7 +293,11 @@ module OpenProject
 
       def configure_empty_state!
         return unless empty_state_behavior.static? || empty_state_behavior.dynamic?
-        return if items.any? || empty_state?
+        return if empty_state?
+        # :dynamic lists always need prototype content for the parked template,
+        # even when currently populated, so a client-side drain to zero rows has
+        # a real blankslate to clone instead of a contentless placeholder.
+        return if empty_state_behavior.static? && items.any?
 
         with_empty_state(
           title: I18n.t(:label_nothing_display),

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -17,9 +17,8 @@
 
   & + .Box-row
     border-top-color: $color
-  // Display the selected state margin for the last child, or the penultimate child,
-  // if the last one is the hidden blankslate.
-  &:is(:last-child, :has(+ [data-empty-list-item]))
+
+  &:last-child
     margin-bottom: calc(var(--borderWidth-thin) * -1)
     border-bottom: var(--borderWidth-thin) solid $color
 
@@ -99,19 +98,6 @@
 
   &[data-drop-container="refused"]
     outline-color: var(--borderColor-danger-muted)
-
-  // The empty-state row only makes sense while it is alone in the list. Hiding
-  // it as soon as a sibling row appears (e.g. dropped by drag and drop) avoids
-  // a flicker between the drop and the server render removing it.
-  > .Box-list
-    > .Box-row
-      &[data-empty-list-item]:not(:only-child)
-        display: none
-      // Display rounded corners for the penultimate child, if the last child is the
-      // hidden blankslate.
-      &:has(+ [data-empty-list-item])
-        border-bottom-right-radius: var(--borderRadius-medium)
-        border-bottom-left-radius: var(--borderRadius-medium)
 
 .op-border-box-list-header
   display: grid

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -154,6 +154,9 @@
     display: flex
     align-items: center
     gap: var(--stack-gap-condensed)
+    // Reserve the height of a medium control so headers whose action
+    // buttons toggle (e.g. hidden while filtering) keep a stable height.
+    min-height: var(--control-medium-size)
 
     .Box-title
       min-width: 0

--- a/app/components/open_project/common/border_box_list_component/empty_state.rb
+++ b/app/components/open_project/common/border_box_list_component/empty_state.rb
@@ -49,6 +49,12 @@ module OpenProject
         #   overlay with this label. The overlay becomes visible while a
         #   sortable item hovers the surrounding `[data-drop-container="active"]`
         #   list.
+        # @param action_label [String, nil] optional call-to-action rendered as
+        #   the blankslate's primary action.
+        # @param action_icon [Symbol, nil] optional leading icon for the
+        #   call-to-action.
+        # @param action_arguments [Hash] forwarded to the primary-action button
+        #   (e.g. `href:`, `scheme:`, `data:`).
         # @param system_arguments [Hash] forwarded to `Primer::Beta::Blankslate`.
         def initialize(
           title:,
@@ -56,6 +62,9 @@ module OpenProject
           icon: nil,
           interactive: false,
           drop_target_label: nil,
+          action_label: nil,
+          action_icon: nil,
+          action_arguments: {},
           **system_arguments
         )
           super()
@@ -64,6 +73,9 @@ module OpenProject
           @description = description
           @icon = icon
           @drop_target_label = drop_target_label
+          @action_label = action_label
+          @action_icon = action_icon
+          @action_arguments = action_arguments.deep_dup
 
           @system_arguments = system_arguments
           return unless interactive
@@ -84,6 +96,12 @@ module OpenProject
           blankslate.with_heading(tag: :h4).with_content(@title)
           blankslate.with_description_content(@description) if @description
           blankslate.with_visual_icon(icon: @icon) if @icon
+
+          if @action_label.present?
+            action = blankslate.with_primary_action(**@action_arguments)
+            action.with_leading_visual_icon(icon: @action_icon) if @action_icon
+            action.with_content(@action_label)
+          end
 
           blankslate
         end

--- a/app/components/open_project/common/border_box_list_component/has_menu.rb
+++ b/app/components/open_project/common/border_box_list_component/has_menu.rb
@@ -40,39 +40,49 @@ module OpenProject
           # @!parse
           #   # Adds a trailing action menu.
           #   #
+          #   # By default the menu renders the standard invisible
+          #   # kebab-horizontal show button. Pass `button_arguments:` to
+          #   # customize that default trigger, or call `with_show_button` in
+          #   # the slot block to provide a custom trigger.
+          #   #
           #   # @param menu_id [String, nil] id prefix for the Primer action menu.
-          #   # @param button_aria_label [String, nil] accessible label for the
-          #   #   menu button.
+          #   # @param button_aria_label [String, nil] compatibility shortcut
+          #   #   for the default menu button accessible label. Prefer
+          #   #   `button_arguments: { aria: { label: ... } }`.
+          #   # @param button_arguments [Hash] forwarded to the default
+          #   #   `with_show_button` call.
           #   # @param system_arguments [Hash] forwarded to
           #   #   `Primer::Alpha::ActionMenu`.
           #   # @return [ViewComponent::Slot]
-          #   def with_menu(menu_id: nil, button_aria_label: nil, **system_arguments, &block)
+          #   def with_menu(menu_id: nil, button_aria_label: nil, button_arguments: {}, **system_arguments, &block)
           #   end
-          renders_one :menu, ->(menu_id: nil, button_aria_label: nil, **system_arguments) do
-            build_menu(menu_id:, button_aria_label:, **system_arguments)
+          renders_one :menu, ->(menu_id: nil, button_aria_label: nil, button_arguments: {}, **system_arguments) do
+            build_menu(menu_id:, button_aria_label:, button_arguments:, **system_arguments)
           end
         end
 
         private
 
-        def build_menu(menu_id: nil, button_aria_label: nil, **system_arguments)
+        def build_menu(menu_id: nil, button_aria_label: nil, button_arguments: {}, **system_arguments)
           system_arguments[:classes] = class_names(
             system_arguments[:classes],
             "hide-when-print"
           )
 
-          menu = Primer::Alpha::ActionMenu.new(
+          if button_aria_label.present?
+            button_arguments = button_arguments.deep_dup
+            button_arguments[:aria] = merge_aria(
+              { aria: { label: button_aria_label } },
+              button_arguments
+            )
+          end
+
+          Menu.new(
             menu_id: menu_id || default_menu_id,
+            button_arguments:,
             anchor_align: :end,
             **system_arguments
           )
-          menu.with_show_button(
-            scheme: :invisible,
-            icon: :"kebab-horizontal",
-            "aria-label": button_aria_label || I18n.t(:label_actions),
-            tooltip_direction: :se
-          )
-          menu
         end
 
         def default_menu_id

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -56,9 +56,12 @@ module OpenProject
         # @!parse
         #   # Renders the header title content.
         #   #
-        #   # Block-based alternative to the `title:` string, for advanced use
-        #   # cases where the title needs more than plain text. Takes precedence
-        #   # over `title:` when both are given.
+        #   # Block-based alternative to the `title:` string, strictly for
+        #   # inline phrasing content — a link or an emphasized fragment that
+        #   # renders inside the heading element. Never nest block layouts,
+        #   # counters, or buttons here: counts belong to `count:`, actions to
+        #   # `with_action_button`/`with_action_icon_button`/`with_menu`.
+        #   # Takes precedence over `title:` when both are given.
         #   #
         #   # @return [ViewComponent::Slot]
         #   def with_title(&block)
@@ -89,9 +92,19 @@ module OpenProject
         #   # @return [ViewComponent::Slot]
         #   def with_action_button(**system_arguments, &block)
         #   end
+        #
+        #   # Adds an icon button to the header actions area.
+        #   #
+        #   # @param system_arguments [Hash] forwarded to `Primer::Beta::IconButton`.
+        #   # @return [ViewComponent::Slot]
+        #   def with_action_icon_button(**system_arguments)
+        #   end
         renders_many :actions, types: {
           button: ->(scheme: DEFAULT_ACTION_SCHEME, **system_arguments) do
             Primer::Beta::Button.new(scheme:, **system_arguments)
+          end,
+          icon_button: ->(**system_arguments) do
+            Primer::Beta::IconButton.new(**system_arguments)
           end
         }
 
@@ -125,7 +138,8 @@ module OpenProject
 
         attr_writer :collapsible_id
 
-        # @param title [String] header title.
+        # @param title [String, nil] header title. Optional when the `title`
+        #   slot is filled.
         # @param count [Integer, Boolean, nil] count badge behavior. Pass
         #   `nil` or `false` to hide it, `true` to infer the rendered item
         #   count, or an integer to render an explicit value.

--- a/app/components/open_project/common/border_box_list_component/menu.rb
+++ b/app/components/open_project/common/border_box_list_component/menu.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Common
+    class BorderBoxListComponent
+      # Action menu wrapper for list headers and rows.
+      #
+      # The wrapper owns the default trigger decision while keeping the normal
+      # Primer ActionMenu slot API available to callers.
+      class Menu < ApplicationComponent
+        include Primer::AttributesHelper
+
+        DEFAULT_BUTTON_ARGUMENTS = {
+          scheme: :invisible,
+          icon: :"kebab-horizontal",
+          tooltip_direction: :se
+        }.freeze
+
+        delegate :items,
+                 :with_item,
+                 :with_avatar_item,
+                 :with_divider,
+                 :with_group,
+                 :with_sub_menu_item,
+                 to: :@menu
+
+        def initialize(button_arguments: {}, **system_arguments)
+          super()
+
+          @button_arguments = DEFAULT_BUTTON_ARGUMENTS.merge(button_arguments.deep_dup)
+          @button_arguments[:aria] = merge_aria(
+            { aria: { label: I18n.t(:label_actions) } },
+            @button_arguments
+          )
+          @show_button_configured = false
+          @menu = Primer::Alpha::ActionMenu.new(**system_arguments)
+        end
+
+        def with_show_button(**system_arguments, &)
+          @show_button_configured = true
+          @menu.with_show_button(**system_arguments, &)
+        end
+
+        def call
+          render(@menu)
+        end
+
+        private
+
+        def before_render
+          content
+          configure_default_show_button!
+        end
+
+        def configure_default_show_button!
+          return if @show_button_configured
+
+          @menu.with_show_button(**@button_arguments)
+        end
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/project_attributes/section_component.html.erb
+++ b/app/components/work_package_types/project_attributes/section_component.html.erb
@@ -5,7 +5,8 @@
         container: "type-project-attribute-section-#{@project_custom_field_section.id}",
         mb: 3,
         classes: "op-project-custom-field-section",
-        test_selector: "type-project-attribute-section-#{@project_custom_field_section.id}"
+        test_selector: "type-project-attribute-section-#{@project_custom_field_section.id}",
+        empty_state_behavior: :none
       )
     ) do |list|
       list.with_header(
@@ -47,24 +48,16 @@
         end
       end
 
-      if @project_custom_fields.empty?
-        list.with_item do
-          render(Primer::Beta::Text.new(color: :subtle)) do
-            t("settings.project_attributes.label_no_project_custom_fields")
-          end
-        end
-      else
-        @project_custom_fields.each do |project_custom_field|
-          list.with_item(data: { "filter--filter-list-target": "searchItem" }) do
-            render(
-              WorkPackageTypes::ProjectAttributes::RowComponent.new(
-                type: @type,
-                project_custom_field:,
-                linked:,
-                exclusion_state:
-              )
+      @project_custom_fields.each do |project_custom_field|
+        list.with_item(data: { "filter--filter-list-target": "searchItem" }) do
+          render(
+            WorkPackageTypes::ProjectAttributes::RowComponent.new(
+              type: @type,
+              project_custom_field:,
+              linked:,
+              exclusion_state:
             )
-          end
+          )
         end
       end
     end

--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -34,7 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
         <%= render(
               OpenProject::Common::BorderBoxListComponent.new(
                 container: "op-types-group-#{root.id}",
-                collapsible: true
+                collapsible: true,
+                empty_state_behavior: :none
               )
             ) do |list| %>
           <% list.with_header(collapsed: collapsed?(root), show_drag_handle: reorderable?(root)) do |header| %>

--- a/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.spec.ts
@@ -1,0 +1,119 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import BorderBoxListController from './border-box-list.controller';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+
+describe('BorderBoxListController', () => {
+  let ctx:StimulusTestContext;
+
+  const HTML = `
+<div data-controller="border-box-list">
+  <div class="Box"><ul data-border-box-list-target="list">
+    <li class="Box-row">one</li><li class="Box-row">two</li>
+  </ul></div>
+  <template data-border-box-list-target="emptyStateTemplate"><li class="Box-row" data-empty-list-item="true">empty</li></template>
+</div>`;
+
+  // Mirrors a server-rendered empty :dynamic list: the ul contains only the
+  // real placeholder row, and the template still parks the prototype.
+  const EMPTY_HTML = `
+<div data-controller="border-box-list">
+  <div class="Box"><ul data-border-box-list-target="list">
+    <li class="Box-row" data-empty-list-item="true">empty</li>
+  </ul></div>
+  <template data-border-box-list-target="emptyStateTemplate"><li class="Box-row" data-empty-list-item="true">empty</li></template>
+</div>`;
+
+  const flush = async () => { await new Promise((resolve) => { setTimeout(resolve); }); };
+  const list = () => ctx.container.querySelector('[data-border-box-list-target="list"]')!;
+  const placeholder = () => list().querySelector('[data-empty-list-item]');
+
+  async function boot():Promise<StimulusTestContext> {
+    return setupStimulusTest({ controllers: { 'border-box-list': BorderBoxListController } });
+  }
+
+  // Replaces the fixture, restarting the Stimulus application from scratch,
+  // so an initially empty list boots with connect()-time state rather than
+  // being mutated into that shape by a running controller instance.
+  async function remount(html:string):Promise<void> {
+    ctx.dispose();
+    ctx = await boot();
+    await ctx.mount(html);
+  }
+
+  beforeEach(async () => {
+    ctx = await boot();
+    await ctx.mount(HTML);
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('inserts the placeholder when the last visible row disappears', async () => {
+    list().querySelectorAll('li').forEach((row) => row.remove());
+    await flush();
+    expect(placeholder()).not.toBeNull();
+  });
+
+  it('inserts the placeholder when all rows are filter-hidden', async () => {
+    list().querySelectorAll('li').forEach((row) => row.classList.add('d-none'));
+    await flush();
+    expect(placeholder()).not.toBeNull();
+  });
+
+  it('removes the placeholder when a hidden row becomes visible again', async () => {
+    list().querySelectorAll('li').forEach((row) => row.classList.add('d-none'));
+    await flush();
+    list().querySelector('li:not([data-empty-list-item])')!.classList.remove('d-none');
+    await flush();
+    expect(placeholder()).toBeNull();
+  });
+
+  it('keeps exactly one placeholder across repeated syncs', async () => {
+    list().querySelectorAll('li').forEach((row) => row.remove());
+    await flush();
+    // the placeholder insertion itself fires the observer again; a second
+    // pass must not insert a duplicate
+    await flush();
+    expect(list().querySelectorAll('[data-empty-list-item]')).toHaveLength(1);
+  });
+
+  it('survives an empty -> populated -> empty cycle on an initially empty list', async () => {
+    await remount(EMPTY_HTML);
+    const row = document.createElement('li');
+    row.className = 'Box-row';
+    list().append(row);
+    await flush();
+    expect(placeholder()).toBeNull();
+    row.remove();
+    await flush();
+    expect(placeholder()).not.toBeNull();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.ts
@@ -53,6 +53,8 @@ export default class BorderBoxListController extends Controller<HTMLElement> {
     const rows = Array.from(this.listTarget.children) as HTMLElement[];
     // legacy generic-drag-and-drop contract: the marker value is exactly "true"
     const placeholder = rows.find((row) => row.getAttribute('data-empty-list-item') === 'true');
+    // 'd-none'/[hidden] are this codebase's existing filtering idioms (e.g. quick-filter,
+    // sortable-lists row hiding) — intentionally scoped to those, not a general visibility check.
     const visibleContent = rows.some((row) => row.getAttribute('data-empty-list-item') !== 'true'
       && !row.classList.contains('d-none') && !row.hidden);
 

--- a/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.ts
@@ -1,0 +1,66 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class BorderBoxListController extends Controller<HTMLElement> {
+  static targets = ['list', 'emptyStateTemplate'];
+
+  declare readonly listTarget:HTMLElement;
+
+  declare readonly emptyStateTemplateTarget:HTMLTemplateElement;
+
+  private observer?:MutationObserver;
+
+  connect():void {
+    this.sync();
+    this.observer = new MutationObserver(() => this.sync());
+    this.observer.observe(this.listTarget, {
+      childList: true, subtree: true, attributes: true, attributeFilter: ['class', 'hidden'],
+    });
+  }
+
+  disconnect():void {
+    this.observer?.disconnect();
+  }
+
+  sync():void {
+    const rows = Array.from(this.listTarget.children) as HTMLElement[];
+    // legacy generic-drag-and-drop contract: the marker value is exactly "true"
+    const placeholder = rows.find((row) => row.getAttribute('data-empty-list-item') === 'true');
+    const visibleContent = rows.some((row) => row.getAttribute('data-empty-list-item') !== 'true'
+      && !row.classList.contains('d-none') && !row.hidden);
+
+    if (visibleContent) {
+      placeholder?.remove();
+    } else if (!placeholder) {
+      const prototype = this.emptyStateTemplateTarget.content.firstElementChild;
+      if (prototype) { this.listTarget.append(prototype.cloneNode(true)); }
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/border-box-list.controller.ts
@@ -27,6 +27,7 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
+import { useMutation } from 'stimulus-use';
 
 export default class BorderBoxListController extends Controller<HTMLElement> {
   static targets = ['list', 'emptyStateTemplate'];
@@ -35,18 +36,20 @@ export default class BorderBoxListController extends Controller<HTMLElement> {
 
   declare readonly emptyStateTemplateTarget:HTMLTemplateElement;
 
-  private observer?:MutationObserver;
-
   connect():void {
     this.sync();
-    this.observer = new MutationObserver(() => this.sync());
-    this.observer.observe(this.listTarget, {
-      childList: true, subtree: true, attributes: true, attributeFilter: ['class', 'hidden'],
+    useMutation(this, {
+      element: this.listTarget,
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'hidden'],
+      dispatchEvent: false,
     });
   }
 
-  disconnect():void {
-    this.observer?.disconnect();
+  mutate():void {
+    this.sync();
   }
 
   sync():void {

--- a/lookbook/docs/components/border-box-list.md.erb
+++ b/lookbook/docs/components/border-box-list.md.erb
@@ -37,6 +37,7 @@ comparable lists should use headers.
 | `scheme` | `Symbol` | `:default` | Visual scheme. Use `:transparent` for list containers that should blend into their surrounding surface |
 | `padding` | `Symbol` | `:default` | Row padding forwarded to the underlying `Primer::Beta::BorderBox`. Supports Primer BorderBox padding values such as `:condensed`, `:default`, and `:spacious` |
 | `header_padding` | `Symbol` | `:inherit` | Header-only vertical padding override. Supports `:inherit`, `:condensed`, `:default`, and `:spacious` |
+| `empty_state_behavior` | `Symbol` | `:static` | Policy for the empty state shown when the list has no items. See [Empty-state behavior](#empty-state-behavior) below |
 | `interactive` | `Boolean` | `false` | Enables polite ARIA live-region announcements for counter and configured empty-state updates |
 | `collapsible` | `Boolean` | `false` | Renders the header as a collapsible toggle when a header is present |
 | `current_user` | `User` | `User.current` | User context forwarded to work package item rows |
@@ -135,6 +136,16 @@ When no items are present, the component renders a generic
 system arguments.
 
 <%= embed OpenProject::Common::BorderBoxListComponentPreview, :empty_state, panels: %i[source] %>
+
+### Empty-state behavior
+
+`empty_state_behavior:` controls what happens when the list has no items:
+
+- `:static` (default) — renders the generic empty state described above, unless a custom one is declared via `with_empty_state`.
+- `:none` — suppresses the empty state entirely, including any declared `with_empty_state` slot. Use this for grouped lists where a generic blankslate per empty group would be noisy.
+- `:dynamic` — reserved for client-side lifecycle handling on sortable and filtered lists; see lifecycle controller.
+
+<%= embed OpenProject::Common::BorderBoxListComponentPreview, :with_behavior_none, panels: %i[source] %>
 
 ## Usage guidelines
 

--- a/lookbook/docs/components/border-box-list.md.erb
+++ b/lookbook/docs/components/border-box-list.md.erb
@@ -18,8 +18,10 @@ of the collapsible header and is hidden when the list is collapsed.
 **Items**
 The list rows. Items can render generic row content or a work package card.
 
-**Empty state** *(optional)*
-Shown when the list has no items.
+**Empty state**
+Shown when the list has no items. The component renders a generic empty state by
+default; use `with_empty_state` only when the list needs domain-specific copy,
+an icon, or custom system arguments.
 
 **Footer** *(optional)*
 Shown below the items. Use it for summary or follow-up content.
@@ -47,7 +49,7 @@ comparable lists should use headers.
 | `with_header` | Optional section header. See [Header parameters](#header-parameters) and [Header slots](#header-slots) below |
 | `with_item` | Generic list row that renders the provided block content |
 | `with_work_package_item` | Work package row that renders a work package card |
-| `with_empty_state` | Empty-state content rendered when no items are present |
+| `with_empty_state` | Custom empty-state content rendered when no items are present |
 | `with_footer` | Optional footer row below the list items |
 
 ## Header
@@ -126,9 +128,11 @@ enough for the list action.
 
 ### Empty state
 
-Use `with_empty_state` when the list can be rendered without items. It renders a
-`Primer::Beta::Blankslate` under the hood, accepting `title:`, `description:`,
-and `icon:` keywords.
+When no items are present, the component renders a generic
+`Primer::Beta::Blankslate` with the global empty-state copy. Use
+`with_empty_state` for domain-specific copy, icons, a call-to-action
+(`action_label:`, `action_icon:`, `action_arguments:`), or custom Blankslate
+system arguments.
 
 <%= embed OpenProject::Common::BorderBoxListComponentPreview, :empty_state, panels: %i[source] %>
 

--- a/lookbook/docs/components/border-box-list.md.erb
+++ b/lookbook/docs/components/border-box-list.md.erb
@@ -71,7 +71,8 @@ comparable lists should use headers.
 | `with_description` | Secondary content below the title, wrapped in `Primer::Beta::Text` with muted color by default. Accepts Primer system arguments |
 | `with_label` | Informational status label (`Primer::Beta::Label`) shown on the title row. Right-aligned, truncated when long, and hidden on small screens, so use it only for supplementary status, never as the sole affordance for an action |
 | `with_action_button` | Button rendered in the header actions area |
-| `with_menu` | Action menu rendered in the header actions area. Pass `button_aria_label:` for the trigger button |
+| `with_action_icon_button` | Icon button rendered in the header actions area |
+| `with_menu` | Action menu rendered in the header actions area. Pass `button_arguments:` for the default trigger button |
 
 ### Collapsible headers
 
@@ -111,6 +112,17 @@ It renders `OpenProject::Common::WorkPackageCardComponent` by default. See the
 for card-specific layout, parameters, and slots.
 
 <%= embed OpenProject::Common::BorderBoxListComponentPreview, :with_work_package_items, panels: %i[source] %>
+
+### Custom header content
+
+Use `with_title` when a header title needs composed **inline phrasing content**,
+such as a link or an emphasized fragment. The slot renders inside the heading
+element, so never nest block layouts, counters, or buttons in it — the counter
+belongs to `count:` and actions to the header action slots. Use
+`menu.with_show_button` when the default action-menu trigger is not specific
+enough for the list action.
+
+<%= embed OpenProject::Common::BorderBoxListComponentPreview, :custom_header_content, panels: %i[source] %>
 
 ### Empty state
 
@@ -172,7 +184,7 @@ render OpenProject::Common::BorderBoxListComponent.new(
     header.with_description(id: "project-attributes-description", font_size: :small) do
       "Visible in the project overview"
     end
-    header.with_menu(button_aria_label: "Project attribute actions") do |menu|
+    header.with_menu(button_arguments: { aria: { label: "Project attribute actions" } }) do |menu|
       menu.with_item(label: "Edit", href: edit_project_path(@project))
     end
   end

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -64,7 +64,7 @@ module OpenProject
               button.with_leading_visual_icon(icon: :pencil)
               "Edit"
             end
-            header.with_menu(button_aria_label: "List actions") do |menu|
+            header.with_menu(button_arguments: { aria: { label: "List actions" } }) do |menu|
               menu.with_item(label: "Configure") do |menu_item|
                 menu_item.with_leading_visual_icon(icon: :gear)
               end
@@ -105,7 +105,7 @@ module OpenProject
               button.with_leading_visual_icon(icon: :rocket)
               "Start sprint"
             end
-            header.with_menu(button_aria_label: "Sprint actions") do |menu|
+            header.with_menu(button_arguments: { aria: { label: "Sprint actions" } }) do |menu|
               menu.with_item(label: "Edit sprint") do |menu_item|
                 menu_item.with_leading_visual_icon(icon: :pencil)
               end
@@ -141,6 +141,35 @@ module OpenProject
         ) do |list|
           list.with_header(title: "Work packages", count: true)
           render_work_package_items(list, work_packages)
+        end
+      end
+
+      # @label Custom header content
+      # List with a linked title slot and a custom action-menu trigger.
+      def custom_header_content
+        render OpenProject::Common::BorderBoxListComponent.new(
+          container: "border-box-list-custom-header-preview"
+        ) do |list|
+          list.with_header(count: true) do |header|
+            header.with_title do
+              '<a href="#" class="Link--primary no-underline">Linked delivery plan</a>'.html_safe
+            end
+            header.with_description do
+              "Milestones grouped by owner."
+            end
+            header.with_menu do |menu|
+              menu.with_show_button(scheme: :primary, aria: { label: "Add delivery item" }) do |button|
+                button.with_leading_visual_icon(icon: :plus)
+                "Add item"
+              end
+              menu.with_item(label: "Import milestones") do |menu_item|
+                menu_item.with_leading_visual_icon(icon: :upload)
+              end
+            end
+          end
+
+          list.with_item { "Alpha release checklist" }
+          list.with_item { "Customer review preparation" }
         end
       end
 

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -257,6 +257,22 @@ module OpenProject
         end
       end
 
+      # @label Empty state (behavior: none)
+      # A grouped outlier that suppresses the generic empty state entirely via
+      # `empty_state_behavior: :none`, even with a header and no items.
+      # @param padding [Symbol] select [default, condensed, spacious]
+      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
+      def with_behavior_none(padding: :default, header_padding: :inherit)
+        render OpenProject::Common::BorderBoxListComponent.new(
+          container: "border-box-list-behavior-none-preview",
+          empty_state_behavior: :none,
+          padding:,
+          header_padding:
+        ) do |list|
+          list.with_header(title: "Empty group", count: 0)
+        end
+      end
+
       # @label With header label
       # Header holding a status label, optionally next to an action button.
       # @param label text

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -220,6 +220,21 @@ module OpenProject
         end
       end
 
+      # @label With header drag handle
+      # Reorderable list whose header and rows show a drag handle.
+      # @param padding [Symbol] select [default, condensed, spacious]
+      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
+      # @param collapsible toggle
+      def with_header_drag_handle(padding: :default, header_padding: :inherit, collapsible: false)
+        render_with_template(
+          locals: {
+            padding:,
+            header_padding:,
+            collapsible: boolean_preview_param(collapsible)
+          }
+        )
+      end
+
       # @label Empty state
       # List with a header and an empty state (Blankslate), no items.
       # @param padding [Symbol] select [default, condensed, spacious]
@@ -291,24 +306,6 @@ module OpenProject
           header_padding:,
           collapsible: true
         )
-      end
-
-      # @label With header drag handle
-      # @param padding [Symbol] select [default, condensed, spacious]
-      # @param header_padding [Symbol] select [inherit, condensed, default, spacious]
-      # @param collapsible toggle
-      def with_header_drag_handle(padding: :default, header_padding: :inherit, collapsible: false)
-        render OpenProject::Common::BorderBoxListComponent.new(
-          container: "border-box-list-header-drag-handle-preview",
-          padding:,
-          header_padding:,
-          collapsible: boolean_preview_param(collapsible)
-        ) do |list|
-          list.with_header(title: "Reorderable section", count: true, show_drag_handle: true)
-
-          list.with_item { "First item" }
-          list.with_item { "Second item" }
-        end
       end
 
       private

--- a/lookbook/previews/open_project/common/border_box_list_component_preview/with_header_drag_handle.html.erb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview/with_header_drag_handle.html.erb
@@ -1,0 +1,20 @@
+<%= render OpenProject::Common::BorderBoxListComponent.new(
+      container: "border-box-list-header-drag-handle-preview",
+      padding:,
+      header_padding:,
+      collapsible:
+    ) do |list| %>
+  <% list.with_header(title: "Reorderable section", count: true, show_drag_handle: true) %>
+  <% list.with_item do %>
+    <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center, ml: -2)) do |row| %>
+      <% row.with_column(style: "width: 1.5rem") { render(Primer::OpenProject::DragHandle.new) } %>
+      <% row.with_column(flex: 1) { "one" } %>
+    <% end %>
+  <% end %>
+  <% list.with_item do %>
+    <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center, ml: -2)) do |row| %>
+      <% row.with_column(style: "width: 1.5rem") { render(Primer::OpenProject::DragHandle.new) } %>
+      <% row.with_column(flex: 1) { "two" } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
       )
     ) do |list|
       list.with_header(title: backlog_bucket.name) do |header|
-        header.with_menu(button_aria_label: t(".label_actions")) do |menu|
+        header.with_menu(button_arguments: { aria: { label: t(".label_actions") } }) do |menu|
           with_item_group(menu) do
             if user_allowed?(:create_sprints)
               menu.with_item(

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -37,6 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
         scheme: :transparent,
         padding: :condensed,
         header_padding: :condensed,
+        empty_state_behavior: :dynamic,
         test_selector: "backlog-inbox",
         data: {
           controller: "sortable-lists--list",

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -93,7 +93,7 @@ See COPYRIGHT and LICENSE files for more details.
           end
         end
 
-        header.with_menu(button_aria_label: t(".label_actions")) do |menu|
+        header.with_menu(button_arguments: { aria: { label: t(".label_actions") } }) do |menu|
           with_item_group(menu) do
             if can_open_edit_dialog?
               menu.with_item(

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
@@ -70,6 +70,7 @@ module Backlogs
         current_user:,
         interactive: true,
         scheme: :transparent,
+        empty_state_behavior: :dynamic,
         **@system_arguments
       )
     end

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -73,6 +73,11 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
 
       it_behaves_like "rendering Box", row_count: 1, header: true, footer: false
 
+      it "parks the empty-state prototype in a template for the dynamic controller" do
+        expect(rendered_component)
+          .to have_css("template[data-border-box-list-target='emptyStateTemplate']", visible: :all)
+      end
+
       it "renders the bucket box id derived from the bucket" do
         expect(rendered_component).to have_css(".Box#backlog_bucket_#{backlog_bucket.id}")
       end

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -148,8 +148,10 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     end
 
     it_behaves_like "rendering Box", row_count: 2, header: true, footer: false
-    # does render the blankslate but it is being hidden by CSS
-    it_behaves_like "rendering Blank Slate", heading: "Backlog inbox is empty"
+
+    it "does not render the blankslate" do
+      expect(rendered_component).to have_no_css(".blankslate")
+    end
 
     it "renders a row for each work package", :aggregate_failures do
       # renders the subject of each work package

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -153,6 +153,11 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       expect(rendered_component).to have_no_css(".blankslate")
     end
 
+    it "parks the empty-state prototype in a template for the dynamic controller" do
+      expect(rendered_component)
+        .to have_css("template[data-border-box-list-target='emptyStateTemplate']", visible: :all)
+    end
+
     it "renders a row for each work package", :aggregate_failures do
       # renders the subject of each work package
       expect(rendered_component).to have_text("First item")

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
 
       it_behaves_like "rendering Box", row_count: 2, header: true, footer: false
 
+      it "parks the empty-state prototype in a template for the dynamic controller" do
+        expect(rendered_component)
+          .to have_css("template[data-border-box-list-target='emptyStateTemplate']", visible: :all)
+      end
+
       it "renders a Primer::Beta::BorderBox with the sprint id" do
         expect(rendered_component).to have_css(".Box#sprint_#{sprint.id}")
       end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
@@ -260,8 +260,8 @@ RSpec.describe Backlogs::WorkPackageCardListComponent, type: :component do
         ]
       end
 
-      it "renders the blankslate in the DOM (hidden by CSS when items are present)" do
-        expect(rendered_component).to have_css(".blankslate")
+      it "does not render the blankslate" do
+        expect(rendered_component).to have_no_css(".blankslate")
       end
     end
   end

--- a/modules/backlogs/spec/features/backlogs/dynamic_empty_state_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/dynamic_empty_state_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+# The sprint/bucket/inbox lists opt into `empty_state_behavior: :dynamic`
+# (DREAM-801): a Stimulus controller inserts the blankslate row the instant
+# the list drains to zero visible rows, and removes it the instant a row
+# reappears, without a page reload. This proves the observable END STATES
+# only (blankslate present once the drag settles, gone again once it
+# settles back) — the *instant* insertion itself, with no network involved,
+# is owned by the controller's own vitest suite (Task 4). A feature spec
+# cannot prove "appears before the server responds" without artificially
+# delaying the request.
+RSpec.describe "Dynamic empty state for backlogs lists",
+               :js, :selenium, :settings_reset do
+  let!(:project) do
+    create(:project,
+           types: [type],
+           enabled_module_names: %w(work_package_tracking backlogs))
+  end
+  let(:manage_sprint_items_role) do
+    create(:project_role,
+           permissions: %i(view_sprints
+                           manage_sprint_items
+                           view_work_packages
+                           edit_work_packages))
+  end
+
+  let(:type) { create(:type) }
+
+  let!(:sprint) { create(:sprint, project:) }
+  let!(:bucket) { create(:backlog_bucket, project:, name: "Backlog bucket") }
+  let!(:work_package) { create(:work_package, sprint:, type:, project:) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user, member_with_roles: { project => manage_sprint_items_role })
+  end
+
+  before do
+    backlogs_page.visit!
+  end
+
+  it "shows the sprint blankslate once its only card leaves, and hides it again once one returns" do
+    blankslate_title = I18n.t("backlogs.sprint_component.blankslate_title", name: sprint.name)
+
+    within_test_selector("sprint-#{sprint.id}") do
+      expect(page).to have_no_css("[data-empty-list-item='true']")
+    end
+
+    backlogs_page.drag_work_package_to_backlog_bucket(work_package, bucket)
+
+    within_test_selector("sprint-#{sprint.id}") do
+      expect(page).to have_css("[data-empty-list-item='true']", text: blankslate_title)
+    end
+
+    backlogs_page.drag_work_package_to_sprint(work_package, sprint)
+
+    within_test_selector("sprint-#{sprint.id}") do
+      expect(page).to have_no_css("[data-empty-list-item='true']")
+    end
+  end
+end

--- a/spec/components/open_project/common/border_box_list_component_preview_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_preview_spec.rb
@@ -123,4 +123,14 @@ RSpec.describe OpenProject::Common::BorderBoxListComponentPreview, type: :compon
     expect(page).to have_css(".op-border-box-list-header_collapsible")
     expect(page).to have_css(".op-border-box-list-header--label .Label", text: "Default")
   end
+
+  it "renders custom header content preview branches" do
+    render_preview(:custom_header_content, from: described_class)
+
+    expect(page).to have_heading("Linked delivery plan", level: 4)
+    expect(page).to have_link("Linked delivery plan")
+    expect(page).to have_button(accessible_name: "Add delivery item")
+    expect(page).to have_text("Add item")
+    expect(page).to have_no_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
+  end
 end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -729,6 +729,56 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
   end
 
   describe "empty state" do
+    it "renders the default empty state when no items are present" do
+      rendered = render_inline(
+        described_class.new(container: "default-empty-list")
+      ) do |list|
+        list.with_header(title: "Empty list")
+      end
+
+      expect(rendered).to have_css(".blankslate")
+      expect(rendered).to have_heading(I18n.t(:label_nothing_display), level: 4)
+      expect(rendered).to have_text(I18n.t(:no_results_title_text))
+    end
+
+    it "renders the default empty state without requiring a header" do
+      rendered = render_inline(
+        described_class.new(container: "default-empty-list-without-header")
+      )
+
+      expect(rendered).to have_css(".Box#default-empty-list-without-header")
+      expect(rendered).to have_css(".blankslate")
+      expect(rendered).to have_heading(I18n.t(:label_nothing_display), level: 4)
+    end
+
+    it "renders a call-to-action as the blankslate primary action" do
+      rendered = render_inline(
+        described_class.new(container: "empty-list-with-action")
+      ) do |list|
+        list.with_empty_state(
+          title: "Nothing here",
+          action_label: "Add item",
+          action_icon: :plus,
+          action_arguments: { href: "/items/new", scheme: :primary }
+        )
+      end
+
+      expect(rendered).to have_css(".blankslate") do |blankslate|
+        expect(blankslate).to have_link("Add item", href: "/items/new") { |link| link.has_css?(".octicon-plus") }
+      end
+    end
+
+    it "renders no primary action without an action label" do
+      rendered = render_inline(
+        described_class.new(container: "empty-list-without-action")
+      ) do |list|
+        list.with_empty_state(title: "Nothing here", action_label: "", action_arguments: { href: "/items/new" })
+      end
+
+      expect(rendered).to have_css(".blankslate")
+      expect(rendered).to have_no_css(".blankslate a, .blankslate button")
+    end
+
     it "renders a Blankslate when no items are present" do
       rendered = render_inline(
         described_class.new(container: "empty-list")
@@ -770,6 +820,14 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       ) do |list|
         list.with_empty_state(title: "Empty")
       end
+
+      expect(rendered).to have_role(:status, aria: { live: "polite" })
+    end
+
+    it "sets aria role and live attributes on the default empty state when the list is interactive" do
+      rendered = render_inline(
+        described_class.new(container: "default-empty-interactive-aria", interactive: true)
+      )
 
       expect(rendered).to have_role(:status, aria: { live: "polite" })
     end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -1183,4 +1183,40 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_no_css(".op-border-box-list-header--drag_handle")
     end
   end
+
+  describe "empty_state_behavior" do
+    it "renders the generic default when static and empty" do
+      render_inline(described_class.new(container: "c"))
+      expect(page).to have_css("[data-empty-list-item]", text: I18n.t(:label_nothing_display))
+    end
+
+    it "renders nothing for the :none behavior when empty" do
+      render_inline(described_class.new(container: "c", empty_state_behavior: :none))
+      expect(page).to have_no_css("[data-empty-list-item]")
+    end
+
+    it "ignores a declared empty state under :none" do
+      render_inline(described_class.new(container: "c", empty_state_behavior: :none)) do |list|
+        list.with_empty_state(title: "Declared")
+      end
+      expect(page).to have_no_css("[data-empty-list-item]")
+      expect(page).to have_no_text("Declared")
+    end
+
+    it "does not render an empty box shell for :none with only a declared empty state" do
+      # render? must treat the ignored slot as absent, or a bare bordered Box renders
+      render_inline(described_class.new(container: "c", empty_state_behavior: :none)) do |list|
+        list.with_empty_state(title: "Declared")
+      end
+      expect(page).to have_no_css(".Box")
+    end
+
+    it "raises for unsupported values in test" do
+      # fetch_or_fallback only falls back to :static silently in production;
+      # in test/development it raises so an unsupported value is caught early.
+      expect do
+        described_class.new(container: "c", empty_state_behavior: :bogus)
+      end.to raise_error Primer::FetchOrFallbackHelper::InvalidValueError
+    end
+  end
 end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -791,7 +791,7 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_text("Add some items")
     end
 
-    it "renders the empty state in the DOM even when items are present (hidden by CSS for drag support)" do
+    it "omits the empty state when items are present" do
       rendered = render_inline(
         described_class.new(container: "non-empty-list")
       ) do |list|
@@ -799,7 +799,7 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
         list.with_item { "Has content" }
       end
 
-      expect(rendered).to have_css(".blankslate")
+      expect(rendered).to have_no_css(".blankslate")
       expect(rendered).to have_text("Has content")
     end
 

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -1219,4 +1219,42 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       end.to raise_error Primer::FetchOrFallbackHelper::InvalidValueError
     end
   end
+
+  describe ":dynamic markup" do
+    # Capybara's `have_css` matcher always converts its target through
+    # `Capybara.string`, which explicitly strips `<template>` inner HTML
+    # (`template.content` is not part of the queryable document per HTML5
+    # semantics) before running the selector. That makes it impossible to
+    # assert *into* a `<template>` via `page`/`have_css`, no matter what the
+    # component renders, so the prototype's markup is asserted directly
+    # against the Nokogiri fragment `render_inline` returns instead.
+    def template_placeholder(rendered)
+      rendered.at_css(
+        "template[data-border-box-list-target='emptyStateTemplate'] li[data-empty-list-item='true']"
+      )
+    end
+
+    it "wraps the box and parks the placeholder in a template when populated" do
+      rendered = render_inline(described_class.new(container: "c", empty_state_behavior: :dynamic)) do |list|
+        list.with_empty_state(title: "Empty!")
+        list.with_item { "Row" }
+      end
+      expect(page).to have_css("[data-controller='border-box-list'] ul[data-border-box-list-target='list']")
+      expect(page).to have_no_css("ul [data-empty-list-item]")
+      # legacy generic-drag-and-drop requires the exact value "true"
+      placeholder = template_placeholder(rendered)
+      expect(placeholder).not_to be_nil
+      expect(placeholder.text).to include("Empty!")
+    end
+
+    it "renders the placeholder as the real row when empty and keeps a template prototype" do
+      rendered = render_inline(described_class.new(container: "c", empty_state_behavior: :dynamic)) do |list|
+        list.with_empty_state(title: "Empty!")
+      end
+      expect(page).to have_css("ul > li[data-empty-list-item='true']", text: "Empty!")
+      # the prototype must ALWAYS be in the template, or an initially empty list
+      # can never restore its placeholder after an empty -> populated -> empty cycle
+      expect(template_placeholder(rendered)).not_to be_nil
+    end
+  end
 end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -198,6 +198,34 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_css(".op-border-box-list-header--description", text: "Some description")
     end
 
+    it "renders custom title slot content inside the title heading" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-title-content")
+      ) do |list|
+        list.with_header(title: "String title") do |header|
+          header.with_title { '<a href="/somewhere">Linked title</a>'.html_safe }
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_heading("Linked title", level: 4)
+      expect(rendered)
+        .to have_css(".op-border-box-list-header--heading-line h4.Box-title a[href='/somewhere']",
+                     text: "Linked title")
+      expect(rendered).to have_no_text("String title")
+    end
+
+    it "raises when the header has neither a title nor title slot" do
+      expect do
+        render_inline(
+          described_class.new(container: "hdr-without-title")
+        ) do |list|
+          list.with_header
+          list.with_item { "row" }
+        end
+      end.to raise_error(ArgumentError, /title/)
+    end
+
     it "forwards system arguments to the description text" do
       rendered = render_inline(
         described_class.new(container: "hdr-description-args")
@@ -247,6 +275,19 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_no_css(".op-border-box-list-header--actions .Label")
     end
 
+    it "renders an action icon button" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-icon-action")
+      ) do |list|
+        list.with_header(title: "Actions") do |header|
+          header.with_action_icon_button(icon: :pencil, aria: { label: "Edit list" })
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_button(accessible_name: "Edit list")
+    end
+
     it "renders a menu in the header" do
       rendered = render_inline(
         described_class.new(container: "hdr-menu")
@@ -262,6 +303,48 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_css(".Box-header")
       expect(rendered).to have_css("action-menu")
       expect(rendered).to have_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
+    end
+
+    it "forwards button arguments to the default menu show button" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-menu-button-arguments")
+      ) do |list|
+        list.with_header(title: "With configured menu") do |header|
+          header.with_menu(
+            button_arguments: {
+              aria: { label: "Configured actions" },
+              data: { test_selector: "configured-actions-button" }
+            }
+          ) do |menu|
+            menu.with_item(label: "Option A", value: "a")
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_button(
+        "hdr-menu-button-arguments_list_menu-button",
+        accessible_name: "Configured actions"
+      )
+      expect(rendered).to have_css("button[data-test-selector='configured-actions-button']")
+    end
+
+    it "renders a custom show button without adding the default show button" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-custom-menu")
+      ) do |list|
+        list.with_header(title: "With custom menu") do |header|
+          header.with_menu do |menu|
+            menu.with_show_button { "Add link" }
+            menu.with_item(label: "Option A", value: "a")
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css("action-menu")
+      expect(rendered).to have_button("Add link")
+      expect(rendered).to have_no_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
     end
 
     it "infers the count from rendered items" do

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -1256,5 +1256,18 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       # can never restore its placeholder after an empty -> populated -> empty cycle
       expect(template_placeholder(rendered)).not_to be_nil
     end
+
+    it "defaults the template prototype to the generic empty state when populated with no declared empty state" do
+      rendered = render_inline(described_class.new(container: "c", empty_state_behavior: :dynamic)) do |list|
+        list.with_item { "Row" }
+      end
+      # a client-side drain to zero rows must clone a real blankslate, not a
+      # contentless placeholder, even though no with_empty_state was declared
+      placeholder = template_placeholder(rendered)
+      expect(placeholder).not_to be_nil
+      expect(placeholder.text).to include(I18n.t(:label_nothing_display))
+      expect(page).to have_css("ul > li", count: 1)
+      expect(page).to have_no_css("ul [data-empty-list-item]")
+    end
   end
 end

--- a/spec/components/work_package_types/project_attributes/section_component_spec.rb
+++ b/spec/components/work_package_types/project_attributes/section_component_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::ProjectAttributes::SectionComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  current_user { create(:admin) }
+
+  let(:type) { create(:type) }
+  let(:project_custom_field_section) { create(:project_custom_field_section, name: "Section title") }
+
+  subject(:rendered_component) do
+    render_inline(
+      described_class.new(
+        type:,
+        project_custom_field_section:,
+        project_custom_fields:
+      )
+    )
+  end
+
+  context "with no custom fields in the section" do
+    let(:project_custom_fields) { [] }
+
+    it "renders the header and no rows", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-header", text: "Section title")
+      expect(rendered_component).to have_no_css(".Box-row")
+      expect(rendered_component).to have_no_css("[data-empty-list-item]")
+      expect(rendered_component).to have_no_css(".blankslate")
+    end
+  end
+
+  context "with custom fields in the section" do
+    let(:project_custom_field) { create(:project_custom_field, project_custom_field_section:) }
+    let(:project_custom_fields) { [project_custom_field] }
+
+    it "renders a row for each custom field" do
+      expect(rendered_component).to have_css(".Box-row", count: 1)
+    end
+  end
+end

--- a/spec/components/work_package_types/types/grouped_list_component_spec.rb
+++ b/spec/components/work_package_types/types/grouped_list_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  current_user { create(:admin) }
+
+  describe "a variant-less root" do
+    let(:root_type) { create(:type, name: "Task") }
+
+    subject(:rendered_component) do
+      with_request_url "/types" do
+        render_inline(described_class.new(types: Type.where(id: root_type.id).page(1).per_page(10)))
+      end
+    end
+
+    it "renders the group header but no generic empty state", :aggregate_failures do
+      expect(rendered_component).to have_css("h4.Box-title", text: root_type.name)
+      expect(rendered_component).to have_no_css("[data-empty-list-item]")
+      expect(rendered_component).to have_no_css(".blankslate")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-801

# What are you trying to accomplish?

First slice of the [DREAM-697](https://community.openproject.org/wp/DREAM-697) split (supersedes the monolithic draft PR #23812): extends the shared `OpenProject::Common::BorderBoxListComponent` API that the consumer migrations later in this stack need.

- `header.with_title` for linked or composed title content inside the configured heading element.
- `header.with_action_icon_button` for icon-only header actions.
- Header and row menus reworked through `BorderBoxListComponent::Menu`: the default kebab trigger stays automatic; callers can restyle it with `button_arguments:` or provide their own `menu.with_show_button`. The Backlogs bucket/sprint callers adopt the new argument.
- `with_empty_state` gains an optional call-to-action (`action_label:`, `action_icon:`, `action_arguments:`).
- Empty states are governed by a single `empty_state_behavior:` option: `:static` (default) renders the declared or generic blankslate only while the list is empty; `:none` suppresses it (used by the grouped WP types and project-attributes sections, where a blankslate under every empty group is noise); `:dynamic` additionally parks a `<template>` prototype next to the list and a small `border-box-list` Stimulus controller shows it client-side whenever no visible row remains (Backlogs opts in). This reverts the always-rendered empty-state row and its CSS sibling selectors from #23950 — the `data-turbo-permanent` fix from that PR is kept.
- The header heading line reserves `min-height: var(--control-medium-size)`, so headers no longer shrink when filtering hides their action buttons (review finding on #24645).
- Lookbook docs, previews and specs cover the new public API.

The originally drafted `label:` header-action deprecation was dropped — superseded by [DREAM-780](https://community.openproject.org/wp/DREAM-780) (PR #24560).

# What approach did you choose and why?

PR #23812 stalled as a 55-file review; this stack splits it into the shared API change (this PR) followed by one consumer-migration batch per PR. The empty-state policy replaces boolean opt-outs so invalid combinations (hidden + persistent) cannot be expressed, and client-side visibility lives in one list-owned controller (`useMutation`) instead of `:only-child`/`:has()` CSS. As [discussed in review](https://github.com/opf/openproject/pull/24643#issuecomment-5265909292), the option may be revisited once #24669 ([DREAM-805](https://community.openproject.org/wp/DREAM-805)) lands — e.g. inferring `:dynamic` and `interactive:` from the declarative sortable wiring.

# Visual comparisons

<details>
<summary>Show baseline/candidate screenshots</summary>

Baseline is shown on the left; the candidate stack is shown on the right. (Screenshots predate the empty-state rework; regeneration pending.)

### Lookbook: custom header content

![Lookbook custom header content — baseline left, candidate right](https://github.com/user-attachments/assets/8fe95df6-585c-456d-b307-300686b52fb3)

### Lookbook: header drag handle

![Lookbook header drag handle — baseline left, candidate right](https://github.com/user-attachments/assets/c4759071-0838-4fa1-b9f3-bf204c458464)

### Lookbook: default empty state

![Lookbook default empty state — baseline left, candidate right](https://github.com/user-attachments/assets/6c570d2b-7a62-45c1-a9ed-1c6f99e0cc05)

</details>

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
