### PR TITLE
[DREAM-805] Add declarative sortable wiring to BorderBoxList

### DIFF
--- a/app/components/op_primer/sortable_lists.rb
+++ b/app/components/op_primer/sortable_lists.rb
@@ -42,6 +42,30 @@ module OpPrimer
   module SortableLists
     ITEM_CONTROLLER = "sortable-lists--item"
     LIST_CONTROLLER = "sortable-lists--list"
+    ROOT_CONTROLLER = "sortable-lists"
+    SCROLLABLE_CONTROLLER = "sortable-lists--scrollable"
+
+    # Marker substituted into `Root`'s lambda-built move URL(s) before being
+    # rewritten to the literal `{id}` template placeholder. A dedicated
+    # marker (rather than e.g. a numeric sentinel) can't collide with real
+    # URL text produced by the route helpers.
+    ROOT_ID_SENTINEL = "__sortable_lists_id__"
+    # Defensive only: `ERB::Util.url_encode` leaves this sentinel's
+    # letters/digits/underscores byte-identical, so today this is the same
+    # string as `ROOT_ID_SENTINEL`. Kept distinct (and gsubbed separately in
+    # `templatize`) in case a route helper ever percent-encodes it.
+    ROOT_ID_SENTINEL_ENCODED = ERB::Util.url_encode(ROOT_ID_SENTINEL)
+
+    ROOT_CHILD_CONTROLLERS = {
+      list: LIST_CONTROLLER,
+      item: ITEM_CONTROLLER,
+      scrollable: SCROLLABLE_CONTROLLER
+    }.freeze
+
+    # Accepted `allowed_axis`/`max_scroll_speed` values, mirroring
+    # `scrollable.controller.ts`'s `allowedAxes`/`maxScrollSpeeds` sets.
+    SCROLLABLE_ALLOWED_AXES = %w[vertical horizontal all].freeze
+    SCROLLABLE_MAX_SCROLL_SPEEDS = %w[standard fast].freeze
 
     # Wiring for an element whose children are sortable rows.
     List = Data.define(:type, :accepted_type, :id, :name, :drop_position) do
@@ -108,6 +132,164 @@ module OpPrimer
           sortable_lists__item_external_url_value: external_url,
           sortable_lists__item_hide_unavailable_value: hide_unavailable,
           sortable_lists__item_target: targets.presence&.join(" ")
+        }.compact
+      end
+    end
+
+    # Wiring for the page-level element that owns the drag-and-drop root
+    # controller, plus its outlet selectors into `List`/`Item`/`Scrollable`
+    # children.
+    Root = Data.define(:scope_id, :move_url_templates, :move_url_template, :optimistic, :outlets) do
+      # @param scope_id [String] id of the element the outlet selectors are
+      #   scoped under (usually the root element's own id).
+      # @param move_urls [Proc, nil] `->(id)` returning a `{ type => url }`
+      #   map; mutually exclusive with `move_url:`.
+      # @param move_url [Proc, nil] `->(id)` returning a single url string;
+      #   mutually exclusive with `move_urls:`.
+      # @param optimistic [Boolean, nil] emits `sortable_lists_optimistic_value`
+      #   when set, matching the `optimistic` Stimulus value the root
+      #   controller reads to skip its own turbo-stream round trip.
+      # @param outlets [Array<Symbol>] child controllers to derive outlet
+      #   selectors for; keys of {ROOT_CHILD_CONTROLLERS}.
+      def initialize(scope_id:, move_urls: nil, move_url: nil, optimistic: nil, outlets: %i[list item])
+        raise ArgumentError, "scope_id is required" if scope_id.blank?
+        if move_urls.nil? == move_url.nil?
+          raise ArgumentError, "provide exactly one of move_urls or move_url"
+        end
+
+        normalized_outlets = Array(outlets).map(&:to_sym).freeze
+        unknown_outlets = normalized_outlets - ROOT_CHILD_CONTROLLERS.keys
+        if unknown_outlets.any?
+          raise ArgumentError, "unknown outlet(s): #{unknown_outlets.join(', ')}"
+        end
+
+        super(
+          scope_id:,
+          move_url_templates: move_urls && build_move_url_templates(move_urls),
+          move_url_template: move_url && build_move_url_template(move_url),
+          optimistic:,
+          outlets: normalized_outlets
+        )
+      end
+
+      # @return [Hash] Stimulus data attributes for the root element.
+      def to_data
+        {
+          controller: ROOT_CONTROLLER,
+          sortable_lists_move_url_templates_value: move_url_templates&.to_json,
+          sortable_lists_move_url_template_value: move_url_template,
+          sortable_lists_optimistic_value: optimistic,
+          **outlet_data
+        }.compact
+      end
+
+      # @param existing_data [Hash] a plain `data:` hash already used on the
+      #   element (e.g. an existing `controller`/`action` pair from another
+      #   Stimulus controller). Keys may be Strings or Symbols — both are
+      #   recognized against this root's own (Symbol) keys.
+      # @return [Hash] a NEW hash: this root's wiring merged in, with
+      #   `:controller`/`:action` STRING values token-joined onto the
+      #   existing ones (a String-keyed `"controller"`/`"action"` in
+      #   `existing_data` is folded into the same canonical Symbol key
+      #   rather than left alongside it as a duplicate) and every other
+      #   existing key preserved untouched. `existing_data` itself is never
+      #   mutated.
+      # @raise [ArgumentError] if `existing_data` already hand-wires any of
+      #   this root's own keys (other than `:controller`/`:action`), under
+      #   either a String or a Symbol key.
+      def merge_into(existing_data)
+        own = to_data
+        reserved = own.keys - %i[controller action]
+        conflicting = existing_data.keys.select { |key| reserved.include?(key.to_s.to_sym) }
+        raise ArgumentError, "existing data already sets #{conflicting.join(', ')}" if conflicting.any?
+
+        merged = existing_data.dup
+        own.each { |key, value| merge_own_key!(merged, key, value) }
+        merged
+      end
+
+      private
+
+      # Merges one `own.to_data` pair into `merged` (mutated in place).
+      # `:controller`/`:action` are folded onto whatever key already carries
+      # them in `merged` — String or Symbol — token-joining String values so
+      # no duplicate (String- and Symbol-keyed) entry survives; every other
+      # key is set directly, since `merge_into`'s conflict check already
+      # guarantees no overlap for those.
+      def merge_own_key!(merged, key, value)
+        return merged[key] = value unless %i[controller action].include?(key)
+
+        existing_key = merged.keys.find { |k| k.to_s.to_sym == key }
+        existing_value = existing_key && merged.delete(existing_key)
+        merged[key] = existing_value.is_a?(String) ? "#{existing_value} #{value}" : value
+      end
+
+      def build_move_url_templates(move_urls)
+        raw_map = move_urls.call(ROOT_ID_SENTINEL)
+        raise ArgumentError, "move_urls must not be empty" if raw_map.blank?
+
+        raw_map.transform_values do |url|
+          unless url.is_a?(String)
+            raise ArgumentError, "move_urls values must be Strings (got #{url.class} for #{url.inspect})"
+          end
+
+          templatize(url)
+        end
+      end
+
+      def build_move_url_template(move_url)
+        templatize(move_url.call(ROOT_ID_SENTINEL))
+      end
+
+      def templatize(built_url)
+        raise ArgumentError, "move_url must not be blank" if built_url.blank?
+
+        template = built_url.gsub(ROOT_ID_SENTINEL_ENCODED, "{id}").gsub(ROOT_ID_SENTINEL, "{id}")
+        count = template.scan("{id}").length
+        case count
+        when 0
+          raise ArgumentError, "move_url must include the {id} placeholder (got #{template.inspect})"
+        when 1
+          template
+        else
+          raise ArgumentError, "move_url must contain exactly one {id} placeholder (got #{count} in #{template.inspect})"
+        end
+      end
+
+      def outlet_data
+        # `outlets` is already validated against ROOT_CHILD_CONTROLLERS in
+        # `initialize`, so this fetch cannot raise.
+        outlets.to_h do |outlet|
+          controller = ROOT_CHILD_CONTROLLERS.fetch(outlet)
+          key = :"sortable_lists_#{controller.tr('-', '_')}_outlet"
+          [key, "##{scope_id} [data-controller~='#{controller}']"]
+        end
+      end
+    end
+
+    # Wiring for an element that owns the Pragmatic DnD auto-scroll
+    # behavior; mirrors the accepted `values` from `scrollable.controller.ts`.
+    Scrollable = Data.define(:allowed_axis, :max_scroll_speed) do
+      def initialize(allowed_axis: nil, max_scroll_speed: nil)
+        if allowed_axis && SCROLLABLE_ALLOWED_AXES.exclude?(allowed_axis)
+          raise ArgumentError,
+                "allowed_axis must be one of #{SCROLLABLE_ALLOWED_AXES.join(', ')} (got #{allowed_axis.inspect})"
+        end
+        if max_scroll_speed && SCROLLABLE_MAX_SCROLL_SPEEDS.exclude?(max_scroll_speed)
+          raise ArgumentError,
+                "max_scroll_speed must be one of #{SCROLLABLE_MAX_SCROLL_SPEEDS.join(', ')} " \
+                "(got #{max_scroll_speed.inspect})"
+        end
+
+        super
+      end
+
+      # @return [Hash] Stimulus data attributes for the scrollable element.
+      def to_data
+        {
+          controller: SCROLLABLE_CONTROLLER,
+          sortable_lists__scrollable_allowed_axis_value: allowed_axis,
+          sortable_lists__scrollable_max_scroll_speed_value: max_scroll_speed
         }.compact
       end
     end

--- a/app/components/op_primer/sortable_lists.rb
+++ b/app/components/op_primer/sortable_lists.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  # Value objects owning the Stimulus `sortable-lists` wiring contract.
+  #
+  # Inspired by LiveComponent's `Target`/`Action` shape: frozen value objects
+  # (`Data.define`) that close over the controller identifier and emit `data`
+  # attributes, so components declare drag-and-drop intent instead of
+  # hand-writing `sortable_lists__*` keys. Emission-only — the Stimulus
+  # suite under `frontend/src/stimulus/controllers/dynamic/sortable-lists`
+  # remains the behavioral contract, and new controller values must be
+  # added here deliberately. Unknown keys raise, preventing typo'd keys
+  # from emitting inert attributes Stimulus silently ignores.
+  module SortableLists
+    ITEM_CONTROLLER = "sortable-lists--item"
+    LIST_CONTROLLER = "sortable-lists--list"
+
+    # Wiring for an element whose children are sortable rows.
+    List = Data.define(:type, :accepted_type, :id, :name, :drop_position) do
+      # @param record [Object] source for `id`/`name` (`record.try(:name)`
+      #   falling back to `record.to_s`). The wire `type:` is never derived:
+      #   wire types are short names keyed into the root's URL template map.
+      def self.for(record, type:, **overrides)
+        new(type:, id: record.id, name: record.try(:name) || record.to_s, **overrides)
+      end
+
+      def initialize(type:, accepted_type: nil, id: nil, name: nil, drop_position: nil)
+        raise ArgumentError, "type is required" if type.blank?
+
+        super(type:, accepted_type: accepted_type || type, id:, name:, drop_position:)
+      end
+
+      # @return [Hash] Stimulus data attributes for the list element.
+      def to_data
+        {
+          controller: LIST_CONTROLLER,
+          sortable_lists__list_type_value: type,
+          sortable_lists__list_accepted_type_value: accepted_type,
+          sortable_lists__list_id_value: id,
+          sortable_lists__list_name_value: name,
+          sortable_lists__list_drop_position_value: drop_position
+        }.compact
+      end
+    end
+
+    # Wiring for a draggable element.
+    Item = Data.define(:id, :type, :label, :targets, :confined, :external_url, :hide_unavailable) do
+      # @param record [Object] source for `id`/`label`. `type:` is never
+      #   derived — see {List.for}.
+      def self.for(record, type:, **overrides)
+        new(
+          type:,
+          id: record.id,
+          label: record.try(:name) || record.to_s,
+          **overrides
+        )
+      end
+
+      def initialize(id:, type:, label: nil, targets: [], confined: nil, external_url: nil, hide_unavailable: nil)
+        raise ArgumentError, "id is required" if id.blank?
+        raise ArgumentError, "type is required" if type.blank?
+
+        normalized_targets = Set.new(Array(targets).map(&:to_s)).freeze
+        super(id:, type:, label:, targets: normalized_targets, confined:, external_url:, hide_unavailable:)
+      end
+
+      # @return [Item] copy with `extra` targets token-merged and deduplicated.
+      def with_targets(*extra)
+        with(targets: (targets | extra.map(&:to_s)).freeze)
+      end
+
+      # @return [Hash] Stimulus data attributes for the item element.
+      def to_data
+        {
+          controller: ITEM_CONTROLLER,
+          sortable_lists__item_id_value: id,
+          sortable_lists__item_type_value: type,
+          sortable_lists__item_label_value: label,
+          sortable_lists__item_confined_value: confined,
+          sortable_lists__item_external_url_value: external_url,
+          sortable_lists__item_hide_unavailable_value: hide_unavailable,
+          sortable_lists__item_target: targets.presence&.join(" ")
+        }.compact
+      end
+    end
+  end
+end

--- a/app/components/open_project/common/border_box_list_collection_component.html.erb
+++ b/app/components/open_project/common/border_box_list_collection_component.html.erb
@@ -28,9 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%= render(Primer::Box.new(**@system_arguments)) do %>
-  <%= flex_layout do |flex| %>
+  <%= render(Primer::Box.new(**list_container_arguments)) do %>
     <% item_rows.each do |row| %>
-      <% flex.with_row(**row.row_args) do %>
+      <%= render(Primer::Box.new(**row.row_args)) do %>
         <%= row %>
       <% end %>
     <% end %>

--- a/app/components/open_project/common/border_box_list_collection_component.html.erb
+++ b/app/components/open_project/common/border_box_list_collection_component.html.erb
@@ -1,0 +1,38 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= render(Primer::Box.new(**@system_arguments)) do %>
+  <%= flex_layout do |flex| %>
+    <% item_rows.each do |row| %>
+      <% flex.with_row(**row.row_args) do %>
+        <%= row %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/open_project/common/border_box_list_collection_component.rb
+++ b/app/components/open_project/common/border_box_list_collection_component.rb
@@ -79,9 +79,10 @@ module OpenProject
       #   selectors (the root's outlets, an explicit root's `scope_id`) are
       #   derived from the resulting id, not from `container` directly.
       # @param sortable_list [OpPrimer::SortableLists::List, Hash, nil]
-      #   sortable wiring for the wrapper, declaring it as a sortable-lists
-      #   drop target for its rows. A Hash is coerced via
-      #   `OpPrimer::SortableLists::List.new(**hash)`.
+      #   sortable wiring for the inner flex container that directly holds
+      #   the item rows (not the wrapper — see {#list_container_arguments}),
+      #   declaring it as a sortable-lists drop target for its rows. A Hash
+      #   is coerced via `OpPrimer::SortableLists::List.new(**hash)`.
       # @param root [true, OpPrimer::SortableLists::Root, nil] page-level
       #   sortable-lists root wiring. `true` derives a
       #   `OpPrimer::SortableLists::Root` scoped to the wrapper's own id, built
@@ -111,11 +112,30 @@ module OpenProject
         content
 
         @root = resolve_root!
-        configure_sortable_list_wiring!
         configure_root_wiring!
       end
 
       private
