### PR TITLE
[FND-110] Allow project administrators to manage their own type variants

### DIFF
--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -28,35 +28,91 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= component_wrapper do %>
-  <%= render(OpenProject::Common::BorderBoxListComponent.new(container: "project-settings-types")) do |list| %>
-    <% active_project_types.each do |project_type| %>
-      <% list.with_item(data: { test_selector: "project-types-row-#{project_type.effective_type.id}" }) do |item| %>
-        <% item.with_menu do |menu| %>
+  <% active_project_types.each do |project_type| %>
+    <%= render(
+          OpenProject::Common::BorderBoxListComponent.new(
+            container: "project-types-group-#{project_type.type.id}",
+            collapsible: true,
+            mt: 3,
+            data: { test_selector: "project-types-row-#{project_type.effective_type.id}" }
+          )
+        ) do |list| %>
+      <% list.with_header(collapsed: true) do |header| %>
+        <% header.with_title do %>
+          <%= render(Primer::Beta::Text.new(tag: :span, pl: 1)) { helpers.icon_for_type(project_type.type) } %>
+          <%= render(Primer::Beta::Text.new(tag: :span, font_weight: :semibold, ml: 2)) { project_type.type.name } %>
+          <% if project_type.variant %>
+            <%= render(Primer::Beta::Text.new(tag: :span, color: :muted, font_size: :small, ml: 2)) do %>
+              <%= t("projects.settings.types.variant_prefix") %>
+            <% end %>
+            <%= render(Primer::Beta::Text.new(tag: :span, color: :muted, font_weight: :semibold, font_size: :small)) do %>
+              <%= project_type.variant.own_name %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% header.with_menu do |menu| %>
           <% switch_action(menu, project_type.effective_type) if switchable?(project_type) %>
           <% remove_action(menu, project_type.effective_type) %>
         <% end %>
-        <%= flex_layout(align_items: :center) do |row| %>
-          <% row.with_column(display: :inline_flex, align_items: :center, mr: 2) do %>
-            <%= helpers.icon_for_type(project_type.type) %>
-          <% end %>
-          <% row.with_column(mr: 2) do %>
-            <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { project_type.type.name } %>
-          <% end %>
-          <% if project_type.variant %>
-            <% row.with_column do %>
-              <%= render(Primer::Beta::Text.new(color: :muted, font_size: :small)) do %>
-                <%= t("projects.settings.types.variant_prefix") %>
+      <% end %>
+
+      <% variants_for(project_type).each do |variant| %>
+        <% list.with_item(data: { test_selector: "project-types-variant-#{variant.id}" }) do |item| %>
+          <% if owned?(variant) && manageable? %>
+            <% item.with_menu do |menu| %>
+              <% menu.with_item(label: t(:button_edit), href: edit_variant_path(variant)) do |entry| %>
+                <% entry.with_leading_visual_icon(icon: :pencil) %>
               <% end %>
-              <%= render(Primer::Beta::Text.new(color: :muted, font_weight: :semibold, font_size: :small)) do %>
-                <%= project_type.variant.own_name %>
+              <% menu.with_item(
+                   label: t(:button_delete),
+                   scheme: :danger,
+                   href: delete_variant_path(variant),
+                   form_arguments: { method: :delete }
+                 ) do |entry| %>
+                <% entry.with_leading_visual_icon(icon: :trash) %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <%= flex_layout(align_items: :center) do |row| %>
+            <% row.with_column(mr: 2) do %>
+              <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { variant.own_name } %>
+            <% end %>
+            <% if owned?(variant) %>
+              <% row.with_column(mr: 2) do %>
+                <%= render(Primer::Beta::Label.new(scheme: :accent)) do %>
+                  <%= t("projects.settings.types.only_available_here") %>
+                <% end %>
+              <% end %>
+            <% end %>
+            <% if in_use?(project_type, variant) %>
+              <% row.with_column do %>
+                <%= render(Primer::Beta::Label.new) { t("projects.settings.types.in_use") } %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
       <% end %>
-    <% end %>
 
-    <% if active_project_types.empty? %>
+      <% if manageable? %>
+        <% list.with_footer do %>
+          <%= render(
+                Primer::Beta::Link.new(
+                  href: add_variant_path(project_type.type),
+                  muted: true,
+                  display: :inline_flex,
+                  align_items: :center
+                )
+              ) do %>
+            <%= render(Primer::Beta::Octicon.new(icon: :plus, mr: 1)) %>
+            <%= t("projects.settings.types.add_variant") %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if active_project_types.empty? %>
+    <%= render(OpenProject::Common::BorderBoxListComponent.new(container: "project-settings-types")) do |list| %>
       <% list.with_empty_state(
            title: t("projects.settings.types.empty_state.title"),
            description: t("projects.settings.types.empty_state.description"),

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% active_project_types.each do |project_type| %>
       <% list.with_item(data: { test_selector: "project-types-row-#{project_type.effective_type.id}" }) do |item| %>
         <% item.with_menu do |menu| %>
-          <% switch_action(menu, project_type.effective_type) if project_type.type.family.many? %>
+          <% switch_action(menu, project_type.effective_type) if switchable?(project_type) %>
           <% remove_action(menu, project_type.effective_type) %>
         <% end %>
         <%= flex_layout(align_items: :center) do |row| %>

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -57,6 +57,11 @@ module Projects
                                         .sort_by { |project_type| project_type.type.position }
           end
 
+          # A family whose only variants belong to other projects offers this one nothing.
+          def switchable?(project_type)
+            project_type.type.variants_available_in(project).any?
+          end
+
           def switch_path(type)
             new_project_settings_work_packages_type_switch_path(project, type)
           end

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -32,8 +32,9 @@ module Projects
   module Settings
     module WorkPackages
       module Types
-        # Lists the type families active in a project: one row per family,
-        # naming the active variant behind the parent type it presents as.
+        # The type families active in a project, each expandable to the variants the
+        # project may use: the global ones plus the ones it owns. One list answers both
+        # "what applies here" and "what do we own".
         class ListComponent < ApplicationComponent
           include OpPrimer::ComponentHelpers
           include OpTurbo::Streamable
@@ -89,6 +90,36 @@ module Projects
             ) do |item|
               item.with_leading_visual_icon(icon: :trash)
             end
+          end
+
+          def variants_for(project_type)
+            project_type.type.variants_available_in(project)
+          end
+
+          def in_use?(project_type, member)
+            project_type.effective_type == member
+          end
+
+          def owned?(variant)
+            variant.project_id == project.id
+          end
+
+          # Only a variant this project owns is one it may configure; the global ones
+          # belong to administration.
+          def manageable?
+            User.current.allowed_in_project?(:manage_project_variants, project)
+          end
+
+          def add_variant_path(root)
+            new_creation_wizard_project_settings_work_packages_types_variants_path(project, parent_id: root.id)
+          end
+
+          def edit_variant_path(variant)
+            edit_project_settings_work_packages_types_variant_details_path(project, variant)
+          end
+
+          def delete_variant_path(variant)
+            project_settings_work_packages_types_variant_path(project, variant)
           end
         end
       end

--- a/app/components/projects/settings/work_packages/types/switch_form_component.rb
+++ b/app/components/projects/settings/work_packages/types/switch_form_component.rb
@@ -56,7 +56,7 @@ module Projects
           end
 
           def available_targets
-            source.family
+            [source.root, *source.root.variants_available_in(project)]
           end
 
           # Constant lookup in a compiled template does not walk the enclosing modules.

--- a/app/components/types/edit_page_header_component.rb
+++ b/app/components/types/edit_page_header_component.rb
@@ -34,26 +34,28 @@ module Types
     include ApplicationHelper
     include TabsHelper
 
-    def initialize(type:, tabs: nil)
+    def initialize(type:, tabs: nil, routes: nil)
       super
       @type = type
       @tabs = tabs
+      @routes = routes || ::WorkPackageTypes::TypeRoutes.for(type)
     end
 
     def breadcrumb_items
-      [{ href: admin_index_path, text: t("label_administration") },
-       { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       { href: types_path, text: t(:label_type_plural) },
+      [*@routes.breadcrumb_root_items,
        *parent_breadcrumb_item,
        breadcrumb_leaf]
     end
 
     private
 
+    # Inside a project the parent is administered somewhere the reader cannot go, so it
+    # names the family as plain text rather than a link that would refuse them.
     def parent_breadcrumb_item
       return [] if @type.parent.nil?
 
-      [{ href: edit_type_details_path(type_id: @type.parent_id), text: @type.parent.name }]
+      href = @routes.parent_details
+      [href ? { href:, text: @type.parent.name } : @type.parent.name]
     end
 
     def breadcrumb_leaf

--- a/app/components/work_package_types/defaults_component.rb
+++ b/app/components/work_package_types/defaults_component.rb
@@ -34,9 +34,10 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(model, subject_configuration_form_data: nil, readonly: false, **)
+    def initialize(model, subject_configuration_form_data: nil, readonly: false, routes: nil, **)
       @subject_configuration_form_data = subject_configuration_form_data
       @readonly = readonly
+      @routes = routes || TypeRoutes.for(model)
       super(model, **)
     end
 
@@ -44,7 +45,7 @@ module WorkPackageTypes
 
     def form_options
       {
-        url: type_defaults_path(type_id: model.id),
+        url: @routes.defaults_submit,
         method: :put,
         model: subject_form_object,
         readonly: @readonly,

--- a/app/components/work_package_types/details_component.rb
+++ b/app/components/work_package_types/details_component.rb
@@ -34,8 +34,13 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
+    def initialize(model, routes: nil, **)
+      @routes = routes || TypeRoutes.for(model)
+      super(model, **)
+    end
+
     def form_options
-      { url: type_details_path(type_id: model.id), method: :patch, model: }
+      { url: @routes.details_submit, method: :patch, model: }
     end
   end
 end

--- a/app/components/work_package_types/export_configuration_component.html.erb
+++ b/app/components/work_package_types/export_configuration_component.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% subhead.with_heading(tag: :h3, size: :medium, mt: 3) { I18n.t("types.edit.export_configuration.templates.section_title") } %>
 <% end %>
 <p><%= I18n.t("types.edit.export_configuration.intro") %></p>
-<%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model, readonly: readonly?)) %>
+<%= render(WorkPackageTypes::ExportTemplateListComponent.new(type: model, readonly: readonly?, routes:)) %>
 
 <%= render(Primer::Beta::Subhead.new) do |subhead| %>
   <% subhead.with_heading(tag: :h3, size: :medium, mt: 3) { I18n.t("types.edit.export_configuration.artefact_export.section_title") } %>

--- a/app/components/work_package_types/export_configuration_component.rb
+++ b/app/components/work_package_types/export_configuration_component.rb
@@ -33,17 +33,20 @@ module WorkPackageTypes
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(model, readonly: false, **)
+    def initialize(model, readonly: false, routes: nil, **)
       @readonly = readonly
+      @routes = routes || TypeRoutes.for(model)
       super(model, **)
     end
+
+    attr_reader :routes
 
     def readonly? = @readonly
 
     def artefact_export_form_options
       {
         model:,
-        url: update_artefact_export_type_pdf_export_template_index_path(type_id: model.id),
+        url: routes.update_artefact_export,
         method: :put,
         readonly: @readonly,
         data: artefact_export_form_data

--- a/app/components/work_package_types/export_template_list_component.html.erb
+++ b/app/components/work_package_types/export_template_list_component.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
                 render(
                   Primer::Beta::Button.new(
                     tag: :a,
-                    href: enable_all_type_pdf_export_template_index_path(type_id: @type.id),
+                    href: routes.enable_all_pdf_templates,
                     scheme: :invisible,
                     font_weight: :bold,
                     color: :subtle,
@@ -59,7 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
                 render(
                   Primer::Beta::Button.new(
                     tag: :a,
-                    href: disable_all_type_pdf_export_template_index_path(type_id: @type.id),
+                    href: routes.disable_all_pdf_templates,
                     scheme: :invisible,
                     font_weight: :bold,
                     color: :subtle,
@@ -81,7 +81,8 @@ See COPYRIGHT and LICENSE files for more details.
             WorkPackageTypes::ExportTemplateRowComponent.new(
               type: @type,
               template:,
-              readonly: readonly?
+              readonly: readonly?,
+              routes:
             )
           )
         end

--- a/app/components/work_package_types/export_template_list_component.rb
+++ b/app/components/work_package_types/export_template_list_component.rb
@@ -34,12 +34,15 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(type:, readonly: false)
+    def initialize(type:, readonly: false, routes: nil)
       super
 
       @type = type
       @readonly = readonly
+      @routes = routes || TypeRoutes.for(type)
     end
+
+    attr_reader :routes
 
     def readonly? = @readonly
 
@@ -64,7 +67,7 @@ module WorkPackageTypes
       {
         "draggable-id": template.id,
         "draggable-type": "template",
-        "drop-url": drop_type_pdf_export_template_path(type_id: @type.id, id: template.id),
+        "drop-url": routes.drop_pdf_template(template.id),
         test_selector: "pdf-export-template-row-#{template.id}"
       }
     end

--- a/app/components/work_package_types/export_template_row_component.html.erb
+++ b/app/components/work_package_types/export_template_row_component.html.erb
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
         # A read-only toggle is disabled, so it never posts; omit the mutation wiring entirely.
         unless readonly?
           toggle_options.merge!(
-            src: toggle_type_pdf_export_template_path(type_id: @type.id, id: @template.id),
+            src: routes.toggle_pdf_template(@template.id),
             csrf_token: form_authenticity_token,
             data: { "turbo-method": :post, "turbo-stream": true },
             classes: "op-primer-adjustments__toggle-switch--hidden-loading-indicator"

--- a/app/components/work_package_types/export_template_row_component.rb
+++ b/app/components/work_package_types/export_template_row_component.rb
@@ -34,13 +34,16 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(type:, template:, readonly: false)
+    def initialize(type:, template:, readonly: false, routes: nil)
       super
 
       @template = template
       @type = type
       @readonly = readonly
+      @routes = routes || TypeRoutes.for(type)
     end
+
+    attr_reader :routes
 
     def readonly? = @readonly
   end

--- a/app/components/work_package_types/reuse_mode_banner_component.html.erb
+++ b/app/components/work_package_types/reuse_mode_banner_component.html.erb
@@ -37,23 +37,25 @@ See COPYRIGHT and LICENSE files for more details.
           description: linked_description
         )
       ) do |banner| %>
-    <% banner.with_action_content do %>
-      <%= render(
-            Primer::Beta::Button.new(
-              tag: :a,
-              scheme: :invisible,
-              href: link_dialog_path,
-              data: { controller: "async-dialog", test_selector: "reuse-mode-change-source" }
-            )
-          ) { t("types.edit.reuse_mode.linked.change_source") } %>
-      <%= render(
-            Primer::Beta::Button.new(
-              tag: :a,
-              ml: 2,
-              href: independent_dialog_path,
-              data: { controller: "async-dialog", test_selector: "reuse-mode-switch-to-independent" }
-            )
-          ) { t("types.edit.reuse_mode.linked.switch_to_independent") } %>
+    <% if mode_switchable? %>
+      <% banner.with_action_content do %>
+        <%= render(
+              Primer::Beta::Button.new(
+                tag: :a,
+                scheme: :invisible,
+                href: link_dialog_path,
+                data: { controller: "async-dialog", test_selector: "reuse-mode-change-source" }
+              )
+            ) { t("types.edit.reuse_mode.linked.change_source") } %>
+        <%= render(
+              Primer::Beta::Button.new(
+                tag: :a,
+                ml: 2,
+                href: independent_dialog_path,
+                data: { controller: "async-dialog", test_selector: "reuse-mode-switch-to-independent" }
+              )
+            ) { t("types.edit.reuse_mode.linked.switch_to_independent") } %>
+      <% end %>
     <% end %>
     <%= t("types.edit.reuse_mode.linked.title") %>
   <% end %>
@@ -67,25 +69,27 @@ See COPYRIGHT and LICENSE files for more details.
           description: t("types.edit.reuse_mode.independent.description")
         )
       ) do |banner| %>
-    <% banner.with_action_content do %>
-      <% if copy_supported? %>
+    <% if mode_switchable? %>
+      <% banner.with_action_content do %>
+        <% if copy_supported? %>
+          <%= render(
+                Primer::Beta::Button.new(
+                  tag: :a,
+                  scheme: :invisible,
+                  href: copy_dialog_path,
+                  data: { controller: "async-dialog", test_selector: "reuse-mode-copy-from-type" }
+                )
+              ) { t("types.edit.reuse_mode.independent.copy_from_type") } %>
+        <% end %>
         <%= render(
               Primer::Beta::Button.new(
                 tag: :a,
-                scheme: :invisible,
-                href: copy_dialog_path,
-                data: { controller: "async-dialog", test_selector: "reuse-mode-copy-from-type" }
+                ml: 2,
+                href: link_dialog_path,
+                data: { controller: "async-dialog", test_selector: "reuse-mode-switch-to-linked" }
               )
-            ) { t("types.edit.reuse_mode.independent.copy_from_type") } %>
+            ) { t("types.edit.reuse_mode.independent.switch_to_linked") } %>
       <% end %>
-      <%= render(
-            Primer::Beta::Button.new(
-              tag: :a,
-              ml: 2,
-              href: link_dialog_path,
-              data: { controller: "async-dialog", test_selector: "reuse-mode-switch-to-linked" }
-            )
-          ) { t("types.edit.reuse_mode.independent.switch_to_linked") } %>
     <% end %>
     <%= t("types.edit.reuse_mode.independent.title") %>
   <% end %>

--- a/app/components/work_package_types/reuse_mode_banner_component.rb
+++ b/app/components/work_package_types/reuse_mode_banner_component.rb
@@ -35,8 +35,9 @@ module WorkPackageTypes
   class ReuseModeBannerComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    def initialize(type:, aspect:)
+    def initialize(type:, aspect:, routes: nil)
       @aspect = aspect
+      @routes = routes || TypeRoutes.for(type)
       super(type)
     end
 
@@ -54,23 +55,38 @@ module WorkPackageTypes
 
     def source_is_parent? = source.present? && source == type.parent
 
-    def source_path = edit_type_details_path(type_id: source.id)
+    def source_path = @routes.source_details(source)
 
     def copy_supported? = CopyConfiguration.supported?(aspect)
 
-    def copy_dialog_path = type_configuration_copy_dialog_path(type_id: type.id, aspect:)
+    def copy_dialog_path = @routes.configuration_copy_dialog(aspect)
 
-    def link_dialog_path = type_configuration_link_dialog_path(type_id: type.id, aspect:)
+    def link_dialog_path = @routes.configuration_link_dialog(aspect)
 
-    def independent_dialog_path = type_configuration_independence_dialog_path(type_id: type.id, aspect:)
+    def independent_dialog_path = @routes.configuration_independence_dialog(aspect)
+
+    # Reuse mode is an administration concern; where its dialogs are out of reach the
+    # banner reports the mode without offering to change it.
+    def mode_switchable? = link_dialog_path.present?
 
     def linked_description
+      return plain_linked_description if source_path.blank?
+
       helpers.link_translate(
         "types.edit.reuse_mode.linked.description",
         i18n_args: { source_name: source.composite_name, source_suffix: parent_suffix },
         links: { source_url: source_path },
         external: false
       )
+    end
+
+    # link_translate always renders an anchor, so the unlinked wording unwraps the
+    # translation's own [name](source_url) markup and keeps the name.
+    def plain_linked_description
+      I18n.t("types.edit.reuse_mode.linked.description",
+             source_name: source.composite_name,
+             source_suffix: parent_suffix)
+        .gsub(/\[([^\]]*)\]\(source_url\)/, '\1')
     end
 
     def parent_suffix

