### PR TITLE
[OP-19855] When running a timer to log time, the work package link doesn't work

### DIFF
--- a/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.html
+++ b/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.html
@@ -16,13 +16,9 @@
     <p>
       <strong>{{ text.tracking_time }}: {{ elapsed$ | async }}</strong>
       <br/>
-      <!-- eslint-disable-next-line @angular-eslint/template/interactive-supports-focus -->
-      <a
-        uiSref="work-packages.show"
-        [uiParams]="{ workPackageId: active.entity.id }"
-        (click)="closeMe()"
-      >
-        {{ active.workPackage.formattedId }}: {{ active.workPackage.name }}
+      <!-- Closing the modal on click would disconnect this anchor mid-dispatch and cancel the navigation. -->
+      <a [href]="PathHelper.workPackagePath(active.entity.id!)">
+        {{ entityName }}
       </a>
     </p>
 

--- a/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.ts
+++ b/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.ts
@@ -28,7 +28,7 @@
 
 import { ChangeDetectionStrategy, Component, HostBinding, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
+import { TimeEntryResource, formatTimeEntryEntityName } from 'core-app/features/hal/resources/time-entry-resource';
 import {
   Observable,
   timer,
@@ -39,7 +39,7 @@ import {
 } from 'rxjs/operators';
 import { formatElapsedTime } from 'core-app/features/work-packages/components/wp-timer-button/time-formatter.helper';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { StateService } from '@uirouter/core';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Component({
   templateUrl: './stop-existing-timer-modal.component.html',
@@ -48,7 +48,7 @@ import { StateService } from '@uirouter/core';
   standalone: false,
 })
 export class StopExistingTimerModalComponent extends OpModalComponent implements OnInit {
-  readonly state = inject(StateService);
+  readonly PathHelper = inject(PathHelperService);
   readonly I18n = inject(I18nService);
 
   @HostBinding('class.op-timer-stop-modal') className = true;
@@ -71,6 +71,10 @@ export class StopExistingTimerModalComponent extends OpModalComponent implements
     timer_already_running: this.I18n.t('js.timer.timer_already_running'),
     tracking_time: this.I18n.t('js.timer.tracking_time'),
   };
+
+  get entityName():string {
+    return formatTimeEntryEntityName(this.active.entity);
+  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.html
+++ b/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.html
@@ -12,9 +12,8 @@
   </span>
   <a
     class="op-timer-account-menu--wp-details"
-    uiSref="work-packages.show"
-    [uiParams]="{ workPackageId: timer.entity.id }"
+    [href]="PathHelper.workPackagePath(timer.entity.id!)"
     >
-    #{{ timer.entity.id }}:  {{ timer.entity.name }}
+    {{ entityName(timer) }}
   </a>
 }

--- a/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.ts
+++ b/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.ts
@@ -29,7 +29,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { TimeEntryTimerService } from 'core-app/shared/components/time_entries/services/time-entry-timer.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
-import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
+import { TimeEntryResource, formatTimeEntryEntityName } from 'core-app/features/hal/resources/time-entry-resource';
 import { firstValueFrom, Observable, switchMap, timer } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { formatElapsedTime } from 'core-app/features/work-packages/components/wp-timer-button/time-formatter.helper';
@@ -74,6 +74,10 @@ export class TimerAccountMenuComponent extends UntilDestroyedMixin implements On
     stop: this.I18n.t('js.time_entry.stop'),
     timer_already_stopped: this.I18n.t('js.timer.timer_already_stopped'),
   };
+
+  entityName(timeEntry:TimeEntryResource):string {
+    return formatTimeEntryEntityName(timeEntry.entity);
+  }
 
   ngOnInit() {
     const parent = this.elementRef.nativeElement.parentElement!;

--- a/modules/costs/spec/features/timer_spec.rb
+++ b/modules/costs/spec/features/timer_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "Work Package timer", :js, :selenium do
       user_menu.open
       expect(page).to have_css(".op-timer-account-menu", wait: 10)
       expect(page).to have_css(".op-timer-account-menu--wp-details", text: "##{work_package_a.id}: WP A")
+      expect(page).to have_css(".op-timer-account-menu--wp-details[href='/work_packages/#{work_package_a.id}']")
       page.find_test_selector("op-timer-account-menu-stop").click
 
       time_logging_modal.is_visible true
@@ -97,6 +98,8 @@ RSpec.describe "Work Package timer", :js, :selenium do
 
       expect(page).to have_css(".op-timer-stop-modal")
       expect(page).to have_text("Tracking time:")
+      expect(page).to have_css(".op-timer-stop-modal a[href='/work_packages/#{work_package_a.id}']",
+                               text: "##{work_package_a.id}: WP A")
 
       active_time_entries = TimeEntry.where(ongoing: true, user:)
       expect(active_time_entries.count).to eq 1
@@ -147,6 +150,21 @@ RSpec.describe "Work Package timer", :js, :selenium do
         wp_view_a.visit!
         timer_button.expect_visible
         timer_button.expect_time /48:0\d:\d+/
+      end
+    end
+
+    context "when a timer is already running on another work package" do
+      let!(:active_timer) { create(:time_entry, project:, entity: work_package_a, user:, ongoing: true) }
+
+      it "opens the running timer's work package from the stop modal" do
+        wp_view_b.visit!
+        timer_button.expect_visible
+        timer_button.start
+
+        expect(page).to have_css(".op-timer-stop-modal")
+        click_link "##{work_package_a.id}: WP A"
+
+        expect(page).to have_current_path(%r{/work_packages/#{work_package_a.id}(/|\?|$)})
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19855

# What are you trying to accomplish?

Make the work package link work in the two places a running timer is shown.

- Account menu side sheet: the link rendered `href=""` and went nowhere.
- "Start new timer" modal (shown when another timer is already running): same dead link, and its label was missing the work package id — it read `" : Start of project"`.

Both now link to the work package and share one id-formatting rule with the other time entry views, so semantic identifiers render as `PROJ-42` rather than `#42`.

## Screenshots

Rendered markup for the account menu link (no image: the change is the `href` and the label text):

| | Result |
|---|---|
| Before | `<a uisref="work-packages.show" href=""> #1: Start of project </a>` |
| After | `<a href="/work_packages/1"> #1: Start of project </a>` |

In the modal, the label goes from `" : Start of project"` to `"#1: Start of project"`.

# What approach did you choose and why?

Both links used `uiSref="work-packages.show"`, but that UI-Router state no longer exists.

- Replaced the name-based `uiSref` with a plain `[href]` from `PathHelperService#workPackagePath`.
- The modal's label read `active.workPackage.formattedId`, but `TimeEntryResource` only has `entity`. The API still exposes a legacy `workPackage` link, so it resolved to a link stub: `.name` worked (link title) while `.formattedId` was `undefined`. Half the expression working is what let this survive unnoticed.
- Both labels now use the existing `formatTimeEntryEntityName(entity)`, already used by `te-calendar` and the time entries widget. That reads `displayId` and pipes it through `formatWorkPackageId`, fixing semantic identifiers as a side effect — the old account menu code built `#${entity.id}` from the numeric id.

Scoped out deliberately: seven further `work-packages.show` references remain. Most sit in unreachable code, but `split-view-routes.template.ts` feeds the name to the mobile guard's `$state.target()`, possibly breaking the split-view on mobile (_not confirmed_). Handling these changes here seems too involving. Should a **Code Maintenance** work package cover them instead?

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
