### PR TITLE
[DREAM-803] Migrate wiki, OAuth and project settings lists to BorderBoxList

### DIFF
--- a/app/components/my/notifications/show_page_component.html.erb
+++ b/app/components/my/notifications/show_page_component.html.erb
@@ -82,43 +82,35 @@ See COPYRIGHT and LICENSE files for more details.
         component.with_description { t("my_account.notifications.project_specific_settings.description") }
       end %>
 
-  <% if project_notification_settings.any? %>
-    <%= render(Primer::Beta::BorderBox.new(mb: 3)) do |box| %>
-      <% box.with_header { t("my_account.notifications.project_specific_settings.list_header") } %>
-      <% project_notification_settings.each do |setting| %>
-        <% box.with_row(test_selector: "project-specific-settings-list") do %>
-          <%= flex_layout(justify_content: :space_between, align_items: :center, width: :full) do |flex| %>
-            <%= flex.with_column do %>
-              <span><%= setting.project.name %></span>
-            <% end %>
-            <%= flex.with_column do %>
-              <%= render(Primer::Alpha::ActionMenu.new(test_selector: "project-specific-settings-list--action-menu")) do |menu|
-                    menu.with_show_button(
-                      scheme: :invisible,
-                      size: :small,
-                      icon: :"kebab-horizontal",
-                      "aria-label": t(:label_open_menu),
-                      tooltip_direction: :w
-                    )
-                    menu.with_item(
-                      label: t("button_edit"),
-                      href: edit_project_settings_url(setting.project_id),
-                      content_arguments: { data: { controller: "async-dialog" } }
-                    ) do |item|
-                      item.with_leading_visual_icon(icon: :pencil)
-                    end
-                    menu.with_item(
-                      label: t("button_delete"),
-                      scheme: :danger,
-                      href: project_setting_url(setting.project_id),
-                      content_arguments: { data: { turbo_method: :delete, turbo_confirm: t("text_are_you_sure") } }
-                    ) do |item|
-                      item.with_leading_visual_icon(icon: :trash)
-                    end
-                  end %>
-            <% end %>
-          <% end %>
-        <% end %>
+  <%= render(OpenProject::Common::BorderBoxListComponent.new(container: "project-specific-notification-settings", mb: 3)) do |list| %>
+    <% list.with_header(title: t("my_account.notifications.project_specific_settings.list_header")) %>
+    <% project_notification_settings.each do |setting| %>
+      <% list.with_item(test_selector: "project-specific-settings-list") do |item| %>
+        <% item.with_menu(
+             test_selector: "project-specific-settings-list--action-menu",
+             button_arguments: {
+               size: :small,
+               aria: { label: t(:label_open_menu) },
+               tooltip_direction: :w
+             }
+           ) do |menu|
+             menu.with_item(
+               label: t("button_edit"),
+               href: edit_project_settings_url(setting.project_id),
+               content_arguments: { data: { controller: "async-dialog" } }
+             ) do |menu_item|
+               menu_item.with_leading_visual_icon(icon: :pencil)
+             end
+             menu.with_item(
+               label: t("button_delete"),
+               scheme: :danger,
+               href: project_setting_url(setting.project_id),
+               content_arguments: { data: { turbo_method: :delete, turbo_confirm: t("text_are_you_sure") } }
+             ) do |menu_item|
+               menu_item.with_leading_visual_icon(icon: :trash)
+             end
+           end %>
+        <span><%= setting.project.name %></span>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/oauth/applications/index_component.html.erb
+++ b/app/components/oauth/applications/index_component.html.erb
@@ -4,58 +4,42 @@
       if OpenProject::FeatureDecisions.built_in_oauth_applications_active?
         index_container.with_row do
           render(
-            border_box_container(
-              mb: 4, data: {
-                "test-selector": "op-admin-oauth--built-in-applications"
-              }
+            OpenProject::Common::BorderBoxListComponent.new(
+              container: "op-admin-oauth--built-in-applications",
+              position: :relative,
+              mb: 4,
+              test_selector: "op-admin-oauth--built-in-applications"
             )
-          ) do |component|
-            component.with_header(font_weight: :bold) do
-              render(Primer::Beta::Text.new) do
-                t("oauth.header.builtin_applications")
-              end
-            end
-
-            if @built_in_applications.empty?
-              component.with_row do
-                render(
-                  Primer::Beta::Text.new(
-                    data: {
-                      "test-selector": "op-admin-oauth--built-in-applications-placeholder"
-                    }
-                  )
-                ) do
-                  t("oauth.empty_application_lists")
-                end
-              end
-            end
+          ) do |list|
+            list.with_header(title: t("oauth.header.builtin_applications"))
 
             @built_in_applications.each do |application|
-              component.with_row { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
+              list.with_item { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
             end
+
+            list.with_empty_state(title: t("oauth.empty_application_lists"))
           end
         end
       end
 
       index_container.with_row do
-        render(border_box_container(mb: 4)) do |component|
-          component.with_header(font_weight: :bold) do
-            render(Primer::Beta::Text.new) do
-              t("oauth.header.other_applications")
-            end
-          end
-
-          if @other_applications.empty?
-            component.with_row do
-              render(Primer::Beta::Text.new(data: { "test-selector": "op-admin-oauth--applications-placeholder" })) do
-                t("oauth.empty_application_lists")
-              end
-            end
-          end
+        render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "op-admin-oauth--other-applications",
+            position: :relative,
+            mb: 4
+          )
+        ) do |list|
+          list.with_header(title: t("oauth.header.other_applications"))
 
           @other_applications.each do |application|
