### PR TITLE
[AGILE-351] Multiple active sprints coexist with sharing

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -117,16 +117,24 @@ module Backlogs
       work_packages.filter_map(&:story_points).sum
     end
 
-    # Starting a sprint can be blocked by two independent rules, each gated by
-    # its own project's allow_multiple_active_sprints setting:
+    # Starting a sprint can be blocked by three independent rules:
+    # - `project` is set to receive shared sprints and `sprint` is one of its
+    #   own (see StartContract) - unconditionally, regardless of
+    #   allow_multiple_active_sprints
     # - the project that actually owns `sprint` already has another active
     #   sprint of its own (the DB-level uniqueness constraint), even if that
-    #   other sprint isn't shared with (and is thus invisible to) `project`
+    #   other sprint isn't shared with (and is thus invisible to) `project`,
+    #   unless the owner allows multiple active sprints
     # - `project` (the project this component is rendered for) already shows
     #   another active sprint on its board - native or shared, as long as it's
-    #   visible here
+    #   visible here, unless `project` allows multiple active sprints
     def project_is_allowed_to_activate_sprint?
-      owner_allows_another_active_sprint? && project_allows_another_active_sprint?
+      !owned_sprint_blocked_by_receiving? &&
+        owner_allows_another_active_sprint? && project_allows_another_active_sprint?
+    end
+
+    def owned_sprint_blocked_by_receiving?
+      sprint.owned_by?(project) && project.receive_shared_sprints?
     end
 
     def owner_allows_another_active_sprint?
@@ -150,7 +158,9 @@ module Backlogs
     def start_sprint_disabled_reason
       return unless disable_start_sprint_action?
 
-      if !sprint.date_range_set?
+      if owned_sprint_blocked_by_receiving?
+        t(".start_sprint_disabled_reason_receiving_shared_sprints")
+      elsif !sprint.date_range_set?
         t(".start_sprint_disabled_reason_missing_dates")
       elsif sprint.owned_by?(project) || project_has_another_active_visible_sprint?
         t(".start_sprint_disabled_reason_active_sprint")

--- a/modules/backlogs/app/contracts/backlogs/projects/backlog_settings_contract.rb
+++ b/modules/backlogs/app/contracts/backlogs/projects/backlog_settings_contract.rb
@@ -37,15 +37,31 @@ module Backlogs::Projects
     validate :validate_global_sprint_sharer_uniqueness
     validates :sprint_sharing, presence: true
     validates :sprint_sharing, inclusion: { in: Project::SPRINT_SHARING_MODES }, allow_blank: true
-    validate :validate_sprint_sharing_in_ee_token
-    validate :validate_multiple_active_sprints_in_ee_token
-    validate :validate_allow_multiple_active_sprints_requires_no_sharing
-    validate :validate_sprint_sharing_locked_when_multiple_active_sprints
-    validate :validate_multiple_active_sprints_setting_not_changeable_while_active
+    validate :validate_sprint_sharing_in_ee_token, if: :sprint_sharing_changed?
+
+    validate :validate_multiple_active_sprints_locked_when_active, if: :allow_multiple_active_sprints_changed?
+
+    with_options if: %i[allow_multiple_active_sprints_changed? allow_multiple_active_sprints?] do
+      validate :validate_multiple_active_sprints_in_ee_token
+      validate :validate_allow_multiple_active_sprints_requires_no_sharing
+    end
+
+    with_options if: %i[sprint_sharing_changed? allow_multiple_active_sprints?] do
+      validate :validate_sprint_sharing_locked_when_multiple_active_sprints
+    end
+
+    with_options if: :sprint_sharing_changed?, unless: :allow_multiple_active_sprints? do
+      validate :validate_only_one_active_sprint_when_receiving_shared_sprints
+      validate :validate_no_work_packages_in_shared_sprints_when_leaving_receiving
+    end
 
     def validate_model? = false
 
     protected
+
+    def allow_multiple_active_sprints? = model.allow_multiple_active_sprints?
+    def allow_multiple_active_sprints_changed? = model.allow_multiple_active_sprints_changed?
+    def sprint_sharing_changed? = model.sprint_sharing_changed?
 
     def validate_permissions
       unless user.allowed_in_project?(:share_sprint, model)
@@ -67,18 +83,15 @@ module Backlogs::Projects
     end
 
     def validate_sprint_sharing_in_ee_token
-      if !model.not_sharing_sprints? &&
-         !EnterpriseToken.allows_to?(:sprint_sharing) &&
-         model.sprint_sharing_changed?
-        errors.add :sprint_sharing,
-                   :enterprise_plan_required,
-                   plan_name: I18n.t("ee.upsell.plan_name", plan: OpenProject::Token.lowest_plan_for(:sprint_sharing))
-      end
+      return if model.not_sharing_sprints?
+      return if EnterpriseToken.allows_to?(:sprint_sharing)
+
+      errors.add :sprint_sharing,
+                 :enterprise_plan_required,
+                 plan_name: I18n.t("ee.upsell.plan_name", plan: OpenProject::Token.lowest_plan_for(:sprint_sharing))
     end
 
     def validate_multiple_active_sprints_in_ee_token
-      return unless model.allow_multiple_active_sprints_changed?
-      return unless model.allow_multiple_active_sprints?
       return if EnterpriseToken.allows_to?(:multiple_active_sprints)
 
       errors.add :allow_multiple_active_sprints,
@@ -87,25 +100,45 @@ module Backlogs::Projects
     end
 
     def validate_allow_multiple_active_sprints_requires_no_sharing
-      return unless model.allow_multiple_active_sprints_changed?
-      return unless model.allow_multiple_active_sprints?
       return if model.not_sharing_sprints?
 
       errors.add :allow_multiple_active_sprints, :requires_no_sharing
     end
 
     def validate_sprint_sharing_locked_when_multiple_active_sprints
-      return unless model.sprint_sharing_changed?
-      return unless model.allow_multiple_active_sprints?
-
       errors.add :sprint_sharing, :locked_by_multiple_active_sprints
     end
 
-    def validate_multiple_active_sprints_setting_not_changeable_while_active
-      return unless model.allow_multiple_active_sprints_changed?
+    def validate_multiple_active_sprints_locked_when_active
       return unless Sprint.for_project(model).active.many?
 
       errors.add :allow_multiple_active_sprints, :locked_by_multiple_active_sprints
