### PR TITLE
[AGILE-385] Check the custom field visibility permission in the JournarFormatter#render_detail

### DIFF
--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -99,7 +99,8 @@ module WorkPackage::Journalized
     register_journal_formatted_fields /\Acustom_fields_\d+\z/,
                                       formatter_key: :custom_field,
                                       view_permission: ->(custom_field) do
-                                        custom_field.present? && visible_custom_field_ids(project).include?(custom_field.id)
+                                        custom_field.present? &&
+                                        visible_work_package_custom_field_ids(project).include?(custom_field.id)
                                       end
     register_journal_formatted_fields "ignore_non_working_days", formatter_key: :ignore_non_working_days
     register_journal_formatted_fields "cause", formatter_key: :cause

--- a/lib/open_project/journal_formatter/custom_comment.rb
+++ b/lib/open_project/journal_formatter/custom_comment.rb
@@ -29,7 +29,7 @@
 #++
 
 class OpenProject::JournalFormatter::CustomComment < OpenProject::JournalFormatter::Diff
-  include OpenProject::JournalFormatter::CustomFieldPermission
+  include OpenProject::JournalFormatter::CustomField::ViewPermission
 
   private
 

--- a/lib/open_project/journal_formatter/custom_comment.rb
+++ b/lib/open_project/journal_formatter/custom_comment.rb
@@ -29,7 +29,7 @@
 #++
 
 class OpenProject::JournalFormatter::CustomComment < OpenProject::JournalFormatter::Diff
-  include OpenProject::JournalFormatter::CustomField::ViewPermission
+  include OpenProject::JournalFormatter::Customizable::ViewPermission
 
   private
 

--- a/lib/open_project/journal_formatter/custom_field.rb
+++ b/lib/open_project/journal_formatter/custom_field.rb
@@ -27,8 +27,8 @@
 #++
 
 class OpenProject::JournalFormatter::CustomField
+  include OpenProject::JournalFormatter::Customizable::ViewPermission
   include SharedMethods
-  include ViewPermission
 
   delegate :project, to: :@journal
 

--- a/lib/open_project/journal_formatter/custom_field.rb
+++ b/lib/open_project/journal_formatter/custom_field.rb
@@ -28,8 +28,12 @@
 
 class OpenProject::JournalFormatter::CustomField
   include SharedMethods
+  include ViewPermission
+
+  delegate :project, to: :@journal
 
   def initialize(journal)
+    @journal = journal
     @plain_formatter = Plain.new(journal)
     @diff_formatter = Diff.new(journal)
   end

--- a/lib/open_project/journal_formatter/custom_field/shared_methods.rb
+++ b/lib/open_project/journal_formatter/custom_field/shared_methods.rb
@@ -27,8 +27,6 @@
 #++
 
 module OpenProject::JournalFormatter::CustomField::SharedMethods
-  include OpenProject::JournalFormatter::CustomFieldPermission
-
   private
 
   def custom_field_for_key(key)
@@ -42,15 +40,6 @@ module OpenProject::JournalFormatter::CustomField::SharedMethods
       custom_field.name
     else
       I18n.t(:label_deleted_custom_field)
-    end
-  end
-
-  # The (user, project) visibility check queries the DB every time it runs; activity feeds
-  # render many custom-field journal entries per request, often for the same project, so we
-  # cache the verdict set per request and per user.
-  def visible_custom_field_ids(project)
-    JournalFormatterCache.fetch(WorkPackageCustomField, project.id) do # rubocop:disable Lint/UselessDefaultValueArgument
-      WorkPackageCustomField.visible(User.current, project:).pluck(:id).to_set
     end
   end
 end

--- a/lib/open_project/journal_formatter/custom_field/view_permission.rb
+++ b/lib/open_project/journal_formatter/custom_field/view_permission.rb
@@ -57,7 +57,7 @@ module OpenProject::JournalFormatter::CustomField::ViewPermission
   # render many custom-field journal entries per request, often for the same project, so we
   # cache the verdict set per request and per user. Only used by view_permission Procs
   # (see WorkPackage::Journalized), which #permission_granted? instance_exec's above.
-  def visible_custom_field_ids(project)
+  def visible_work_package_custom_field_ids(project)
     JournalFormatterCache.fetch(WorkPackageCustomField, project.id) do # rubocop:disable Lint/UselessDefaultValueArgument
       WorkPackageCustomField.visible(User.current, project:).pluck(:id).to_set
     end

