### PR TITLE
[COMMS-844] Admin switch to enable multiple target versions

### DIFF
--- a/app/components/work_packages/admin/settings/categories_section_component.html.erb
+++ b/app/components/work_packages/admin/settings/categories_section_component.html.erb
@@ -1,0 +1,36 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%= render(WorkPackages::Admin::Settings::NoticeBoxComponent.new(heading: scoped_t(:"planned_changes.heading"))) do |box| %>
+  <% box.with_row(icon: :info) { scoped_t(:"planned_changes.renamed") } %>
+  <% box.with_row(icon: :info) { scoped_t(:"planned_changes.single_value") } %>
+  <% box.with_row(icon: :hourglass) { scoped_t(:"planned_changes.upcoming_choice") } %>
+<% end %>

--- a/app/components/work_packages/admin/settings/categories_section_component.rb
+++ b/app/components/work_packages/admin/settings/categories_section_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Admin
+    module Settings
+      class CategoriesSectionComponent < ApplicationComponent
+        private
+
+        def scoped_t(key, **)
+          t(key, scope: "admin.settings.versions_and_categories.categories", **)
+        end
+      end
+    end
+  end
+end

--- a/app/components/work_packages/admin/settings/enable_multiple_versions_dialog_component.html.erb
+++ b/app/components/work_packages/admin/settings/enable_multiple_versions_dialog_component.html.erb
@@ -1,0 +1,63 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  render(
+    Primer::OpenProject::DangerDialog.new(
+      id: "enable-multiple-versions-dialog",
+      title: scoped_t(:title),
+      confirm_button_text: scoped_t(:confirm_button),
+      cancel_button_text: t(:button_close),
+      size: :large,
+      form_arguments: {
+        action: enable_multiple_versions_admin_settings_versions_and_categories_path,
+        method: :post
+      }
+    )
+  ) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { scoped_t(:heading) }
+
+      message.with_description do
+        safe_join(
+          [
+            scoped_t(:description_html, link: documentation_url),
+            render(Primer::Beta::Text.new(font_weight: :bold, display: :block, mt: 2)) do
+              scoped_t(:irreversible_notice)
+            end
+          ]
+        )
+      end
+    end
+
+    dialog.with_confirmation_check_box_content(scoped_t(:checkbox_label))
+  end
+%>

--- a/app/components/work_packages/admin/settings/enable_multiple_versions_dialog_component.rb
+++ b/app/components/work_packages/admin/settings/enable_multiple_versions_dialog_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Admin
+    module Settings
+      class EnableMultipleVersionsDialogComponent < ApplicationComponent
+        include OpTurbo::Streamable
+
+        private
+
+        def scoped_t(key, **)
+          t(key, scope: "admin.settings.versions_and_categories.dialog", **)
+        end
+
+        def documentation_url
+          OpenProject::Static::Links.url_for(:multiple_versions_documentation)
+        end
+      end
+    end
+  end
+end

--- a/app/components/work_packages/admin/settings/notice_box_component.html.erb
+++ b/app/components/work_packages/admin/settings/notice_box_component.html.erb
@@ -1,0 +1,37 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%= render(OpPrimer::InsetBoxComponent.new(**system_arguments)) do %>
+  <%= render(Primer::Beta::Heading.new(tag: :h4)) { heading } %>
+  <% rows.each do |row| %>
+    <%= row %>
+  <% end %>
+<% end %>

