### PR TITLE
Code maintenance/agile 386 use the JournalFormatterCache in the JournalFormatter::NamedAssociation#reachable? method

### DIFF
--- a/lib/open_project/journal_formatter/custom_field/shared_methods.rb
+++ b/lib/open_project/journal_formatter/custom_field/shared_methods.rb
@@ -49,7 +49,7 @@ module OpenProject::JournalFormatter::CustomField::SharedMethods
   # render many custom-field journal entries per request, often for the same project, so we
   # cache the verdict set per request and per user.
   def visible_custom_field_ids(project)
-    JournalFormatterCache.request_instance.fetch(WorkPackageCustomField, project.id) do # rubocop:disable Lint/UselessDefaultValueArgument
+    JournalFormatterCache.fetch(WorkPackageCustomField, project.id) do # rubocop:disable Lint/UselessDefaultValueArgument
       WorkPackageCustomField.visible(User.current, project:).pluck(:id).to_set
     end
   end

--- a/lib/open_project/journal_formatter/subproject_named_association.rb
+++ b/lib/open_project/journal_formatter/subproject_named_association.rb
@@ -29,7 +29,7 @@
 class OpenProject::JournalFormatter::SubprojectNamedAssociation < JournalFormatter::NamedAssociation
   private
 
-  def format_details(key, values, cache:)
+  def format_details(key, values)
     label = if values.first.nil?
               label(key)
             elsif values.last.nil?
@@ -38,7 +38,7 @@ class OpenProject::JournalFormatter::SubprojectNamedAssociation < JournalFormatt
               I18n.t("activity.item.parent_without_of")
             end
 
-    old_value, value = *format_values(values, key, cache:)
+    old_value, value = *format_values(values, key)
 
     [label, old_value, value]
   end

--- a/lib/open_project/journal_formatter/target_versions.rb
+++ b/lib/open_project/journal_formatter/target_versions.rb
@@ -45,14 +45,14 @@ class OpenProject::JournalFormatter::TargetVersions < JournalFormatter::NamedAss
     end
   end
 
-  def format_values(values, key, cache:)
+  def format_values(values, key)
     klass = class_from_field(key)
 
     values.map do |value|
       next if value.blank? || klass.nil?
 
       value.to_s.split(",")
-           .filter_map { |id| name_or_placeholder(associated_object(klass, id.to_i, cache:)) }
+           .filter_map { |id| name_or_placeholder(associated_object(klass, id.to_i)) }
            .join(", ")
            .presence
     end

--- a/lib/open_project/journal_formatter/time_entry_named_association.rb
+++ b/lib/open_project/journal_formatter/time_entry_named_association.rb
@@ -30,10 +30,10 @@ class OpenProject::JournalFormatter::TimeEntryNamedAssociation <
   OpenProject::JournalFormatter::PublicNamedAssociation
   private
 
-  def format_details(key, values, cache:)
+  def format_details(key, values)
     label = I18n.t("activity.item.time_entry.logged_for")
 
-    old_value, value = *format_values(values, key, cache:)
+    old_value, value = *format_values(values, key)
 
     [label, old_value, value]
   end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -101,7 +101,7 @@ module JournalFormatter
   end
 
   def render_detail(detail, options = {}) # rubocop:disable Metrics/AbcSize
-    options = options.reverse_merge(html: true, only_path: true, cache: JournalFormatterCache.request_instance)
+    options = options.reverse_merge(html: true, only_path: true)
 
     if detail.respond_to? :to_ary
       field = detail.first

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -74,10 +74,17 @@ module JournalFormatter
     # moved between projects keeps journal entries naming the parent, version,
     # category and budget it had in a project the reader cannot open.
     #
-    # The reader is part of the key, so a verdict left behind in a thread that
-    # outlives a single request cannot be read back for somebody else.
+    # The reader is folded into the cache key by default, so a verdict left behind in
+    # a thread that outlives a single request cannot be read back for somebody else.
+    #
+    # :journal_reachable is used as the "klass" part of the key so this verdict cache
+    # never collides with the raw-record cache entries #associated_object stores under
+    # the object's actual class.
+    #
+    # Overridden by PublicNamedAssociation to skip the check for fields that name
+    # people the journable already names elsewhere (assignee, responsible, author).
     def reachable?(object)
-      RequestStore.fetch("journal_reachable/#{User.current.id}/#{object.class.name}/#{object.id}") do
+      JournalFormatterCache.request_instance.fetch(:journal_reachable, [object.class, object.id]) do # rubocop:disable Lint/UselessDefaultValueArgument
         reader_may_see?(object)
       end
     end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -34,7 +34,7 @@ module JournalFormatter
       return render_permission_denied_message(options) unless permission_granted?(options.merge(key: key_with_id))
 
       key = key_with_id.to_s.delete_suffix("_id")
-      label, old_value, value = format_details(key, values, cache: options[:cache])
+      label, old_value, value = format_details(key, values)
 
       if options[:html]
         label, old_value, value = *format_html_details(label, old_value, value)
@@ -45,21 +45,21 @@ module JournalFormatter
 
     private
 
-    def format_details(key, values, cache:)
+    def format_details(key, values)
       label = label(key)
 
-      old_value, value = *format_values(values, key, cache:)
+      old_value, value = *format_values(values, key)
 
       [label, old_value, value]
     end
 
