### PR TITLE
[MEET-583] No way to send meeting notification mails via the API  

### DIFF
--- a/docs/api/apiv3/components/schemas/meeting_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_model.yml
@@ -74,7 +74,10 @@ properties:
     description: Whether this meeting is a template.
   notify:
     type: boolean
-    description: Whether to send email notifications to participants.
+    description: |-
+      Whether email notifications are enabled for this meeting. When enabled, changes made
+      through the API (leaving draft, updating the schedule, adding or removing participants,
+      deleting the meeting) notify participants, mirroring the web application.
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/components/schemas/recurring_meeting_model.yml
+++ b/docs/api/apiv3/components/schemas/recurring_meeting_model.yml
@@ -124,7 +124,11 @@ properties:
     description: The meeting duration in hours (inherited from the template meeting).
   notify:
     type: boolean
-    description: Whether to send email notifications to participants (inherited from the template meeting).
+    description: |-
+      Whether email notifications are enabled for the series (read from the template meeting).
+      Read-only on this resource: set it when completing the template via
+      `POST /recurring_meetings/{id}/template_completed`, or change it later by updating the
+      template meeting (`PATCH /meetings/{template_id}`).
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -455,6 +455,10 @@ paths:
     "$ref": "./paths/recurring_meetings.yml"
   "/api/v3/recurring_meetings/{id}":
     "$ref": "./paths/recurring_meeting.yml"
+  "/api/v3/recurring_meetings/{id}/end":
+    "$ref": "./paths/recurring_meeting_end.yml"
+  "/api/v3/recurring_meetings/{id}/template_completed":
+    "$ref": "./paths/recurring_meeting_template_completed.yml"
   "/api/v3/recurring_meetings/{id}/occurrences/upcoming":
     "$ref": "./paths/recurring_meeting_occurrences_upcoming.yml"
   "/api/v3/recurring_meetings/{id}/occurrences/past":

--- a/docs/api/apiv3/paths/recurring_meeting_end.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_end.yml
@@ -1,39 +1,34 @@
-# /api/v3/recurring_meetings/{id}/occurrences/{start_time}/init
+# /api/v3/recurring_meetings/{id}/end
 ---
 post:
-  summary: Instantiate an occurrence
-  operationId: init_recurring_meeting_occurrence
+  summary: End a meeting series
+  operationId: end_recurring_meeting
   tags:
     - Recurring Meetings
   description: |-
-    Instantiates the occurrence at the given `start_time` by creating a real meeting from
-    the recurring meeting's template. Returns the newly created `Meeting` resource.
+    Ends the recurring meeting series. The series end date is set so that no further
+    occurrences are scheduled, any future already-instantiated occurrences are cancelled
+    and removed, and participants receive cancellation and "series ended" notification emails
+    if `notify` is set to true for the series.
 
-    If a previously cancelled occurrence exists for this `start_time`, it is restored, and
-    if `notify` is set to true, its participants are notified via email.
+    Ending a series before its first occurrence is rejected.
+
+    Returns the updated `RecurringMeeting` resource.
   parameters:
-    - description: Recurring meeting identifier
+    - description: Recurring meeting ID
       example: 1
       in: path
       name: id
       required: true
       schema:
         type: integer
-    - description: The ISO 8601 start time of the occurrence to instantiate (e.g. `2025-06-02T10:00:00Z`)
-      example: "2025-06-02T10:00:00Z"
-      in: path
-      name: start_time
-      required: true
-      schema:
-        type: string
-        format: date-time
   responses:
-    '201':
-      description: Created — the occurrence was successfully instantiated as a meeting.
+    '200':
+      description: Returned if the series was ended successfully.
       content:
         application/hal+json:
           schema:
-            $ref: "../components/schemas/meeting_model.yml"
+            $ref: "../components/schemas/recurring_meeting_model.yml"
     '403':
       content:
         application/hal+json:
@@ -48,7 +43,7 @@ post:
       description: |-
         Returned if the client does not have sufficient permissions.
 