--- a/app/components/work_packages/admin/settings/notice_box_component.rb
+++ b/app/components/work_packages/admin/settings/notice_box_component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Admin
+    module Settings
+      class NoticeBoxComponent < ApplicationComponent
+        renders_many :rows, "RowComponent"
+
+        def initialize(heading:, **system_arguments)
+          super()
+          @heading = heading
+          @system_arguments = system_arguments
+        end
+
+        private
+
+        attr_reader :heading, :system_arguments
+
+        class RowComponent < Primer::Component
+          def initialize(icon:, color: :muted)
+            super()
+            @icon = icon
+            @color = color
+          end
+
+          # The text is one flex item so that inline markup inside it keeps the
+          # surrounding spaces; separate items would have theirs discarded.
+          def call
+            render(Primer::Box.new(display: :flex, mt: 2)) do
+              render(Primer::Beta::Octicon.new(icon: @icon, mr: 2, color: @color)) +
+                render(Primer::Beta::Text.new) { content }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/work_packages/admin/settings/target_versions_section_component.html.erb
+++ b/app/components/work_packages/admin/settings/target_versions_section_component.html.erb
@@ -1,0 +1,74 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%= component_wrapper(**wrapper_data_attrs) do %>
+  <% if action_required? %>
+    <%= render(WorkPackages::Admin::Settings::NoticeBoxComponent.new(heading: scoped_t(:"planned_changes.heading"))) do |box| %>
+      <% box.with_row(icon: :info) { scoped_t(:"planned_changes.renamed") } %>
+      <% box.with_row(icon: :info) { scoped_t(:"planned_changes.single_value") } %>
+    <% end %>
+
+    <%= render(WorkPackages::Admin::Settings::NoticeBoxComponent.new(heading: scoped_t(:"action_required.heading"), mt: 3)) do |box| %>
+      <% if multiple_versions_writable? %>
+        <% box.with_row(icon: :tools) { scoped_t(:"action_required.manual_conversion_hint") } %>
+      <% else %>
+        <% box.with_row(icon: :alert) { scoped_t(:"action_required.not_writable_hint") } %>
+      <% end %>
+    <% end %>
+
+    <% if multiple_versions_writable? %>
+      <%=
+        render(
+          Primer::Beta::Button.new(
+            tag: :a,
+            scheme: :secondary,
+            mt: 3,
+            href: confirm_dialog_admin_settings_versions_and_categories_path,
+            data: { turbo_stream: true }
+          )
+        ) { scoped_t(:"action_required.button") }
+      %>
+    <% end %>
+  <% elsif in_progress? %>
+    <%= render(OpPrimer::InsetBoxComponent.new) do %>
+      <%= render(Primer::Box.new(display: :flex, align_items: :center)) do %>
+        <%= render(Primer::Beta::Spinner.new(size: :small, mr: 2)) %>
+        <%= render(Primer::Beta::Text.new(font_weight: :bold)) { scoped_t(:"in_progress.heading") } %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= render(WorkPackages::Admin::Settings::NoticeBoxComponent.new(heading: scoped_t(:"recent_changes.heading"))) do |box| %>
+      <% box.with_row(icon: :check, color: :success) { scoped_t(:"recent_changes.renamed") } %>
+      <% box.with_row(icon: :check, color: :success) { scoped_t(:"recent_changes.multiple_values") } %>
+      <% box.with_row(icon: :info) { scoped_t(:"recent_changes.documentation_html", link: documentation_url) } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/work_packages/admin/settings/target_versions_section_component.rb
+++ b/app/components/work_packages/admin/settings/target_versions_section_component.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Admin
+    module Settings
+      class TargetVersionsSectionComponent < ApplicationComponent
+        include OpTurbo::Streamable
+
+        STATES = %i[action_required in_progress completed].freeze
+
+        attr_reader :state
+
+        def initialize(state:)
+          raise ArgumentError, "Unknown state: #{state}" unless STATES.include?(state)
+
+          super()
+          @state = state
+        end
+
+        private
+
+        def action_required? = state == :action_required
+        def in_progress? = state == :in_progress
+        def completed? = state == :completed
+
+        def multiple_versions_writable? = Setting.work_package_multiple_versions_writable?
+
+        def scoped_t(key, **)
+          t(key, scope: "admin.settings.versions_and_categories.target_versions", **)
+        end
+
+        def documentation_url
+          OpenProject::Static::Links.url_for(:multiple_versions_documentation)
+        end
+
+        # Polling stops because the status action replaces the whole wrapper and a
+        # terminal state's markup mounts no controller to re-arm.
+        def wrapper_data_attrs
+          return {} unless in_progress?
+
+          {
+            data: {
+              controller: "poll-for-changes",
+              poll_for_changes_url_value: url_helpers.status_admin_settings_versions_and_categories_path,
+              poll_for_changes_interval_value: 3000
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/settings/versions_and_categories_controller.rb
+++ b/app/controllers/admin/settings/versions_and_categories_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin::Settings
+  class VersionsAndCategoriesController < ::Admin::SettingsController
+    include OpTurbo::ComponentStream
+
+    before_action :require_feature_flag
+
+    current_menu_item :show do
+      :versions_and_categories
+    end
+
+    def show
+      @target_versions_state = target_versions_state
+    end
+
+    def enable_multiple_versions
+      unless WorkPackages::EnableMultipleVersionsJob.in_progress? ||
+             Setting.work_package_multiple_versions? ||
+             !Setting.work_package_multiple_versions_writable?
+        WorkPackages::EnableMultipleVersionsJob.perform_later
+      end
+
+      redirect_to action: :show
+    end
+
+    def status
+      replace_via_turbo_stream(
+        component: WorkPackages::Admin::Settings::TargetVersionsSectionComponent.new(state: target_versions_state)
+      )
+      respond_with_turbo_streams
+    end
+
+    def confirm_dialog
+      respond_with_dialog WorkPackages::Admin::Settings::EnableMultipleVersionsDialogComponent.new
+    end
+
+    private
+
+    def require_feature_flag
+      render_404 unless OpenProject::FeatureDecisions.work_package_multiple_versions_active?
+    end
+
+    # The job is checked before the setting because the setting only flips once the job
+    # finishes, so a run in progress would otherwise be reported as :action_required.
+    def target_versions_state
+      if WorkPackages::EnableMultipleVersionsJob.in_progress?
+        :in_progress
+      elsif Setting.work_package_multiple_versions?
+        :completed
+      else
+        :action_required
+      end
+    end
+  end
+end

--- a/app/controllers/admin/settings/versions_and_categories_controller.rb
+++ b/app/controllers/admin/settings/versions_and_categories_controller.rb
@@ -43,19 +43,19 @@ module Admin::Settings
     end
 
     def enable_multiple_versions
-      unless WorkPackages::EnableMultipleVersionsJob.in_progress? ||
-             Setting.work_package_multiple_versions? ||
-             !Setting.work_package_multiple_versions_writable?
+      state = target_versions_state
+
+      if state == :action_required && Setting.work_package_multiple_versions_writable?
         WorkPackages::EnableMultipleVersionsJob.perform_later
+        state = :in_progress
       end
 
-      redirect_to action: :show
+      replace_target_versions_section_via_turbo_stream(state)
+      respond_with_turbo_streams
     end
 
     def status
-      replace_via_turbo_stream(
-        component: WorkPackages::Admin::Settings::TargetVersionsSectionComponent.new(state: target_versions_state)
-      )
+      replace_target_versions_section_via_turbo_stream(target_versions_state)
       respond_with_turbo_streams
     end
 
@@ -67,6 +67,12 @@ module Admin::Settings
 
     def require_feature_flag
       render_404 unless OpenProject::FeatureDecisions.work_package_multiple_versions_active?
+    end
+
+    def replace_target_versions_section_via_turbo_stream(state)
+      replace_via_turbo_stream(
+        component: WorkPackages::Admin::Settings::TargetVersionsSectionComponent.new(state:)
+      )
     end
 
     # The job is checked before the setting because the setting only flips once the job

--- a/app/views/admin/settings/versions_and_categories/show.html.erb
+++ b/app/views/admin/settings/versions_and_categories/show.html.erb
@@ -1,0 +1,71 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<% html_title t(:label_administration), t(:label_work_package_plural), t(:label_versions_and_categories) -%>
+
+<%=
+  render Primer::OpenProject::PageHeader.new do |header|
+    header.with_title { t(:label_versions_and_categories) }
+    header.with_breadcrumbs(
+      [{ href: admin_index_path, text: t("label_administration") },
+       { href: admin_settings_versions_and_categories_path, text: t(:label_work_package_plural), skip_for_mobile: true },
+       t(:label_versions_and_categories)]
+    )
+  end
+%>
+
+<%=
+  render(Primer::Alpha::Banner.new(scheme: :warning, mb: 3)) do |banner|
+    banner.with_action_button(
+      tag: :a,
+      scheme: :invisible,
+      href: OpenProject::Static::Links.url_for(:multiple_versions_documentation),
+      target: "_blank",
+      rel: "noopener"
+    ) { t("admin.settings.versions_and_categories.banner.button_more_information") }
+
+    t("admin.settings.versions_and_categories.banner.message")
+  end
+%>
+
+<%=
+  render(Primer::Beta::Subhead.new) do |component|
+    component.with_heading(tag: :h3, size: :medium) { t("admin.settings.versions_and_categories.target_versions.heading") }
+  end
+%>
+<%= render(WorkPackages::Admin::Settings::TargetVersionsSectionComponent.new(state: @target_versions_state)) %>
+
+<%=
+  render(Primer::Beta::Subhead.new(mt: 3)) do |component|
+    component.with_heading(tag: :h3, size: :medium) { t("admin.settings.versions_and_categories.categories.heading") }
+  end
+%>
+<%= render(WorkPackages::Admin::Settings::CategoriesSectionComponent.new) %>

--- a/app/workers/work_packages/enable_multiple_versions_job.rb
+++ b/app/workers/work_packages/enable_multiple_versions_job.rb
@@ -43,23 +43,47 @@ class WorkPackages::EnableMultipleVersionsJob < ApplicationJob
 
     # Must run before the flip, or a work package with a version_id but no
     # target row reads as having no target version once multi-value mode is on.
-    backfill_missing_target_versions
+    repaired_ids = backfill_missing_target_versions
+    journal_repaired_work_packages(repaired_ids)
     enable_multiple_versions!
   end
 
   private
 
   def backfill_missing_target_versions
-    result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
+    repaired_ids = ActiveRecord::Base.connection.select_values(<<~SQL.squish)
       INSERT INTO work_package_versions (work_package_id, version_id, kind, created_at, updated_at)
           SELECT work_packages.id, work_packages.version_id, 'target', now(), now()
           FROM work_packages
           INNER JOIN versions ON versions.id = work_packages.version_id
           WHERE work_packages.version_id IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM work_package_versions
+              WHERE work_package_versions.work_package_id = work_packages.id
+                AND work_package_versions.version_id = work_packages.version_id
+                AND work_package_versions.kind = 'target'
+            )
       ON CONFLICT (work_package_id, version_id, kind) DO NOTHING
+      RETURNING work_package_id
     SQL
 
-    log_repaired_target_versions(result.cmd_tuples)
+    log_repaired_target_versions(repaired_ids.count)
+    repaired_ids
+  end
+
+  # A repaired row diverges from the last journal's snapshot, so without a
+  # catch-up journal the next unrelated save would record the change as if
+  # that editor had set the target version.
+  def journal_repaired_work_packages(work_package_ids)
+    return if work_package_ids.empty?
+
+    cause = Journal::CausedBySystemUpdate.new(feature: "target_versions_repaired")
+
+    Journal::NotificationConfiguration.with(false) do
+      WorkPackage.where(id: work_package_ids).find_each do |work_package|
+        Journals::CreateService.new(work_package, User.system).call(cause:)
+      end
+    end
   end
 
   # Every write path mirrors version_id into a target row already, so a non-zero

--- a/app/workers/work_packages/enable_multiple_versions_job.rb
+++ b/app/workers/work_packages/enable_multiple_versions_job.rb
@@ -50,7 +50,7 @@ class WorkPackages::EnableMultipleVersionsJob < ApplicationJob
   private
 
   def backfill_missing_target_versions
-    ActiveRecord::Base.connection.execute(<<~SQL.squish)
+    result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
       INSERT INTO work_package_versions (work_package_id, version_id, kind, created_at, updated_at)
           SELECT work_packages.id, work_packages.version_id, 'target', now(), now()
           FROM work_packages
@@ -58,6 +58,18 @@ class WorkPackages::EnableMultipleVersionsJob < ApplicationJob
           WHERE work_packages.version_id IS NOT NULL
       ON CONFLICT (work_package_id, version_id, kind) DO NOTHING
     SQL
+
+    log_repaired_target_versions(result.cmd_tuples)
+  end
+
+  # Every write path mirrors version_id into a target row already, so a non-zero
+  # count means something reached the column directly and is worth investigating.
+  def log_repaired_target_versions(count)
+    return if count.zero?
+
+    Rails.logger.warn(
+      "[#{self.class.name}] Added #{count} missing target version row(s) before enabling multiple versions."
+    )
   end
 
   def enable_multiple_versions!

--- a/app/workers/work_packages/enable_multiple_versions_job.rb
+++ b/app/workers/work_packages/enable_multiple_versions_job.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackages::EnableMultipleVersionsJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(total_limit: 1)
+  queue_with_priority :above_normal
+
+  class EnablingFailed < StandardError; end
+
+  def self.in_progress? = GoodJob::Job.where(job_class: name).exists?(finished_at: nil)
+
+  def perform
+    return if Setting.work_package_multiple_versions?
+
+    # Must run before the flip, or a work package with a version_id but no
+    # target row reads as having no target version once multi-value mode is on.
+    backfill_missing_target_versions
+    enable_multiple_versions!
+  end
+
+  private
+
+  def backfill_missing_target_versions
+    ActiveRecord::Base.connection.execute(<<~SQL.squish)
+      INSERT INTO work_package_versions (work_package_id, version_id, kind, created_at, updated_at)
+          SELECT work_packages.id, work_packages.version_id, 'target', now(), now()
+          FROM work_packages
+          INNER JOIN versions ON versions.id = work_packages.version_id
+          WHERE work_packages.version_id IS NOT NULL
+      ON CONFLICT (work_package_id, version_id, kind) DO NOTHING
+    SQL
+  end
+
+  def enable_multiple_versions!
+    # Settings::UpdateService strips every scalar it is given, so a boolean has to arrive as a string.
+    result = Settings::UpdateService.new(user: User.system).call(work_package_multiple_versions: "1")
+
+    raise EnablingFailed, "Failed to enable multiple versions: #{result.message}" unless result.success?
+  end
+end

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -412,6 +412,12 @@ Redmine::MenuManager.map :admin_menu do |menu|
             caption: :label_status_plural,
             parent: :admin_work_packages
 
+  menu.push :versions_and_categories,
+            { controller: "/admin/settings/versions_and_categories", action: :show },
+            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.work_package_multiple_versions_active? },
+            caption: :label_versions_and_categories,
+            parent: :admin_work_packages
+
   menu.push :priorities,
             { controller: "/admin/settings/work_package_priorities" },
             if: ->(_) { User.current.admin? },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1552,7 +1552,7 @@ en:
           planned_changes:
             heading: Planned changes in a future release
             renamed: The “Category” field will be renamed “Categories”.
