### PR TITLE
[OP-18140] Materialise visible id sets for single-embed semi-joins

### DIFF
--- a/app/models/capabilities/scopes/visible.rb
+++ b/app/models/capabilities/scopes/visible.rb
@@ -38,7 +38,7 @@ module Capabilities::Scopes
                   all
                 else
                   where(context_id: nil)
-                    .or(where(context_id: Project.visible(user).select(:id)))
+                    .or(where(context_id: Project.visible_ids(user)))
                 end
 
         scope.where(principal_id: Principal.visible(user).not_builtin.not_locked)

--- a/app/models/members/scopes/visible.rb
+++ b/app/models/members/scopes/visible.rb
@@ -63,7 +63,7 @@ module Members::Scopes
       # Work package shares the user may list, limited to entities they can view.
       def shared_work_package_members(user)
         view_shared_work_packages_projects = Project.allowed_to(user, :view_shared_work_packages)
-        visible_shared_work_package_ids = WorkPackage.visible(user).select(:id)
+        visible_shared_work_package_ids = WorkPackage.visible_ids(user)
 
         where(project_id: view_shared_work_packages_projects.select(:id), entity_type: WorkPackage.name)
           .where(entity_id: visible_shared_work_package_ids)

--- a/app/models/notifications/scopes/visible.rb
+++ b/app/models/notifications/scopes/visible.rb
@@ -40,7 +40,7 @@ module Notifications::Scopes
       # As currently only notifications for work packages exist, the implementation is work package specific.
       def visible(user)
         recipient(user)
-          .where(resource_type: "WorkPackage", resource_id: WorkPackage.visible(user).select(:id))
+          .where(resource_type: "WorkPackage", resource_id: WorkPackage.visible_ids(user))
       end
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -199,7 +199,7 @@ class Project < ApplicationRecord
   }
   scope :public_projects, -> { where(public: true) }
   scope :with_visible_work_packages, ->(user = User.current) do
-    where(id: WorkPackage.visible(user).select(:project_id)).or(allowed_to(user, :view_work_packages))
+    where(id: WorkPackage.visible_ids(user, column: :project_id)).or(allowed_to(user, :view_work_packages))
   end
   scope :newest, -> { order(created_at: :desc) }
   scope :active, -> { where(active: true) }

--- a/app/models/projects/scopes/visible.rb
+++ b/app/models/projects/scopes/visible.rb
@@ -46,6 +46,31 @@ module Projects::Scopes
           active.public_projects.or(active.where(id: user.members.select(:project_id)))
         end
       end
+
+      # Ids of the projects visible to +user+, for use as a semi-join operand:
+      # +where(project_id: Project.visible_ids(user))+.
+      #
+      # With +shared_permissions_cte+ on, the set is wrapped in an +AS MATERIALIZED+
+      # CTE and built once instead of re-derived per row; off, it is the plain
+      # +visible(user).select(:id)+ subquery. Both return the same ids. The nested
+      # inner CTE only carries the materialization hint (see
+      # +WorkPackages::Scopes::AllowedTo.visible_ids+).
+      def visible_ids(user = User.current)
+        ids = visible(user).select(:id)
+
+        return ids unless OpenProject::FeatureDecisions.shared_permissions_cte_active?
+
+        visible_projects = Arel::Table.new(:visible_projects)
+
+        with(visible_projects: Arel.sql(<<~SQL.squish))
+          WITH materialized_visible_projects AS MATERIALIZED (
+            #{ids.to_sql}
+          )
+          SELECT id FROM materialized_visible_projects
+        SQL
+          .select(visible_projects[:id])
+          .from(visible_projects)
+      end
     end
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -40,7 +40,7 @@ class Reminder < ApplicationRecord
   # and who still has access to the remindable.
   def self.visible(user)
     where(creator: user)
