### PR TITLE
[OP-19885] User cannot update own profile because password confirmation autosaves

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.spec.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.spec.ts
@@ -73,4 +73,36 @@ describe('CkeditorAugmentedTextareaComponent', () => {
 
     expect(sync).toHaveBeenCalledTimes(1);
   });
+
+  describe('form submit interception', () => {
+    let form:HTMLFormElement;
+    let sync:ReturnType<typeof vi.spyOn>;
+    let saveForm:ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      form = document.createElement('form');
+      component.formElement = form;
+      sync = vi.spyOn(component, 'syncToTextarea').mockImplementation(() => undefined);
+      saveForm = vi.spyOn(component, 'saveForm').mockResolvedValue(undefined);
+      (component as unknown as { registerFormSubmitListener():void }).registerFormSubmitListener();
+    });
+
+    it('delegates to saveForm when submit is not already prevented', () => {
+      const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
+      form.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(saveForm).toHaveBeenCalledWith(event);
+      expect(sync).not.toHaveBeenCalled();
+    });
+
+    it('only syncs when another handler already prevented default', () => {
+      const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
+      event.preventDefault();
+      form.dispatchEvent(event);
+
+      expect(saveForm).not.toHaveBeenCalled();
+      expect(sync).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -178,6 +178,15 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
         this.untilDestroyed(),
       )
       .subscribe((evt:SubmitEvent) => {
+        // Another handler (e.g. require-password-confirmation) already owns this
+        // submit. Still flush editor → textarea so a later confirmed submit has
+        // the latest content, but do not re-submit — Turbo's navigator.submitForm
+        // would bypass that other handler and POST without confirmation.
+        if (evt.defaultPrevented) {
+          this.syncToTextarea();
+          return;
+        }
+
         evt.preventDefault();
         void this.saveForm(evt);
       });
@@ -214,7 +223,11 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
         (evt.submitter as HTMLInputElement).disabled = false;
       }
 