-            single_value: This field is currently single-value. It will both be converted to allow multiple values.
+            single_value: This field is currently single-value. It will also be converted to allow multiple values.
             upcoming_choice: You will be able to choose to enable multiple values before this automatic conversion happens.
         dialog:
           checkbox_label: I understand that this action is not reversible
@@ -1573,7 +1573,7 @@ en:
           planned_changes:
             heading: Planned changes in a future release
             renamed: The “Version” field will be renamed “Target versions”.
-            single_value: This field is currently single-value. It will both be converted to allow multiple values.
+            single_value: This field is currently single-value. It will also be converted to allow multiple values.
           recent_changes:
             documentation_html: For more information on this change and how to update API clients, please refer to <a href="%{link}" target="_blank" rel="noopener">our documentation</a>.
             heading: Recent changes
@@ -3008,6 +3008,8 @@ en:
         scheduling_mode_adjusted: >-
           Scheduling mode automatically adjusted with version update.
         sprint_migration: "Version '%{version_name}' has been copied as a sprint."
+        target_versions_repaired: >-
+          Target versions automatically synchronized with the Version field before enabling multiple target versions.
         totals_removed_from_childless_work_packages: >-
           Work and progress totals automatically removed for non-parent work packages with <a href="%{href}" target="_blank">version update</a>.
           This is a maintenance task and can be safely ignored.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1543,6 +1543,42 @@ en:
           error: "The section could not be reordered."
         move:
           error: "The section could not be reordered."