-        **Required permission:** create meetings in the recurring meeting's project
+        **Required permission:** edit meetings in the recurring meeting's project
     '404':
       content:
         application/hal+json:
@@ -66,6 +61,14 @@ post:
         **Required permission:** view meetings in the recurring meeting's project
     '422':
       description: |-
-        Returned if:
-
-        * a constraint for a property was violated (`PropertyConstraintViolation`)
+        Returned if the series could not be ended, for example because it has not started yet.
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:PropertyConstraintViolation
+                message: End date must be after the series start date.

--- a/docs/api/apiv3/paths/recurring_meeting_template_completed.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_template_completed.yml
@@ -1,0 +1,105 @@
+# /api/v3/recurring_meetings/{id}/template_completed
+---
+post:
+  summary: Complete the series template
+  operationId: complete_recurring_meeting_template
+  tags:
+    - Recurring Meetings
+  description: |-
+    Completes the series template and starts the recurring meeting. This exits draft mode,
+    initiates the first occurrence from it, and schedules the job that creates the next
+    occurrence.
+
+    The `notify` flag sets the series-wide email notification setting (stored on the template).
+    When `true`, the initial series invitations are sent to the template participants. 
+    `notify` must be provided explicitly.
+
+    Completing an already-completed series is rejected.
+
+    Returns the updated `RecurringMeeting` resource.
+  parameters:
+    - description: Recurring meeting ID
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - notify
+          properties:
+            notify:
+              type: boolean
+              description: |-
+                Enable email notifications for the series.
+                When `true`, the initial invitations are sent to the template participants.
+        example:
+          notify: true
+  responses:
+    '200':
+      description: Returned when the template is completed successfully.
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_model.yml"
+    '400':
+      description: Returned if the required `notify` parameter is missing.
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:BadRequest
+                message: 'Bad request: notify is missing'
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** edit meetings in the recurring meeting's project
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project
+    '422':
+      description: |-
+        Returned if the template could not be completed, for example because the series has no
+        next occurrence to schedule or it has already been completed.
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:UnprocessableContent
+                message: The first occurrence of this meeting series is already instantiated.

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -439,7 +439,6 @@ class MeetingsController < ApplicationController
       .call({ state: "open", notify: meeting_params[:notify] == "1" })
 
     if call.success?
-      deliver_invitation_mails
       update_all_via_turbo_stream
       update_backlog_via_turbo_stream(collapsed: nil)
 
@@ -465,21 +464,6 @@ class MeetingsController < ApplicationController
         request.format = "html"
         render_403
       end
-    end
-  end
-
-  def deliver_invitation_mails
-    return false unless @meeting.notify?
-
-    @meeting
-      .participants
-      .invited
-      .find_each do |participant|
-      MeetingMailer.invited(
-        @meeting,
-        participant.user,
-        User.current
-      ).deliver_later
     end
   end
 

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -50,17 +50,14 @@ class RecurringMeetingsController < ApplicationController
     @recurring_meeting = RecurringMeeting.new(project: @project)
   end
 
-  def init # rubocop:disable Metrics/AbcSize
+  def init
     start_time = DateTime.iso8601(params[:start_time])
-    existing = @recurring_meeting.meetings.not_templated.find_by(recurrence_start_time: start_time)
-    is_restoration = existing&.cancelled?
 
     call = ::RecurringMeetings::InitOccurrenceService
       .new(user: current_user, recurring_meeting: @recurring_meeting)
       .call(start_time:)
 
     if call.success?
-      send_restoration_notifications(call.result) if is_restoration
       redirect_to project_meeting_path(call.result.project, call.result), status: :see_other
     else
       flash[:error] = call.message
@@ -267,22 +264,6 @@ class RecurringMeetingsController < ApplicationController
           participant.user,
           User.current
         ).deliver_later