--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -62,6 +62,9 @@ See COPYRIGHT and LICENSE files for more details.
                         )
                       ) { child.own_name } %>
                   <%= render(Primer::Beta::Text.new(color: :muted, ml: 2)) { t("types.index.variant_label") } %>
+                  <% if child.project_owned? %>
+                    <%= render(Primer::Beta::Label.new(scheme: :accent, ml: 2)) { owner_label(child) } %>
+                  <% end %>
                 <% end %>
                 <% if child.is_default? %>
                   <% variant.with_column(mr: 3) { render(Primer::Beta::Label.new) { t("types.index.enabled_in_new_projects") } } %>

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -69,6 +69,12 @@ module WorkPackageTypes
         root.children.find(&:is_default?)
       end
 
+      # An administrator sees every project's variants side by side, so an unattributed
+      # row would be indistinguishable from a global one.
+      def owner_label(variant)
+        t("types.index.owned_by", project: variant.project.name)
+      end
+
       def add_variant_path(root)
         new_creation_wizard_types_path(parent_id: root.id)
       end

--- a/app/components/work_package_types/wizard/footer_component.rb
+++ b/app/components/work_package_types/wizard/footer_component.rb
@@ -54,11 +54,11 @@ module WorkPackageTypes
 
       def first_step? = current_step == Steps.first
 
-      def last_step? = current_step == Steps.last
+      def last_step? = current_step == Steps.last_for(type)
 
-      def current_number = Steps.index(current_step) + 1
+      def current_number = Steps.available_for(type).index(current_step).to_i + 1
 
-      def total_steps = Steps.all.size
+      def total_steps = Steps.available_for(type).size
 
       def progress_percentage = (current_number.to_f / total_steps * 100).round
 
@@ -68,7 +68,7 @@ module WorkPackageTypes
       end
 
       def back_href
-        previous_step = Steps.previous_before(current_step)
+        previous_step = Steps.previous_before(current_step, type)
         @routes.wizard(step: previous_step) if previous_step && type.persisted?
       end
 

--- a/app/components/work_package_types/wizard/footer_component.rb
+++ b/app/components/work_package_types/wizard/footer_component.rb
@@ -39,10 +39,11 @@ module WorkPackageTypes
 
       FORM_IDENTIFIER = "type-wizard-form"
 
-      def initialize(type:, current_step:)
+      def initialize(type:, current_step:, routes: nil)
         super(type)
 
         @current_step = current_step
+        @routes = routes || TypeRoutes.for(type)
       end
 
       private
@@ -68,11 +69,11 @@ module WorkPackageTypes
 
       def back_href
         previous_step = Steps.previous_before(current_step)
-        type_creation_wizard_path(type, step: previous_step) if previous_step && type.persisted?
+        @routes.wizard(step: previous_step) if previous_step && type.persisted?
       end
 
       def cancel_href
-        type.persisted? ? edit_type_details_path(type_id: type.id) : types_path
+        type.persisted? ? @routes.details : @routes.index
       end
     end
   end

--- a/app/components/work_package_types/wizard/form_configuration_step_component.rb
+++ b/app/components/work_package_types/wizard/form_configuration_step_component.rb
@@ -56,7 +56,7 @@ module WorkPackageTypes
       private
 
       def reload_url
-        helpers.type_creation_wizard_path(model, step: :form_configuration)
+        helpers.type_routes.wizard(step: :form_configuration)
       end
 
       def no_filter_query