--- a/lib/open_project/journal_formatter/custom_field/view_permission.rb
+++ b/lib/open_project/journal_formatter/custom_field/view_permission.rb
@@ -29,19 +29,37 @@
 #++
 
 # Shared by formatters whose rendered field resolves to a CustomField
-# (OpenProject::JournalFormatter::CustomComment and the
-# OpenProject::JournalFormatter::CustomField::* formatters). Requires the
-# including class to implement +custom_field_for_key(key)+.
-module OpenProject::JournalFormatter::CustomFieldPermission
-  private
-
-  # A Proc :view_permission is instance_exec'd with the CustomField being
+# (OpenProject::JournalFormatter::CustomComment and
+# OpenProject::JournalFormatter::CustomField). Requires the including class to
+# implement +custom_field_for_key(key)+ and +project+.
+#
+# Self-contained (does not rely on a JournalFormatter::Base ancestor via
+# +super+) so it can be mixed into formatters that aren't Base subclasses,
+# such as CustomField, which is a plain dispatcher and has no other use for
+# Base's rendering machinery.
+module OpenProject::JournalFormatter::CustomField::ViewPermission
+  # A Proc permission is instance_exec'd with the CustomField being
   # rendered (or nil, if it has since been deleted) as its sole argument,
   # rather than with no arguments as JournalFormatter::Base does.
-  def permission_granted?(options)
-    permission = options[:view_permission]
-    return super unless permission.is_a?(Proc)
+  def permission_granted?(permission, key: nil)
+    return true unless permission
 
-    instance_exec(custom_field_for_key(options[:key]), &permission)
+    if permission.is_a?(Proc)
+      instance_exec(custom_field_for_key(key), &permission)
+    else
+      User.current.allowed_in_project?(permission, project)
+    end
+  end
+
+  private
+
+  # The (user, project) visibility check queries the DB every time it runs; activity feeds
+  # render many custom-field journal entries per request, often for the same project, so we
+  # cache the verdict set per request and per user. Only used by view_permission Procs
+  # (see WorkPackage::Journalized), which #permission_granted? instance_exec's above.
+  def visible_custom_field_ids(project)
+    JournalFormatterCache.fetch(WorkPackageCustomField, project.id) do # rubocop:disable Lint/UselessDefaultValueArgument
+      WorkPackageCustomField.visible(User.current, project:).pluck(:id).to_set
+    end
   end
 end

--- a/lib/open_project/journal_formatter/customizable/view_permission.rb
+++ b/lib/open_project/journal_formatter/customizable/view_permission.rb
@@ -37,10 +37,12 @@
 # +super+) so it can be mixed into formatters that aren't Base subclasses,
 # such as CustomField, which is a plain dispatcher and has no other use for
 # Base's rendering machinery.
-module OpenProject::JournalFormatter::CustomField::ViewPermission
-  # A Proc permission is instance_exec'd with the CustomField being
-  # rendered (or nil, if it has since been deleted) as its sole argument,
-  # rather than with no arguments as JournalFormatter::Base does.
+module OpenProject::JournalFormatter::Customizable::ViewPermission
+  # @param permission [Symbol, Proc, nil] a permission to check via
+  #   User.current.allowed_in_project?, or a lambda/proc performing a custom
+  #   permission check, instance_exec'd with the CustomField being rendered
+  #   (or nil, if it has since been deleted)
+  # @param key [String] the key of CustomField being rendered.
   def permission_granted?(permission, key: nil)
     return true unless permission
 

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -33,11 +33,7 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
     merge_options = { only_path: true,
                       html: true }.merge(options)
 
-    if permission_granted?(merge_options.merge(key:))
-      render_ternary_detail_text(key, values.last, values.first, merge_options)
-    else
-      render_permission_denied_message(merge_options)
-    end
+    render_ternary_detail_text(key, values.last, values.first, merge_options)
   end
 
   private

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -66,8 +66,6 @@ require_relative "journal_formatter/percentage"
 require_relative "journal_formatter/plaintext"
 
 module JournalFormatter
-  include ActionView::Helpers::TagHelper
-
   mattr_accessor :formatters, :registered_fields
 
   def self.register(hash)
@@ -130,9 +128,10 @@ module JournalFormatter
   # unlike #permission_granted? this needs no per-formatter dispatch.
   def render_permission_denied_message(options)
     message = I18n.t(:text_journal_permission_denied)