-    end
-  end
-
-  def send_restoration_notifications(meeting)
-    return unless meeting.notify?
-
-    meeting
-      .participants
-      .invited
-      .find_each do |participant|
-        MeetingMailer
-          .invited(
-            meeting,
-            participant.user,
-            User.current
-          ).deliver_later
     end
   end
 

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -171,9 +171,6 @@ class RecurringMeetingsController < ApplicationController
       .call(notify: params[:meeting][:notify] == "1", first_occurrence: @first_occurrence)
 
     if call.success?
-      init_next_occurrence_job(@first_occurrence)
-      deliver_invitation_mails
-
       flash.now[:success] = I18n.t("recurring_meeting.occurrence.first_created")
     else
       flash.now[:error] = call.message
@@ -239,16 +236,6 @@ class RecurringMeetingsController < ApplicationController
     return if @project
 
     redirect_to project_recurring_meeting_path(@recurring_meeting.project, @recurring_meeting), status: :see_other
-  end
-
-  def init_next_occurrence_job(from_time)
-    # Now we can schedule the job to create the next occurrence
-    next_occurrence = @recurring_meeting.next_occurrence(from_time:)
-    return if next_occurrence.nil?
-
-    ::RecurringMeetings::InitNextOccurrenceJob
-      .set(wait_until: from_time)
-      .perform_later(@recurring_meeting, next_occurrence)
   end
 
   def deliver_invitation_mails

--- a/modules/meeting/app/services/meeting_notification_service.rb
+++ b/modules/meeting/app/services/meeting_notification_service.rb
@@ -20,7 +20,7 @@ class MeetingNotificationService
 
   def send_notifications!(action, **)
     recipients_with_errors = []
-    meeting.participants.includes(:user).find_each do |recipient|
+    meeting.participants.invited.includes(:user).find_each do |recipient|
       send_notification(action, recipient, **)
     rescue StandardError => e
       Rails.logger.error do

--- a/modules/meeting/app/services/meetings/update_service.rb
+++ b/modules/meeting/app/services/meetings/update_service.rb
@@ -29,5 +29,30 @@
 
 module Meetings
   class UpdateService < ::BaseServices::Update
+    protected
+
+    def after_perform(call)
+      send_invitation_mails(call.result) if call.success?
+
+      super
+    end
+
+    def send_invitation_mails(meeting)
+      return if meeting.recurring? || meeting.template?
+      return unless meeting.notify?
+      return unless exiting_draft?(meeting) || enabling_notifications?(meeting)
+
+      MeetingNotificationService.new(meeting).call(:invited)
+    end
+
+    def exiting_draft?(meeting)
+      meeting.saved_change_to_state? &&
+        meeting.open? &&
+        meeting.state_before_last_save.to_s == "draft"
+    end
+
+    def enabling_notifications?(meeting)
+      meeting.saved_change_to_notify? && meeting.notify?
+    end
   end
 end

--- a/modules/meeting/app/services/meetings/update_service.rb
+++ b/modules/meeting/app/services/meetings/update_service.rb
@@ -70,7 +70,7 @@ module Meetings
 
     def exiting_draft?(meeting)
       meeting.saved_change_to_state? &&
-        meeting.open? &&
+        (meeting.open? || meeting.in_progress?) &&
         meeting.state_before_last_save.to_s == "draft"
     end
 

--- a/modules/meeting/app/services/meetings/update_service.rb
+++ b/modules/meeting/app/services/meetings/update_service.rb
@@ -31,18 +31,41 @@ module Meetings
   class UpdateService < ::BaseServices::Update
     protected
 
-    def after_perform(call)
-      send_invitation_mails(call.result) if call.success?
+    def before_perform(*)
+      @invited_user_ids_before = invited_user_ids
 
       super
     end
 
-    def send_invitation_mails(meeting)
-      return if meeting.recurring? || meeting.template?
-      return unless meeting.notify?
-      return unless exiting_draft?(meeting) || enabling_notifications?(meeting)
+    def after_perform(call)
+      if call.success?
+        meeting = call.result
 