--- a/app/components/work_package_types/wizard/form_configuration_step_component.rb
+++ b/app/components/work_package_types/wizard/form_configuration_step_component.rb
@@ -43,7 +43,8 @@ module WorkPackageTypes
         render(WorkPackageTypes::ReloadableConfigurationFrameComponent.new(reload_url:)) do
           render(WorkPackageTypes::ReuseModeBannerComponent.new(
                    type: model,
-                   aspect: Type::ConfigurationLink::FORM_CONFIGURATION
+                   aspect: Type::ConfigurationLink::FORM_CONFIGURATION,
+                   routes: helpers.type_routes
                  )) +
             render(WorkPackageTypes::FormConfigurationComponent.new(
                      type: model,

--- a/app/components/work_package_types/wizard/page_component.html.erb
+++ b/app/components/work_package_types/wizard/page_component.html.erb
@@ -17,7 +17,7 @@
   <%= layout.with_wizard_content do %>
     <%= grid_layout("op-work-package-types-wizard", tag: :div) do |page| %>
       <% page.with_area("sidebar") do %>
-        <%= render(WorkPackageTypes::Wizard::SidebarComponent.new(type:, current_step:)) %>
+        <%= render(WorkPackageTypes::Wizard::SidebarComponent.new(type:, current_step:, routes:)) %>
       <% end %>
 
       <% page.with_area("main") do %>
@@ -46,6 +46,6 @@
   <% end %>
 
   <%= layout.with_footer do %>
-    <%= render(WorkPackageTypes::Wizard::FooterComponent.new(type:, current_step:)) %>
+    <%= render(WorkPackageTypes::Wizard::FooterComponent.new(type:, current_step:, routes:)) %>
   <% end %>
 <% end %>

--- a/app/components/work_package_types/wizard/page_component.rb
+++ b/app/components/work_package_types/wizard/page_component.rb
@@ -122,7 +122,7 @@ module WorkPackageTypes
       def reuse_mode_banner
         return unless step_editor.linkable_aspect?
 
-        render(WorkPackageTypes::ReuseModeBannerComponent.new(type:, aspect: step_editor.aspect))
+        render(WorkPackageTypes::ReuseModeBannerComponent.new(type:, aspect: step_editor.aspect, routes:))
       end
 
       # Editors that self-persist through their own turbo endpoints.

--- a/app/components/work_package_types/wizard/page_component.rb
+++ b/app/components/work_package_types/wizard/page_component.rb
@@ -33,15 +33,16 @@ module WorkPackageTypes
     class PageComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      def initialize(type:, current_step:)
+      def initialize(type:, current_step:, routes: nil)
         super(type)
 
         @current_step = current_step
+        @routes = routes || TypeRoutes.for(type)
       end
 
       private
 
-      attr_reader :current_step
+      attr_reader :current_step, :routes
 
       def type = model
 
@@ -54,33 +55,30 @@ module WorkPackageTypes
       end
 
       def breadcrumb_items
-        [
-          { href: admin_index_path, text: I18n.t("label_administration") },
-          { href: admin_settings_work_packages_general_path, text: I18n.t(:label_work_package_plural) },
-          { href: types_path, text: I18n.t(:label_type_plural) },
-          *parent_breadcrumb_item,
-          title
-        ]
+        [*routes.breadcrumb_root_items, *parent_breadcrumb_item, title]
       end
 
+      # Inside a project the parent is administered somewhere the reader cannot go, so it
+      # names the family as plain text rather than a link that would refuse them.
       def parent_breadcrumb_item
         return [] if type.parent.nil?
 
-        [{ href: edit_type_details_path(type_id: type.parent_id), text: type.parent.name }]
+        href = routes.parent_details
+        [href ? { href:, text: type.parent.name } : type.parent.name]
       end
 
       def cancel_href
-        type.persisted? ? edit_type_details_path(type_id: type.id) : types_path
+        type.persisted? ? routes.details : routes.index
       end
 
       def step_title = Steps.title(current_step)
 
-      def step_url = type_creation_wizard_path(type, step: current_step)
+      def step_url = routes.wizard(step: current_step)
 
       # A brand-new variant is created on the first step's submit; every later
       # submit patches the existing record for its step.
       def step_form_url
-        type.new_record? ? creation_wizard_types_path : step_url
+        type.new_record? ? routes.wizard_submit : step_url
       end
 
       def step_form_method

--- a/app/components/work_package_types/wizard/pdf_step_component.rb
+++ b/app/components/work_package_types/wizard/pdf_step_component.rb
@@ -56,7 +56,7 @@ module WorkPackageTypes
       private
 
       def reload_url
-        helpers.type_creation_wizard_path(model, step: :pdf)
+        helpers.type_routes.wizard(step: :pdf)
       end
     end
   end

--- a/app/components/work_package_types/wizard/pdf_step_component.rb
+++ b/app/components/work_package_types/wizard/pdf_step_component.rb
@@ -44,7 +44,8 @@ module WorkPackageTypes
         render(WorkPackageTypes::ReloadableConfigurationFrameComponent.new(reload_url:)) do
           render(WorkPackageTypes::ReuseModeBannerComponent.new(
                    type: model,
-                   aspect: Type::ConfigurationLink::PDF_EXPORT
+                   aspect: Type::ConfigurationLink::PDF_EXPORT,
+                   routes: helpers.type_routes
                  )) +
             render(WorkPackageTypes::ExportConfigurationComponent.new(
                      model,

--- a/app/components/work_package_types/wizard/project_attributes_step_component.rb
+++ b/app/components/work_package_types/wizard/project_attributes_step_component.rb
@@ -57,7 +57,7 @@ module WorkPackageTypes
       end
 
       def reload_url
-        helpers.type_creation_wizard_path(model, step: :project_attributes)
+        helpers.type_routes.wizard(step: :project_attributes)
       end
     end
   end

--- a/app/components/work_package_types/wizard/project_attributes_step_component.rb
+++ b/app/components/work_package_types/wizard/project_attributes_step_component.rb
@@ -41,7 +41,8 @@ module WorkPackageTypes
         render(WorkPackageTypes::ReloadableConfigurationFrameComponent.new(reload_url:)) do
           render(WorkPackageTypes::ReuseModeBannerComponent.new(
                    type: model,
-                   aspect: Type::ConfigurationLink::PROJECT_ATTRIBUTES
+                   aspect: Type::ConfigurationLink::PROJECT_ATTRIBUTES,
+                   routes: helpers.type_routes
                  )) +
             render(WorkPackageTypes::ProjectAttributes::IndexComponent.new(
                      type: model,

--- a/app/components/work_package_types/wizard/sidebar_component.rb
+++ b/app/components/work_package_types/wizard/sidebar_component.rb
@@ -33,10 +33,11 @@ module WorkPackageTypes
     class SidebarComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      def initialize(type:, current_step:)
+      def initialize(type:, current_step:, routes: nil)
         super(type)
 
         @current_step = current_step
+        @routes = routes || TypeRoutes.for(type)
       end
 
       LEADING_ICONS = {
@@ -85,7 +86,7 @@ module WorkPackageTypes
       # Only visited/creatable steps are navigable: before the record exists we
       # cannot address a step by its type id.
       def href_for(step)
-        type_creation_wizard_path(type, step:) if type.persisted?
+        @routes.wizard(step:) if type.persisted?
       end
     end
   end

--- a/app/components/work_package_types/wizard/sidebar_component.rb
+++ b/app/components/work_package_types/wizard/sidebar_component.rb
@@ -64,7 +64,7 @@ module WorkPackageTypes
 
       def type = model
 
-      def steps = Steps.all
+      def steps = Steps.available_for(type)
 
       def leading_icon(step) = LEADING_ICONS.fetch(step)
 

--- a/app/components/work_package_types/wizard/steps.rb
+++ b/app/components/work_package_types/wizard/steps.rb
@@ -35,15 +35,29 @@ module WorkPackageTypes
     module Steps
       ALL = %i[details defaults form_configuration project_attributes workflows projects pdf].freeze
 
+      # Picking the projects to use a type in has nothing to offer a project-owned variant:
+      # it may only ever be activated in the project owning it. Keyed off the type rather
+      # than off where it is being administered from, because that rule holds for an
+      # instance administrator editing the variant too.
+      OWNED_ONLY_EXCLUDED = %i[projects].freeze
+
       module_function
 
       def title(step) = I18n.t("types.creation_wizard.steps.#{step}")
 
       def all = ALL
 
+      def available_for(type)
+        type.project_owned? ? ALL - OWNED_ONLY_EXCLUDED : ALL
+      end
+
+      def available?(step, type) = available_for(type).include?(step)
+
       def first = ALL.first
 
       def last = ALL.last
+
+      def last_for(type) = available_for(type).last
 
       def for_key(key)
         return nil if key.blank?
@@ -53,14 +67,16 @@ module WorkPackageTypes
 
       def index(step) = ALL.index(step)
 
-      def next_after(step)
-        idx = ALL.index(step)
-        ALL[idx + 1] if idx && idx + 1 < ALL.length
+      def next_after(step, type = nil)
+        steps = type ? available_for(type) : ALL
+        idx = steps.index(step)
+        steps[idx + 1] if idx && idx + 1 < steps.length
       end
 
-      def previous_before(step)
-        idx = ALL.index(step)
-        ALL[idx - 1] if idx&.positive?
+      def previous_before(step, type = nil)
+        steps = type ? available_for(type) : ALL
+        idx = steps.index(step)
+        steps[idx - 1] if idx&.positive?
       end
     end
   end

--- a/app/components/work_package_types/wizard/workflows_step_component.rb
+++ b/app/components/work_package_types/wizard/workflows_step_component.rb
@@ -44,8 +44,7 @@ module WorkPackageTypes
       def type = model
 
       def matrix_url
-        helpers.type_workflow_matrix_path(
-          type,
+        helpers.type_routes.workflow_matrix(
           tab: helpers.params[:tab],
           role_ids: roles.map(&:id),
           status_ids: helpers.params[:status_ids]

--- a/app/components/workflows/blankslate_component.html.erb
+++ b/app/components/workflows/blankslate_component.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
     blankslate.with_description_content(t(description_key))
     unless readonly?
       blankslate.with_primary_action(
-        href: helpers.status_dialog_type_workflow_matrix_path(type, tab:, role_ids: roles.map(&:id)),
+        href: helpers.type_routes.workflow_matrix_status_dialog(tab:, role_ids: roles.map(&:id)),
         scheme: :secondary,
         data: { controller: "async-dialog" }
       ) do |button|

--- a/app/components/workflows/matrix_editor_component.html.erb
+++ b/app/components/workflows/matrix_editor_component.html.erb
@@ -103,23 +103,25 @@ See COPYRIGHT and LICENSE files for more details.
           scheme: :secondary,
           leading_icon: :plus,
           label: t("admin.workflows.status_button"),
-          href: helpers.status_dialog_type_workflow_matrix_path(type, tab:, role_ids: roles.map(&:id), status_ids: statuses.pluck(:id).presence),
+          href: helpers.type_routes.workflow_matrix_status_dialog(tab:, role_ids: roles.map(&:id), status_ids: statuses.pluck(:id).presence),
           data: { controller: "async-dialog" }
         ) do
           t("admin.workflows.status_button")
         end
 
-        subheader.with_action_button(
-          tag: :a,
-          scheme: :secondary,
-          leading_icon: :copy,
-          label: copy_button_label,
-          href: helpers.new_type_workflow_copy_path(type, source_role_id: roles.first&.id),
-          aria: { label: copy_button_label },
-          title: copy_button_label,
-          data: { controller: "async-dialog", "admin--workflow-checkbox-state-confirmation-trigger": "click" }
-        ) do
-          copy_button_label
+        if helpers.type_routes.workflow_copy(source_role_id: roles.first&.id)
+          subheader.with_action_button(
+            tag: :a,
+            scheme: :secondary,
+            leading_icon: :copy,
+            label: copy_button_label,
+            href: helpers.type_routes.workflow_copy(source_role_id: roles.first&.id),
+            aria: { label: copy_button_label },
+            title: copy_button_label,
+            data: { controller: "async-dialog", "admin--workflow-checkbox-state-confirmation-trigger": "click" }
+          ) do
+            copy_button_label
+          end
         end
       end
     end

--- a/app/components/workflows/matrix_editor_component.rb
+++ b/app/components/workflows/matrix_editor_component.rb
@@ -63,7 +63,7 @@ module Workflows
         controller: "admin--workflow-checkbox-state",
         "admin--workflow-checkbox-state-has-status-changes-value": context.status_changes?,
         # for saving the workflow when switching tabs
-        "admin--workflow-checkbox-state-save-url-value": helpers.type_workflow_matrix_path(type, tab:)
+        "admin--workflow-checkbox-state-save-url-value": helpers.type_routes.workflow_matrix(tab:)
       }
     end
 
@@ -76,7 +76,7 @@ module Workflows
         name:,
         label: I18n.t(:"admin.workflows.tabs.#{name}"),
         description: I18n.t(:"admin.workflows.tabs.descriptions.#{name}"),
-        path: helpers.type_workflow_matrix_path(type, tab: name, role_ids: roles.map(&:id)),
+        path: helpers.type_routes.workflow_matrix(tab: name, role_ids: roles.map(&:id)),
         data: {
           controller: "admin--workflow-tab-select",
           action: "click->admin--workflow-tab-select#select",
@@ -93,7 +93,7 @@ module Workflows
     def data_attributes
       {
         controller: "admin--workflow-role-select",
-        "admin--workflow-role-select-base-url-value": helpers.type_workflow_matrix_path(type, tab:),
+        "admin--workflow-role-select-base-url-value": helpers.type_routes.workflow_matrix(tab:),
         "admin--workflow-role-select-current-role-ids-value": roles.map(&:id),
         "admin--workflow-role-select-admin--workflow-checkbox-state-outlet": "##{STATE_ID}"
       }

--- a/app/components/workflows/status_form_component.html.erb
+++ b/app/components/workflows/status_form_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   primer_form_with(
-    url: helpers.confirm_statuses_type_workflow_matrix_path(type, tab:, role_ids: roles.map(&:id)),
+    url: helpers.type_routes.workflow_matrix_confirm_statuses(tab:, role_ids: roles.map(&:id)),
     method: :post,
     id: FORM_ID,
     data: { turbo_frame: "workflow-table" }

--- a/app/components/workflows/status_removal_danger_dialog_component.html.erb
+++ b/app/components/workflows/status_removal_danger_dialog_component.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
       id: DIALOG_ID,
       title: t("admin.workflows.statuses_removal_dialog.title"),
       confirm_button_text: t("admin.workflows.statuses_removal_dialog.confirm"),
-      form_arguments: { action: helpers.type_workflow_matrix_path(type, tab:), method: :get, data: { turbo_frame: "workflow-table" } }
+      form_arguments: { action: helpers.type_routes.workflow_matrix(tab:), method: :get, data: { turbo_frame: "workflow-table" } }
     )
   ) do |dialog|
     dialog.with_confirmation_message do |message|

--- a/app/contracts/projects/types/switch_variant_contract.rb
+++ b/app/contracts/projects/types/switch_variant_contract.rb
@@ -40,17 +40,23 @@ module Projects
 
       protected
 
-      def validate_target_selectable
+      def validate_target_selectable # rubocop:disable Metrics/AbcSize
         if target.nil?
           errors.add(:types, :switch_target_blank)
         elsif target == source
           errors.add(:types, :switch_target_identical)
         elsif source.root_id != target.root_id
           errors.add(:types, :switch_target_not_in_family)
+        elsif !target_available_in_project?
+          errors.add(:types, :switch_target_not_available)
         end
       end
 
       private
+
+      def target_available_in_project?
+        target.project_id.nil? || target.project_id == model.id
+      end
 
       def source = options[:source]
 

--- a/app/contracts/work_package_types/base_contract.rb
+++ b/app/contracts/work_package_types/base_contract.rb
@@ -30,8 +30,20 @@
 
 module WorkPackageTypes
   class BaseContract < ::ModelContract
-    include RequiresAdminGuard
+    validate :validate_manageable
 
     def self.model = Type
+
+    private
+
+    # Instance administrators manage every type. Everyone else reaches only the variants
+    # their own project owns, and inheriting the rule here is what keeps each write path
+    # from having to remember it.
+    def validate_manageable
+      return if user.admin? && user.active?
+      return if model.project_owned? && user.allowed_in_project?(:manage_project_variants, model.project)
+
+      errors.add :base, :error_unauthorized
+    end
   end
 end

--- a/app/contracts/work_package_types/create_contract.rb
+++ b/app/contracts/work_package_types/create_contract.rb
@@ -40,6 +40,9 @@ module WorkPackageTypes
     attribute :name
     attribute :parent_id
     attribute :attribute_groups
+    # Writable on creation only: transferring a variant between projects is out of scope,
+    # so no update contract declares it.
+    attribute :project_id
 
     validates :is_default, :is_milestone, :is_in_roadmap, inclusion: { in: [true, false] }
   end

--- a/app/controllers/concerns/work_package_types/type_routing.rb
+++ b/app/controllers/concerns/work_package_types/type_routing.rb
@@ -29,18 +29,20 @@
 #++
 
 module WorkPackageTypes
-  class BaseTabController < ApplicationController
-    include TypeRouting
+  # Hands the tab components the paths for wherever this controller administers a type
+  # from. Administration answers with the admin routes whoever owns the type;
+  # Projects::Settings::WorkPackages::Types::Variants::ProjectScoped overrides it.
+  module TypeRouting
+    extend ActiveSupport::Concern
 
-    layout "admin"
-
-    before_action :require_admin
-    before_action :find_type
+    included do
+      helper_method :type_routes
+    end
 
     private
 
-    def find_type
-      @type = ::Type.find(params[:type_id])
+    def type_routes
+      @type_routes ||= ::WorkPackageTypes::TypeRoutes.for(@type)
     end
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/creation_wizard_controller.rb
@@ -32,6 +32,8 @@ module Projects::Settings::WorkPackages::Types::Variants
   class CreationWizardController < ::WorkPackageTypes::CreationWizardController
     include ProjectScoped
 
+    before_action :find_type, only: %i[show update]
+
     # The wizard fills the screen in administration too, and nothing about being inside a
     # project changes that.
     layout "no_menu"

--- a/app/controllers/projects/settings/work_packages/types/variants/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/creation_wizard_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class CreationWizardController < ::WorkPackageTypes::CreationWizardController
+    include ProjectScoped
+
+    # The wizard fills the screen in administration too, and nothing about being inside a
+    # project changes that.
+    layout "no_menu"
+
+    def new
+      @type = ::Type.new(parent_id: params[:parent_id], project: @project)
+      @current_step = ::WorkPackageTypes::Wizard::Steps.first
+
+      render :show
+    end
+
+    private
+
+    # The owner is never read off the request: a project administrator running this wizard
+    # is creating a variant here and nowhere else.
+    def details_params
+      super.to_h.symbolize_keys.merge(project: @project)
+    end
+
+    def redirect_to_step(step)
+      if step
+        redirect_to project_settings_work_packages_types_variant_creation_wizard_path(@project, @type, step:),
+                    status: :see_other
+      else
+        redirect_to project_settings_work_packages_types_path(@project),
+                    notice: t("types.creation_wizard.success"),
+                    status: :see_other
+      end
+    end
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/creation_wizard_controller.rb
@@ -32,7 +32,14 @@ module Projects::Settings::WorkPackages::Types::Variants
   class CreationWizardController < ::WorkPackageTypes::CreationWizardController
     include ProjectScoped
 
+    # set_current_step decides whether the type even has the requested step, so it has to
+    # follow the re-registered lookup rather than keep its inherited position ahead of it.
+    skip_before_action :set_current_step
+
+    # rubocop:disable Rails/LexicallyScopedActionFilter -- both actions are inherited
     before_action :find_type, only: %i[show update]
+    before_action :set_current_step, only: %i[show update]
+    # rubocop:enable Rails/LexicallyScopedActionFilter
 
     # The wizard fills the screen in administration too, and nothing about being inside a
     # project changes that.

--- a/app/controllers/projects/settings/work_packages/types/variants/defaults_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/defaults_tab_controller.rb
@@ -31,5 +31,7 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class DefaultsTabController < ::WorkPackageTypes::DefaultsTabController
     include ProjectScoped
+
+    before_action :find_type
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/defaults_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/defaults_tab_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class DefaultsTabController < ::WorkPackageTypes::DefaultsTabController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/details_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/details_tab_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class DetailsTabController < ::WorkPackageTypes::DetailsTabController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/details_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/details_tab_controller.rb
@@ -31,5 +31,7 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class DetailsTabController < ::WorkPackageTypes::DetailsTabController
     include ProjectScoped
+
+    before_action :find_type
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/form_configuration_groups_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/form_configuration_groups_tab_controller.rb
@@ -31,5 +31,7 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class FormConfigurationGroupsTabController < ::WorkPackageTypes::FormConfigurationGroupsTabController
     include ProjectScoped
+
+    before_action :find_type
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/form_configuration_groups_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/form_configuration_groups_tab_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class FormConfigurationGroupsTabController < ::WorkPackageTypes::FormConfigurationGroupsTabController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/form_configuration_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/form_configuration_tab_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class FormConfigurationTabController < ::WorkPackageTypes::FormConfigurationTabController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/form_configuration_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/form_configuration_tab_controller.rb
@@ -31,5 +31,7 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class FormConfigurationTabController < ::WorkPackageTypes::FormConfigurationTabController
     include ProjectScoped
+
+    before_action :find_type
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/matrix_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/matrix_controller.rb
@@ -28,19 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackageTypes
-  class BaseTabController < ApplicationController
-    include TypeRouting
+module Projects::Settings::WorkPackages::Types::Variants
+  # The workflow matrix editor, re-homed inside a project's settings. The parent resolves
+  # its type lazily through #type, which reads the @type this sets.
+  class MatrixController < ::Workflows::MatrixController
+    include ProjectScoped
 
-    layout "admin"
-
-    before_action :require_admin
     before_action :find_type
 
-    private
+    def show
+      return if turbo_frame_request?
 
-    def find_type
-      @type = ::Type.find(params[:type_id])
+      redirect_to type_routes.workflow(role_ids: params[:role_ids], tab: matrix_context.tab)
     end
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/pdf_export_template_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/pdf_export_template_controller.rb
@@ -31,5 +31,13 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class PdfExportTemplateController < ::WorkPackageTypes::PdfExportTemplateController
     include ProjectScoped
+
+    # find_template reads @type, so it has to follow the re-registered lookup rather than
+    # keep its inherited position ahead of it.
+    skip_before_action :find_template
+    before_action :find_type
+    # rubocop:disable Rails/LexicallyScopedActionFilter -- both actions are inherited
+    before_action :find_template, only: %i[toggle drop]
+    # rubocop:enable Rails/LexicallyScopedActionFilter
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/pdf_export_template_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/pdf_export_template_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class PdfExportTemplateController < ::WorkPackageTypes::PdfExportTemplateController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/project_attributes_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/project_attributes_tab_controller.rb
@@ -31,5 +31,7 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class ProjectAttributesTabController < ::WorkPackageTypes::ProjectAttributesTabController
     include ProjectScoped
+
+    before_action :find_type
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/project_attributes_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/project_attributes_tab_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class ProjectAttributesTabController < ::WorkPackageTypes::ProjectAttributesTabController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/project_scoped.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/project_scoped.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  # Re-homes a global type-administration tab inside a project's settings. The tab bodies
+  # are the administration ones untouched; what changes is who may reach them and which
+  # types they can name at all.
+  #
+  # The project lookup is prepended because the inherited find_type runs before anything
+  # a subclass appends, and it needs the project to scope against.
+  module ProjectScoped
+    extend ActiveSupport::Concern
+    include ::WorkPackageTypes::TypeVariantsFeature
+
+    included do
+      layout "base"
+      menu_item :settings_work_packages
+
+      skip_before_action :require_admin
+      prepend_before_action :find_project_by_project_id, :authorize
+      before_action :require_type_variants_feature
+    end
+
+    private
+
+    # A variant of another project is absent rather than forbidden, so a project
+    # administrator cannot tell the two apart by probing ids.
+    def find_type
+      @type = @project.owned_types.find_by(id: params[:variant_id])
+
+      render_404 if @type.nil?
+    end
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants/project_scoped.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/project_scoped.rb
@@ -57,5 +57,9 @@ module Projects::Settings::WorkPackages::Types::Variants
 
       render_404 if @type.nil?
     end
+
+    def type_routes
+      @type_routes ||= ::WorkPackageTypes::TypeRoutes.for(@type, project: @project)
+    end
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/project_scoped.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/project_scoped.rb
@@ -33,8 +33,11 @@ module Projects::Settings::WorkPackages::Types::Variants
   # are the administration ones untouched; what changes is who may reach them and which
   # types they can name at all.
   #
-  # The project lookup is prepended because the inherited find_type runs before anything
-  # a subclass appends, and it needs the project to scope against.
+  # The inherited lookup is dropped and re-registered rather than prepended. Prepending put
+  # it and #authorize ahead of ApplicationController's user_setup, so User.current was still
+  # anonymous, Project.visible found nothing and every request bounced to the login page.
+  # Request specs cannot see that: login_as sets User.current directly, so they pass either
+  # way. Each including controller re-adds :find_type for the actions that need one.
   module ProjectScoped
     extend ActiveSupport::Concern
     include ::WorkPackageTypes::TypeVariantsFeature
@@ -44,7 +47,10 @@ module Projects::Settings::WorkPackages::Types::Variants
       menu_item :settings_work_packages
 
       skip_before_action :require_admin
-      prepend_before_action :find_project_by_project_id, :authorize
+      skip_before_action :find_type, raise: false
+
+      before_action :find_project_by_project_id
+      before_action :authorize
       before_action :require_type_variants_feature
     end
 

--- a/app/controllers/projects/settings/work_packages/types/variants/workflow_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/workflow_tab_controller.rb
@@ -31,5 +31,7 @@
 module Projects::Settings::WorkPackages::Types::Variants
   class WorkflowTabController < ::WorkPackageTypes::WorkflowTabController
     include ProjectScoped
+
+    before_action :find_type
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/variants/workflow_tab_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants/workflow_tab_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Settings::WorkPackages::Types::Variants
+  class WorkflowTabController < ::WorkPackageTypes::WorkflowTabController
+    include ProjectScoped
+  end
+end

--- a/app/controllers/projects/settings/work_packages/types/variants_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/variants_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Projects::Settings::WorkPackages::Types::VariantsController < Projects::SettingsController
+  include ::WorkPackageTypes::TypeVariantsFeature
+
+  menu_item :settings_work_packages
+
+  before_action :require_type_variants_feature
+  before_action :find_variant, only: %i[destroy]
+
+  # The project's variants are listed by the types page itself, under the family they
+  # belong to, so this resource only ever writes.
+  def destroy
+    @variant.destroy!
+
+    redirect_to project_settings_work_packages_types_path(@project), status: :see_other
+  end
+
+  private
+
+  # Scoping the lookup to the project is the isolation. A variant of another project is
+  # absent rather than forbidden, so the two cases are indistinguishable from outside.
+  def find_variant
+    @variant = @project.owned_types.find_by(id: params[:id])
+
+    render_404 if @variant.nil?
+  end
+end

--- a/app/controllers/work_package_types/configuration_copies_controller.rb
+++ b/app/controllers/work_package_types/configuration_copies_controller.rb
@@ -92,7 +92,7 @@ module WorkPackageTypes
     def source
       return @source if defined?(@source)
 
-      @source = Type.global.find_by(id: params[:source_id])
+      @source = Type.selectable_as_source_for(@type).find_by(id: params[:source_id])
     end
 
     def require_supported_aspect

--- a/app/controllers/work_package_types/configuration_links_controller.rb
+++ b/app/controllers/work_package_types/configuration_links_controller.rb
@@ -77,7 +77,7 @@ module WorkPackageTypes
     def source
       return @source if defined?(@source)
 
-      @source = Type.global.find_by(id: params[:source_id])
+      @source = Type.selectable_as_source_for(@type).find_by(id: params[:source_id])
     end
 
     def respond_to_switch(result)

--- a/app/controllers/work_package_types/creation_wizard_controller.rb
+++ b/app/controllers/work_package_types/creation_wizard_controller.rb
@@ -59,7 +59,7 @@ module WorkPackageTypes
       @type = service_call.result
 
       if service_call.success?
-        redirect_to_step Wizard::Steps.next_after(Wizard::Steps.first)
+        redirect_to_step Wizard::Steps.next_after(Wizard::Steps.first, @type)
       else
         @current_step = Wizard::Steps.first
         render :show, status: :unprocessable_entity
@@ -131,7 +131,7 @@ module WorkPackageTypes
     end
 
     def advance
-      redirect_to_step Wizard::Steps.next_after(@current_step)
+      redirect_to_step Wizard::Steps.next_after(@current_step, @type)
     end
 
     def redirect_to_step(step)
@@ -146,8 +146,12 @@ module WorkPackageTypes
       @type = ::Type.find(params.expect(:type_id))
     end
 
+    # A step the type does not have is not merely hidden from the sidebar: reaching it by
+    # URL must not render it either.
     def set_current_step
       @current_step = Wizard::Steps.for_key(params[:step]) || Wizard::Steps.first
+
+      render_404 unless Wizard::Steps.available?(@current_step, @type)
     end
 
     # The core settings are only editable while creating a root type; a variant

--- a/app/controllers/work_package_types/creation_wizard_controller.rb
+++ b/app/controllers/work_package_types/creation_wizard_controller.rb
@@ -37,6 +37,7 @@ module WorkPackageTypes
   # persists to that same record (see FND-117).
   class CreationWizardController < ApplicationController
     include TypeVariantsFeature
+    include TypeRouting
 
     layout "no_menu"
 

--- a/app/controllers/work_package_types/pdf_export_template_controller.rb
+++ b/app/controllers/work_package_types/pdf_export_template_controller.rb
@@ -31,6 +31,8 @@
 module WorkPackageTypes
   class PdfExportTemplateController < ApplicationController
     include OpTurbo::ComponentStream
+    include TypeRouting
+
     layout "admin"
 
     before_action :require_admin

--- a/app/controllers/workflows/matrix_controller.rb
+++ b/app/controllers/workflows/matrix_controller.rb
@@ -32,6 +32,7 @@
 # that the editor can be modified regardless of the context it is used in
 class Workflows::MatrixController < ApplicationController
   include OpTurbo::ComponentStream
+  include WorkPackageTypes::TypeRouting
 
   layout false
 
@@ -72,6 +73,12 @@ class Workflows::MatrixController < ApplicationController
 
   def type
     @type ||= ::Type.find(params.expect(:type_id))
+  end
+
+  # Resolved off #type rather than @type: this controller finds its type lazily, so the
+  # ivar is not yet set when a view asks for the routes.
+  def type_routes
+    @type_routes ||= ::WorkPackageTypes::TypeRoutes.for(type)
   end
 
   def matrix_context

--- a/app/forms/work_package_types/source_options.rb
+++ b/app/forms/work_package_types/source_options.rb
@@ -35,7 +35,7 @@ module WorkPackageTypes
     private
 
     def source_options
-      Type.global.in_family_order.reject { |source| source == type }
+      Type.in_family_order_available_in(type.project).reject { |source| source == type }
     end
 
     # Variants carry their parent in the composite name; the current type's own

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -31,48 +31,48 @@
 module ::TypesHelper
   include CustomFieldsHelper
 
-  # rubocop:disable Rails/HelperInstanceVariable
-  def types_tabs
+  # A tab whose route builder answers nil has no destination where the type is being
+  # administered from, and is dropped rather than rendered as a dead link.
+  def types_tabs # rubocop:disable Metrics/AbcSize
     [
       {
         name: "details",
-        path: edit_type_details_path(type_id: @type.id),
+        path: type_routes.details,
         label: I18n.t("types.edit.details.tab")
       },
       {
         name: "defaults",
-        path: edit_type_defaults_path(type_id: @type.id),
+        path: type_routes.defaults,
         label: I18n.t("types.edit.defaults.tab")
       },
       {
         name: "form_configuration",
-        path: edit_type_form_configuration_path(@type),
+        path: type_routes.form_configuration,
         label: I18n.t("types.edit.form_configuration.tab")
       },
       {
         name: "workflow",
-        path: edit_type_workflow_path(@type),
+        path: type_routes.workflow,
         label: I18n.t("types.edit.workflow.tab")
       },
       {
         name: "project_attributes",
-        path: edit_type_project_attributes_path(@type),
+        path: type_routes.project_attributes,
         label: I18n.t("types.edit.project_attributes.tab")
       },
       {
         name: "projects",
-        path: edit_type_projects_path(@type),
+        path: type_routes.projects,
         label: I18n.t("types.edit.projects.tab")
       },
       {
         name: "export_configuration",
-        path: edit_type_pdf_export_template_index_path(type_id: @type.id),
+        path: type_routes.pdf_export,
         label: I18n.t("types.edit.export_configuration.tab"),
         view_component: WorkPackageTypes::ExportConfigurationComponent
       }
-    ]
+    ].select { |tab| tab[:path].present? }
   end
-  # rubocop:enable Rails/HelperInstanceVariable
 
   def icon_for_type(type)
     return unless type

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -72,6 +72,8 @@ class Project < ApplicationRecord
 
   has_many :enabled_modules, dependent: :delete_all, after_remove: :module_disabled
   has_many :project_types, dependent: :delete_all
+  # Variants this project owns. They exist nowhere else, so they go when it does.
+  has_many :owned_types, class_name: "Type", dependent: :destroy, inverse_of: :project
 
   # Enabled root-types, variants need to be determined explicitly
   has_many :types, -> { order("#{::Type.table_name}.position") }, through: :project_types

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -47,6 +47,9 @@ class Type < ApplicationRecord
 
   belongs_to :color, optional: true, class_name: "Color"
 
+  # The owning project, or nil for a global type.
+  belongs_to :project, optional: true
+
   has_many :work_packages
   # The write target and the eager-loadable association.
   # Reads go through #project_custom_field_type_mappings, which resolves the
@@ -91,9 +94,11 @@ class Type < ApplicationRecord
 
   acts_as_list scope: :parent_id
 
+  # Scoped by owner as well as family: two projects naming their own variant the same
+  # is the expected case, not a clash.
   validates :name,
             presence: true,
-            uniqueness: { scope: :parent_id, case_sensitive: false },
+            uniqueness: { scope: %i[parent_id project_id], case_sensitive: false },
             length: { maximum: 255 }
 
   validate :parent_is_a_root
@@ -101,6 +106,8 @@ class Type < ApplicationRecord
   validate :cannot_have_children_when_child
   validate :standard_type_stays_root
   validate :parent_frozen_while_used_by_projects
+  validate :owned_type_is_a_variant
+  validate :owned_type_parent_is_global
 
   scopes :milestone,
          :with_effective_configuration,
@@ -241,6 +248,10 @@ class Type < ApplicationRecord
     parent_id.present?
   end
 
+  def project_owned?
+    project_id.present?
+  end
+
   # A variant's acts_as_list position is append order and users cannot reorder
   # variants, so position is not a display order for them; alphabetical is.
   # Every screen that lists a family reads this, so the orders cannot drift.
@@ -347,6 +358,20 @@ class Type < ApplicationRecord
 
   def standard_type_stays_root
     errors.add(:parent, :standard_type_must_be_root) if is_standard? && parent_id.present?
+  end
+
+  # Owning a root would be owning a global type, which :manage_project_variants
+  # deliberately does not grant.
+  def owned_type_is_a_variant
+    return if project_id.blank? || parent_id.present?
+
+    errors.add(:project, :must_own_a_variant)
+  end
+
+  def owned_type_parent_is_global
+    return if project_id.blank? || parent.nil? || parent.project_id.nil?
+
+    errors.add(:parent, :must_be_global)
   end
 
   # Re-parenting moves a type into another family or out of one, which would leave every

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -117,9 +117,10 @@ class Type < ApplicationRecord
 
   scope :roots, -> { where(parent_id: nil) }
   scope :variants, -> { where.not(parent_id: nil) }
-  # All types are global until project-owned variants exist; this is the seam the
-  # configuration source picker and contract scope against (see FND-103 :manage_type_variants).
-  scope :global, -> { all }
+  scope :global, -> { where(project_id: nil) }
+  # A source is a global type, or a variant owned by the same project as the type being
+  # configured. A global type's project_id is nil, so this collapses to global-only.
+  scope :selectable_as_source_for, ->(type) { where(project_id: [nil, type.project_id]) }
   scope :without_standard, -> { where(is_standard: false).order(:position) }
   scope :default, -> { where(is_default: true) }
   scope :visible, ->(user = User.current) {
@@ -137,6 +138,12 @@ class Type < ApplicationRecord
   # over the flat table can keep a family together.
   def self.in_family_order
     roots.includes(:children).flat_map(&:family)
+  end
+
+  # Cannot go through in_family_order: that walks #family, which reads #children and so
+  # would surface variants owned by other projects.
+  def self.in_family_order_available_in(project)
+    global.roots.includes(:children).flat_map { |root| [root, *root.variants_available_in(project)] }
   end
 
   def <=>(other)
@@ -257,6 +264,11 @@ class Type < ApplicationRecord
   # Every screen that lists a family reads this, so the orders cannot drift.
   def sorted_variants
     children.sort_by { |variant| variant.own_name.downcase }
+  end
+
+  # The variants of this root the given project may see: the global ones plus its own.
+  def variants_available_in(project)
+    sorted_variants.select { |variant| variant.project_id.nil? || variant.project_id == project&.id }
   end
 
   def family

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -123,9 +123,11 @@ class Type < ApplicationRecord
   scope :selectable_as_source_for, ->(type) { where(project_id: [nil, type.project_id]) }
   scope :without_standard, -> { where(is_standard: false).order(:position) }
   scope :default, -> { where(is_default: true) }
+  # An owned variant only reaches someone who can see its project. Without this the
+  # /api/v3/types/:id and MCP show paths served any variant by id.
   scope :visible, ->(user = User.current) {
     if user.allowed_in_any_project?(:view_work_packages) || user.allowed_in_any_project?(:manage_types)
-      all
+      global.or(where(project_id: Project.allowed_to(user, :view_work_packages).select(:id)))
     else
       none
     end

--- a/app/models/work_package_types/type_routes.rb
+++ b/app/models/work_package_types/type_routes.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # Where a type is administered from. The same tab components serve global administration
+  # and a project's own settings, and they ask this instead of naming a route.
+  #
+  # Which one you get depends on where you are, not on what the type is: an administrator
+  # browsing /types configures a project-owned variant through the admin routes, while a
+  # project administrator configures that same variant through their project's.
+  class TypeRoutes
+    include Rails.application.routes.url_helpers
+
+    def self.for(type, project: nil)
+      project ? ProjectScoped.new(type, project) : Global.new(type)
+    end
+
+    def initialize(type)
+      @type = type
+    end
+
+    attr_reader :type
+
+    class Global < TypeRoutes
+      def breadcrumb_root_items
+        [{ href: admin_index_path, text: I18n.t("label_administration") },
+         { href: admin_settings_work_packages_general_path, text: I18n.t(:label_work_package_plural) },
+         { href: types_path, text: I18n.t(:label_type_plural) }]
+      end
+
+      def parent_details = edit_type_details_path(type_id: type.parent_id)
+
+      def index = types_path
+      def details = edit_type_details_path(type_id: type.id)
+      def details_submit = type_details_path(type_id: type.id)
+      def defaults = edit_type_defaults_path(type)
+      def defaults_submit = type_defaults_path(type_id: type.id)
+      def form_configuration = edit_type_form_configuration_path(type)
+      def workflow(**) = edit_type_workflow_path(type, **)
+      def project_attributes = edit_type_project_attributes_path(type)
+      def pdf_export = edit_type_pdf_export_template_index_path(type_id: type.id)
+      def projects = edit_type_projects_path(type)
+
+      def wizard(step: nil) = type_creation_wizard_path(type, step:)
+      def wizard_submit = creation_wizard_types_path
+
+      def workflow_matrix(**) = type_workflow_matrix_path(type, **)
+      def workflow_matrix_status_dialog(**) = status_dialog_type_workflow_matrix_path(type, **)
+      def workflow_matrix_confirm_statuses(**) = confirm_statuses_type_workflow_matrix_path(type, **)
+      def workflow_copy(**) = new_type_workflow_copy_path(type, **)
+      def form_configuration_reset_dialog = reset_dialog_type_form_configuration_path(type)
+      def form_configuration_groups = type_form_configuration_groups_path(type)
+      def add_form_configuration_group = add_group_type_form_configuration_groups_path(type)
+      def form_configuration_group(key) = type_form_configuration_group_path(type, key)
+      def edit_form_configuration_group(key) = edit_type_form_configuration_group_path(type, key)
+      def move_form_configuration_group(key) = move_type_form_configuration_group_path(type, key)
+      def drop_form_configuration_group(key) = drop_type_form_configuration_group_path(type, key)
+      def cancel_edit_form_configuration_group(key) = cancel_edit_type_form_configuration_group_path(type, key)
+      def update_query_form_configuration_group(key) = update_query_type_form_configuration_group_path(type, key)
+      def drop_form_configuration_row(key) = drop_type_form_configuration_row_path(type, key)
+      def move_form_configuration_row(key) = move_type_form_configuration_row_path(type, key)
+
+      def toggle_project_attribute = toggle_type_project_attributes_path(type)
+      def enable_all_project_attributes = enable_all_of_section_type_project_attributes_path(type)
+      def disable_all_project_attributes = disable_all_of_section_type_project_attributes_path(type)
+
+      def toggle_pdf_template(id) = toggle_type_pdf_export_template_path(type_id: type.id, id:)
+      def drop_pdf_template(id) = drop_type_pdf_export_template_path(type_id: type.id, id:)
+      def enable_all_pdf_templates = enable_all_type_pdf_export_template_index_path(type_id: type.id)
+      def disable_all_pdf_templates = disable_all_type_pdf_export_template_index_path(type_id: type.id)
+      def update_artefact_export = update_artefact_export_type_pdf_export_template_index_path(type_id: type.id)
+
+      def configuration_link_dialog(aspect) = type_configuration_link_dialog_path(type_id: type.id, aspect:)
+      def configuration_copy_dialog(aspect) = type_configuration_copy_dialog_path(type_id: type.id, aspect:)
+      def source_details(source) = edit_type_details_path(type_id: source.id)
+
+      def configuration_independence_dialog(aspect)
+        type_configuration_independence_dialog_path(type_id: type.id, aspect:)
+      end
+    end
+
+    class ProjectScoped < TypeRoutes
+      def initialize(type, project)
+        super(type)
+
+        @project = project
+      end
+
+      attr_reader :project
+
+      def breadcrumb_root_items
+        [{ href: project_settings_general_path(project), text: I18n.t("label_project_settings") },
+         { href: project_settings_work_packages_path(project), text: I18n.t(:label_work_package_plural) },
+         { href: index, text: I18n.t(:label_type_plural) }]
+      end
+
+      # The parent is a global type, administered somewhere this user cannot go, so it
+      # names the family without pretending to be a way there.
+      def parent_details = nil
+
+      def index = project_settings_work_packages_types_path(project)
+      def details = edit_project_settings_work_packages_types_variant_details_path(project, type)
+      def details_submit = project_settings_work_packages_types_variant_details_path(project, type)
+      def defaults = edit_project_settings_work_packages_types_variant_defaults_path(project, type)
+      def defaults_submit = project_settings_work_packages_types_variant_defaults_path(project, type)
+      def workflow(**) = edit_project_settings_work_packages_types_variant_workflow_path(project, type, **)
+
+      def form_configuration
+        edit_project_settings_work_packages_types_variant_form_configuration_path(project, type)
+      end
+
+      def project_attributes
+        edit_project_settings_work_packages_types_variant_project_attributes_path(project, type)
+      end
+
+      def pdf_export
+        edit_project_settings_work_packages_types_variant_pdf_export_template_index_path(project, type)
+      end
+
+      # A project-owned variant is only usable in its owner, so there is nothing to
+      # activate elsewhere and no tab to reach.
+      def projects = nil
+
+      def wizard(step: nil)
+        project_settings_work_packages_types_variant_creation_wizard_path(project, type, step:)
+      end
+
+      def wizard_submit = creation_wizard_project_settings_work_packages_types_variants_path(project)
+
+      def workflow_matrix(**)
+        project_settings_work_packages_types_variant_workflow_matrix_path(project, type, **)
+      end
+
+      def workflow_matrix_status_dialog(**)
+        status_dialog_project_settings_work_packages_types_variant_workflow_matrix_path(project, type, **)
+      end
+
+      def workflow_matrix_confirm_statuses(**)
+        confirm_statuses_project_settings_work_packages_types_variant_workflow_matrix_path(project, type, **)
+      end
+
+      # Copying a workflow reaches across every type and role in the instance, which is
+      # more than owning one variant grants.
+      def workflow_copy(**) = nil
+
+      def form_configuration_reset_dialog
+        reset_dialog_project_settings_work_packages_types_variant_form_configuration_path(project, type)
+      end
+
+      def form_configuration_groups
+        project_settings_work_packages_types_variant_form_configuration_groups_path(project, type)
+      end
+
+      def add_form_configuration_group
+        add_group_project_settings_work_packages_types_variant_form_configuration_groups_path(project, type)
+      end
+
+      def form_configuration_group(key)
+        project_settings_work_packages_types_variant_form_configuration_group_path(project, type, key)
+      end
+
+      def edit_form_configuration_group(key)
+        edit_project_settings_work_packages_types_variant_form_configuration_group_path(project, type, key)
+      end
+
+      def move_form_configuration_group(key)
+        move_project_settings_work_packages_types_variant_form_configuration_group_path(project, type, key)
+      end
+
+      def drop_form_configuration_group(key)
+        drop_project_settings_work_packages_types_variant_form_configuration_group_path(project, type, key)
+      end
+
+      def cancel_edit_form_configuration_group(key)
+        cancel_edit_project_settings_work_packages_types_variant_form_configuration_group_path(project, type, key)
+      end
+
+      def update_query_form_configuration_group(key)
+        update_query_project_settings_work_packages_types_variant_form_configuration_group_path(project, type, key)
+      end
+
+      def drop_form_configuration_row(key)
+        drop_project_settings_work_packages_types_variant_form_configuration_row_path(project, type, key)
+      end
+
+      def move_form_configuration_row(key)
+        move_project_settings_work_packages_types_variant_form_configuration_row_path(project, type, key)
+      end
+
+      def toggle_project_attribute
+        toggle_project_settings_work_packages_types_variant_project_attributes_path(project, type)
+      end
+
+      def enable_all_project_attributes
+        enable_all_of_section_project_settings_work_packages_types_variant_project_attributes_path(project, type)
+      end
+
+      def disable_all_project_attributes
+        disable_all_of_section_project_settings_work_packages_types_variant_project_attributes_path(project, type)
+      end
+
+      def toggle_pdf_template(id)
+        toggle_project_settings_work_packages_types_variant_pdf_export_template_path(project, type, id)
+      end
+
+      def drop_pdf_template(id)
+        drop_project_settings_work_packages_types_variant_pdf_export_template_path(project, type, id)
+      end
+
+      def enable_all_pdf_templates
+        enable_all_project_settings_work_packages_types_variant_pdf_export_template_index_path(project, type)
+      end
+
+      def disable_all_pdf_templates
+        disable_all_project_settings_work_packages_types_variant_pdf_export_template_index_path(project, type)
+      end
+
+      def update_artefact_export
+        update_artefact_export_project_settings_work_packages_types_variant_pdf_export_template_index_path(project, type)
+      end
+
+      # Reuse mode is still configured from administration only. Rather than render buttons
+      # that would refuse the project administrator, the banner states the mode and stops.
+      def configuration_link_dialog(_aspect) = nil
+      def configuration_copy_dialog(_aspect) = nil
+      def configuration_independence_dialog(_aspect) = nil
+
+      # The source is a global type or another of this project's variants; either way its
+      # own configuration screen is in administration.
+      def source_details(_source) = nil
+    end
+  end
+end

--- a/app/views/work_package_types/creation_wizard/show.html.erb
+++ b/app/views/work_package_types/creation_wizard/show.html.erb
@@ -1,3 +1,3 @@
-<% html_title t(:label_administration), t("types.creation_wizard.create_variant") %>
+<% html_title *type_routes.breadcrumb_root_items.pluck(:text).reverse, t("types.creation_wizard.create_variant") %>
 
 <%= render(WorkPackageTypes::Wizard::PageComponent.new(type: @type, current_step: @current_step, routes: type_routes)) %>

--- a/app/views/work_package_types/creation_wizard/show.html.erb
+++ b/app/views/work_package_types/creation_wizard/show.html.erb
@@ -1,3 +1,3 @@
 <% html_title t(:label_administration), t("types.creation_wizard.create_variant") %>
 
-<%= render(WorkPackageTypes::Wizard::PageComponent.new(type: @type, current_step: @current_step)) %>
+<%= render(WorkPackageTypes::Wizard::PageComponent.new(type: @type, current_step: @current_step, routes: type_routes)) %>

--- a/app/views/work_package_types/defaults_tab/edit.html.erb
+++ b/app/views/work_package_types/defaults_tab/edit.html.erb
@@ -29,18 +29,20 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
 <%= render(
       WorkPackageTypes::ReloadableConfigurationFrameComponent.new(
-        reload_url: edit_type_defaults_path(type_id: @type.id)
+        reload_url: type_routes.defaults
       )
     ) do %>
-  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::DEFAULTS)) %>
+  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::DEFAULTS, routes: type_routes)) %>
   <% if @type.linked?(Type::ConfigurationLink::DEFAULTS) %>
-    <%= render WorkPackageTypes::DefaultsComponent.new(@type, readonly: true) %>
+    <%= render WorkPackageTypes::DefaultsComponent.new(@type, readonly: true, routes: type_routes) %>
   <% else %>
     <%= render WorkPackageTypes::DefaultsComponent
-                 .new(@type, subject_configuration_form_data: params[:work_package_types_forms_defaults_form_model]) %>
+                 .new(@type,
+                      subject_configuration_form_data: params[:work_package_types_forms_defaults_form_model],
+                      routes: type_routes) %>
   <% end %>
 <% end %>

--- a/app/views/work_package_types/details_tab/edit.html.erb
+++ b/app/views/work_package_types/details_tab/edit.html.erb
@@ -29,6 +29,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
-<%= render WorkPackageTypes::DetailsComponent.new(@type) %>
+<%= render WorkPackageTypes::DetailsComponent.new(@type, routes: type_routes) %>

--- a/app/views/work_package_types/form_configuration_tab/edit.html.erb
+++ b/app/views/work_package_types/form_configuration_tab/edit.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
 <% no_filter_query = ::API::V3::Queries::QueryParamsRepresenter.new(Query.new_default.tap { |q| q.filters = [] }).to_json %>
 <%= render(
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
         reload_url: edit_type_form_configuration_path(type_id: @type.id)
       )
     ) do %>
-  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::FORM_CONFIGURATION)) %>
+  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::FORM_CONFIGURATION, routes: type_routes)) %>
   <%= render(
         WorkPackageTypes::FormConfigurationComponent.new(
           type: @type,

--- a/app/views/work_package_types/pdf_export_template/edit.html.erb
+++ b/app/views/work_package_types/pdf_export_template/edit.html.erb
@@ -29,17 +29,18 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
 <%= render(
       WorkPackageTypes::ReloadableConfigurationFrameComponent.new(
-        reload_url: edit_type_pdf_export_template_index_path(type_id: @type.id)
+        reload_url: type_routes.pdf_export
       )
     ) do %>
-  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::PDF_EXPORT)) %>
+  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::PDF_EXPORT, routes: type_routes)) %>
 
   <%= render WorkPackageTypes::ExportConfigurationComponent.new(
         @type,
-        readonly: @type.linked?(Type::ConfigurationLink::PDF_EXPORT)
+        readonly: @type.linked?(Type::ConfigurationLink::PDF_EXPORT),
+        routes: type_routes
       ) %>
 <% end %>