-            component.with_row { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
+            list.with_item { render(OAuth::Applications::ApplicationRowComponent.new(application:)) }
           end
+
+          list.with_empty_state(
+            title: t("oauth.empty_application_lists"),
+            test_selector: "op-admin-oauth--applications-placeholder"
+          )
         end
       end
     end

--- a/app/components/portfolios/index_component.html.erb
+++ b/app/components/portfolios/index_component.html.erb
@@ -3,33 +3,17 @@
     flex_layout do |index_container|
       index_container.with_row do
         render(
-          border_box_container(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "op-portfolios--portfolios",
+            position: :relative,
             mb: 4,
-            data: {
-              "test-selector": "op-portfolios--portfolios"
-            }
+            test_selector: "op-portfolios--portfolios"
           )
-        ) do |component|
-          if portfolios.empty?
-            component.with_row do
-              render(
-                Primer::Beta::Text.new(
-                  data: {
-                    "test-selector": "op-portfolios--portfolios-placeholder"
-                  }
-                )
-              ) do
-                I18n.t(:no_results_title_text)
-              end
-            end
-          end
-
+        ) do |list|
           portfolios.each do |portfolio|
-            component.with_row(
+            list.with_item(
               classes: "portfolio",
-              data: {
-                test_selector: "op-portfolios--portfolio-#{portfolio.id}"
-              }
+              test_selector: "op-portfolios--portfolio-#{portfolio.id}"
             ) do
               render(Portfolios::DetailsComponent.new(portfolio:, current_user: @current_user))
             end

--- a/app/components/projects/settings/creation_wizard/project_custom_field_sections/show_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/project_custom_field_sections/show_component.html.erb
@@ -1,84 +1,64 @@
 <%=
   component_wrapper do
     render(
-      border_box_container(
-        mb: 3, classes: "op-project-custom-field-section", data: {
-          test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
-        }
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "project-custom-field-section-#{@project_custom_field_section.id}",
+        position: :relative,
+        mb: 3,
+        classes: "op-project-custom-field-section",
+        test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
       )
-    ) do |component|
-      component.with_header(font_weight: :bold, py: 2) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(py: 2) do
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              @project_custom_field_section.name
-            end
-          end
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: enable_all_of_section_project_settings_creation_wizard_path(
-                    @project,
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_enable_all"),
-                  data: { "turbo-method": :put, test_selector: "enable-all-creation-wizard-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                t("projects.settings.actions.label_enable_all")
-              end
-            end
-            actions_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: disable_all_of_section_project_settings_creation_wizard_path(
-                    @project,
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_disable_all"),
-                  data: { "turbo-method": :put, test_selector: "disable-all-creation-wizard-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                t("projects.settings.actions.label_disable_all")
-              end
-            end
-          end
+    ) do |list|
+      list.with_header(title: @project_custom_field_section.name) do |header|
+        header.with_action_button(
+          tag: :a,
+          href: enable_all_of_section_project_settings_creation_wizard_path(
+            @project,
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          aria: { label: t("projects.settings.actions.label_enable_all") },
+          data: { turbo_method: :put }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+          t("projects.settings.actions.label_enable_all")
+        end
+        header.with_action_button(
+          tag: :a,
+          href: disable_all_of_section_project_settings_creation_wizard_path(
+            @project,
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          aria: { label: t("projects.settings.actions.label_disable_all") },
+          data: { turbo_method: :put }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+          t("projects.settings.actions.label_disable_all")
         end
       end
-      if @project_custom_fields.empty?
-        component.with_row do
-          render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
-        end
-      else
-        @project_custom_fields.each do |project_custom_field|
-          component.with_row do
-            render(
-              Projects::Settings::CreationWizard::ProjectCustomFieldSections::CustomFieldRowComponent.new(
-                project: @project,
-                project_custom_field:
-              )
+      @project_custom_fields.each do |project_custom_field|
+        list.with_item do
+          render(
+            Projects::Settings::CreationWizard::ProjectCustomFieldSections::CustomFieldRowComponent.new(
+              project: @project,
+              project_custom_field:
             )
-          end
+          )
         end
       end
+
+      list.with_empty_state(title: t("settings.project_attributes.label_no_project_custom_fields"))
     end
   end
 %>
-

--- a/app/components/projects/settings/life_cycle/index_component.html.erb
+++ b/app/components/projects/settings/life_cycle/index_component.html.erb
@@ -26,7 +26,8 @@
         OpenProject::Common::BorderBoxListComponent.new(
           container: "project-life-cycle-administration",
           position: :relative,
-          mb: 3
+          mb: 3,
+          empty_state_behavior: :dynamic
         )
       ) do |list|
         list.with_header(title: I18n.t("projects.settings.life_cycle.section_header")) do |header|
@@ -73,16 +74,6 @@
         end
 
         list.with_empty_state(title: t("projects.settings.life_cycle.non_defined"))
-      end
-    end
-    flex.with_row do
-      render Primer::Beta::Text.new(
-        display: :none,
-        data: {
-          "projects--settings--border-box-filter-target": "noResultsText"
-        }
-      ) do
-        I18n.t("js.autocompleter.notFoundText")
       end
     end
   end

--- a/app/components/projects/settings/life_cycle/index_component.html.erb
+++ b/app/components/projects/settings/life_cycle/index_component.html.erb
@@ -22,66 +22,57 @@
     end
 
     flex.with_row do
-      render(border_box_container(mb: 3, data: { test_selector: "project-life-cycle-administration" })) do |component|
-        component.with_header(font_weight: :bold, py: 2) do
-          flex_layout(justify_content: :space_between, align_items: :center) do |header_container|
-            header_container.with_column(py: 2) do
-              # adding py: 2 here to match the padding of the actions_container
-              # otherwise the header height changes when the actions gets hidden when filtering
-              render(Primer::Beta::Text.new(font_weight: :bold)) do
-                I18n.t("projects.settings.life_cycle.section_header")
-              end
-            end
-            header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-              actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-                render(
-                  Primer::Beta::Button.new(
-                    tag: :a,
-                    href: enable_all_project_settings_life_cycle_steps_path(project_id: project),
-                    scheme: :invisible,
-                    font_weight: :bold,
-                    color: :subtle,
-                    "aria-label": t("projects.settings.actions.label_enable_all"),
-                    data: { "turbo-method": :post, test_selector: "enable-all-life-cycle-steps" }
-                  )
-                ) do |button|
-                  button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                  t("projects.settings.actions.label_enable_all")
-                end
-              end
-              actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-                render(
-                  Primer::Beta::Button.new(
-                    tag: :a,
-                    href: disable_all_project_settings_life_cycle_steps_path(project_id: project),
-                    scheme: :invisible,
-                    font_weight: :bold,
-                    color: :subtle,
-                    "aria-label": t("projects.settings.actions.label_disable_all"),
-                    data: { "turbo-method": :post, test_selector: "disable-all-life-cycle-steps" }
-                  )
-                ) do |button|
-                  button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                  t("projects.settings.actions.label_disable_all")
-                end
-              end
-            end
+      render(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "project-life-cycle-administration",
+          position: :relative,
+          mb: 3
+        )
+      ) do |list|
+        list.with_header(title: I18n.t("projects.settings.life_cycle.section_header")) do |header|
+          header.with_action_button(
+            tag: :a,
+            href: enable_all_project_settings_life_cycle_steps_path(project_id: project),
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            aria: { label: t("projects.settings.actions.label_enable_all") },
+            test_selector: "enable-all-life-cycle-steps",
+            data: {
+              turbo_method: :post,
+              "projects--settings--border-box-filter-target": "hideWhenFiltering"
+            }
+          ) do |button|
+            button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+            t("projects.settings.actions.label_enable_all")
+          end
+          header.with_action_button(
+            tag: :a,
+            href: disable_all_project_settings_life_cycle_steps_path(project_id: project),
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            aria: { label: t("projects.settings.actions.label_disable_all") },
+            test_selector: "disable-all-life-cycle-steps",
+            data: {
+              turbo_method: :post,
+              "projects--settings--border-box-filter-target": "hideWhenFiltering"
+            }
+          ) do |button|
+            button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+            t("projects.settings.actions.label_disable_all")
           end
         end
-        if life_cycle_definitions.empty?
-          component.with_row do
-            render(Primer::Beta::Text.new(color: :subtle)) { t("projects.settings.life_cycle.non_defined") }
-          end
-        else
-          life_cycle_definitions_and_step_active.each do |definition, active|
-            component.with_row(
-              data: { "projects--settings--border-box-filter-target": "searchItem" },
-              test_selector: "project-life-cycle-step-#{definition.id}"
-            ) do
-              render(Projects::Settings::LifeCycle::PhaseComponent.new(definition:, active?: active))
-            end
+        life_cycle_definitions_and_step_active.each do |definition, active|
+          list.with_item(
+            data: { "projects--settings--border-box-filter-target": "searchItem" },
+            test_selector: "project-life-cycle-step-#{definition.id}"
+          ) do
+            render(Projects::Settings::LifeCycle::PhaseComponent.new(definition:, active?: active))
           end
         end
+
+        list.with_empty_state(title: t("projects.settings.life_cycle.non_defined"))
       end
     end
     flex.with_row do

--- a/app/components/projects/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/projects/settings/project_custom_field_sections/show_component.html.erb
@@ -1,83 +1,72 @@
 <%=
   component_wrapper do
     render(
-      border_box_container(
-        mb: 3, classes: "op-project-custom-field-section", data: {
-          test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
-        }
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "project-custom-field-section-#{@project_custom_field_section.id}",
+        position: :relative,
+        mb: 3,
+        classes: "op-project-custom-field-section",
+        test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
       )
-    ) do |component|
-      component.with_header(font_weight: :bold, py: 2) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(py: 2) do |_content_container|
-            # adding py: 2 here to match the padding of the actions_container
-            # otherwise the header height changes when the actions gets hidden when filtering
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              @project_custom_field_section.name
-            end
-          end
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: enable_all_of_section_project_settings_project_custom_fields_path(
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_enable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "enable-all-project-custom-field-mappings-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
-                t("projects.settings.actions.label_enable_all")
-              end
-            end
-            actions_container.with_column(data: { "projects--settings--border-box-filter-target": "hideWhenFiltering" }) do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: disable_all_of_section_project_settings_project_custom_fields_path(
-                    project_custom_field_project_mapping: {
-                      project_id: @project.id,
-                      custom_field_section_id: @project_custom_field_section.id
-                    }
-                  ),
-                  scheme: :invisible,
-                  font_weight: :bold,
-                  color: :subtle,
-                  "aria-label": t("projects.settings.actions.label_disable_all"),
-                  data: { "turbo-method": :put, "turbo-stream": true, test_selector: "disable-all-project-custom-field-mappings-#{@project_custom_field_section.id}" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
-                t("projects.settings.actions.label_disable_all")
-              end
-            end
-          end
+    ) do |list|
+      list.with_header(title: @project_custom_field_section.name) do |header|
+        header.with_action_button(
+          tag: :a,
+          href: enable_all_of_section_project_settings_project_custom_fields_path(
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          aria: { label: t("projects.settings.actions.label_enable_all") },
+          test_selector: "enable-all-project-custom-field-mappings-#{@project_custom_field_section.id}",
+          data: {
+            turbo_method: :put,
+            turbo_stream: true,
+            "projects--settings--border-box-filter-target": "hideWhenFiltering"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "check-circle", color: :subtle)
+          t("projects.settings.actions.label_enable_all")
+        end
+        header.with_action_button(
+          tag: :a,
+          href: disable_all_of_section_project_settings_project_custom_fields_path(
+            project_custom_field_project_mapping: {
+              project_id: @project.id,
+              custom_field_section_id: @project_custom_field_section.id
+            }
+          ),
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          aria: { label: t("projects.settings.actions.label_disable_all") },
+          test_selector: "disable-all-project-custom-field-mappings-#{@project_custom_field_section.id}",
+          data: {
+            turbo_method: :put,
+            turbo_stream: true,
+            "projects--settings--border-box-filter-target": "hideWhenFiltering"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: "x-circle", color: :subtle)
+          t("projects.settings.actions.label_disable_all")
         end
       end
-      if @project_custom_fields.empty?
-        component.with_row do
-          render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
-        end
-      else
-        @project_custom_fields.each do |project_custom_field|
-          component.with_row(data: { "projects--settings--border-box-filter-target": "searchItem" }) do
-            render(
-              Projects::Settings::ProjectCustomFieldSections::CustomFieldRowComponent.new(
-                project: @project,
-                project_custom_field:
-              )
+      @project_custom_fields.each do |project_custom_field|
+        list.with_item(data: { "projects--settings--border-box-filter-target": "searchItem" }) do
+          render(
+            Projects::Settings::ProjectCustomFieldSections::CustomFieldRowComponent.new(
+              project: @project,
+              project_custom_field:
             )
-          end
+          )
         end
       end
+
+      list.with_empty_state(title: t("settings.project_attributes.label_no_project_custom_fields"))
     end
   end
 %>

--- a/app/components/projects/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/projects/settings/project_custom_field_sections/show_component.html.erb
@@ -5,6 +5,7 @@
         container: "project-custom-field-section-#{@project_custom_field_section.id}",
         position: :relative,
         mb: 3,
+        empty_state_behavior: :dynamic,
         classes: "op-project-custom-field-section",
         test_selector: "project-custom-field-section-#{@project_custom_field_section.id}"
       )

--- a/modules/wikis/app/components/wikis/collapsible_page_links_component.html.erb
+++ b/modules/wikis/app/components/wikis/collapsible_page_links_component.html.erb
@@ -28,16 +28,11 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Beta::BorderBox.new(padding: :condensed)) do |box|
-    box.with_header do
-      render(Primer::OpenProject::BorderBox::CollapsibleHeader.new(collapsed: true)) do |header|
-        header.with_title { heading }
-        header.with_count(count: page_links.count)
-      end
-    end
+  render(OpenProject::Common::BorderBoxListComponent.new(container:, collapsible: true, padding: :condensed)) do |list|
+    list.with_header(title: heading, count: page_links.count, collapsed: true)
 
     page_links.each do |view_model|
-      box.with_row do
+      list.with_item do
         render(
           Wikis::PageLinkComponent.new(
             view_model.page_info_result,

--- a/modules/wikis/app/components/wikis/collapsible_page_links_component.rb
+++ b/modules/wikis/app/components/wikis/collapsible_page_links_component.rb
@@ -33,12 +33,13 @@ module Wikis
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    attr_reader :heading
+    attr_reader :heading, :container
 
     alias_method :page_links, :model
 
-    def initialize(model = nil, heading:, linkable:, already_related_page_keys:, **)
+    def initialize(model = nil, heading:, container:, linkable:, already_related_page_keys:, **)
       @heading = heading
+      @container = container
       @linkable = linkable
       @already_related_page_keys = already_related_page_keys
 

--- a/modules/wikis/app/components/wikis/relation_page_links_component.html.erb
+++ b/modules/wikis/app/components/wikis/relation_page_links_component.html.erb
@@ -28,57 +28,44 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Beta::BorderBox.new(padding: :condensed)) do |box|
-    box.with_header do
-      flex_layout(align_items: :center, justify_content: :space_between) do |header|
-        header.with_column do
-          concat(render(Primer::Beta::Text.new(font_weight: :bold, mr: 2)) { provider.name })
-          concat(render(Primer::Beta::Counter.new(count: page_links.count, round: true, scheme: :primary)))
-        end
-        header.with_column do
-          render(Primer::Alpha::ActionMenu.new) do |menu|
-            menu.with_show_button(disabled: !can_manage_links?) do |button|
-              button.with_leading_visual_icon(icon: :plus)
-              button.with_trailing_action_icon(icon: :"triangle-down")
+  render(OpenProject::Common::BorderBoxListComponent.new(container: provider, padding: :condensed)) do |list|
+    list.with_header(
+      title: provider.name,
+      count: page_links.count,
+      count_arguments: { hide_if_zero: false }
+    ) do |header|
+      header.with_menu do |menu|
+        menu.with_show_button(disabled: !can_manage_links?) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          button.with_trailing_action_icon(icon: :"triangle-down")
 
-              t("wikis.buttons.wiki_page")
-            end
-
-            menu.with_item(
-              label: t(".link_existing"),
-              tag: :a,
-              href: link_existing_dialog_relation_wiki_page_links_path(work_package:, provider:),
-              content_arguments: { data: { controller: "async-dialog" } }
-            )
-            menu.with_item(
-              label: t(".link_new"),
-              tag: :a,
-              href: create_new_page_dialog_wiki_pages_path(create_new_page_parameters),
-              content_arguments: { data: { controller: "async-dialog" } }
-            )
-          end
+          t("wikis.buttons.wiki_page")
         end
+
+        menu.with_item(
+          label: t(".link_existing"),
+          tag: :a,
+          href: link_existing_dialog_relation_wiki_page_links_path(work_package:, provider:),
+          content_arguments: { data: { controller: "async-dialog" } }
+        )
+        menu.with_item(
+          label: t(".link_new"),
+          tag: :a,
+          href: create_new_page_dialog_wiki_pages_path(create_new_page_parameters),
+          content_arguments: { data: { controller: "async-dialog" } }
+        )
       end
     end
 
     if !user_connected?
-      box.with_row do
+      list.with_item do
         render(Wikis::OAuthLoginComponent.new(provider, return_url: work_package_url(work_package, tab: :wikis)))
       end
     elsif page_links.empty?
-      box.with_row do
-        if user_connected?
-          render(Primer::Beta::Blankslate.new(border: false)) do |blankslate|
-            blankslate.with_heading(tag: :h2).with_content(t(".empty_heading"))
-            blankslate.with_description { t(".empty_text") }
-          end
-        else
-          render(Wikis::OAuthLoginComponent.new(provider, return_url: work_package_url(work_package, tab: :wikis)))
-        end
-      end
+      list.with_empty_state(title: t(".empty_heading"), description: t(".empty_text"))
     else
       page_links.each do |page_link_aggregate|
-        box.with_row do
+        list.with_item do
           render(
             Wikis::PageLinkComponent.new(
               page_link_aggregate.page_info_result,

--- a/modules/wikis/app/components/wikis/work_package_wikis_tab_component.html.erb
+++ b/modules/wikis/app/components/wikis/work_package_wikis_tab_component.html.erb
@@ -43,6 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
               ::Wikis::CollapsiblePageLinksComponent.new(
                 inline_page_links,
                 heading: t(".inline_page_links"),
+                container: :inline_page_links,
                 linkable: work_package,
                 already_related_page_keys:
               )
@@ -56,6 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
               ::Wikis::CollapsiblePageLinksComponent.new(
                 referencing_wiki_pages,
                 heading: t(".referencing_pages"),
+                container: :referencing_wiki_pages,
                 linkable: work_package,
                 already_related_page_keys:
               )

--- a/modules/wikis/spec/components/wikis/collapsible_page_links_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/collapsible_page_links_component_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Wikis::CollapsiblePageLinksComponent, type: :component do
   let(:project) { create(:project) }
   let(:work_package) { create(:work_package, project:) }
   let(:provider) { create(:internal_wiki_provider) }
+  let(:heading) { "Referenced in" }
   let(:page_info) do
     Wikis::Adapters::Results::PageInfo.new(
       identifier: "MyPage",
@@ -47,23 +48,47 @@ RSpec.describe Wikis::CollapsiblePageLinksComponent, type: :component do
   let(:already_related_page_keys) { Set.new }
   let(:permissions) { [:manage_wiki_page_links] }
   let(:view_model) { Wikis::PageLinkViewModel.from_page_info_result(page_info_result) }
+  let(:page_links) { [view_model] }
 
   current_user { create(:user, member_with_permissions: { project => permissions }) }
 
-  subject(:render_component) do
+  subject(:rendered_component) do
     render_inline(
-      described_class.new([view_model],
-                          heading: "Referenced in",
+      described_class.new(page_links,
+                          heading:,
+                          container: :inline_page_links,
                           linkable: work_package,
                           already_related_page_keys:)
     )
   end
 
-  before { render_component }
+  before { rendered_component }
+
+  it_behaves_like "rendering Box", row_count: 1
 
   it "renders the heading and the page link" do
-    expect(page).to have_text("Referenced in")
+    expect(page).to have_text(heading)
     expect(page).to have_link(text: page_info.title, href: page_info.href)
+  end
+
+  it "renders a collapsible header with the heading and item count", :aggregate_failures do
+    expect(page).to have_css("collapsible-header")
+    expect(page).to have_css(".Box-header") do |header|
+      expect(header).to have_heading(heading)
+      expect(header).to have_css(".Counter", text: "1")
+    end
+  end
+
+  context "without page links" do
+    let(:page_links) { [] }
+
+    it "still renders the collapsible header with a hidden zero count", :aggregate_failures do
+      expect(page).to have_css("collapsible-header")
+      expect(page).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(heading)
+        expect(header).to have_css(".Counter[hidden]", text: "0", visible: :all)
+      end
+    end
   end
 
   context "when the user may manage wiki page links" do

--- a/modules/wikis/spec/components/wikis/relation_page_links_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/relation_page_links_component_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Wikis::RelationPageLinksComponent, type: :component do
 
     it { expect(page).to have_text(I18n.t("wikis.relation_page_links_component.empty_heading")) }
     it { expect(page).to have_no_text(I18n.t("wikis.oauth_login_component.heading", provider: provider.name)) }
+    it { expect(page).to have_button(I18n.t("wikis.buttons.wiki_page"), disabled: true) }
   end
 
   context "when the user has a token and there are page links" do
@@ -106,7 +107,7 @@ RSpec.describe Wikis::RelationPageLinksComponent, type: :component do
       render_component
     end
 
-    it { expect(page).to have_text("My Wiki Page") }
+    it { expect(page).to have_css(".Box-row", text: "My Wiki Page") }
     it { expect(page).to have_no_text(I18n.t("wikis.relation_page_links_component.empty_heading")) }
     it { expect(page).to have_no_text(I18n.t("wikis.oauth_login_component.heading", provider: provider.name)) }
   end

--- a/modules/wikis/spec/components/wikis/work_package_wikis_tab_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/work_package_wikis_tab_component_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::WorkPackageWikisTabComponent, type: :component do
+  let(:provider) { build_stubbed(:xwiki_provider) }
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:inline_page_links) { [] }
+  let(:referencing_wiki_pages) { [] }
+
+  let(:page_link_service) do
+    instance_double(
+      Wikis::PageLinkService,
+      inline_page_link_infos_for: inline_page_links,
+      referencing_wiki_page_references_for: referencing_wiki_pages,
+      relation_page_link_keys_for: Set.new
+    )
+  end
+
+  def page_info_result(title)
+    Dry::Monads::Success(
+      Wikis::Adapters::Results::PageInfo.new(
+        identifier: title,
+        title:,
+        href: "https://wiki.example.com/#{title}",
+        provider:
+      )
+    )
+  end
+
+  def page_reference_result(title, source: :mention)
+    page_info_result(title).fmap do |page_info|
+      Wikis::Adapters::Results::PageReference.new(page_info:, source:)
+    end
+  end
+
+  subject(:render_component) { render_inline(described_class.new(work_package)) }
+
+  before do
+    allow(Wikis::PageLinkService).to receive(:new).and_return(page_link_service)
+    render_component
+  end
+
+  context "without inline or referencing page links" do
+    it "renders the turbo-frame wrapper without any section", :aggregate_failures do
+      expect(page).to have_css("turbo-frame#work-package-wikis-tab-content")
+      expect(page).to have_no_text(I18n.t("wikis.work_package_wikis_tab_component.inline_page_links"))
+      expect(page).to have_no_text(I18n.t("wikis.work_package_wikis_tab_component.referencing_pages"))
+    end
+  end
+
+  context "with inline and referencing page links" do
+    let(:inline_page_links) { [page_info_result("Inline page")] }
+    let(:referencing_wiki_pages) { [page_reference_result("Referencing page")] }
+
+    it "renders a collapsible section for each link group" do
+      expect(page).to have_css("collapsible-header", count: 2)
+    end
+
+    it "renders the inline page links section", :aggregate_failures do
+      expect(page).to have_text(I18n.t("wikis.work_package_wikis_tab_component.inline_page_links"))
+      expect(page).to have_text("Inline page")
+    end
+
+    it "renders the referencing pages section", :aggregate_failures do
+      expect(page).to have_text(I18n.t("wikis.work_package_wikis_tab_component.referencing_pages"))
+      expect(page).to have_text("Referencing page")
+    end
+  end
+end

--- a/spec/components/my/notifications/show_page_component_spec.rb
+++ b/spec/components/my/notifications/show_page_component_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe My::Notifications::ShowPageComponent, type: :component do
+  let(:user) { create(:user) }
+  # create(:user) already seeds the global (project-less) notification setting.
+  let(:global_setting) { user.notification_settings.find_by!(project: nil) }
+
+  subject(:rendered_component) do
+    with_request_url("/my/notifications") do
+      render_inline(
+        described_class.new(
+          user:,
+          global_notification_setting: global_setting,
+          update_participating_url: { action: "update_participating" },
+          update_non_participating_url: { action: "update_non_participating" },
+          update_date_alerts_url: { action: "update_date_alerts" },
+          new_project_settings_url: "/my/project_notifications/new",
+          edit_project_settings_url: ->(project_id) { "/my/project_notifications/#{project_id}/edit" },
+          project_setting_url: ->(project_id) { "/my/project_notifications/#{project_id}" }
+        )
+      )
+    end
+  end
+
+  context "with project-specific settings" do
+    let(:project) { create(:project) }
+    let!(:project_setting) { create(:notification_setting, user:, project:) }
+
+    it "renders the list header and the add-project action", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(I18n.t("my_account.notifications.project_specific_settings.list_header"))
+      end
+      expect(rendered_component).to have_link(
+        I18n.t("my_account.notifications.project_specific_settings.add_button"),
+        href: "/my/project_notifications/new"
+      )
+    end
+
+    it "renders a row per project-specific setting with an edit/delete actions menu", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-row", text: project.name) do |row|
+        expect(row).to have_button(accessible_name: I18n.t(:label_open_menu))
+        expect(row).to have_link(I18n.t(:button_edit), href: "/my/project_notifications/#{project.id}/edit")
+        expect(row).to have_link(I18n.t(:button_delete), href: "/my/project_notifications/#{project.id}")
+      end
+    end
+  end
+
+  context "without project-specific settings" do
+    it_behaves_like "rendering Blank Slate",
+                    heading: I18n.t(:label_nothing_display)
+  end
+end

--- a/spec/components/oauth/applications/index_component_spec.rb
+++ b/spec/components/oauth/applications/index_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OAuth::Applications::IndexComponent, type: :component do
+  subject(:rendered_component) { render_inline(described_class.new(oauth_applications:)) }
+
+  context "with applications" do
+    let(:oauth_applications) { [create(:oauth_application, name: "My external app")] }
+
+    it "renders the other-applications list with a header and a row per application", :aggregate_failures do
+      expect(rendered_component).to have_css("#op-admin-oauth--other-applications.Box") do |box|
+        expect(box).to have_css(".Box-header") do |header|
+          expect(header).to have_heading(I18n.t("oauth.header.other_applications"))
+        end
+        expect(box).to have_css(".Box-row", text: "My external app")
+      end
+    end
+
+    it "keeps the other-applications empty state in the row hidden once rows exist" do
+      expect(rendered_component).to have_css("#op-admin-oauth--other-applications .Box-row[data-empty-list-item]") do |row|
+        expect(row).to have_css(".blankslate")
+      end
+    end
+  end
+
+  context "without applications" do
+    let(:oauth_applications) { [] }
+
+    it_behaves_like "rendering Blank Slate", heading: I18n.t("oauth.empty_application_lists")
+
+    it "renders the empty state inside the other-applications list" do
+      expect(rendered_component).to have_css("#op-admin-oauth--other-applications .blankslate")
+    end
+  end
+end

--- a/spec/components/oauth/applications/index_component_spec.rb
+++ b/spec/components/oauth/applications/index_component_spec.rb
@@ -45,10 +45,8 @@ RSpec.describe OAuth::Applications::IndexComponent, type: :component do
       end
     end
 
-    it "keeps the other-applications empty state in the row hidden once rows exist" do
-      expect(rendered_component).to have_css("#op-admin-oauth--other-applications .Box-row[data-empty-list-item]") do |row|
-        expect(row).to have_css(".blankslate")
-      end
+    it "renders no empty-state row once rows exist" do
+      expect(rendered_component).to have_no_css("#op-admin-oauth--other-applications .Box-row[data-empty-list-item]")
     end
   end
 

--- a/spec/components/portfolios/index_component_spec.rb
+++ b/spec/components/portfolios/index_component_spec.rb
@@ -52,13 +52,15 @@ RSpec.describe Portfolios::IndexComponent, type: :component do
 
   describe "Portfolios" do
     context "when the query returns a result" do
-      it "renders a list" do
-        expect(subject).to have_test_selector("op-portfolios--portfolio-#{portfolio_a.id}")
-        expect(subject).to have_test_selector("op-portfolios--portfolio-#{portfolio_b.id}")
+      it_behaves_like "rendering Box", row_count: 2, header: false
+
+      it "renders a row per portfolio", :aggregate_failures do
+        expect(rendered_component).to have_css(".Box-row.portfolio", text: portfolio_a.name)
+        expect(rendered_component).to have_css(".Box-row.portfolio", text: portfolio_b.name)
       end
 
-      it "does not render a placeholder" do
-        expect(subject).not_to have_test_selector("op-portfolios--portfolios-placeholder")
+      it "renders no empty state once portfolios exist" do
+        expect(rendered_component).to have_no_css(".blankslate")
       end
     end
 
@@ -67,13 +69,11 @@ RSpec.describe Portfolios::IndexComponent, type: :component do
       let!(:portfolio_a) { create(:project) }
       let!(:portfolio_b) { create(:project) }
 
-      it "does not render a list" do
-        expect(subject).not_to have_test_selector("op-portfolios--portfolio-#{portfolio_a.id}")
-        expect(subject).not_to have_test_selector("op-portfolios--portfolio-#{portfolio_b.id}")
-      end
+      it_behaves_like "rendering an empty Border Box List",
+                      heading: I18n.t(:label_nothing_display), header: false
 
-      it "renders a placeholder" do
-        expect(subject).to have_test_selector("op-portfolios--portfolios-placeholder")
+      it "does not render a portfolio row" do
+        expect(rendered_component).to have_no_css(".Box-row.portfolio")
       end
     end
   end

--- a/spec/components/projects/settings/creation_wizard/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/projects/settings/creation_wizard/project_custom_field_sections/show_component_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::CreationWizard::ProjectCustomFieldSections::ShowComponent, type: :component do
+  let(:project) { create(:project) }
+  let(:section) { create(:project_custom_field_section) }
+
+  subject(:rendered_component) do
+    with_request_url("/projects/#{project.id}/settings/creation_wizard") do
+      render_inline(described_class.new(project:, project_custom_field_section: section))
+    end
+  end
+
+  context "with enabled custom fields" do
+    let!(:custom_field) do
+      create(:project_custom_field, name: "My field", project_custom_field_section: section, projects: [project])
+    end
+
+    before { section.reload }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+
+    it "renders a row per custom field" do
+      expect(rendered_component).to have_css(".Box-row", text: "My field")
+    end
+
+    it "renders the enable-all and disable-all header actions", :aggregate_failures do
+      expect(rendered_component).to have_link(
+        accessible_name: I18n.t("projects.settings.actions.label_enable_all"),
+        href: %r{enable_all_of_section}
+      )
+      expect(rendered_component).to have_link(
+        accessible_name: I18n.t("projects.settings.actions.label_disable_all"),
+        href: %r{disable_all_of_section}
+      )
+      expect(rendered_component).to have_css('a[data-turbo-method="put"]', count: 2)
+    end
+  end
+
+  context "without custom fields" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("settings.project_attributes.label_no_project_custom_fields")
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+  end
+end

--- a/spec/components/projects/settings/life_cycle/index_component_spec.rb
+++ b/spec/components/projects/settings/life_cycle/index_component_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::LifeCycle::IndexComponent, type: :component do
+  let(:project) { create(:project) }
+
+  subject(:rendered_component) do
+    with_request_url("/projects/#{project.id}/settings/life_cycle") do
+      render_inline(
+        described_class.new(project:, life_cycle_definitions: Project::PhaseDefinition.order(position: :asc))
+      )
+    end
+  end
+
+  context "with definitions" do
+    let!(:definition) { create(:project_phase_definition) }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders a row per definition" do
+      expect(rendered_component).to have_css(".Box-row", text: definition.name)
+    end
+
+    it "renders the enable-all and disable-all header actions", :aggregate_failures do
+      expect(rendered_component).to have_link(accessible_name: I18n.t("projects.settings.actions.label_enable_all"))
+      expect(rendered_component).to have_link(accessible_name: I18n.t("projects.settings.actions.label_disable_all"))
+    end
+  end
+
+  context "without definitions" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("projects.settings.life_cycle.non_defined")
+  end
+end

--- a/spec/components/projects/settings/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/projects/settings/project_custom_field_sections/show_component_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::ProjectCustomFieldSections::ShowComponent, type: :component do
+  let(:project) { create(:project) }
+  let(:section) { create(:project_custom_field_section) }
+
+  subject(:rendered_component) do
+    with_request_url("/projects/#{project.id}/settings/project_custom_fields") do
+      render_inline(described_class.new(project:, project_custom_field_section: section))
+    end
+  end
+
+  context "with custom fields" do
+    let!(:custom_field) do
+      create(:project_custom_field, name: "My field", project_custom_field_section: section, projects: [project])
+    end
+
+    before { section.reload }
+
+    it_behaves_like "rendering Box", row_count: 1
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+
+    it "renders a row per custom field" do
+      expect(rendered_component).to have_css(".Box-row", text: "My field")
+    end
+
+    it "renders the enable-all and disable-all header actions", :aggregate_failures do
+      expect(rendered_component).to have_link(
+        accessible_name: I18n.t("projects.settings.actions.label_enable_all"),
+        href: %r{enable_all_of_section}
+      )
+      expect(rendered_component).to have_link(
+        accessible_name: I18n.t("projects.settings.actions.label_disable_all"),
+        href: %r{disable_all_of_section}
+      )
+      expect(rendered_component).to have_css('a[data-turbo-method="put"]', count: 2)
+    end
+  end
+
+  context "without custom fields" do
+    it_behaves_like "rendering an empty Border Box List",
+                    heading: I18n.t("settings.project_attributes.label_no_project_custom_fields")
+
+    it "renders the section name as the header heading" do
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_heading(section.name)
+      end
+    end
+  end
+end

--- a/spec/features/projects/project_custom_fields/settings/mapping_spec.rb
+++ b/spec/features/projects/project_custom_fields/settings/mapping_spec.rb
@@ -364,6 +364,47 @@ RSpec.describe "Projects custom fields mapping via project settings", :js do
       end
     end
 
+    it "shows each section's own blankslate when the filter matches nothing, and restores rows on clear" do
+      visit project_settings_project_custom_fields_path(project)
+
+      fill_in "border-box-filter", with: "no such attribute exists"
+
+      [section_for_input_fields, section_for_select_fields, section_for_multi_select_fields].each do |section|
+        within_custom_field_section_container(section) do
+          expect(page).to have_css(
+            "[data-empty-list-item='true']",
+            text: I18n.t("settings.project_attributes.label_no_project_custom_fields")
+          )
+        end
+      end
+
+      # Cuprite's Node#set clears a field's existing value without firing an
+      # `input` event before it types the replacement characters, so setting
+      # `with: ""` never reaches the border-box-filter Stimulus controller.
+      # Backspacing through the native key-event path (like a real user
+      # clearing the field) does fire `input` on every keystroke — but the
+      # field must be (re-)focused first, since Node#set blurs it afterwards.
+      filter_field = find_field("border-box-filter")
+      filter_field.click
+      clear_input_field_contents(filter_field)
+
+      within_custom_field_section_container(section_for_input_fields) do
+        expect(page).to have_no_css("[data-empty-list-item]")
+        expect(page).to have_text("Boolean field")
+        expect(page).to have_text("String field")
+      end
+
+      within_custom_field_section_container(section_for_select_fields) do
+        expect(page).to have_no_css("[data-empty-list-item]")
+        expect(page).to have_text("List field")
+      end
+
+      within_custom_field_section_container(section_for_multi_select_fields) do
+        expect(page).to have_no_css("[data-empty-list-item]")
+        expect(page).to have_text("Multi list field")
+      end
+    end
+
     it "shows the project custom field sections in the correct order" do
       visit project_settings_project_custom_fields_path(project)
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-803

# What are you trying to accomplish?

Third slice of the [DREAM-697](https://community.openproject.org/wp/DREAM-697) split: mechanical consumer migrations from `Primer::Beta::BorderBox` / `border_box_container` to `OpenProject::Common::BorderBoxListComponent`, one commit per surface.

- `Wikis::CollapsiblePageLinksComponent` and `Wikis::RelationPageLinksComponent`
- `Portfolios::IndexComponent`
- `OAuth::Applications::IndexComponent`
- `Projects::Settings::LifeCycle::IndexComponent`
- `Projects::Settings::ProjectCustomFieldSections::ShowComponent` and its CreationWizard twin
- `My::Notifications::ShowPageComponent`

The life cycle and project custom-field sections lists opt into `empty_state_behavior: :dynamic`: filtering to no matches shows the blankslate inside each box, replacing the life cycle page's detached plain-text "No items found" notice.

# What approach did you choose and why?

Each migration is a focused vertical slice with its component spec, so surfaces can be reviewed independently and reverted individually if needed. Stacked on #24644 only for linear review order; it does not depend on those surfaces.

# Visual comparisons

<details>
<summary>Show baseline/candidate screenshots</summary>

Baseline is shown on the left; the candidate stack is shown on the right. (Screenshots predate the empty-state rework; regeneration pending.)

### Work package wiki tab

![Work package wiki tab — baseline left, candidate right](https://github.com/user-attachments/assets/540e366c-b78e-41de-8146-b7a5ad742649)

### Portfolios

![Portfolios — baseline left, candidate right](https://github.com/user-attachments/assets/3fb83d7f-decd-42a5-b0d3-c9b8b0b7fc73)

### OAuth applications

![OAuth applications — baseline left, candidate right](https://github.com/user-attachments/assets/a2d8f110-f979-4df6-8d83-634f4b6a6ecd)

### Project life cycle

![Project life cycle — baseline left, candidate right](https://github.com/user-attachments/assets/4b18d043-0f80-4cf7-b9bb-8f6b0db5f4eb)

### Project custom-field sections

![Project custom-field sections — baseline left, candidate right](https://github.com/user-attachments/assets/9c2b344f-717f-450a-9893-427c31de0183)

### Project creation wizard attributes

![Project creation wizard attributes — baseline left, candidate right](https://github.com/user-attachments/assets/7b35c395-e8da-4a62-89d5-de21633304c9)

### My notifications

![My notifications — baseline left, candidate right](https://github.com/user-attachments/assets/d88405b0-ed04-435b-b0b8-4a475a114660)

</details>

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

