### PR TITLE
[OP-19880] Show correct counter for matching users on generic allocations

### DIFF
--- a/app/models/queries/users/filters/member_filter.rb
+++ b/app/models/queries/users/filters/member_filter.rb
@@ -28,24 +28,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Mirrors Queries::Principals::Filters::MemberFilter for user queries. The
-# enclosing query's default scope already restricts visibility, so membership is
-# the only condition applied here.
 class Queries::Users::Filters::MemberFilter < Queries::Users::Filters::UserFilter
+  include Queries::Filters::Shared::ProjectFilter::Optional
+
   def self.key
     :member
   end
 
-  def type
-    :list_optional
-  end
-
   def human_name
     I18n.t(:label_member_of_project)
-  end
-
-  def allowed_values
-    Project.visible.active.pluck(:name, :id)
   end
 
   def apply_to(query_scope)

--- a/app/models/queries/users/filters/member_filter.rb
+++ b/app/models/queries/users/filters/member_filter.rb
@@ -28,34 +28,36 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
-
-  def self.model
-    User
+# Mirrors Queries::Principals::Filters::MemberFilter for user queries. The
+# enclosing query's default scope already restricts visibility, so membership is
+# the only condition applied here.
+class Queries::Users::Filters::MemberFilter < Queries::Users::Filters::UserFilter
+  def self.key
+    :member
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  def type
+    :list_optional
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  def human_name
+    I18n.t(:label_member_of_project)
+  end
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
+  def allowed_values
+    Project.visible.active.pluck(:name, :id)
+  end
 
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::CustomField
+  def apply_to(query_scope)
+    case operator
+    when "="
+      query_scope.in_project(values)
+    when "!"
+      query_scope.not_in_project(values)
+    when "*"
+      query_scope.where(id: Member.of_any_project.select(:user_id))
+    when "!*"
+      query_scope.where.not(id: Member.of_any_project.select(:user_id))
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3325,6 +3325,7 @@ en:
   label_me: "me"
   label_member_all_admin: "(All roles due to admin status)"
   label_member_new: "New member"
+  label_member_of_project: "Member of project"
   label_member_plural: "Members"
   label_member_role: "Project role"
   label_membership_added: "Member added"