+    end
+
+    # It raises a validation error when an active sprint has work packages assigned.
+    # Active sprints from this project with no work packages assigned to them will just
+    # silently disappear, once the sharing mode is set to receive.
+    # This also covers the case of "borrowed" sprints via work package assignment.
+    def validate_only_one_active_sprint_when_receiving_shared_sprints
+      return unless model.receive_shared_sprints?
+      return unless WorkPackage.where(project: model).joins(:sprint).merge(Sprint.active).exists?
+
+      errors.add :sprint_sharing, :only_one_active_sprint_allowed
+    end
+
+    # Once the project stops receiving, the sharer could activate a "borrowed" sprint
+    # at any later point, which could lead to a second active sprint.
+    # A validation error is raised when disabling sprint receiving, if any work package
+    # is still assigned to the shared sprints, regardless of whether the sprint is active or not.
+    def validate_no_work_packages_in_shared_sprints_when_leaving_receiving
+      return unless model.receive_shared_sprints_was?
+
+      return unless WorkPackage.where(project: model)
+                               .joins(:sprint)
+                               .where.not(sprints: { project_id: model.id })
+                               .exists?
+
+      errors.add :sprint_sharing, :work_packages_still_linked_to_shared_sprints
     end
   end
 end

--- a/modules/backlogs/app/contracts/backlogs/projects/backlog_settings_contract.rb
+++ b/modules/backlogs/app/contracts/backlogs/projects/backlog_settings_contract.rb
@@ -59,9 +59,10 @@ module Backlogs::Projects
 
     protected
 
-    def allow_multiple_active_sprints? = model.allow_multiple_active_sprints?
-    def allow_multiple_active_sprints_changed? = model.allow_multiple_active_sprints_changed?
-    def sprint_sharing_changed? = model.sprint_sharing_changed?
+    delegate :allow_multiple_active_sprints?,
+             :allow_multiple_active_sprints_changed?,
+             :sprint_sharing_changed?,
+             to: :model
 
     def validate_permissions
       unless user.allowed_in_project?(:share_sprint, model)
@@ -144,7 +145,7 @@ module Backlogs::Projects
     # Once the project stops receiving, the former sharer could activate a "borrowed" sprint
     # at any later point, which will lead to multiple active sprints.
     def validate_no_work_packages_in_shared_sprints_when_leaving_receiving
-      return unless model.receive_shared_sprints_was?
+      return unless model.sprint_sharing_was_receiving?
       return unless has_borrowed_sprints_via_work_packages?
 
       errors.add :sprint_sharing, :work_packages_still_linked_to_shared_sprints

--- a/modules/backlogs/app/contracts/backlogs/projects/backlog_settings_contract.rb
+++ b/modules/backlogs/app/contracts/backlogs/projects/backlog_settings_contract.rb
@@ -51,7 +51,7 @@ module Backlogs::Projects
     end
 
     with_options if: :sprint_sharing_changed?, unless: :allow_multiple_active_sprints? do
-      validate :validate_only_one_active_sprint_when_receiving_shared_sprints
+      validate :validate_no_active_or_borrowed_sprint_when_receiving_shared_sprints
       validate :validate_no_work_packages_in_shared_sprints_when_leaving_receiving
     end
 
@@ -115,28 +115,37 @@ module Backlogs::Projects
       errors.add :allow_multiple_active_sprints, :locked_by_multiple_active_sprints
     end
 
-    # It raises a validation error when an active sprint has work packages assigned.
-    # Active sprints from this project with no work packages assigned to them will just
-    # silently disappear, once the sharing mode is set to receive.
-    # This also covers the case of "borrowed" sprints via work package assignment.
-    def validate_only_one_active_sprint_when_receiving_shared_sprints
+    # Block enabling sprint receiving if the project has:
+    #   - its own active sprint with a work package assigned.
+    #   - any borrowed sprints from another project via work package assignment.
+    #     A borrowed sprint is not allowed since the foreign project could activate it later,
+    #     leading to multiple active sprints.
+    # Project owned sprints are allowed only if they:
+    #   - have no work packages because once receiving is set, they become invisible.
+    #   - are inactive (with or without work packages assigned), because once receiving is set
+    #     they cannot be activated anymore.
+    def validate_no_active_or_borrowed_sprint_when_receiving_shared_sprints
       return unless model.receive_shared_sprints?
-      return unless WorkPackage.where(project: model).joins(:sprint).merge(Sprint.active).exists?
+      return unless own_active_sprint_with_work_packages? || has_borrowed_sprints_via_work_packages?
 
-      errors.add :sprint_sharing, :only_one_active_sprint_allowed
+      errors.add :sprint_sharing, :active_or_borrowed_sprint_blocks_receiving
     end
 
-    # Once the project stops receiving, the sharer could activate a "borrowed" sprint
-    # at any later point, which could lead to a second active sprint.
-    # A validation error is raised when disabling sprint receiving, if any work package
-    # is still assigned to the shared sprints, regardless of whether the sprint is active or not.
+    def own_active_sprint_with_work_packages?
+      model.sprints.active.joins(:work_packages).exists?
+    end
+
+    def has_borrowed_sprints_via_work_packages?
+      model.work_packages.joins(:sprint).where.not(sprints: { project_id: model.id }).exists?
+    end
+
+    # Block disabling sprint receiving, if any work package is still assigned to a shared sprint
+    # regardless of whether the sprint is active or not.
+    # Once the project stops receiving, the former sharer could activate a "borrowed" sprint
+    # at any later point, which will lead to multiple active sprints.
     def validate_no_work_packages_in_shared_sprints_when_leaving_receiving
       return unless model.receive_shared_sprints_was?
-
-      return unless WorkPackage.where(project: model)
-                               .joins(:sprint)
-                               .where.not(sprints: { project_id: model.id })
-                               .exists?
+      return unless has_borrowed_sprints_via_work_packages?
 
       errors.add :sprint_sharing, :work_packages_still_linked_to_shared_sprints
     end

--- a/modules/backlogs/app/contracts/backlogs/sprints/start_contract.rb
+++ b/modules/backlogs/app/contracts/backlogs/sprints/start_contract.rb
@@ -32,8 +32,14 @@ module Backlogs::Sprints
   class StartContract < ::BaseContract
     validate :validate_permission
     validate :validate_status_in_planning