+    helpers = ActionController::Base.helpers
 
     if options[:html]
-      content_tag("em", message)
+      helpers.content_tag("em", message)
     else
       "_#{message}_"
     end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -66,6 +66,8 @@ require_relative "journal_formatter/percentage"
 require_relative "journal_formatter/plaintext"
 
 module JournalFormatter
+  include ActionView::Helpers::TagHelper
+
   mattr_accessor :formatters, :registered_fields
 
   def self.register(hash)
@@ -117,11 +119,26 @@ module JournalFormatter
     formatter = formatter_instance(config[:formatter_key])
     return if formatter.nil?
 
-    formatter_options = options.merge(view_permission: config[:view_permission])
+    rendered_details =
+      if formatter.permission_granted?(config[:view_permission], key: field)
+        formatter.render(field, values, options)
+      else
+        render_permission_denied_message(options)
+      end
 
-    formatter
-      .render(field, values, formatter_options)
-      &.html_safe # rubocop:disable Rails/OutputSafety
+    rendered_details&.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  # The message is the same regardless of which formatter denied access, so
+  # unlike #permission_granted? this needs no per-formatter dispatch.
+  def render_permission_denied_message(options)
+    message = I18n.t(:text_journal_permission_denied)
+
+    if options[:html]
+      content_tag("em", message)
+    else
+      "_#{message}_"
+    end
   end
 
   def formatter_instance(formatter_key)

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -119,14 +119,11 @@ module JournalFormatter
     formatter = formatter_instance(config[:formatter_key])
     return if formatter.nil?
 
-    rendered_details =
-      if formatter.permission_granted?(config[:view_permission], key: field)
-        formatter.render(field, values, options)
-      else
-        render_permission_denied_message(options)
-      end
-
-    rendered_details&.html_safe # rubocop:disable Rails/OutputSafety
+    if formatter.permission_granted?(config[:view_permission], key: field)
+      formatter.render(field, values, options)&.html_safe # rubocop:disable Rails/OutputSafety
+    else
+      render_permission_denied_message(options)
+    end
   end
 
   # The message is the same regardless of which formatter denied access, so

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -63,7 +63,7 @@ module JournalFormatter
     #   permission check, instance_exec'd against this formatter with no
     #   arguments. Subclasses may override this method to instance_exec the
     #   proc with additional context relevant to the field being rendered
-    #   (see e.g. OpenProject::JournalFormatter::CustomField::ViewPermission).
+    #   (see e.g. OpenProject::JournalFormatter::Customizable::ViewPermission).
     def permission_granted?(permission, **)
       return true unless permission
 

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -49,8 +49,6 @@ module JournalFormatter
     end
 
     def render(key, values, options = { html: true })
-      return render_permission_denied_message(options) unless permission_granted?(options.merge(key:))
-
       label, old_value, value = format_details(key, values)
 
       if options[:html]
@@ -58,6 +56,27 @@ module JournalFormatter
       end
 
       render_ternary_detail_text(label, value, old_value, options)
+    end
+
+    # @param permission [Symbol, Proc, nil] a permission to check via
+    #   User.current.allowed_in_project?, or a lambda/proc performing a custom
+    #   permission check, instance_exec'd against this formatter with no
+    #   arguments. Subclasses may override this method to instance_exec the
+    #   proc with additional context relevant to the field being rendered
+    #   (see e.g. OpenProject::JournalFormatter::CustomField::ViewPermission).
+    # @param key [String] the field being rendered. Unused here, but
+    #   JournalFormatter#render_detail calls every formatter's
+    #   #permission_granted? the same way, so the signature must accept it
+    #   even where it goes unused (mirrors #render's own unused +key+ param
+    #   in e.g. OpenProject::JournalFormatter::Template).
+    def permission_granted?(permission, key: nil) # rubocop:disable Lint/UnusedMethodArgument
+      return true unless permission
+
+      if permission.is_a?(Symbol)
+        User.current.allowed_in_project?(permission, project)
+      else
+        instance_exec(&permission)
+      end
     end
 
     private
@@ -99,36 +118,6 @@ module JournalFormatter
              linebreak:,
              old: old_value,
              new: value)