-      MeetingNotificationService.new(meeting).call(:invited)
+        if send_initial_invitations?(meeting)
+          MeetingNotificationService.new(meeting).call(:invited)
+        else
+          notify_participant_changes(meeting)
+        end
+      end
+
+      super
+    end
+
+    def send_initial_invitations?(meeting)
+      return false if meeting.recurring? || meeting.template?
+      return false unless meeting.notify?
+
+      exiting_draft?(meeting) || enabling_notifications?(meeting)
+    end
+
+    # For when participants are added/removed via the API and skip the web only
+    # MeetingParticipants service flows
+    def notify_participant_changes(meeting)
+      return unless meeting.notify?
+      return if invited_user_ids.sort == @invited_user_ids_before.sort
+
+      meeting.touch_and_save_journals
+      Meetings::NotificationDebounceJob.debounce(meeting, since_invited_ids: @invited_user_ids_before)
     end
 
     def exiting_draft?(meeting)
@@ -53,6 +76,10 @@ module Meetings
 
     def enabling_notifications?(meeting)
       meeting.saved_change_to_notify? && meeting.notify?
+    end
+
+    def invited_user_ids
+      MeetingParticipant.where(meeting_id: model.id, invited: true).pluck(:user_id)
     end
   end
 end

--- a/modules/meeting/app/services/recurring_meetings/end_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/end_service.rb
@@ -95,7 +95,7 @@ module RecurringMeetings
       recurring_meeting.template.participants.where(invited: true).find_each do |participant|
         MeetingMailer
           .ended_series(recurring_meeting, participant.user, User.current)
-          .deliver_now
+          .deliver_later
       rescue StandardError => e
         Rails.logger.error do
           "Failed to deliver series ended notification for #{recurring_meeting.id} to #{participant.user.mail}: #{e.message}"

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -51,13 +51,36 @@ module RecurringMeetings
       start_time = params.fetch(:start_time)
       return draft_template_failure if recurring_meeting.template.draft?
 
-      in_context(recurring_meeting, send_notifications: false) do
-        call = instantiate(start_time)
-        if call.success?
-          move_interim_responses_to_participants(call.result)
-        end
+      restoring = restoring?(start_time)
+      call = instantiate_in_context(start_time)
 
-        call
+      send_restoration_invitations(call.result) if call.success? && restoring
+
+      call
+    end
+
+    def instantiate_in_context(start_time)
+      in_context(recurring_meeting, send_notifications: false) do
+        result = instantiate(start_time)
+        move_interim_responses_to_participants(result.result) if result.success?
+
+        result
+      end
+    end
+
+    def restoring?(start_time)
+      recurring_meeting
+        .meetings
+        .not_templated
+        .find_by(recurrence_start_time: start_time)
+        &.cancelled?
+    end
+
+    def send_restoration_invitations(meeting)
+      return unless meeting.notify?
+
+      meeting.participants.invited.find_each do |participant|
+        MeetingMailer.invited(meeting, participant.user, user).deliver_later
       end
     end
 

--- a/modules/meeting/app/services/recurring_meetings/template_completed_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/template_completed_service.rb
@@ -45,15 +45,28 @@ module RecurringMeetings
       return no_next_occurrence_failure if first_occurrence.nil?
       return already_completed_failure if already_completed?(first_occurrence)
 
-      call = update_template(notify)
-      init_first_occurrence(call, first_occurrence) if call.success?
+      restoring = restoring?(first_occurrence)
 
-      if call.success?
-        schedule_next_occurrence(first_occurrence)
-        deliver_invitation_mails
-      end
+      call = update_template(notify)
+      finalize(call, first_occurrence, restoring) if call.success?
 
       call
+    end
+
+    def finalize(call, first_occurrence, restoring)
+      init_first_occurrence(call, first_occurrence)
+      return unless call.success?
+
+      schedule_next_occurrence(first_occurrence)
+      deliver_invitation_mails unless restoring
+    end
+
+    def restoring?(first_occurrence)
+      @recurring_meeting
+        .meetings
+        .not_templated
+        .find_by(recurrence_start_time: first_occurrence)
+        &.cancelled?
     end
 
     def update_template(notify)