-    validate :validate_dates_present
-    validate :validate_only_one_active_sprint, unless: -> { model.allow_multiple_active_sprints? }
+
+    # The in_planning status is already validated. If it's not in_planning,
+    # stop running the rest of validations in order to avoid stacking error messages.
+    with_options if: -> { model.in_planning? } do
+      validate :validate_dates_present
+      validate :validate_only_one_active_sprint, unless: -> { model.allow_multiple_active_sprints? }
+      validate :validate_not_receiving_shared_sprints
+    end
 
     def self.can_start_or_complete?(user:, sprint:)
       user.allowed_in_project?(:start_complete_sprint, sprint.project)
@@ -59,17 +65,24 @@ module Backlogs::Sprints
     end
 
     def validate_dates_present
-      return unless model.in_planning?
       return if model.start_date? && model.finish_date?
 
       errors.add :base, :dates_required
     end
 
     def validate_only_one_active_sprint
-      return unless model.in_planning?
-      return unless Sprint.for_project(model.project).active.where.not(id: model.id).exists?
+      return if Sprint.for_project(model.project).active.where.not(id: model.id).none?
 
       errors.add :status, :only_one_active_sprint_allowed
+    end
+
+    # A project's own sprints shouldn't be started if the project is set to receive sprints.
+    # Ignoring the multiple active sprints settings, because that is available only when
+    # the project is not sharing sprints.
+    def validate_not_receiving_shared_sprints
+      return unless model.project.receive_shared_sprints?
+
+      errors.add :status, :cannot_start_while_receiving_shared_sprints
     end
   end
 end

--- a/modules/backlogs/app/contracts/backlogs/sprints/start_contract.rb
+++ b/modules/backlogs/app/contracts/backlogs/sprints/start_contract.rb
@@ -67,7 +67,7 @@ module Backlogs::Sprints
 
     def validate_only_one_active_sprint
       return unless model.in_planning?
-      return unless Sprint.where(project: model.project).active.where.not(id: model.id).exists?
+      return unless Sprint.for_project(model.project).active.where.not(id: model.id).exists?
 
       errors.add :status, :only_one_active_sprint_allowed
     end

--- a/modules/backlogs/app/forms/projects/settings/backlogs/sharing_form.rb
+++ b/modules/backlogs/app/forms/projects/settings/backlogs/sharing_form.rb
@@ -79,6 +79,11 @@ module Projects
         def initialize(only_fallback_allowed: false)
           super()
           @only_fallback_allowed = only_fallback_allowed
+
+          # The controller already surfaces contract failures via a flash banner, so clear
+          # any :sprint_sharing errors here to avoid also showing Primer's inline validation
+          # message underneath the radio buttons.
+          model.errors.delete(:sprint_sharing)
         end
 
         private

--- a/modules/backlogs/app/models/projects/sprint_settings.rb
+++ b/modules/backlogs/app/models/projects/sprint_settings.rb
@@ -142,7 +142,7 @@ module Projects::SprintSettings
     sprint_sharing == RECEIVE_SHARED
   end
 
-  def receive_shared_sprints_was?
+  def sprint_sharing_was_receiving?
     sprint_sharing_was == RECEIVE_SHARED
   end
 

--- a/modules/backlogs/app/models/projects/sprint_settings.rb
+++ b/modules/backlogs/app/models/projects/sprint_settings.rb
@@ -142,6 +142,10 @@ module Projects::SprintSettings
     sprint_sharing == RECEIVE_SHARED
   end
 
+  def receive_shared_sprints_was?
+    sprint_sharing_was == RECEIVE_SHARED
+  end
+
   def not_sharing_sprints?
     sprint_sharing == NO_SHARING
   end

--- a/modules/backlogs/app/models/sprint.rb
+++ b/modules/backlogs/app/models/sprint.rb
@@ -77,13 +77,7 @@ class Sprint < ApplicationRecord
             comparison: { greater_than_or_equal_to: :start_date },
             if: :date_range_set?
 
-  validates :status,
-            uniqueness: {
-              scope: :project_id,
-              conditions: -> { active },
-              message: :only_one_active_sprint_allowed
-            },
-            if: -> { active? && !allow_multiple_active_sprints? }
+  validate :validate_only_one_active_sprint, if: -> { active? && !allow_multiple_active_sprints? }
 
   def date_range_set?
     start_date? && finish_date?
@@ -124,4 +118,12 @@ class Sprint < ApplicationRecord
   end
 
   def to_s = name
+
+  private
+
+  def validate_only_one_active_sprint
+    return unless self.class.for_project(project).active.where.not(id:).exists?
+
+    errors.add :status, :only_one_active_sprint_allowed
+  end
 end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
               locked_by_multiple_active_sprints: "cannot be changed while multiple active sprints are enabled."
               share_all_projects_already_taken: "cannot be set because project \"%{name}\" is already sharing with all projects."
               share_all_projects_already_taken_anonymous: "cannot be set because another project is already sharing with all projects."
+              work_packages_still_linked_to_shared_sprints: "cannot be changed because work packages are still linked to shared sprints. Unassign them first."
           receiving_sprints: "is receiving shared sprints. Own sprints cannot be created."
         sprint:
           attributes:

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -212,6 +212,7 @@ en:
       label_start_sprint: "Start sprint"
       start_sprint_disabled_reason_active_sprint: "Another sprint is already active."
       start_sprint_disabled_reason_missing_dates: "Start and finish dates are required in order to start the sprint."
+      start_sprint_disabled_reason_receiving_shared_sprints: "This project's own sprints cannot be started while it is receiving shared sprints."
       start_sprint_disabled_reason_shared_sprint: "This sprint is from another project that doesn't support multiple active sprints."
 
     sprint_form:

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
               locked_by_multiple_active_sprints: "cannot be changed while multiple active sprints are running."
               requires_no_sharing: "can only be enabled when sprint sharing is set to 'Don't share'."
             sprint_sharing:
+              active_or_borrowed_sprint_blocks_receiving: "cannot be set to receive because the project has an active or borrowed sprint. Close or unassign it first."
               locked_by_multiple_active_sprints: "cannot be changed while multiple active sprints are enabled."
               share_all_projects_already_taken: "cannot be set because project \"%{name}\" is already sharing with all projects."
               share_all_projects_already_taken_anonymous: "cannot be set because another project is already sharing with all projects."

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
               locked_by_multiple_active_sprints: "cannot be changed while multiple active sprints are running."
               requires_no_sharing: "can only be enabled when sprint sharing is set to 'Don't share'."
             sprint_sharing:
-              active_or_borrowed_sprint_blocks_receiving: "cannot be set to receive because the project has an active or borrowed sprint. Close or unassign it first."
+              active_or_borrowed_sprint_blocks_receiving: "cannot be set to receive because the project has an active or borrowed sprint. Close or unassign the work packages first."
               locked_by_multiple_active_sprints: "cannot be changed while multiple active sprints are enabled."
               share_all_projects_already_taken: "cannot be set because project \"%{name}\" is already sharing with all projects."
               share_all_projects_already_taken_anonymous: "cannot be set because another project is already sharing with all projects."

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
 
     errors:
       messages:
+        cannot_start_while_receiving_shared_sprints: "cannot be started while the project is receiving shared sprints."
         dates_required: "Start and finish dates are required in order to start the sprint."
         must_be_in_planning: "must be in planning to start."
         only_one_active_sprint_allowed: "only one active sprint is allowed per project."

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -549,6 +549,47 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
           end
         end
       end
+
+      context "when the project is set to receive shared sprints" do
+        let(:parent) { create(:project, sprint_sharing: "share_subprojects", types: [type_feature, type_task]) }
+        let(:project) { create(:project, parent:, sprint_sharing: "receive_shared", types: [type_feature, type_task]) }
+        let(:sprint) do
+          create(:sprint, project:, name: "Sprint 1",
+                          start_date: Date.tomorrow, finish_date: Date.tomorrow + 7,
+                          status: "in_planning")
+        end
+
+        it "disables the start-sprint button for own sprints" do
+          expect(rendered_component).to have_selector(:link_or_button, "Start sprint", aria: { disabled: true })
+        end
+
+        it "gives the receiving-shared-sprints reason" do
+          expect(rendered_component).to have_element(
+            "tool-tip",
+            text: I18n.t("backlogs.sprint_component.start_sprint_disabled_reason_receiving_shared_sprints")
+          )
+        end
+
+        context "when the project allows multiple active sprints" do
+          before { project.update!(allow_multiple_active_sprints: true) }
+
+          it "still disables the start-sprint button for own sprints" do
+            expect(rendered_component).to have_selector(:link_or_button, "Start sprint", aria: { disabled: true })
+          end
+        end
+
+        context "when the sprint is received from the sharer" do
+          let(:sprint) do
+            create(:sprint, project: parent, name: "Shared Sprint",
+                            start_date: Date.tomorrow, finish_date: Date.tomorrow + 7,
+                            status: "in_planning")
+          end
+
+          it "renders the start-sprint link enabled" do
+            expect(rendered_component).to have_link("Start sprint")
+          end
+        end
+      end
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -559,6 +559,8 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
                           status: "in_planning")
         end
 
+        # This testcase is reproducible on the UI, only if the owned sprint has work packages associated to it.
+        # Otherwise it won't show up when the project sprint sharing mode is set to receive sprints.
         it "disables the start-sprint button for own sprints" do
           expect(rendered_component).to have_selector(:link_or_button, "Start sprint", aria: { disabled: true })
         end

--- a/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
@@ -153,6 +153,264 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
         end
       end
     end