-    end
-
-    # @param options [Hash] the rendering options.
-    # @option options [Symbol, Proc] :view_permission a permission to check via
-    #   User.current.allowed_in_project?, or a lambda/proc performing a custom
-    #   permission check, instance_exec'd against this formatter with no
-    #   arguments. Subclasses may override this method to instance_exec the
-    #   proc with additional context relevant to the field being rendered
-    #   (see e.g. OpenProject::JournalFormatter::CustomComment#permission_granted?).
-    # @option options [String] :key the field being rendered, made available
-    #   to such overrides.
-    def permission_granted?(options)
-      permission = options[:view_permission]
-      return true unless permission
-
-      if permission.is_a?(Symbol)
-        User.current.allowed_in_project?(permission, project)
-      else
-        instance_exec(&permission)
-      end
-    end
-
-    def render_permission_denied_message(options)
-      message = I18n.t(:text_journal_permission_denied)
-
-      if options[:html]
-        content_tag("em", message)
-      else
-        "_#{message}_"
-      end
     end
 
     def should_linebreak?(old_value, new_value)

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -64,12 +64,7 @@ module JournalFormatter
     #   arguments. Subclasses may override this method to instance_exec the
     #   proc with additional context relevant to the field being rendered
     #   (see e.g. OpenProject::JournalFormatter::CustomField::ViewPermission).
-    # @param key [String] the field being rendered. Unused here, but
-    #   JournalFormatter#render_detail calls every formatter's
-    #   #permission_granted? the same way, so the signature must accept it
-    #   even where it goes unused (mirrors #render's own unused +key+ param
-    #   in e.g. OpenProject::JournalFormatter::Template).
-    def permission_granted?(permission, key: nil) # rubocop:disable Lint/UnusedMethodArgument
+    def permission_granted?(permission, **)
       return true unless permission
 
       if permission.is_a?(Symbol)

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -67,10 +67,10 @@ module JournalFormatter
     def permission_granted?(permission, **)
       return true unless permission
 
-      if permission.is_a?(Symbol)
-        User.current.allowed_in_project?(permission, project)
-      else
+      if permission.is_a?(Proc)
         instance_exec(&permission)
+      else
+        User.current.allowed_in_project?(permission, project)
       end
     end
 

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -31,8 +31,6 @@
 module JournalFormatter
   class NamedAssociation < Attribute
     def render(key_with_id, values, options = { html: true })
-      return render_permission_denied_message(options) unless permission_granted?(options.merge(key: key_with_id))
-
       key = key_with_id.to_s.delete_suffix("_id")
       label, old_value, value = format_details(key, values)
 

--- a/modules/meeting/app/helpers/meetings_helper.rb
+++ b/modules/meeting/app/helpers/meetings_helper.rb
@@ -42,39 +42,6 @@ module MeetingsHelper
     end
   end
 
-  def render_meeting_journal(model, journal, options = {})
-    return "" if journal.initial?
-
-    journal_content = render_journal_details(journal, :label_updated_time_by, model, options)
-    content_tag "div", journal_content, id: "change-#{journal.id}", class: "journal"
-  end
-
-  # This renders a journal entry with a header and details
-  def render_journal_details(journal, header_label = :label_updated_time_by, _model = nil, options = {})
-    header = <<-HTML
-      <div class="profile-wrap">
-        #{avatar(journal.user)}
-      </div>
-      <h4>
-        <div class="journal-link" style="float:right;">#{link_to "##{journal.anchor}", anchor: "note-#{journal.anchor}"}</div>
-        #{authoring journal.created_at, journal.user, label: header_label}
-        #{content_tag('a', '', name: "note-#{journal.anchor}")}
-      </h4>
-    HTML
-
-    if journal.details.any?
-      details = content_tag "ul", class: "details journal-attributes" do
-        journal.details.filter_map do |detail|
-          if d = journal.render_detail(detail, cache: options[:cache])
-            content_tag("li", d.html_safe)
-          end
-        end.join(" ").html_safe
-      end
-    end
-
-    content_tag("div", "#{header}#{details}".html_safe, id: "change-#{journal.id}", class: "journal")
-  end
-
   def global_meeting_create_context?
     global_new_meeting_action? || global_create_meeting_action?
   end

--- a/spec/lib/open_project/journal_formatter/base_spec.rb
+++ b/spec/lib/open_project/journal_formatter/base_spec.rb
@@ -75,18 +75,20 @@ RSpec.describe JournalFormatter::Base do
       let(:project) { build_stubbed(:project) }
       let(:work_package) { build_stubbed(:work_package, project:) }
 