+
+      # System arguments for the inner flex container whose direct children
+      # are the item rows. Kept a separate element from the wrapper — rather
+      # than merging `sortable_list:`'s `data:` onto the wrapper itself —
+      # because the wrapper also carries the page-level `root:` wiring when
+      # set, and the root's outlet selectors are plain CSS descendant
+      # combinators (`##{wrapper_id} [data-controller~='...']`), which by the
+      # DOM spec can never match the wrapper element they are scoped from.
+      # Mounting the list role on the wrapper would make it invisible to the
+      # root's own outlets; mounting it here, on a genuine descendant, keeps
+      # it reachable.
+      #
+      # @return [Hash] forwarded to the inner `Primer::Box`.
+      def list_container_arguments
+        system_arguments = { display: :flex, direction: :column }
+        return system_arguments unless @sortable_list
+
+        system_arguments[:data] = @sortable_list.to_data
+        system_arguments
+      end
 
       # @return [OpPrimer::SortableLists::Root, nil]
       # @raise [ArgumentError] if `root: true` is given without `move_urls:`,
@@ -146,20 +166,6 @@ module OpenProject
 
         raise ArgumentError,
               "root scope_id (#{root.scope_id.inspect}) must match the wrapper id (#{@wrapper_id.inspect})"
-      end
-
-      # Wires the wrapper as a sortable-lists drop target for its rows.
-      #
-      # @return [void]
-      def configure_sortable_list_wiring!
-        return unless @sortable_list
-
-        list_data = @sortable_list.to_data
-        assert_no_sortable_conflicts!(@system_arguments[:data], list_data)
-        @system_arguments[:data] = merge_data(
-          { data: @system_arguments[:data] || {} },
-          { data: list_data }
-        )
       end
 
       # Wires the wrapper as the page-level sortable-lists root.

--- a/app/components/open_project/common/border_box_list_collection_component.rb
+++ b/app/components/open_project/common/border_box_list_collection_component.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Common
+    # A stable-id wrapper that owns the outer sortable-lists region for a page:
+    # the drop target for its rows, and — for pages composed of a single
+    # collection — the page-level root wiring too.
+    #
+    # Use this component when a page is a flat collection of rows (e.g. a
+    # sections index), or when several `BorderBoxListComponent` boxes need a
+    # shared page-level root without any one of them claiming ownership of it.
+    # Row content is free-form: unlike `BorderBoxListComponent#with_item`,
+    # `with_item_row` does not assume Primer BorderBox row semantics, so a row
+    # can itself be a `BorderBoxListComponent` (a dual-role page's per-box
+    # list) or any other content.
+    class BorderBoxListCollectionComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+      include OpPrimer::AttributesHelper
+
+      attr_reader :container
+
+      # Free-form collection row content.
+      #
+      # @!parse
+      #   # Adds a collection row.
+      #   #
+      #   # @param sortable [OpPrimer::SortableLists::Item, Hash, nil] sortable
+      #   #   wiring for this row. A Hash's `type:` defaults from the
+      #   #   component's `sortable_list:` accepted type when omitted.
+      #   #   Requires the component's `sortable_list:` to be set.
+      #   # @param system_arguments [Hash] forwarded to the outer flex row.
+      #   # @return [ViewComponent::Slot]
+      #   def with_item_row(sortable: nil, **system_arguments, &block)
+      #   end
+      renders_many :item_rows, ->(sortable: nil, **system_arguments) {
+        if sortable
+          sortable = coerce_row_sortable(sortable)
+          item_data = sortable.to_data
+          assert_no_sortable_conflicts!(system_arguments[:data], item_data)
+          system_arguments[:data] = merge_data(
+            { data: system_arguments[:data] || {} },
+            { data: item_data }
+          )
+        end
+
+        ItemRow.new(**system_arguments)
+      }
+
+      # @param container [String, Symbol, Class, Object] value passed to
+      #   `dom_target` to derive the wrapper's DOM id. Related sortable-lists
+      #   selectors (the root's outlets, an explicit root's `scope_id`) are
+      #   derived from the resulting id, not from `container` directly.
+      # @param sortable_list [OpPrimer::SortableLists::List, Hash, nil]
+      #   sortable wiring for the wrapper, declaring it as a sortable-lists
+      #   drop target for its rows. A Hash is coerced via
+      #   `OpPrimer::SortableLists::List.new(**hash)`.
+      # @param root [true, OpPrimer::SortableLists::Root, nil] page-level
+      #   sortable-lists root wiring. `true` derives a
+      #   `OpPrimer::SortableLists::Root` scoped to the wrapper's own id, built
+      #   from `move_urls:`. An explicit `OpPrimer::SortableLists::Root` is
+      #   used as-is once its `scope_id` is confirmed to match the wrapper id
+      #   (see {#before_render}) — this is how several boxes composed inside
+      #   one collection share a single page-level root without any one box
+      #   claiming ownership of it.
+      # @param move_urls [Proc, nil] `->(id)` returning a `{ type => url }`
+      #   map, forwarded to `OpPrimer::SortableLists::Root` when `root: true`.
+      #   Required when `root: true`; ignored otherwise.
+      # @param system_arguments [Hash] forwarded to the wrapper element
+      #   (`Primer::Box`). Pass `id:` to override the derived wrapper id.
+      def initialize(container:, sortable_list: nil, root: nil, move_urls: nil, **system_arguments)
+        super()
+
+        @container = container
+        @sortable_list = coerce_sortable(sortable_list, OpPrimer::SortableLists::List)
+        @root_option = root
+        @move_urls = move_urls
+        @system_arguments = system_arguments
+        @system_arguments[:id] ||= dom_target(container)
+        @wrapper_id = @system_arguments[:id]
+      end
+
+      def before_render
+        content
+
+        @root = resolve_root!
+        configure_sortable_list_wiring!
+        configure_root_wiring!
+      end
+
+      private
+
+      # @return [OpPrimer::SortableLists::Root, nil]
+      # @raise [ArgumentError] if `root: true` is given without `move_urls:`,
+      #   if an explicit `root:` `Root`'s `scope_id` does not match the
+      #   wrapper id, or if `root:` is any other value.
+      def resolve_root!
+        case @root_option
+        when true
+          raise ArgumentError, "move_urls is required when root: true" if @move_urls.nil?
+
+          OpPrimer::SortableLists::Root.new(scope_id: @wrapper_id, move_urls: @move_urls)
+        when OpPrimer::SortableLists::Root
+          assert_root_scope_matches_wrapper!(@root_option)
+          @root_option
+        when nil
+          nil
+        else
+          raise ArgumentError, "expected true, OpPrimer::SortableLists::Root, or nil — got #{@root_option.class}"
+        end
+      end
+
+      # @return [void]
+      # @raise [ArgumentError] if `root`'s `scope_id` does not match the
+      #   wrapper id — a mismatched scope would derive outlet selectors that
+      #   search under the wrong element.
+      def assert_root_scope_matches_wrapper!(root)
+        return if root.scope_id == @wrapper_id
+
+        raise ArgumentError,
+              "root scope_id (#{root.scope_id.inspect}) must match the wrapper id (#{@wrapper_id.inspect})"
+      end
+
+      # Wires the wrapper as a sortable-lists drop target for its rows.
+      #
+      # @return [void]
+      def configure_sortable_list_wiring!
+        return unless @sortable_list
+
+        list_data = @sortable_list.to_data
+        assert_no_sortable_conflicts!(@system_arguments[:data], list_data)
+        @system_arguments[:data] = merge_data(
+          { data: @system_arguments[:data] || {} },
+          { data: list_data }
+        )
+      end
+
+      # Wires the wrapper as the page-level sortable-lists root.
+      #
+      # @return [void]
+      def configure_root_wiring!
+        return unless @root
+
+        @system_arguments[:data] = @root.merge_into(@system_arguments[:data] || {})
+      end
+
+      # @param config [OpPrimer::SortableLists::List, Hash, nil]
+      # @param klass [Class] `OpPrimer::SortableLists::List`.
+      # @return [Object, nil] a `klass` instance, or `nil`.
+      def coerce_sortable(config, klass)
+        case config
+        when nil, klass then config
+        when Hash then klass.new(**config)
+        else
+          raise ArgumentError, "expected #{klass}, Hash, or nil — got #{config.class}"
+        end
+      end
+
+      # @param config [OpPrimer::SortableLists::Item, Hash] row-level sortable
+      #   wiring. A Hash without `type:` defaults it from `@sortable_list`'s
+      #   accepted type.
+      # @return [OpPrimer::SortableLists::Item]
+      def coerce_row_sortable(config)
+        raise ArgumentError, "with_item_row(sortable:) requires the component's sortable_list:" unless @sortable_list
+
+        case config
+        when OpPrimer::SortableLists::Item then config
+        when Hash then OpPrimer::SortableLists::Item.new(type: @sortable_list.accepted_type, **config)
+        else
+          raise ArgumentError, "expected OpPrimer::SortableLists::Item, Hash, or nil — got #{config.class}"
+        end
+      end
+
+      # @param caller_data [Hash, nil] hand-wired `data:` hash supplied by the caller.
+      # @param generated_data [Hash] sortable-lists `data:` hash produced internally.
+      # @return [void]
+      # @raise [ArgumentError] if `caller_data` hand-wires a `sortable_lists__*`
+      #   key that the generated wiring also sets.
+      def assert_no_sortable_conflicts!(caller_data, generated_data)
+        return if caller_data.blank?
+
+        generated_keys = generated_data.keys.map(&:to_s).select { |key| key.start_with?("sortable_lists__") }
+        caller_keys = caller_data.keys.map(&:to_s)
+        conflicts = generated_keys & caller_keys
+        return if conflicts.empty?
+
+        raise ArgumentError, "sortable wiring conflicts with hand-wired data keys: #{conflicts.join(', ')}"
+      end
+    end
+  end
+end

--- a/app/components/open_project/common/border_box_list_collection_component/item_row.html.erb
+++ b/app/components/open_project/common/border_box_list_collection_component/item_row.html.erb
@@ -1,0 +1,30 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= content %>

--- a/app/components/open_project/common/border_box_list_collection_component/item_row.rb
+++ b/app/components/open_project/common/border_box_list_collection_component/item_row.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Common
+    class BorderBoxListCollectionComponent
+      # Free-form collection row that renders its slot content directly. The
+      # sortable-lists wiring (when any) lives in `row_args`, not on this
+      # component's own render — it is applied to the outer flex row element
+      # that wraps this component, so the collection controls exactly one
+      # element per row regardless of what the row's content renders.
+      class ItemRow < ApplicationComponent
+        # @param system_arguments [Hash] forwarded to the outer flex row.
+        def initialize(**system_arguments)
+          super()
+
+          @system_arguments = system_arguments
+        end
+
+        # @return [Hash] arguments forwarded to the outer flex row element.
+        def row_args
+          @system_arguments.deep_dup
+        end
+      end
+    end
+  end
+end

--- a/app/components/open_project/common/border_box_list_component.rb
+++ b/app/components/open_project/common/border_box_list_component.rb
@@ -37,6 +37,7 @@ module OpenProject
     # header actions, collapsible behavior, and row rendering.
     class BorderBoxListComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
+      include OpPrimer::AttributesHelper
       include Primer::FetchOrFallbackHelper
 
       SCHEME_DEFAULT = :default
@@ -70,6 +71,7 @@ module OpenProject
         system_arguments[:list_id] = list_id
         system_arguments[:interactive] = interactive?
         system_arguments[:collapsible] = collapsible?
+        system_arguments[:sortable_handle] = @sortable_item.present? || @sortable_handle
 
         Header.new(**system_arguments)
       }
@@ -84,9 +86,13 @@ module OpenProject
       # @!parse
       #   # Adds a generic list row.
       #   #
+      #   # @param sortable [OpPrimer::SortableLists::Item, Hash, nil] sortable
+      #   #   wiring for this row. A Hash's `type:` defaults from the
+      #   #   component's `sortable_list:` accepted type when omitted.
+      #   #   Requires the component's `sortable_list:` to be set.
       #   # @param system_arguments [Hash] forwarded to Primer's BorderBox row.
       #   # @return [ViewComponent::Slot]
-      #   def with_item(**system_arguments, &block)
+      #   def with_item(sortable: nil, **system_arguments, &block)
       #   end
       #
       #   # Adds a work-package list row.
