### PR TITLE
[AGILE-297] Sprint goal on sprint report page

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_reports/widgets/goal.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_reports/widgets/goal.html.erb
@@ -27,11 +27,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t("backlogs.sprint_reports.page_header_component.title", sprint: @sprint.name) %>
-
-<%= render(Backlogs::SprintReports::PageHeaderComponent.new(sprint: @sprint, project: @project)) %>
-
-<%= render(Grids::WidgetGridComponent.new) do |grid| %>
-  <% grid.with_widget(Backlogs::SprintReports::Widgets::Goal, @sprint, @project) %>
-  <% grid.with_widget(Backlogs::SprintReports::Widgets::BurndownChart, @sprint, @project) %>
-<% end %>
+<%=
+  widget_wrapper do |container|
+    container.with_body do
+      render(Primer::Beta::Text.new(tag: :p, mb: 0)) { goal_text }
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/sprint_reports/widgets/goal.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_reports/widgets/goal.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  module SprintReports
+    module Widgets
+      class Goal < Grids::WidgetComponent
+        include Backlogs::CommonHelper
+
+        param :sprint
+        param :project
+
+        def title
+          Sprint.human_attribute_name(:goal)
+        end
+
+        def wrapper_arguments
+          { full_width: true }
+        end
+
+        def render? = goal_text.present? && user_allowed?(:view_sprints)
+
+        private
+
+        def goal_text
+          return @goal_text if defined?(@goal_text)
+
+          @goal_text = sprint.goal_text_for(project)
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/sprint_reports/widgets/goal_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_reports/widgets/goal_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::SprintReports::Widgets::Goal, type: :component do
+  shared_let(:project) { create(:project) }
+  shared_let(:sprint) { create(:sprint, project:) }
+  shared_let(:user) { create(:user, member_with_permissions: { project => %i[view_sprints] }) }
+
+  current_user { user }
+
+  subject(:rendered_component) { render_inline(described_class.new(sprint, project)) }
+
+  context "when the sprint has a goal for the project" do
+    before { create(:sprint_goal, sprint:, project:, text: "Add sprint goal widget") }
+
+    it "renders the goal text under the widget title" do
+      expect(rendered_component).to have_text(Sprint.human_attribute_name(:goal))
+      expect(rendered_component).to have_text("Add sprint goal widget")
+    end
+  end
+
+  context "when the sprint has no goal for the project" do
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
+  end
+
+  context "when the sprint only has a goal for another project" do
+    shared_let(:other_project) { create(:project) }
+
+    before { create(:sprint_goal, sprint:, project: other_project, text: "Goal of the other project") }
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
+  end
+
+  context "when the user lacks the view_sprints permission" do
+    let(:user) { create(:user, member_with_permissions: { project => [] }) }
+
+    before { create(:sprint_goal, sprint:, project:, text: "Add sprint goal widget") }
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
+  end
+end

--- a/modules/backlogs/spec/features/backlogs/sprint_reports/show_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/sprint_reports/show_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Sprint report page", :js, with_flag: :sprint_reports do
            finish_date: Date.tomorrow,
            status: :active)
   end
+  shared_let(:sprint_goal) { create(:sprint_goal, sprint:, project:, text: "Add sprint goal widget") }
 
   let(:permissions) { %i[view_sprints view_work_packages show_board_views] }
 
@@ -73,8 +74,14 @@ RSpec.describe "Sprint report page", :js, with_flag: :sprint_reports do
   describe "widget area" do
     before { visit_sprint_report }
 
-    it "renders the burndown chart widget" do
-      expect(page).to have_element(:"opce-burndown-chart")
+    let(:widget_boxes) { page.all(".widget-boxes .widget-box", minimum: 2) }
+
+    it "renders the sprint goal widget first" do
+      expect(widget_boxes[0]).to have_text("Add sprint goal widget")
+    end
+
+    it "renders the burndown chart widget second" do
+      expect(widget_boxes[1]).to have_css("opce-burndown-chart")
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-297

# What are you trying to accomplish?
Add widget showing sprint goal

## Screenshots
<img width="307" height="113" alt="image" src="https://github.com/user-attachments/assets/c69c4e4c-6d0a-4eb7-8cf5-5f2ee02d517c" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