-      context "when the current user has the permission in the project" do
-        before do
-          allow(User.current).to receive(:allowed_in_project?).with(:view_work_packages, project).and_return(true)
+      before do
+        mock_permissions_for(User.current) do |mock|
+          mock.allow_in_project(*permissions, project:)
         end
+      end
+
+      context "when the current user has the permission in the project" do
+        let(:permissions) { [:view_work_packages] }
 
         it { is_expected.to be(true) }
       end
 
       context "when the current user lacks the permission in the project" do
-        before do
-          allow(User.current).to receive(:allowed_in_project?).with(:view_work_packages, project).and_return(false)
-        end
+        let(:permissions) { [] }
 
         it { is_expected.to be(false) }
       end

--- a/spec/lib/open_project/journal_formatter/base_spec.rb
+++ b/spec/lib/open_project/journal_formatter/base_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe JournalFormatter::Base do
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:journal) { build_stubbed(:work_package_journal, journable: work_package) }
+  let(:instance) { described_class.new(journal) }
+  let(:key) { "name" }
+
+  # JournalFormatter#render_detail calls this before #render for every formatter
+  # (see spec/models/journal_spec.rb), so the formatters themselves no longer
+  # check it in their own #render methods. The denied-message rendering itself
+  # has no per-formatter behavior, so it lives directly on JournalFormatter#render_detail
+  # (see spec/models/journal_spec.rb) rather than on individual formatters.
+  describe "#permission_granted?" do
+    subject { instance.permission_granted?(permission, key:) }
+
+    context "without a permission" do
+      let(:permission) { nil }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with a Proc permission" do
+      context "when the proc allows" do
+        let(:permission) { -> { true } }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the proc denies" do
+        let(:permission) { -> { false } }
+
+        it { is_expected.to be(false) }
+      end
+
+      it "is instance_exec'd against the formatter" do
+        permission = proc { self }
+
+        expect(instance.permission_granted?(permission, key:)).to be(instance)
+      end
+    end
+
+    context "with a named (Symbol) permission" do
+      let(:permission) { :view_work_packages }
+      let(:project) { build_stubbed(:project) }
+      let(:work_package) { build_stubbed(:work_package, project:) }
+
+      context "when the current user has the permission in the project" do
+        before do
+          allow(User.current).to receive(:allowed_in_project?).with(:view_work_packages, project).and_return(true)
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the current user lacks the permission in the project" do
+        before do
+          allow(User.current).to receive(:allowed_in_project?).with(:view_work_packages, project).and_return(false)
+        end
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/journal_formatter/custom_comment_spec.rb
+++ b/spec/lib/open_project/journal_formatter/custom_comment_spec.rb
@@ -116,57 +116,52 @@ RSpec.describe OpenProject::JournalFormatter::CustomComment do
     include_examples "results are expected"
   end
 
-  context "with a Proc-based :view_permission option" do
-    let(:expected_label) { "<strong>#{custom_field.name} comment</strong>" }
-    let(:expected_link) { relative_link }
-    let(:values) { [nil, "new value"] }
+  # The permission check itself has moved to JournalFormatter#render_detail, which
+  # calls #permission_granted? on the formatter before calling #render. Here we
+  # only verify the dispatch this formatter (via CustomField::ViewPermission) exposes
+  # to that caller.
+  describe "#permission_granted?" do
+    subject { instance.permission_granted?(permission, key:) }
 
-    context "when the proc, receiving the resolved custom field, allows" do
-      let(:options) do
-        expected_custom_field = custom_field
-        { view_permission: ->(field) { field == expected_custom_field } }
+    context "with a Proc permission" do
+      context "when the proc, receiving the resolved custom field, allows" do
+        let(:permission) do
+          expected_custom_field = custom_field
+          ->(field) { field == expected_custom_field }
+        end
+
+        it { is_expected.to be(true) }
       end
 
-      include_examples "results are expected"
+      context "when the proc, receiving the resolved custom field, denies" do
+        let(:permission) do
+          expected_custom_field = custom_field
+          ->(field) { field != expected_custom_field }
+        end
+
+        it { is_expected.to be(false) }
+      end
     end
 
-    context "when the proc, receiving the resolved custom field, denies" do
-      let(:options) do
-        expected_custom_field = custom_field
-        { view_permission: ->(field) { field != expected_custom_field } }
+    context "with a named (Symbol) permission" do
+      let(:permission) { :view_project }
+      let(:project) { build_stubbed(:project) }
+      let(:journal) { instance_double(Journal, id:, project:) }
+
+      context "when the current user has the permission in the project" do
+        before do
+          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(true)
+        end
+
+        it { is_expected.to be(true) }
       end
 