@@ -110,7 +116,19 @@ module OpenProject
       #   end
       renders_many :items, types: {
         item: {
-          renders: ->(**system_arguments) {
+          renders: ->(sortable: nil, **system_arguments) {
+            if sortable
+              raise ArgumentError, "with_item(sortable:) requires the component's sortable_list:" unless @sortable_list
+
+              sortable = coerce_row_sortable(sortable)
+              item_data = sortable.to_data
+              assert_no_sortable_conflicts!(system_arguments[:data], item_data)
+              system_arguments[:data] = merge_data(
+                { data: system_arguments[:data] || {} },
+                { data: item_data }
+              )
+            end
+
             Item.new(**system_arguments)
           },
           as: :item
@@ -148,7 +166,8 @@ module OpenProject
       #   # @param drop_target_label [String, nil] when given, renders a
       #   #   drop-zone overlay with this label. The overlay becomes visible
       #   #   while a sortable item hovers the surrounding
-      #   #   `[data-drop-container="active"]` list.
+      #   #   `[data-drop-container="active"]` list. Defaults to the
+      #   #   component's `sortable_list:` name when set and no label is given.
       #   # @param action_label [String, nil] optional call-to-action rendered
       #   #   as the blankslate's primary action.
       #   # @param action_icon [Symbol, nil] optional leading icon for the
@@ -160,7 +179,7 @@ module OpenProject
       #   def with_empty_state(title:, description: nil, icon: nil, drop_target_label: nil,
       #                        action_label: nil, action_icon: nil, action_arguments: {}, **system_arguments)
       #   end
-      renders_one :empty_state, ->(title:, description: nil, icon: nil, drop_target_label: nil,
+      renders_one :empty_state, ->(title:, description: nil, icon: nil, drop_target_label: @sortable_list&.name,
                                    action_label: nil, action_icon: nil, action_arguments: {}, **system_arguments) {
         EmptyState.new(
           title:,
@@ -213,6 +232,36 @@ module OpenProject
       #   and empty-state content.
       # @param collapsible [Boolean] whether the header renders a collapsible
       #   toggle. Defaults to `false`.
+      # @param sortable_list [OpPrimer::SortableLists::List, Hash, nil]
+      #   sortable wiring for the box root, declaring it as a sortable-lists
+      #   drop target for its rows. A Hash is coerced via
+      #   `OpPrimer::SortableLists::List.new(**hash)`. Always mounts on the
+      #   box root. Mutually exclusive with `sortable_item:` — see there for
+      #   why.
+      # @param sortable_item [OpPrimer::SortableLists::Item, Hash, nil]
+      #   sortable wiring for the box root, declaring the whole list as a
+      #   draggable item (e.g. a collapsible group nested inside another
+      #   sortable list). A Hash is coerced via
+      #   `OpPrimer::SortableLists::Item.new(**hash)`. Automatically gains a
+      #   `"preview"` target and wires the header's drag handle when a header
+      #   with `show_drag_handle: true` is present. Mutually exclusive with
+      #   `sortable_list:`: `list.controller` and `item.controller` each
+      #   unconditionally register their own Pragmatic `dropTargetForElements`
+      #   on `this.element`, and Pragmatic's element adapter keys that
+      #   registration by DOM node in a single shared registry, so mounting
+      #   both controllers on one element would make whichever connects
+      #   second silently replace the first's registration, breaking drops
+      #   (see `frontend/.../pragmatic-drag-and-drop/.../make-drop-target.js`'s
+      #   `registry.set`). Until the Stimulus controllers are taught to
+      #   coexist on one element, the two stay mutually exclusive.
+      # @param sortable_handle [Boolean] whether the box root gains a bare
+      #   `"preview"` target and the header's drag handle gets wired, without
+      #   a full `sortable_item:` (and its own item Stimulus controller). Use
+      #   when the group's *rows* are the draggable unit but the group itself
+      #   still needs a `preview` target for a header drag handle driven by
+      #   some other reordering mechanism. Requires a header with
+      #   `show_drag_handle: true` and is mutually exclusive with
+      #   `sortable_item:` (which already implies it). Defaults to `false`.
       # @param current_user [User] user context passed to work-package items.
       # @param system_arguments [Hash] forwarded to `Primer::Beta::BorderBox`.
       #   Pass `id:` to set the box id; related ids are derived from it.
@@ -223,6 +272,9 @@ module OpenProject
         empty_state_behavior: EMPTY_STATE_BEHAVIOR_DEFAULT,
         interactive: false,
         collapsible: false,
+        sortable_list: nil,
+        sortable_item: nil,
+        sortable_handle: false,
         current_user: User.current,
         **system_arguments
       )
@@ -240,8 +292,13 @@ module OpenProject
         )
         @interactive = interactive
         @collapsible = collapsible
+        @sortable_list = coerce_sortable(sortable_list, OpPrimer::SortableLists::List)
+        @sortable_item = coerce_sortable(sortable_item, OpPrimer::SortableLists::Item)
+        @sortable_handle = sortable_handle
         @current_user = current_user
         @system_arguments = system_arguments.except(:list_id, :list_arguments)
+
+        assert_no_combined_sortable_roles!
 
         @system_arguments[:id] ||= dom_target(container)
         @list_id = dom_target(@system_arguments[:id], :list)
@@ -260,12 +317,24 @@ module OpenProject
           "op-border-box-list_header-padding-spacious" => @header_padding.spacious?
         )
 
+        # The list role lands on the box root (not the items `<ul>`): the CSS
+        # drop indicators and the empty-state drop overlay both key off
+        # `.op-border-box-list[data-drop-container]`, and `list.controller`
+        # resolves its own rows container relative to its own element via
+        # `:scope > ul`, so it needs to mount above that `<ul>`, not on it.
+        # `sortable_list:` and `sortable_item:` can no longer be combined
+        # (see `assert_no_combined_sortable_roles!`), so this is now
+        # unconditional — no more falling back to the items `<ul>`.
+        configure_sortable_list_wiring!
+        configure_sortable_item_wiring!
+
         @header_id = dom_target(@system_arguments[:id], :header)
         @footer_id = dom_target(@system_arguments[:id], :footer)
       end
 
       def before_render
         content
+        assert_sortable_handle_requires_drag_handle!
         configure_empty_state!
         configure_header!
       end
@@ -303,6 +372,109 @@ module OpenProject
           title: I18n.t(:label_nothing_display),
           description: I18n.t(:no_results_title_text)
         )
+      end
+
+      # Wires the box root as a sortable-lists drop target for its rows.
+      #
+      # @return [void]
+      def configure_sortable_list_wiring!
+        return unless @sortable_list
+
+        list_data = @sortable_list.to_data
+        assert_no_sortable_conflicts!(@system_arguments[:data], list_data)
+        @system_arguments[:data] = merge_data(
+          { data: @system_arguments[:data] || {} },
+          { data: list_data }
+        )
+      end
+
+      # Wires the box root as a draggable item (`sortable_item:`), or — when
+      # only `sortable_handle:` is set — as a bare `"preview"` target for a
+      # header drag handle, without an item Stimulus controller.
+      #
+      # @return [void]
+      def configure_sortable_item_wiring!
+        return unless @sortable_item || @sortable_handle
+
+        item_data =
+          if @sortable_item
+            @sortable_item.with_targets("preview").to_data
+          else
+            { sortable_lists__item_target: "preview" }
+          end
+
+        assert_no_sortable_conflicts!(@system_arguments[:data], item_data)
+        @system_arguments[:data] = merge_data(
+          { data: @system_arguments[:data] || {} },
+          { data: item_data }
+        )
+      end
+
+      # @param config [OpPrimer::SortableLists::List, OpPrimer::SortableLists::Item, Hash, nil]
+      # @param klass [Class] `OpPrimer::SortableLists::List` or `OpPrimer::SortableLists::Item`.
+      # @return [Object, nil] a `klass` instance, or `nil`.
+      def coerce_sortable(config, klass)
+        case config
+        when nil, klass then config
+        when Hash then klass.new(**config)
+        else
+          raise ArgumentError, "expected #{klass}, Hash, or nil — got #{config.class}"
+        end
+      end
+
+      # @param config [OpPrimer::SortableLists::Item, Hash] row-level sortable
+      #   wiring. A Hash without `type:` defaults it from `@sortable_list`'s
+      #   accepted type.
+      # @return [OpPrimer::SortableLists::Item]
+      def coerce_row_sortable(config)
+        case config
+        when OpPrimer::SortableLists::Item then config
+        when Hash then OpPrimer::SortableLists::Item.new(type: @sortable_list.accepted_type, **config)
+        else
+          raise ArgumentError, "expected OpPrimer::SortableLists::Item, Hash, or nil — got #{config.class}"
+        end
+      end
+
+      # @param caller_data [Hash, nil] hand-wired `data:` hash supplied by the caller.
+      # @param generated_data [Hash] sortable-lists `data:` hash produced internally.
+      # @return [void]
+      # @raise [ArgumentError] if `caller_data` hand-wires a `sortable_lists__*`
+      #   key that the generated wiring also sets.
+      def assert_no_sortable_conflicts!(caller_data, generated_data)
+        return if caller_data.blank?
+
+        generated_keys = generated_data.keys.map(&:to_s).select { |key| key.start_with?("sortable_lists__") }
+        caller_keys = caller_data.keys.map(&:to_s)
+        conflicts = generated_keys & caller_keys
+        return if conflicts.empty?
+
+        raise ArgumentError, "sortable wiring conflicts with hand-wired data keys: #{conflicts.join(', ')}"
+      end
+
+      # @return [void]
+      # @raise [ArgumentError] if `sortable_list:` and `sortable_item:` are
+      #   both given, or if `sortable_handle:` is combined with
+      #   `sortable_item:` (which already implies the handle wiring).
+      def assert_no_combined_sortable_roles!
+        if @sortable_list && @sortable_item
+          raise ArgumentError,
+                "BorderBoxListCollectionComponent cannot combine sortable_list: with sortable_item: — " \
+                "list.controller and item.controller cannot yet share one element (see sortable_item: docs)"
+        end
+
+        return unless @sortable_handle && @sortable_item
+
+        raise ArgumentError, "sortable_handle: is redundant with sortable_item:, which already wires the handle"
+      end
+
+      # @return [void]
+      # @raise [ArgumentError] if `sortable_handle:` is set without a header
+      #   showing `show_drag_handle: true`.
+      def assert_sortable_handle_requires_drag_handle!
+        return unless @sortable_handle
+        return if header&.show_drag_handle?
+
+        raise ArgumentError, "sortable_handle: requires a header with show_drag_handle: true"
       end
     end
   end

--- a/app/components/open_project/common/border_box_list_component/header.html.erb
+++ b/app/components/open_project/common/border_box_list_component/header.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
     ) do |grid| %>
   <% if show_drag_handle? %>
     <% grid.with_area(:drag_handle, classes: "hide-when-print") do %>
-      <%= render(Primer::OpenProject::DragHandle.new) %>
+      <%= render(Primer::OpenProject::DragHandle.new(**drag_handle_arguments)) %>
     <% end %>
   <% end %>
 

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -150,9 +150,11 @@ module OpenProject
                     :interactive,
                     :collapsed,
                     :collapsible,
-                    :show_drag_handle
+                    :show_drag_handle,
+                    :sortable_handle
 
         alias_method :show_drag_handle?, :show_drag_handle
+        alias_method :sortable_handle?, :sortable_handle
 
         attr_writer :collapsible_id
 
@@ -177,6 +179,11 @@ module OpenProject
         #   with a toggle button.
         # @param show_drag_handle [Boolean] whether the header renders a leading
         #   drag handle. Defaults to `false`.
+        # @param sortable_handle [Boolean] whether the rendered drag handle
+        #   carries sortable-lists wiring. Injected internally by the parent
+        #   list based on its `sortable_item:` or `sortable_handle:`
+        #   configuration; has no effect unless `show_drag_handle` is also
+        #   `true`.
         # @param system_arguments [Hash] forwarded to `Primer::Beta::BorderBox#with_header`.
         def initialize(
           title: nil,
@@ -190,6 +197,7 @@ module OpenProject
           collapsed: false,
           collapsible: false,
           show_drag_handle: false,
+          sortable_handle: false,
           **system_arguments
         )
           super()
@@ -206,6 +214,7 @@ module OpenProject
           @collapsed = collapsed
           @collapsible = collapsible
           @show_drag_handle = show_drag_handle
+          @sortable_handle = sortable_handle
           @system_arguments = system_arguments
         end
 
@@ -276,6 +285,15 @@ module OpenProject
         # @return [String, nil] ids controlled by the collapsible header.
         def collapsible_id
           @collapsible_id.presence
+        end
+
+        # @return [Hash] arguments forwarded to the leading drag handle's
+        #   `Primer::OpenProject::DragHandle`. Empty unless `sortable_handle`
+        #   is set.
+        def drag_handle_arguments
+          return {} unless sortable_handle?
+
+          { classes: "handle", data: { sortable_lists__item_target: "handle" } }
         end
 
         private

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -117,12 +117,28 @@ module OpenProject
         #   # @return [ViewComponent::Slot]
         #   def with_action_icon_button(**system_arguments)
         #   end
+        #
+        #   # Adds an inline labeled action menu to the header actions area.
+        #   #
+        #   # A deliberate local extension (upstream's DataTable has the same
+        #   # arm on main, but it is not in the locked gem). Use this for
+        #   # visible, labeled menus such as a position selector — the
+        #   # trailing overflow/kebab menu stays on `with_menu`. The caller
+        #   # composes the show button.
+        #   #
+        #   # @param system_arguments [Hash] forwarded to `Primer::Alpha::ActionMenu`.
+        #   # @return [ViewComponent::Slot]
+        #   def with_action_menu(**system_arguments, &block)
+        #   end
         renders_many :actions, types: {
           button: ->(scheme: DEFAULT_ACTION_SCHEME, **system_arguments) do
             Primer::Beta::Button.new(scheme:, **system_arguments)
           end,
           icon_button: ->(**system_arguments) do
             Primer::Beta::IconButton.new(**system_arguments)
+          end,
+          menu: ->(**system_arguments) do
+            Primer::Alpha::ActionMenu.new(**system_arguments)
           end
         }
 

--- a/app/components/settings/project_custom_field_sections/index_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/index_component.html.erb
@@ -1,13 +1,21 @@
 <%=
-  component_wrapper(data: wrapper_data_attributes) do
-    if @project_custom_field_sections.any?
-      flex_layout(data: sections_list_data) do |flex|
-        @project_custom_field_sections.each do |section|
-          flex.with_row(
-            data: section_item_data(section)
-          ) do
-            render(row_component_class.new(project_custom_field_section: section, first_and_last:))
-          end
+  component_wrapper do
+    render(
+      OpenProject::Common::BorderBoxListCollectionComponent.new(
+        container: "project-custom-field-sections",
+        sortable_list: { type: "section" },
+        root: true,
+        move_urls: ->(id) {
+          {
+            section: drop_admin_settings_project_custom_field_section_path(id),
+            custom_field: drop_admin_settings_project_custom_field_path(id)
+          }
+        }
+      )
+    ) do |collection|
+      @project_custom_field_sections.each do |section|
+        collection.with_item_row(sortable: OpPrimer::SortableLists::Item.for(section, type: "section")) do
+          render(row_component_class.new(project_custom_field_section: section, first_and_last:))
         end
       end
     end

--- a/app/components/settings/project_custom_field_sections/index_component.rb
+++ b/app/components/settings/project_custom_field_sections/index_component.rb
@@ -48,44 +48,6 @@ module Settings
       def first_and_last
         [@project_custom_field_sections.first, @project_custom_field_sections.last]
       end
-
-      private
-
-      def wrapper_data_attributes
-        {
-          controller: "sortable-lists",
-          sortable_lists_move_url_templates_value: move_url_templates.to_json,
-          sortable_lists_sortable_lists__list_outlet: "##{wrapper_key} [data-controller~='sortable-lists--list']",
-          sortable_lists_sortable_lists__item_outlet: "##{wrapper_key} [data-controller~='sortable-lists--item']"
-        }
-      end
-
-      # Built from route helpers with a sentinel so relative-URL-root
-      # installations keep working; {id} is expanded client-side.
-      def move_url_templates
-        id_placeholder = "__id__"
-        {
-          section: drop_admin_settings_project_custom_field_section_path(id_placeholder).sub(id_placeholder, "{id}"),
-          custom_field: drop_admin_settings_project_custom_field_path(id_placeholder).sub(id_placeholder, "{id}")
-        }
-      end
-
-      def sections_list_data
-        {
-          controller: "sortable-lists--list",
-          sortable_lists__list_type_value: "section",
-          sortable_lists__list_accepted_type_value: "section"
-        }
-      end
-
-      def section_item_data(section)
-        {
-          controller: "sortable-lists--item",
-          sortable_lists__item_id_value: section.id,
-          sortable_lists__item_type_value: "section",
-          sortable_lists__item_label_value: section.name
-        }
-      end
     end
   end
 end

--- a/app/components/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/show_component.html.erb
@@ -1,136 +1,128 @@
 <%=
   component_wrapper(class: "op-project-custom-field-section-container", data: { test_selector: "project-custom-field-section-container-#{@project_custom_field_section.id}" }) do
-    render(border_box_container(mt: 3, data: field_list_data)) do |component|
-      component.with_header(font_weight: :bold) do
-        flex_layout(justify_content: :space_between, align_items: :center) do |section_header_container|
-          section_header_container.with_column(flex_layout: true, align_items: :center) do |content_container|
-            content_container.with_column(mr: 2) do
-              render(Primer::OpenProject::DragHandle.new(classes: "handle", data: { sortable_lists__item_target: "handle" }))
+    concat(
+      render(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "project-custom-field-section-#{@project_custom_field_section.id}",
+          mt: 3,
+          sortable_list: OpPrimer::SortableLists::List.for(@project_custom_field_section, type: "custom_field"),
+          sortable_handle: true
+        )
+      ) do |list|
+        list.with_header(title: @project_custom_field_section.name, show_drag_handle: true) do |header|
+          header.with_action_menu(select_variant: :single, size: :small, test_selector: "section-position-selector") do |menu|
+            menu.with_show_button(
+              aria: { label: t("settings.project_attributes.sections.display_representation.overview.label") }
+            ) do |button|
+              button.with_trailing_visual_icon(icon: :"triangle-down")
+              button.with_leading_visual_icon(icon: display_representation_icon_for_section(@project_custom_field_section))
+              display_representation_label_for_section(@project_custom_field_section)
             end
-            content_container.with_column do
-              render(Primer::Beta::Text.new(font_weight: :bold)) do
-                @project_custom_field_section.name
-              end
+
+            menu.with_item(
+              label: t("settings.project_attributes.sections.display_representation.overview.side_panel.label"),
+              active: @project_custom_field_section.shown_in_overview_sidebar?,
+              test_selector: "section-position-selector--side-panel-option",
+              **menu_item_options_for(@project_custom_field_section, ProjectCustomFieldSection::OVERVIEW__SIDEBAR_KEY)
+            ) do |item|
+              item.with_leading_visual_icon(icon: :"op-view-split")
+              item.with_description.with_content(t("settings.project_attributes.sections.display_representation.overview.side_panel.description"))
+            end
+            menu.with_item(
+              label: t("settings.project_attributes.sections.display_representation.overview.main_area.label"),
+              active: @project_custom_field_section.shown_in_overview_main_area?,
+              test_selector: "section-position-selector--main-section-option",
+              **menu_item_options_for(@project_custom_field_section, ProjectCustomFieldSection::OVERVIEW__MAIN_AREA_KEY)
+            ) do |item|
+              item.with_leading_visual_icon(icon: :"op-view-cards")
+              item.with_description.with_content(t("settings.project_attributes.sections.display_representation.overview.main_area.description"))
             end
           end
 
-          section_header_container.with_column(flex_layout: true, justify_content: :flex_end) do |actions_container|
-            actions_container.with_column do
-              render(Primer::Alpha::ActionMenu.new(select_variant: :single, size: :small, test_selector: "section-position-selector")) do |menu|
-                menu.with_show_button(
-                  mr: 2,
-                  aria: { label: t("settings.project_attributes.sections.display_representation.overview.label") }
-                ) do |button|
-                  button.with_trailing_visual_icon(icon: :"triangle-down")
-                  button.with_leading_visual_icon(icon: display_representation_icon_for_section(@project_custom_field_section))
-                  display_representation_label_for_section(@project_custom_field_section)
-                end
-
-                menu.with_item(
-                  label: t("settings.project_attributes.sections.display_representation.overview.side_panel.label"),
-                  active: @project_custom_field_section.shown_in_overview_sidebar?,
-                  test_selector: "section-position-selector--side-panel-option",
-                  **menu_item_options_for(@project_custom_field_section, ProjectCustomFieldSection::OVERVIEW__SIDEBAR_KEY)
-                ) do |item|
-                  item.with_leading_visual_icon(icon: :"op-view-split")
-                  item.with_description.with_content(t("settings.project_attributes.sections.display_representation.overview.side_panel.description"))
-                end
-                menu.with_item(
-                  label: t("settings.project_attributes.sections.display_representation.overview.main_area.label"),
-                  active: @project_custom_field_section.shown_in_overview_main_area?,
-                  test_selector: "section-position-selector--main-section-option",
-                  **menu_item_options_for(@project_custom_field_section, ProjectCustomFieldSection::OVERVIEW__MAIN_AREA_KEY)
-                ) do |item|
-                  item.with_leading_visual_icon(icon: :"op-view-cards")
-                  item.with_description.with_content(t("settings.project_attributes.sections.display_representation.overview.main_area.description"))
-                end
-              end
+          header.with_menu(
+            button_aria_label: t("settings.project_attributes.label_section_actions"),
+            test_selector: "project-custom-field-section-action-menu"
+          ) do |menu|
+            edit_action_item(menu)
+            move_actions(menu)
+            if @ordered_cfs.empty?
+              delete_action_item(menu)
+            else
+              disabled_delete_action_item(menu)
             end
 
-            actions_container.with_column do
-              render(Primer::Alpha::ActionMenu.new(data: { test_selector: "project-custom-field-section-action-menu" })) do |menu|
-                menu.with_show_button(icon: "kebab-horizontal", "aria-label": t("settings.project_attributes.label_section_actions"), scheme: :invisible)
-                edit_action_item(menu)
-                move_actions(menu)
-                if @ordered_cfs.empty?
-                  delete_action_item(menu)
-                else
-                  disabled_delete_action_item(menu)
-                end
+            menu.with_divider
 
-                menu.with_divider
+            menu.with_sub_menu_item(
+              label: t("settings.project_attributes.label_new_attribute"),
+              content_arguments: {
+                aria: { label: t("settings.project_attributes.label_add_attribute") },
+                data: { test_selector: "new-project-custom-field-in-section-submenu" }
+              }
+            ) do |sub_menu|
+              sub_menu.with_leading_visual_icon(icon: :plus)
+              OpenProject::CustomFieldFormat.available_for_class_name("Project")
+                                            .sort_by(&:name)
+                                            .each do |format|
+                action_menu_item_for_custom_field_format(sub_menu, format)
+              end
+            end
+          end
+        end
 
-                menu.with_sub_menu_item(
-                  label: t("settings.project_attributes.label_new_attribute"),
-                  content_arguments: {
-                    aria: { label: t("settings.project_attributes.label_add_attribute") },
-                    data: { test_selector: "new-project-custom-field-in-section-submenu" }
-                  }
-                ) do |sub_menu|
-                  sub_menu.with_leading_visual_icon(icon: :plus)
+        if @ordered_cfs.empty?
+          list.with_item(data: { empty_list_item: true }) do
+            flex_layout(align_items: :center, justify_content: :space_between) do |empty_list_container|
+              empty_list_container.with_column(ml: 4, mr: 2) do
+                render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
+              end
+              empty_list_container.with_column do
+                render(Primer::Alpha::ActionMenu.new(data: { test_selector: "new-project-custom-field-in-section-button" })) do |menu|
+                  menu.with_show_button(
+                    scheme: :secondary,
+                    "aria-label": t("settings.project_attributes.label_new_attribute")
+                  ) do |btn|
+                    btn.with_leading_visual_icon(icon: :plus)
+                    btn.with_trailing_visual_icon(icon: :"triangle-down")
+
+                    t("settings.project_attributes.label_new_attribute")
+                  end
+
                   OpenProject::CustomFieldFormat.available_for_class_name("Project")
                                                 .sort_by(&:name)
                                                 .each do |format|
-                    action_menu_item_for_custom_field_format(sub_menu, format)
+                    action_menu_item_for_custom_field_format(menu, format)
                   end
                 end
               end
             end
-
-            actions_container.with_column do
+          end
+        else
+          @ordered_cfs.each_with_index do |cf, index|
+            list.with_item(sortable: { id: cf.id, label: cf.name }) do
               render(
-                Primer::Alpha::Dialog.new(
-                  id: "project-custom-field-section-dialog#{@project_custom_field_section.id}", title: t("settings.project_attributes.label_new_section"),
-                  size: :medium_portrait,
-                  data: { "keep-open-on-submit": true }
+                custom_field_row_component_class.new(
+                  project_custom_field: cf,
+                  first: index == 0,
+                  last: index == @ordered_cfs.size - 1
                 )
-              ) do |_dialog|
-                render(Settings::ProjectCustomFieldSections::DialogBodyFormComponent.new(project_custom_field_section: @project_custom_field_section))
-              end
-            end
-          end
-        end
-      end
-      if @ordered_cfs.empty?
-        component.with_row(data: { "empty-list-item": true }) do
-          flex_layout(align_items: :center, justify_content: :space_between) do |empty_list_container|
-            empty_list_container.with_column(ml: 4, mr: 2) do
-              render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
-            end
-            empty_list_container.with_column do
-              render(Primer::Alpha::ActionMenu.new(data: { test_selector: "new-project-custom-field-in-section-button" })) do |menu|
-                menu.with_show_button(
-                  scheme: :secondary,
-                  "aria-label": t("settings.project_attributes.label_new_attribute")
-                ) do |btn|
-                  btn.with_leading_visual_icon(icon: :plus)
-                  btn.with_trailing_visual_icon(icon: :"triangle-down")
-
-                  t("settings.project_attributes.label_new_attribute")
-                end
-
-                OpenProject::CustomFieldFormat.available_for_class_name("Project")
-                                              .sort_by(&:name)
-                                              .each do |format|
-                  action_menu_item_for_custom_field_format(menu, format)
-                end
-              end
-            end
-          end
-        end
-      else
-        @ordered_cfs.each_with_index do |cf, index|
-          component.with_row(data: field_item_data(cf)) do
-            render(
-              custom_field_row_component_class.new(
-                project_custom_field: cf,
-                first: index == 0,
-                last: index == @ordered_cfs.size - 1
               )
-            )
+            end
           end
         end
       end
-    end
+    )
+
+    concat(
+      render(
+        Primer::Alpha::Dialog.new(
+          id: "project-custom-field-section-dialog#{@project_custom_field_section.id}", title: t("settings.project_attributes.label_new_section"),
+          size: :medium_portrait,
+          data: { keep_open_on_submit: true }
+        )
+      ) do |_dialog|
+        render(Settings::ProjectCustomFieldSections::DialogBodyFormComponent.new(project_custom_field_section: @project_custom_field_section))
+      end
+    )
   end
 %>

--- a/app/components/settings/project_custom_field_sections/show_component.rb
+++ b/app/components/settings/project_custom_field_sections/show_component.rb
@@ -54,29 +54,6 @@ module Settings
         @project_custom_field_section.id
       end
 
-      def field_list_data
-        {
-          controller: "sortable-lists--list",
-          sortable_lists__list_type_value: "custom_field",
-          sortable_lists__list_accepted_type_value: "custom_field",
-          sortable_lists__list_id_value: @project_custom_field_section.id,
-          sortable_lists__list_name_value: @project_custom_field_section.name,
-          # The section's drag preview snapshots the box itself rather than
-          # the browser's native capture of the row wrapper, which paints the
-          # box's top margin and squares off the rounded corners.
-          sortable_lists__item_target: "preview"
-        }
-      end
-
-      def field_item_data(project_custom_field)
-        {
-          controller: "sortable-lists--item",
-          sortable_lists__item_id_value: project_custom_field.id,
-          sortable_lists__item_type_value: "custom_field",
-          sortable_lists__item_label_value: project_custom_field.name
-        }
-      end
-
       def move_actions(menu)
         unless first?
           move_action_item(menu, :highest, t("label_agenda_item_move_to_top"),
@@ -95,8 +72,7 @@ module Settings
         menu.with_item(label: label_text,
                        href: move_admin_settings_project_custom_field_section_path(@project_custom_field_section, move_to:),
                        form_arguments: {
-                         method: :put, data: { "turbo-stream": true,
-                                               test_selector: "project-custom-field-section-move-#{move_to}" }
+                         method: :put, data: { turbo_stream: true }
                        }) do |item|
           item.with_leading_visual_icon(icon:)
         end
@@ -113,8 +89,7 @@ module Settings
         menu.with_item(label: t("settings.project_attributes.label_edit_section"),
                        tag: :button,
                        content_arguments: {
-                         "data-show-dialog-id": "project-custom-field-section-dialog#{@project_custom_field_section.id}",
-                         "data-test-selector": "project-custom-field-section-edit"
+                         data: { show_dialog_id: "project-custom-field-section-dialog#{@project_custom_field_section.id}" }
                        },
                        value: "") do |item|
           item.with_leading_visual_icon(icon: :pencil)
@@ -129,8 +104,7 @@ module Settings
                          method: :delete,
                          data: {
                            turbo_confirm: t(:text_are_you_sure),
-                           turbo_stream: true,
-                           test_selector: "project-custom-field-section-delete"
+                           turbo_stream: true
                          }
                        }) do |item|
           item.with_leading_visual_icon(icon: :trash)