+      versions_and_categories:
+        banner:
+          button_more_information: More information
+          message: There are important upcoming changes to versions and categories. Please carefully review the following settings.
+        categories:
+          heading: Categories
+          planned_changes:
+            heading: Planned changes in a future release
+            renamed: The “Category” field will be renamed “Categories”.
+            single_value: This field is currently single-value. It will both be converted to allow multiple values.
+            upcoming_choice: You will be able to choose to enable multiple values before this automatic conversion happens.
+        dialog:
+          checkbox_label: I understand that this action is not reversible
+          confirm_button: Enable
+          description_html: This will convert the existing single-value Version field to accept multiple values. No data will be lost but this may affect custom integrations. Please refer to the <a href="%{link}" target="_blank" rel="noopener">documentation</a> before proceeding.
+          heading: Enable multiple target versions?
+          irreversible_notice: Once enabled, it will not be possible to go back to single values.
+          title: Enable multiple target versions
+        target_versions:
+          action_required:
+            button: Enable multiple values
+            heading: Action required
+            manual_conversion_hint: You can choose to manually run the conversion to enable multiple values before this automatic migration happens.
+            not_writable_hint: This setting is configured via environment variables or the configuration.yml file and cannot be changed here. Remove the override to enable multiple values from this page.
+          heading: Target versions
+          in_progress:
+            heading: Enabling multiple versions
+          planned_changes:
+            heading: Planned changes in a future release
+            renamed: The “Version” field will be renamed “Target versions”.
+            single_value: This field is currently single-value. It will both be converted to allow multiple values.
+          recent_changes:
+            documentation_html: For more information on this change and how to update API clients, please refer to <a href="%{link}" target="_blank" rel="noopener">our documentation</a>.
+            heading: Recent changes
+            multiple_values: The “Target versions” field now allows multiple values.
+            renamed: The “Version” field has now been renamed “Target versions”.
       work_packages_identifier:
         autofix_preview:
           error_does_not_start_with_letter: Must start with an uppercase letter
@@ -3703,6 +3739,7 @@ en:
   label_version_sharing_none: "Not shared"
   label_version_sharing_system: "With all projects"
   label_version_sharing_tree: "With project tree"
+  label_versions_and_categories: "Versions and categories"
   label_videos: "Videos"
   label_view_all_revisions: "View all revisions"
   label_view_diff: "View differences"
@@ -5515,6 +5552,7 @@ en:
     Changing status will change <i>% Complete</i>.
   setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"
   setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
+  setting_work_package_multiple_versions: "Multiple target versions"
   setting_work_package_properties: "Work package properties"
   setting_work_package_startdate_is_adddate: "Use current date as start date for new work packages"
   setting_work_packages_identifier_classic: Instance-wide numerical sequence (default)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1566,7 +1566,7 @@ en:
             button: Enable multiple values
             heading: Action required
             manual_conversion_hint: You can choose to manually run the conversion to enable multiple values before this automatic migration happens.
-            not_writable_hint: This setting is configured via environment variables or the configuration.yml file and cannot be changed here. Remove the override to enable multiple values from this page.
+            not_writable_hint: These settings are configured via environment variables. If you would like to manually run the conversion to enable multiple values before the automatic migration, update your configuration.yml file.
           heading: Target versions
           in_progress:
             heading: Enabling multiple versions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -764,6 +764,11 @@ Rails.application.routes.draw do
         get :status, on: :member
         get :confirm_dialog, on: :member, defaults: { format: :turbo_stream }
       end
+      resource :versions_and_categories, controller: "/admin/settings/versions_and_categories", only: %i[show] do
+        post :enable_multiple_versions, on: :member
+        get :status, on: :member
+        get :confirm_dialog, on: :member, defaults: { format: :turbo_stream }
+      end
       resources :work_package_priorities, except: [:show] do
         member do
           put :move

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -106,7 +106,7 @@ manual_installation:
   label: Manual installation
 multiple_versions_documentation:
   # Placeholder until the documentation team publishes the multiple target versions page.
-  href: https://www.openproject.org/docs/system-admin-guide/multiple-target-versions/
+  href: https://www.openproject.org/docs/system-admin-guide/
 newsletter:
   href: https://www.openproject.org/newsletter
   label: homescreen.links.newsletter

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -104,6 +104,8 @@ ldap_encryption_documentation:
 manual_installation:
   href: https://www.openproject.org/docs/installation-and-operations/installation/manual/
   label: Manual installation
+multiple_versions_documentation:
+  href: https://www.openproject.org/docs/system-admin-guide/
 newsletter:
   href: https://www.openproject.org/newsletter
   label: homescreen.links.newsletter

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -105,7 +105,8 @@ manual_installation:
   href: https://www.openproject.org/docs/installation-and-operations/installation/manual/
   label: Manual installation
 multiple_versions_documentation:
-  href: https://www.openproject.org/docs/system-admin-guide/
+  # Placeholder until the documentation team publishes the multiple target versions page.
+  href: https://www.openproject.org/docs/system-admin-guide/multiple-target-versions/
 newsletter:
   href: https://www.openproject.org/newsletter
   label: homescreen.links.newsletter