-      it "renders the permission denied message" do
-        expect(rendered).to eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
-      end
-    end
-  end
+      context "when the current user lacks the permission in the project" do
+        before do
+          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(false)
+        end
 
-  context "with a named (Symbol) :view_permission option" do
-    let(:values) { [nil, "new value"] }
-    let(:options) { { view_permission: :view_project } }
-    let(:project) { build_stubbed(:project) }
-    let(:journal) { instance_double(Journal, id:, project:) }
-    let(:expected_label) { "<strong>#{custom_field.name} comment</strong>" }
-    let(:expected_link) { relative_link }
-
-    context "when the current user has the permission in the project" do
-      before do
-        allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(true)
-      end
-
-      include_examples "results are expected"
-    end
-
-    context "when the current user lacks the permission in the project" do
-      before do
-        allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(false)
-      end
-
-      it "renders the permission denied message" do
-        expect(rendered).to include(I18n.t(:text_journal_permission_denied))
-        expect(rendered).not_to include(expected_label)
-        expect(rendered).not_to include(expected_link)
+        it { is_expected.to be(false) }
       end
     end
   end

--- a/spec/lib/open_project/journal_formatter/custom_comment_spec.rb
+++ b/spec/lib/open_project/journal_formatter/custom_comment_spec.rb
@@ -116,10 +116,12 @@ RSpec.describe OpenProject::JournalFormatter::CustomComment do
     include_examples "results are expected"
   end
 
-  # The permission check itself has moved to JournalFormatter#render_detail, which
-  # calls #permission_granted? on the formatter before calling #render. Here we
-  # only verify the dispatch this formatter (via CustomField::ViewPermission) exposes
-  # to that caller.
+  # The #permission_granted? method is used by the JournalFormatter#render_detail
+  # to check whether the user has the permission to see the rendered activity.
+  # It receives a permission as a Proc or a Symbol and a CustomField key.
+  # In case a Symbol is provided, the permission check happens on the project.
+  # In case a Proc is provided, the CustomField resolved by the key is yielded
+  # to the Proc allowing customized permission checks.
   describe "#permission_granted?" do
     subject { instance.permission_granted?(permission, key:) }
 
@@ -148,18 +150,20 @@ RSpec.describe OpenProject::JournalFormatter::CustomComment do
       let(:project) { build_stubbed(:project) }
       let(:journal) { instance_double(Journal, id:, project:) }
 
-      context "when the current user has the permission in the project" do
-        before do
-          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(true)
+      before do
+        mock_permissions_for(User.current) do |mock|
+          mock.allow_in_project(*permissions, project:)
         end
+      end
+
+      context "when the current user has the permission in the project" do
+        let(:permissions) { [:view_project] }
 
         it { is_expected.to be(true) }
       end
 
       context "when the current user lacks the permission in the project" do
-        before do
-          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(false)
-        end
+        let(:permissions) { [] }
 
         it { is_expected.to be(false) }
       end

--- a/spec/lib/open_project/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/open_project/journal_formatter/custom_field_spec.rb
@@ -489,11 +489,12 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
     end
   end
 
-  # The permission check itself has moved to JournalFormatter#render_detail, which
-  # calls #permission_granted? on the formatter before calling #render (see
-  # spec/models/journal/work_package_journal_spec.rb and project_journal_spec.rb
-  # for the end-to-end behavior). Here we only verify the dispatch this formatter
-  # exposes to that caller.
+  # The #permission_granted? method is used by the JournalFormatter#render_detail
+  # to check whether the user has the permission to see the rendered activity.
+  # It receives a permission as a Proc or a Symbol and a CustomField key.
+  # In case a Symbol is provided, the permission check happens on the project.
+  # In case a Proc is provided, the CustomField resolved by the key is yielded
+  # to the Proc allowing customized permission checks.
   describe "#permission_granted?" do
     subject { instance.permission_granted?(permission, key:) }
 
@@ -520,20 +521,22 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
     context "with a named (Symbol) permission" do
       let(:permission) { :view_project }
       let(:project) { build_stubbed(:project) }