+
+    describe "#allow_multiple_active_sprints" do
+      context "when the `multiple_active_sprints` EE feature is not available", with_ee: [] do
+        context "when enabling the setting" do
+          before { project.allow_multiple_active_sprints = true }
+
+          it_behaves_like "contract is invalid",
+                          allow_multiple_active_sprints: { error: :enterprise_plan_required, plan_name: "basic enterprise plan" }
+        end
+
+        context "when disabling the setting" do
+          let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+          before { project.allow_multiple_active_sprints = false }
+
+          it_behaves_like "contract is valid"
+        end
+
+        context "when the setting is unchanged" do
+          let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+          it_behaves_like "contract is valid"
+        end
+      end
+
+      context "when enabling the setting while sprint sharing is no_sharing (default)" do
+        before { project.allow_multiple_active_sprints = true }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when enabling the setting while sprint sharing is not no_sharing" do
+        before do
+          project.sprint_sharing = Project::SHARE_ALL_PROJECTS
+          project.allow_multiple_active_sprints = true
+        end
+
+        it_behaves_like "contract is invalid", allow_multiple_active_sprints: :requires_no_sharing
+      end
+
+      context "when sprint_sharing is changed to 'share_subprojects' while allow_multiple_active_sprints is enabled" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+        before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+      end
+
+      context "when sprint_sharing is changed to 'share_all_projects' while allow_multiple_active_sprints is enabled" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+        before { project.sprint_sharing = Project::SHARE_ALL_PROJECTS }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+      end
+
+      context "when sprint_sharing is changed to 'receive_shared' while allow_multiple_active_sprints is enabled" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+      end
+
+      context "when sprint_sharing is unchanged while allow_multiple_active_sprints is enabled" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when sprint_sharing is explicitly set to its current value while allow_multiple_active_sprints is enabled" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true, sprint_sharing: Project::NO_SHARING) }
+
+        before { project.sprint_sharing = Project::NO_SHARING }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when toggling allow_multiple_active_sprints while multiple active sprints exist" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+        before do
+          create(:sprint, project:, status: "active")
+          create(:sprint, project:, status: "active")
+          project.allow_multiple_active_sprints = false
+        end
+
+        it_behaves_like "contract is invalid", allow_multiple_active_sprints: :locked_by_multiple_active_sprints
+      end
+
+      context "when toggling allow_multiple_active_sprints while only one active sprint exists" do
+        let(:project) { create(:project, allow_multiple_active_sprints: true) }
+
+        before do
+          create(:sprint, project:, status: "active")
+          project.allow_multiple_active_sprints = false
+        end
+
+        it_behaves_like "contract is valid"
+      end
+    end
+
+    describe "#validate_no_active_or_borrowed_sprint_when_receiving_shared_sprints" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+
+      context "when an active sprint of its own has a work package assigned" do
+        let(:active_sprint) { create(:sprint, project:, status: "active") }
+        let!(:work_package) { create(:work_package, project:, sprint: active_sprint) }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
+
+        context "when the project allows multiple active sprints" do
+          before { project.allow_multiple_active_sprints = true }
+
+          it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+        end
+      end
+
+      context "when an active sprint of its own has no work packages assigned" do
+        let!(:active_sprint) { create(:sprint, project:, status: "active") }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when the project has no active sprint of its own" do
+        let!(:in_planning_sprint) { create(:sprint, project:, status: "in_planning") }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when a non-active sprint of its own has a work package assigned" do
+        let(:in_planning_sprint) { create(:sprint, project:, status: "in_planning") }
+        let!(:work_package) { create(:work_package, project:, sprint: in_planning_sprint) }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when an active borrowed sprint has a work packages assigned" do
+        let(:borrowed_active_sprint) do
+          create(:sprint, project: create(:project, sprint_sharing: Project::NO_SHARING), status: "active")
+        end
+        let!(:work_package) { create(:work_package, project:, sprint: borrowed_active_sprint) }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
+      end
+
+      context "when a non-active borrowed sprint has a work package assigned" do
+        let(:borrowed_in_planning_sprint) do
+          create(:sprint, project: create(:project, sprint_sharing: Project::NO_SHARING), status: "in_planning")
+        end
+        let!(:work_package) { create(:work_package, project:, sprint: borrowed_in_planning_sprint) }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
+      end
+
+      context "when a borrowed sprint from the sharer has a work package assigned" do
+        let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+        let(:borrowed_active_sprint) { create(:sprint, project: sharer, status: "active") }
+        let!(:work_package) { create(:work_package, project:, sprint: borrowed_active_sprint) }
+
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
+      end
+
+      context "when no work packages are linked to any foreign sprint" do
+        before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when sprint_sharing is unchanged" do
+        let(:active_sprint) { create(:sprint, project:, status: "active") }
+
+        before do
+          create(:work_package, project:, sprint: active_sprint)
+          project.update!(sprint_sharing: Project::RECEIVE_SHARED)
+        end
+
+        it_behaves_like "contract is valid"
+      end
+    end
+
+    describe "#validate_no_work_packages_in_shared_sprints_when_leaving_receiving" do
+      let(:sharer) { nil }
+      let(:sprint_sharing) { Project::RECEIVE_SHARED }
+      let(:project) { create(:project, parent: sharer, sprint_sharing:) }
+
+      context "when the sharer has a sprint" do
+        let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+        let!(:sharer_sprint) { create(:sprint, project: sharer, status: "in_planning") }
+
+        before { project.sprint_sharing = Project::NO_SHARING }
+
+        it_behaves_like "contract is valid"
+
+        context "when the project allows multiple active sprints" do
+          before { project.allow_multiple_active_sprints = true }
+
+          it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+        end
+
+        context "and a work package is assigned to it" do
+          let!(:work_package) { create(:work_package, project:, sprint: sharer_sprint) }
+
+          it_behaves_like "contract is invalid", sprint_sharing: :work_packages_still_linked_to_shared_sprints
+
+          context "when the sharer's sprint is active" do
+            let(:sharer_sprint) { create(:sprint, project: sharer, status: "active") }
+
+            it_behaves_like "contract is invalid", sprint_sharing: :work_packages_still_linked_to_shared_sprints
+          end
+        end
+      end
+
+      context "when a work package is linked to a native sprint of its own" do
+        let(:own_sprint) { create(:sprint, project:) }
+        let!(:work_package) { create(:work_package, project:, sprint: own_sprint) }
+
+        before { project.sprint_sharing = Project::NO_SHARING }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when no work packages are linked to any foreign sprint" do
+        before { project.sprint_sharing = Project::NO_SHARING }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when sprint_sharing stays receive_shared" do
+        let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+        let(:sharer_sprint) { create(:sprint, project: sharer, status: "active") }
+        let!(:work_package) { create(:work_package, project:, sprint: sharer_sprint) }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when switching between two non-receiving modes" do
+        let(:sprint_sharing) { Project::NO_SHARING }
+
+        before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
+
+        it_behaves_like "contract is valid"
+      end
+    end
   end
 
   describe "#writable_attributes" do
@@ -191,287 +449,6 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
       end
 
       it_behaves_like "contract is invalid", settings: :error_readonly