--- a/modules/meeting/app/services/recurring_meetings/template_completed_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/template_completed_service.rb
@@ -41,10 +41,17 @@ module RecurringMeetings
 
     def perform
       notify = params.fetch(:notify)
-      first_occurrence = params.fetch(:first_occurrence)
+      first_occurrence = params[:first_occurrence] || @recurring_meeting.next_occurrence
+      return no_next_occurrence_failure if first_occurrence.nil?
+      return already_completed_failure if already_completed?(first_occurrence)
 
       call = update_template(notify)
       init_first_occurrence(call, first_occurrence) if call.success?
+
+      if call.success?
+        schedule_next_occurrence(first_occurrence)
+        deliver_invitation_mails
+      end
 
       call
     end
@@ -61,6 +68,36 @@ module RecurringMeetings
                     .call(start_time: first_occurrence)
 
       call.merge!(init_call)
+    end
+
+    def schedule_next_occurrence(from_time)
+      next_occurrence = @recurring_meeting.next_occurrence(from_time:)
+      return if next_occurrence.nil?
+
+      ::RecurringMeetings::InitNextOccurrenceJob
+        .set(wait_until: from_time)
+        .perform_later(@recurring_meeting, next_occurrence)
+    end
+
+    def deliver_invitation_mails
+      return unless @recurring_meeting.template.notify?
+
+      @recurring_meeting.template.participants.invited.find_each do |participant|
+        MeetingSeriesMailer.invited(@recurring_meeting, participant.user, @user).deliver_later
+      end
+    end
+
+    def no_next_occurrence_failure
+      ServiceResult.failure(message: I18n.t("recurring_meeting.occurrence.error_no_next"))
+    end
+
+    def already_completed?(first_occurrence)
+      !@recurring_meeting.template.draft? &&
+        @recurring_meeting.meetings.not_templated.not_cancelled.exists?(recurrence_start_time: first_occurrence)
+    end
+
+    def already_completed_failure
+      ServiceResult.failure(message: I18n.t("recurring_meeting.occurrence.first_already_exists"))
     end
   end
 end

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meetings_api.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meetings_api.rb
@@ -50,6 +50,23 @@ module API
 
             delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
 
+            post "end" do
+              authorize_in_project(:edit_meetings, project: @recurring_meeting.project)
+
+              call = ::RecurringMeetings::EndService
+                       .new(@recurring_meeting, current_user:)
+                       .call
+
+              if call.success?
+                status 200
+                ::API::V3::RecurringMeetings::RecurringMeetingRepresenter.create(
+                  @recurring_meeting.reload, current_user:, embed_links: true
+                )
+              else
+                fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
+              end
+            end
+
             mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
           end
         end

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meetings_api.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meetings_api.rb
@@ -32,6 +32,21 @@ module API
   module V3
     module RecurringMeetings
       class RecurringMeetingsAPI < ::API::OpenProjectAPI
+        helpers do
+          def represent_recurring_meeting_result(call)
+            if call.success?
+              status 200
+              ::API::V3::RecurringMeetings::RecurringMeetingRepresenter.create(
+                @recurring_meeting.reload, current_user:, embed_links: true
+              )
+            elsif call.errors.blank?
+              raise ::API::Errors::UnprocessableContent.new(call.message)
+            else
+              fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
+            end
+          end
+        end
+
         resources :recurring_meetings do
           get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
 
@@ -57,14 +72,22 @@ module API
                        .new(@recurring_meeting, current_user:)
                        .call
 
-              if call.success?
-                status 200
-                ::API::V3::RecurringMeetings::RecurringMeetingRepresenter.create(
-                  @recurring_meeting.reload, current_user:, embed_links: true
-                )
-              else
-                fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
-              end
+              represent_recurring_meeting_result(call)
+            end
+
+            params do
+              requires :notify,
+                       type: Boolean,
+                       desc: "Enable email notifications for the series"
+            end
+            post "template_completed" do
+              authorize_in_project(:edit_meetings, project: @recurring_meeting.project)
+
+              call = ::RecurringMeetings::TemplateCompletedService
+                       .new(user: current_user, recurring_meeting: @recurring_meeting)
+                       .call(notify: params[:notify])
+
+              represent_recurring_meeting_result(call)
             end
 
             mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -416,6 +416,32 @@ RSpec.describe "API v3 Meeting resource", content_type: :json do
         expect(meeting.reload.state).to eq("open")
         expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(participant.mail)
       end