--- a/app/views/work_package_types/project_attributes_tab/edit.html.erb
+++ b/app/views/work_package_types/project_attributes_tab/edit.html.erb
@@ -11,14 +11,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
 <%= render(
       WorkPackageTypes::ReloadableConfigurationFrameComponent.new(
         reload_url: edit_type_project_attributes_path(@type)
       )
     ) do %>
-  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::PROJECT_ATTRIBUTES)) %>
+  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::PROJECT_ATTRIBUTES, routes: type_routes)) %>
 
   <%= render WorkPackageTypes::ProjectAttributes::IndexComponent.new(
         type: @type,

--- a/app/views/work_package_types/projects_tab/edit.html.erb
+++ b/app/views/work_package_types/projects_tab/edit.html.erb
@@ -29,6 +29,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
 <%= render WorkPackageTypes::ProjectsComponent.new(@type, projects: @projects) %>

--- a/app/views/work_package_types/workflow_tab/edit.html.erb
+++ b/app/views/work_package_types/workflow_tab/edit.html.erb
@@ -28,23 +28,23 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title t(:label_administration), t(:label_type_plural), @type.name -%>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs, routes: type_routes) %>
 
 <%= render(
       WorkPackageTypes::ReloadableConfigurationFrameComponent.new(
-        reload_url: edit_type_workflow_path(type_id: @type.id)
+        reload_url: type_routes.workflow
       )
     ) do %>
