### PR TITLE
[DREAM-794] Harmonize card colours with list items

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -8,24 +8,30 @@
   display: block
 
 .op-wp-single-card
+  // The card background is stated once per state and inherited by everything
+  // that has to sit flush against it — the icon wrappers and the shadow that
+  // fades the inline buttons out over the card.
+  --op-wp-single-card-bg-color: var(--box-list-item-bg-color)
   display: flex
   user-select: none
   // Leave space for the shadow to be displayed
   width: calc(100% - 2px)
-  border: 1px solid var(--borderColor-default)
+  border: 1px solid var(--box-list-item-border-color)
   border-radius: 2px
   padding: 10px
   position: relative
   box-shadow: 1px 1px 3px 0px var(--borderColor-default)
-  background: var(--body-background)
+  background: var(--op-wp-single-card-bg-color)
   color: var(--body-font-color)
   font-size: var(--body-font-size)
 
   &:hover
+    --op-wp-single-card-bg-color: var(--box-list-item-bg-hover-color)
+
     .op-wp-single-card--inline-buttons
       opacity: 1
       z-index: 2
-      box-shadow: -4px -4px 10px 4px var(--body-background)
+      box-shadow: -4px -4px 10px 4px var(--op-wp-single-card-bg-color)
 
   &_new
     padding-right: 25px
@@ -33,21 +39,20 @@
   &_ghosted
     opacity: 0.5
 
+  // Selected and closed tie with the hover rule above on specificity, so they
+  // have to stay below it to win.
   &_selected
-    background-color: var(--selection-bgColor)
-    .op-icon--wrapper
-      background: var(--selection-bgColor)
+    --op-wp-single-card-bg-color: var(--box-list-item-selected-bg-color)
+    border-color: var(--box-list-item-selected-border-color)
+
     &:hover
-      .op-wp-single-card--inline-buttons
-        box-shadow: none
+      --op-wp-single-card-bg-color: var(--box-list-item-selected-bg-hover-color)
 
   &_closed:not(&_selected)
-    background-color: var(--display-gray-bgColor-muted)
-    .op-icon--wrapper
-      background: var(--display-gray-bgColor-muted)
+    --op-wp-single-card-bg-color: var(--display-gray-bgColor-muted)
+
     &:hover
-      .op-wp-single-card--inline-buttons
-        box-shadow: -4px -4px 10px 4px var(--display-gray-bgColor-muted)
+      --op-wp-single-card-bg-color: hsl(from var(--display-gray-bgColor-muted) h s calc(l - 3.5))
 
   &_horizontal
     height: 100%
@@ -74,8 +79,8 @@
   // Keep the picked-up card visible in place, dimmed, rather than leaving a
   // dashed hole behind — matching the Backlogs list and the WP table row.
   wp-single-card:host([data-dragging='source']) &
+    --op-wp-single-card-bg-color: var(--bgColor-inset)
     opacity: 0.4
-    background-color: var(--bgColor-inset)
     pointer-events: none
 
   &--content
@@ -178,8 +183,8 @@
     .op-wp-single-card_selected &
       padding-left: 15px
 
-    .op-icon--wrapper:not(&_selected)
-      background: var(--body-background)
+    .op-icon--wrapper
+      background: var(--op-wp-single-card-bg-color)
 
     &.-show
       opacity: 1

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -39,8 +39,9 @@
   &_ghosted
     opacity: 0.5
 
-  // Selected and closed tie with the hover rule above on specificity, so they
-  // have to stay below it to win.
+  // Some state selectors below need to override the base :hover rule above.
+  // Keep them after `&:hover` so equal-specificity selectors (e.g. `&_selected:hover`)
+  // and the closed selector can win via source order.
   &_selected
     --op-wp-single-card-bg-color: var(--box-list-item-selected-bg-color)
     border-color: var(--box-list-item-selected-border-color)

--- a/lookbook/docs/styles/10-box-list-item-states.md.erb
+++ b/lookbook/docs/styles/10-box-list-item-states.md.erb
@@ -37,3 +37,4 @@ This pattern is currently used in:
 * WorkPackage list
 * Notification center
 * Backlogs