--- a/lookbook/docs/components/border-box-list-collection.md.erb
+++ b/lookbook/docs/components/border-box-list-collection.md.erb
@@ -1,0 +1,108 @@
+The `BorderBoxListCollectionComponent` is a stable-id wrapper that owns the
+outer sortable-lists region for a page: the drop target for its rows, and —
+for pages composed of a single collection — the page-level root wiring too.
+
+## Overview
+
+<%= embed OpenProject::Common::BorderBoxListCollectionComponentPreview, :default, panels: %i[source] %>
+
+## Anatomy
+
+The collection is structured in three layers:
+
+**Wrapper**
+The outer element, identified by `container:`. Carries the page-level
+`sortable-lists` root wiring when `root:` is set.
+
+**Inner list container**
+A genuine descendant of the wrapper that directly holds the item rows.
+Carries the `sortable_list:` wiring when set. Kept separate from the
+wrapper because a page-level root's outlet selectors are plain CSS
+descendant combinators scoped from the wrapper id, and by the DOM spec a
+descendant combinator can never match the element it is scoped from — so
+mounting the list role on the wrapper itself would make it invisible to
+the root's own outlets.
+
+**Item rows**
+Free-form row content, one `with_item_row` per row. Unlike
+`BorderBoxListComponent#with_item`, `with_item_row` does not assume Primer
+BorderBox row semantics: a row can itself be a `BorderBoxListComponent`
+box (a dual-role page's per-box list, as shown above) or any other
+content.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `container` | `String`, `Symbol`, `Class`, `Object` | required | Seed used to derive the wrapper's stable DOM id. Related sortable-lists selectors (the root's outlets, an explicit root's `scope_id`) are derived from the resulting id, not from `container` directly |
+| `sortable_list` | `OpPrimer::SortableLists::List`, `Hash`, `nil` | - | Marks the inner list container (not the wrapper) as a sortable-lists drop target for its rows, providing the type/accepted_type context row items default from |
+| `root` | `true`, `OpPrimer::SortableLists::Root`, `nil` | - | Page-level sortable-lists root wiring. `true` derives a `Root` scoped to the wrapper's own id, built from `move_urls:`. An explicit `Root` is used as-is once its `scope_id` is confirmed to match the wrapper id — this is how several boxes composed inside one collection share a single page-level root without any one box claiming ownership of it |
+| `move_urls` | `Proc`, `nil` | - | `->(id)` returning a `{ type => url }` map, forwarded to `Root` when `root: true`. Required when `root: true`; ignored otherwise |
+| `system_arguments` | `Hash` | `{}` | Forwarded to the wrapper element (`Primer::Box`). Pass `id:` to override the derived wrapper id |
+
+## Slots
+
+| Slot | Description |
+|---|---|
+| `with_item_row` | Free-form collection row. Pass `sortable:` with the row's identity when the component's `sortable_list:` is set — a Hash's `type:` defaults from the `sortable_list:`'s accepted type when omitted |
+
+## Root wiring
+
+Use this component when a page is a flat collection of rows (e.g. a
+sections index), or when several `BorderBoxListComponent` boxes need a
+shared page-level root without any one of them claiming ownership of it.
+`root: true` and `move_urls:` derive that root for you — see the
+[Border Box List sortable lists docs](./border_box_list#sortable-lists)
+for the full page-level root story, including the `move_url:`/`#merge_into`
+variant for plain views that don't use this component.
+
+An explicit `Root` (rather than `root: true`) is only accepted when its
+`scope_id` matches the wrapper's own id — a mismatched scope would derive
+outlet selectors that search under the wrong element, so the component
+raises rather than silently wiring a root that can never see its own
+children.
+
+## Usage guidelines
+
+**Do**
+
+- Use this component to give a flat collection of rows (no per-row
+  headers or footers) a stable, sortable-lists-ready wrapper.
+- Use `root: true` when the collection page owns the whole page-level
+  root by itself.
+- Nest `BorderBoxListComponent` boxes as row content for a dual-role page
+  — a collection-level list of boxes, each with its own inner list.
+
+**Don't**
+
+- Don't reach for this component for a single `BorderBoxListComponent`
+  box on its own — it only adds value once a page needs a shared root or
+  free-form (non-BorderBox) row content.
+
+## Code structure
+
+```ruby
+render(
+  OpenProject::Common::BorderBoxListCollectionComponent.new(
+    container: "project-custom-field-sections",
+    sortable_list: { type: "section" },
+    root: true,
+    move_urls: ->(id) {
+      {
+        section: drop_admin_settings_project_custom_field_section_path(id),
+        custom_field: drop_admin_settings_project_custom_field_path(id)
+      }
+    }
+  )
+) do |collection|
+  @project_custom_field_sections.each do |section|
+    collection.with_item_row(sortable: OpPrimer::SortableLists::Item.for(section, type: "section")) do
+      render(row_component_class.new(project_custom_field_section: section, first_and_last:))
+    end
+  end
+end
+```
+
+See `Settings::ProjectCustomFieldSections::IndexComponent` for the live
+example, and the [Border Box List docs](./border_box_list) for the
+`BorderBoxListComponent` boxes nested inside each row.

--- a/lookbook/docs/components/border-box-list.md.erb
+++ b/lookbook/docs/components/border-box-list.md.erb
@@ -40,6 +40,9 @@ comparable lists should use headers.
 | `empty_state_behavior` | `Symbol` | `:static` | Policy for the empty state shown when the list has no items. See [Empty-state behavior](#empty-state-behavior) below |
 | `interactive` | `Boolean` | `false` | Enables polite ARIA live-region announcements for counter and configured empty-state updates |
 | `collapsible` | `Boolean` | `false` | Renders the header as a collapsible toggle when a header is present |
+| `sortable_list` | `OpPrimer::SortableLists::List`, `Hash`, `nil` | - | Marks the box root as a sortable-lists drop target for its rows, providing the type/accepted_type context row items default from. Mutually exclusive with `sortable_item:`. Requires a page-level `sortable-lists` controller root |
+| `sortable_item` | `OpPrimer::SortableLists::Item`, `Hash`, `nil` | - | Marks the whole box as a draggable drag-and-drop item (e.g. a collapsible group nested inside another sortable list). Wires the drag-preview target automatically, and wires the header drag handle automatically when a header with `show_drag_handle: true` is present. Mutually exclusive with `sortable_list:` and redundant with `sortable_handle:` |
+| `sortable_handle` | `Boolean` | `false` | Wires a bare drag-preview target and the header drag handle without a full `sortable_item:` (and its own item Stimulus controller). Use when the group's *rows* are the draggable unit but the group itself still needs a handle driven by some other reordering mechanism. Requires a header with `show_drag_handle: true`; mutually exclusive with `sortable_item:` |
 | `current_user` | `User` | `User.current` | User context forwarded to work package item rows |
 | `system_arguments` | `Hash` | `{}` | Forwarded to the underlying `Primer::Beta::BorderBox` |
 
@@ -48,7 +51,7 @@ comparable lists should use headers.
 | Slot | Description |
 |---|---|
 | `with_header` | Optional section header. See [Header parameters](#header-parameters) and [Header slots](#header-slots) below |
-| `with_item` | Generic list row that renders the provided block content |
+| `with_item` | Generic list row that renders the provided block content. Pass `sortable:` with the row's identity when the list is sortable |
 | `with_work_package_item` | Work package row that renders a work package card |
 | `with_empty_state` | Custom empty-state content rendered when no items are present |
 | `with_footer` | Optional footer row below the list items |
@@ -76,7 +79,8 @@ comparable lists should use headers.
 | `with_label` | Informational status label (`Primer::Beta::Label`) shown on the title row. Right-aligned, truncated when long, and hidden on small screens, so use it only for supplementary status, never as the sole affordance for an action |
 | `with_action_button` | Button rendered in the header actions area |
 | `with_action_icon_button` | Icon button rendered in the header actions area |
-| `with_menu` | Action menu rendered in the header actions area. Pass `button_arguments:` for the default trigger button |
+| `with_action_menu` | Inline labeled action menu in the actions area. The trailing overflow menu stays on `with_menu` |
+| `with_menu` | The single trailing overflow/kebab menu, rendered in its own menu area after the actions — not the actions area used by `with_action_button`/`with_action_icon_button`/`with_action_menu`. Pass `button_arguments:` for the default trigger button |
 
 ### Collapsible headers
 
@@ -138,6 +142,118 @@ heading navigation intact. The last crumb is marked as the current page
 automatically. Breadcrumbs are not available on collapsible headers.
 
 <%= embed OpenProject::Common::BorderBoxListComponentPreview, :header_breadcrumbs, panels: %i[source] %>
+
+### Sortable lists
+
+Declare drag-and-drop wiring instead of hand-writing Stimulus data
+attributes. Values come from `OpPrimer::SortableLists::List` / `Item` /
+`Root` (or equivalent hashes); wire `type`s are never derived from
+models — pass the short names your page's URL-template map uses.
+
+**Box-level wiring**
+
+`sortable_list:` always mounts on the box root, marking it a drop target
+for its own rows; each row then passes `sortable:` with its identity.
+`sortable_item:` marks the whole box as a draggable item instead — for a
+box that is itself a draggable row in an outer list, such as a
+collapsible group nested inside another sortable list. `sortable_list:`
+and `sortable_item:` mount on the same element and so cannot be combined:
+`list.controller` and `item.controller` each register their own Pragmatic
+drop target on `this.element`, and Pragmatic's element adapter keys that
+registration by DOM node, so mounting both would make whichever connects
+second silently replace the first's registration.
+
+When a box's rows need to be draggable but the box itself is reordered by
+some other mechanism (move-up/move-down menu items rather than dragging
+the group), use `sortable_handle: true` instead of `sortable_item:`. It
+wires the bare drag-preview target and the header drag handle without a
+full item Stimulus controller. `sortable_handle:` raises unless a header
+with `show_drag_handle: true` is present; `sortable_item:` wires the
+drag handle too, but only when such a header happens to be present — it
+does not require one.
+
+<%= embed OpenProject::Common::BorderBoxListComponentPreview, :sortable_wiring, panels: %i[source] %>
+
+**The page-level root**
+
+The component only emits its own wiring — dragging additionally needs a
+page-level element carrying the `sortable-lists` root controller, which
+supplies the move URL(s) and reaches outward to the list/item (and
+optionally scrollable) children through outlets. Build one with
+`OpPrimer::SortableLists::Root` instead of hand-writing the
+`sortable_lists_*` data attributes.
+
+Inside a `BorderBoxListCollectionComponent`, pass `root: true` with
+`move_urls:` (a `->(id) { { type => url } }` lambda) and the collection
+derives a `Root` scoped to its own wrapper id. This is how
+`Settings::ProjectCustomFieldSections::IndexComponent` wires page-level
+dragging for a page mixing two draggable types — sections themselves and
+the custom fields nested inside them:
+
+```ruby
+render(
+  OpenProject::Common::BorderBoxListCollectionComponent.new(
+    container: "project-custom-field-sections",
+    sortable_list: { type: "section" },
+    root: true,
+    move_urls: ->(id) {
+      {
+        section: drop_admin_settings_project_custom_field_section_path(id),
+        custom_field: drop_admin_settings_project_custom_field_path(id)
+      }
+    }
+  )
+) do |collection|
+  @project_custom_field_sections.each do |section|
+    collection.with_item_row(sortable: OpPrimer::SortableLists::Item.for(section, type: "section")) do
+      render(row_component_class.new(project_custom_field_section: section, first_and_last:))
+    end
+  end
+end
+```
+
+See the [Border Box List Collection docs](./border_box_list_collection)
+for the collection component's own parameters and slots. An explicit
+`Root` (rather than `root: true`) is also how several
+`BorderBoxListComponent` boxes on the same page can share one page-level
+root without any single box claiming ownership of it — a pattern this
+codebase doesn't exercise yet, but the intended shape for pages beyond a
+single collection, such as a Backlogs board with one box per sprint
+(part of the same prospective DREAM-806 adoption below).
+
+For a plain view element with a single draggable type, build a `Root`
+directly with `move_url:` (a `->(id) { url }` lambda) and merge it in
+with `#merge_into`, which token-joins onto any existing `controller`/
+`action` values instead of overwriting them — so the root can share an
+element with other Stimulus controllers already wired on it. Backlogs'
+turbo frame is the motivating case: it hand-writes this same
+`sortable_lists_*` data hash today (see
+`modules/backlogs/app/views/backlogs/backlog/show.html.erb`), and
+adopting `Root`/`#merge_into` there is prospective, tracked as a
+follow-up (DREAM-806) rather than done — this is the shape that
+migration would take:
+
+```ruby
+# How a page like the backlogs board — which today hand-writes this data
+# on its turbo frame — would adopt Root/#merge_into (DREAM-806):
+root = OpPrimer::SortableLists::Root.new(
+  scope_id: "backlogs_container",
+  move_url: ->(id) { move_project_backlogs_work_package_path(@project, id) },
+  optimistic: true,
+  outlets: %i[list item scrollable]
+)
+
+turbo_frame_tag(
+  :backlogs_container,
+  refresh: :morph,
+  src: project_backlogs_backlog_path(@project, backlog_filter_params),
+  class: "op-backlogs-page",
+  data: root.merge_into(
+    controller: "backlogs--list-refresh backlogs--split-view-sync",
+    action: "#{Backlogs::WorkPackagesController::WORK_PACKAGE_MOVED_EVENT}@document->backlogs--split-view-sync#onWorkPackageMoved"
+  )
+)
+```
 
 ### Empty state
 

--- a/lookbook/previews/open_project/common/border_box_list_collection_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_collection_component_preview.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Common
+    # @logical_path OpenProject/Common
+    class BorderBoxListCollectionComponentPreview < ViewComponent::Preview
+      # @label Default (static)
+      # Emission-only preview: a page-level collection of two rows, each a
+      # section-shaped BorderBoxListComponent box. Dragging needs a real
+      # browser and a page-level sortable-lists root outside the box being
+      # previewed, so this only shows the declared wiring — the same
+      # dual-role composition `Settings::ProjectCustomFieldSections::IndexComponent`
+      # uses: the collection owns the page-level root and the "section" row
+      # type, each row box owns its own "custom_field" list. Uses
+      # `render_with_template` (rather than nested `render` calls in Ruby)
+      # because `ViewComponent::Preview#render` only produces a real
+      # component tree at the top level of a preview method — nested calls
+      # from inside a captured slot block return an unrendered descriptor.
+      def default
+        render_with_template
+      end
+    end
+  end
+end

--- a/lookbook/previews/open_project/common/border_box_list_collection_component_preview/default.html.erb
+++ b/lookbook/previews/open_project/common/border_box_list_collection_component_preview/default.html.erb
@@ -1,0 +1,35 @@
+<%= render(
+      OpenProject::Common::BorderBoxListCollectionComponent.new(
+        container: "border-box-list-collection-preview",
+        sortable_list: { type: "section" },
+        root: true,
+        move_urls: ->(id) { { section: "/sections/#{id}/drop", custom_field: "/custom-fields/#{id}/drop" } }
+      )
+    ) do |collection| %>
+  <% collection.with_item_row(sortable: { id: 1, label: "Team information" }) do %>
+    <%= render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "border-box-list-collection-preview-section-1",
+            sortable_list: { type: "custom_field" },
+            sortable_handle: true
+          )
+        ) do |list| %>
+      <% list.with_header(title: "Team information", show_drag_handle: true) %>
+      <% list.with_item(sortable: { id: "1-0", label: "Team size" }) { "Team size" } %>
+      <% list.with_item(sortable: { id: "1-1", label: "Time zone" }) { "Time zone" } %>
+    <% end %>
+  <% end %>
+  <% collection.with_item_row(sortable: { id: 2, label: "Delivery details" }) do %>
+    <%= render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "border-box-list-collection-preview-section-2",
+            sortable_list: { type: "custom_field" },
+            sortable_handle: true
+          )
+        ) do |list| %>
+      <% list.with_header(title: "Delivery details", show_drag_handle: true) %>
+      <% list.with_item(sortable: { id: "2-0", label: "Target date" }) { "Target date" } %>
+      <% list.with_item(sortable: { id: "2-1", label: "Release owner" }) { "Release owner" } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/lookbook/previews/open_project/common/border_box_list_component_preview.rb
+++ b/lookbook/previews/open_project/common/border_box_list_component_preview.rb
@@ -192,6 +192,28 @@ module OpenProject
         end
       end
 