-  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::WORKFLOWS)) %>
+  <%= render(WorkPackageTypes::ReuseModeBannerComponent.new(type: @type, aspect: Type::ConfigurationLink::WORKFLOWS, routes: type_routes)) %>
 
   <% if @type && @roles.any? %>
     <%= form_tag(
-          type_workflow_matrix_path(@type, tab: @current_tab),
+          type_routes.workflow_matrix(tab: @current_tab),
           method: :patch,
           autocomplete: "off",
           class: "workflow-table--pinned-save-bar"
         ) do %>
-      <%= turbo_frame_tag "workflow-table", src: type_workflow_matrix_path(@type, tab: @current_tab, role_ids: @roles.map(&:id), status_ids: params[:status_ids]) %>
+      <%= turbo_frame_tag "workflow-table", src: type_routes.workflow_matrix(tab: @current_tab, role_ids: @roles.map(&:id), status_ids: params[:status_ids]) %>
 
       <% unless @type.linked?(Type::ConfigurationLink::WORKFLOWS) %>
         <div class="workflow-save-bar">

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -248,6 +248,7 @@ Rails.application.reloader.to_prepare do
       map.permission :manage_project_variants,
                      {
                        "projects/settings/work_packages/types/variants": %i[destroy],
+                       "projects/settings/work_packages/types/variants/creation_wizard": %i[new create show update],
                        "projects/settings/work_packages/types/variants/details_tab": %i[edit update],
                        "projects/settings/work_packages/types/variants/defaults_tab": %i[edit update],
                        "projects/settings/work_packages/types/variants/workflow_tab": %i[edit],

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -246,7 +246,9 @@ Rails.application.reloader.to_prepare do
                      require: :member
 
       map.permission :manage_project_variants,
-                     {},
+                     {
+                       "projects/settings/work_packages/types/variants": %i[destroy]
+                     },
                      permissible_on: :project,
                      require: :member
 

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -252,6 +252,8 @@ Rails.application.reloader.to_prepare do
                        "projects/settings/work_packages/types/variants/details_tab": %i[edit update],
                        "projects/settings/work_packages/types/variants/defaults_tab": %i[edit update],
                        "projects/settings/work_packages/types/variants/workflow_tab": %i[edit],
+                       "projects/settings/work_packages/types/variants/matrix":
+                         %i[show update status_dialog confirm_statuses],
                        "projects/settings/work_packages/types/variants/form_configuration_tab":
                          %i[edit update reset_dialog destroy drop move],
                        "projects/settings/work_packages/types/variants/form_configuration_groups_tab":

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -247,7 +247,18 @@ Rails.application.reloader.to_prepare do
 
       map.permission :manage_project_variants,
                      {
-                       "projects/settings/work_packages/types/variants": %i[destroy]
+                       "projects/settings/work_packages/types/variants": %i[destroy],
+                       "projects/settings/work_packages/types/variants/details_tab": %i[edit update],
+                       "projects/settings/work_packages/types/variants/defaults_tab": %i[edit update],
+                       "projects/settings/work_packages/types/variants/workflow_tab": %i[edit],
+                       "projects/settings/work_packages/types/variants/form_configuration_tab":
+                         %i[edit update reset_dialog destroy drop move],
+                       "projects/settings/work_packages/types/variants/form_configuration_groups_tab":
+                         %i[create edit update destroy add_group cancel_edit drop move update_query],
+                       "projects/settings/work_packages/types/variants/project_attributes_tab":
+                         %i[edit toggle enable_all_of_section disable_all_of_section],
+                       "projects/settings/work_packages/types/variants/pdf_export_template":
+                         %i[edit toggle drop enable_all disable_all update_artefact_export]
                      },
                      permissible_on: :project,
                      require: :member

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -245,6 +245,11 @@ Rails.application.reloader.to_prepare do
                      permissible_on: :project,
                      require: :member
 
+      map.permission :manage_project_variants,
+                     {},
+                     permissible_on: :project,
+                     require: :member
+
       map.permission :select_custom_fields,
                      {
                        "projects/settings/work_packages/custom_fields": %i[show update]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6300,6 +6300,7 @@ en:
       make_default_notice: "%{name} is now activated in new projects."
       no_results_content_text: Create a new type
       no_results_title_text: There are currently no types.
+      owned_by: "Owned by %{project}"
       remove_default: "Do not activate in new projects"
       remove_default_notice: "%{name} is no longer activated in new projects."
       type_label: "Type"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -833,9 +833,12 @@ en:
               cannot_change_while_used_by_projects: "can't be changed while projects still use this type."
               cannot_have_children: "can't be set because this type already has variants."
               must_be_a_root: "must itself be a top-level type. Types can only be nested one level deep."
+              must_be_global: "must be a global type."
               standard_type_must_be_root: "can't be set for the standard type."
             patterns:
               invalid_tokens: "One or more attributes inside the field are not valid. Please, fix the attributes before saving."
+            project:
+              must_own_a_variant: "must be set on a variant only."
         type/configuration_link:
           attributes:
             source_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5063,12 +5063,15 @@ en:
           type_label: "Type"
           type_placeholder: "Select a type"
         add_type: "Add type"
+        add_variant: "Add a variant for this project"
         empty_state:
           description: "Add a type to let people create work packages of that type in this project."
           title: "No types are active in this project"
+        in_use: "In use"
         form:
           enable_type_in_project: 'Enable type "%{type}"'
         no_results_title_text: There are currently no types available.
+        only_available_here: "Only available in this project"
         remove_from_project: "Remove from project"
         switch_dialog:
           apply: "Apply"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -711,6 +711,7 @@ en:
               in_use_by_work_packages: "still in use by work packages: %{types}"
               switch_target_blank: "Select the variant to switch to"
               switch_target_identical: "The target type must be different from the type the project uses now"
+              switch_target_not_available: "That variant is not available in this project"
               switch_target_not_in_family: "Can only switch to another type of the same family"
           cannot_be_assigned_to_artifact_work_package: "The chosen user is not allowed to be assigned to work packages."
           foreign_wps_reference_version: "Work packages in non descendant projects reference versions of the project or its descendants."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4745,6 +4745,7 @@ en:
     Allows users to manage their own working times, and personal non-working days.
   permission_manage_placeholder_user: "Create, edit, and delete placeholder users"
   permission_manage_project_activities: "Manage project activities"
+  permission_manage_project_variants: "Manage the project's own type variants"
   permission_manage_public_bcf_queries: "Manage public BCF queries"
   permission_manage_public_project_queries: "Manage public project lists"
   permission_manage_public_queries: "Manage public views"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -438,6 +438,11 @@ Rails.application.routes.draw do
 
             resource :switch, only: %i[new create], controller: "types/switches"
           end
+          # Variants this project owns. Not nested under a type id: a variant already
+          # knows its parent, and the project is the only scope that matters here.
+          namespace :types do
+            resources :variants, only: %i[destroy]
+          end
           resource :custom_fields, only: %i[show update]
           resource :categories, only: %i[show update]
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,7 +441,57 @@ Rails.application.routes.draw do
           # Variants this project owns. Not nested under a type id: a variant already
           # knows its parent, and the project is the only scope that matters here.
           namespace :types do
-            resources :variants, only: %i[destroy]
+            # The Projects tab is deliberately absent: activating a type across projects
+            # is meaningless for a variant only its owner may use.
+            resources :variants, only: %i[destroy] do
+              resource :details, controller: "variants/details_tab", only: %i[edit update]
+              resource :defaults, controller: "variants/defaults_tab", only: %i[edit update]
+              resource :workflow, controller: "variants/workflow_tab", only: %i[edit]
+
+              resource :form_configuration, controller: "variants/form_configuration_tab", only: %i[edit update] do
+                get :reset_dialog
+                resources :groups, only: %i[create edit update destroy],
+                                   controller: "variants/form_configuration_groups_tab", param: :key do
+                  collection do
+                    post :add_group
+                  end
+
+                  member do
+                    post :cancel_edit
+                    put :drop
+                    put :move
+                    patch :update_query
+                  end
+                end
+                resources :rows, only: %i[destroy], controller: "variants/form_configuration_tab", param: :row_key do
+                  member do
+                    put :drop
+                    put :move
+                  end
+                end
+              end
+
+              resource :project_attributes, controller: "variants/project_attributes_tab", only: %i[edit] do
+                post :toggle
+                put :enable_all_of_section
+                put :disable_all_of_section
+              end
+
+              resources :pdf_export_template, only: %i[],
+                                              controller: "variants/pdf_export_template",
+                                              path: "pdf_export" do
+                member do
+                  post :toggle
+                  put :drop
+                end
+                collection do
+                  get :edit
+                  put :enable_all
+                  put :disable_all
+                  put :update_artefact_export
+                end
+              end
+            end
           end
           resource :custom_fields, only: %i[show update]
           resource :categories, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,7 +452,12 @@ Rails.application.routes.draw do
 
               resource :details, controller: "variants/details_tab", only: %i[edit update]
               resource :defaults, controller: "variants/defaults_tab", only: %i[edit update]
-              resource :workflow, controller: "variants/workflow_tab", only: %i[edit]
+              resource :workflow, controller: "variants/workflow_tab", only: %i[edit] do
+                resource :matrix, only: %i[show update], controller: "variants/matrix" do
+                  get :status_dialog
+                  post :confirm_statuses
+                end
+              end
 
               resource :form_configuration, controller: "variants/form_configuration_tab", only: %i[edit update] do
                 get :reset_dialog

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -444,6 +444,12 @@ Rails.application.routes.draw do
             # The Projects tab is deliberately absent: activating a type across projects
             # is meaningless for a variant only its owner may use.
             resources :variants, only: %i[destroy] do
+              collection do
+                get "creation_wizard/new", to: "variants/creation_wizard#new", as: :new_creation_wizard
+                post "creation_wizard", to: "variants/creation_wizard#create", as: :creation_wizard
+              end
+              resource :creation_wizard, controller: "variants/creation_wizard", only: %i[show update]
+
               resource :details, controller: "variants/details_tab", only: %i[edit update]
               resource :defaults, controller: "variants/defaults_tab", only: %i[edit update]
               resource :workflow, controller: "variants/workflow_tab", only: %i[edit]

--- a/db/migrate/20260807135442_add_project_to_types.rb
+++ b/db/migrate/20260807135442_add_project_to_types.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# A NULL owner means the type is global. Only variants may be owned; the model enforces it.
+class AddProjectToTypes < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :types, :project, foreign_key: true, null: true, index: true
+  end
+end

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -110,6 +110,74 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
+  describe "expanded family rows" do
+    shared_let(:stranger) { create(:project) }
+    shared_let(:global_variant) { create(:type, name: "Global bug", parent: bug) }
+
+    let(:project) { create(:project, types: [bug]) }
+
+    before do
+      create(:type, name: "Our bug", parent: bug, project:)
+      create(:type, name: "Their bug", parent: bug, project: stranger)
+      render_inline(component)
+    end
+
+    it "names the family" do
+      expect(page).to have_text("Bug")
+    end
+
+    # Global variants apply here too, so the project administrator has to see them.
+    it "lists the global variant" do
+      expect(page).to have_text("Global bug")
+    end
+
+    it "lists the project's own variant" do
+      expect(page).to have_text("Our bug")
+    end
+
+    # The isolation criterion, checked where a user would actually notice it.
+    it "never mentions another project's variant" do
+      expect(page).to have_no_text("Their bug")
+    end
+
+    it "marks the project's own variant as confined to it" do
+      expect(page).to have_text("Only available in this project")
+    end
+  end
+
+  describe "actions on a variant" do
+    let(:project) { create(:project, types: [bug]) }
+    let!(:owned) { create(:type, name: "Our bug", parent: bug, project:) }
+
+    context "with the permission to manage the project's variants" do
+      current_user { create(:user, member_with_permissions: { project => %i[manage_project_variants] }) }
+
+      before { render_inline(component) }
+
+      it "offers to add a variant" do
+        expect(page).to have_link("Add a variant for this project")
+      end
+
+      it "points the edit action at the project-scoped details tab" do
+        expect(page).to have_css(
+          "a[href='#{edit_project_settings_work_packages_types_variant_details_path(project, owned)}']",
+          visible: :all
+        )
+      end
+    end
+
+    # Someone who may only select types for the project has nothing to manage here.
+    context "without the permission" do
+      current_user { create(:user, member_with_permissions: { project => %i[manage_types] }) }
+
+      before { render_inline(component) }
+
+      it "does not offer to add a variant" do
+        expect(page).to have_no_link("Add a variant for this project")
+      end
+    end
+  end
+
   context "when the family's only variant belongs to another project" do
     let(:project) { create(:project, types: [bug]) }
 

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -109,4 +109,31 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_text("No types are active in this project")
     end
   end
+
+  context "when the family's only variant belongs to another project" do
+    let(:project) { create(:project, types: [bug]) }
+
+    before do
+      create(:type, name: "Theirs", parent: bug, project: create(:project))
+      render_inline(component)
+    end
+
+    # There is nothing here for this project to switch to, so offering the action would lie.
+    it "hides the switch action" do
+      expect(page).to have_no_link("Switch variant", visible: :all)
+    end
+  end
+
+  context "when the family has a variant this project owns" do
+    let(:project) { create(:project, types: [bug]) }
+
+    before do
+      create(:type, name: "Ours", parent: bug, project:)
+      render_inline(component)
+    end
+
+    it "offers the switch action" do
+      expect(page).to have_link("Switch variant", visible: :all)
+    end
+  end
 end

--- a/spec/contracts/work_package_types/create_contract_spec.rb
+++ b/spec/contracts/work_package_types/create_contract_spec.rb
@@ -145,5 +145,49 @@ module WorkPackageTypes
         end
       end
     end
+
+    describe "as a project administrator" do
+      shared_let(:owner) { create(:project) }
+      shared_let(:root) { create(:type) }
+      shared_let(:project_admin) do
+        create(:user, member_with_permissions: { owner => %i[manage_project_variants] })
+      end
+
+      let(:user) { project_admin }
+
+      context "with a variant its own project owns" do
+        let(:attributes) { { name: "Ours", parent_id: root.id, project: owner } }
+
+        it "is valid" do
+          expect(contract.validate).to be_truthy
+        end
+      end
+
+      context "with a variant another project owns" do
+        let(:attributes) { { name: "Theirs", parent_id: root.id, project: create(:project) } }
+
+        it "is invalid" do
+          expect(contract.validate).to be_falsey
+        end
+      end
+
+      # Global types stay an instance-administrator concern.
+      context "with a global variant" do
+        let(:attributes) { { name: "Global", parent_id: root.id } }
+
+        it "is invalid" do
+          expect(contract.validate).to be_falsey
+        end
+      end
+
+      context "without the permission" do
+        let(:user) { create(:user, member_with_permissions: { owner => %i[view_project] }) }
+        let(:attributes) { { name: "Ours", parent_id: root.id, project: owner } }
+
+        it "is invalid" do
+          expect(contract.validate).to be_falsey
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/projects/settings/work_packages/types/variants/callback_order_spec.rb
+++ b/spec/controllers/projects/settings/work_packages/types/variants/callback_order_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Pinned here rather than in a request spec on purpose. These controllers authorize against
+# the current user and look the project up through Project.visible, both of which need
+# ApplicationController's user_setup to have run. When authorization was prepended it ran
+# first, User.current was still anonymous, and every request redirected to the login page —
+# yet every request spec passed, because login_as sets User.current directly and so hides
+# the missing user_setup entirely. Only a real browser session showed the bug.
+RSpec.describe "Project-scoped variant controllers' callback order" do # rubocop:disable RSpec/DescribeClass
+  controllers = [
+    Projects::Settings::WorkPackages::Types::Variants::DetailsTabController,
+    Projects::Settings::WorkPackages::Types::Variants::DefaultsTabController,
+    Projects::Settings::WorkPackages::Types::Variants::WorkflowTabController,
+    Projects::Settings::WorkPackages::Types::Variants::ProjectAttributesTabController,
+    Projects::Settings::WorkPackages::Types::Variants::FormConfigurationTabController,
+    Projects::Settings::WorkPackages::Types::Variants::FormConfigurationGroupsTabController,
+    Projects::Settings::WorkPackages::Types::Variants::PdfExportTemplateController,
+    Projects::Settings::WorkPackages::Types::Variants::CreationWizardController,
+    Projects::Settings::WorkPackages::Types::Variants::MatrixController
+  ]
+
+  def before_filters(controller)
+    controller._process_action_callbacks.select { |callback| callback.kind == :before }.map(&:filter)
+  end
+
+  controllers.each do |controller|
+    describe controller.name do
+      let(:filters) { before_filters(controller) }
+
+      it "establishes the current user before authorizing" do
+        expect(filters.index(:authorize)).to be > filters.index(:user_setup)
+      end
+
+      it "establishes the current user before looking the project up" do
+        expect(filters.index(:find_project_by_project_id)).to be > filters.index(:user_setup)
+      end
+
+      it "authorizes before looking the type up" do
+        next if filters.exclude?(:find_type)
+
+        expect(filters.index(:find_type)).to be > filters.index(:authorize)
+      end
+
+      it "no longer requires an instance administrator" do
+        expect(filters).not_to include(:require_admin)
+      end
+    end
+  end
+end

--- a/spec/controllers/projects/settings/work_packages/types/variants/session_authentication_spec.rb
+++ b/spec/controllers/projects/settings/work_packages/types/variants/session_authentication_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# The user is established from the session here, deliberately, instead of through the
+# current_user helper. That helper stubs RequestStore[:current_user] — the very thing
+# ApplicationController#user_setup fills in — so it resolves User.current whether or not
+# user_setup ran. A controller whose authorization ran before user_setup therefore passed
+# every request and feature spec while redirecting real signed-in administrators to the
+# login page. Reading the session is what makes that visible.
+RSpec.describe "Project-scoped variant screens for a session-authenticated user",
+               type: :controller,
+               with_flag: { type_variants: true } do
+  shared_let(:project) { create(:project) }
+  shared_let(:root) { create(:type, name: "Bug") }
+  shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project:) }
+  shared_let(:project_admin) do
+    create(:user, member_with_permissions: { project => %i[manage_project_variants] })
+  end
+
+  before { session[:user_id] = project_admin.id }
+
+  describe Projects::Settings::WorkPackages::Types::Variants::DetailsTabController do
+    it "renders the tab rather than bouncing to the login page" do
+      get :edit, params: { project_id: project.identifier, variant_id: owned_variant.id }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "still hides a variant the project does not own" do
+      foreign = create(:type, name: "Theirs", parent: root, project: create(:project))
+
+      get :edit, params: { project_id: project.identifier, variant_id: foreign.id }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the member may not manage the project's variants" do
+      before { session[:user_id] = create(:user, member_with_permissions: { project => %i[view_project] }).id }
+
+      it "is refused rather than served" do
+        get :edit, params: { project_id: project.identifier, variant_id: owned_variant.id }
+
+        expect(response).not_to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe Projects::Settings::WorkPackages::Types::Variants::CreationWizardController do
+    it "opens the first step rather than bouncing to the login page" do
+      get :new, params: { project_id: project.identifier, parent_id: root.id }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe Projects::Settings::WorkPackages::Types::Variants::PdfExportTemplateController do
+    it "renders the tab, whose template lookup follows the type" do
+      get :edit, params: { project_id: project.identifier, variant_id: owned_variant.id }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/features/projects/settings/project_owned_variants_spec.rb
+++ b/spec/features/projects/settings/project_owned_variants_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "support/pages/projects/settings/work_package_types"
+
+RSpec.describe "Managing a project's own type variants", :js, with_flag: { type_variants: true } do
+  shared_let(:stranger) { create(:project, name: "Someone else") }
+  shared_let(:bug) { create(:type, name: "Bug") }
+  shared_let(:global_variant) { create(:type, name: "Regression", parent: bug) }
+
+  let(:project) { create(:project, name: "Apollo", types: [bug]) }
+  let(:settings_page) { Pages::Projects::Settings::WorkPackageTypes.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[edit_project manage_types manage_project_variants view_work_packages]
+           })
+  end
+
+  before do
+    create(:type, name: "Their bug", parent: bug, project: stranger)
+    settings_page.visit!
+  end
+
+  it "shows the family's global variants but never another project's" do
+    settings_page.expand_family(bug)
+
+    expect(page).to have_text("Regression")
+    # The isolation criterion, seen where a project administrator would notice it.
+    expect(page).to have_no_text("Their bug")
+  end
+
+  it "creates a variant the project owns and configures it without leaving the project" do
+    settings_page.expand_family(bug)
+    click_on "Add a variant for this project"
+
+    expect(page).to have_field("Name")
+
+    fill_in "Name", with: "Internal bug"
+    click_on "Continue"
+
+    # The variant is persisted after the first step, before the wizard moves on.
+    expect(page).to have_no_field("Name", with: "Internal bug")
+
+    created = project.owned_types.find_by(name: "Internal bug")
+    expect(created).to be_present
+
+    # The wizard must hand over to the project's own routes, not administration's.
+    expect(page).to have_current_path(
+      %r{/projects/#{project.identifier}/settings/work_packages/types/variants/#{created.id}/creation_wizard}
+    )
+  end
+
+  context "for a member who may select types but not own variants" do
+    current_user do
+      create(:user, member_with_permissions: { project => %i[edit_project manage_types view_work_packages] })
+    end
+
+    it "offers no way to add one" do
+      settings_page.expand_family(bug)
+
+      expect(page).to have_no_link("Add a variant for this project")
+    end
+  end
+end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -884,5 +884,34 @@ RSpec.describe Type do
         expect(described_class.in_family_order_available_in(owner)).to include(owned_variant)
       end
     end
+
+    describe ".visible" do
+      shared_let(:member) do
+        create(:user, member_with_permissions: { owner => %i[view_work_packages] })
+      end
+
+      it "shows global types" do
+        expect(described_class.visible(member)).to include(root, global_variant)
+      end
+
+      # The member can already see the project, so its variants are no secret from them.
+      it "shows the variants of a project the user can see" do
+        expect(described_class.visible(member)).to include(owned_variant)
+      end
+
+      # The whole point of the feature: another project's variant is not theirs to see.
+      it "hides the variants of a project the user cannot see" do
+        expect(described_class.visible(member)).not_to include(foreign_variant)
+      end
+
+      it "shows an admin every variant" do
+        expect(described_class.visible(create(:admin)))
+          .to include(root, owned_variant, foreign_variant)
+      end
+
+      it "shows nothing to a user with no work package access at all" do
+        expect(described_class.visible(create(:user))).to be_empty
+      end
+    end
   end
 end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -819,4 +819,70 @@ RSpec.describe Type do
       expect(described_class).to exist(root.id)
     end
   end
+
+  describe "ownership-aware scopes" do
+    shared_let(:owner) { create(:project) }
+    shared_let(:stranger) { create(:project) }
+    shared_let(:root) { create(:type, name: "Bug") }
+    shared_let(:global_variant) { create(:type, name: "Global", parent: root) }
+    shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project: owner) }
+    shared_let(:foreign_variant) { create(:type, name: "Theirs", parent: root, project: stranger) }
+
+    describe ".global" do
+      it "keeps global types" do
+        expect(described_class.global).to include(root, global_variant)
+      end
+
+      it "drops every owned variant" do
+        expect(described_class.global).not_to include(owned_variant, foreign_variant)
+      end
+    end
+
+    describe ".selectable_as_source_for" do
+      # The chosen reading of the acceptance criteria: same-project sources are allowed.
+      it "offers an owned variant the global types and its own project's" do
+        expect(described_class.selectable_as_source_for(owned_variant))
+          .to include(root, global_variant, owned_variant)
+      end
+
+      it "never offers another project's variant" do
+        expect(described_class.selectable_as_source_for(owned_variant)).not_to include(foreign_variant)
+      end
+
+      # A global type's project_id is nil, so the scope collapses to global-only.
+      it "offers a global type nothing but global sources" do
+        sources = described_class.selectable_as_source_for(global_variant)
+
+        expect(sources).to include(root)
+        expect(sources).not_to include(owned_variant, foreign_variant)
+      end
+    end
+
+    describe "#variants_available_in" do
+      it "lists the global variants and the project's own" do
+        expect(root.variants_available_in(owner)).to contain_exactly(global_variant, owned_variant)
+      end
+
+      it "lists only global variants without a project" do
+        expect(root.variants_available_in(nil)).to contain_exactly(global_variant)
+      end
+    end
+
+    describe ".in_family_order_available_in" do
+      # #family walks #children, which ignores ownership, so this cannot reuse in_family_order.
+      it "puts a root ahead of its own variants" do
+        ordered = described_class.in_family_order_available_in(owner)
+
+        expect(ordered.index(root)).to be < ordered.index(owned_variant)
+      end
+
+      it "hides another project's variant" do
+        expect(described_class.in_family_order_available_in(owner)).not_to include(foreign_variant)
+      end
+
+      it "keeps the project's own variant" do
+        expect(described_class.in_family_order_available_in(owner)).to include(owned_variant)
+      end
+    end
+  end
 end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -760,4 +760,63 @@ RSpec.describe Type do
       expect(build(:type, pdf_export_templates_config: { "artefact_export_mode" => "file_link" })).to be_artefact_export_enabled
     end
   end