+* WorkPackage cards (Boards, the cards view, embedded card tables, the BCF list and Team planner)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-794

# What are you trying to accomplish?

#DREAM-696 introduced the `--box-list-item-*` variables for list item hover, selection and hover-on-selection, and applied them to the Notification center, the work package table and Backlogs (#23458). Cards were never converted, so Boards drifted.

`wp-single-card` carried its own colours: the rest border on `--borderColor-default` rather than the shared list-item token, **no hover background at all** (hover only faded in the inline buttons), and selection on `--selection-bgColor` — Primer's *text-selection* token, which is translucent (`#0969da33` light, `#1f6febb3` dark) and so composites the selected card over whatever sits behind it.

| State | Before | After |
| --- | --- | --- |
| rest border | `--borderColor-default` | `--box-list-item-border-color` |
| hover background | none | `--box-list-item-bg-hover-color` |
| selected | `--selection-bgColor` | `--box-list-item-selected-bg-color` + `--box-list-item-selected-border-color` |
| hover on selected | none | `--box-list-item-selected-bg-hover-color` |
| hover on closed | none | `--display-gray-bgColor-muted` darkened |

The rest state is a visual no-op: `--box-list-item-border-color` is `#d1d9e0`, the same value as `--borderColor-default` in the light theme, and the Primer mapping aliases it straight to `var(--borderColor-default)` in dark and high contrast. The swap is semantic.

Three points go beyond the work package's goal list, and are called out for review:

* **Closed cards gain a hover too.** They already carry a gray background, so a flat gray was the one card state left without feedback. The darkening mirrors the notification centre's read-state precedent, `hsl(from var(--display-gray-bgColor-muted) h s calc(l - 3.5))`.
* **Selected cards also take the selected border**, matching Box rows and the work package table's `-checked`. The work package named backgrounds only.
* **`.op-icon--wrapper:not(&_selected)` was dead.** Inside `&--inline-buttons` the `&` resolves to `--inline-buttons`, so the rule compiled to `:not(.op-wp-single-card--inline-buttons_selected)` — a `:not()` that never matched, at a specificity of (0,3,0) that outranked the `_selected` rule at (0,2,0). That is why selected cards kept white icon wrappers.

Out of scope, per the work package: the fourth #DREAM-696 state, the work package open in the split view. Cards have no equivalent — `selectedWhenOpen` collapses it into the ordinary selected state, and Boards seeds its selection from the URL, so a split-view card is indistinguishable from a multi-selected one. A distinct state needs a new modifier plus selection service wiring.

## Screenshots

Not captured yet — I have not run the visual pass. Happy to add before/after shots for Boards, Team planner and a closed card across light, dark and `light_high_contrast` if that would help the review.

# What approach did you choose and why?

The stylesheet stated the card background three times (base, `_selected`, `_closed`) and then repeated each value twice more — once for the icon wrappers that sit flush against the card, once for the shadow that fades the inline buttons out over it. Nine declarations for three states, and one of them was the broken selector above.

Rather than swapping colour values in place, this introduces one local custom property, `--op-wp-single-card-bg-color`, set once per state on `.op-wp-single-card`. Custom properties inherit, so the icon wrappers and the fade shadow follow the card automatically and a fourth state costs one line. The naming follows the existing `--op-backlogs-drop-gap-*` convention in `border_box_list_component.sass`.

That also let `box-shadow: none` on hovering a selected card go. It existed because the translucent selection token made the white glow look wrong; with an opaque selected background the glow can track the card like every other state.

The block order carries meaning and should not be reshuffled: `&_selected` ties with `&:hover` on specificity and wins only by appearing later in the file. A comment says so in place.

`wp-single-card` is shared, so this reaches Boards, the work package module's cards view, `wp-grid`, the BIM/BCF list, embedded card tables and Team planner. One set of state colours across the product is the point, but the blast radius is wider than Boards alone.

# Merge checklist

- [ ] Added/updated tests — CSS-only; no existing spec, Ruby or frontend, asserts these colours
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