-    end
-  end
-
-  describe "allow_multiple_active_sprints validations" do
-    context "when the `multiple_active_sprints` EE feature is not available", with_ee: [] do
-      context "when enabling the setting" do
-        before { project.allow_multiple_active_sprints = true }
-
-        it_behaves_like "contract is invalid",
-                        allow_multiple_active_sprints: { error: :enterprise_plan_required, plan_name: "basic enterprise plan" }
-      end
-
-      context "when disabling the setting" do
-        let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-        before { project.allow_multiple_active_sprints = false }
-
-        it_behaves_like "contract is valid"
-      end
-
-      context "when the setting is unchanged" do
-        let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-        it_behaves_like "contract is valid"
-      end
-    end
-
-    context "when enabling the setting while sprint sharing is no_sharing (default)" do
-      before { project.allow_multiple_active_sprints = true }
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when enabling the setting while sprint sharing is not no_sharing" do
-      before do
-        project.sprint_sharing = Project::SHARE_ALL_PROJECTS
-        project.allow_multiple_active_sprints = true
-      end
-
-      it_behaves_like "contract is invalid", allow_multiple_active_sprints: :requires_no_sharing
-    end
-
-    context "when sprint_sharing is changed to 'share_subprojects' while allow_multiple_active_sprints is enabled" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-      before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
-
-      it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
-    end
-
-    context "when sprint_sharing is changed to 'share_all_projects' while allow_multiple_active_sprints is enabled" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-      before { project.sprint_sharing = Project::SHARE_ALL_PROJECTS }
-
-      it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
-    end
-
-    context "when sprint_sharing is changed to 'receive_shared' while allow_multiple_active_sprints is enabled" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-      before { project.sprint_sharing = Project::RECEIVE_SHARED }
-
-      it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
-    end
-
-    context "when sprint_sharing is unchanged while allow_multiple_active_sprints is enabled" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when sprint_sharing is explicitly set to its current value while allow_multiple_active_sprints is enabled" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true, sprint_sharing: Project::NO_SHARING) }
-
-      before { project.sprint_sharing = Project::NO_SHARING }
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when toggling allow_multiple_active_sprints while multiple active sprints exist" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-      before do
-        create(:sprint, project:, status: "active")
-        create(:sprint, project:, status: "active")
-        project.allow_multiple_active_sprints = false
-      end
-
-      it_behaves_like "contract is invalid", allow_multiple_active_sprints: :locked_by_multiple_active_sprints
-    end
-
-    context "when toggling allow_multiple_active_sprints while only one active sprint exists" do
-      let(:project) { create(:project, allow_multiple_active_sprints: true) }
-
-      before do
-        create(:sprint, project:, status: "active")
-        project.allow_multiple_active_sprints = false
-      end
-
-      it_behaves_like "contract is valid"
-    end
-  end
-
-  describe "#validate_no_active_or_borrowed_sprint_when_receiving_shared_sprints" do
-    context "when an active sprint of its own has a work package assigned" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-      let(:active_sprint) { create(:sprint, project:, status: "active") }
-
-      before do
-        create(:work_package, project:, sprint: active_sprint)
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
-
-      context "when the project allows multiple active sprints" do
-        before { project.allow_multiple_active_sprints = true }
-
-        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
-      end
-    end
-
-    context "when an active sprint of its own has no work packages assigned" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-
-      before do
-        create(:sprint, project:, status: "active")
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when the project has no active sprint of its own" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-
-      before do
-        create(:sprint, project:, status: "in_planning")
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when a non-active sprint of its own has a work package assigned" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-      let(:in_planning_sprint) { create(:sprint, project:, status: "in_planning") }
-
-      before do
-        create(:work_package, project:, sprint: in_planning_sprint)
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when a work package is assigned to an active sprint borrowed from another project" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-      let(:foreign_active_sprint) do
-        create(:sprint, project: create(:project, sprint_sharing: Project::NO_SHARING), status: "active")
-      end
-
-      before do
-        create(:work_package, project:, sprint: foreign_active_sprint)
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
-    end
-
-    context "when a work package is assigned to a non-active sprint borrowed from another project" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-      let(:foreign_in_planning_sprint) do
-        create(:sprint, project: create(:project, sprint_sharing: Project::NO_SHARING), status: "in_planning")
-      end
-
-      before do
-        create(:work_package, project:, sprint: foreign_in_planning_sprint)
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
-    end
-
-    context "when a work package is linked to a borrowed sprint from the sharer" do
-      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
-      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::NO_SHARING) }
-      let(:borrowed_sprint) { create(:sprint, project: sharer, status: "active") }
-
-      before do
-        create(:work_package, project:, sprint: borrowed_sprint)
-        project.sprint_sharing = Project::RECEIVE_SHARED
-      end
-
-      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
-    end
-
-    context "when no work packages are linked to any foreign sprint" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-
-      before { project.sprint_sharing = Project::RECEIVE_SHARED }
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when sprint_sharing is unchanged" do
-      let(:project) { create(:project, sprint_sharing: Project::RECEIVE_SHARED) }
-
-      before { create(:sprint, project:, status: "active") }
-
-      it_behaves_like "contract is valid"
-    end
-  end
-
-  describe "#validate_no_work_packages_in_shared_sprints_when_leaving_receiving" do
-    context "when the sharer has a sprint" do
-      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
-      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::RECEIVE_SHARED) }
-      let!(:sharer_sprint) { create(:sprint, project: sharer, status: "in_planning") }
-
-      before { project.sprint_sharing = Project::NO_SHARING }
-
-      it_behaves_like "contract is valid"
-
-      context "when the project allows multiple active sprints" do
-        before { project.allow_multiple_active_sprints = true }
-
-        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
-      end
-
-      context "and a work package is assigned to it" do
-        let!(:work_package) { create(:work_package, project:, sprint: sharer_sprint) }
-
-        it_behaves_like "contract is invalid", sprint_sharing: :work_packages_still_linked_to_shared_sprints
-
-        context "when the sharer's sprint is active" do
-          let(:sharer_sprint) { create(:sprint, project: sharer, status: "active") }
-
-          it_behaves_like "contract is invalid", sprint_sharing: :work_packages_still_linked_to_shared_sprints
-        end
-      end
-    end
-
-    context "when a work package is linked to a native sprint of its own" do
-      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
-      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::RECEIVE_SHARED) }
-      let(:own_sprint) { create(:sprint, project:, status: "active") }
-
-      before do
-        create(:work_package, project:, sprint: own_sprint)
-        project.sprint_sharing = Project::NO_SHARING
-      end
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when no work packages are linked to any foreign sprint" do
-      let(:project) { create(:project, sprint_sharing: Project::RECEIVE_SHARED) }
-
-      before { project.sprint_sharing = Project::NO_SHARING }
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when sprint_sharing stays receive_shared" do
-      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
-      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::RECEIVE_SHARED) }
-      let(:sharer_sprint) { create(:sprint, project: sharer, status: "active") }
-
-      before { create(:work_package, project:, sprint: sharer_sprint) }
-
-      it_behaves_like "contract is valid"
-    end
-
-    context "when switching between two non-receiving modes" do
-      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-
-      before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
-
-      it_behaves_like "contract is valid"
     end
   end
 end

--- a/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
@@ -294,4 +294,159 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
       it_behaves_like "contract is valid"
     end
   end
