### PR TITLE
[SC-99] Setting to disable password login for SSO users with bypass option

### DIFF
--- a/app/controllers/admin/settings/authentication_settings_controller.rb
+++ b/app/controllers/admin/settings/authentication_settings_controller.rb
@@ -31,5 +31,20 @@
 module Admin::Settings
   class AuthenticationSettingsController < ::Admin::SettingsController
     menu_item :authentication_settings
+
+    def settings_params
+      super.tap do |settings|
+        key = "password_login_sso_bypass_logins"
+        settings[key] = bypass_logins_for(settings[key]) if settings.key?(key)
+      end
+    end
+
+    private
+
+    # The user autocompleter submits principal ids, while the setting stores logins so that it
+    # stays usable as an environment variable when nobody can reach the administration anymore.
+    def bypass_logins_for(user_ids)
+      User.where(id: Array(user_ids).compact_blank).pluck(:login)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -218,7 +218,7 @@ class User < Principal
 
   # create new password if password was set
   def update_password
-    if password && ldap_auth_source_id.blank?
+    if password && ldap_auth_source_id.blank? && !password_login_disabled_by_sso?
       new_password = passwords.build(type: UserPassword.active_type.to_s)
       new_password.plain_password = password
       new_password.save
@@ -287,6 +287,9 @@ class User < Principal
     if user.ldap_auth_source
       # user has an external authentication method
       return nil unless user.ldap_auth_source.authenticate(user.login, password)
+    elsif user.password_login_disabled_by_sso?
+      Rails.logger.info { "Refused password login for #{user.login}, who authenticates through an OmniAuth provider." }
+      return nil
     else
       # authentication with local password
       return nil unless user.check_password?(password)
@@ -397,6 +400,7 @@ class User < Principal
     if ldap_auth_source.present?
       ldap_auth_source.authenticate(login, clear_password)
     else
+      return false if password_login_disabled_by_sso?
       return false if current_password.nil?
 
       current_password.matches_plaintext?(clear_password, update_legacy:)
@@ -406,6 +410,7 @@ class User < Principal
   # Does the backend storage allow this user to change their password?
   def change_password_allowed?
     return false if OpenProject::Configuration.disable_password_login?
+    return false if password_login_disabled_by_sso?
     return false if uses_external_authentication? && current_password.nil?
 
     ldap_auth_source_id.blank?
@@ -414,6 +419,15 @@ class User < Principal
   # Is the user authenticated via an external authentication source via OmniAuth?
   def uses_external_authentication?
     user_auth_provider_links.exists?
+  end
+
+  # Instances may forbid OmniAuth users from authenticating with a password, so that a password
+  # predating the OmniAuth link cannot be used to sidestep the provider (and its MFA).
+  def password_login_disabled_by_sso?
+    return false unless OpenProject::Configuration.disable_password_login_for_sso_users?
+    return false if password_login_sso_bypass?
+
+    uses_external_authentication?
   end
 
   #
@@ -726,6 +740,11 @@ class User < Principal
   end
 
   private
+
+  def password_login_sso_bypass?
+    login.present? &&
+      OpenProject::Configuration.password_login_sso_bypass_logins.any? { |exempt| exempt.casecmp?(login) }
+  end
 
   def system_non_working_dates_for_year(year)
     NonWorkingDay.for_year(year).pluck(:date).to_set

--- a/app/models/users/scopes/find_by_login.rb
+++ b/app/models/users/scopes/find_by_login.rb
@@ -38,6 +38,10 @@ module Users::Scopes
         where(["LOWER(login) = ?", login.to_s.downcase])
       end
 
+      def by_logins(logins)
+        where(["LOWER(login) IN (?)", Array(logins).map { it.to_s.downcase }])
+      end
+
       # Find a user scope by matching the exact login and then a case-insensitive
       # version. Exact matches will be given priority.
       def find_by_login(login)

--- a/app/views/admin/settings/authentication_settings/_sso.html.erb
+++ b/app/views/admin/settings/authentication_settings/_sso.html.erb
@@ -27,11 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<% bypass_user_ids = User.by_logins(Setting.password_login_sso_bypass_logins).pluck(:id) %>
+
 <% with_enterprise_banner_guard(:sso_auth_providers, variant: :large, video: "enterprise/sso-login.mp4") do %>
   <%=