+
+  describe "project ownership" do
+    shared_let(:owner) { create(:project) }
+    shared_let(:root) { create(:type) }
+
+    it "is global when no project owns it" do
+      expect(create(:type, parent: root)).not_to be_project_owned
+    end
+
+    it "is project owned when a project does" do
+      expect(create(:type, parent: root, project: owner)).to be_project_owned
+    end
+
+    # Owning a root would be owning a global type, which the permission does not grant.
+    it "refuses to own a root" do
+      owned_root = build(:type, parent: nil, project: owner)
+
+      expect(owned_root).not_to be_valid
+      expect(owned_root.errors[:project]).to include("must be set on a variant only.")
+    end
+
+    # Otherwise one project's variant could hang off another project's.
+    it "refuses a parent owned by a project" do
+      owned_parent = create(:type, parent: root, project: owner)
+
+      expect(build(:type, parent: owned_parent, project: owner)).not_to be_valid
+    end
+
+    # Two projects naming their variant the same is the expected case, not a clash.
+    it "allows the same name in a different project" do
+      create(:type, name: "Internal", parent: root, project: owner)
+
+      expect(build(:type, name: "Internal", parent: root, project: create(:project))).to be_valid
+    end
+
+    it "still rejects a duplicate name within the same project" do
+      create(:type, name: "Internal", parent: root, project: owner)
+
+      expect(build(:type, name: "Internal", parent: root, project: owner)).not_to be_valid
+    end
+
+    it "still rejects a duplicate name among global variants" do
+      create(:type, name: "Internal", parent: root)
+
+      expect(build(:type, name: "Internal", parent: root)).not_to be_valid
+    end
+
+    # A work package stores the root's id, so an owned variant never blocks the cascade.
+    it "goes away with its owning project" do
+      doomed = create(:project)
+      variant = create(:type, parent: root, project: doomed)
+      create(:project_type, project: doomed, type: root, variant:)
+
+      doomed.destroy
+
+      expect(described_class).not_to exist(variant.id)
+      expect(described_class).to exist(root.id)
+    end
+  end
 end

