### PR TITLE
Keep new and removed state of non-working days on error state

### DIFF
--- a/app/controllers/admin/settings/working_days_and_hours_settings_controller.rb
+++ b/app/controllers/admin/settings/working_days_and_hours_settings_controller.rb
@@ -96,12 +96,45 @@ module Admin::Settings
     end
 
     def modified_non_working_days_for(result)
-      return if result.nil?
+      records = non_working_day_records_from(result)
+      return if records.blank?
 
-      result.map do |record|
+      records.map do |record|
         json_attributes = record.as_json(only: %i[id name date])
+        json_attributes["date"] = json_attributes["date"].iso8601 if json_attributes["date"].respond_to?(:iso8601)
         json_attributes["_destroy"] = true if record.marked_for_destruction?
         json_attributes
+      end
+    end
+
+    # If we fails to save the new NonWorkingDay records, we will return the state
+    # as the user submitted it.
+    # That allows them to correct the mistake or wait for the unprocessed job to finish.
+    def non_working_day_records_from(result)
+      if result.is_a?(Enumerable) && result.all?(NonWorkingDay)
+        result.to_a
+      else
+        non_working_day_records_from_params
+      end
+    end
+
+    def non_working_day_records_from_params
+      non_working_days_params.filter_map do |attrs|
+        attrs = attrs.to_h.with_indifferent_access
+        record = find_or_build_non_working_day(attrs)
+        next unless record
+
+        record.assign_attributes(attrs.slice(:name, :date))
+        record.mark_for_destruction if attrs[:_destroy].present?
+        record
+      end
+    end
+
+    def find_or_build_non_working_day(attrs)
+      if attrs[:id].present?
+        NonWorkingDay.find_by(id: attrs[:id])
+      else
+        NonWorkingDay.new
       end
     end
   end

--- a/spec/controllers/admin/settings/working_days_and_hours_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/working_days_and_hours_settings_controller_spec.rb
@@ -104,5 +104,35 @@ RSpec.describe Admin::Settings::WorkingDaysAndHoursSettingsController do
         expect { nwd_to_delete.reload }.not_to raise_error
       end
     end
+
+    context "when fails because a previous apply job is still unprocessed",
+            with_good_job: WorkPackages::ApplyWorkingDaysChangeJob do
+      let(:non_working_days_attributes) do
+        {
+          "0" => { "name" => "Boxing Day", "date" => "2022-12-26" },
+          "1" => { "name" => "New Year", "date" => "2023-01-01" }
+        }
+      end
+
+      before do
+        WorkPackages::ApplyWorkingDaysChangeJob
+          .set(wait: 10.minutes)
+          .perform_later(user_id: user.id,
+                         previous_non_working_days: [],
+                         previous_working_days: Setting.working_days)
+      end
+
+      it "displays the error and keeps the submitted non-working days" do
+        subject
+
+        expect(response).to render_template :show
+        expect(flash[:error]).to include("have not been applied yet")
+        expect(assigns(:modified_non_working_days)).to contain_exactly(
+          hash_including("name" => "Boxing Day", "date" => "2022-12-26"),
+          hash_including("name" => "New Year", "date" => "2023-01-01")
+        )
+        expect(NonWorkingDay.where(date: %w[2022-12-26 2023-01-01])).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
When the non working days cannot be saved for some reason, keep them around so the user can either correct their mistake, or wait for the changes to be applied.