+
+      context "when transitioning directly from draft to in_progress" do
+        # notify is already enabled, so only the state transition can trigger invitations
+        let(:meeting) do
+          create(:meeting, project:, author: current_user, state: :draft, notify: true).tap do |m|
+            create(:meeting_participant, meeting: m, user: participant, invited: true)
+          end
+        end
+        let(:body) do
+          {
+            state: "in_progress",
+            lockVersion: meeting.lock_version
+          }.to_json
+        end
+
+        it "still sends invitation mails to the invited participants" do
+          expect(meeting.state).to eq("draft")
+          expect(ActionMailer::Base.deliveries).to be_empty
+
+          perform_enqueued_jobs { response }
+
+          expect(last_response).to have_http_status(:ok)
+          expect(meeting.reload.state).to eq("in_progress")
+          expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(participant.mail)
+        end
+      end
     end
 
     context "when changing participants on an open meeting with notifications enabled" do

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -417,6 +417,67 @@ RSpec.describe "API v3 Meeting resource", content_type: :json do
         expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(participant.mail)
       end
     end
+
+    context "when changing participants on an open meeting with notifications enabled" do
+      let(:existing_participant) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+      let(:added_participant) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+      let(:other_participant) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+      let(:meeting) do
+        create(:meeting, project:, author: current_user, notify: true).tap do |m|
+          create(:meeting_participant, meeting: m, user: existing_participant, invited: true)
+        end
+      end
+
+      before { ActionMailer::Base.deliveries.clear }
+
+      def perform_debounced_jobs
+        perform_enqueued_jobs(only: Meetings::NotificationDebounceJob, at: 2.minutes.from_now)
+        perform_enqueued_jobs
+      end
+
+      it "invites a newly added participant" do
+        body = {
+          lockVersion: meeting.lock_version,
+          _links: {
+            participants: [
+              { href: api_v3_paths.user(existing_participant.id) },
+              { href: api_v3_paths.user(added_participant.id) }
+            ]
+          }
+        }.to_json
+
+        patch path, body
+        expect(last_response).to have_http_status(:ok)
+
+        perform_debounced_jobs
+
+        expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(added_participant.mail)
+      end
+
+      it "notifies a removed participant" do
+        create(:meeting_participant, meeting:, user: other_participant, invited: true)
+
+        body = {
+          lockVersion: meeting.lock_version,
+          _links: {
+            participants: [{ href: api_v3_paths.user(existing_participant.id) }]
+          }
+        }.to_json
+
+        patch path, body
+        expect(last_response).to have_http_status(:ok)
+
+        perform_debounced_jobs
+
+        expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(other_participant.mail)
+      end
+    end
   end
 
   describe "DELETE /api/v3/meetings/:id" do

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -366,6 +366,57 @@ RSpec.describe "API v3 Meeting resource", content_type: :json do
         subject { last_response }
       end
     end