+
+  describe "#validate_only_one_active_sprint_when_receiving_shared_sprints" do
+    context "when the project has an active sprint of its own" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+      let!(:active_sprint) { create(:sprint, project:, status: "active") }
+
+      before do
+        project.sprint_sharing = Project::RECEIVE_SHARED
+      end
+
+      it_behaves_like "contract is valid"
+
+      context "when the project allows multiple active sprints" do
+        before { project.allow_multiple_active_sprints = true }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+      end
+
+      context "and a work package is assigned to it" do
+        let!(:work_package) { create(:work_package, project:, sprint: active_sprint) }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :only_one_active_sprint_allowed
+      end
+    end
+
+    context "when the project has no active sprint of its own" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+
+      before do
+        create(:sprint, project:, status: "in_planning")
+        project.sprint_sharing = Project::RECEIVE_SHARED
+      end
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when a work package is assigned to a non-active sprint of its own" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+      let(:in_planning_sprint) { create(:sprint, project:, status: "in_planning") }
+
+      before do
+        create(:work_package, project:, sprint: in_planning_sprint)
+        project.sprint_sharing = Project::RECEIVE_SHARED
+      end
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when a work package is assigned to an active sprint borrowed from another project" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+      let(:foreign_active_sprint) do
+        create(:sprint, project: create(:project, sprint_sharing: Project::NO_SHARING), status: "active")
+      end
+
+      before do
+        create(:work_package, project:, sprint: foreign_active_sprint)
+        project.sprint_sharing = Project::RECEIVE_SHARED
+      end
+
+      it_behaves_like "contract is invalid", sprint_sharing: :only_one_active_sprint_allowed
+    end
+
+    context "when a work package is linked to a borrowed sprint from the sharer" do
+      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::NO_SHARING) }
+      let(:borrowed_sprint) { create(:sprint, project: sharer, status: "active") }
+
+      before do
+        create(:work_package, project:, sprint: borrowed_sprint)
+        project.sprint_sharing = Project::RECEIVE_SHARED
+      end
+
+      it_behaves_like "contract is invalid", sprint_sharing: :only_one_active_sprint_allowed
+    end
+
+    context "when sprint_sharing is unchanged" do
+      let(:project) { create(:project, sprint_sharing: Project::RECEIVE_SHARED) }
+      let(:active_sprint) { create(:sprint, project:, status: "active") }
+
+      before do
+        create(:work_package, project:, sprint: active_sprint)
+      end
+
+      it_behaves_like "contract is valid"
+    end
+  end
+
+  describe "#validate_no_work_packages_in_shared_sprints_when_leaving_receiving" do
+    context "when the sharer has a sprint" do
+      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::RECEIVE_SHARED) }
+      let!(:sharer_sprint) { create(:sprint, project: sharer, status: "in_planning") }
+
+      before { project.sprint_sharing = Project::NO_SHARING }
+
+      it_behaves_like "contract is valid"
+
+      context "when the project allows multiple active sprints" do
+        before { project.allow_multiple_active_sprints = true }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
+      end
+
+      context "and a work package is assigned to it" do
+        let!(:work_package) { create(:work_package, project:, sprint: sharer_sprint) }
+
+        it_behaves_like "contract is invalid", sprint_sharing: :work_packages_still_linked_to_shared_sprints
+
+        context "when the sharer's sprint is active" do
+          let(:sharer_sprint) { create(:sprint, project: sharer, status: "active") }
+
+          it_behaves_like "contract is invalid", sprint_sharing: :work_packages_still_linked_to_shared_sprints
+        end
+      end
+    end
+
+    context "when a work package is linked to a native sprint of its own" do
+      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::RECEIVE_SHARED) }
+      let(:own_sprint) { create(:sprint, project:, status: "active") }
+
+      before do
+        create(:work_package, project:, sprint: own_sprint)
+        project.sprint_sharing = Project::NO_SHARING
+      end
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when no work packages are linked to any foreign sprint" do
+      let(:project) { create(:project, sprint_sharing: Project::RECEIVE_SHARED) }
+
+      before { project.sprint_sharing = Project::NO_SHARING }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when sprint_sharing stays receive_shared" do
+      let(:sharer) { create(:project, sprint_sharing: Project::SHARE_SUBPROJECTS) }
+      let(:project) { create(:project, parent: sharer, sprint_sharing: Project::RECEIVE_SHARED) }
+      let(:sharer_sprint) { create(:sprint, project: sharer, status: "active") }
+
+      before { create(:work_package, project:, sprint: sharer_sprint) }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when switching between two non-receiving modes" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+
+      before { project.sprint_sharing = Project::SHARE_SUBPROJECTS }
+
+      it_behaves_like "contract is valid"
+    end
+  end
 end

--- a/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/projects/backlog_settings_contract_spec.rb
@@ -295,28 +295,34 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
     end
   end
 
-  describe "#validate_only_one_active_sprint_when_receiving_shared_sprints" do
-    context "when the project has an active sprint of its own" do
+  describe "#validate_no_active_or_borrowed_sprint_when_receiving_shared_sprints" do
+    context "when an active sprint of its own has a work package assigned" do
       let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
-      let!(:active_sprint) { create(:sprint, project:, status: "active") }
+      let(:active_sprint) { create(:sprint, project:, status: "active") }
 
       before do
+        create(:work_package, project:, sprint: active_sprint)
         project.sprint_sharing = Project::RECEIVE_SHARED
       end
 
-      it_behaves_like "contract is valid"
+      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
 
       context "when the project allows multiple active sprints" do
         before { project.allow_multiple_active_sprints = true }
 
         it_behaves_like "contract is invalid", sprint_sharing: :locked_by_multiple_active_sprints
       end
+    end
 
-      context "and a work package is assigned to it" do
-        let!(:work_package) { create(:work_package, project:, sprint: active_sprint) }
+    context "when an active sprint of its own has no work packages assigned" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
 
-        it_behaves_like "contract is invalid", sprint_sharing: :only_one_active_sprint_allowed
+      before do
+        create(:sprint, project:, status: "active")
+        project.sprint_sharing = Project::RECEIVE_SHARED
       end
+
+      it_behaves_like "contract is valid"
     end
 
     context "when the project has no active sprint of its own" do
@@ -330,7 +336,7 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
       it_behaves_like "contract is valid"
     end
 
-    context "when a work package is assigned to a non-active sprint of its own" do
+    context "when a non-active sprint of its own has a work package assigned" do
       let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
       let(:in_planning_sprint) { create(:sprint, project:, status: "in_planning") }
 
@@ -353,7 +359,21 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
         project.sprint_sharing = Project::RECEIVE_SHARED
       end
 
-      it_behaves_like "contract is invalid", sprint_sharing: :only_one_active_sprint_allowed
+      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
+    end
+
+    context "when a work package is assigned to a non-active sprint borrowed from another project" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+      let(:foreign_in_planning_sprint) do
+        create(:sprint, project: create(:project, sprint_sharing: Project::NO_SHARING), status: "in_planning")
+      end
+
+      before do
+        create(:work_package, project:, sprint: foreign_in_planning_sprint)
+        project.sprint_sharing = Project::RECEIVE_SHARED
+      end
+
+      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
     end
 
     context "when a work package is linked to a borrowed sprint from the sharer" do