-      .where(remindable_type: WorkPackage.name, remindable_id: WorkPackage.visible(user).select(:id))
+      .where(remindable_type: WorkPackage.name, remindable_id: WorkPackage.visible_ids(user))
   end
 
   def self.upcoming_and_visible_to(user)

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -51,6 +51,35 @@ module WorkPackages::Scopes
         end
       end
 
+      # Ids of the work packages visible to +user+, for use as a semi-join operand:
+      # +where(resource_id: WorkPackage.visible_ids(user))+. +column:+ projects a
+      # different column (e.g. +:project_id+) and is validated, since it lands in
+      # the CTE's SELECT list.
+      #
+      # With +shared_permissions_cte+ on, the set is wrapped in an +AS MATERIALIZED+
+      # CTE and built once with a real cardinality instead of re-derived per row;
+      # off, it is the plain subquery. Both return the same ids. The nested inner
+      # CTE only carries the materialization hint — see the rails/rails#54322 note
+      # in +logged_in_non_admin_allowed_to+.
+      def visible_ids(user, column: :id)
+        raise ArgumentError, "unknown column #{column.inspect}" unless column_names.include?(column.to_s)
+
+        ids = visible(user).select(column)
+
+        return ids unless OpenProject::FeatureDecisions.shared_permissions_cte_active?
+
+        visible_work_packages = Arel::Table.new(:visible_work_packages)
+
+        with(visible_work_packages: Arel.sql(<<~SQL.squish))
+          WITH materialized_visible_work_packages AS MATERIALIZED (
+            #{ids.to_sql}
+          )
+          SELECT #{column} FROM materialized_visible_work_packages
+        SQL
+          .select(visible_work_packages[column])
+          .from(visible_work_packages)
+      end
+
       private
 
       def admin_allowed_to(permissions)

--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -59,3 +59,8 @@ OpenProject::FeatureDecisions.add :type_variants,
 OpenProject::FeatureDecisions.add :sprint_reports,
                                   description: "Enables sprint reporting within the backlogs module. " \
                                                "It shows a dashboard with various widgets regarding the sprint progress."
+
+OpenProject::FeatureDecisions.add :shared_permissions_cte,
+                                  description: "OP-18140: materialise the per-user visible id set in a single CTE where it " \
+                                               "is embedded once as a semi-join, so the planner is given a concrete " \
+                                               "cardinality instead of a user-independent heuristic. Kill-switch."