+
+    context "when updating the notify flag" do
+      let(:meeting) { create(:meeting, project:, author: current_user, notify: false) }
+      let(:body) do
+        {
+          notify: true,
+          lockVersion: meeting.lock_version
+        }.to_json
+      end
+
+      it "updates the notify flag" do
+        expect(meeting.notify).to be(false)
+
+        response
+
+        expect(response).to have_http_status(:ok)
+        expect(meeting.reload.notify).to be(true)
+        expect(response.body).to be_json_eql(true.to_json).at_path("notify")
+      end
+    end
+
+    context "when exiting draft mode with notifications enabled" do
+      let(:participant) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+      let(:meeting) do
+        create(:meeting, project:, author: current_user, state: :draft, notify: false).tap do |m|
+          create(:meeting_participant, meeting: m, user: participant, invited: true)
+        end
+      end
+      let(:body) do
+        {
+          state: "open",
+          notify: true,
+          lockVersion: meeting.lock_version
+        }.to_json
+      end
+
+      before { ActionMailer::Base.deliveries.clear }
+
+      it "sends invitation mails to the invited participants" do
+        expect(meeting.state).to eq("draft")
+        expect(ActionMailer::Base.deliveries).to be_empty
+
+        perform_enqueued_jobs { response }
+
+        expect(last_response).to have_http_status(:ok)
+        expect(meeting.reload.state).to eq("open")
+        expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(participant.mail)
+      end
+    end
   end
 
   describe "DELETE /api/v3/meetings/:id" do

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/occurrences_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/occurrences_resource_spec.rb
@@ -168,6 +168,37 @@ RSpec.describe "API v3 Recurring Meeting Occurrences", content_type: :json do
         expect(cancelled_occurrence.reload).to be_cancelled
       end
     end