-      if (this.turboMode && !this.formElement.dataset.action) {
+      // Honor the form's data-turbo="false" even when this component was created
+      // with turboMode (Primer rich_text_area default). Turbo's submitForm skips
+      // the submit event and would bypass other submit interceptors.
+      const turboDisabled = this.formElement.dataset.turbo === 'false';
+      if (this.turboMode && !turboDisabled && !this.formElement.dataset.action) {
         navigator.submitForm(this.formElement, evt?.submitter ?? undefined);
       } else {
         this.formElement.requestSubmit(evt?.submitter);

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
@@ -135,6 +135,46 @@ describe('Require password confirmation controller', () => {
     expect(requestSubmit).toHaveBeenCalled();
   });
 
+  it('reopens the dialog after a cancelled confirmation', async () => {
+    const form = await renderForm();
+
+    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Primer/Turbo removes the dialog during `close`, then dispatches dialog:close.
+    const dialog = document.createElement('dialog');
+    dialog.id = 'password-confirmation-dialog';
+    document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: false } }));
+
+    fetchSpy.mockClear();
+    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('ignores dialog:close events for other dialogs', async () => {
+    const form = await renderForm();
+
+    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const other = document.createElement('dialog');
+    other.id = 'some-other-dialog';
+    document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog: other, submitted: false } }));
+
+    fetchSpy.mockClear();
+    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+
+    await ctx.nextFrame();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('intercepts submits arriving before the plugin context resolves', async () => {
     let resolveContext!:(context:unknown) => void;
     window.OpenProject = {

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
@@ -102,6 +102,21 @@ describe('Require password confirmation controller', () => {
     });
   });
 
+  it('intercepts submit in the capture phase before bubble listeners', async () => {
+    const form = await renderForm();
+    const bubbleOrder:string[] = [];
+
+    form.addEventListener('submit', (event) => {
+      bubbleOrder.push(`bubble:prevented=${event.defaultPrevented}`);
+    });
+
+    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(bubbleOrder).toEqual(['bubble:prevented=true']);
+  });
+
   it('appends the confirmed password and resubmits the form', async () => {
     const form = await renderForm();
     const requestSubmit = vi.fn();

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
@@ -52,7 +52,10 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
   connect() {
     super.connect();
 
-    this.element.addEventListener('submit', this.formListener);
+    // Capture phase so we run before other submit interceptors on the same form
+    // (notably CKEditor-augmented textareas), which can otherwise re-submit via
+    // Turbo and bypass the confirmation dialog.
+    this.element.addEventListener('submit', this.formListener, { capture: true });
     document.addEventListener('password-confirmation-dialog:close', this.dialogCloseListener);
     document.addEventListener('password-confirmation-dialog:submit', this.dialogSubmitListener);
 
@@ -64,7 +67,7 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
   disconnect() {
     super.disconnect();
 
-    this.element.removeEventListener('submit', this.formListener);
+    this.element.removeEventListener('submit', this.formListener, { capture: true });
     document.removeEventListener('password-confirmation-dialog:close', this.dialogCloseListener);
     document.removeEventListener('password-confirmation-dialog:submit', this.dialogSubmitListener);
   }

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
@@ -36,7 +36,7 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
   declare services:Promise<PickedServices<'pathHelperService'>>;
 
   private formListener:(evt:SubmitEvent) => unknown = this.onFormSubmit.bind(this);
-  private dialogCloseListener:(evt:Event) => unknown = this.onDialogClose.bind(this);
+  private dialogCloseListener:(evt:CustomEvent) => unknown = this.onDialogClose.bind(this);
   private dialogSubmitListener:(evt:CustomEvent) => unknown = this.onConfirmationSubmit.bind(this);
 
   private activeDialog = false;
@@ -56,7 +56,10 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
     // (notably CKEditor-augmented textareas), which can otherwise re-submit via
     // Turbo and bypass the confirmation dialog.
     this.element.addEventListener('submit', this.formListener, { capture: true });
-    document.addEventListener('password-confirmation-dialog:close', this.dialogCloseListener);
+    // Use the shared Primer/Turbo `dialog:close` event. The dialog's own Stimulus
+    // controller may be disconnected (DOM removed) during `close` before it can
+    // emit a custom event, which would leave activeDialog stuck true after cancel.
+    document.addEventListener('dialog:close', this.dialogCloseListener);
     document.addEventListener('password-confirmation-dialog:submit', this.dialogSubmitListener);
 
     this.submitButton = this.element.querySelector("button[type='submit']");
@@ -68,11 +71,16 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
     super.disconnect();
 
     this.element.removeEventListener('submit', this.formListener, { capture: true });
-    document.removeEventListener('password-confirmation-dialog:close', this.dialogCloseListener);
+    document.removeEventListener('dialog:close', this.dialogCloseListener);
     document.removeEventListener('password-confirmation-dialog:submit', this.dialogSubmitListener);
   }
 
-  private onDialogClose(_event:Event) {
+  private onDialogClose(event:CustomEvent) {
+    const dialog = (event.detail as { dialog?:HTMLElement }|undefined)?.dialog;
+    if (dialog?.id !== 'password-confirmation-dialog') {
+      return;
+    }
+
     this.activeDialog = false;
   }
 

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -143,44 +143,77 @@ RSpec.describe "my", :js do
     describe "#account" do
       let(:dialog) { Components::PasswordConfirmationDialog.new }
 
-      before do
-        visit my_account_path
+      context "when updating profile fields" do
+        before do
+          visit my_account_path
 
-        fill_in "user[mail]", with: "foo@mail.com"
-        fill_in "user[firstname]", with: "Foo"
-        fill_in "user[lastname]", with: "Bar"
-        click_on "Update profile"
-      end
-
-      context "when confirmation disabled",
-              with_config: { internal_password_confirmation: false } do
-        it "does not request confirmation" do
-          expect_changed!
-        end
-      end
-
-      context "when confirmation required",
-              with_config: { internal_password_confirmation: true } do
-        it "requires the password for a regular user" do
-          dialog.confirm_flow_with(user_password)
-          expect_changed!
+          fill_in "user[mail]", with: "foo@mail.com"
+          fill_in "user[firstname]", with: "Foo"
+          fill_in "user[lastname]", with: "Bar"
+          click_on "Update profile"
         end
 
-        it "declines the change when invalid password is given" do
-          dialog.confirm_flow_with(user_password + "INVALID", should_fail: true)
-
-          user.reload
-          expect(user.mail).to eq("old@mail.com")
-        end
-
-        context "as admin" do
-          shared_let(:admin) { create(:admin) }
-          let(:user) { admin }
-
-          it "requires the password" do
-            dialog.confirm_flow_with("adminADMIN!")
+        context "when confirmation disabled",
+                with_config: { internal_password_confirmation: false } do
+          it "does not request confirmation" do
             expect_changed!
           end
+        end
+
+        context "when confirmation required",
+                with_config: { internal_password_confirmation: true } do
+          it "requires the password for a regular user" do
+            dialog.confirm_flow_with(user_password)
+            expect_changed!
+          end
+
+          it "declines the change when invalid password is given" do
+            dialog.confirm_flow_with("#{user_password}INVALID", should_fail: true)
+
+            user.reload
+            expect(user.mail).to eq("old@mail.com")
+          end
+
+          context "as admin" do
+            shared_let(:admin) { create(:admin) }
+            let(:user) { admin }
+
+            it "requires the password" do
+              dialog.confirm_flow_with("adminADMIN!")
+              expect_changed!
+            end
+          end
+        end
+      end
+
+      # CKEditor-augmented text custom fields also intercept submit (to flush
+      # editor → textarea). With turboMode they used to call Turbo's
+      # navigator.submitForm, which bypassed password confirmation and POSTed
+      # immediately — flashing notice_password_confirmation_failed.
+      context "with a long text custom field",
+              with_config: { internal_password_confirmation: true } do
+        let!(:text_cf) { create(:user_custom_field, :text, name: "Biography") }
+        let(:editor) { Components::WysiwygEditor.new("[data-test-selector='#{text_cf.attribute_name(:kebab_case)}']") }
+
+        it "still requires password confirmation and does not submit without it" do
+          visit my_account_path
+
+          editor.expect_value("")
+          editor.set_markdown("Loves hiking")
+
+          fill_in "user[mail]", with: "foo@mail.com"
+          fill_in "user[firstname]", with: "Foo"
+          fill_in "user[lastname]", with: "Bar"
+          click_on "Update profile"
+
+          dialog.expect_open
+          expect(page).to have_no_text(I18n.t(:notice_password_confirmation_failed))
+
+          dialog.confirm_flow_with(user_password)
+          expect_changed!
+
+          user.reload
+          expect(user.typed_custom_value_for(text_cf)).to include("Loves hiking")
         end
       end
     end

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -174,6 +174,14 @@ RSpec.describe "my", :js do
             expect(user.mail).to eq("old@mail.com")
           end
 
+          it "allows submitting again after cancelling the confirmation dialog" do
+            dialog.cancel
+
+            click_on "Update profile"
+            dialog.confirm_flow_with(user_password)
+            expect_changed!
+          end
+
           context "as admin" do
             shared_let(:admin) { create(:admin) }
             let(:user) { admin }

--- a/spec/support/components/password_confirmation_dialog.rb
+++ b/spec/support/components/password_confirmation_dialog.rb
@@ -52,7 +52,15 @@ module Components
     end
 
     def expect_closed
-      expect(page).to have_no_test_selector(test_selector)
+      expect(page).not_to have_test_selector(test_selector)
+    end
+
+    def cancel
+      expect_open
+      page.within_test_selector(test_selector) do
+        click_on I18n.t("button_cancel")
+      end
+      expect_closed
     end
 
     def submit_button


### PR DESCRIPTION
Capture the submit event so we can stop other submit handlers (such as the CKEditor component) from firing and submitting the form again in absence of the confirmation

https://community.openproject.org/work_packages/OP-19885