### PR TITLE
[COMMS-840] Retain version column in WP list view after conversion to Target Versions

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -125,6 +125,7 @@ module WorkPackagesHelper
 
   def selected_work_packages_columns_options
     Setting[:work_package_list_default_columns]
+      .map { Query::DeprecatedVersionSelect.normalize_name(it) }
       .filter_map { |column| work_packages_columns_options.find { |c| c[:id] == column } }
   end
 

--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -100,9 +100,8 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
       sortable: "name",
       groupable: "#{WorkPackage.table_name}.category_id"
     },
-    # `version` and `target_versions` replace one another, so only ever one of
-    # the two is available. Names stored while the feature was in the other
-    # state are translated on read, see Query::DeprecatedVersionSelect.
+    # `version` and `target_versions` replace one another; stored names are
+    # translated on read, see Query::DeprecatedVersionSelect.
     version: {
       if: -> { !Setting::WorkPackageMultipleVersions.active? },
       group_by_class_name: "Version",

--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -100,6 +100,9 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
       sortable: "name",
       groupable: "#{WorkPackage.table_name}.category_id"
     },
+    # `version` and `target_versions` replace one another, so only ever one of
+    # the two is available. Names stored while the feature was in the other
+    # state are translated on read, see Query::DeprecatedVersionSelect.
     version: {
       if: -> { !Setting::WorkPackageMultipleVersions.active? },
       group_by_class_name: "Version",

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -33,6 +33,7 @@ class Query < ApplicationRecord
   include Timestamps
   include Highlighting
   include ManualSorting
+  include DeprecatedVersionSelect
   include Queries::Filters::AvailableFilters
 
   belongs_to :project
@@ -293,14 +294,7 @@ class Query < ApplicationRecord
   end
 
   def columns
-    column_list = if has_default_columns?
-                    column_list = Setting.work_package_list_default_columns.dup.map(&:to_sym)
-                    # Adds the project column by default for cross-project lists
-                    column_list += [:project] if project.nil? && column_list.exclude?(:project)
-                    column_list
-                  else
-                    column_names
-                  end
+    column_list = column_names.presence || default_column_names
 
     # preserve the order
     column_list.filter_map { |name| displayable_columns.find { |col| col.name == name.to_sym } }
@@ -446,6 +440,13 @@ class Query < ApplicationRecord
 
   private
 
+  def default_column_names
+    names = normalize_select_names(Setting.work_package_list_default_columns)
+    # Adds the project column by default for cross-project lists
+    names += [:project] if project.nil? && names.exclude?(:project)
+    names
+  end
+
   ##
   # Determine whether there are explicit filters
   # on whether work packages from
@@ -490,7 +491,9 @@ class Query < ApplicationRecord
   def valid_sort_criteria_subset!
     available_criteria = sortable_columns.map(&:name).map(&:to_s)
 
-    sort_criteria.select! do |criteria|
+    # Assigns rather than mutating in place, as `sort_criteria` no longer hands
+    # out the stored array itself. Matches valid_column_subset! below.
+    self.sort_criteria = sort_criteria.select do |criteria|
       available_criteria.include? criteria.first.to_s
     end
   end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -491,8 +491,8 @@ class Query < ApplicationRecord
   def valid_sort_criteria_subset!
     available_criteria = sortable_columns.map(&:name).map(&:to_s)
 
-    # Assigns rather than mutating in place, as `sort_criteria` no longer hands
-    # out the stored array itself. Matches valid_column_subset! below.
+    # Assigns rather than mutating: `sort_criteria` no longer hands out the
+    # stored array itself.
     self.sort_criteria = sort_criteria.select do |criteria|
       available_criteria.include? criteria.first.to_s
     end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -294,7 +294,14 @@ class Query < ApplicationRecord
   end
 
   def columns
-    column_list = column_names.presence || default_column_names
+    column_list = if has_default_columns?
+                    column_list = normalize_select_names(Setting.work_package_list_default_columns)
+                    # Adds the project column by default for cross-project lists
+                    column_list += [:project] if project.nil? && column_list.exclude?(:project)
+                    column_list
+                  else
+                    column_names
+                  end
 
     # preserve the order
     column_list.filter_map { |name| displayable_columns.find { |col| col.name == name.to_sym } }
@@ -439,13 +446,6 @@ class Query < ApplicationRecord
   end
 
   private
-
-  def default_column_names
-    names = normalize_select_names(Setting.work_package_list_default_columns)
-    # Adds the project column by default for cross-project lists
-    names += [:project] if project.nil? && names.exclude?(:project)
-    names
-  end
 
   ##
   # Determine whether there are explicit filters

--- a/app/models/query/deprecated_version_select.rb
+++ b/app/models/query/deprecated_version_select.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Translates the interchangeable `version` / `target_versions` select names when
+# reading the stored query attributes, so that validation, `valid_subset!` and
+# SQL generation all see the name that is currently available. Without it, a
+# name stored while Setting::WorkPackageMultipleVersions was in the other state
+# points at a select that no longer exists, and the column, the grouping or the
+# sort criterion is silently dropped from the query.
+#
+# This is a transitional shim. It is removed together with the `version` select
+# once the multiple-versions feature stops being switchable, at which point the
+# following go as one unit:
+#
+#   * this module and its spec, and the `include` of it in Query
+#   * the `version` entry in PropertySelect.property_selects, with its subqueries
+#   * the `.normalize_name` call in
+#     WorkPackagesHelper#selected_work_packages_columns_options
+#   * the `normalize_select_names` call in Query#default_column_names, which
+#     goes back to a plain `map(&:to_sym)`
+#
+# Names persisted by then need a backfill migration rewriting `version` to
+# `target_versions` in queries.column_names, .group_by and .sort_criteria.
+module Query::DeprecatedVersionSelect
+  extend ActiveSupport::Concern
+
+  INTERCHANGEABLE_NAMES = %w[version target_versions].freeze
+
+  # @param name [String, Symbol, nil]
+  # @return [String, Symbol, nil] the currently available counterpart (as a
+  #   String) of an interchangeable version name, or the given name untouched
+  def self.normalize_name(name)
+    return name if INTERCHANGEABLE_NAMES.exclude?(name.to_s)
+
+    Setting::WorkPackageMultipleVersions.active? ? "target_versions" : "version"
+  end
+
+  # Prepended rather than included: `sort_criteria` is defined in the Query class
+  # body itself, so a plain `include` would sit below it and never be consulted.
+  module PrependNormalizedSelectNames
+    def column_names
+      normalize_select_names(super)
+    end
+
+    def group_by
+      normalize_select_name(super)
+    end
+
+    def sort_criteria
+      super.map { |attr, direction| [normalize_select_name(attr), direction] }
+    end
+  end
+
+  included do
+    prepend PrependNormalizedSelectNames
+  end
+
+  private
+
+  def normalize_select_names(names)
+    names.map { normalize_select_name(it).to_sym }.uniq
+  end
+
+  def normalize_select_name(name)
+    Query::DeprecatedVersionSelect.normalize_name(name)
+  end
+end

--- a/app/models/query/deprecated_version_select.rb
+++ b/app/models/query/deprecated_version_select.rb
@@ -35,8 +35,7 @@
 #
 # TODO(COMMS-949): once that migrates the stored names, drop this module and its
 # spec, the `include` in Query, the `version` select, and the calls in
-# WorkPackagesHelper#selected_work_packages_columns_options and
-# Query#default_column_names.
+# WorkPackagesHelper#selected_work_packages_columns_options and Query#columns.
 module Query::DeprecatedVersionSelect
   extend ActiveSupport::Concern
 

--- a/app/models/query/deprecated_version_select.rb
+++ b/app/models/query/deprecated_version_select.rb
@@ -33,9 +33,8 @@
 # stored while Setting::WorkPackageMultipleVersions was in the other state would
 # otherwise be dropped from the columns, the grouping or the sort criterion.
 #
-# TODO(COMMS-949): once that migrates the stored names, drop this module and its
-# spec, the `include` in Query, the `version` select, and the calls in
-# WorkPackagesHelper#selected_work_packages_columns_options and Query#columns.
+# TODO(COMMS-949): remove this and the `version` select once that ticket has
+# migrated the stored names.
 module Query::DeprecatedVersionSelect
   extend ActiveSupport::Concern
 

--- a/app/models/query/deprecated_version_select.rb
+++ b/app/models/query/deprecated_version_select.rb
@@ -28,42 +28,30 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Translates the interchangeable `version` / `target_versions` select names when
-# reading the stored query attributes, so that validation, `valid_subset!` and
-# SQL generation all see the name that is currently available. Without it, a
-# name stored while Setting::WorkPackageMultipleVersions was in the other state
-# points at a select that no longer exists, and the column, the grouping or the
-# sort criterion is silently dropped from the query.
+# Translates the `version` / `target_versions` select names when reading the
+# stored query attributes: only one of the two is available at a time, so a name
+# stored while Setting::WorkPackageMultipleVersions was in the other state would
+# otherwise be dropped from the columns, the grouping or the sort criterion.
 #
-# This is a transitional shim. It is removed together with the `version` select
-# once the multiple-versions feature stops being switchable, at which point the
-# following go as one unit:
-#
-#   * this module and its spec, and the `include` of it in Query
-#   * the `version` entry in PropertySelect.property_selects, with its subqueries
-#   * the `.normalize_name` call in
-#     WorkPackagesHelper#selected_work_packages_columns_options
-#   * the `normalize_select_names` call in Query#default_column_names, which
-#     goes back to a plain `map(&:to_sym)`
-#
-# Names persisted by then need a backfill migration rewriting `version` to
-# `target_versions` in queries.column_names, .group_by and .sort_criteria.
+# TODO(COMMS-949): once that migrates the stored names, drop this module and its
+# spec, the `include` in Query, the `version` select, and the calls in
+# WorkPackagesHelper#selected_work_packages_columns_options and
+# Query#default_column_names.
 module Query::DeprecatedVersionSelect
   extend ActiveSupport::Concern
 
   INTERCHANGEABLE_NAMES = %w[version target_versions].freeze
 
-  # @param name [String, Symbol, nil]
-  # @return [String, Symbol, nil] the currently available counterpart (as a
-  #   String) of an interchangeable version name, or the given name untouched
+  # @return [String, Symbol, nil] the available counterpart (a String) of an
+  #   interchangeable version name, or the given name untouched
   def self.normalize_name(name)
     return name if INTERCHANGEABLE_NAMES.exclude?(name.to_s)
 
     Setting::WorkPackageMultipleVersions.active? ? "target_versions" : "version"
   end
 
-  # Prepended rather than included: `sort_criteria` is defined in the Query class
-  # body itself, so a plain `include` would sit below it and never be consulted.
+  # Prepended, not included: `sort_criteria` is defined in the Query class body,
+  # so an include would sit below it and never be consulted.
   module PrependNormalizedSelectNames
     def column_names
       normalize_select_names(super)

--- a/spec/features/work_packages/table/target_versions_column_spec.rb
+++ b/spec/features/work_packages/table/target_versions_column_spec.rb
@@ -95,6 +95,31 @@ RSpec.describe "Work package table target versions column", :js do
       columns.expect_checked "Target versions"
       columns.expect_column_not_available(/^Version$/)
     end
+
+    context "with a query saved while the feature was still inactive" do
+      let!(:query) do
+        create(:query,
+               user:,
+               project:,
+               column_names: %w[id subject version],
+               group_by: "version",
+               sort_criteria: [%w[version asc]])
+      end
+
+      it "keeps showing the column, now as target versions" do
+        wp_table.visit_query query
+        wp_table.expect_work_package_listed work_package
+
+        expect(page).to have_css(".wp-table--table-header", text: "TARGET VERSIONS")
+
+        field = wp_table.edit_field(work_package, :targetVersions)
+        field.expect_text version_one.name
+        field.expect_text version_two.name
+
+        columns.open_modal
+        columns.expect_checked "Target versions"
+      end
+    end
   end
 
   context "with multiple versions inactive" do

--- a/spec/models/query/deprecated_version_select_spec.rb
+++ b/spec/models/query/deprecated_version_select_spec.rb
@@ -31,10 +31,8 @@
 require "spec_helper"
 
 RSpec.describe Query::DeprecatedVersionSelect do
-  # The version and target_versions selects replace one another depending on the
-  # multiple-versions feature. A query saved with one of them has to keep working
-  # - and stay valid - once the feature is toggled, instead of silently losing
-  # its column, grouping and sort criterion.
+  # A query saved with either name has to keep working - and stay valid - once
+  # the multiple-versions feature is toggled.
   subject(:query) do
     build(:query,
           column_names: %i[id subject version],

--- a/spec/models/query/deprecated_version_select_spec.rb
+++ b/spec/models/query/deprecated_version_select_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Query::DeprecatedVersionSelect do
+  # The version and target_versions selects replace one another depending on the
+  # multiple-versions feature. A query saved with one of them has to keep working
+  # - and stay valid - once the feature is toggled, instead of silently losing
+  # its column, grouping and sort criterion.
+  subject(:query) do
+    build(:query,
+          column_names: %i[id subject version],
+          group_by: "version",
+          sort_criteria: [%w[version asc]])
+  end
+
+  describe ".normalize_name" do
+    context "with multiple versions active",
+            with_flag: { work_package_multiple_versions: true },
+            with_settings: { work_package_multiple_versions: true } do
+      it "translates the version name to target_versions" do
+        expect(described_class.normalize_name(:version)).to eq "target_versions"
+        expect(described_class.normalize_name("version")).to eq "target_versions"
+      end
+
+      it "keeps the target_versions name" do
+        expect(described_class.normalize_name(:target_versions)).to eq "target_versions"
+      end
+    end
+
+    context "with multiple versions inactive",
+            with_flag: { work_package_multiple_versions: false },
+            with_settings: { work_package_multiple_versions: false } do
+      it "translates the target_versions name to version" do
+        expect(described_class.normalize_name(:target_versions)).to eq "version"
+        expect(described_class.normalize_name("target_versions")).to eq "version"
+      end
+
+      it "keeps the version name" do
+        expect(described_class.normalize_name(:version)).to eq "version"
+      end
+    end
+
+    it "keeps every other name untouched" do
+      expect(described_class.normalize_name(:subject)).to eq :subject
+      expect(described_class.normalize_name("assigned_to")).to eq "assigned_to"
+      expect(described_class.normalize_name(nil)).to be_nil
+    end
+  end
+
+  context "with multiple versions active",
+          with_flag: { work_package_multiple_versions: true },
+          with_settings: { work_package_multiple_versions: true } do
+    it "reads the stored version name as target_versions" do
+      expect(query.column_names).to eq %i[id subject target_versions]
+      expect(query.group_by).to eq "target_versions"
+      expect(query.sort_criteria).to eq [%w[target_versions asc]]
+    end
+
+    it "keeps the column, grouping and sorting in place" do
+      expect(query.columns.map(&:name)).to eq %i[id subject target_versions]
+      expect(query.group_by_column.name).to eq :target_versions
+      expect(query.sort_criteria_columns.map { |column, _| column.name }).to eq %i[target_versions]
+    end
+
+    it "is valid and survives valid_subset!" do
+      expect(query).to be_valid
+
+      query.valid_subset!
+
+      expect(query.column_names).to include :target_versions
+      expect(query.group_by).to eq "target_versions"
+      expect(query.sort_criteria).to eq [%w[target_versions asc]]
+    end
+
+    it "does not list the column twice when both names are stored" do
+      query.column_names = %i[id version target_versions]
+
+      expect(query.column_names).to eq %i[id target_versions]
+    end
+
+    it "translates on read only, leaving the stored attributes alone" do
+      query.save!
+      query.column_names && query.group_by && query.sort_criteria
+
+      expect(query).not_to be_changed
+      expect(query.reload.read_attribute(:sort_criteria)).to eq [%w[version asc]]
+    end
+  end
+
+  context "with multiple versions inactive",
+          with_flag: { work_package_multiple_versions: false },
+          with_settings: { work_package_multiple_versions: false } do
+    subject(:query) do
+      build(:query,
+            column_names: %i[id subject target_versions],
+            group_by: "target_versions",
+            sort_criteria: [%w[target_versions asc]])
+    end
+
+    it "reads the stored target_versions name as version" do
+      expect(query.column_names).to eq %i[id subject version]
+      expect(query.group_by).to eq "version"
+      expect(query.sort_criteria).to eq [%w[version asc]]
+    end
+
+    it "is valid and keeps the column, grouping and sorting in place" do
+      expect(query).to be_valid
+      expect(query.columns.map(&:name)).to eq %i[id subject version]
+      expect(query.group_by_column.name).to eq :version
+      expect(query.sort_criteria_columns.map { |column, _| column.name }).to eq %i[version]
+    end
+  end
+
+  context "with default columns and multiple versions active",
+          with_flag: { work_package_multiple_versions: true },
+          with_settings: { work_package_multiple_versions: true,
+                           work_package_list_default_columns: %w[id subject version] } do
+    subject(:query) { build(:query, column_names: []) }
+
+    it "translates the default version column to target_versions" do
+      expect(query.columns.map(&:name)).to eq %i[id subject target_versions]
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-840/activity

# What are you trying to accomplish?
Add backwards compatibility for rendering the legacy saved "Version" column as "Target Versions".

Do this via a new `DeprecatedVersionSelect` compatibility concern, which is easily deletable once we take care of the relevant tech debt item ([COMMS-949](https://community.openproject.org/projects/COMMS/work_packages/COMMS-949/activity))

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