-    settings_primer_form_with(scope: :settings,
-                              url: admin_settings_authentication_path(tab: params[:tab]),
-                              method: :patch) do |f|
+    settings_primer_form_with(
+      scope: :settings,
+      url: admin_settings_authentication_path(tab: params[:tab]),
+      method: :patch
+    ) do |f|
       render_inline_settings_form(f) do |form|
         form.select_list(
           name: :omniauth_direct_login_provider,
@@ -60,6 +64,39 @@ See COPYRIGHT and LICENSE files for more details.
         form.check_box(
           name: :oauth_allow_remapping_of_existing_users,
           caption: I18n.t("settings.authentication.remapping_existing_users_hint")
+        )
+
+        form.check_box(
+          name: :disable_password_login_for_sso_users,
+          caption: I18n.t("settings.authentication.disable_password_login_for_sso_users_hint")
+        )
+
+        # The autocompleter submits nothing when cleared, so a blank entry keeps the key present
+        # and lets the list be emptied again.
+        form.hidden(
+          name: "settings[password_login_sso_bypass_logins][]",
+          value: "",
+          scope_name_to_model: false,
+          scope_id_to_model: false
+        )
+
+        form.autocompleter(
+          name: :password_login_sso_bypass_logins,
+          label: I18n.t(:setting_password_login_sso_bypass_logins),
+          caption: I18n.t("settings.authentication.password_login_sso_bypass_logins_hint"),
+          disabled: form.setting_disabled?(:password_login_sso_bypass_logins),
+          autocomplete_options: {
+            resource: "principals",
+            component: "opce-user-autocompleter",
+            url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals,
+            searchKey: "any_name_attribute",
+            filters: [{ name: "type", operator: "=", values: %w[User] }],
+            multiple: true,
+            defaultData: false,
+            focusDirectly: false,
+            disabled: form.setting_disabled?(:password_login_sso_bypass_logins),
+            inputValue: bypass_user_ids
+          }
         )
 
         form.submit

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -423,6 +423,11 @@ module Settings
         description: "Disable internal logins and instead only allow SSO through OmniAuth.",
         default: false
       },
+      disable_password_login_for_sso_users: {
+        description: "Disable password login for users linked to an OmniAuth provider, " \
+                     "so a leftover password cannot be used to bypass SSO.",
+        default: false
+      },
       display_subprojects_work_packages: {
         default: true
       },