--- a/spec/models/work_package_types/type_routes_spec.rb
+++ b/spec/models/work_package_types/type_routes_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackageTypes::TypeRoutes do
+  shared_let(:project) { create(:project) }
+  shared_let(:root) { create(:type, name: "Bug") }
+  shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project:) }
+
+  # Every path the tab components can ask for. Calling them all is what catches a
+  # mistyped helper name, which would otherwise only surface when a tab is opened.
+  let(:no_argument_paths) do
+    %i[
+      index details defaults form_configuration workflow project_attributes pdf_export
+      wizard wizard_submit workflow_matrix workflow_matrix_status_dialog
+      workflow_matrix_confirm_statuses workflow_copy form_configuration_reset_dialog
+      form_configuration_groups add_form_configuration_group toggle_project_attribute
+      enable_all_project_attributes disable_all_project_attributes
+      enable_all_pdf_templates disable_all_pdf_templates update_artefact_export projects
+      breadcrumb_root_items parent_details
+    ]
+  end
+
+  let(:keyed_paths) do
+    %i[
+      form_configuration_group edit_form_configuration_group move_form_configuration_group
+      drop_form_configuration_group cancel_edit_form_configuration_group
+      update_query_form_configuration_group drop_form_configuration_row
+      move_form_configuration_row toggle_pdf_template drop_pdf_template
+    ]
+  end
+
+  let(:aspect_paths) do
+    %i[
+      configuration_link_dialog configuration_copy_dialog configuration_independence_dialog
+    ]
+  end
+
+  shared_examples "a complete set of type paths" do
+    it "answers every argument-free path" do
+      no_argument_paths.each do |name|
+        expect { routes.public_send(name) }.not_to raise_error, "#{name} could not build a path"
+      end
+    end
+
+    it "answers every keyed path" do
+      keyed_paths.each do |name|
+        expect { routes.public_send(name, "some-key") }.not_to raise_error, "#{name} could not build a path"
+      end
+    end
+
+    it "answers every aspect path" do
+      aspect_paths.each do |name|
+        expect { routes.public_send(name, "workflows") }.not_to raise_error, "#{name} could not build a path"
+      end
+    end
+  end
+
+  describe "in global administration" do
+    let(:routes) { described_class.for(owned_variant) }
+
+    it_behaves_like "a complete set of type paths"
+
+    # Where you are decides, not what the type is: an administrator browsing /types
+    # configures an owned variant through the admin routes.
+    it "builds admin paths even for a project-owned variant" do
+      expect(routes.details).to eq("/types/#{owned_variant.id}/details/edit")
+    end
+  end
+
+  describe "inside a project's settings" do
+    let(:routes) { described_class.for(owned_variant, project:) }
+
+    it_behaves_like "a complete set of type paths"
+
+    it "stays inside the project" do
+      expect(routes.details).to start_with("/projects/#{project.identifier}/settings/work_packages/types/variants")
+    end
+
+    # There is nothing to activate elsewhere, so the tab has no destination.
+    it "has no projects tab" do
+      expect(routes.projects).to be_nil
+    end
+  end
+end

--- a/spec/requests/api/v3/types/type_resource_spec.rb
+++ b/spec/requests/api/v3/types/type_resource_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe "API v3 Type resource" do
 
           it_behaves_like "not found"
         end
+
+        # Type.visible feeds this endpoint. Without narrowing it, any variant was
+        # fetchable by id regardless of who owned it.
+        context "for a variant owned by a project the user cannot see" do
+          let(:type) { create(:type, parent: create(:type), project: create(:project)) }
+
+          it_behaves_like "not found"
+        end
+
+        context "for a variant owned by a project the user can see" do
+          let(:type) { create(:type, parent: create(:type), project:) }
+
+          it { expect(response).to have_http_status(:ok) }
+        end
       end
 
       context "not logged in user" do

--- a/spec/requests/projects/settings/work_packages/types/variant_creation_wizard_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/variant_creation_wizard_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Creating a project-owned variant",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:project) { create(:project) }
+  shared_let(:root) { create(:type, name: "Bug") }
+  shared_let(:project_admin) do
+    create(:user, member_with_permissions: { project => %i[manage_project_variants] })
+  end
+
+  before { login_as project_admin }
+
+  def create_variant(attributes)
+    post creation_wizard_project_settings_work_packages_types_variants_path(project), params: { type: attributes }
+  end
+
+  it "opens the first step" do
+    get new_creation_wizard_project_settings_work_packages_types_variants_path(project, parent_id: root.id)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "stamps the project as the owner of what it creates" do
+    create_variant(name: "Internal bug", parent_id: root.id)
+
+    expect(project.owned_types.pluck(:name)).to include("Internal bug")
+  end
+
+  # A project administrator has no route to a global type, and the wizard is the one place
+  # they could otherwise make one.
+  it "refuses to create a root" do
+    create_variant(name: "Rogue root", parent_id: nil)
+
+    expect(Type.global.where(name: "Rogue root")).to be_empty
+  end
+
+  # The owner comes from the URL, never from the request body.
+  it "ignores a project named in the request" do
+    create_variant(name: "Smuggled", parent_id: root.id, project_id: create(:project).id)
+
+    expect(project.owned_types.pluck(:name)).to include("Smuggled")
+  end
+
+  it "moves on to the next step rather than to global administration" do
+    create_variant(name: "Internal bug", parent_id: root.id)
+
+    expect(response).to redirect_to(
+      %r{/projects/#{project.identifier}/settings/work_packages/types/variants/\d+/creation_wizard}
+    )
+  end
+
+  context "without the permission" do
+    before { login_as create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+    it "creates nothing" do
+      create_variant(name: "Nope", parent_id: root.id)
+
+      expect(Type.where(name: "Nope")).to be_empty
+    end
+  end
+
+  context "with the variants feature disabled", with_flag: { type_variants: false } do
+    it "is absent" do
+      get new_creation_wizard_project_settings_work_packages_types_variants_path(project, parent_id: root.id)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/projects/settings/work_packages/types/variant_creation_wizard_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/variant_creation_wizard_spec.rb
@@ -52,6 +52,23 @@ RSpec.describe "Creating a project-owned variant",
     expect(response).to have_http_status(:ok)
   end
 
+  describe "the links and forms the wizard renders" do
+    before { get new_creation_wizard_project_settings_work_packages_types_variants_path(project, parent_id: root.id) }
+
+    # The page rendering is not enough: the step form posting to /types is what silently
+    # refused the project administrator on "Continue".
+    it "submits into the project rather than into administration" do
+      expect(response.body).to include(
+        creation_wizard_project_settings_work_packages_types_variants_path(project)
+      )
+      expect(response.body).not_to include('action="/types')
+    end
+
+    it "links nowhere into global type administration" do
+      expect(response.body).not_to include('href="/types')
+    end
+  end
+
   it "stamps the project as the owner of what it creates" do
     create_variant(name: "Internal bug", parent_id: root.id)
 

--- a/spec/requests/projects/settings/work_packages/types/variant_creation_wizard_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/variant_creation_wizard_spec.rb
@@ -52,6 +52,49 @@ RSpec.describe "Creating a project-owned variant",
     expect(response).to have_http_status(:ok)
   end
 
+  describe "the steps an owned variant has" do
+    shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project:) }
+
+    # The acceptance criterion is that an owned variant is only ever activated in the project
+    # owning it. The step that picks projects offered a checkbox per project in the instance,
+    # so hiding it from the sidebar is not enough — the URL must not serve it either.
+    it "gives 404 for the projects step" do
+      get project_settings_work_packages_types_variant_creation_wizard_path(
+        project, owned_variant, step: "projects"
+      )
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "still serves the steps it does have" do
+      get project_settings_work_packages_types_variant_creation_wizard_path(
+        project, owned_variant, step: "defaults"
+      )
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # Only owned variants lose the step; a global variant is still activated per project.
+    it "leaves the projects step alone for a global variant" do
+      login_as create(:admin)
+      global_variant = create(:type, name: "Global", parent: root)
+
+      get type_creation_wizard_path(global_variant, step: "projects")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # Reuse mode is configured from administration, whose dialogs this user cannot open.
+    it "offers no reuse-mode switch it cannot honour" do
+      get project_settings_work_packages_types_variant_creation_wizard_path(
+        project, owned_variant, step: "defaults"
+      )
+
+      expect(response.body).not_to include("Switch to independent mode")
+      expect(response.body).not_to include("Change source type")
+    end
+  end
+
   describe "the links and forms the wizard renders" do
     before { get new_creation_wizard_project_settings_work_packages_types_variants_path(project, parent_id: root.id) }
 