@@ -366,16 +386,21 @@ RSpec.describe Backlogs::Projects::BacklogSettingsContract, type: :model, with_e
         project.sprint_sharing = Project::RECEIVE_SHARED
       end
 
-      it_behaves_like "contract is invalid", sprint_sharing: :only_one_active_sprint_allowed
+      it_behaves_like "contract is invalid", sprint_sharing: :active_or_borrowed_sprint_blocks_receiving
+    end
+
+    context "when no work packages are linked to any foreign sprint" do
+      let(:project) { create(:project, sprint_sharing: Project::NO_SHARING) }
+
+      before { project.sprint_sharing = Project::RECEIVE_SHARED }
+
+      it_behaves_like "contract is valid"
     end
 
     context "when sprint_sharing is unchanged" do
       let(:project) { create(:project, sprint_sharing: Project::RECEIVE_SHARED) }
-      let(:active_sprint) { create(:sprint, project:, status: "active") }
 
-      before do
-        create(:work_package, project:, sprint: active_sprint)
-      end
+      before { create(:sprint, project:, status: "active") }
 
       it_behaves_like "contract is valid"
     end

--- a/modules/backlogs/spec/contracts/backlogs/sprints/start_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/sprints/start_contract_spec.rb
@@ -101,12 +101,29 @@ RSpec.describe Backlogs::Sprints::StartContract do
       end
     end
 
-    context "when an active sprint exists in a different project" do
+    context "when an active sprint exists in a different, unrelated project" do
       before do
         create(:sprint, project: create(:project), status: "active")
       end
 
       it_behaves_like "contract is valid"
+    end
+
+    context "when an active sprint is shared into the project from a share_subprojects ancestor" do
+      let(:parent) { create(:project, sprint_sharing: "share_subprojects") }
+      let(:project) { create(:project, parent:, sprint_sharing: "receive_shared") }
+
+      before do
+        create(:sprint, project: parent, status: "active")
+      end
+
+      it_behaves_like "contract is invalid", status: :only_one_active_sprint_allowed
+
+      context "when the project allows multiple active sprints" do
+        before { project.update!(allow_multiple_active_sprints: true) }
+
+        it_behaves_like "contract is valid"
+      end
     end
   end
 end

--- a/modules/backlogs/spec/contracts/backlogs/sprints/start_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/backlogs/sprints/start_contract_spec.rb
@@ -117,12 +117,26 @@ RSpec.describe Backlogs::Sprints::StartContract do
         create(:sprint, project: parent, status: "active")
       end
 
-      it_behaves_like "contract is invalid", status: :only_one_active_sprint_allowed
+      it_behaves_like "contract is invalid",
+                      status: %i[only_one_active_sprint_allowed cannot_start_while_receiving_shared_sprints]
 
       context "when the project allows multiple active sprints" do
         before { project.update!(allow_multiple_active_sprints: true) }
 
-        it_behaves_like "contract is valid"
+        it_behaves_like "contract is invalid", status: :cannot_start_while_receiving_shared_sprints
+      end
+    end
+
+    context "when the project is receiving shared sprints" do
+      let(:parent) { create(:project, sprint_sharing: "share_subprojects") }
+      let(:project) { create(:project, parent:, sprint_sharing: "receive_shared") }
+
+      it_behaves_like "contract is invalid", status: :cannot_start_while_receiving_shared_sprints
+
+      context "when the project allows multiple active sprints" do
+        before { project.update!(allow_multiple_active_sprints: true) }
+
+        it_behaves_like "contract is invalid", status: :cannot_start_while_receiving_shared_sprints
       end
     end
   end

--- a/modules/backlogs/spec/models/sprint_spec.rb
+++ b/modules/backlogs/spec/models/sprint_spec.rb
@@ -102,6 +102,16 @@ RSpec.describe Sprint do
         expect(sprint).to be_valid
       end
 
+      it "prevents an active sprint when another active sprint is shared into the project" do
+        parent = create(:project, sprint_sharing: "share_subprojects")
+        receiving_project = create(:project, parent:, sprint_sharing: "receive_shared")
+        create(:sprint, project: parent, status: "active")
+        sprint.project = receiving_project
+
+        expect(sprint).not_to be_valid
+        expect(sprint.errors[:status]).to include("only one active sprint is allowed per project.")
+      end
+
       it "allows updating an existing active sprint" do
         sprint.save!
         sprint.name = "Updated Sprint"

--- a/modules/backlogs/spec/services/backlogs/sprints/start_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/sprints/start_service_spec.rb
@@ -171,8 +171,7 @@ RSpec.describe Backlogs::Sprints::StartService do
       expect { result }.not_to raise_error
 
       expect(result).not_to be_success
-      expect(result.errors.symbols_for(:status)).to include(:taken)
-      expect(result.errors[:status]).to include("only one active sprint is allowed per project.")
+      expect(result.errors.symbols_for(:status)).to include(:only_one_active_sprint_allowed)
       expect(sprint.reload).to be_in_planning
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-351

# What are you trying to accomplish?
Fix the case where a project already had its own active sprint before sprint sharing/receiving was enabled, letting it end up with two visibly active sprints.

# What approach did you choose and why?

Provide a set of validations when changing project sharing settings and starting a sprint in order to prevent the above mentioned case of multiple active sprints. Additionally, the validations also reduce the possibility of actions resulting in borrowed/dangling sprints in the project.

  - [X] BacklogSettingsContract:
    - [X] Switching a project to `receive_shared` is blocked if it has an own active sprint with a work package assigned, or any sprint borrowed from another project via a work package (active or not). An active sprint with no work packages is allowed through, since it becomes invisible once receiving.
    - [X] Switching away from `receive_shared` is blocked while a work package is still linked to a shared sprint, since the sharer could activate it independently later.
  - [X] StartContract: starting a project's own sprint is blocked while the project is set to receive shared sprints, regardless of `allow_multiple_active_sprints`.
  - [X] SprintComponent: the "Start sprint" button is disabled, with an explanatory tooltip, for the same case the start contract blocks.  


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
