### PR TITLE
Always show project wiki settings

### DIFF
--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -27,26 +27,31 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= component_wrapper(class: "op-admin-settings-form-wrapper") do %>
-  <% if globally_disabled? %>
-    <%= render(Primer::Alpha::Banner.new(mb: 3)) { t(".globally_disabled_hint") } %>
-  <% end %>
-
+<% if globally_disabled? %>
   <%=
-    render(
-      Primer::Forms::ToggleSwitchForm.new(
-        name: "enable_interal_wiki",
-        label: t(".enable"),
-        caption: t(".caption"),
-        src: project_settings_wiki_path(@project),
-        csrf_token: form_authenticity_token,
-        status_label_position: :start,
-        checked: wiki_enabled?,
-        enabled: !globally_disabled?,
-        data: { turbo: true },
-        mb: 3,
-        test_selector: "project-settings-enable-wiki"
-      )
-    )
+    render(Primer::Beta::Blankslate.new(border: true)) do |component|
+      component.with_visual_icon(icon: :book)
+      component.with_heading(tag: :h2) { t(".blankslate_title") }
+      component.with_description { t(".blankslate_description") }
+    end
   %>
+<% else %>
+  <%= component_wrapper(class: "op-admin-settings-form-wrapper") do %>
+    <%=
+      render(
+        Primer::Forms::ToggleSwitchForm.new(
+          name: "enable_interal_wiki",
+          label: t(".enable"),
+          caption: t(".caption"),
+          src: project_settings_wiki_path(@project),
+          csrf_token: form_authenticity_token,
+          status_label_position: :start,
+          checked: wiki_enabled?,
+          data: { turbo: true },
+          mb: 3,
+          test_selector: "project-settings-enable-wiki"
+        )
+      )
+    %>
+  <% end %>
 <% end %>

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.html.erb
@@ -28,6 +28,10 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= component_wrapper(class: "op-admin-settings-form-wrapper") do %>
+  <% if globally_disabled? %>
+    <%= render(Primer::Alpha::Banner.new(mb: 3)) { t(".globally_disabled_hint") } %>
+  <% end %>
+
   <%=
     render(
       Primer::Forms::ToggleSwitchForm.new(
@@ -38,6 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
         csrf_token: form_authenticity_token,
         status_label_position: :start,
         checked: wiki_enabled?,
+        enabled: !globally_disabled?,
         data: { turbo: true },
         mb: 3,
         test_selector: "project-settings-enable-wiki"

--- a/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
+++ b/modules/wikis/app/components/wikis/project_settings/project_internal_wiki_component.rb
@@ -42,6 +42,8 @@ module Wikis
       def wiki_enabled?
         !!@project.wiki&.enabled?
       end
+
+      def globally_disabled? = !Wikis::InternalProvider.enabled?
     end
   end
 end

--- a/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
+++ b/modules/wikis/app/controllers/wikis/project_settings/wiki_controller.rb
@@ -48,7 +48,7 @@ module Wikis
       private
 
       def new_or_changed_wiki
-        @wiki = Wiki.find_or_initialize_by(project: @project, start_page: "Wiki")
+        @wiki = Wiki.find_or_initialize_by(project: @project) { |w| w.start_page = "Wiki" }
         @wiki.enabled = params.require(:value) unless @wiki.new_record?
 
         @wiki

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -217,6 +217,7 @@ en:
           This enables native wiki functionality for this project. Members will be able to create and read wiki pages
           that are stored in OpenProject.
         enable: Enable the internal wiki for this project
+        globally_disabled_hint: Project wikis were disabled globally on this OpenProject instance. Thus you can't enable it in this project.
     provider_types:
       xwiki:
         name: XWiki

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -213,11 +213,12 @@ en:
         parent: As parent
     project_settings:
       project_internal_wiki_component:
+        blankslate_description: For this instance, project wikis are disabled globally and therefore can’t be enabled per project. Please, ask your administrator to enable the global wikis in the administration settings.
+        blankslate_title: Project wikis are disabled globally
         caption: >-
           This enables native wiki functionality for this project. Members will be able to create and read wiki pages
           that are stored in OpenProject.
         enable: Enable the internal wiki for this project
-        globally_disabled_hint: Project wikis were disabled globally on this OpenProject instance. Thus you can't enable it in this project.
     provider_types:
       xwiki:
         name: XWiki

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -194,7 +194,6 @@ module OpenProject::Wikis
            :settings_project_wiki,
            { controller: "/wikis/project_settings/wiki", action: :show },
            parent: :settings,
-           if: ->(_) { Wikis::InternalProvider.enabled? }, # What to do on projects that have a wiki but later disabled it?
            after: :settings_backlogs,
            caption: :project_module_wiki_internal
     end


### PR DESCRIPTION
Even if project wikis have been disabled globally, we'll show their settings menu and disable controls while showing a hint on why controls have been disabled.

# Ticket
https://community.openproject.org/wp/XWI-154