+      # @label Sortable wiring (static)
+      # Emission-only preview: shows the declared wiring. Dragging needs a
+      # page-level sortable-lists root, which Lookbook does not provide.
+      #
+      # `sortable_list:` and `sortable_item:` mount on the same element and
+      # cannot be combined, so this pairs `sortable_list:` (rows are the
+      # draggable unit) with `sortable_handle:` (the group's own handle,
+      # without a full item Stimulus controller) — the same shape
+      # `Settings::ProjectCustomFieldSections::ShowComponent` uses for its
+      # custom-field rows.
+      def sortable_wiring
+        render OpenProject::Common::BorderBoxListComponent.new(
+          container: "border-box-list-sortable-preview",
+          sortable_list: { type: "sprint", accepted_type: "task", name: "Sprint backlog" },
+          sortable_handle: true
+        ) do |list|
+          list.with_header(title: "Sprint backlog", show_drag_handle: true)
+          list.with_item(sortable: { id: 11, label: "Set up CI" }) { "Set up CI" }
+          list.with_item(sortable: { id: 12, label: "Write docs" }) { "Write docs" }
+        end
+      end
+
       # @label Playground
       # @param title_tag [Symbol] select [h2, h3, h4, h5]
       # @param count [Symbol] select [inferred, hidden, explicit, zero]

--- a/spec/components/op_primer/sortable_lists_spec.rb
+++ b/spec/components/op_primer/sortable_lists_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OpPrimer::SortableLists do
+  describe "#{described_class}::List" do
+    it "emits the list controller and values" do
+      list = described_class::List.new(type: "custom_field", id: 42, name: "General")
+
+      expect(list.to_data).to eq(
+        controller: "sortable-lists--list",
+        sortable_lists__list_type_value: "custom_field",
+        sortable_lists__list_accepted_type_value: "custom_field",
+        sortable_lists__list_id_value: 42,
+        sortable_lists__list_name_value: "General"
+      )
+    end
+
+    it "omits nil-valued fields so Stimulus defaults stay in charge" do
+      list = described_class::List.new(type: "work_package", drop_position: "start")
+
+      expect(list.to_data).to eq(
+        controller: "sortable-lists--list",
+        sortable_lists__list_type_value: "work_package",
+        sortable_lists__list_accepted_type_value: "work_package",
+        sortable_lists__list_drop_position_value: "start"
+      )
+    end
+
+    it "keeps an explicit accepted_type" do
+      list = described_class::List.new(type: "custom_field", accepted_type: "attribute")
+
+      expect(list.to_data[:sortable_lists__list_accepted_type_value]).to eq("attribute")
+    end
+
+    it "derives id and name from a record but never the type" do
+      section = Struct.new(:id, :name).new(7, "Marketing")
+      list = described_class::List.for(section, type: "section")
+
+      expect(list.id).to eq(7)
+      expect(list.name).to eq("Marketing")
+      expect(list.type).to eq("section")
+      expect { described_class::List.for(section) }.to raise_error(ArgumentError)
+    end
+
+    it "rejects unknown keys" do
+      expect { described_class::List.new(type: "x", externalHref: "nope") }
+        .to raise_error(ArgumentError, /externalHref/)
+    end
+
+    it "returns frozen instances" do
+      expect(described_class::List.new(type: "x")).to be_frozen
+      expect(described_class::Item.new(id: 1, type: "x")).to be_frozen
+    end
+  end
+
+  describe "#{described_class}::Item" do
+    it "emits the item controller, values, and token-joined targets" do
+      item = described_class::Item.new(id: 5, type: "custom_field", label: "Phone", targets: %w[moveMenu preview])
+
+      expect(item.to_data).to eq(
+        controller: "sortable-lists--item",
+        sortable_lists__item_id_value: 5,
+        sortable_lists__item_type_value: "custom_field",
+        sortable_lists__item_label_value: "Phone",
+        sortable_lists__item_target: "moveMenu preview"
+      )
+    end
+
+    it "merges and deduplicates role-added targets" do
+      item = described_class::Item.new(id: 1, type: "section", targets: %w[moveMenu preview])
+
+      expect(item.with_targets("preview").to_data[:sortable_lists__item_target]).to eq("moveMenu preview")
+    end
+
+    it "emits a meaningful false for hide_unavailable" do
+      item = described_class::Item.new(id: 1, type: "x", hide_unavailable: false)
+
+      expect(item.to_data[:sortable_lists__item_hide_unavailable_value]).to be(false)
+    end
+
+    it "requires id and type" do
+      expect { described_class::Item.new(type: "x") }.to raise_error(ArgumentError)
+      expect { described_class::Item.new(id: 1) }.to raise_error(ArgumentError)
+    end
+
+    it "derives id and label from a record but never the type" do
+      cf = Struct.new(:id, :name).new(3, "Phone")
+      item = described_class::Item.for(cf, type: "custom_field")
+
+      expect(item.id).to eq(3)
+      expect(item.label).to eq("Phone")
+      expect { described_class::Item.for(cf) }.to raise_error(ArgumentError)
+    end
+
+    it "exposes targets as an insertion-ordered set" do
+      item = described_class::Item.new(id: 1, type: "x", targets: %w[moveMenu preview moveMenu])
+
+      expect(item.targets).to be_a(Set)
+      expect(item.targets.to_a).to eq(%w[moveMenu preview])
+    end
+  end
+end