--- a/spec/components/work_packages/admin/settings/target_versions_section_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/target_versions_section_component_spec.rb
@@ -68,8 +68,9 @@ RSpec.describe WorkPackages::Admin::Settings::TargetVersionsSectionComponent, ty
       render_inline(component)
 
       expect(page).to have_text(
-        "This setting is configured via environment variables or the configuration.yml file and cannot be changed here. " \
-        "Remove the override to enable multiple values from this page."
+        "These settings are configured via environment variables. " \
+        "If you would like to manually run the conversion to enable multiple values before the automatic migration, " \
+        "update your configuration.yml file."
       )
       expect(page).to have_no_text(
         "You can choose to manually run the conversion to enable multiple values before this automatic migration happens."

--- a/spec/components/work_packages/admin/settings/target_versions_section_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/target_versions_section_component_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::Admin::Settings::TargetVersionsSectionComponent, type: :component do
+  subject(:component) { described_class.new(state: :action_required) }
+
+  context "when the setting is writable" do
+    before do
+      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(true)
+    end
+
+    it "renders the enable button" do
+      render_inline(component)
+
+      expect(page).to have_link("Enable multiple values")
+    end
+
+    it "shows the manual conversion hint" do
+      render_inline(component)
+
+      expect(page).to have_text(
+        "You can choose to manually run the conversion to enable multiple values before this automatic migration happens."
+      )
+    end
+  end
+
+  context "when the setting is not writable" do
+    before do
+      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
+    end
+
+    it "does not render the enable button" do
+      render_inline(component)
+
+      expect(page).to have_no_link("Enable multiple values")
+    end
+
+    it "shows the not writable explanation instead of the manual conversion hint" do
+      render_inline(component)
+
+      expect(page).to have_text(
+        "This setting is configured via environment variables or the configuration.yml file and cannot be changed here. " \
+        "Remove the override to enable multiple values from this page."
+      )
+      expect(page).to have_no_text(
+        "You can choose to manually run the conversion to enable multiple values before this automatic migration happens."
+      )
+    end
+  end
+
+  context "when the conversion has completed" do
+    subject(:component) { described_class.new(state: :completed) }
+
+    it "nests the documentation link inside the row text rather than beside it" do
+      render_inline(component)
+
+      expect(page).to have_css("span a[href]", text: "our documentation")
+    end
+  end
+end

--- a/spec/controllers/admin/settings/versions_and_categories_controller_spec.rb
+++ b/spec/controllers/admin/settings/versions_and_categories_controller_spec.rb
@@ -68,18 +68,31 @@ RSpec.describe Admin::Settings::VersionsAndCategoriesController do
   describe "POST #enable_multiple_versions",
            with_flag: { work_package_multiple_versions: true },
            with_settings: { work_package_multiple_versions: false } do
-    it "enqueues the job and redirects to show" do
+    let(:component_target) { "work-packages-admin-settings-target-versions-section-component" }
+
+    it "enqueues the job and streams the section in the in_progress state" do
       expect do
-        post :enable_multiple_versions
+        post :enable_multiple_versions, format: :turbo_stream
       end.to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
 
-      expect(response).to redirect_to(action: "show")
+      expect(response).to have_http_status(:ok)
+      expect(response).to have_turbo_stream(action: "replace", target: component_target)
+      expect(response.body).to include("Enabling multiple versions")
+    end
+
+    # The response asserts in_progress instead of re-deriving the state, so the admin
+    # sees the spinner even when the job finishes before the first poll.
+    it "streams the in_progress state although the job is not yet visible as running" do
+      post :enable_multiple_versions, format: :turbo_stream
+
+      expect(WorkPackages::EnableMultipleVersionsJob.in_progress?).to be false
+      expect(response.body).to include("Enabling multiple versions")
     end
 
     context "when the work_package_multiple_versions flag is disabled", with_flag: { work_package_multiple_versions: false } do
       it "renders 404 without enqueueing the job" do
         expect do
-          post :enable_multiple_versions
+          post :enable_multiple_versions, format: :turbo_stream
         end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
 
         expect(response).to have_http_status(:not_found)
@@ -91,22 +104,24 @@ RSpec.describe Admin::Settings::VersionsAndCategoriesController do
         allow(WorkPackages::EnableMultipleVersionsJob).to receive(:in_progress?).and_return(true)
       end
 
-      it "does not enqueue another job but still redirects" do
+      it "does not enqueue another job and streams the in_progress state" do
         expect do
-          post :enable_multiple_versions
+          post :enable_multiple_versions, format: :turbo_stream
         end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
 
-        expect(response).to redirect_to(action: "show")
+        expect(response).to have_turbo_stream(action: "replace", target: component_target)
+        expect(response.body).to include("Enabling multiple versions")
       end
     end
 
     context "when the setting is already on", with_settings: { work_package_multiple_versions: true } do
-      it "does not enqueue another job but still redirects" do
+      it "does not enqueue another job and streams the completed state" do
         expect do
-          post :enable_multiple_versions
+          post :enable_multiple_versions, format: :turbo_stream
         end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
 
-        expect(response).to redirect_to(action: "show")
+        expect(response).to have_turbo_stream(action: "replace", target: component_target)
+        expect(response.body).to include("Recent changes")
       end
     end
 
@@ -115,12 +130,13 @@ RSpec.describe Admin::Settings::VersionsAndCategoriesController do
         allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
       end
 
-      it "does not enqueue the job but still redirects" do
+      it "does not enqueue the job and streams the action_required state" do
         expect do
-          post :enable_multiple_versions
+          post :enable_multiple_versions, format: :turbo_stream
         end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
 
-        expect(response).to redirect_to(action: "show")
+        expect(response).to have_turbo_stream(action: "replace", target: component_target)
+        expect(response.body).to include("Action required")
       end
     end
   end

--- a/spec/controllers/admin/settings/versions_and_categories_controller_spec.rb
+++ b/spec/controllers/admin/settings/versions_and_categories_controller_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Admin::Settings::VersionsAndCategoriesController do
+  shared_let(:admin) { create(:admin) }
+
+  current_user { admin }
+
+  describe "GET #show" do
+    context "when the work_package_multiple_versions flag is disabled" do
+      it "renders 404" do
+        get :show
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the work_package_multiple_versions flag is enabled",
+            with_flag: { work_package_multiple_versions: true } do
+      it "renders the show template" do
+        get :show
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context "when the current user is not an admin", with_flag: { work_package_multiple_versions: true } do
+      current_user { create(:user) }
+
+      it "renders 403" do
+        get :show
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST #enable_multiple_versions",
+           with_flag: { work_package_multiple_versions: true },
+           with_settings: { work_package_multiple_versions: false } do
+    it "enqueues the job and redirects to show" do
+      expect do
+        post :enable_multiple_versions
+      end.to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
+
+      expect(response).to redirect_to(action: "show")
+    end
+
+    context "when the work_package_multiple_versions flag is disabled", with_flag: { work_package_multiple_versions: false } do
+      it "renders 404 without enqueueing the job" do
+        expect do
+          post :enable_multiple_versions
+        end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the job is already in progress" do
+      before do
+        allow(WorkPackages::EnableMultipleVersionsJob).to receive(:in_progress?).and_return(true)
+      end
+
+      it "does not enqueue another job but still redirects" do
+        expect do
+          post :enable_multiple_versions
+        end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
+
+        expect(response).to redirect_to(action: "show")
+      end
+    end
+
+    context "when the setting is already on", with_settings: { work_package_multiple_versions: true } do
+      it "does not enqueue another job but still redirects" do
+        expect do
+          post :enable_multiple_versions
+        end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
+
+        expect(response).to redirect_to(action: "show")
+      end
+    end
+
+    context "when the setting is not writable" do
+      before do
+        allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
+      end
+
+      it "does not enqueue the job but still redirects" do
+        expect do
+          post :enable_multiple_versions
+        end.not_to have_enqueued_job(WorkPackages::EnableMultipleVersionsJob)
+
+        expect(response).to redirect_to(action: "show")
+      end
+    end
+  end
+
+  describe "GET #status",
+           with_flag: { work_package_multiple_versions: true },
+           with_settings: { work_package_multiple_versions: false } do
+    let(:component_target) { "work-packages-admin-settings-target-versions-section-component" }
+
+    context "when the job is in progress" do
+      before do
+        allow(WorkPackages::EnableMultipleVersionsJob).to receive(:in_progress?).and_return(true)
+      end
+
+      it "returns 200 with a turbo stream replacing the section component in the in_progress state" do
+        get :status, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to have_turbo_stream(action: "replace", target: component_target)
+        expect(response.body).to include("Enabling multiple versions")
+      end
+
+      it "re-arms the polling controller so the page keeps checking until the job finishes" do
+        get :status, format: :turbo_stream
+
+        expect(response.body).to include("data-controller=\"poll-for-changes\"")
+        expect(response.body).to include("data-poll-for-changes-url-value")
+      end
+    end
+
+    context "when the setting is already on", with_settings: { work_package_multiple_versions: true } do
+      it "returns 200 with a turbo stream replacing the section component in the completed state" do
+        get :status, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to have_turbo_stream(action: "replace", target: component_target)
+        expect(response.body).to include("Recent changes")
+      end
+
+      it "stops the polling by returning markup without the polling controller" do
+        get :status, format: :turbo_stream
+
+        expect(response.body).not_to include("poll-for-changes")
+      end
+    end
+
+    context "when neither the job is in progress nor the setting is on" do
+      it "returns 200 with a turbo stream replacing the section component in the action_required state" do
+        get :status, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to have_turbo_stream(action: "replace", target: component_target)
+        expect(response.body).to include("Action required")
+      end
+    end
+  end
+
+  describe "GET #confirm_dialog", with_flag: { work_package_multiple_versions: true } do
+    it "renders the dialog turbo stream" do
+      get :confirm_dialog, format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Enable multiple target versions?")
+    end
+  end
+
+  describe "404 handling for the additional actions" do
+    it "renders 404 for #status when the flag is disabled" do
+      get :status, format: :turbo_stream
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Versions and categories admin settings" do
       )
       expect(page).to have_link(
         "More information",
-        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/}
+        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/multiple-target-versions/}
       )
       expect(page).to have_css(
         "a.Button--invisible[target='_blank'][rel='noopener']",
@@ -79,7 +79,7 @@ RSpec.describe "Versions and categories admin settings" do
     it "shows the planned changes for target versions" do
       expect(page).to have_text("The “Version” field will be renamed “Target versions”.")
       expect(page).to have_text(
-        "This field is currently single-value. It will both be converted to allow multiple values.",
+        "This field is currently single-value. It will also be converted to allow multiple values.",
         count: 2
       )
       expect(page).to have_text(
@@ -128,7 +128,7 @@ RSpec.describe "Versions and categories admin settings" do
       expect(page).to have_text("The “Target versions” field now allows multiple values.")
       expect(page).to have_link(
         "our documentation",
-        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/}
+        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/multiple-target-versions/}
       )
       expect(page).to have_no_link("Enable multiple values")
     end

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Versions and categories admin settings" do
+  shared_let(:admin) { create(:admin) }
+
+  before do
+    login_as(admin)
+  end
+
+  context "when the work_package_multiple_versions flag is disabled" do
+    it "does not show the sidebar entry" do
+      visit "/admin/settings/work_packages_general"
+
+      expect(page).to have_css("#menu-sidebar")
+      expect(page).to have_no_css("#menu-sidebar .op-menu--item-title", text: "Versions and categories")
+    end
+  end
+
+  context "when the work_package_multiple_versions flag is enabled",
+          with_flag: { work_package_multiple_versions: true } do
+    before do
+      visit "/admin/settings/versions_and_categories"
+    end
+
+    it "shows the sidebar entry" do
+      expect(page).to have_css("#menu-sidebar .op-menu--item-title", text: "Versions and categories")
+    end
+
+    it "shows the warning banner with a link to more information" do
+      expect(page).to have_text(
+        "There are important upcoming changes to versions and categories. Please carefully review the following settings."
+      )
+      expect(page).to have_link(
+        "More information",
+        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/}
+      )
+      expect(page).to have_css(
+        "a.Button--invisible[target='_blank'][rel='noopener']",
+        text: "More information"
+      )
+    end
+
+    it "shows the target versions and categories subheads" do
+      expect(page).to have_css("h3", text: "Target versions")
+      expect(page).to have_css("h3", text: "Categories")
+      expect(page).to have_css("h4", text: "Action required")
+    end
+
+    it "shows the planned changes for target versions" do
+      expect(page).to have_text("The “Version” field will be renamed “Target versions”.")
+      expect(page).to have_text(
+        "This field is currently single-value. It will both be converted to allow multiple values.",
+        count: 2
+      )
+      expect(page).to have_text(
+        "You can choose to manually run the conversion to enable multiple values before this automatic migration happens."
+      )
+    end
+
+    it "shows the planned changes for categories" do
+      expect(page).to have_text("The “Category” field will be renamed “Categories”.")
+      expect(page).to have_text(
+        "You will be able to choose to enable multiple values before this automatic conversion happens."
+      )
+    end
+
+    it "shows the action required button" do
+      expect(page).to have_link("Enable multiple values")
+    end
+  end
+
+  context "when the setting is not writable",
+          with_flag: { work_package_multiple_versions: true } do
+    before do
+      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
+      visit "/admin/settings/versions_and_categories"
+    end
+
+    it "shows the not writable explanation instead of the enable button" do
+      expect(page).to have_no_link("Enable multiple values")
+      expect(page).to have_text(
+        "This setting is configured via environment variables or the configuration.yml file and cannot be changed here. " \
+        "Remove the override to enable multiple values from this page."
+      )
+    end
+  end
+
+  context "when the setting is already on",
+          with_flag: { work_package_multiple_versions: true },
+          with_settings: { work_package_multiple_versions: true } do
+    before do
+      visit "/admin/settings/versions_and_categories"
+    end
+
+    it "shows the recent changes notice with the documentation link" do
+      expect(page).to have_css("h4", text: "Recent changes")
+      expect(page).to have_text("The “Version” field has now been renamed “Target versions”.")
+      expect(page).to have_text("The “Target versions” field now allows multiple values.")
+      expect(page).to have_link(
+        "our documentation",
+        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/}
+      )
+      expect(page).to have_no_link("Enable multiple values")
+    end
+  end
+
+  context "when confirming the enable dialog", :js, with_flag: { work_package_multiple_versions: true } do
+    before do
+      visit "/admin/settings/versions_and_categories"
+    end
+
+    it "disables the confirm button until the checkbox is checked" do
+      click_on "Enable multiple values"
+
+      within "[role=alertdialog]" do
+        expect(page).to have_button("Enable", disabled: true)
+
+        check "I understand that this action is not reversible"
+
+        expect(page).to have_button("Enable", disabled: false)
+      end
+    end
+
+    it "enqueues the job and shows the in-progress state",
+       with_good_job_batches: [WorkPackages::EnableMultipleVersionsJob] do
+      click_on "Enable multiple values"
+
+      within_dialog "Enable multiple target versions" do
+        check "I understand that this action is not reversible"
+        click_button "Enable"
+      end
+
+      expect(page).to have_text("Enabling multiple versions", wait: 10)
+      expect(WorkPackages::EnableMultipleVersionsJob.in_progress?).to be true
+    end
+  end
+end

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Versions and categories admin settings" do
       )
       expect(page).to have_link(
         "More information",
-        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/multiple-target-versions/}
+        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/}
       )
       expect(page).to have_css(
         "a.Button--invisible[target='_blank'][rel='noopener']",
@@ -129,7 +129,7 @@ RSpec.describe "Versions and categories admin settings" do
       expect(page).to have_text("The “Target versions” field now allows multiple values.")
       expect(page).to have_link(
         "our documentation",
-        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/multiple-target-versions/}
+        href: %r{\Ahttps://www\.openproject\.org/docs/system-admin-guide/}
       )
       expect(page).to have_no_link("Enable multiple values")
     end

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -109,8 +109,9 @@ RSpec.describe "Versions and categories admin settings" do
     it "shows the not writable explanation instead of the enable button" do
       expect(page).to have_no_link("Enable multiple values")
       expect(page).to have_text(
-        "This setting is configured via environment variables or the configuration.yml file and cannot be changed here. " \
-        "Remove the override to enable multiple values from this page."
+        "These settings are configured via environment variables. " \
+        "If you would like to manually run the conversion to enable multiple values before the automatic migration, " \
+        "update your configuration.yml file."
       )
     end
   end

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -164,5 +164,26 @@ RSpec.describe "Versions and categories admin settings" do
       expect(page).to have_text("Enabling multiple versions", wait: 10)
       expect(WorkPackages::EnableMultipleVersionsJob.in_progress?).to be true
     end
+
+    # The inline adapter completes the job during the request, so the spinner can only
+    # come from the response asserting in_progress instead of re-deriving the state.
+    it "shows the in-progress state even when the job finishes immediately, then flips to success",
+       with_good_job: [WorkPackages::EnableMultipleVersionsJob] do
+      click_on "Enable multiple values"
+
+      within_dialog "Enable multiple target versions" do
+        check "I understand that this action is not reversible"
+        click_button "Enable"
+      end
+
+      expect(page).to have_text("Enabling multiple versions", wait: 10)
+      expect(page).to have_no_css("dialog")
+
+      expect(page).to have_text("Recent changes", wait: 10)
+      expect(page).to have_no_text("Enable multiple values")
+      # Read the row directly: the spec thread's setting cache still holds the value
+      # from before the job ran.
+      expect(Setting.find_by(name: "work_package_multiple_versions")).to have_attributes(value: true)
+    end
   end
 end

--- a/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
+++ b/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
@@ -91,6 +91,27 @@ RSpec.describe WorkPackages::EnableMultipleVersionsJob do
       expect(Setting.work_package_multiple_versions?).to be true
     end
 
+    it "warns with the row count when it had to repair target versions" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version: nil)
+      work_package.update_column(:version_id, version.id)
+
+      allow(Rails.logger).to receive(:warn)
+      job.perform
+
+      expect(Rails.logger).to have_received(:warn).with(/Added 1 missing target version row/)
+    end
+
+    it "stays quiet when every target version is already in place" do
+      version = create(:version, project:)
+      create(:work_package, project:, version:)
+
+      allow(Rails.logger).to receive(:warn)
+      job.perform
+
+      expect(Rails.logger).not_to have_received(:warn).with(/missing target version row/)
+    end
+
     it "raises so GoodJob records the failure when the setting is not writable" do
       allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
 

