### PR TITLE
[COMMS-844] Center align inset box row icons

### DIFF
--- a/app/components/work_packages/admin/settings/notice_box_component.rb
+++ b/app/components/work_packages/admin/settings/notice_box_component.rb
@@ -51,10 +51,8 @@ module WorkPackages
             @color = color
           end
 
-          # The text is one flex item so that inline markup inside it keeps the
-          # surrounding spaces; separate items would have theirs discarded.
           def call
-            render(Primer::Box.new(display: :flex, mt: 2)) do
+            render(Primer::Box.new(display: :flex, align_items: :center, mt: 2)) do
               render(Primer::Beta::Octicon.new(icon: @icon, mr: 2, color: @color)) +
                 render(Primer::Beta::Text.new) { content }
             end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-844

_Before_

<img width="1328" height="611" alt="Screenshot 2026-08-12 at 5 57 36 PM" src="https://github.com/user-attachments/assets/a71d95f6-f6ff-4ceb-8fc8-08454fb515b4" />

_After_

<img width="1350" height="616" alt="Screenshot 2026-08-12 at 5 58 09 PM" src="https://github.com/user-attachments/assets/b267d12e-e647-445d-9668-1f021ff25d91" />