--- a/spec/components/op_primer/sortable_lists_spec.rb
+++ b/spec/components/op_primer/sortable_lists_spec.rb
@@ -128,4 +128,112 @@ RSpec.describe OpPrimer::SortableLists do
       expect(item.targets.to_a).to eq(%w[moveMenu preview])
     end
   end
+
+  describe "#{described_class}::Root" do
+    it "emits the root controller, url template map, and derived outlet selectors" do
+      root = described_class::Root.new(
+        scope_id: "sections-page",
+        move_urls: ->(id) { { section: "/sections/#{id}/drop", custom_field: "/cfs/#{id}/drop" } }
+      )
+
+      expect(root.to_data).to eq(
+        controller: "sortable-lists",
+        sortable_lists_move_url_templates_value: { section: "/sections/{id}/drop", custom_field: "/cfs/{id}/drop" }.to_json,
+        sortable_lists_sortable_lists__list_outlet: "#sections-page [data-controller~='sortable-lists--list']",
+        sortable_lists_sortable_lists__item_outlet: "#sections-page [data-controller~='sortable-lists--item']"
+      )
+    end
+
+    it "emits the singular template variant, optimistic value, and scrollable outlet" do
+      root = described_class::Root.new(
+        scope_id: "backlogs_container",
+        move_url: ->(id) { "/backlogs/#{id}/move" },
+        optimistic: true,
+        outlets: %i[list item scrollable]
+      )
+
+      data = root.to_data
+      expect(data[:sortable_lists_move_url_template_value]).to eq("/backlogs/{id}/move")
+      expect(data[:sortable_lists_optimistic_value]).to be(true)
+      expect(data[:sortable_lists_sortable_lists__scrollable_outlet])
+        .to eq("#backlogs_container [data-controller~='sortable-lists--scrollable']")
+    end
+
+    it "requires exactly one template variant and exactly one {id} per template" do
+      expect { described_class::Root.new(scope_id: "x") }.to raise_error(ArgumentError, /move_url/)
+      expect do
+        described_class::Root.new(scope_id: "x", move_url: ->(_id) { "/static" })
+      end.to raise_error(ArgumentError, /\{id\}/)
+      expect do
+        described_class::Root.new(scope_id: "x", move_urls: ->(_id) { {} })
+      end.to raise_error(ArgumentError, /empty/)
+      expect do
+        described_class::Root.new(scope_id: "x", move_url: ->(id) { "/a/#{id}/b/#{id}" })
+      end.to raise_error(ArgumentError, /exactly one/)
+    end
+
+    it "rejects unknown outlets eagerly, at construction time" do
+      expect do
+        described_class::Root.new(scope_id: "x", move_url: ->(id) { "/a/#{id}" }, outlets: [:bogus])
+      end.to raise_error(ArgumentError, /bogus/)
+    end
+
+    describe "#merge_into" do
+      it "token-joins controller and action while preserving existing data, without mutating the input" do
+        root = described_class::Root.new(scope_id: "frame", move_url: ->(id) { "/move/#{id}" })
+        existing = { controller: "backlogs--list-refresh", action: "evt@document->x#y", refresh: :morph }
+
+        merged = root.merge_into(existing)
+
+        expect(merged[:controller]).to eq("backlogs--list-refresh sortable-lists")
+        expect(merged[:action]).to eq("evt@document->x#y")
+        expect(merged[:refresh]).to eq(:morph)
+        expect(merged[:sortable_lists_move_url_template_value]).to eq("/move/{id}")
+        expect(existing).to eq(controller: "backlogs--list-refresh", action: "evt@document->x#y", refresh: :morph)
+      end
+
+      it "raises on conflicting hand-wired root keys" do
+        root = described_class::Root.new(scope_id: "frame", move_url: ->(id) { "/move/#{id}" })
+
+        expect { root.merge_into(sortable_lists_move_url_template_value: "/other/{id}") }
+          .to raise_error(ArgumentError, /move_url_template/)
+      end
+
+      it "token-joins a String-keyed controller into the canonical Symbol key, without a duplicate" do
+        root = described_class::Root.new(scope_id: "frame", move_url: ->(id) { "/move/#{id}" })
+        existing = { "controller" => "backlogs--list-refresh" }
+
+        merged = root.merge_into(existing)
+
+        expect(merged[:controller]).to eq("backlogs--list-refresh sortable-lists")
+        expect(merged.keys).not_to include("controller")
+        expect(existing).to eq("controller" => "backlogs--list-refresh")
+      end
+
+      it "raises on a String-keyed conflicting root value key" do
+        root = described_class::Root.new(scope_id: "frame", move_url: ->(id) { "/move/#{id}" })
+
+        expect { root.merge_into("sortable_lists_move_url_template_value" => "/other/{id}") }
+          .to raise_error(ArgumentError, /move_url_template/)
+      end
+    end
+  end
+
+  describe "#{described_class}::Scrollable" do
+    it "emits the scrollable controller and validated values" do
+      scrollable = described_class::Scrollable.new(allowed_axis: "vertical")
+
+      expect(scrollable.to_data).to eq(
+        controller: "sortable-lists--scrollable",
+        sortable_lists__scrollable_allowed_axis_value: "vertical"
+      )
+    end
+
+    it "raises where the Stimulus controller would silently fall back" do
+      expect { described_class::Scrollable.new(allowed_axis: "diagonal") }
+        .to raise_error(ArgumentError, /allowed_axis/)
+      expect { described_class::Scrollable.new(max_scroll_speed: "ludicrous") }
+        .to raise_error(ArgumentError, /max_scroll_speed/)
+    end
+  end
 end

--- a/spec/components/open_project/common/border_box_list_collection_component_preview_spec.rb
+++ b/spec/components/open_project/common/border_box_list_collection_component_preview_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+require Rails.root.join("lookbook/previews/open_project/common/border_box_list_collection_component_preview").to_s
+
+RSpec.describe OpenProject::Common::BorderBoxListCollectionComponentPreview, type: :component do
+  # The `default` example composes a nested BorderBoxListComponent per row,
+  # which needs a real Rails `render` call inside the captured slot block —
+  # `ViewComponent::Preview#render` only builds a component tree when
+  # returned from the top of a preview method, so nested composition uses
+  # `render_with_template` (an `.html.erb` sibling) instead. Resolving that
+  # template requires `lookbook/previews` on the ViewComponent previews path,
+  # which the app only adds when `lookbook_enabled?` (development only, see
+  # `config/initializers/lookbook.rb`) — add it for this example only.
+  around do |example|
+    previews_config = Rails.application.config.view_component.previews
+    lookbook_previews_path = Rails.root.join("lookbook/previews").to_s
+    added = previews_config.paths.exclude?(lookbook_previews_path)
+    previews_config.paths << lookbook_previews_path if added
+
+    begin
+      example.run
+    ensure
+      previews_config.paths.delete(lookbook_previews_path) if added
+    end
+  end
+
+  it "renders the default preview as a page-level root wrapping two section boxes" do
+    render_preview(:default, from: described_class)
+
+    expect(page).to have_css("#border-box-list-collection-preview[data-controller~='sortable-lists']")
+    expect(page).to have_css(
+      "#border-box-list-collection-preview [data-controller~='sortable-lists--list']", count: 3
+    )
+    expect(page).to have_heading("Team information", level: 4)
+    expect(page).to have_heading("Delivery details", level: 4)
+    expect(page).to have_text("Team size")
+    expect(page).to have_text("Release owner")
+  end
+end

--- a/spec/components/open_project/common/border_box_list_collection_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_collection_component_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OpenProject::Common::BorderBoxListCollectionComponent, type: :component do
+  subject(:rendered_component) { page }
+
+  def render_collection(**args, &)
+    render_inline(described_class.new(container: "sections-collection", **args), &)
+  end
+
+  it "renders a stable identified wrapper even when empty" do
+    render_collection(sortable_list: { type: "section" })
+
+    expect(rendered_component).to have_element("div", id: "sections-collection")
+  end
+
+  it "derives a root scoped to its own wrapper for root: true" do
+    render_collection(
+      sortable_list: { type: "section" },
+      root: true,
+      move_urls: ->(id) { { section: "/sections/#{id}/drop" } }
+    )
+
+    expect(rendered_component).to have_element("div", id: "sections-collection") do |wrapper|
+      expect(wrapper["data-controller"]).to include("sortable-lists")
+      expect(wrapper["data-sortable-lists-sortable-lists--item-outlet"])
+        .to eq("#sections-collection [data-controller~='sortable-lists--item']")
+    end
+  end
+
+  it "raises when root: true is given without move_urls" do
+    expect { render_collection(sortable_list: { type: "section" }, root: true) }
+      .to raise_error(ArgumentError, /move_urls/)
+  end
+
+  it "raises for an explicit Root whose scope does not match the wrapper" do
+    mismatched = OpPrimer::SortableLists::Root.new(scope_id: "elsewhere", move_url: ->(id) { "/m/#{id}" })
+
+    expect { render_collection(root: mismatched) }.to raise_error(ArgumentError, /scope_id/)
+  end
+
+  it "accepts an explicit Root whose scope matches the wrapper" do
+    matching = OpPrimer::SortableLists::Root.new(scope_id: "sections-collection", move_url: ->(id) { "/m/#{id}" })
+
+    render_collection(sortable_list: { type: "section" }, root: matching)
+
+    expect(rendered_component).to have_element("div", id: "sections-collection") do |wrapper|
+      expect(wrapper["data-controller"]).to include("sortable-lists")
+    end
+  end
+
+  it "wires exactly one item controller per row, on the row element" do
+    render_collection(sortable_list: { type: "section" }) do |collection|
+      collection.with_item_row(sortable: { id: 7, label: "Marketing" }) { "box one" }
+      collection.with_item_row(sortable: { id: 9, label: "PR" }) { "box two" }
+    end
+
+    expect(rendered_component).to have_css("[data-controller~='sortable-lists--item']", count: 2)
+    expect(rendered_component).to have_element("div", "data-sortable-lists--item-id-value": "7") do |row|
+      expect(row["data-sortable-lists--item-type-value"]).to eq("section")
+      expect(row.text).to include("box one")
+    end
+  end
+
+  it "defaults a row's sortable type from the collection's sortable_list accepted_type" do
+    render_collection(sortable_list: { type: "section", accepted_type: "custom_field" }) do |collection|
+      collection.with_item_row(sortable: { id: 3, label: "Priority" }) { "row content" }
+    end
+
+    expect(rendered_component).to have_element("div", "data-sortable-lists--item-id-value": "3") do |row|
+      expect(row["data-sortable-lists--item-type-value"]).to eq("custom_field")
+    end
+  end
+
+  it "raises when a row's sortable is given without the component's sortable_list" do
+    expect do
+      render_collection do |collection|
+        collection.with_item_row(sortable: { id: 3, label: "Priority" }) { "row content" }
+      end
+    end.to raise_error(ArgumentError, /sortable_list/)
+  end
+
+  it "renders free-form row content without imposing BorderBox row semantics" do
+    render_collection do |collection|
+      collection.with_item_row { "<span>plain content</span>".html_safe }
+    end
+
+    expect(rendered_component).to have_css("span", text: "plain content")
+  end
+end

--- a/spec/components/open_project/common/border_box_list_collection_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_collection_component_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe OpenProject::Common::BorderBoxListCollectionComponent, type: :com
     end
   end
 
+  it "wires the inner list container — never the wrapper itself — as the sortable-lists list" do
+    render_collection(sortable_list: { type: "section" })
+
+    expect(rendered_component).to have_element("div", id: "sections-collection") do |wrapper|
+      expect(wrapper["data-controller"].to_s.split).not_to include("sortable-lists--list")
+    end
+
+    # The exact shape of a root's own outlet selector
+    # (`##{wrapper_id} [data-controller~='sortable-lists--list']`): a plain
+    # CSS descendant combinator, which by the DOM spec can never match the
+    # wrapper element it is scoped from. Asserting the list role resolves
+    # through that selector — not just "somewhere in the markup" — proves it
+    # sits on a genuine descendant the root can actually see.
+    expect(rendered_component).to have_css("#sections-collection [data-controller~='sortable-lists--list']") do |list|
+      expect(list["data-sortable-lists--list-type-value"]).to eq("section")
+      expect(list["data-sortable-lists--list-accepted-type-value"]).to eq("section")
+    end
+  end
+
   it "raises when root: true is given without move_urls" do
     expect { render_collection(sortable_list: { type: "section" }, root: true) }
       .to raise_error(ArgumentError, /move_urls/)

--- a/spec/components/open_project/common/border_box_list_component_preview_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_preview_spec.rb
@@ -133,4 +133,12 @@ RSpec.describe OpenProject::Common::BorderBoxListComponentPreview, type: :compon
     expect(page).to have_text("Add item")
     expect(page).to have_no_css("tool-tip[data-type='label']", text: I18n.t(:label_actions))
   end
+
+  it "renders the sortable wiring preview" do
+    render_preview(:sortable_wiring, from: described_class)
+
+    expect(page).to have_heading("Sprint backlog", level: 4)
+    expect(page).to have_text("Set up CI")
+    expect(page).to have_text("Write docs")
+  end
 end

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -586,6 +586,38 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
         aria: { describedby: "goal-text" }
       )
     end
+
+    it "renders an inline action menu in the actions area" do
+      rendered = render_inline(described_class.new(container: "hdr-action-menu")) do |list|
+        list.with_header(title: "Sections") do |header|
+          header.with_action_menu(test_selector: "position-menu") do |menu|
+            menu.with_show_button { "Overview" }
+            menu.with_item(label: "Side panel")
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css(".op-border-box-list-header--actions action-menu[data-test-selector='position-menu']")
+    end
+
+    it "lets an inline action menu coexist with the trailing overflow menu" do
+      rendered = render_inline(described_class.new(container: "hdr-two-menus")) do |list|
+        list.with_header(title: "Sections") do |header|
+          header.with_action_menu do |menu|
+            menu.with_show_button { "Position" }
+            menu.with_item(label: "Side panel")
+          end
+          header.with_menu do |menu|
+            menu.with_item(label: "Edit") { |item| item.with_leading_visual_icon(icon: :pencil) }
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css(".op-border-box-list-header--actions action-menu")
+      expect(rendered).to have_css(".op-border-box-list-header--menu action-menu")
+    end
   end
 
   describe "header collapsible behavior" do

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -1323,4 +1323,219 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(page).to have_no_css("ul [data-empty-list-item]")
     end
   end