--- a/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
+++ b/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
@@ -54,6 +54,27 @@ RSpec.describe WorkPackages::EnableMultipleVersionsJob do
       expect(WorkPackageVersion.find_by(work_package_id: work_package.id, kind: "target").version_id).to eq(version.id)
     end
 
+    it "journals the repair as a system update instead of leaking it into the next editor's save" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version: nil)
+      work_package.update_column(:version_id, version.id)
+
+      expect { job.perform }.to change { work_package.journals.count }.by(1)
+
+      journal = work_package.journals.reload.last
+      expect(journal.user).to eq(User.system)
+      expect(journal.cause_type).to eq("system_update")
+      expect(journal.cause["feature"]).to eq("target_versions_repaired")
+      expect(journal.work_package_version_journals.pluck(:version_id, :kind)).to contain_exactly([version.id, "target"])
+    end
+
+    it "does not journal work packages whose target rows were already in sync" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version:)
+
+      expect { job.perform }.not_to change { work_package.journals.count }
+    end
+
     it "does not duplicate an existing target row" do
       version = create(:version, project:)
       work_package = create(:work_package, project:, version:)
@@ -117,6 +138,17 @@ RSpec.describe WorkPackages::EnableMultipleVersionsJob do
 
       expect { job.perform }.to raise_error(described_class::EnablingFailed, /not writable/i)
       expect(Setting.work_package_multiple_versions?).to be false
