### PR TITLE
[COMMS-938] Allow to search for "#<semantic WP ID>"

### DIFF
--- a/app/models/queries/work_packages/filter/typeahead_filter.rb
+++ b/app/models/queries/work_packages/filter/typeahead_filter.rb
@@ -47,9 +47,12 @@ class Queries::WorkPackages::Filter::TypeaheadFilter <
   def conditions_for(part)
     conditions = [subject_condition(part),
                   project_name_condition(part),
-                  work_package_identifier_condition(part),
                   type_name_condition(part),
                   status_condition(part)]
+
+    if (match = part.match(/\A(#)?(#{Projects::Identifier::SEMANTIC_FORMAT.source}-?\d*)\z/i))
+      conditions << work_package_identifier_condition(match[2])
+    end
 
     if (match = part.match(/\A(#)?(\d+)\z/))
       conditions << id_or_sequence_number_condition(hash_prefixed: match[1].present?, search_term: match[2])

--- a/app/models/queries/work_packages/filter/typeahead_filter.rb
+++ b/app/models/queries/work_packages/filter/typeahead_filter.rb
@@ -44,21 +44,21 @@ class Queries::WorkPackages::Filter::TypeaheadFilter <
     parts.map { |part| "(#{conditions_for(part).join(' OR ')})" }.join(" AND ")
   end
 
-  def conditions_for(part)
+  def conditions_for(part) # rubocop:disable Metrics/AbcSize
     conditions = [subject_condition(part),
                   project_name_condition(part),
                   type_name_condition(part),
                   status_condition(part)]
 
     if (match = part.match(/\A(#)?(#{Projects::Identifier::SEMANTIC_FORMAT.source}-?\d*)\z/i))
-      conditions << work_package_identifier_condition(match[2])
+      conditions << work_package_identifier_condition(hash_prefixed: match[1].present?, search_term: match[2])
     end
 
     if (match = part.match(/\A(#)?(\d+)\z/))
       conditions << id_or_sequence_number_condition(hash_prefixed: match[1].present?, search_term: match[2])
     end
 
-    conditions
+    conditions.compact
   end
 
   def subject_condition(string)
@@ -67,14 +67,6 @@ class Queries::WorkPackages::Filter::TypeaheadFilter <
 
   def project_name_condition(string)
     Queries::Operators::Contains.sql_for_field([string], Project.table_name, "name")
-  end
-
-  def work_package_identifier_condition(string)
-    alias_condition = Queries::Operators::StartsWith.sql_for_field(
-      [string], WorkPackageSemanticAlias.table_name, "identifier"
-    )
-    "#{WorkPackage.table_name}.id IN " \
-      "(SELECT work_package_id FROM #{WorkPackageSemanticAlias.table_name} WHERE #{alias_condition})"
   end
 
   def type_name_condition(string)
@@ -97,6 +89,16 @@ class Queries::WorkPackages::Filter::TypeaheadFilter <
       # Match statuses by name
       Queries::Operators::Contains.sql_for_field([string], Status.table_name, "name")
     end
+  end
+
+  def work_package_identifier_condition(hash_prefixed:, search_term:)
+    return unless Setting::WorkPackageIdentifier.semantic? || hash_prefixed
+
+    alias_condition = Queries::Operators::StartsWith.sql_for_field(
+      [search_term], WorkPackageSemanticAlias.table_name, "identifier"
+    )
+    "#{WorkPackage.table_name}.id IN " \
+      "(SELECT work_package_id FROM #{WorkPackageSemanticAlias.table_name} WHERE #{alias_condition})"
   end
 
   def id_or_sequence_number_condition(hash_prefixed:, search_term:)

--- a/app/models/queries/work_packages/selects/exact_match_select.rb
+++ b/app/models/queries/work_packages/selects/exact_match_select.rb
@@ -65,18 +65,13 @@ class Queries::WorkPackages::Selects::ExactMatchSelect < Queries::WorkPackages::
     stripped = query_string.to_s.strip
     return nil if stripped.blank? || stripped.match?(/\s/)
 
+    hash_prefixed = stripped.start_with?("#")
     candidate = stripped.delete_prefix("#")
     condition =
       if candidate.match?(/\A[1-9]\d*\z/)
-        numeric_exact_match_condition(candidate, hash_prefixed: stripped.start_with?("#"))
+        numeric_exact_match_condition(candidate, hash_prefixed:)
       elsif candidate.match?(/\A#{WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN.source}\z/i)
-        # So far, semantic identifiers are always upper case.
-        # We can leverage this to match in a way that allows index usage.
-        OpenProject::SqlSanitization.sanitize(
-          "#{WorkPackage.table_name}.id IN (SELECT work_package_id FROM " \
-          "#{WorkPackageSemanticAlias.table_name} WHERE identifier = ?)",
-          candidate.upcase
-        )
+        semantic_exact_match_condition(candidate, hash_prefixed:)
       end
 
     return nil unless condition
@@ -94,5 +89,17 @@ class Queries::WorkPackages::Selects::ExactMatchSelect < Queries::WorkPackages::
         "#{WorkPackage.table_name}.sequence_number = ?", candidate.to_i
       )
     end
+  end
+
+  def self.semantic_exact_match_condition(candidate, hash_prefixed:)
+    return nil unless Setting::WorkPackageIdentifier.semantic? || hash_prefixed
+
+    # So far, semantic identifiers are always upper case.
+    # We can leverage this to match in a way that allows index usage.
+    OpenProject::SqlSanitization.sanitize(
+      "#{WorkPackage.table_name}.id IN (SELECT work_package_id FROM " \
+      "#{WorkPackageSemanticAlias.table_name} WHERE identifier = ?)",
+      candidate.upcase
+    )
   end
 end

--- a/app/models/queries/work_packages/selects/exact_match_select.rb
+++ b/app/models/queries/work_packages/selects/exact_match_select.rb
@@ -69,13 +69,13 @@ class Queries::WorkPackages::Selects::ExactMatchSelect < Queries::WorkPackages::
     condition =
       if candidate.match?(/\A[1-9]\d*\z/)
         numeric_exact_match_condition(candidate, hash_prefixed: stripped.start_with?("#"))
-      elsif stripped.match?(/\A#{WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN.source}\z/i)
+      elsif candidate.match?(/\A#{WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN.source}\z/i)
         # So far, semantic identifiers are always upper case.
         # We can leverage this to match in a way that allows index usage.
         OpenProject::SqlSanitization.sanitize(
           "#{WorkPackage.table_name}.id IN (SELECT work_package_id FROM " \
           "#{WorkPackageSemanticAlias.table_name} WHERE identifier = ?)",
-          stripped.upcase
+          candidate.upcase
         )
       end
 

--- a/modules/boards/spec/features/board_reference_work_package_ranking_spec.rb
+++ b/modules/boards/spec/features/board_reference_work_package_ranking_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Board 'Add existing work package' ranks exact matches first",
     page.find(".menu-item", text: "Add existing").click
 
     dropdown = search_autocomplete(page.find("ng-select.wp-inline-create--reference-autocompleter"),
-                                   query: "BOARDRANK-5",
+                                   query: "#BOARDRANK-5",
                                    results_selector: "body")
 
     within(dropdown) do

--- a/spec/features/work_packages/table/queries/id_filter_ranking_spec.rb
+++ b/spec/features/work_packages/table/queries/id_filter_ranking_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Work package filtering by id ranks exact matches first", :js, :s
 
   it "shows the exact identifier match first in the dropdown, despite being older" do
     dropdown = search_autocomplete(page.find_by_id("values-id"),
-                                   query: "IDFILTER-5",
+                                   query: "#IDFILTER-5",
                                    results_selector: "body")
 
     within(dropdown) do

--- a/spec/features/work_packages/table/queries/parent_ancestor_filter_ranking_spec.rb
+++ b/spec/features/work_packages/table/queries/parent_ancestor_filter_ranking_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Work package filtering by Parent/Ancestor ranks exact matches fi
     filters.add_filter("Parent")
 
     dropdown = search_autocomplete(page.find_by_id("values-parent"),
-                                   query: "PARENTFILTER-5",
+                                   query: "#PARENTFILTER-5",
                                    results_selector: "body")
 
     within(dropdown) do
@@ -87,7 +87,7 @@ RSpec.describe "Work package filtering by Parent/Ancestor ranks exact matches fi
     filters.add_filter("Descendants of")
 
     dropdown = search_autocomplete(page.find_by_id("values-ancestor"),
-                                   query: "PARENTFILTER-5",
+                                   query: "#PARENTFILTER-5",
                                    results_selector: "body")
 
     within(dropdown) do

--- a/spec/features/work_packages/table/queries/parent_field_ranking_spec.rb
+++ b/spec/features/work_packages/table/queries/parent_field_ranking_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Work package Parent field ranks exact matches first", :js, :sele
     field = wp_table.edit_field(child_work_package, :parent)
     field.activate!
 
-    dropdown = field.autocomplete("PARENTFIELD-5", select: false)
+    dropdown = field.autocomplete("#PARENTFIELD-5", select: false)
 
     within(dropdown) do
       # The first option is always a "-" (clear/no-parent) entry, unrelated to ranking.

--- a/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
@@ -352,11 +352,20 @@ RSpec.describe Queries::WorkPackages::Filter::TypeaheadFilter do
                identifier: "PHO-2")
       end
 
-      context "and there are still entries in the semantic alias registry" do
-        let(:values) { [identifier_work_package1_semantic_alias.identifier] }
+      context "when searching by a semantic identifier prefixed with '#'" do
+        let(:values) { ["##{identifier_work_package1_semantic_alias.identifier}"] }
 
         it "still finds by existing identifiers" do
           expect(subject).to include(identifier_work_package1)
+          expect(subject).not_to include(identifier_work_package2)
+        end
+      end
+
+      context "when searching by a semantic identifier not prefixed with '#'" do
+        let(:values) { [identifier_work_package1_semantic_alias.identifier] }
+
+        it "does not find by existing identifiers" do
+          expect(subject).not_to include(identifier_work_package1)
           expect(subject).not_to include(identifier_work_package2)
         end
       end

--- a/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
@@ -254,6 +254,15 @@ RSpec.describe Queries::WorkPackages::Filter::TypeaheadFilter do
         end
       end
 
+      context "when searching by work package identifier prefixed with a hash" do
+        let(:values) { ["##{identifier_work_package1.identifier}"] }
+
+        it "returns work packages with matching identifier" do
+          expect(subject).to include(identifier_work_package1)
+          expect(subject).not_to include(identifier_work_package2)
+        end
+      end
+
       context "when searching for partial identifier" do
         let(:values) { [project.identifier] }
 

--- a/spec/models/queries/work_packages/selects/exact_match_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/exact_match_select_spec.rb
@@ -121,34 +121,46 @@ RSpec.describe Queries::WorkPackages::Selects::ExactMatchSelect do
       end
       let(:query_string) { "COM-5" }
 
-      it "ranks the exact identifier match above one that only shares the prefix" do
-        expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
-          .to eq(exact_work_package.id)
-      end
-
-      context "when the query is given in lower case" do
-        let(:query_string) { "com-5" }
-
-        it "still matches COM-5" do
+      context "and the instance is in semantic identifier mode",
+              with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::SEMANTIC } do
+        it "ranks the exact identifier match above one that only shares the prefix" do
           expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
             .to eq(exact_work_package.id)
         end
-      end
 
-      context "when matching a historical alias in classic mode",
-              with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::CLASSIC } do
-        it "still matches through the alias table" do
-          expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
-            .to eq(exact_work_package.id)
+        context "when the query is given in lower case" do
+          let(:query_string) { "com-5" }
+
+          it "still matches COM-5" do
+            expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
+              .to eq(exact_work_package.id)
+          end
+        end
+
+        context "when the query is hash-prefixed" do
+          let(:query_string) { "#COM-5" }
+
+          it "still ranks the exact identifier match above one that only shares the prefix" do
+            expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
+              .to eq(exact_work_package.id)
+          end
         end
       end
 
-      context "when the query is hash-prefixed" do
-        let(:query_string) { "#COM-5" }
+      context "and the instance is in classic identifier mode" do
+        context "when the query is hash-prefixed" do
+          let(:query_string) { "#COM-5" }
 
-        it "still ranks the exact identifier match above one that only shares the prefix" do
-          expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
-            .to eq(exact_work_package.id)
+          it "still ranks the exact identifier match above one that only shares the prefix" do
+            expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
+              .to eq(exact_work_package.id)
+          end
+        end
+
+        context "when the query is not hash-prefixed" do
+          let(:query_string) { "COM-5" }
+
+          it { is_expected.to be_nil }
         end
       end
     end

--- a/spec/models/queries/work_packages/selects/exact_match_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/exact_match_select_spec.rb
@@ -142,6 +142,15 @@ RSpec.describe Queries::WorkPackages::Selects::ExactMatchSelect do
             .to eq(exact_work_package.id)
         end
       end
+
+      context "when the query is hash-prefixed" do
+        let(:query_string) { "#COM-5" }
+
+        it "still ranks the exact identifier match above one that only shares the prefix" do
+          expect(ranked_ids([exact_work_package.id, prefix_work_package.id]).first)
+            .to eq(exact_work_package.id)
+        end
+      end
     end
   end
 end

--- a/spec/models/query/sort_criteria_spec.rb
+++ b/spec/models/query/sort_criteria_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Query::SortCriteria do
       context "when a typeahead filter is active on the query" do
         let(:query) do
           build_stubbed(:query, show_hierarchies: false).tap do |q|
-            q.add_filter(:typeahead, "**", "COM-5")
+            q.add_filter(:typeahead, "**", "#COM-5")
           end
         end
 

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
 
     describe "relation candidates for wp1 (in hierarchy) with exact_match sorting" do
       let(:href) do
-        "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=RELCAND-5" \
+        "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=%23RELCAND-5" \
           "&sortBy=[[\"exactMatch\",\"desc\"],[\"updatedAt\",\"desc\"]]"
       end
 

--- a/spec/requests/api/v3/work_packages/index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/index_resource_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "API v3 Work package resource",
           {
             typeahead: {
               operator: "**",
-              values: "COM-5"
+              values: "#COM-5"
             }
           }
         ]


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-938

# What are you trying to accomplish?
Searching for "#PROJ-11" should lead to the same result as searching for "PROJ-11".

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