+
+  describe "sortable wiring" do
+    it "emits list wiring on the box root even for dual-role consumers" do
+      # replaced: combining roles now raises; list wiring is always root-mounted
+      rendered = render_inline(
+        described_class.new(
+          container: "sortable-list",
+          sortable_list: { type: "custom_field", id: 7, name: "General" }
+        )
+      ) do |list|
+        list.with_item(sortable: { id: 1, label: "Row" }) { "row" }
+      end
+
+      expect(rendered).to have_element("div", class: "op-border-box-list") do |box|
+        expect(box["data-controller"]).to include("sortable-lists--list")
+        expect(box["data-sortable-lists--list-type-value"]).to eq("custom_field")
+        expect(box["data-sortable-lists--list-accepted-type-value"]).to eq("custom_field")
+        expect(box["data-sortable-lists--list-id-value"]).to eq("7")
+        expect(box["data-sortable-lists--list-name-value"]).to eq("General")
+      end
+      expect(rendered).to have_css("[data-controller~='sortable-lists--list']", count: 1)
+      expect(rendered).to have_no_css("ul[data-controller~='sortable-lists--list']")
+    end
+
+    it "rejects combining sortable_list: with sortable_item:" do
+      expect do
+        render_inline(
+          described_class.new(
+            container: "dual-role",
+            sortable_list: { type: "custom_field" },
+            sortable_item: { id: 1, type: "section" }
+          )
+        ) { |list| list.with_item { "row" } }
+      end.to raise_error(ArgumentError, /BorderBoxListCollectionComponent/)
+    end
+
+    it "defaults a row's item type from the list's accepted type" do
+      rendered = render_inline(
+        described_class.new(container: "sortable-rows", sortable_list: { type: "sprint", accepted_type: "work_package" })
+      ) do |list|
+        list.with_item(sortable: { id: 3, label: "Task" }) { "row" }
+      end
+
+      expect(rendered).to have_css("li") do |row|
+        expect(row["data-controller"]).to include("sortable-lists--item")
+        expect(row["data-sortable-lists--item-id-value"]).to eq("3")
+        expect(row["data-sortable-lists--item-type-value"]).to eq("work_package")
+        expect(row["data-sortable-lists--item-label-value"]).to eq("Task")
+      end
+    end
+
+    it "defaults a row's item type from the list type when no accepted type is given" do
+      rendered = render_inline(
+        described_class.new(container: "sortable-rows-sym", sortable_list: { type: "custom_field" })
+      ) do |list|
+        list.with_item(sortable: { id: 4 }) { "row" }
+      end
+
+      expect(rendered).to have_css("li[data-sortable-lists--item-type-value='custom_field']")
+    end
+
+    it "raises when hand-wired sortable keys on a row conflict with generated wiring" do
+      expect do
+        render_inline(
+          described_class.new(container: "sortable-row-conflict", sortable_list: { type: "custom_field" })
+        ) do |list|
+          list.with_item(sortable: { id: 5 }, data: { sortable_lists__item_id_value: 99 }) { "row" }
+        end
+      end.to raise_error(ArgumentError, /sortable_lists__item_id_value/)
+    end
+
+    it "emits box-item wiring with a preview target and wires the header drag handle" do
+      rendered = render_inline(
+        described_class.new(
+          container: "sortable-box",
+          sortable_item: { id: 9, type: "section", label: "Marketing" }
+        )
+      ) do |list|
+        list.with_header(title: "Marketing", show_drag_handle: true)
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_element("div", class: "op-border-box-list") do |box|
+        expect(box["data-controller"]).to include("sortable-lists--item")
+        expect(box["data-sortable-lists--item-id-value"]).to eq("9")
+        expect(box["data-sortable-lists--item-type-value"]).to eq("section")
+        expect(box["data-sortable-lists--item-target"]).to include("preview")
+      end
+      expect(rendered).to have_css(
+        ".op-border-box-list-header--drag_handle .handle[data-sortable-lists--item-target~='handle']"
+      )
+    end
+
+    it "emits handle and preview targets without an item controller for sortable_handle" do
+      rendered = render_inline(
+        described_class.new(container: "handle-only", sortable_list: { type: "custom_field" }, sortable_handle: true)
+      ) do |list|
+        list.with_header(title: "Section", show_drag_handle: true)
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_element("div", class: "op-border-box-list") do |box|
+        expect(box["data-sortable-lists--item-target"]).to include("preview")
+        expect(box["data-controller"]).not_to include("sortable-lists--item")
+      end
+      expect(rendered).to have_css(".Box-header .handle[data-sortable-lists--item-target~='handle']")
+    end
+
+    it "rejects sortable_handle without a drag-handle-showing header" do
+      expect do
+        render_inline(
+          described_class.new(container: "handle-orphan", sortable_handle: true)
+        ) { |list| list.with_item { "row" } }
+      end.to raise_error(ArgumentError, /show_drag_handle/)
+    end
+
+    it "rejects sortable_handle combined with sortable_item" do
+      expect do
+        render_inline(
+          described_class.new(container: "handle-redundant", sortable_item: { id: 1, type: "x" }, sortable_handle: true)
+        ) { |list| list.with_item { "row" } }
+      end.to raise_error(ArgumentError, /sortable_item/)
+    end
+
+    it "token-merges configured and role-added targets into one attribute" do
+      rendered = render_inline(
+        described_class.new(
+          container: "sortable-targets",
+          sortable_item: { id: 2, type: "section", targets: %w[moveMenu preview] }
+        )
+      ) do |list|
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css(".op-border-box-list[data-sortable-lists--item-target='moveMenu preview']")
+    end
+
+    it "preserves caller data and combines controller tokens without mutating the caller hash" do
+      caller_data = { controller: "other-controller", test_selector: "kept" }
+      rendered = render_inline(
+        described_class.new(
+          container: "sortable-merge",
+          sortable_item: { id: 4, type: "section" },
+          data: caller_data
+        )
+      ) do |list|
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css(".op-border-box-list") do |box|
+        expect(box["data-controller"]).to include("other-controller")
+        expect(box["data-controller"]).to include("sortable-lists--item")
+        expect(box["data-test-selector"]).to eq("kept")
+      end
+      expect(caller_data).to eq(controller: "other-controller", test_selector: "kept")
+    end
+
+    it "raises when hand-wired sortable keys conflict with generated wiring" do
+      expect do
+        render_inline(
+          described_class.new(
+            container: "sortable-conflict",
+            sortable_item: { id: 4, type: "section" },
+            data: { sortable_lists__item_id_value: 99 }
+          )
+        ) { |list| list.with_item { "row" } }
+      end.to raise_error(ArgumentError, /sortable_lists__item_id_value/)
+    end
+
+    it "raises when a string-keyed hand-wired sortable key conflicts with generated wiring" do
+      expect do
+        render_inline(
+          described_class.new(
+            container: "sortable-conflict-string-key",
+            sortable_item: { id: 4, type: "section" },
+            data: { "sortable_lists__item_id_value" => 99 }
+          )
+        ) { |list| list.with_item { "row" } }
+      end.to raise_error(ArgumentError, /sortable_lists__item_id_value/)
+    end
+
+    it "raises for a sortable row without a sortable_list" do
+      expect do
+        render_inline(described_class.new(container: "sortable-orphan")) do |list|
+          list.with_item(sortable: { id: 1, type: "x" }) { "row" }
+        end
+      end.to raise_error(ArgumentError, /sortable_list/)
+    end
+
+    it "defaults the empty-state drop target label from the list name" do
+      rendered = render_inline(
+        described_class.new(container: "sortable-empty", sortable_list: { type: "custom_field", name: "General" })
+      )
+
+      # The empty-state slot renders the supplied drop_target_label string
+      # directly (border_box_list_component.rb:145,:160) — no i18n involved;
+      # the default is the list's name verbatim. Assert on the overlay node
+      # itself, since "General" also appears in the list's own data
+      # attributes and would make a bare text-inclusion check vacuous.
+      expect(rendered).to have_css(".op-border-box-list-empty-state--drop-overlay", text: "General")
+    end
+
+    it "accepts value objects directly" do
+      rendered = render_inline(
+        described_class.new(
+          container: "sortable-objects",
+          sortable_list: OpPrimer::SortableLists::List.new(type: "custom_field")
+        )
+      ) do |list|
+        list.with_item(sortable: OpPrimer::SortableLists::Item.new(id: 1, type: "custom_field")) { "row" }
+      end
+
+      expect(rendered).to have_css("li[data-controller~='sortable-lists--item']")
+    end
+  end
 end

--- a/spec/components/settings/project_custom_field_sections/index_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/index_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Settings::ProjectCustomFieldSections::IndexComponent, type: :comp
   let(:section_a) { create(:project_custom_field_section) }
   let(:section_b) { create(:project_custom_field_section) }
 
-  subject do
+  subject(:rendered_component) do
     with_request_url "/admin/settings/project_custom_fields" do
       render_inline(described_class.new(project_custom_field_sections: [section_a, section_b]))
     end
@@ -45,57 +45,80 @@ RSpec.describe Settings::ProjectCustomFieldSections::IndexComponent, type: :comp
     section_b
   end
 
-  it "wires the wrapper as the sortable-lists root with per-type move URL templates and no optimistic flag" do
+  it_behaves_like "a sortable Border Box List collection",
+                  list_type: "section", item_type: "section", item_count: 2,
+                  wrapper_id: "project-custom-field-sections"
+
+  it "wires the collection wrapper as the sortable-lists root with per-type move URL templates and no optimistic flag" do
     subject
 
-    root = page.find("[data-controller='sortable-lists']", visible: :all)
-    move_url_templates = JSON.parse(root["data-sortable-lists-move-url-templates-value"])
+    # The wrapper's `data-controller` also carries the page-level `root:`
+    # wiring's outlet-derived tokens alongside any other controllers on the
+    # element, so it is checked as a token list — not an exact match. The
+    # sections `sortable_list:` role itself mounts on an inner descendant
+    # of the wrapper, not on the wrapper element (see the "wires the list
+    # role on an inner descendant" example below).
+    expect(page).to have_element(:div, id: "project-custom-field-sections", visible: :all) do |root|
+      expect(root["data-controller"]).to include("sortable-lists")
 
-    expect(move_url_templates["section"]).to include("/admin/settings/project_custom_field_sections/{id}/drop")
-    expect(move_url_templates["custom_field"]).to include("/admin/settings/project_custom_fields/{id}/drop")
-    expect(root["data-sortable-lists-optimistic-value"]).to be_nil
+      move_url_templates = JSON.parse(root["data-sortable-lists-move-url-templates-value"])
+      expect(move_url_templates["section"]).to include("/admin/settings/project_custom_field_sections/{id}/drop")
+      expect(move_url_templates["custom_field"]).to include("/admin/settings/project_custom_fields/{id}/drop")
+      expect(root["data-sortable-lists-optimistic-value"]).to be_nil
+    end
   end
 
   it "wires the root's outlet selectors so they actually resolve to the rendered list/items" do
     subject
 
-    root = page.find("[data-controller='sortable-lists']", visible: :all)
-    list_outlet_selector = root["data-sortable-lists-sortable-lists--list-outlet"]
-    item_outlet_selector = root["data-sortable-lists-sortable-lists--item-outlet"]
+    expect(page).to have_element(:div, id: "project-custom-field-sections", visible: :all) do |root|
+      list_outlet_selector = root["data-sortable-lists-sortable-lists--list-outlet"]
+      item_outlet_selector = root["data-sortable-lists-sortable-lists--item-outlet"]
 
-    expect(list_outlet_selector).to be_present
-    expect(item_outlet_selector).to be_present
+      expect(list_outlet_selector).to be_present
+      expect(item_outlet_selector).to be_present
 
-    # Prove the selector-to-DOM link, not just attribute presence: if the
-    # dasherization or the `##{wrapper_key}` interpolation drifts, these
-    # selectors silently stop matching anything and the outlets connect
-    # to nothing with no failing test or console warning.
-    expect(page).to have_css(list_outlet_selector)
-    expect(page).to have_css(item_outlet_selector)
+      # Prove the selector-to-DOM link, not just attribute presence: if the
+      # dasherization or the `##{wrapper_key}` interpolation drifts, these
+      # selectors silently stop matching anything and the outlets connect
+      # to nothing with no failing test or console warning.
+      expect(page).to have_css(list_outlet_selector)
+      expect(page).to have_css(item_outlet_selector)
+    end
   end
 
   it "wires the sections flex container as a sortable-lists list of type section without a list id" do
     subject
 
-    expect(page).to have_css(
-      "[data-controller~='sortable-lists--list']" \
-      "[data-sortable-lists--list-type-value='section']" \
-      "[data-sortable-lists--list-accepted-type-value='section']" \
-      ":not([data-sortable-lists--list-id-value])"
-    )
+    expect(page).to have_css("[data-controller~='sortable-lists--list']") do |list|
+      expect(list["data-sortable-lists--list-type-value"]).to eq("section")
+      expect(list["data-sortable-lists--list-accepted-type-value"]).to eq("section")
+      expect(list["data-sortable-lists--list-id-value"]).to be_nil
+    end
   end
 
   it "wires each section row as a sortable-lists item of type section" do
     subject
 
     [section_a, section_b].each do |section|
-      expect(page).to have_css(
-        "[data-controller~='sortable-lists--item']" \
-        "[data-sortable-lists--item-id-value='#{section.id}']" \
-        "[data-sortable-lists--item-type-value='section']" \
-        "[data-sortable-lists--item-label-value='#{section.name}']"
-      )
+      expect(page).to have_css("[data-sortable-lists--item-id-value='#{section.id}']") do |item|
+        expect(item["data-controller"]).to include("sortable-lists--item")
+        expect(item["data-sortable-lists--item-type-value"]).to eq("section")
+        expect(item["data-sortable-lists--item-label-value"]).to eq(section.name)
+      end
     end
+  end
+
+  it "wires exactly one sortable-lists item per section, none on the section's own BorderBox" do
+    subject
+
+    # The collection's row wrapper carries the item wiring now (via
+    # IndexComponent's `with_item_row(sortable:)`); the section's own
+    # BorderBox is no longer a draggable item itself — it only wires a bare
+    # preview target and drag handle via `sortable_handle:` in
+    # ShowComponent — so there is exactly one `sortable-lists--item` per
+    # section below, not two.
+    expect(page).to have_css("[data-sortable-lists--item-type-value='section']", count: 2)
   end
 
   it "has no generic-drag-and-drop remnants" do

--- a/spec/components/settings/project_custom_field_sections/show_component_spec.rb
+++ b/spec/components/settings/project_custom_field_sections/show_component_spec.rb
@@ -32,10 +32,8 @@ require "rails_helper"
 
 RSpec.describe Settings::ProjectCustomFieldSections::ShowComponent, type: :component do
   let(:section) { create(:project_custom_field_section) }
-  let(:field_a) { create(:project_custom_field, project_custom_field_section: section) }
-  let(:field_b) { create(:project_custom_field, project_custom_field_section: section) }
 
-  subject do
+  subject(:rendered_component) do
     with_request_url "/admin/settings/project_custom_fields" do
       # `custom_fields_in_order` reads the section's in-memory
       # `attribute_order`, which the fields' after_create_commit
@@ -46,64 +44,83 @@ RSpec.describe Settings::ProjectCustomFieldSections::ShowComponent, type: :compo
     end
   end
 
-  before do
-    field_a
-    field_b
-  end
+  context "with custom fields" do
+    let!(:field_a) { create(:project_custom_field, project_custom_field_section: section) }
+    let!(:field_b) { create(:project_custom_field, project_custom_field_section: section) }
 
-  it "wires the BorderBox as a sortable-lists list of type custom_field scoped to the section" do
-    subject
+    it_behaves_like "a sortable Border Box List",
+                    list_type: "custom_field", item_type: "custom_field", item_count: 2
 
