### PR TITLE
[JIM-168] Buttons are misaligned on second step of jira import run - Part II

### DIFF
--- a/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.html.erb
@@ -77,13 +77,14 @@ See COPYRIGHT and LICENSE files for more details.
           )
         end
         if model.in_state?(:projects_meta_done)
-          box.with_row do
+          box.with_row(display: :flex, align_items: :center) do
             concat(
               render(
                 Primer::Beta::Button.new(
                   scheme: :primary,
                   tag: :a,
                   size: :medium,
+                  mr: 2,
                   href: import_modal_admin_import_jira_run_path(jira_id: model.jira.id, id: model.id),
                   data: { controller: "async-dialog" }
                 )

--- a/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
@@ -65,13 +65,14 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
       if model.in_state?(:initial)
-        box.with_row do
+        box.with_row(display: :flex, align_items: :center) do
           concat(
             render(
               Primer::Beta::Button.new(
                 scheme: :primary,
                 tag: :a,
                 size: :medium,
+                mr: 2,
                 href: continue_admin_import_jira_run_path(jira_id: model.jira.id, id: model.id, step: "fetch_instance_meta"),
                 data: { turbo_stream: true }
               )
@@ -96,7 +97,7 @@ See COPYRIGHT and LICENSE files for more details.
           render(Admin::Import::Jira::ImportRuns::ErrorBannerComponent.new(model, "fetch_instance_meta"))
         end
       elsif model.in_state?(:instance_meta_fetching)
-        box.with_row do
+        box.with_row(display: :flex, align_items: :center) do
           concat(
             render(
               Primer::Beta::Button.new(
@@ -126,13 +127,14 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
         end
-        box.with_row do
+        box.with_row(display: :flex, align_items: :center) do
           concat(
             render(
               Primer::Beta::Button.new(
                 scheme: :primary,
                 size: :medium,
                 tag: :a,
+                mr: 2,
                 href: continue_admin_import_jira_run_path(jira_id: model.jira.id, id: model.id, step: "configure"),
                 data: { turbo_stream: true }
               )

--- a/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.html.erb
@@ -66,12 +66,13 @@ See COPYRIGHT and LICENSE files for more details.
             I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_import")
           end
         end
-        box.with_row(mb: 1) do
+        box.with_row(mb: 1, display: :flex, align_items: :center) do
           concat(
             render(
               Primer::Beta::Button.new(
                 size: :medium,
                 tag: :a,
+                mr: 2,
                 href: admin_import_jira_run_select_projects_path(jira_id: model.jira.id, run_id: model.id),
                 data: { controller: "async-dialog" }
               )
@@ -87,6 +88,7 @@ See COPYRIGHT and LICENSE files for more details.
                   scheme: :primary,
                   size: :medium,
                   tag: :a,
+                  mr: 2,
                   href: continue_admin_import_jira_run_path(jira_id: model.jira.id, id: model.id, step: "fetch_projects_meta"),
                   data: { turbo_stream: true },
                   disabled: model.projects.blank?
@@ -119,6 +121,7 @@ See COPYRIGHT and LICENSE files for more details.
             render(
               Primer::Beta::Button.new(
                 size: :medium,
+                mr: 2,
                 disabled: true
               )
             ) do |component|
@@ -129,8 +132,7 @@ See COPYRIGHT and LICENSE files for more details.
           concat(
             render(
               Primer::Beta::Button.new(
-                size: :medium,
-                ml: 1
+                size: :medium
               )
             ) do |button|
               button.with_leading_visual_icon(icon: :sync, animation: :rotate)

--- a/app/components/admin/import/jira/import_runs/wizard_step_review_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_review_component.html.erb
@@ -116,7 +116,7 @@ See COPYRIGHT and LICENSE files for more details.
           end
         end
         if model.in_state?(:imported)
-          box.with_row do
+          box.with_row(display: :flex, align_items: :center) do
             concat(
               render(
                 Primer::Beta::Button.new(
@@ -136,6 +136,7 @@ See COPYRIGHT and LICENSE files for more details.
                   tag: :a,
                   size: :medium,
                   color: :danger,
+                  mr: 2,
                   href: revert_modal_admin_import_jira_run_path(jira_id: model.jira.id, id: model.id),
                   data: { controller: "async-dialog" }
                 )


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-168

# What are you trying to achieve?

Align buttons