@@ -846,6 +851,12 @@ module Settings
       },
       password_days_valid: {
         default: 0
+      },
+      password_login_sso_bypass_logins: {
+        description: "Logins exempt from disable_password_login_for_sso_users, " \
+                     "so they keep password login as a break-glass access.",
+        format: :array,
+        default: []
       },
       password_min_length: {
         default: 10,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5369,6 +5369,7 @@ en:
   setting_default_projects_public: "New projects are public by default"
   setting_diff_max_lines_displayed: "Max number of diff lines displayed"
   setting_disable_password_login: "Disable password authentication"
+  setting_disable_password_login_for_sso_users: "Disable password authentication for SSO users"
   setting_display_subprojects_work_packages: "Display subprojects work packages on main projects by default"
   setting_duration_format: "Duration format"
   setting_duration_format_days_and_hours: "Days and hours"
@@ -5416,6 +5417,7 @@ en:
   setting_password_active_rules: "Password requirements"
   setting_password_count_former_banned: "Number of most recently used passwords banned for reuse"
   setting_password_days_valid: "Number of days, after which to enforce a password change"
+  setting_password_login_sso_bypass_logins: "Users exempt from this restriction"
   setting_password_min_length: "Minimum length"
   setting_per_page_options: "Objects per page options"
   setting_percent_complete_on_status_closed: "% Complete when status is closed"
@@ -5573,6 +5575,10 @@ en:
         Leave empty to allow any file type to be uploaded.
         Multiple values allowed (one line for each value).
     authentication:
+      disable_password_login_for_sso_users_hint: >
+        If enabled, users that are linked to an identity provider can only sign in through that provider.
+        A password they may still have from before, for instance from being remapped to the provider,
+        is refused and can no longer be changed or recovered. Users without such a link keep their password login.
       login: "Login"
       omniauth_direct_login_hint_html: >
         If this option is active, login requests will redirect to the configured omniauth provider.
@@ -5580,6 +5586,9 @@ en:
         <br/>
         <strong>Note:</strong> Unless you also disable password logins, with this option enabled,
         users can still log in internally by visiting the <code>%{internal_path}</code> login page.
+      password_login_sso_bypass_logins_hint: >
+        Users selected here keep their password login even when they are linked to an identity provider,
+        so that you retain a way in if the provider becomes unavailable. Only applies while the option above is enabled.
       registration: "Registration"
       remapping_existing_users_hint: >
         If enabled, allows any configured identity provider to login existing users based on their username,

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -357,6 +357,8 @@ OPENPROJECT_SEED_DESIGN_EXPORT__COVER="..."
 - [`omniauth_direct_login_provider`](#omniauth-direct-login-provider) (default: nil)
 - [`oauth_allow_remapping_of_existing_users`](#prevent-omniauth-remapping-of-existing-users) (default: true)
 - [`disable_password_login`](#disable-password-login) (default: false)
+- [`disable_password_login_for_sso_users`](#disable-password-login-for-sso-users) (default: false)
+- [`password_login_sso_bypass_logins`](#disable-password-login-for-sso-users) (default: [])
 - [`attachments_storage`](#attachments-storage) (default: file)
 - [`direct_uploads`](#direct-uploads) (default: true)
 - [`fog_download_url_expires_in`](#fog-download-url-expires-in) (default: 21600)
@@ -509,6 +511,40 @@ _default: false_
 
 ```yaml
 OPENPROJECT_DISABLE__PASSWORD__LOGIN="true"
+```
+
+### Disable password login for SSO users
+
+Unlike `disable_password_login`, which switches off password authentication for the whole
+instance, this option only affects users that are linked to an omniauth provider.
+
+This matters when users existed before the provider was introduced, or when
+[remapping of existing users](#prevent-omniauth-remapping-of-existing-users) is enabled: such a
+user keeps the password they had before, and can keep using it to sign in — bypassing the
+provider and any MFA enforced there. Enabling this option refuses those password logins, and
+also removes the password change and password recovery options for the affected users, since
+their password can no longer be used.
+
+Users that are not linked to an omniauth provider are unaffected and keep their password login.
+
+Both options below are also available in the administration under *Authentication → Settings → Single
+Sign-On*. Setting them here takes precedence and renders them read-only in that form.
+
+_default: false_
+
+```yaml
+OPENPROJECT_DISABLE__PASSWORD__LOGIN__FOR__SSO__USERS="true"
+```
+
+Individual logins can be exempted, so that you keep a break-glass access in case the provider
+becomes unavailable. Logins are matched case-insensitively. This is deliberately a list of logins
+rather than user ids, so that you can still grant yourself access through the environment when
+nobody is able to reach the administration anymore.
+
+_default: []_
+
+```yaml
+OPENPROJECT_PASSWORD__LOGIN__SSO__BYPASS__LOGINS="[admin, breakglass]"
 ```
 
 ### Omniauth direct login provider

--- a/spec/controllers/admin/settings/authentication_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/authentication_settings_controller_spec.rb
@@ -92,5 +92,29 @@ RSpec.describe Admin::Settings::AuthenticationSettingsController do
         end
       end
     end
+
+    describe "password_login_sso_bypass_logins" do
+      shared_let(:bypass_user) { create(:user, login: "breakglass") }
+
+      it "stores the logins of the selected users" do
+        patch "update", params: { settings: { password_login_sso_bypass_logins: ["", bypass_user.id.to_s] } }
+
+        expect(Setting.password_login_sso_bypass_logins).to eq ["breakglass"]
+      end
+
+      it "clears the list when the autocompleter submits only its blank entry" do
+        Setting.password_login_sso_bypass_logins = ["breakglass"]
+
+        patch "update", params: { settings: { password_login_sso_bypass_logins: [""] } }
+
+        expect(Setting.password_login_sso_bypass_logins).to eq []
+      end
+
+      it "ignores ids that do not belong to a user" do
+        patch "update", params: { settings: { password_login_sso_bypass_logins: ["", "0"] } }
+
+        expect(Setting.password_login_sso_bypass_logins).to eq []
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -463,6 +463,55 @@ RSpec.describe User do
         expect(user).not_to be_change_password_allowed
       end
     end
+
+    context "for an external authentication user that still has a password" do
+      let(:provider) { create(:oidc_provider) }
+      let(:user) { create(:user, login: "sso_user", authentication_provider: provider) }
+
+      it "allows a password change so the leftover password can be rotated" do
+        expect(user).to be_change_password_allowed
+      end
+
+      context "with password login disabled for SSO users",
+              with_config: { disable_password_login_for_sso_users: true } do
+        it "does not allow a password change, as the password is unusable" do
+          expect(user).not_to be_change_password_allowed
+        end
+
+        context "and the user on the bypass list",
+                with_config: { password_login_sso_bypass_logins: ["sso_user"] } do
+          it "allows a password change" do
+            expect(user).to be_change_password_allowed
+          end
+        end
+      end
+    end
+  end
+
+  describe "#update_password" do
+    let(:provider) { create(:oidc_provider) }
+
+    context "with password login disabled for SSO users",
+            with_config: { disable_password_login_for_sso_users: true } do
+      it "does not store a password for a user linked to an OmniAuth provider" do
+        user = create(:user, :passwordless, login: "sso_user", authentication_provider: provider)
+
+        user.update!(password: "pwd123Password!", password_confirmation: "pwd123Password!")
+
+        expect(user.passwords).to be_empty
+      end
+
+      context "and the user on the bypass list",
+              with_config: { password_login_sso_bypass_logins: ["sso_user"] } do
+        it "stores a password" do
+          user = create(:user, :passwordless, login: "sso_user", authentication_provider: provider)
+
+          user.update!(password: "pwd123Password!", password_confirmation: "pwd123Password!")
+
+          expect(user.passwords).not_to be_empty
+        end
+      end
+    end
   end
 
   describe "#watches" do
@@ -540,6 +589,41 @@ RSpec.describe User do
     end
   end
 
+  describe "#password_login_disabled_by_sso?" do
+    let(:provider) { create(:oidc_provider) }
+    let(:user) { create(:user, login: "sso_user", authentication_provider: provider) }
+
+    context "when the setting is disabled" do
+      it "is false even for an OmniAuth user" do
+        expect(user).not_to be_password_login_disabled_by_sso
+      end
+    end
+
+    context "when the setting is enabled", with_config: { disable_password_login_for_sso_users: true } do
+      it "is true for an OmniAuth user" do
+        expect(user).to be_password_login_disabled_by_sso
+      end
+
+      it "is false for a user without an OmniAuth link" do
+        expect(create(:user)).not_to be_password_login_disabled_by_sso
+      end
+
+      context "and the user is on the bypass list",
+              with_config: { password_login_sso_bypass_logins: ["SSO_User"] } do
+        it "is false, matching the login case-insensitively" do
+          expect(user).not_to be_password_login_disabled_by_sso
+        end
+      end
+
+      context "and another login is on the bypass list",
+              with_config: { password_login_sso_bypass_logins: ["someone_else"] } do
+        it "is true" do
+          expect(user).to be_password_login_disabled_by_sso
+        end
+      end
+    end
+  end
+
   describe "user create with empty password" do
     let(:user) { described_class.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo") }
 
@@ -580,10 +664,11 @@ RSpec.describe User do
   describe "#try_authentication_for_existing_user" do
     def build_user_double_with_expired_password(is_expired)
       user_double = double("User")
-      allow(user_double).to receive(:check_password?).and_return(true)
-      allow(user_double).to receive(:active?).and_return(true)
-      allow(user_double).to receive(:ldap_auth_source).and_return(nil)
-      allow(user_double).to receive(:force_password_change).and_return(false)
+      allow(user_double).to receive_messages(check_password?: true,
+                                             active?: true,
+                                             ldap_auth_source: nil,
+                                             password_login_disabled_by_sso?: false,
+                                             force_password_change: false)
 
       # check for expired password should always happen
       expect(user_double).to receive(:password_expired?) { is_expired }
@@ -1016,6 +1101,35 @@ RSpec.describe User do
       it "returns the user" do
         expect(described_class.try_to_login(login, new_password))
           .to eq user
+      end
+    end
+
+    context "with the user having been remapped to an OmniAuth provider" do
+      let(:provider) { create(:oidc_provider) }
+
+      before do
+        user.user_auth_provider_links.create!(auth_provider: provider, external_id: "external-id")
+      end
+
+      it "still accepts the password while the setting is disabled" do
+        expect(described_class.try_to_login(login, password))
+          .to eq user
+      end
+
+      context "with password login disabled for SSO users",
+              with_config: { disable_password_login_for_sso_users: true } do
+        it "refuses the password" do
+          expect(described_class.try_to_login(login, password))
+            .to be_nil
+        end
+
+        context "and the login on the bypass list",
+                with_config: { password_login_sso_bypass_logins: ["the_login"] } do
+          it "accepts the password" do
+            expect(described_class.try_to_login(login, password))
+              .to eq user
+          end
+        end
       end
     end
   end

--- a/spec/requests/admin/settings/authentication_settings_spec.rb
+++ b/spec/requests/admin/settings/authentication_settings_spec.rb
@@ -69,6 +69,27 @@ RSpec.describe "Authentication Settings",
     end
   end
 
+  describe "GET /admin/settings/authentication?tab=sso", with_ee: %i[sso_auth_providers] do
+    let!(:bypass_user) { create(:user, login: "breakglass") }
+
+    before do
+      Setting.password_login_sso_bypass_logins = ["BreakGlass"]
+      get "/admin/settings/authentication.html?tab=sso"
+    end
+
+    it "shows the SSO password restriction settings" do
+      expect(response).to have_http_status(:success)
+
+      expect(page).to have_field(I18n.t(:setting_disable_password_login_for_sso_users), disabled: false)
+    end
+
+    it "preselects the exempt users, resolving the stored logins case-insensitively" do
+      input_value = page.find("opce-user-autocompleter")["data-input-value"]
+
+      expect(JSON.parse(input_value)).to eq [bypass_user.id]
+    end
+  end
+
   describe "PATCH /admin/settings/authentication?tab=passwords" do
     context "when all password requirement checkboxes are unchecked" do
       before do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/SC-99

# What are you trying to accomplish?
- Add a new setting to disable password login for SSO users
- Add a new setting to bypass that for specific users (i.e. allow an admin to login via password when SSO config becomes stale)
- Enforce setting when logging in and changing password

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