+
+    context "when restoring a cancelled occurrence with notifications enabled" do
+      let(:invited_user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+      let!(:cancelled_occurrence) do
+        create(:meeting,
+               project:,
+               author: current_user,
+               recurring_meeting:,
+               start_time:,
+               recurrence_start_time: start_time,
+               state: :cancelled)
+      end
+
+      before do
+        recurring_meeting.template.update!(notify: true)
+        create(:meeting_participant, meeting: recurring_meeting.template, user: invited_user, invited: true)
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it "restores the occurrence and re-invites its participants" do
+        expect(cancelled_occurrence).to be_cancelled
+
+        perform_enqueued_jobs { response }
+
+        expect(last_response).to have_http_status(:created)
+        expect(cancelled_occurrence.reload).not_to be_cancelled
+        expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(invited_user.mail)
+      end
+    end
   end
 
   describe "an in progress occurrence" do

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
@@ -229,4 +229,52 @@ RSpec.describe "API v3 Recurring Meeting resource", content_type: :json do
       it_behaves_like "unauthorized access"
     end
   end
+
+  describe "POST /api/v3/recurring_meetings/:id/end" do
+    let(:recurring_meeting) do
+      create(:recurring_meeting, project:, author: current_user, start_time: 1.week.ago)
+    end
+    let(:path) { "#{api_v3_paths.recurring_meeting(recurring_meeting.id)}/end" }
+
+    subject(:response) { post path }
+
+    context "with required permissions" do
+      it "responds with 200 and the updated series" do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_json_eql("RecurringMeeting".to_json).at_path("_type")
+      end
+
+      it "ends the series" do
+        response
+        expect(recurring_meeting.reload.end_date).to eq(Time.zone.yesterday)
+      end
+    end
+
+    context "with notifications enabled" do
+      let(:invited_user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+
+      before do
+        recurring_meeting.template.update!(notify: true)
+        create(:meeting_participant, meeting: recurring_meeting.template, user: invited_user, invited: true)
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it "notifies the participants that the series has ended" do
+        response
+
+        expect(last_response).to have_http_status(:ok)
+        expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(invited_user.mail)
+      end
+    end
+
+    context "without edit_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      before { response }
+
+      it_behaves_like "unauthorized access"
+    end
+  end
 end

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
@@ -277,4 +277,81 @@ RSpec.describe "API v3 Recurring Meeting resource", content_type: :json do
       it_behaves_like "unauthorized access"
     end
   end
+
+  describe "POST /api/v3/recurring_meetings/:id/template_completed" do
+    let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+    let(:path) { "#{api_v3_paths.recurring_meeting(recurring_meeting.id)}/template_completed" }
+    let(:invited_user) do
+      create(:user, member_with_permissions: { project => %i[view_meetings] })
+    end
+
+    before do
+      create(:meeting_participant, meeting: recurring_meeting.template, user: invited_user, invited: true)
+      ActionMailer::Base.deliveries.clear
+    end
+
+    subject(:response) { post path, { notify: true }.to_json }
+
+    context "with required permissions" do
+      it "responds with 200 and initiates the first occurrence" do
+        first_occurrence = recurring_meeting.next_occurrence
+
+        perform_enqueued_jobs { response }
+
+        expect(last_response).to have_http_status(:ok)
+        expect(last_response.body).to be_json_eql("RecurringMeeting".to_json).at_path("_type")
+
+        occurrence = recurring_meeting.meetings.not_templated
+                                      .find_by(recurrence_start_time: first_occurrence)
+        expect(occurrence).to be_present
+        expect(occurrence).to be_open
+        expect(occurrence.start_time).to eq(first_occurrence)
+        expect(occurrence.title).to eq(recurring_meeting.template.title)
+      end
+
+      it "sends series invitations to the template participants when notify: true" do
+        perform_enqueued_jobs { response }
+
+        expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(invited_user.mail)
+      end
+
+      it "does not send invitations when notify: false, but still initiates the first occurrence" do
+        first_occurrence = recurring_meeting.next_occurrence
+
+        perform_enqueued_jobs { post path, { notify: false }.to_json }
+
+        expect(last_response).to have_http_status(:ok)
+        expect(ActionMailer::Base.deliveries).to be_empty
+        expect(recurring_meeting.meetings.not_templated.find_by(recurrence_start_time: first_occurrence)).to be_open
+      end
+
+      it "requires notify to be passed explicitly" do
+        post path
+
+        expect(last_response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "when the template has already been completed" do
+      before do
+        perform_enqueued_jobs { post path, { notify: true }.to_json }
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it "is rejected and does not re-send invitations" do
+        perform_enqueued_jobs { post path, { notify: true }.to_json }
+
+        expect(last_response).to have_http_status(:unprocessable_entity)
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
+
+    context "without edit_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      before { response }
+
+      it_behaves_like "unauthorized access"
+    end
+  end
 end

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "API v3 Recurring Meeting resource", content_type: :json do
       end
 
       it "notifies the participants that the series has ended" do
-        response
+        perform_enqueued_jobs { response }
 
         expect(last_response).to have_http_status(:ok)
         expect(ActionMailer::Base.deliveries.flat_map(&:to)).to include(invited_user.mail)
@@ -343,6 +343,25 @@ RSpec.describe "API v3 Recurring Meeting resource", content_type: :json do
 
         expect(last_response).to have_http_status(:unprocessable_entity)
         expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
+
+    context "when the first occurrence was cancelled after completion" do
+      let!(:first_occurrence) do
+        perform_enqueued_jobs { post path, { notify: true }.to_json }
+        recurring_meeting.meetings.not_templated.first.tap { |m| m.update!(state: :cancelled) }
+      end
+
+      before { ActionMailer::Base.deliveries.clear }
+
+      it "restores the occurrence without re-sending the series invitation" do
+        allow(MeetingSeriesMailer).to receive(:invited).and_call_original
+
+        perform_enqueued_jobs { post path, { notify: true }.to_json }
+
+        expect(last_response).to have_http_status(:ok)
+        expect(first_occurrence.reload).not_to be_cancelled
+        expect(MeetingSeriesMailer).not_to have_received(:invited)
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/MEET-583

# What are you trying to accomplish?
Bring the API to parity with the web in terms of allowed actions and corresponding notification behaviour

# What approach did you choose and why?
New endpoints for missing actions:
- POST /api/v3/recurring_meetings/{id}/end
- POST /api/v3/recurring_meetings/{id}/template_completed

Behaviour changes to existing endpoints:
- PATCH /meetings/{id} - now emails participants when leaving draft, enabling notifications, or adding/removing participants
- POST /recurring_meetings/{id}/occurrences/{start_time}/init - now re-invites participants when restoring a cancelled occurrence - previously silent via the API

Notification related logic was moved out of the controller actions to the relevant services

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)