-      let(:journal) { instance_double(Journal, id:, project:) }
+      let(:journal) { instance_double(Journal, project:) }
+
+      before do
+        mock_permissions_for(User.current) do |mock|
+          mock.allow_in_project(*permissions, project:)
+        end
+      end
 
       context "when the current user has the permission in the project" do
-        before do
-          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(true)
-        end
+        let(:permissions) { [:view_project] }
 
         it { is_expected.to be(true) }
       end
 
       context "when the current user lacks the permission in the project" do
-        before do
-          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(false)
-        end
+        let(:permissions) { [] }
 
         it { is_expected.to be(false) }
       end

--- a/spec/lib/open_project/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/open_project/journal_formatter/custom_field_spec.rb
@@ -489,67 +489,53 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
     end
   end
 
-  context "with a Proc-based :view_permission option" do
-    let(:values) { [nil, "1"] }
+  # The permission check itself has moved to JournalFormatter#render_detail, which
+  # calls #permission_granted? on the formatter before calling #render (see
+  # spec/models/journal/work_package_journal_spec.rb and project_journal_spec.rb
+  # for the end-to-end behavior). Here we only verify the dispatch this formatter
+  # exposes to that caller.
+  describe "#permission_granted?" do
+    subject { instance.permission_granted?(permission, key:) }
 
-    context "when the proc, receiving the resolved custom field, allows" do
-      let(:options) do
-        expected_custom_field = custom_field
-        { view_permission: ->(field) { field == expected_custom_field } }
+    context "with a Proc permission" do
+      context "when the proc, receiving the resolved custom field, allows" do
+        let(:permission) do
+          expected_custom_field = custom_field
+          ->(field) { field == expected_custom_field }
+        end
+
+        it { is_expected.to be(true) }
       end
 
-      let(:expected) do
-        I18n.t(:text_journal_set_to,
-               label: custom_field.name,
-               value: format_value(values.last, custom_field))
-      end
+      context "when the proc, receiving the resolved custom field, denies" do
+        let(:permission) do
+          expected_custom_field = custom_field
+          ->(field) { field != expected_custom_field }
+        end
 
-      it "renders normally" do
-        expect(rendered).to eq(expected)
-      end
-    end
-
-    context "when the proc, receiving the resolved custom field, denies" do
-      let(:options) do
-        expected_custom_field = custom_field
-        { view_permission: ->(field) { field != expected_custom_field } }
-      end
-
-      it "renders the permission denied message" do
-        expect(rendered).to eq("_#{I18n.t(:text_journal_permission_denied)}_")
-      end
-    end
-  end
-
-  context "with a named (Symbol) :view_permission option" do
-    let(:values) { [nil, "1"] }
-    let(:options) { { view_permission: :view_project } }
-    let(:project) { build_stubbed(:project) }
-    let(:journal) { instance_double(Journal, id:, project:) }
-    let(:expected_journal_set_to_message) do
-      I18n.t(:text_journal_set_to,
-             label: custom_field.name,
-             value: format_value(values.last, custom_field))
-    end
-
-    context "when the current user has the permission in the project" do
-      before do
-        allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(true)
-      end
-
-      it "renders normally" do
-        expect(rendered).to eq(expected_journal_set_to_message)
+        it { is_expected.to be(false) }
       end
     end
 
-    context "when the current user lacks the permission in the project" do
-      before do
-        allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(false)
+    context "with a named (Symbol) permission" do
+      let(:permission) { :view_project }
+      let(:project) { build_stubbed(:project) }
+      let(:journal) { instance_double(Journal, id:, project:) }
+
+      context "when the current user has the permission in the project" do
+        before do
+          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(true)
+        end
+
+        it { is_expected.to be(true) }
       end
 
-      it "renders the permission denied message" do
-        expect(rendered).to include(I18n.t(:text_journal_permission_denied))
-        expect(rendered).not_to include(expected_journal_set_to_message)
+      context "when the current user lacks the permission in the project" do
+        before do
+          allow(User.current).to receive(:allowed_in_project?).with(:view_project, project).and_return(false)
+        end
+
+        it { is_expected.to be(false) }
       end
     end
   end

--- a/spec/models/journal/work_package_journal_spec.rb
+++ b/spec/models/journal/work_package_journal_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Journal::WorkPackageJournal do
       let(:formatter) { OpenProject::JournalFormatter::CustomField.new(journal) }
 
       it "does not re-query the visible custom field ids for a project already checked" do