--- a/spec/requests/projects/settings/work_packages/types/variant_tabs_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/variant_tabs_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project-scoped variant configuration tabs",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:project) { create(:project) }
+  shared_let(:stranger) { create(:project) }
+  shared_let(:root) { create(:type, name: "Bug") }
+  shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project:) }
+  shared_let(:foreign_variant) { create(:type, name: "Theirs", parent: root, project: stranger) }
+  shared_let(:project_admin) do
+    create(:user, member_with_permissions: { project => %i[manage_project_variants] })
+  end
+
+  before { login_as project_admin }
+
+  # Enumerated rather than spot-checked: a tab added later without the project scoping
+  # is the regression this feature most needs to catch.
+  def tab_paths(variant)
+    {
+      "details" => edit_project_settings_work_packages_types_variant_details_path(project, variant),
+      "defaults" => edit_project_settings_work_packages_types_variant_defaults_path(project, variant),
+      "form configuration" =>
+        edit_project_settings_work_packages_types_variant_form_configuration_path(project, variant),
+      "workflow" => edit_project_settings_work_packages_types_variant_workflow_path(project, variant),
+      "project attributes" =>
+        edit_project_settings_work_packages_types_variant_project_attributes_path(project, variant),
+      "export configuration" =>
+        edit_project_settings_work_packages_types_variant_pdf_export_template_index_path(project, variant)
+    }
+  end
+
+  it "opens every tab of a variant the project owns" do
+    tab_paths(owned_variant).each do |name, path|
+      get path
+
+      expect(response).to have_http_status(:ok), "expected the #{name} tab to open"
+    end
+  end
+
+  # A 200 alone would not prove the tab resolved the right type.
+  it "shows the variant being configured" do
+    get edit_project_settings_work_packages_types_variant_details_path(project, owned_variant)
+
+    expect(response.body).to include("Ours")
+  end
+
+  it "gives 404 on every tab of another project's variant" do
+    tab_paths(foreign_variant).each do |name, path|
+      get path
+
+      expect(response).to have_http_status(:not_found), "expected the #{name} tab to be absent"
+    end
+  end
+
+  it "gives 404 on every tab of a global variant" do
+    global_variant = create(:type, name: "Global", parent: root)
+
+    tab_paths(global_variant).each do |name, path|
+      get path
+
+      expect(response).to have_http_status(:not_found), "expected the #{name} tab to be absent"
+    end
+  end
+
+  context "without the permission" do
+    before { login_as create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+    it "refuses every tab" do
+      tab_paths(owned_variant).each do |name, path|
+        get path
+
+        expect(response).not_to have_http_status(:ok), "expected the #{name} tab to be refused"
+      end
+    end
+  end
+
+  context "with the variants feature disabled", with_flag: { type_variants: false } do
+    it "hides every tab" do
+      tab_paths(owned_variant).each do |name, path|
+        get path
+
+        expect(response).to have_http_status(:not_found), "expected the #{name} tab to be absent"
+      end
+    end
+  end
+end

--- a/spec/requests/projects/settings/work_packages/types/variant_tabs_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/variant_tabs_spec.rb
@@ -76,6 +76,46 @@ RSpec.describe "Project-scoped variant configuration tabs",
     expect(response.body).to include("Ours")
   end
 
+  describe "the links a tab renders" do
+    before { get edit_project_settings_work_packages_types_variant_details_path(project, owned_variant) }
+
+    # Rendering is not enough: a tab bar pointing at /types strands the project
+    # administrator on the first click, since administration refuses them.
+    it "keeps the tab bar inside the project" do
+      expect(response.body)
+        .to include(edit_project_settings_work_packages_types_variant_workflow_path(project, owned_variant))
+    end
+
+    it "links nowhere into global type administration" do
+      expect(response.body).not_to include('href="/types')
+    end
+
+    it "posts nowhere into global type administration" do
+      expect(response.body).not_to include('action="/types')
+    end
+
+    # Activating a type across projects is meaningless for a variant only its owner uses.
+    it "offers no projects tab" do
+      expect(response.body).not_to include("/projects/edit")
+    end
+
+    it "breadcrumbs through project settings rather than administration" do
+      expect(response.body).to include(project_settings_work_packages_types_path(project))
+    end
+  end
+
+  # Any tab still naming an admin route strands the project administrator on click.
+  it "keeps every tab's links and forms inside the project" do
+    aggregate_failures do
+      tab_paths(owned_variant).each do |name, path|
+        get path
+
+        expect(response.body).not_to include('href="/types'), "the #{name} tab links into administration"
+        expect(response.body).not_to include('action="/types'), "the #{name} tab posts into administration"
+      end
+    end
+  end
+
   it "gives 404 on every tab of another project's variant" do
     tab_paths(foreign_variant).each do |name, path|
       get path

--- a/spec/requests/projects/settings/work_packages/types/variants_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/variants_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Project-owned type variants",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:project) { create(:project) }
+  shared_let(:stranger) { create(:project) }
+  shared_let(:root) { create(:type, name: "Bug") }
+  shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project:) }
+  shared_let(:foreign_variant) { create(:type, name: "Theirs", parent: root, project: stranger) }
+  shared_let(:project_admin) do
+    create(:user, member_with_permissions: { project => %i[manage_project_variants] })
+  end
+
+  before { login_as project_admin }
+
+  describe "#destroy" do
+    it "deletes a variant the project owns" do
+      delete project_settings_work_packages_types_variant_path(project, owned_variant)
+
+      expect(Type).not_to exist(owned_variant.id)
+    end
+
+    context "without the permission" do
+      before { login_as create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+      it "refuses and keeps the variant" do
+        delete project_settings_work_packages_types_variant_path(project, owned_variant)
+
+        expect(response).not_to have_http_status(:see_other)
+        expect(Type).to exist(owned_variant.id)
+      end
+    end
+
+    context "with the variants feature disabled", with_flag: { type_variants: false } do
+      it "is absent" do
+        delete project_settings_work_packages_types_variant_path(project, owned_variant)
+
+        expect(response).to have_http_status(:not_found)
+        expect(Type).to exist(owned_variant.id)
+      end
+    end
+
+    # A foreign variant is not merely forbidden: as far as this project is concerned it
+    # does not exist, so the two cases stay indistinguishable from outside.
+    it "gives 404 for another project's variant" do
+      delete project_settings_work_packages_types_variant_path(project, foreign_variant)
+
+      expect(response).to have_http_status(:not_found)
+      expect(Type).to exist(foreign_variant.id)
+    end
+
+    it "gives 404 for a global variant" do
+      global_variant = create(:type, name: "Global", parent: root)
+
+      delete project_settings_work_packages_types_variant_path(project, global_variant)
+
+      expect(response).to have_http_status(:not_found)
+      expect(Type).to exist(global_variant.id)
+    end
+  end
+end

--- a/spec/requests/work_package_types/configuration_link_spec.rb
+++ b/spec/requests/work_package_types/configuration_link_spec.rb
@@ -222,6 +222,45 @@ RSpec.describe "Work package type configuration source",
     end
   end
 
+  describe "with project-owned variants" do
+    shared_let(:owner) { create(:project) }
+    shared_let(:stranger) { create(:project) }
+    shared_let(:root) { create(:type, name: "Bug") }
+    shared_let(:owned_variant) { create(:type, name: "Ours", parent: root, project: owner) }
+    shared_let(:sibling) { create(:type, name: "Sibling", parent: root, project: owner) }
+    shared_let(:foreign_variant) { create(:type, name: "Theirs", parent: root, project: stranger) }
+
+    it "keeps another project's variant out of the picker" do
+      get type_configuration_link_dialog_path(type_id: owned_variant.id, aspect:), as: :turbo_stream
+
+      expect(source_option_labels).not_to include("Bug: Theirs")
+    end
+
+    it "offers a variant owned by the same project" do
+      get type_configuration_link_dialog_path(type_id: owned_variant.id, aspect:), as: :turbo_stream
+
+      expect(source_option_labels).to include("Bug: Sibling")
+    end
+
+    # A variant links every aspect to its parent on creation, so isolation shows up as the
+    # source staying put rather than as the type being unlinked.
+    it "refuses another project's variant as a source" do
+      post type_configuration_link_switch_path(type_id: owned_variant.id, aspect:),
+           params: { source_id: foreign_variant.id },
+           as: :turbo_stream
+
+      expect(owned_variant.reload.source_for(aspect)).to eq(root)
+    end
+
+    it "accepts a variant owned by the same project" do
+      post type_configuration_link_switch_path(type_id: owned_variant.id, aspect:),
+           params: { source_id: sibling.id },
+           as: :turbo_stream
+
+      expect(owned_variant.reload.source_for(aspect)).to eq(sibling)
+    end
+  end
+
   # A decorated autocompleter ships its options to the Angular component as a
   # JSON payload rather than rendering them as markup.
   def source_option_labels

--- a/spec/requests/work_package_types/types_index_spec.rb
+++ b/spec/requests/work_package_types/types_index_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Types index in global administration",
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:apollo) { create(:project, name: "Apollo") }
+  shared_let(:root) { create(:type, name: "Bug") }
+  shared_let(:global_variant) { create(:type, name: "Regression", parent: root) }
+  shared_let(:owned_variant) { create(:type, name: "Internal", parent: root, project: apollo) }
+
+  before { login_as create(:admin) }
+
+  # An administrator sees every project's variants at once, so an unattributed row
+  # would be indistinguishable from a global one.
+  it "attributes an owned variant to the project owning it" do
+    get types_path(expand: root.id)
+
+    expect(response.body).to include("Owned by Apollo")
+  end
+
+  it "shows the owned variant alongside the global one" do
+    get types_path(expand: root.id)
+
+    expect(response.body).to include("Internal")
+    expect(response.body).to include("Regression")
+  end
+
+  # Ownership is the only thing distinguishing the two, so the global one must not
+  # pick up the label.
+  it "attributes nothing to a global variant" do
+    get types_path(expand: root.id)
+
+    expect(response.body.scan("Owned by Apollo").size).to eq(1)
+  end
+end

--- a/spec/services/projects/types/switch_variant_service_spec.rb
+++ b/spec/services/projects/types/switch_variant_service_spec.rb
@@ -127,4 +127,24 @@ RSpec.describe Projects::Types::SwitchVariantService, with_flag: { type_variants
       expect(resolved_variant).to eq(variant)
     end
   end
+
+  # The dialog never offers a foreign variant, so reaching here means a forged request.
+  context "when the target is a variant of another project" do
+    let(:target) { create(:type, parent: parent_type, project: create(:project)) }
+
+    it "fails without changing anything" do
+      expect(service_call).to be_failure
+      expect(service_call.errors.symbols_for(:types)).to contain_exactly(:switch_target_not_available)
+      expect(resolved_variant).to eq(variant)
+    end
+  end
+
+  context "when the target is a variant this project owns" do
+    let(:target) { create(:type, parent: parent_type, project:) }
+
+    it "resolves the project to it" do
+      expect(service_call).to be_success
+      expect(resolved_variant).to eq(target)
+    end
+  end
 end

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -95,6 +95,12 @@ module Pages
           expect(page).to have_no_text("Switch variant")
         end
 
+        # A family's group is collapsed by default, hiding the variants and the
+        # "Add a variant" footer link.
+        def expand_family(type)
+          within(find_row(type)) { find(:button, aria: { expanded: false }).click }
+        end
+
         def find_row(type)
           page.find("[data-test-selector='project-types-row-#{type.id}']")
         end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/FND-110

> [!WARNING]
> **This is a spike, not production-grade code.** It was built to clear the ground and find out where the real problems are, not to be merged as-is. Expect to throw parts of it away. Read the *Approach* and *Known gaps* sections before reviewing line by line — several deliberate shortcuts are called out there, and the interesting output of this branch is the list of things it discovered.

# What are you trying to accomplish?

Lets a project administrator create and configure type variants **owned by their project**, invisible and unusable everywhere else.

- New `:manage_project_variants` project permission, independent of `:manage_types`
- New nullable `types.project_id`: `NULL` means global, a value means owned
- Owned variants are managed from **Project settings → Work packages → Types**, where each family row now expands to the variants the project may use
- Instance administrators still see owned variants in `/types`, attributed with "Owned by {project}"
- All behind the existing `type_variants` feature flag

Isolation is enforced at every read path that could leak: `Type.global`, the reuse-source picker, the variant-switch dialog and its contract, `Type.visible` (which fed `/api/v3/types/:id` and MCP), and the project settings list.

## Screenshots

<img width="748" height="730" alt="Screenshot of project types administration" src="https://github.com/user-attachments/assets/c2a51cd7-605f-45a3-b259-aadb3af414a4" />

<img width="748" height="820" alt="Screenshot of global types administration" src="https://github.com/user-attachments/assets/6ec18527-de31-45d2-8eab-22ba16cf8b0c" />

# What approach did you choose and why?

**Project-scoped controllers subclass the administration ones.** The tab bodies are identical; only the lookup and the authorization differ. This avoided duplicating ~700 lines of controller code across seven controllers.

**A `WorkPackageTypes::TypeRoutes` seam replaces hardcoded route helpers.** The same tab components serve both administration and project settings, and ~55 distinct route helpers were hardcoded across ~45 files. Components now ask *where this type is administered from* rather than naming a route. Which builder you get depends on **where you are, not what the type is** — an administrator browsing `/types` configures an owned variant through the admin routes.

**Same-project reuse sources are allowed.** The WP contradicts itself: the acceptance criteria permit linking to "global types **or** project-specific variants in the same project", the resolved decisions say global only. Built to the acceptance criteria; one scope collapses both cases, since a global type's `project_id` is `nil`.

**Name uniqueness is scoped `[parent_id, project_id]`** — looser than the WP's literal "unique per project", so two projects can each own a "Bug: Internal" and one project can own both "Bug: Internal" and "Task: Internal".

## What this spike actually found

Three of these were only visible in a browser. The test suite was structurally incapable of seeing the first two.

1. **Authorization ran before authentication.** `prepend_before_action :find_project_by_project_id, :authorize` put both ahead of `ApplicationController#user_setup`, so `User.current` was anonymous, `Project.visible` found nothing, and *every* project-scoped screen redirected a signed-in project administrator to the login page. Over 900 specs passed against a completely dead UI, because `login_as` stubs `RequestStore[:current_user]` — precisely what `user_setup` populates.
2. **The wizard offered cross-project activation of an owned variant.** Its Projects step listed every project in the instance with a checkbox, directly contradicting "a project-owned variant can only be activated in its owning project". The Projects *tab* had been removed; the Projects *wizard step* had not.
3. **`Type::ConfigurationLink` has no "global source" validation**, despite `SwitchToLinkedModeService`'s comment claiming the link record enforces "present, global, not-self, acyclic". The old `Type.global` controller lookup was the only thing enforcing it.
4. **The WP's "Project sub-type" wording is stale** — FND-181 renamed sub-type to variant. Not used.

Guards were added for 1 and 2, each verified to fail without its fix:

- `callback_order_spec` — nine controllers, asserts `authorize` and the project lookup follow `user_setup` (18/36 fail with the old ordering)
- `session_authentication_spec` — controller specs authenticating from `session[:user_id]`, with no `RequestStore` stub, so the real `user_setup` path runs
- The wizard's projects step 404s by URL for an owned variant, and stays available for a global one

# Known gaps

Deliberate, and the main reason this is a spike:

1. **Reuse-mode switching is administration-only.** A project administrator sees the banner stating Independent/Linked but not the switch actions — there are no project-scoped routes for `configuration_links`, `configuration_copies` or `configuration_independence`. Buttons are hidden rather than rendered-and-refused.
2. **"Copy workflow from another type/role" is hidden** in project scope; it reaches across every type and role in the instance.
3. **The parent breadcrumb is plain text** in project scope, since the parent is a global type administered out of reach.
4. **The `:js` suite is unverified locally.** `spec/features/types` fails 69/82 on unmodified `dev` on this machine — the browser dies mid-run. Needs CI. The specs that cover this feature pass when run on their own.
5. **`TypeRoutes` only covers what the mirrored tabs and wizard render.** Global-only screens still name routes directly, on purpose — converting them would be churn with no consumer.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — Chrome only