--- a/spec/models/authorization/authorization_visibility_equivalence_spec.rb
+++ b/spec/models/authorization/authorization_visibility_equivalence_spec.rb
@@ -1,0 +1,375 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Security equivalence / characterization harness for permission visibility.
+#
+# Pins CURRENT permission-SQL result sets so a future refactor
+# (shared CTE, memoization, etc.) can assert identical id sets for a matrix of
+# users × roles × project visibility × module state.
+#
+# When a flag-gated alternative exists, compare old vs new by calling both
+# implementations on the same matrix (not only these hand-written expectations).
+
+RSpec.describe Authorization, "permission visibility equivalence harness" do
+  shared_let(:type) { create(:type_standard) }
+  shared_let(:status) { create(:status) }
+
+  shared_let(:private_project) { create(:project, public: false, enabled_module_names: %i[work_package_tracking costs]) }
+  shared_let(:public_project) { create(:project, public: true, enabled_module_names: %i[work_package_tracking costs]) }
+  shared_let(:private_no_costs) { create(:project, public: false, enabled_module_names: %i[work_package_tracking]) }
+  # Costs enabled so it can hold a decoy time entry: admins see it (module gated),
+  # but non-members must not — proving exclusion is by membership, not just module.
+  shared_let(:decoy_project) { create(:project, public: false, enabled_module_names: %i[work_package_tracking costs]) }
+
+  shared_let(:wp_private) { create(:work_package, project: private_project, type:, status:) }
+  shared_let(:wp_public) { create(:work_package, project: public_project, type:, status:) }
+  shared_let(:wp_private_no_costs) { create(:work_package, project: private_no_costs, type:, status:) }
+  shared_let(:wp_other_in_private) { create(:work_package, project: private_project, type:, status:) }
+  shared_let(:wp_decoy) { create(:work_package, project: decoy_project, type:, status:) }
+
+  shared_let(:member_role) do
+    create(:project_role, permissions: %i[view_project view_work_packages view_time_entries view_own_time_entries])
+  end
+  shared_let(:viewer_role) do
+    create(:project_role, permissions: %i[view_project view_work_packages])
+  end
+  shared_let(:wp_editor_role) do
+    create(:work_package_role, permissions: %i[view_work_packages])
+  end
+
+  shared_let(:admin) { create(:admin) }
+  shared_let(:anonymous) { User.anonymous }
+  shared_let(:non_member_user) { create(:user) }
+
+  shared_let(:project_member) do
+    create(:user, member_with_roles: { private_project => member_role, private_no_costs => viewer_role })
+  end
+
+  shared_let(:entity_member) do
+    user = create(:user)
+    create(:member, user:, project: private_project, entity: wp_private, roles: [wp_editor_role])
+    user
+  end
+
+  # Time entries exercise the intertwined cost/time permissions the visibility
+  # mega-query nests (view_time_entries / view_own_time_entries), gated on the
+  # `costs` module. decoy has no costs module → invisible to non-admins regardless.
+  # Defined after the user shared_lets so `project_member` is materialised first.
+  shared_let(:te_private) { create(:time_entry, entity: wp_private, user: project_member) }
+  shared_let(:te_public) { create(:time_entry, entity: wp_public, user: admin) }
+  shared_let(:te_decoy) { create(:time_entry, entity: wp_decoy, user: admin) }
+
+  # Restore-safe anonymous / non-member grants (see spec/support/roles.rb pattern)
+  around do |example|
+    non_member = ProjectRole.non_member
+    anon = ProjectRole.anonymous
+    previous_non_member = non_member.permissions.dup
+    previous_anon = anon.permissions.dup
+
+    non_member.permissions = (non_member.permissions + %i[view_project view_work_packages]).uniq
+    non_member.save!
+    anon.permissions = (anon.permissions + %i[view_project view_work_packages]).uniq
+    anon.save!
+
+    example.run
+  ensure
+    non_member.permissions = previous_non_member
+    non_member.save!
+    anon.permissions = previous_anon
+    anon.save!
+  end
+
+  def fixture_wp_ids
+    [wp_private, wp_public, wp_private_no_costs, wp_other_in_private, wp_decoy].map(&:id)
+  end
+
+  def fixture_project_ids
+    [private_project, public_project, private_no_costs, decoy_project].map(&:id)
+  end
+
+  def fixture_time_entry_ids
+    [te_private, te_public, te_decoy].map(&:id)
+  end
+
+  def ids_for(user, scope_name)
+    case scope_name
+    when :work_package_allowed_view
+      WorkPackage.allowed_to(user, :view_work_packages).order(:id).pluck(:id)
+    when :project_allowed_view_wp
+      Project.allowed_to(user, :view_work_packages).order(:id).pluck(:id)
+    when :project_visible
+      Project.visible(user).order(:id).pluck(:id)
+    when :notification_visible
+      Notification.visible(user).order(:id).pluck(:id)
+    when :time_entry_visible
+      TimeEntry.visible(user).order(:id).pluck(:id)
+    else
+      raise ArgumentError, "unknown scope #{scope_name}"
+    end
+  end
+
+  shared_examples "wp equivalence cell" do
+    it "returns the expected fixture WP ids and excludes decoys" do
+      user = instance_exec(&user_proc)
+      expected = instance_exec(&expected_wp_proc)
+      actual = ids_for(user, :work_package_allowed_view) & fixture_wp_ids
+
+      expect(actual).to match_array(expected)
+      expect(actual).not_to include(wp_decoy.id) unless expected.include?(wp_decoy.id)
+    end
+  end
+
+  shared_examples "project equivalence cell" do
+    it "returns the expected fixture project ids and excludes decoys" do
+      user = instance_exec(&user_proc)
+      expected = instance_exec(&expected_project_proc)
+      actual = ids_for(user, :project_allowed_view_wp) & fixture_project_ids
+
+      expect(actual).to match_array(expected)
+      expect(actual).not_to include(decoy_project.id) unless expected.include?(decoy_project.id)
+    end
+  end
+
+  describe "WorkPackage.allowed_to(:view_work_packages)" do
+    {
+      "admin sees all fixture WPs including decoy" => [
+        -> { admin },
+        -> { fixture_wp_ids }
+      ],
+      "anonymous sees only public WP" => [
+        -> { anonymous },
+        -> { [wp_public.id] }
+      ],
+      "non-member sees public WP" => [
+        -> { non_member_user },
+        -> { [wp_public.id] }
+      ],
+      "project member sees private + public + no-costs private (not decoy)" => [
+        -> { project_member },
+        -> { [wp_private.id, wp_public.id, wp_private_no_costs.id, wp_other_in_private.id] }
+      ],
+      "entity member sees only the shared WP plus public" => [
+        -> { entity_member },
+        -> { [wp_private.id, wp_public.id] }
+      ]
+    }.each do |label, (user_proc, expected_wp_proc)|
+      context label do
+        let(:user_proc) { user_proc }
+        let(:expected_wp_proc) { expected_wp_proc }
+
+        include_examples "wp equivalence cell"
+      end
+    end
+  end
+
+  describe "Project.allowed_to(:view_work_packages)" do
+    {
+      "admin sees all fixture projects including decoy" => [
+        -> { admin },
+        -> { fixture_project_ids }
+      ],
+      "anonymous sees only public project" => [
+        -> { anonymous },
+        -> { [public_project.id] }
+      ],
+      "non-member sees public project" => [
+        -> { non_member_user },
+        -> { [public_project.id] }
+      ],
+      "project member sees private + public + no-costs (not decoy)" => [
+        -> { project_member },
+        -> { [private_project.id, public_project.id, private_no_costs.id] }
+      ]
+    }.each do |label, (user_proc, expected_project_proc)|
+      context label do
+        let(:user_proc) { user_proc }
+        let(:expected_project_proc) { expected_project_proc }
+
+        include_examples "project equivalence cell"
+      end
+    end
+  end
+
+  describe "Notification.visible embeds WorkPackage.visible" do
+    shared_let(:recipient) { project_member }
+
+    shared_let(:visible_notification) do
+      create(:notification, recipient:, resource: wp_private, reason: :mentioned)
+    end
+
+    # A non-member: sees only the public WP. Its notification on the private WP
+    # must be filtered out, the one on the public WP kept.
+    shared_let(:stranger) { create(:user) }
+    shared_let(:stranger_note_on_private) do
+      create(:notification, recipient: stranger, resource: wp_private, reason: :mentioned)
+    end
+    shared_let(:stranger_note_on_public) do
+      create(:notification, recipient: stranger, resource: wp_public, reason: :mentioned)
+    end
+
+    shared_examples "notification visibility rules" do
+      it "includes notifications for the recipient when the WP is visible" do
+        expect(Notification.visible(recipient).pluck(:id)).to include(visible_notification.id)
+      end
+
+      it "excludes notifications whose WP is not visible to the recipient" do
+        ids = Notification.visible(stranger).pluck(:id)
+        expect(ids).not_to include(stranger_note_on_private.id)
+        expect(ids).to include(stranger_note_on_public.id)
+      end
+    end
+
+    # The shared_permissions_cte flag swaps the visible-WP `IN (subquery)`
+    # for a MATERIALIZED CTE. The rules must hold identically under both paths.
+    context "with the legacy path (flag off)", with_flag: { shared_permissions_cte: false } do
+      include_examples "notification visibility rules"
+    end
+
+    context "with the shared materialized CTE (flag on)", with_flag: { shared_permissions_cte: true } do
+      include_examples "notification visibility rules"
+    end
+
+    it "returns an identical id set with the flag off and on (old-vs-new equivalence)" do
+      users = [recipient, stranger, admin, non_member_user, anonymous]
+
+      allow(OpenProject::FeatureDecisions).to receive(:shared_permissions_cte_active?).and_return(false)
+      legacy = users.to_h { |user| [user.id, Notification.visible(user).order(:id).pluck(:id)] }
+
+      allow(OpenProject::FeatureDecisions).to receive(:shared_permissions_cte_active?).and_return(true)
+      shared_cte = users.to_h { |user| [user.id, Notification.visible(user).order(:id).pluck(:id)] }
+
+      expect(shared_cte).to eq(legacy)
+    end
+  end
+
+  describe "ResourceIdFilter#allowed_values shape" do
+    it "enumerates WorkPackage.visible ids for the current user and excludes decoys" do
+      ids = WorkPackage.visible(project_member).pluck(:id)
+      expect(ids).to include(wp_private.id, wp_public.id, wp_private_no_costs.id, wp_other_in_private.id)
+      expect(ids).not_to include(wp_decoy.id)
+    end
+  end
+
+  describe "TimeEntry.visible (view_time_entries / view_own_time_entries)" do
+    # Result-level pin for the cost/time permissions nested by include_spent_time.
+    # This is the coverage the plain SQL-string characterization below cannot give.
+    {
+      "admin sees all fixture time entries incl. decoy" => [
+        -> { admin },
+        -> { fixture_time_entry_ids }
+      ],
+      "project member sees only the private-project entry (has view_time_entries there)" => [
+        -> { project_member },
+        -> { [te_private.id] }
+      ],
+      "non-member sees no time entries (no view_time_entries granted)" => [
+        -> { non_member_user },
+        -> { [] }
+      ],
+      "anonymous sees no time entries" => [
+        -> { anonymous },
+        -> { [] }
+      ]
+    }.each do |label, (user_proc, expected_te_proc)|
+      context label do
+        it "returns the expected fixture time-entry ids and excludes decoys" do
+          user = instance_exec(&user_proc)
+          expected = instance_exec(&expected_te_proc)
+          actual = ids_for(user, :time_entry_visible) & fixture_time_entry_ids
+
+          expect(actual).to match_array(expected)
+          expect(actual).not_to include(te_decoy.id) unless expected.include?(te_decoy.id)
+        end
+      end
+    end
+  end
+
+  describe "include_spent_time composition (characterization)" do
+    it "embeds time-entry visibility SQL used by the spent-time CTE" do
+      sql = WorkPackage.include_spent_time(project_member).limit(1).to_sql
+      expect(sql).to match(/visible_time_entries|time_entries/i)
+      # Intertwined permission signature: multiple permission names appear
+      expect(sql.scan(/view_time_entries|view_own_time_entries|view_work_packages/).size).to be >= 1
+    end
+
+    # Result-level pin on the summed hours per work package. This is the guard for
+    # any future refactor that shares/materialises the permission derivation the
+    # spent-time query nests: the SUMs must not change. project_member has
+    # view_time_entries only in private_project, so only te_private (1.0h) counts.
+    def spent_hours(user, work_package)
+      WorkPackage.include_spent_time(user, work_package).first&.hours.to_f
+    end
+
+    it "sums only the time entries visible to the user" do
+      expect(spent_hours(project_member, wp_private)).to eq(1.0)
+      expect(spent_hours(project_member, wp_public)).to eq(0.0)   # te_public not visible to member
+      expect(spent_hours(project_member, wp_decoy)).to eq(0.0)    # te_decoy in decoy project
+      expect(spent_hours(project_member, wp_private_no_costs)).to eq(0.0)
+    end
+  end
+
+  describe "project-side shared-CTE primitives (old-vs-new equivalence)" do
+    def both_flag_states(users)
+      allow(OpenProject::FeatureDecisions).to receive(:shared_permissions_cte_active?).and_return(false)
+      legacy = users.to_h { |user| [user.id, yield(user)] }
+      allow(OpenProject::FeatureDecisions).to receive(:shared_permissions_cte_active?).and_return(true)
+      shared_cte = users.to_h { |user| [user.id, yield(user)] }
+      [legacy, shared_cte]
+    end
+
+    let(:matrix) { [admin, anonymous, non_member_user, project_member] }
+
+    it "Project.visible_ids yields an identical project set embedded either way" do
+      legacy, shared_cte = both_flag_states(matrix) do |user|
+        Project.where(id: Project.visible_ids(user)).order(:id).pluck(:id) & fixture_project_ids
+      end
+      expect(shared_cte).to eq(legacy)
+    end
+
+    it "WorkPackage.visible_ids(column: :project_id) via Project.with_visible_work_packages is identical" do
+      legacy, shared_cte = both_flag_states(matrix) do |user|
+        Project.with_visible_work_packages(user).order(:id).pluck(:id) & fixture_project_ids
+      end
+      expect(shared_cte).to eq(legacy)
+    end
+
+    # `column` reaches raw SQL whichever path runs, so the guard must hold in both states.
+    it "WorkPackage.visible_ids rejects a column outside the table in both flag states" do
+      [false, true].each do |flag_active|
+        allow(OpenProject::FeatureDecisions).to receive(:shared_permissions_cte_active?).and_return(flag_active)
+
+        expect { WorkPackage.visible_ids(project_member, column: "id FROM work_packages; --") }
+          .to raise_error(ArgumentError, /unknown column/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/OP-18140

(Part of the performance initiative https://community.openproject.org/work_packages/OP-18047.)

# What are you trying to accomplish?

The unread-notification bell renders on every page load and, on large instances,
can take on the order of ~10 s for users with many visible work packages.

`Notification.visible(user)` filters `resource_id IN (<visible work packages>)`.
When PostgreSQL's row estimate for a recipient's notifications is stale and too
low, the planner chooses a **nested-loop semi-join** that re-derives the entire
visible work-package set **once per notification**. On a production instance we
observed this as ~39 × ~66k ≈ **2.6M index probes → ~10.6 s**, versus a **~150 ms**
hash semi-join whenever the statistics are current.

`notifications` is a high-churn table (rows are created and marked read
constantly), so with the default analyze cadence
(`autovacuum_analyze_scale_factor = 0.1`, i.e. after ~10% of rows change) its
statistics can lag well behind reality between autovacuum runs. This migration
lowers that table's `autovacuum_analyze_scale_factor` (and threshold) so
autovacuum `ANALYZE`s it far more often, keeping the planner's estimate accurate
and the plan a hash semi-join.

No SQL or permission semantics change: this is purely a planner-statistics fix.

# What approach did you choose and why?

The root cause is stale planner statistics, not the query itself, so the durable
fix is to keep the statistics fresh; the in-database way to do that for a
high-churn table is to tune its autovacuum analyze cadence.

Alternatives considered:

- **One-off / scheduled `ANALYZE`** — fixes it, but is operational and easy to
  miss; this migration makes it automatic and durable. On instances that manage
  autovacuum at the infrastructure layer, that remains a valid equivalent.
- **Composite `(recipient_id, resource_type, resource_id)` index, and a raised
  per-column statistics target** — both measured, neither changes the plan. Only
  fresh statistics do. That is why this tunes the cadence rather than adding an index.

This change is intentionally narrow and independent of the separate structural
work under OP-18140 (consolidating the repeated permission subqueries). It targets
the acute bell latency on its own and can be adopted or reverted independently.

# Testing & performance

**Reproduction.** On a seeded instance (a recipient with 40 unread notifications who can
see 5,141 work packages) I recreated the stale-statistics condition the way it arises in
production — statistics captured while the recipient had no notifications, then
notifications present without a re-analyze. `EXPLAIN (ANALYZE, BUFFERS)` on the unread
`Notification.visible(user)` query:

| `notifications` statistics | Plan | Execution time |
| -------------------------- | ---- | -------------- |
| Stale  `reltuples` 0 vs 40 actual | `Nested Loop Semi Join`, estimated `rows=1` against `rows=40` actual; visible set re-derived **per notification** (`loops=102,071`) | **46.7 ms** |
| After `ANALYZE`  `reltuples` 40   | `Hash Semi Join`, estimated `rows=40`; visible set built **once** (`loops=5,141`)                                                    | **4.0 ms** |

**11.7× from statistics alone**, with the query itself unchanged. On a separate, larger
55k-work-package seed the same flip measured ~610 ms → ~55 ms, so the gap widens with the
size of the visible set the direction production points.

Every figure here is specific to a seed and to hardware, and the effect scales with how many
work packages the recipient can see; on a small instance there may be no measurable difference.
What reproduces anywhere is the plan flip `Nested Loop Semi Join` re-deriving the visible
set per notification, becoming `Hash Semi Join` building it once, purely from running `ANALYZE`.
That flip is what this migration keeps on the right side of.

**Migration.** Verified reversible against `dev` @ `36d730dca55`, applying and reverting it in
isolation and reading `pg_class.reloptions` at each step:

| Step | `notifications.reloptions` | `schema_migrations` |
| ---- | -------------------------- | ------------------- |
| before | *(none)* | not applied |
| after `up` | `autovacuum_analyze_scale_factor=0.02, autovacuum_analyze_threshold=200` | applied |
| after `down` | *(none)* | not applied |

`up` took 0.0020s and `down` 0.0012s, consistent with it touching nothing but two table storage
parameters.

## How you can verify it

**Path 1 is enough to review the change**; Path 2 is there if you'd rather see the pathology
than take my word for the numbers above.

### Path 1: the change does what it says (~2 minutes, no data needed)

```bash
bundle exec rails db:migrate
```

```sql
SELECT relname, reloptions FROM pg_class WHERE relname = 'notifications';
-- expect: {autovacuum_analyze_scale_factor=0.02,autovacuum_analyze_threshold=200}
```

```bash
bundle exec rails db:rollback STEP=1
```

...then re-run the query and confirm `reloptions` is back to empty. That is the whole surface
area of this PR: two table storage parameters, set and reverted.

### Path 2: see the plan flip (optional, needs a recipient with many visible work packages)

Recreate the stale condition deliberately: `ANALYZE notifications;` **while the recipient has no
notifications**, then create notifications for them without re-analyzing.

```ruby
user = User.find(<id>)
sql  = Notification.visible(user).unread.to_sql
puts ActiveRecord::Base.connection.select_all("EXPLAIN (ANALYZE, BUFFERS) #{sql}").rows.join("\n")
```

Expect a **Nested Loop Semi Join** whose inner side is the visible-work-package derivation, with
`loops=` equal to the recipient's notification count. Then `ANALYZE notifications;` and run the
same `EXPLAIN`: it becomes a **Hash Semi Join** that builds the set once.

# Merge checklist

- [x] Added/updated tests — n/a: this migration only sets PostgreSQL table
  storage parameters (`autovacuum_analyze_scale_factor` / `_threshold`); there is
  no application behaviour to unit-test. Validated by reproducing the query-plan
  change (nested-loop → hash) with stale vs fresh statistics.
- [x] Added/updated documentation in Lookbook — n/a (no UI/pattern changes).
- [x] Tested major browsers — n/a (backend / database-only change).
