### PR TITLE
[JIM-162] Error during import „undefined method ‚strip' for nil"

### DIFF
--- a/app/services/import/jira_wiki_markup/parser.rb
+++ b/app/services/import/jira_wiki_markup/parser.rb
@@ -583,7 +583,11 @@ module Import
 
         params = {}
         raw.split("|").each do |segment|
-          key, value = segment.strip.split("=", 2)
+          part = segment.strip
+          next if part.empty?
+          next unless part.include?("=")
+
+          key, value = part.split("=", 2)
           params[key.strip] = value&.strip
         end
         params

--- a/spec/services/import/jira_wiki_markup_converter_spec.rb
+++ b/spec/services/import/jira_wiki_markup_converter_spec.rb
@@ -585,6 +585,56 @@ RSpec.describe Import::JiraWikiMarkupConverter do
         expect(result).to eq(output)
       end
     end
+
+    context "having malformed parameters" do
+      context "with empty segments" do
+        let(:input) { "{panel:title=Test||another=value}\nPanel content\n{panel}" }
+
+        it "gracefully handles empty parameter segments" do
+          expect(result).to eq("**Test**\nPanel content")
+        end
+      end
+
+      context "with empty string segments" do
+        let(:input) { "{panel:title=Test| |another=value}\nPanel content\n{panel}" }
+
+        it "gracefully handles empty string segments" do
+          expect(result).to eq("**Test**\nPanel content")
+        end
+      end
+
+      context "with empty key and value" do
+        let(:input) { "{panel:title=Test|=|another=value}\nPanel content\n{panel}" }
+
+        it "gracefully handles empty key and value" do
+          expect(result).to eq("**Test**\nPanel content")
+        end
+      end
+
+      context "with empty key" do
+        let(:input) { "{panel:title=Test|=value|another=value}\nPanel content\n{panel}" }
+
+        it "gracefully handles empty key" do
+          expect(result).to eq("**Test**\nPanel content")
+        end
+      end
+
+      context "with empty value" do
+        let(:input) { "{panel:title=Test|key=|another=value}\nPanel content\n{panel}" }
+
+        it "gracefully handles empty value" do
+          expect(result).to eq("**Test**\nPanel content")
+        end
+      end
+
+      context "without equals sign" do
+        let(:input) { "{panel:title=Test|invalid_param}\nPanel content\n{panel}" }
+
+        it "gracefully handles missing equals sign" do
+          expect(result).to eq("**Test**\nPanel content")
+        end
+      end
+    end
   end
 
   describe "combined formatting" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-162

# What are you trying to achieve?

markup parsing fails for invalid Jira panel macro

```
## empty parameter ||

{panel:title=Test||another=value}
Panel content
{panel}

## parameter without =value

{panel:title=Test|invalid_param}
Panel content
{panel}
```

# What approach did you choose and why?

Handle empty/invalid parameters gracefully

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