-        formatter.send(:visible_custom_field_ids, project) # warms the cache
+        formatter.send(:visible_work_package_custom_field_ids, project) # warms the cache
 
-        expect { formatter.send(:visible_custom_field_ids, project) }.to have_a_query_limit(0)
+        expect { formatter.send(:visible_work_package_custom_field_ids, project) }.to have_a_query_limit(0)
       end
     end
   end

--- a/spec/models/journal/work_package_journal_spec.rb
+++ b/spec/models/journal/work_package_journal_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Journal::WorkPackageJournal do
     end
 
     describe "the backing visibility check (N+1 guard)" do
-      let(:formatter) { OpenProject::JournalFormatter::CustomField::Plain.new(journal) }
+      let(:formatter) { OpenProject::JournalFormatter::CustomField.new(journal) }
 
       it "does not re-query the visible custom field ids for a project already checked" do
         formatter.send(:visible_custom_field_ids, project) # warms the cache

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Journal do
       # formatter for it.
       it "renders the permission denied message instead of the detail" do
         expect(journal.render_detail([field, values]))
-          .to eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
+          .to be_html_safe.and eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
       end
 
       it "does not call render" do
@@ -204,7 +204,7 @@ RSpec.describe Journal do
     context "with html requested" do
       it "wraps the message in an em tag" do
         expect(journal.render_permission_denied_message(html: true))
-          .to eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
+          .to be_html_safe.and eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
       end
     end
 

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -149,6 +149,73 @@ RSpec.describe Journal do
     end
   end
 
+  describe "#render_detail" do
+    let(:journal) { build_stubbed(:work_package_journal) }
+    let(:field) { "some_field" }
+    let(:values) { [nil, "value"] }
+    let(:formatter) { instance_double(JournalFormatter::Base) }
+
+    before do
+      allow(journal).to receive(:lookup_formatter_config)
+        .with(field)
+        .and_return({ formatter_key: :some_formatter, view_permission: :some_permission })
+      allow(journal).to receive(:formatter_instance)
+        .with(:some_formatter)
+        .and_return(formatter)
+    end
+
+    context "when the formatter grants permission" do
+      before do
+        allow(formatter).to receive(:permission_granted?).with(:some_permission, key: field).and_return(true)
+        allow(formatter).to receive(:render).and_return("rendered detail")
+      end
+
+      it "renders the detail" do
+        expect(journal.render_detail([field, values])).to eq("rendered detail")
+      end
+    end
+
+    context "when the formatter denies permission" do
+      before do
+        allow(formatter).to receive(:permission_granted?).with(:some_permission, key: field).and_return(false)
+      end
+
+      # The denied message itself is JournalFormatter#render_permission_denied_message's
+      # concern (see below), not the formatter's, so #render_detail never calls the
+      # formatter for it.
+      it "renders the permission denied message instead of the detail" do
+        expect(journal.render_detail([field, values]))
+          .to eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
+      end
+
+      it "does not call render" do
+        allow(formatter).to receive(:render)
+
+        journal.render_detail([field, values])
+
+        expect(formatter).not_to have_received(:render)
+      end
+    end
+  end
+
+  describe "#render_permission_denied_message" do
+    let(:journal) { build_stubbed(:work_package_journal) }
+
+    context "with html requested" do
+      it "wraps the message in an em tag" do
+        expect(journal.render_permission_denied_message(html: true))
+          .to eq("<em>#{I18n.t(:text_journal_permission_denied)}</em>")
+      end
+    end
+
+    context "without html requested" do
+      it "wraps the message in underscores" do
+        expect(journal.render_permission_denied_message(html: false))
+          .to eq("_#{I18n.t(:text_journal_permission_denied)}_")
+      end
+    end
+  end
+
   describe "#notifications" do
     let(:work_package) { create(:work_package) }
     let(:journal) { work_package.journals.first }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-385

# What are you trying to accomplish?
Clean up the scattered permission checking and permission denied message rendering from the Formatters and move it to the `JournalFormatter#render_detail`

# What approach did you choose and why?
- [X] Rename `JournalFormatter::CustomFieldPermission` to `JournalFormatter::CustomField::ViewPermission`.
- [X] Simplify routing for the `permission_granted?` method, moved it from the Plain and Diff formatters to the router `JournalFormatter::CustomField`.
- [X] Simplify routing for the `render_permission_denied_message`, move it to the common `JournalFormatter`, because all formatters will use the same message.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
