### PR TITLE
Allow to fill missing custom fields during Omniauth registration

### DIFF
--- a/app/controllers/concerns/accounts/registration.rb
+++ b/app/controllers/concerns/accounts/registration.rb
@@ -74,7 +74,7 @@ module Accounts::Registration
       user.assign_attributes permitted_params.user_register_via_omniauth
       return unless consent_given_for_registration?(user)
 
-      register_via_omniauth(session, user.attributes)
+      register_via_omniauth(session, permitted_params.user_register_via_omniauth)
     else
       user.attributes = permitted_params.user
       user.activate
@@ -85,8 +85,8 @@ module Accounts::Registration
     end
   end
 
-  def register_via_omniauth(session, user_attributes)
-    handle_omniauth_authentication(session[:auth_source_registration], user_params: user_attributes)
+  def register_via_omniauth(session, user_params)
+    handle_omniauth_authentication(session[:auth_source_registration], user_params:)
   end
 
   def handle_omniauth_authentication(auth_hash, user_params: nil) # rubocop:disable Metrics/AbcSize

--- a/app/controllers/concerns/accounts/registration.rb
+++ b/app/controllers/concerns/accounts/registration.rb
@@ -72,8 +72,6 @@ module Accounts::Registration
     # on-the-fly registration via omniauth or via auth source
     if pending_omniauth_registration?
       user.assign_attributes permitted_params.user_register_via_omniauth
-      return unless consent_given_for_registration?(user)
-
       register_via_omniauth(session, permitted_params.user_register_via_omniauth)
     else
       user.attributes = permitted_params.user

--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -56,7 +56,7 @@ class RegistrationForm < ApplicationForm
 
     f.submit(name: :submit, label: I18n.t(:button_create), scheme: :primary)
 
-    authentication_providers(f)
+    authentication_providers(f) unless model.uses_external_authentication?
     registration_footer(f)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -413,7 +413,8 @@ class User < Principal
 
   # Is the user authenticated via an external authentication source via OmniAuth?
   def uses_external_authentication?
-    user_auth_provider_links.exists?
+    # using #any? instead of #exists? so that it also works on unpersisted auth provider links
+    user_auth_provider_links.any?
   end
 
   #

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -48,7 +48,7 @@ module Authentication
       self.contract = ::Authentication::OmniauthAuthHashContract.new(auth_hash)
     end
 
-    def call(additional_user_params = nil)
+    def call(additional_user_params = nil) # rubocop:disable Metrics/AbcSize
       inspect_response(Logger::DEBUG)
 
       unless contract.validate
@@ -68,8 +68,7 @@ module Authentication
 
       # Create or update the user from omniauth
       # and assign non-nil parameters from the registration form - if any
-      assignable_params = (additional_user_params || {}).compact
-      update_user_from_omniauth!(assignable_params)
+      update_user_from_omniauth!((additional_user_params || {}).compact)
 
       # If we have a new or invited user, we still need to register them
       call = activate_user!

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -1416,5 +1416,84 @@ RSpec.describe AccountController, :skip_2fa_stage do
         end
       end
     end
+
+    context "when there are missing required custom fields" do
+      let(:slug) { "google" }
+      let(:omniauth_strategy) { double("Google Strategy", name: slug) } # rubocop:disable RSpec/VerifiedDoubles
+      let!(:oidc_google) { create(:oidc_provider_google, slug:) }
+      let(:omniauth_hash) do
+        OmniAuth::AuthHash.new(
+          provider: slug,
+          strategy: omniauth_strategy,
+          uid: "123545",
+          info: { name: "foo",
+                  email: "foo@bar.com",
+                  first_name: "foo",
+                  last_name: "bar" }
+        )
+      end
+      let(:custom_field) { create(:user_custom_field, :string, is_required: true) }
+
+      before do
+        custom_field.save!
+
+        request.env["omniauth.auth"] = omniauth_hash
+        request.env["omniauth.strategy"] = omniauth_strategy
+      end
+
+      it "registers user via post" do
+        allow(OpenProject::OmniAuth::Authorization).to receive(:after_login!)
+
+        auth_source_registration = omniauth_hash.merge(
+          omniauth: true,
+          timestamp: Time.current
+        )
+        session[:auth_source_registration] = auth_source_registration
+        post :register,
+             params: {
+               user: {
+                 login: "login@bar.com",
+                 firstname: "Foo",
+                 lastname: "Smith",
+                 mail: "foo@bar.com",
+                 custom_field_values: { custom_field.id => "A string" }
+               }
+             }
+        expect(response).to redirect_to home_url(first_time_user: true)
+
+        user = User.find_by_login("login@bar.com")
+        expect(OpenProject::OmniAuth::Authorization)
+          .to have_received(:after_login!).with(user, a_hash_including(omniauth_hash), any_args)
+        expect(user).to be_an_instance_of(User)
+        expect(user.ldap_auth_source_id).to be_nil
+        expect(user.current_password).to be_nil
+        expect(user.custom_field_values).to include(have_attributes(custom_field_id: custom_field.id, value: "A string"))
+        expect(user.identity_url).to eql("google:123545")
+      end
+
+      context "when after a timeout expired" do
+        before do
+          session[:auth_source_registration] = omniauth_hash.merge(
+            omniauth: true,
+            timestamp: 42.days.ago
+          )
+        end
+
+        it "does not register the user when providing all the missing fields" do
+          post :register,
+               params: {
+                 user: {
+                   firstname: "Foo",
+                   lastname: "Smith",
+                   mail: "foo@bar.com"
+                 }
+               }
+
+          expect(response).to redirect_to signin_path
+          expect(flash[:error]).to eq(I18n.t(:error_omniauth_registration_timed_out))
+          expect(User.find_by_login("foo@bar.com")).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -1365,33 +1365,6 @@ RSpec.describe AccountController, :skip_2fa_stage do
         expect(user.identity_url).to eql("google:123545")
       end
 
-      context "with consent required",
-              with_settings: {
-                consent_required: true,
-                consent_info: { en: "# Consent header!" }
-              } do
-        it "renders the registration form with a consent error" do
-          session[:auth_source_registration] = omniauth_hash.merge(
-            omniauth: true,
-            timestamp: Time.current
-          )
-
-          post :register,
-               params: {
-                 user: {
-                   login: "login@bar.com",
-                   firstname: "Foo",
-                   lastname: "Smith",
-                   mail: "foo@bar.com"
-                 }
-               }
-
-          expect(response).to render_template :register
-          expect(assigns(:user).errors[:consent_check]).to contain_exactly(I18n.t("consent.failure_message"))
-          expect(User.find_by_login("login@bar.com")).to be_nil
-        end
-      end
-
       context "when after a timeout expired" do
         before do
           session[:auth_source_registration] = omniauth_hash.merge(


### PR DESCRIPTION
This PR solves several issues around registering users via Omniauth when their information is not yet complete. We explicitly did want to support this (see methods such as `render_omniauth_registration_form`), but lost the ability to do so long ago.

This should now be working again.

# Ticket
https://community.openproject.org/wp/SI-235