+    end
+
+    it "repairs target versions before flipping the setting" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version: nil)
+      work_package.update_column(:version_id, version.id)
+
+      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
+
+      expect { job.perform }.to raise_error(described_class::EnablingFailed)
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").count).to eq(1)
     end
   end
 

--- a/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
+++ b/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::EnableMultipleVersionsJob do
+  subject(:job) { described_class.new }
+
+  shared_let(:project) { create(:project) }
+
+  before do
+    Setting.work_package_multiple_versions = false
+  end
+
+  describe "#perform" do
+    it "flips the setting from false to true" do
+      expect { job.perform }.to change(Setting, :work_package_multiple_versions?).from(false).to(true)
+    end
+
+    it "inserts a missing target join row for a work package whose version_id bypassed the callbacks" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version: nil)
+      work_package.update_column(:version_id, version.id)
+
+      expect { job.perform }
+        .to change { WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").count }.from(0).to(1)
+      expect(WorkPackageVersion.find_by(work_package_id: work_package.id, kind: "target").version_id).to eq(version.id)
+    end
+
+    it "does not duplicate an existing target row" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version:)
+
+      expect { job.perform }
+        .not_to change { WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").count }.from(1)
+    end
+
+    it "does not touch observed_in rows" do
+      target_version = create(:version, project:)
+      observed_version = create(:version, project:)
+      work_package = create(:work_package, project:, version: target_version)
+      create(:work_package_version, work_package:, version: observed_version, kind: "observed_in")
+
+      expect { job.perform }
+        .not_to change { WorkPackageVersion.where(work_package_id: work_package.id, kind: "observed_in").count }.from(1)
+    end
+
+    it "leaves a work package with a nil version_id alone" do
+      work_package = create(:work_package, project:, version: nil)
+
+      expect { job.perform }
+        .not_to change { WorkPackageVersion.where(work_package_id: work_package.id).count }.from(0)
+    end
+
+    it "does nothing on a second run once the setting is already enabled" do
+      version = create(:version, project:)
+      work_package = create(:work_package, project:, version: nil)
+      work_package.update_column(:version_id, version.id)
+
+      job.perform
+
+      expect { described_class.new.perform }
+        .not_to change { WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").count }.from(1)
+      expect(Setting.work_package_multiple_versions?).to be true
+    end
+
+    it "raises so GoodJob records the failure when the setting is not writable" do
+      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
+
+      expect { job.perform }.to raise_error(described_class::EnablingFailed, /not writable/i)
+      expect(Setting.work_package_multiple_versions?).to be false
+    end
+  end
+
+  describe ".in_progress?" do
+    it "is false when no job has been enqueued" do
+      expect(described_class.in_progress?).to be false
+    end
+
+    context "when a job is enqueued but not yet finished",
+            with_good_job_batches: [described_class] do
+      it "is true" do
+        described_class.perform_later
+        expect(described_class.in_progress?).to be true
+      end
+    end
+
+    context "when the enqueued job has finished",
+            with_good_job_batches: [described_class] do
+      it "is false" do
+        described_class.perform_later
+        GoodJob::Job.where(job_class: described_class.name).update_all(finished_at: Time.current)
+        expect(described_class.in_progress?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-844

Adds Administration → Work packages → Versions and categories, where an admin is told about the upcoming move of the work package Version and Category fields to multi-value, and can opt into enabling multiple target versions ahead of the automatic migration so integrations can be updated on their own schedule.

Includes a background job that sweeps any work package whose `version_id` was written outside the existing callbacks, then flips the setting; it deliberately sweeps first, because a row with a `version_id` and no `target` join row would otherwise read as having no target version the moment the setting turns on.

> [!NOTE]
> _Documentation will be handled separately in [COMMS-951](https://community.openproject.org/wp/COMMS-951)_ 

 <details><summary>Job run against an edge dump (1988 repaired work packages)</summary>

```ruby
[ActiveJob] [WorkPackages::EnableMultipleVersionsJob] [76e0497d-957e-412b-ae53-26653dfccbff] Performing WorkPackages::EnableMultipleVersionsJob (Job ID: 76e0497d-957e-412b-ae53-26653dfccbff) from GoodJob(default) enqueued at 2026-08-11T10:33:08.967635251Z
[ActiveJob] [WorkPackages::EnableMultipleVersionsJob] [76e0497d-957e-412b-ae53-26653dfccbff] [WorkPackages::EnableMultipleVersionsJob] Added 1988 missing target version row(s) before enabling multiple versions.
[ActiveJob] [WorkPackages::EnableMultipleVersionsJob] [76e0497d-957e-412b-ae53-26653dfccbff] [Journals::CreateService] Inserting new journal for WorkPackage #9917
[ActiveJob] [WorkPackages::EnableMultipleVersionsJob] [76e0497d-957e-412b-ae53-26653dfccbff] [Journals::CreateService] Inserting new journal for WorkPackage #9918
...
[ActiveJob] [WorkPackages::EnableMultipleVersionsJob] [76e0497d-957e-412b-ae53-26653dfccbff]   Setting Update (0.4ms)  UPDATE "settings" SET "value" = $1, "updated_at" = $2 WHERE "settings"."id" = $3  [["value", "1"], ["updated_at", "2026-08-11 10:33:24.792053"], ["id", 291]]
[ActiveJob] [WorkPackages::EnableMultipleVersionsJob] [76e0497d-957e-412b-ae53-26653dfccbff] Performed WorkPackages::EnableMultipleVersionsJob (Job ID: 76e0497d-957e-412b-ae53-26653dfccbff) from GoodJob(default) in 15740.19ms
```

</details>

https://github.com/user-attachments/assets/8979c624-b843-43ce-8ee4-7620d7cc0e14

_Scope is Case 1 of the ticket._ Categories is informational only, since there is no multi-category backend yet, and the other cases change only the copy in the same components.

<details>
<summary>1. Action required</summary>

<img width="1400" height="1100" alt="01-action-required" src="https://github.com/user-attachments/assets/37c74c2e-1a2a-42a4-8032-cb8e5279627f" />

</details>

<details>
<summary>2. Confirmation dialog</summary>

<img width="1400" height="1100" alt="02-dialog-large" src="https://github.com/user-attachments/assets/d927ddb2-0c96-48a8-b1ca-8d6d48e6f5c8" />

</details>

<details>
<summary>3. Enabling in progress</summary>

<img width="1400" height="1100" alt="03-dialog-checked" src="https://github.com/user-attachments/assets/4d2fd0c3-9ca4-42d2-8351-86003edc299b" />

</details>

<details>
<summary>4. Recent changes, once enabled</summary>

<img width="1400" height="1100" alt="04-in-progress" src="https://github.com/user-attachments/assets/096c4bc6-9393-4232-bbaa-b4913bd32cbd" />
<img width="1400" height="1100" alt="05-completed" src="https://github.com/user-attachments/assets/75efe555-2c0c-4f27-920f-63ae7246705e" />

</details>

<details>
<summary>5. Setting locked by ENV or configuration.yml</summary>

<img width="1400" height="1100" alt="06-not-writable" src="https://github.com/user-attachments/assets/839e2d20-b086-4bdd-967f-ab43fefdbcf8" />

</details>

