### PR TITLE
Fix HourlyRate display in admin area to include only relevant projects

### DIFF
--- a/modules/costs/app/models/hourly_rate.rb
+++ b/modules/costs/app/models/hourly_rate.rb
@@ -62,7 +62,10 @@ class HourlyRate < Rate
     rates = {}
 
     projects_with_costs.each do |project|
-      rates[project] = rates_by_project.fetch(project, [])
+      project_rates = rates_by_project.fetch(project, [])
+      next if project_rates.empty? && usr.members.none? { |m| m.project_id == project.id }
+
+      rates[project] = project_rates
     end
 
     # FIXME: What permissions to apply here?

--- a/modules/costs/app/models/hourly_rate.rb
+++ b/modules/costs/app/models/hourly_rate.rb
@@ -63,7 +63,7 @@ class HourlyRate < Rate
 
     projects_with_costs.each do |project|
       project_rates = rates_by_project.fetch(project, [])
-      next if project_rates.empty? && usr.members.none? { |m| m.project_id == project.id }
+      next if project_rates.empty? && usr.projects.exclude?(project)
 
       rates[project] = project_rates
     end

--- a/modules/costs/app/models/hourly_rate.rb
+++ b/modules/costs/app/models/hourly_rate.rb
@@ -61,6 +61,9 @@ class HourlyRate < Rate
 
     rates = {}
 
+    # pre-cache projects on the user
+    usr.projects.load_target
+
     projects_with_costs.each do |project|
       project_rates = rates_by_project.fetch(project, [])
       next if project_rates.empty? && usr.projects.exclude?(project)

--- a/modules/costs/app/models/hourly_rate.rb
+++ b/modules/costs/app/models/hourly_rate.rb
@@ -44,7 +44,7 @@ class HourlyRate < Rate
       .first
   end
 
-  def self.history_for_user(usr)
+  def self.history_for_user(usr) # rubocop:disable Metrics/AbcSize
     projects_with_costs = Project.has_module(:costs)
                                         .active
                                         .visible

--- a/modules/costs/app/views/hourly_rates/_list_project.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_project.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 <div class="user-rate-history-list">
 <div class="contextual">
-  <% if project && User.current.allowed_in_project?({:controller => '/hourly_rates', :action => 'edit'}, project) %>
+  <% if project && @user.projects.include?(project) && User.current.allowed_in_project?({:controller => '/hourly_rates', :action => 'edit'}, project) %>
     <%= link_to t(:button_update), { controller: "/hourly_rates", action: "edit", project_id: project, id: @user }, class: "icon icon-edit", accesskey: accesskey(:edit) %>
   <% end %>
 </div>

--- a/modules/costs/spec/features/user_rate_history_spec.rb
+++ b/modules/costs/spec/features/user_rate_history_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative "../spec_helper"
+
+RSpec.describe "rate history on the user rates tab" do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:user) { create(:user) }
+
+  shared_let(:member_project) { create(:project, name: "Member project", member_with_permissions: { user => [] }) }
+  shared_let(:former_member_project) { create(:project, name: "Former member project") }
+  shared_let(:unrelated_project) { create(:project, name: "Unrelated project") }
+
+  shared_let(:member_rate) { create(:hourly_rate, user:, project: member_project) }
+  shared_let(:former_member_rate) { create(:hourly_rate, user:, project: former_member_project) }
+
+  def rate_history_for(project)
+    page.find(".user-rate-history-list", text: project.name)
+  end
+
+  before do
+    login_as admin
+    visit edit_user_path(user, tab: "rates")
+  end
+
+  it "allows updating the rates of a project the user is a member of" do
+    within rate_history_for(member_project) do
+      expect(page).to have_link I18n.t(:button_update)
+    end
+  end
+
+  it "shows the rates of a project the user is no longer a member of without an update link" do
+    within rate_history_for(former_member_project) do
+      expect(page).to have_css("table.rates td", text: former_member_rate.valid_from.to_s)
+      expect(page).to have_no_link I18n.t(:button_update)
+    end
+  end
+
+  it "does not show a project the user is neither a member of nor has rates in" do
+    expect(page).to have_no_css(".user-rate-history-list", text: unrelated_project.name)
+  end
+end

--- a/modules/costs/spec/models/hourly_rate_spec.rb
+++ b/modules/costs/spec/models/hourly_rate_spec.rb
@@ -57,4 +57,46 @@ RSpec.describe HourlyRate do
       it { expect(rate.user).to eq(DeletedUser.first) }
     end
   end
+
+  describe ".history_for_user" do
+    shared_let(:current_user) { create(:admin) }
+    shared_let(:rated_user) { create(:user) }
+
+    shared_let(:member_project) { create(:project, name: "Member project", member_with_permissions: { rated_user => [] }) }
+    shared_let(:member_project_without_rates) do
+      create(:project, name: "Member project without rates", member_with_permissions: { rated_user => [] })
+    end
+    shared_let(:former_member_project) { create(:project, name: "Former member project") }
+    shared_let(:unrelated_project) { create(:project, name: "Unrelated project") }
+
+    shared_let(:member_rate) { create(:hourly_rate, user: rated_user, project: member_project) }
+    shared_let(:former_member_rate) { create(:hourly_rate, user: rated_user, project: former_member_project) }
+    shared_let(:default_rate) { create(:default_hourly_rate, user: rated_user) }
+
+    subject(:history) { described_class.history_for_user(rated_user) }
+
+    before do
+      login_as current_user
+    end
+
+    it "includes the rates of a project the user is a member of" do
+      expect(history[member_project]).to eq([member_rate])
+    end
+
+    it "includes a project the user is a member of without any rates" do
+      expect(history[member_project_without_rates]).to eq([])
+    end
+
+    it "includes a project the user is no longer a member of but has rates in" do
+      expect(history[former_member_project]).to eq([former_member_rate])
+    end
+
+    it "excludes a project the user is neither a member of nor has rates in" do
+      expect(history).not_to have_key(unrelated_project)
+    end
+
+    it "returns the default rates under the nil key" do
+      expect(history[nil]).to contain_exactly(default_rate)
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-19843/activity

# What are you trying to accomplish?
- When the user is not a member of the project and they never had a rate defined for the project, we will not list the project in that view
- When the user is not a member of the project but they have a rate set up for the project, we list the project but hide the Update button
- When the user is a member of the project, it is listed there with the Update button.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
