### PR TITLE
[COMMS-844] Pin the definition value in the non-writable enable job specs

### DIFF
--- a/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
+++ b/spec/workers/work_packages/enable_multiple_versions_job_spec.rb
@@ -133,22 +133,27 @@ RSpec.describe WorkPackages::EnableMultipleVersionsJob do
       expect(Rails.logger).not_to have_received(:warn).with(/missing target version row/)
     end
 
-    it "raises so GoodJob records the failure when the setting is not writable" do
-      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
+    context "when the configuration pins the setting off" do
+      # A non-writable setting reads its value from the definition rather than the
+      # database, so the definition has to carry the off state the job reacts to.
+      before do
+        allow(Settings::Definition[:work_package_multiple_versions])
+          .to receive_messages(writable?: false, value: false)
+      end
 
-      expect { job.perform }.to raise_error(described_class::EnablingFailed, /not writable/i)
-      expect(Setting.work_package_multiple_versions?).to be false
-    end
+      it "raises so GoodJob records the failure" do
+        expect { job.perform }.to raise_error(described_class::EnablingFailed, /not writable/i)
+        expect(Setting.work_package_multiple_versions?).to be false
+      end
 
-    it "repairs target versions before flipping the setting" do
-      version = create(:version, project:)
-      work_package = create(:work_package, project:, version: nil)
-      work_package.update_column(:version_id, version.id)
+      it "repairs target versions before failing to flip the setting" do
+        version = create(:version, project:)
+        work_package = create(:work_package, project:, version: nil)
+        work_package.update_column(:version_id, version.id)
 
-      allow(Settings::Definition[:work_package_multiple_versions]).to receive(:writable?).and_return(false)
-
-      expect { job.perform }.to raise_error(described_class::EnablingFailed)
-      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").count).to eq(1)
+        expect { job.perform }.to raise_error(described_class::EnablingFailed)
+        expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").count).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-844

Enable versions job should fail when the setting is not writable: set vie env, configuration.yml- however, it does go ahead and repair target versions (as the previous migrations would have)

Followup to #24714, resulting to: https://github.com/opf/openproject/actions/runs/31580575016/job/94062430239