### PR TITLE
Update op-blocknote-extensions to 0.2.3

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.3.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
         "tsx": "^4.22.5"
       },
       "devDependencies": {
@@ -3401,12 +3401,12 @@
       }
     },
     "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
       "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
+      "funding": {
+        "url": "https://locize.com"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4168,14 +4168,15 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.2",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
-      "integrity": "sha512-GxVcbHAnxCHszxxirgqTBnRhbStdAu3RYvG5ggY79HfE5og1DFduMJcbP5WO7ItlKiYuzAeXxU+ua6QW+LXrAQ==",
+      "version": "0.2.3",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+      "integrity": "sha512-wtkbqjIGECasx/cKkB016YVGIveO8/ezQJ+agTWNTUxqTfPjycAtag5xpdjW5poq22vkdHGU9lYfsluIPpiR/Q==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^26.3.5",
-        "react-i18next": "^16.3.5",
-        "styled-components": "^6.4.3"
+        "react-i18next": "^17.0.11",
+        "styled-components": "^6.4.3",
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "@blocknote/core": ">=0.51.3",
@@ -4598,19 +4599,19 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.6.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "html-parse-stringify": "^3.0.1",
+        "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 25.10.9",
+        "i18next": ">= 26.2.0",
         "react": ">= 16.8.0",
-        "typescript": "^5 || ^6"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -5312,15 +5313,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-keyname": {

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.3.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
     "tsx": "^4.22.5"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -111,7 +111,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^22.0.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
         "openapi-explorer": "^2.4.801",
         "pako": "^2.2.0",
         "qr-creator": "^1.0.0",
@@ -10866,21 +10866,12 @@
       "dev": true
     },
     "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
       "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
-    "node_modules/html-parse-stringify/node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "url": "https://locize.com"
       }
     },
     "node_modules/html-standard": {
@@ -13072,14 +13063,15 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.2",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
-      "integrity": "sha512-GxVcbHAnxCHszxxirgqTBnRhbStdAu3RYvG5ggY79HfE5og1DFduMJcbP5WO7ItlKiYuzAeXxU+ua6QW+LXrAQ==",
+      "version": "0.2.3",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+      "integrity": "sha512-wtkbqjIGECasx/cKkB016YVGIveO8/ezQJ+agTWNTUxqTfPjycAtag5xpdjW5poq22vkdHGU9lYfsluIPpiR/Q==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^26.3.5",
-        "react-i18next": "^16.3.5",
-        "styled-components": "^6.4.3"
+        "react-i18next": "^17.0.11",
+        "styled-components": "^6.4.3",
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "@blocknote/core": ">=0.51.3",
@@ -14136,19 +14128,19 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.3.5",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.3.5.tgz",
-      "integrity": "sha512-F7Kglc+T0aE6W2rO5eCAFBEuWRpNb5IFmXOYEgztjZEuiuSLTe/xBIEG6Q3S0fbl8GXMNo+Q7gF8bpokFNWJww==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "html-parse-stringify": "^3.0.1",
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 25.6.2",
+        "i18next": ">= 26.2.0",
         "react": ">= 16.8.0",
-        "typescript": "^5"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^22.0.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.2/op-blocknote-extensions-0.2.2.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
     "openapi-explorer": "^2.4.801",
     "pako": "^2.2.0",
     "qr-creator": "^1.0.0",


### PR DESCRIPTION
This includes:

- [[BNE-119](https://community.openproject.org/wp/BNE-119)] Update dependencies
- [[COMMS-927](https://community.openproject.org/wp/COMMS-927)] Use new exactMatch order in op-blocknote-extensions
- [[BNE-131](https://community.openproject.org/wp/BNE-131)] Give feedback when waiting for work package search
- [[BNE-125](https://community.openproject.org/wp/BNE-125)] Clickling / selecting a work package link block sometimes looks weird on Safari

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