-    expect(page).to have_css(
-      "[data-controller~='sortable-lists--list']" \
-      "[data-sortable-lists--list-type-value='custom_field']" \
-      "[data-sortable-lists--list-accepted-type-value='custom_field']" \
-      "[data-sortable-lists--list-id-value='#{section.id}']" \
-      "[data-sortable-lists--list-name-value='#{section.name}']"
-    )
-  end
+    # The box itself is no longer a draggable item (that role now lives on the
+    # collection's row wrapper in IndexComponent, via `sortable_handle: true`
+    # rather than `sortable_item:` here) — it only needs a bare preview target
+    # and a wired header drag handle for the outer drag to work.
+    it "wires the box root as a bare preview target, without its own item controller" do
+      expect(rendered_component).to have_element(:div, id: "project-custom-field-section-#{section.id}") do |box|
+        expect(box["data-sortable-lists--item-target"]).to include("preview")
+        expect(box["data-controller"]).not_to include("sortable-lists--item")
+      end
+    end
 
-  it "wires the BorderBox as the section item's drag preview target" do
-    subject
+    it "wires the header drag handle" do
+      # Scoped to `.Box-header`: each field row also renders its own
+      # `.handle` (see custom_field_row_component.html.erb), so an
+      # unscoped match would pass even if the header's own handle broke.
+      expect(rendered_component).to have_css(".Box-header") do |header|
+        expect(header).to have_element(:div, class: "handle", count: 1) do |handle|
+          expect(handle["data-sortable-lists--item-target"]).to include("handle")
+        end
+      end
+    end
 
-    # The box, not the row wrapper, is the preview so the native drag
-    # snapshot's margin whitespace and squared-off corners never show.
-    expect(page).to have_css(
-      "[data-sortable-lists--list-type-value='custom_field']" \
-      "[data-sortable-lists--item-target='preview']"
-    )
-  end
+    it "wires each field row's li with the sortable-lists item label" do
+      [field_a, field_b].each do |field|
+        expect(rendered_component).to have_css("li[data-sortable-lists--item-id-value='#{field.id}']") do |row|
+          expect(row["data-controller"]).to include("sortable-lists--item")
+          expect(row["data-sortable-lists--item-type-value"]).to eq("custom_field")
+          expect(row["data-sortable-lists--item-label-value"]).to eq(field.name)
+        end
+      end
+    end
 
-  it "wires the section-header drag handle as the sortable-lists item handle target" do
-    subject
+    it "renders the position selector as an inline header action menu" do
+      expect(rendered_component).to have_css(
+        ".op-border-box-list-header--actions [data-test-selector='section-position-selector']"
+      )
+    end
 
-    # Scoped to the header: the two field-row handles carry the same
-    # class + data attribute, so an unscoped assertion here would stay
-    # green even if the header's own handle lost its `data:` hash.
-    expect(page).to have_css(
-      ".Box-header .handle[data-sortable-lists--item-target='handle']",
-      count: 1
-    )
-  end
-
-  it "wires each field row's li as a sortable-lists item of type custom_field" do
-    subject
-
-    [field_a, field_b].each do |field|
-      expect(page).to have_css(
-        "li[data-controller~='sortable-lists--item']" \
-        "[data-sortable-lists--item-id-value='#{field.id}']" \
-        "[data-sortable-lists--item-type-value='custom_field']" \
-        "[data-sortable-lists--item-label-value='#{field.name}']"
+    it "has no generic-drag-and-drop remnants" do
+      expect(rendered_component.to_html).not_to match(
+        /generic-drag-and-drop|target-container-accessor|target-allowed-drag-type|draggable-type|drop-url/
       )
     end
   end
 
-  it "has no generic-drag-and-drop remnants" do
-    subject
+  context "with no custom fields" do
+    it "renders the custom empty row with its new-attribute menu and no default blankslate" do
+      expect(rendered_component).to have_css("li[data-empty-list-item]")
+      expect(rendered_component).to have_css("[data-test-selector='new-project-custom-field-in-section-button']")
+      expect(rendered_component).to have_no_css(".blankslate")
+    end
 
-    expect(page.native.to_html).not_to match(
-      /generic-drag-and-drop|target-container-accessor|target-allowed-drag-type|draggable-type|drop-url/
-    )
+    # ShowComponent always fills its own custom empty row above, so
+    # BorderBoxListComponent's built-in empty state never fires here. This
+    # proves the underlying primitive it is built from — configured with the
+    # exact `sortable_list:` this section passes — renders the drop-zone
+    # overlay labeled with the section's own list name once it has no items,
+    # now that `sortable_list:` unconditionally wires the list role onto the
+    # box root (rather than falling back onto the items `<ul>` whenever
+    # combined with `sortable_item:`, which made the box root's own
+    # `[data-drop-container]` ancestry unreliable for this overlay).
+    it "renders the drop-zone overlay labeled with the section's list name once the underlying list is empty" do
+      rendered = render_inline(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "project-custom-field-section-#{section.id}",
+          sortable_list: OpPrimer::SortableLists::List.for(section, type: "custom_field")
+        )
+      )
+
+      expect(rendered).to have_css(".op-border-box-list-empty-state--drop-overlay", text: section.name)
+    end
   end
 end

--- a/spec/features/admin/custom_fields/projects/reorder_spec.rb
+++ b/spec/features/admin/custom_fields/projects/reorder_spec.rb
@@ -129,6 +129,31 @@ RSpec.describe "Reordering project attribute sections and fields", :js, :seleniu
     expect_fields_in_order(date_project_custom_field, string_project_custom_field, text_project_custom_field)
   end
 
+  it "still drags a section after its box morphed from a field move, and again after the index morph" do
+    # (a) move a field within the first section -> morphs that ShowComponent
+    drag_field(boolean_project_custom_field, after: string_project_custom_field)
+
+    expect_fields_in_order(string_project_custom_field, boolean_project_custom_field, integer_project_custom_field)
+
+    # (b) drag the morphed section below the next section -> asserts order
+    # persisted. A section drop replaces the whole IndexComponent, morphing
+    # every section's box (including the one just patched by (a)).
+    drag_section(section_for_input_fields, after: section_for_select_fields)
+
+    expect_sections_in_order(section_for_select_fields, section_for_input_fields, section_for_multi_select_fields)
+
+    # (c) drag it again after the index-level morph from (b) settles ->
+    # asserts order again, proving the section's drag handle survived being
+    # patched (not replaced) by that morph.
+    drag_section(section_for_input_fields, after: section_for_multi_select_fields)
+
+    expect_sections_in_order(section_for_select_fields, section_for_multi_select_fields, section_for_input_fields)
+
+    cf_index_page.visit!
+
+    expect_sections_in_order(section_for_select_fields, section_for_multi_select_fields, section_for_input_fields)
+  end
+
   # helper methods:
 
   def within_project_custom_field_section_container(section, &)
@@ -199,8 +224,17 @@ RSpec.describe "Reordering project attribute sections and fields", :js, :seleniu
     expect(page).to have_css(custom_fields.map { |cf| field_row_selector(cf) }.join(" + "))
   end
 
+  # Unlike fields (plain `<li>` siblings inside their section's `<ul>`),
+  # each section is independently turbo-streamable, so its sortable-lists
+  # item wiring sits on its own `component_wrapper`-nested BorderBox root
+  # rather than on a shared direct-sibling row element. A `+`-combinator
+  # adjacency check can't span that per-section wrapper, so order is
+  # asserted from document order instead.
   def expect_sections_in_order(*sections)
-    expect(page).to have_css(sections.map { |s| section_row_selector(s) }.join(" + "))
+    actual_ids = page.all("[data-sortable-lists--item-type-value='section']", visible: :all)
+                      .map { |el| el["data-sortable-lists--item-id-value"] }
+
+    expect(actual_ids).to eq(sections.map { |s| s.id.to_s })
   end
 
   def expect_field_in_section(section, custom_field)

--- a/spec/support/shared/components/border_box_list_component.rb
+++ b/spec/support/shared/components/border_box_list_component.rb
@@ -83,3 +83,109 @@ RSpec.shared_examples_for "a reorderable Border Box List" do |drag_type:|
     end
   end
 end
+
+# Asserts the declarative sortable wiring of a Border Box List consumer:
+# the list role on the box root, exactly one item controller per row, and
+# no stray sortable-lists attributes outside the declared roles. Pages
+# where the box itself is also a draggable item wire that through the
+# Border Box List collection instead (see "a sortable Border Box List
+# collection" below) — BorderBoxListComponent raises if `sortable_list:`
+# and `sortable_item:` are combined, since the list and item Stimulus
+# controllers cannot yet share one element (see
+# BorderBoxListComponent#assert_no_combined_sortable_roles!). `item_type:`
+# is separate from `list_type:` because a list may accept a different type
+# than it is (a sprint list accepting work packages).
+RSpec.shared_examples_for "a sortable Border Box List" do |list_type:, item_type:, item_count:|
+  it "wires the list role on the box root" do
+    expect(rendered_component).to have_css(
+      ".op-border-box-list[data-controller~='sortable-lists--list'][data-sortable-lists--list-type-value='#{list_type}']",
+      count: 1
+    )
+    expect(rendered_component).to have_no_css("ul[data-controller~='sortable-lists--list']")
+  end
+
+  it "wires exactly one item controller per row" do
+    expect(rendered_component).to have_css(
+      "ul > li[data-controller~='sortable-lists--item'][data-sortable-lists--item-type-value='#{item_type}']",
+      count: item_count
+    )
+  end
+
+  it_behaves_like "having no stray sortable-lists attributes"
+end
+
+# Ownership schema for sortable-lists Stimulus wiring: an element either
+# HOSTS exactly one sortable-lists controller (the root `sortable-lists`, or
+# one of `sortable-lists--list`/`--item`/`--scrollable`), or is TARGET-ONLY,
+# carrying nothing among its `data-sortable-lists*` attributes but
+# `data-sortable-lists--item-target`. The per-role assertions above only
+# check that a given role's attributes ARE present somewhere; they cannot
+# see wiring that drifted onto a shared element (e.g. a list and an item
+# controller landing on the same node), which is what this guards against.
+#
+# Attribute-name prefixes are not CSS-selectable, so this inspects the
+# rendered fragment's own attribute nodes directly rather than composing a
+# selector. Including contexts must define +rendered_component+ as the raw
+# object `render_inline` (or `with_request_url { render_inline(...) }`)
+# returns — a Nokogiri fragment responding to `#css` directly, not a
+# Capybara node requiring `#native`.
+RSpec.shared_examples_for "having no stray sortable-lists attributes" do
+  it "has no stray sortable-lists attributes outside the declared roles" do
+    hosts = rendered_component.css("*").select do |el|
+      el.attribute_nodes.any? do |attribute|
+        attribute.name.start_with?("data-sortable-lists") ||
+          (attribute.name == "data-controller" && attribute.value.include?("sortable-lists"))
+      end
+    end
+
+    hosts.each do |el|
+      controllers = (el["data-controller"] || "").split
+      sortable_controllers = controllers.grep(/\Asortable-lists/)
+
+      if sortable_controllers.empty?
+        expect(el.attribute_nodes.map(&:name)).to(
+          all(satisfy { |name| !name.start_with?("data-sortable-lists") || name == "data-sortable-lists--item-target" }),
+          "target-only <#{el.name}> carries non-target sortable attributes: #{el.attribute_nodes.map(&:name)}"
+        )
+      else
+        expect(sortable_controllers.size).to(
+          eq(1),
+          "<#{el.name}> hosts multiple sortable-lists controllers: #{sortable_controllers}"
+        )
+      end
+    end
+  end
+end
+
+# Shared expectations for a Border Box List collection (a
+# BorderBoxListCollectionComponent consumer): the page-level sortable-lists
+# root wired onto the collection wrapper, the list role wired onto an inner
+# descendant of the wrapper rather than the wrapper itself (see
+# BorderBoxListCollectionComponent#list_container_arguments for why — a
+# root's outlet selectors are plain CSS descendant combinators, which can
+# never match the wrapper they are scoped from), exactly one item
+# controller per row, and no stray sortable-lists attributes outside the
+# declared roles.
+RSpec.shared_examples_for "a sortable Border Box List collection" do |list_type:, item_type:, item_count:, wrapper_id:|
+  it "wires the collection wrapper with the sortable-lists root" do
+    expect(rendered_component).to have_css("##{wrapper_id}") do |wrapper|
+      expect(wrapper["data-controller"]).to include("sortable-lists")
+    end
+  end
+
+  it "wires the list role on an inner descendant of the wrapper, not the wrapper itself" do
+    expect(rendered_component).to have_no_css("##{wrapper_id}[data-controller~='sortable-lists--list']")
+    expect(rendered_component).to have_css("##{wrapper_id} [data-controller~='sortable-lists--list']") do |list|
+      expect(list["data-sortable-lists--list-type-value"]).to eq(list_type)
+    end
+  end
+
+  it "wires exactly one item controller per row" do
+    expect(rendered_component).to have_css(
+      "[data-controller~='sortable-lists--item'][data-sortable-lists--item-type-value='#{item_type}']",
+      count: item_count
+    )
+  end
+
+  it_behaves_like "having no stray sortable-lists attributes"
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-805

# What are you trying to accomplish?

Slice of [DREAM-671](https://community.openproject.org/wp/DREAM-671): `BorderBoxListComponent` consumers currently hand-wire the `sortable-lists` Stimulus contract at every call site. This PR makes the component own that wiring declaratively, so callers state intent instead of data attributes, and migrates the admin project-attributes sections page (the DREAM-786 surface) onto the new API as the reference implementation for the remaining DREAM-671 migrations.

- `OpPrimer::SortableLists::List` / `Item` value objects own the Stimulus contract (allowlisted fields — unknown keys raise instead of emitting inert attributes; `.for(record, type:)` derives id/label/name but never the wire type)
- `sortable_list:` / `sortable_item:` component options plus a per-row `with_item(sortable:)` argument; generated wiring merges into caller data, combines controller tokens, and raises on conflicting hand-wired keys
- `sortable_item:` auto-wires the header drag handle (with `show_drag_handle: true`) and the drag-preview target on the box
- A `with_action_menu` header arm for inline labeled menus (e.g. the sections position selector), distinct from the trailing overflow `with_menu`
- Shared RSpec examples ("a sortable Border Box List") for consumer specs — the follow-up Backlogs adoption ([DREAM-806](https://community.openproject.org/wp/DREAM-806)) reuses them
- Lookbook documentation including the page-root prerequisite (the emitted wiring cannot drag without a `sortable-lists` root providing the URL template map and outlets)

Emission-only: the Stimulus suite is untouched.

# What approach did you choose and why?

The value objects borrow LiveComponent's `Target`/`Action` shape (tiny objects closing over the controller identifier, emitting `data-*`) without any LiveComponent dependency. Wire types are never derived from model names: they are short names keyed into the root's URL template map, so deriving `project_custom_field_section` where the wire says `section` would break silently — `type:` stays explicit.

The list role lands on the box root, matching the shipped contract (the `data-drop-container` CSS indicators and both existing consumers anchor there). Noteworthy discovery while verifying that: `sortable-lists--list` and `sortable-lists--item` cannot share one element — Pragmatic's element adapter keys its drop-target registry per element, and the second registration silently replaces the first (reproducible as feature-spec drag timeouts). Dual-role consumers (a sections box that is both a draggable item and a list of fields) therefore fall back to mounting the list role on the inner `ul`; lifting that limitation needs a Stimulus-side change tracked under DREAM-671.

Stacked on the [DREAM-804](https://community.openproject.org/wp/DREAM-804) branch (#24646) only because it touches the same component files; the surfaces are independent. Will be retargeted to `dev` once the DREAM-697 stack merges.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
