### PR TITLE
[COMMS-934] Drop primary-version nomenclature from comments and cost query join

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -103,9 +103,9 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
     version: {
       if: -> { !Setting::WorkPackageMultipleVersions.active? },
       group_by_class_name: "Version",
-      # The primary target version (the lowest version id) represents the work
-      # package, matching the version_id mirror column and the cost report's
-      # primary-version join; the sort key is that version's name.
+      # The lowest-id target version represents the work package, matching the
+      # version_id mirror column and the cost report's single-version join;
+      # the sort key is that version's name.
       sortable: <<~SQL.squish,
         (SELECT LOWER(v.name)
            FROM work_package_versions wpv

--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -244,9 +244,9 @@ module WorkPackage::Versions
     system_version_overrides.clear
   end
 
-  # Keeps the deprecated single version_id column in sync with the primary
-  # target version (the lowest version id, i.e. what target_versions.first
-  # reads), so code still reading version_id sees the same version.
+  # Keeps the deprecated single version_id column in sync with the lowest-id
+  # target version (what target_versions.first reads), so code still reading
+  # version_id sees the same version.
   # Can be dropped once the version_id column is removed.
   def update_legacy_version_field
     new_version_id = target_version_ids_replacements.min

--- a/modules/reporting/app/models/cost_query/work_package_target_version_join.rb
+++ b/modules/reporting/app/models/cost_query/work_package_target_version_join.rb
@@ -38,9 +38,9 @@ module CostQuery::WorkPackageTargetVersionJoin
   #
   # With multiple target versions on, the join is one-to-many: a work package
   # with several target versions is reported under each of them. With the
-  # feature off a work package is single-version, so the join is narrowed to the
-  # primary target version (the lowest version id, matching target_versions.first)
-  # and stays one-to-one.
+  # feature off a work package is single-version, so the join is narrowed to
+  # the lowest-id target version (what target_versions.first reads) and stays
+  # one-to-one.
   JOIN_ALL = <<~SQL.squish
     LEFT OUTER JOIN work_package_versions
       ON work_package_versions.work_package_id = entries.entity_id
@@ -48,13 +48,13 @@ module CostQuery::WorkPackageTargetVersionJoin
      AND work_package_versions.kind = 'target'
   SQL
 
-  JOIN_PRIMARY = <<~SQL.squish
+  JOIN_SINGLE_VERSION = <<~SQL.squish
     #{JOIN_ALL}
      AND work_package_versions.version_id = (
-           SELECT MIN(primary_target.version_id)
-           FROM work_package_versions primary_target
-           WHERE primary_target.work_package_id = entries.entity_id
-             AND primary_target.kind = 'target'
+           SELECT MIN(lowest_target.version_id)
+           FROM work_package_versions lowest_target
+           WHERE lowest_target.work_package_id = entries.entity_id
+             AND lowest_target.kind = 'target'
          )
   SQL
 
@@ -62,6 +62,6 @@ module CostQuery::WorkPackageTargetVersionJoin
   # restart. The filter and group-by must resolve to the exact same string so
   # the engine collapses them into a single join.
   def self.sql
-    Setting::WorkPackageMultipleVersions.active? ? JOIN_ALL : JOIN_PRIMARY
+    Setting::WorkPackageMultipleVersions.active? ? JOIN_ALL : JOIN_SINGLE_VERSION
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-934

Name the convention literally (the lowest version id) instead; the primary notion is only inferred during the version_id migration period. Reworks #24486