--- a/modules/resource_management/app/components/resource_allocations/allocation_step/form_component.rb
+++ b/modules/resource_management/app/components/resource_allocations/allocation_step/form_component.rb
@@ -82,6 +82,8 @@ module ResourceAllocations
                        ::Filters::FilterFormComponent.new(
                          builder: form,
                          query: @allocation.candidate_query,
+                         # Membership in the allocation's project is implied, not a criterion to edit.
+                         excluded_filters: [:member],
                          wrap_with_controller: true,
                          hidden_input_name: "filters",
                          output_format: :json,

--- a/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.html.erb
@@ -17,7 +17,12 @@
 
   <% if candidate_badge? %>
     <span class="op-rm-timeline-bar--badge">
-      <%= render(Primer::Beta::Label.new) { candidate_label } %>
+      <%= render(Primer::Beta::Label.new(id: candidate_tooltip_id)) { candidate_label } %>
+      <%= render Primer::Alpha::Tooltip.new(
+            for_id: candidate_tooltip_id,
+            type: :description,
+            text: candidate_tooltip
+          ) %>
     </span>
   <% end %>
 </div>

--- a/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.html.erb
@@ -17,7 +17,7 @@
 
   <% if candidate_badge? %>
     <span class="op-rm-timeline-bar--badge">
-      <%= render(Primer::Beta::Label.new(id: candidate_tooltip_id)) { candidate_label } %>
+      <%= render(Primer::Beta::Label.new(id: candidate_tooltip_id)) { candidate_count.to_s } %>
       <%= render Primer::Alpha::Tooltip.new(
             for_id: candidate_tooltip_id,
             type: :description,

--- a/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.rb
@@ -75,10 +75,6 @@ module ResourcePlannerViews
         candidate_count.positive?
       end
 
-      def candidate_label
-        t("resource_management.work_package_timeline.allocation_bar.matching_members", count: candidate_count)
-      end
-
       def candidate_tooltip
         t("resource_management.work_package_timeline.allocation_bar.matching_members_description", count: candidate_count)
       end

--- a/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_timeline/allocation_bar_component.rb
@@ -37,15 +37,16 @@ module ResourcePlannerViews
     class AllocationBarComponent < ApplicationComponent
       include AvatarHelper
 
-      def initialize(allocation:, visible_principal_ids: nil)
+      def initialize(allocation:, visible_principal_ids: nil, candidate_count: 0)
         super
         @allocation = allocation
         @visible_principal_ids = visible_principal_ids
+        @candidate_count = candidate_count
       end
 
       private
 
-      attr_reader :allocation, :visible_principal_ids
+      attr_reader :allocation, :visible_principal_ids, :candidate_count
 
       def hours_label
         t("resource_management.allocation.hours", value: allocation.allocated_hours.round)
@@ -70,23 +71,20 @@ module ResourcePlannerViews
         end
       end
 
-      # Resolving the candidate query can fail for an incomplete filter; fall back
-      # to no badge rather than erroring the whole timeline.
-      def candidate_count
-        return 0 unless filter_based?
-
-        allocation.candidate_query.results.count
-      rescue StandardError => e
-        Rails.logger.warn("Resource timeline candidate_count failed: #{e.class}: #{e.message}")
-        0
-      end
-
       def candidate_badge?
         candidate_count.positive?
       end
 
       def candidate_label
-        t("resource_management.work_package_list.allocated_members.additional", count: candidate_count)
+        t("resource_management.work_package_timeline.allocation_bar.matching_members", count: candidate_count)
+      end
+
+      def candidate_tooltip
+        t("resource_management.work_package_timeline.allocation_bar.matching_members_description", count: candidate_count)
+      end
+
+      def candidate_tooltip_id
+        "wp-timeline-candidates-#{allocation.id}"
       end
     end
   end

--- a/modules/resource_management/app/contracts/resource_allocations/assign_contract.rb
+++ b/modules/resource_management/app/contracts/resource_allocations/assign_contract.rb
@@ -64,7 +64,7 @@ module ResourceAllocations
     end
 
     def principal_selected_by_filter?
-      model.candidate_query.results.in_project(model.project).exists?(id: model.principal_id)
+      model.candidate_query.results.exists?(id: model.principal_id)
     end
   end
 end

--- a/modules/resource_management/app/controllers/resource_management/staffing_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/staffing_controller.rb
@@ -187,7 +187,7 @@ module ::ResourceManagement
 
     # Project members the stored filter selects.
     def candidates_for(allocation)
-      allocation.candidate_query.results.in_project(@project).to_a
+      allocation.candidate_query(project: @project).results.to_a
     end
 
     def candidate_principal

--- a/modules/resource_management/app/controllers/resource_management/work_package_timeline/events_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/work_package_timeline/events_controller.rb
@@ -40,6 +40,7 @@ module ResourceManagement
         allocations = allocations_by_work_package.values.flatten
         overbooked = ResourceAllocation.overbooked_ids(allocations)
         visible = ResourceAllocation.visible_principal_ids(allocations, current_user)
+        candidates = ResourceAllocation.candidate_counts(allocations, project: @project)
 
         events = allocations.map do |allocation|
           {
@@ -50,7 +51,7 @@ module ResourceManagement
             extendedProps: {
               overbooked: overbooked.include?(allocation.id),
               editUrl: edit_url_for(allocation),
-              html: render_bar(allocation, visible)
+              html: render_bar(allocation, visible, candidates.fetch(allocation.id, 0))
             }
           }
         end
@@ -133,9 +134,9 @@ module ResourceManagement
         Date::DAYNAMES.fetch(first_day % 7).downcase.to_sym
       end
 
-      def render_bar(allocation, visible_principal_ids)
+      def render_bar(allocation, visible_principal_ids, candidate_count)
         ResourcePlannerViews::WorkPackageTimeline::AllocationBarComponent
-          .new(allocation:, visible_principal_ids:)
+          .new(allocation:, visible_principal_ids:, candidate_count:)
           .render_in(view_context)
       end
     end

--- a/modules/resource_management/app/models/resource_allocation.rb
+++ b/modules/resource_management/app/models/resource_allocation.rb
@@ -190,11 +190,17 @@ class ResourceAllocation < ApplicationRecord
     !principal_explicit? && principal_id.blank?
   end
 
-  def candidate_query
+  # Only project members can be allocated, so the stored criteria are always
+  # narrowed to the project's members. Callers that already hold the project pass
+  # it in to avoid loading the entity. Applying the membership filter last means a
+  # `member` value smuggled into the stored filter is overwritten, not honoured.
+  def candidate_query(project: self.project)
     UserQuery.new.tap do |query|
       user_filter.each do |filter|
         query.where(filter.field, filter.operator, filter.values)
       end
+
+      query.where(:member, "=", [project.id.to_s]) if project
     end
   end
 

--- a/modules/resource_management/app/models/resource_allocation.rb
+++ b/modules/resource_management/app/models/resource_allocation.rb
@@ -109,6 +109,22 @@ class ResourceAllocation < ApplicationRecord
     Principal.visible(user).where(id: principal_ids).pluck(:id).to_set
   end
 
+  # Counts the candidates each filter-based allocation selects, keyed by
+  # allocation id. Allocations commonly share a stored filter, so the candidate
+  # pool is resolved once per distinct filter rather than once per allocation.
+  def self.candidate_counts(allocations, project:)
+    return {} if project.nil?
+
+    counts_by_filter = {}
+
+    allocations.select(&:filter_based?).to_h do |allocation|
+      signature = allocation.user_filter.map { |filter| [filter.name, filter.operator, filter.values] }
+      count = counts_by_filter.fetch(signature) { counts_by_filter[signature] = allocation.candidate_count(project:) }
+
+      [allocation.id, count]
+    end
+  end
+
   # Users without configured working hours are skipped — their capacity is
   # unknown, not zero (mirroring the check made when an allocation is created).
   # The users' working hours and booked allocations are each fetched in one
@@ -202,6 +218,15 @@ class ResourceAllocation < ApplicationRecord
 
       query.where(:member, "=", [project.id.to_s]) if project
     end
+  end
+
+  # Resolving the query can fail for an incompletely configured filter; a single
+  # broken filter must not take down the whole view it is rendered in.
+  def candidate_count(project: self.project)
+    candidate_query(project:).results.count
+  rescue StandardError => e
+    Rails.logger.warn("Candidate count for resource allocation #{id} failed: #{e.class}: #{e.message}")
+    0
   end
 
   def allocated_hours

--- a/modules/resource_management/config/locales/en.yml
+++ b/modules/resource_management/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
       resource_planner: Resource Planner
       resource_user_card: User cards
       resource_work_package_list: Work packages list
+  button_next: Next
   ee:
     features:
       resource_management: Resource management
@@ -52,7 +53,6 @@ en:
           Plan and balance your team's workload with resource planners. Allocate people to work packages,
           track capacity over time and spot over- and under-allocation at a glance.
         title: Resource management
-  button_next: Next
   label_resource_management: Resource management
   permission_allocate_user_resources: Allocate user resources
   permission_allocate_user_resources_explanation: >-
@@ -306,6 +306,13 @@ en:
         allocate: Allocate
         settings: Configure view
     work_package_timeline:
+      allocation_bar:
+        matching_members:
+          one: "%{count} matching member"
+          other: "%{count} matching members"
+        matching_members_description:
+          one: "%{count} member of this project matches the allocation's filter criteria."
+          other: "%{count} members of this project match the allocation's filter criteria."
       blank:
         add_work_package: Add work package
         configure_view: Configure view

--- a/modules/resource_management/config/locales/en.yml
+++ b/modules/resource_management/config/locales/en.yml
@@ -307,9 +307,6 @@ en:
         settings: Configure view
     work_package_timeline:
       allocation_bar:
-        matching_members:
-          one: "%{count} matching member"
-          other: "%{count} matching members"
         matching_members_description:
           one: "%{count} member of this project matches the allocation's filter criteria."
           other: "%{count} members of this project match the allocation's filter criteria."

--- a/modules/resource_management/spec/components/resource_planner_views/work_package_timeline/allocation_bar_component_spec.rb
+++ b/modules/resource_management/spec/components/resource_planner_views/work_package_timeline/allocation_bar_component_spec.rb
@@ -62,4 +62,27 @@ RSpec.describe ResourcePlannerViews::WorkPackageTimeline::AllocationBarComponent
     expect(page).to have_text("20h")
     expect(page).to have_text(allocation.filter_name)
   end
+
+  describe "the candidate badge" do
+    let(:allocation) { create(:resource_allocation, :with_user_filter, allocated_time: 20 * 60) }
+
+    it "spells out how many project members match the filter" do
+      render_inline(described_class.new(allocation:, visible_principal_ids: Set.new, candidate_count: 3))
+
+      expect(page).to have_text("3 matching members")
+      expect(page).to have_css("tool-tip", text: "3 members of this project match the allocation's filter criteria.")
+    end
+
+    it "uses the singular form for a single match" do
+      render_inline(described_class.new(allocation:, visible_principal_ids: Set.new, candidate_count: 1))
+
+      expect(page).to have_text("1 matching member")
+    end
+
+    it "is omitted when nothing matches" do
+      render_inline(described_class.new(allocation:, visible_principal_ids: Set.new, candidate_count: 0))
+
+      expect(page).to have_no_css(".op-rm-timeline-bar--badge")
+    end
+  end
 end

--- a/modules/resource_management/spec/components/resource_planner_views/work_package_timeline/allocation_bar_component_spec.rb
+++ b/modules/resource_management/spec/components/resource_planner_views/work_package_timeline/allocation_bar_component_spec.rb
@@ -66,17 +66,18 @@ RSpec.describe ResourcePlannerViews::WorkPackageTimeline::AllocationBarComponent
   describe "the candidate badge" do
     let(:allocation) { create(:resource_allocation, :with_user_filter, allocated_time: 20 * 60) }
 
-    it "spells out how many project members match the filter" do
+    it "shows the bare count, with the meaning carried by the tooltip" do
       render_inline(described_class.new(allocation:, visible_principal_ids: Set.new, candidate_count: 3))
 
-      expect(page).to have_text("3 matching members")
+      expect(page).to have_css(".op-rm-timeline-bar--badge", text: "3")
       expect(page).to have_css("tool-tip", text: "3 members of this project match the allocation's filter criteria.")
     end
 
-    it "uses the singular form for a single match" do
+    it "describes a single match in the singular" do
       render_inline(described_class.new(allocation:, visible_principal_ids: Set.new, candidate_count: 1))
 
-      expect(page).to have_text("1 matching member")
+      expect(page).to have_css(".op-rm-timeline-bar--badge", text: "1")
+      expect(page).to have_css("tool-tip", text: "1 member of this project matches the allocation's filter criteria.")
     end
 
     it "is omitted when nothing matches" do

--- a/modules/resource_management/spec/models/resource_allocation_spec.rb
+++ b/modules/resource_management/spec/models/resource_allocation_spec.rb
@@ -288,6 +288,92 @@ RSpec.describe ResourceAllocation do
     end
   end
 
+  describe "candidate resolution" do
+    shared_let(:project) { create(:project) }
+    shared_let(:work_package) { create(:work_package, project:) }
+    shared_let(:admin) { create(:admin) }
+
+    # A developer speaking German, which is what the :with_user_filter trait selects.
+    def developer(member_of: nil)
+      attributes = member_of ? { member_with_permissions: { member_of => %i[view_work_packages] } } : {}
+      create(:user, **attributes).tap do |candidate|
+        job_title = UserCustomField.find_by(name: "Job title")
+        language = UserCustomField.find_by(name: "Spoken language")
+        candidate.custom_field_values = {
+          job_title.id => job_title.custom_options.find_by(value: "Developer").id,
+          language.id => [language.custom_options.find_by(value: "German").id]
+        }
+        candidate.save!
+      end
+    end
+
+    before { login_as(admin) }
+
+    describe "#candidate_query" do
+      it "selects matching users that are members of the allocation's project" do
+        allocation = create(:resource_allocation, :with_user_filter, entity: work_package)
+        member = developer(member_of: project)
+
+        expect(allocation.candidate_query.results).to contain_exactly(member)
+      end
+
+      it "excludes matching users that are not members of the project" do
+        allocation = create(:resource_allocation, :with_user_filter, entity: work_package)
+        developer(member_of: create(:project))
+
+        expect(allocation.candidate_query.results).to be_empty
+      end
+
+      it "overrides a member filter smuggled into the stored criteria" do
+        other_project = create(:project)
+        allocation = create(:resource_allocation, :with_user_filter, entity: work_package)
+        allocation.user_filter += UserQuery.new.tap { |q| q.where(:member, "=", [other_project.id.to_s]) }.filters
+        member = developer(member_of: project)
+        developer(member_of: other_project)
+
+        expect(allocation.candidate_query.results).to contain_exactly(member)
+      end
+    end
+
+    describe ".candidate_counts" do
+      it "counts the project members each filter-based allocation selects" do
+        allocation = create(:resource_allocation, :with_user_filter, entity: work_package)
+        developer(member_of: project)
+        developer(member_of: project)
+        developer(member_of: create(:project))
+
+        expect(described_class.candidate_counts([allocation], project:)).to eq(allocation.id => 2)
+      end
+
+      it "ignores allocations with an explicitly assigned principal" do
+        assigned = create(:resource_allocation, entity: work_package)
+
+        expect(described_class.candidate_counts([assigned], project:)).to eq({})
+      end
+
+      it "resolves the pool once for allocations sharing the same filter" do
+        first = create(:resource_allocation, :with_user_filter, entity: work_package)
+        second = create(:resource_allocation, :with_user_filter, entity: work_package)
+        developer(member_of: project)
+
+        allow(first).to receive(:candidate_count).and_call_original
+        allow(second).to receive(:candidate_count).and_call_original
+
+        counts = described_class.candidate_counts([first, second], project:)
+
+        expect(counts).to eq(first.id => 1, second.id => 1)
+        expect(second).not_to have_received(:candidate_count)
+      end
+
+      it "falls back to zero when a filter cannot be resolved" do
+        allocation = create(:resource_allocation, :with_user_filter, entity: work_package)
+        allow(allocation).to receive(:candidate_query).and_raise(StandardError, "broken filter")
+
+        expect(described_class.candidate_counts([allocation], project:)).to eq(allocation.id => 0)
+      end
+    end
+  end
+
   describe "entity GlobalID handling" do
     shared_let(:project) { create(:project) }
     shared_let(:work_package) { create(:work_package, project:) }
@@ -599,7 +685,7 @@ RSpec.describe ResourceAllocation do
     end
 
     def user_with(job_title_value, *languages)
-      create(:user).tap do |user|
+      create(:user, member_with_permissions: { project => %i[view_work_packages] }).tap do |user|
         user.custom_field_values = {
           job_title.id => option_id(job_title, job_title_value),
           language.id => languages.map { |spoken| option_id(language, spoken) }
@@ -618,12 +704,12 @@ RSpec.describe ResourceAllocation do
       # `UserQuery#results` is scoped to what the current user may see.
       current_user { create(:admin) }
 
-      it "is a UserQuery carrying the stored filter criteria" do
+      it "is a UserQuery carrying the stored filter criteria, narrowed to the project's members" do
         query = allocation.candidate_query
 
         expect(query).to be_a(UserQuery)
         expect(query.filters.map { |f| f.name.to_s })
-          .to contain_exactly(job_title.column_name, language.column_name)
+          .to contain_exactly(job_title.column_name, language.column_name, "member")
       end
 
       it "resolves to developers speaking German or English (is (OR)), and excludes the rest" do

--- a/spec/models/queries/users/filters/member_filter_spec.rb
+++ b/spec/models/queries/users/filters/member_filter_spec.rb
@@ -37,33 +37,42 @@ RSpec.describe Queries::Users::Filters::MemberFilter do
     let(:name) { I18n.t(:label_member_of_project) }
   end
 
-  describe "#allowed_values" do
+  describe "the project values" do
     shared_let(:public_project) { create(:public_project) }
     shared_let(:private_project) { create(:project) }
-    shared_let(:archived_project) { create(:public_project, active: false) }
     shared_let(:user) { create(:user, member_with_permissions: { private_project => %i[view_work_packages] }) }
 
-    subject(:allowed_ids) do
-      described_class.create!(name: :member, operator: "=", values: []).allowed_values.map(&:last)
-    end
+    let(:instance) { described_class.create!(name: :member, operator: "=", values: [private_project.id.to_s]) }
+
+    before { login_as(user) }
 
     it "offers the projects the current user may see" do
-      login_as(user)
-
-      expect(allowed_ids).to contain_exactly(public_project.id, private_project.id)
+      expect(instance.allowed_values.map(&:last))
+        .to contain_exactly(public_project.id.to_s, private_project.id.to_s)
     end
 
     it "omits projects the current user cannot see" do
       login_as(create(:user))
 
-      expect(allowed_ids).to contain_exactly(public_project.id)
+      expect(instance.allowed_values.map(&:last)).to contain_exactly(public_project.id.to_s)
     end
 
-    it "omits archived projects even for an admin" do
-      login_as(create(:admin))
+    it "resolves the selected values to visible projects" do
+      expect(instance.value_objects).to contain_exactly(private_project)
+    end
 
-      expect(allowed_ids).to include(public_project.id, private_project.id)
-      expect(allowed_ids).not_to include(archived_project.id)
+    # The UI picks projects through the autocompleter, so the filter does not have
+    # to enumerate them for validation.
+    it "is validated as a list of integers rather than against the project list" do
+      expect(instance.type_strategy).to be_a(Queries::Filters::Strategies::IntegerListOptional)
+      expect(described_class.create!(name: :member, operator: "=", values: ["-42"])).to be_valid
+    end
+
+    it "autocompletes against the active projects" do
+      expect(instance.autocomplete_options)
+        .to include(component: "opce-project-autocompleter",
+                    resource: "projects",
+                    filters: [{ name: "active", operator: "=", values: ["t"] }])
     end
   end
 

--- a/spec/models/queries/users/filters/member_filter_spec.rb
+++ b/spec/models/queries/users/filters/member_filter_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Users::Filters::MemberFilter do
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :member }
+    let(:type) { :list_optional }
+    let(:name) { I18n.t(:label_member_of_project) }
+  end
+
+  describe "#allowed_values" do
+    shared_let(:public_project) { create(:public_project) }
+    shared_let(:private_project) { create(:project) }
+    shared_let(:archived_project) { create(:public_project, active: false) }
+    shared_let(:user) { create(:user, member_with_permissions: { private_project => %i[view_work_packages] }) }
+
+    subject(:allowed_ids) do
+      described_class.create!(name: :member, operator: "=", values: []).allowed_values.map(&:last)
+    end
+
+    it "offers the projects the current user may see" do
+      login_as(user)
+
+      expect(allowed_ids).to contain_exactly(public_project.id, private_project.id)
+    end
+
+    it "omits projects the current user cannot see" do
+      login_as(create(:user))
+
+      expect(allowed_ids).to contain_exactly(public_project.id)
+    end
+
+    it "omits archived projects even for an admin" do
+      login_as(create(:admin))
+
+      expect(allowed_ids).to include(public_project.id, private_project.id)
+      expect(allowed_ids).not_to include(archived_project.id)
+    end
+  end
+
+  describe "#apply_to" do
+    shared_let(:project) { create(:project) }
+    shared_let(:other_project) { create(:project) }
+    shared_let(:role) { create(:project_role) }
+
+    shared_let(:member) { create(:user).tap { |user| create(:member, project:, principal: user, roles: [role]) } }
+    shared_let(:other_member) do
+      create(:user).tap { |user| create(:member, project: other_project, principal: user, roles: [role]) }
+    end
+    shared_let(:non_member) { create(:user) }
+
+    def filtered(operator, values = [project.id.to_s])
+      described_class.create!(name: :member, operator:, values:).apply_to(User.user)
+    end
+
+    it "selects the members of the given project for '='" do
+      expect(filtered("=")).to contain_exactly(member)
+    end
+
+    it "excludes the members of the given project for '!'" do
+      expect(filtered("!")).to include(other_member, non_member)
+      expect(filtered("!")).not_to include(member)
+    end
+
+    it "selects users that are a member of any project for '*'" do
+      expect(filtered("*", [])).to include(member, other_member)
+      expect(filtered("*", [])).not_to include(non_member)
+    end
+
+    it "selects users that are a member of no project for '!*'" do
+      expect(filtered("!*", [])).to include(non_member)
+      expect(filtered("!*", [])).not_to include(member, other_member)
+    end
+
+    context "with memberships that are not project memberships" do
+      shared_let(:work_package_member) do
+        create(:user).tap do |user|
+          create(:work_package_member,
+                 entity: create(:work_package, project:),
+                 principal: user,
+                 roles: [create(:work_package_role)])
+        end
+      end
+      shared_let(:global_member) do
+        create(:user).tap { |user| create(:global_member, principal: user, roles: [create(:global_role)]) }
+      end
+
+      it "does not count a work package share as project membership" do
+        expect(filtered("=")).not_to include(work_package_member)
+        expect(filtered("!*", [])).to include(work_package_member)
+      end
+
+      it "does not count a global membership as project membership" do
+        expect(filtered("*", [])).not_to include(global_member)
+        expect(filtered("!*", [])).to include(global_member)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-19880

# What are you trying to accomplish?
- Add a `member` filter for the user query
- Use that query instead of attaching `in_project` manually
- Show the correct counter how many users a generic allocation applies to
  - Remove the `+` prefix as this was not really a plus counter (like in the work package list)
  - Scope the count to only show project members. Right now it shows a global count 

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