-    def format_values(values, key, cache:)
+    def format_values(values, key)
       klass = class_from_field(key)
 
       values.map do |value|
         next unless klass && value
 
-        name_or_placeholder(associated_object(klass, value.to_i, cache:))
+        name_or_placeholder(associated_object(klass, value.to_i))
       end
     end
 
@@ -84,7 +84,7 @@ module JournalFormatter
     # Overridden by PublicNamedAssociation to skip the check for fields that name
     # people the journable already names elsewhere (assignee, responsible, author).
     def reachable?(object)
-      JournalFormatterCache.request_instance.fetch(:journal_reachable, [object.class, object.id]) do # rubocop:disable Lint/UselessDefaultValueArgument
+      JournalFormatterCache.fetch(:journal_reachable, [object.class, object.id]) do # rubocop:disable Lint/UselessDefaultValueArgument
         reader_may_see?(object)
       end
     end
@@ -100,12 +100,8 @@ module JournalFormatter
       object&.name
     end
 
-    def associated_object(klass, id, cache:)
-      if cache
-        cache.fetch(klass, id) do
-          klass.find_by(id:)
-        end
-      else
+    def associated_object(klass, id)
+      JournalFormatterCache.fetch(klass, id) do # rubocop:disable Lint/UselessDefaultValueArgument
         klass.find_by(id:)
       end
     end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/polymorphic_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/polymorphic_association.rb
@@ -32,7 +32,7 @@ module JournalFormatter
   class PolymorphicAssociation < Attribute
     def render(key_with_gid, values, options = { html: true })
       key = key_with_gid.to_s.delete_suffix("_gid")
-      label, old_value, value = format_details(key, values, cache: options[:cache])
+      label, old_value, value = format_details(key, values)
 
       if options[:html]
         label, old_value, value = *format_html_details(label, old_value, value)
@@ -43,19 +43,19 @@ module JournalFormatter
 
     private
 
-    def format_details(key, values, cache:)
+    def format_details(key, values)
       label = label(key)
 
-      old_value, value = *format_values(values, cache:)
+      old_value, value = *format_values(values)
 
       [label, old_value, value]
     end
 
-    def format_values(values, cache:)
+    def format_values(values)
       values.map do |value|
         next if value.nil?
 
-        record = associated_object(value, cache:)
+        record = associated_object(value)
         associated_object_name(record)
       end
     end
@@ -64,15 +64,11 @@ module JournalFormatter
       object&.name
     end
 
-    def associated_object(gid, cache:)
+    def associated_object(gid)
       global_id = GlobalID.parse(gid)
       return if global_id.nil?
 
-      if cache
-        cache.fetch(global_id.model_name, global_id.model_id) do # rubocop:disable Lint/UselessDefaultValueArgument
-          locate(global_id)
-        end
-      else
+      JournalFormatterCache.fetch(global_id.model_name, global_id.model_id) do # rubocop:disable Lint/UselessDefaultValueArgument
         locate(global_id)
       end
     end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter_cache.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter_cache.rb
@@ -33,6 +33,8 @@ class JournalFormatterCache
     RequestStore.store[:journal_formatter_cache] ||= new
   end
 
+  def self.fetch(...) = request_instance.fetch(...)
+
   def initialize
     @cache = Hash.new
   end

--- a/spec/lib/acts_as_journalized/journal_formatter_cache_spec.rb
+++ b/spec/lib/acts_as_journalized/journal_formatter_cache_spec.rb
@@ -78,4 +78,12 @@ RSpec.describe JournalFormatterCache do
       end
     end
   end
+
+  describe ".fetch" do
+    it "delegates to the per-request singleton, so separate calls share one cache" do
+      expect(described_class.fetch(User, 3) { "user_3" }).to eq("user_3") # rubocop:disable Lint/UselessDefaultValueArgument
+      expect(described_class.fetch(User, 3) { "another value" }).to eq("user_3") # rubocop:disable Lint/UselessDefaultValueArgument
+      expect(described_class.request_instance).to be(described_class.request_instance) # rubocop:disable RSpec/IdenticalEqualityAssertion
+    end
+  end
 end

--- a/spec/lib/open_project/journal_formatter/polymorphic_association_spec.rb
+++ b/spec/lib/open_project/journal_formatter/polymorphic_association_spec.rb
@@ -108,13 +108,6 @@ RSpec.describe JournalFormatter::PolymorphicAssociation do
                         label: "Logged for",
                         value: new_wp.subject))
       end
-
-      it "renders only the new value when a formatter cache is used" do
-        expect(instance.render("entity_gid", [old_value, new_value], html: false, cache: JournalFormatterCache.new))
-          .to eq(I18n.t(:text_journal_set_to,
-                        label: "Logged for",
-                        value: new_wp.subject))
-      end
     end
 
     context "when both values reference records that have since been deleted" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-386

# What are you trying to accomplish?
Unify the caching logic in the formatters.

# What approach did you choose and why?
- Use the `JournalFormatterCache` when caching visibility permissions inside the `JournalFormatter::NamedAssociation#reachable?` method.
- Make the `JournalFormatterCache` a singleton by providing  a `JournalFormatterCache.fetch` method. This eliminates the need of passing a cache instance around by just simply calling the `.fetch` class method.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
