### PR TITLE
[FND-220][FND-221] Use the standard projects table and tree view component for managing variants

### DIFF
--- a/app/components/projects/settings/work_packages/types/switch_form_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/switch_form_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= component_wrapper do %>
-  <%= primer_form_with(url: switch_path, method: :post) do |form| %>
+  <%= primer_form_with(url:, method: :post) do |form| %>
     <%= render(Primer::Alpha::Dialog::Body.new) do %>
       <%= flex_layout(direction: :column) do |body| %>
         <% body.with_row(mb: 3) do %>

--- a/app/components/work_package_types/projects_tab/add_dialog_component.html.erb
+++ b/app/components/work_package_types/projects_tab/add_dialog_component.html.erb
@@ -27,16 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(
-      Primer::Alpha::Dialog.new(
-        id: DIALOG_ID,
-        title: t("projects.settings.types.switch_dialog.title", type: source.name),
-        size: :medium_portrait
-      )
-    ) do |dialog| %>
+<%= render(Primer::Alpha::Dialog.new(id: dialog_id, title:, size: :medium_portrait)) do |dialog| %>
   <% dialog.with_header(variant: :large) %>
 
-  <%= render(
-        Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(project:, source:, url:)
-      ) %>
+  <% dialog.with_body(classes: "Overlay-body_autocomplete_height") do %>
+    <%= render(WorkPackageTypes::ProjectsTab::AddFormComponent.new(variant:)) %>
+  <% end %>
+
+  <% dialog.with_footer(show_divider: true) do %>
+    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) { t(:button_cancel) } %>
+    <%= render(Primer::Beta::Button.new(scheme: :primary, form: form_id, type: :submit)) { t(:button_add) } %>
+  <% end %>
 <% end %>

--- a/app/components/work_package_types/projects_tab/add_dialog_component.rb
+++ b/app/components/work_package_types/projects_tab/add_dialog_component.rb
@@ -28,42 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
-  module Settings
-    module WorkPackages
-      module Types
-        # The switch dialog's form. Separate from the dialog so a refused switch can replace
-        # it: replacing the dialog component would swap out the <dialog> element and close it.
-        class SwitchFormComponent < ApplicationComponent
-          include OpPrimer::ComponentHelpers
-          include OpTurbo::Streamable
+module WorkPackageTypes
+  module ProjectsTab
+    class AddDialogComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
 
-          # Two places switch a project's variant through the same service, so each names the
-          # route it posts to rather than one of them being the default.
-          def initialize(project:, source:, url:, selected: source, validation_message: nil)
-            super()
+      def initialize(variant:)
+        super()
 
-            @project = project
-            @source = source
-            @url = url
-            @selected = selected
-            @validation_message = validation_message
-          end
-
-          private
-
-          attr_reader :project, :source, :url, :selected, :validation_message
-
-          def available_targets
-            source.type.variants.in_display_order
-          end
-
-          # Constant lookup in a compiled template does not walk the enclosing modules.
-          def dialog_id
-            SwitchDialogComponent::DIALOG_ID
-          end
-        end
+        @variant = variant
       end
+
+      private
+
+      attr_reader :variant
+
+      def dialog_id = AddFormComponent::DIALOG_ID
+
+      def form_id = AddFormComponent::FORM_ID
+
+      def title = I18n.t(:label_add_projects)
     end
   end
 end

--- a/app/components/work_package_types/projects_tab/add_form_component.html.erb
+++ b/app/components/work_package_types/projects_tab/add_form_component.html.erb
@@ -27,16 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(
-      Primer::Alpha::Dialog.new(
-        id: DIALOG_ID,
-        title: t("projects.settings.types.switch_dialog.title", type: source.name),
-        size: :medium_portrait
-      )
-    ) do |dialog| %>
-  <% dialog.with_header(variant: :large) %>
+<%= component_wrapper do %>
+  <%= primer_form_with(**form_arguments) do |form| %>
+    <% if validation_message.present? %>
+      <%= render(Primer::Alpha::Banner.new(scheme: :danger, icon: :alert, mb: 3)) { validation_message } %>
+    <% end %>
 
-  <%= render(
-        Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(project:, source:, url:)
-      ) %>
+    <%= render(WorkPackageTypes::ProjectsTab::AddProjectsForm.new(form, tree_src:)) %>
+  <% end %>
 <% end %>

--- a/app/components/work_package_types/projects_tab/add_form_component.rb
+++ b/app/components/work_package_types/projects_tab/add_form_component.rb
@@ -28,42 +28,37 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
-  module Settings
-    module WorkPackages
-      module Types
-        # The switch dialog's form. Separate from the dialog so a refused switch can replace
-        # it: replacing the dialog component would swap out the <dialog> element and close it.
-        class SwitchFormComponent < ApplicationComponent
-          include OpPrimer::ComponentHelpers
-          include OpTurbo::Streamable
+module WorkPackageTypes
+  module ProjectsTab
+    class AddFormComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
 
-          # Two places switch a project's variant through the same service, so each names the
-          # route it posts to rather than one of them being the default.
-          def initialize(project:, source:, url:, selected: source, validation_message: nil)
-            super()
+      DIALOG_ID = "work-package-type-add-projects-dialog"
+      FORM_ID = "work-package-type-add-projects-form"
+      FIELD_NAME = "project_ids"
 
-            @project = project
-            @source = source
-            @url = url
-            @selected = selected
-            @validation_message = validation_message
-          end
+      def initialize(variant:, validation_message: nil)
+        super()
 
-          private
-
-          attr_reader :project, :source, :url, :selected, :validation_message
-
-          def available_targets
-            source.type.variants.in_display_order
-          end
-
-          # Constant lookup in a compiled template does not walk the enclosing modules.
-          def dialog_id
-            SwitchDialogComponent::DIALOG_ID
-          end
-        end
+        @variant = variant
+        @validation_message = validation_message
       end
+
+      def form_arguments
+        {
+          id: FORM_ID,
+          url: url_helpers.link_type_projects_path(**variant.path_args),
+          method: :post,
+          data: { turbo: true }
+        }
+      end
+
+      private
+
+      attr_reader :variant, :validation_message
+
+      def tree_src = url_helpers.tree_type_projects_path(**variant.path_args, name: FIELD_NAME)
     end
   end
 end

--- a/app/components/work_package_types/projects_tab/row_component.html.erb
+++ b/app/components/work_package_types/projects_tab/row_component.html.erb
@@ -27,16 +27,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(
-      Primer::Alpha::Dialog.new(
-        id: DIALOG_ID,
-        title: t("projects.settings.types.switch_dialog.title", type: source.name),
-        size: :medium_portrait
-      )
-    ) do |dialog| %>
-  <% dialog.with_header(variant: :large) %>
+<%= component_wrapper(tag: "tr", class: row_css_class) do %>
+  <% columns.each do |column| %>
+    <td class="<%= column_css_class(column) %>">
+      <%= column_value(column) %>
+    </td>
+  <% end %>
 
-  <%= render(
-        Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(project:, source:, url:)
-      ) %>
+  <td class="buttons">
+    <% button_links.each do |link| %>
+      <%= link %>
+    <% end %>
+  </td>
 <% end %>

--- a/app/components/work_package_types/projects_tab/row_component.rb
+++ b/app/components/work_package_types/projects_tab/row_component.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module ProjectsTab
+    class RowComponent < ::Projects::RowComponent
+      include OpTurbo::Streamable
+
+      def wrapper_uniq_by
+        "project-#{project.id}"
+      end
+
+      def menu_items
+        @menu_items ||= [switch_variant_item, remove_item].compact
+      end
+
+      private
+
+      def variant = @table.variant
+
+      def switch_variant_item
+        return unless variant.type.variants.many?
+
+        {
+          scheme: :default,
+          icon: :"list-ordered",
+          label: I18n.t("types.edit.projects.actions.switch_variant"),
+          href: url_helpers.new_switch_type_projects_path(**variant.path_args, project_id: project.id),
+          data: { controller: "async-dialog" }
+        }
+      end
+
+      def remove_item
+        {
+          scheme: :danger,
+          icon: :trash,
+          label: I18n.t("types.edit.projects.actions.remove_from_project"),
+          href: url_helpers.unlink_type_projects_path(**variant.path_args,
+                                                      project_id: project.id,
+                                                      page: current_page),
+          data: { turbo_method: :delete, turbo_confirm: confirm_removal }
+        }
+      end
+
+      def confirm_removal
+        I18n.t("types.edit.projects.actions.confirm_remove",
+               project: project.name,
+               type: variant.type.name)
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/projects_tab/sub_header_component.html.erb
+++ b/app/components/work_package_types/projects_tab/sub_header_component.html.erb
@@ -27,17 +27,32 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
+<%= component_wrapper do %>
+  <%= render(Primer::OpenProject::SubHeader.new(test_selector: "type-projects-sub-header")) do |sub_header| %>
+    <%
+      sub_header.with_action_button(
+        scheme: :primary,
+        leading_icon: :"op-include-projects",
+        label: t(:label_add_projects),
+        tag: :a,
+        href: add_path,
+        test_selector: "type-projects-add-button",
+        data: { controller: "async-dialog" }
+      ) { t(:label_add_projects) }
+    %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, variant: @variant, tabs: types_tabs) %>
-
-<%= render(WorkPackageTypes::ProjectsTab::SubHeaderComponent.new(variant: @variant)) %>
-
-<%=
-  render(
-    WorkPackageTypes::ProjectsTab::TableComponent.new(
-      query: @query,
-      params: params.merge(variant: @variant, url_for_action: :edit)
-    )
-  )
-%>
+    <% if toggle_all_available? %>
+      <%
+        sub_header.with_action_button(
+          scheme: :secondary,
+          tag: :a,
+          label: toggle_all_label,
+          leading_icon: toggle_all_icon,
+          href: toggle_all_path,
+          test_selector: "type-projects-enable-all",
+          data: { turbo_method: :post, turbo_stream: true }
+        ) { toggle_all_label }
+      %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/work_package_types/projects_tab/sub_header_component.rb
+++ b/app/components/work_package_types/projects_tab/sub_header_component.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module ProjectsTab
+    class SubHeaderComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
+
+      def initialize(variant:)
+        super()
+
+        @variant = variant
+      end
+
+      private
+
+      attr_reader :variant
+
+      def add_path = url_helpers.new_link_type_projects_path(**variant.path_args)
+
+      def toggle_all_path
+        url_helpers.enable_all_type_projects_path(**variant.path_args, value: enabled_everywhere? ? "0" : "1")
+      end
+
+      def toggle_all_label
+        enabled_everywhere? ? I18n.t("types.edit.projects.disable_all") : I18n.t("types.edit.projects.enable_all")
+      end
+
+      def toggle_all_icon = enabled_everywhere? ? :"x-circle" : :"check-circle"
+
+      def toggle_all_available? = variant.default?
+
+      def enabled_everywhere?
+        return @enabled_everywhere unless @enabled_everywhere.nil?
+
+        @enabled_everywhere = ProjectType.where(variant_id: variant.id).count == ::Project.count
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/projects_tab/table_component.rb
+++ b/app/components/work_package_types/projects_tab/table_component.rb
@@ -28,41 +28,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
-  module Settings
-    module WorkPackages
-      module Types
-        # The switch dialog's form. Separate from the dialog so a refused switch can replace
-        # it: replacing the dialog component would swap out the <dialog> element and close it.
-        class SwitchFormComponent < ApplicationComponent
-          include OpPrimer::ComponentHelpers
-          include OpTurbo::Streamable
+module WorkPackageTypes
+  module ProjectsTab
+    class TableComponent < ::Projects::TableComponent
+      include ::Projects::Concerns::TableComponent::StreamablePaginationLinksConstraints
 
-          # Two places switch a project's variant through the same service, so each names the
-          # route it posts to rather than one of them being the default.
-          def initialize(project:, source:, url:, selected: source, validation_message: nil)
-            super()
+      def columns
+        @columns ||= query.selects.grep_v(Queries::Selects::NotExistingSelect)
+      end
 
-            @project = project
-            @source = source
-            @url = url
-            @selected = selected
-            @validation_message = validation_message
-          end
+      def sortable? = false
 
-          private
+      def use_quick_action_table_headers? = false
 
-          attr_reader :project, :source, :url, :selected, :validation_message
+      def variant = params[:variant]
 
-          def available_targets
-            source.type.variants.in_display_order
-          end
-
-          # Constant lookup in a compiled template does not walk the enclosing modules.
-          def dialog_id
-            SwitchDialogComponent::DIALOG_ID
-          end
-        end
+      def empty_row_message
+        I18n.t("types.edit.projects.empty_state.description")
       end
     end
   end

--- a/app/components/work_package_types/projects_tab/tree_component.html.erb
+++ b/app/components/work_package_types/projects_tab/tree_component.html.erb
@@ -27,16 +27,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(
-      Primer::Alpha::Dialog.new(
-        id: DIALOG_ID,
-        title: t("projects.settings.types.switch_dialog.title", type: source.name),
-        size: :medium_portrait
-      )
-    ) do |dialog| %>
-  <% dialog.with_header(variant: :large) %>
-
-  <%= render(
-        Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(project:, source:, url:)
-      ) %>
-<% end %>
+<%=
+  render(
+    Primer::Alpha::TreeView.new(
+      form_arguments: { builder:, name: form_name },
+      data: { target: "filterable-tree-view.treeViewList" }
+    )
+  ) do |tree_view|
+    build_tree(tree_view)
+  end
+%>

--- a/app/components/work_package_types/projects_tab/tree_component.rb
+++ b/app/components/work_package_types/projects_tab/tree_component.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  module ProjectsTab
+    class TreeComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+
+      def initialize(variant:, nodes:, builder:, form_name:)
+        super()
+
+        @variant = variant
+        @nodes = nodes
+        @builder = builder
+        @form_name = form_name
+      end
+
+      def build_tree(tree)
+        add_sub_tree(tree, @nodes)
+      end
+
+      private
+
+      attr_reader :variant, :nodes, :builder, :form_name
+
+      def add_sub_tree(parent, level)
+        level.each do |node|
+          if node[:children].any?
+            parent.with_sub_tree(**item_options(node[:project])) do |sub_tree|
+              add_sub_tree(sub_tree, node[:children])
+            end
+          else
+            parent.with_leaf(**item_options(node[:project]))
+          end
+        end
+      end
+
+      def item_options(project)
+        {
+          label: label_for(project),
+          select_variant: :multiple,
+          disabled: applied_variants[project.id] == variant,
+          expanded: true,
+          data: { node_id: project.id }
+        }
+      end
+
+      def label_for(project)
+        applied = applied_variants[project.id]
+        return project.name if applied.nil? || applied == variant
+
+        render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :center)) do
+          safe_join([project.name, render(Primer::Beta::Label.new(scheme: :secondary, ml: 2)) { applied.composite_name }])
+        end
+      end
+
+      def applied_variants
+        @applied_variants ||= ProjectType
+                                .where(type_id: variant.type_id, project_id: project_ids)
+                                .includes(:variant)
+                                .to_h { |project_type| [project_type.project_id, project_type.variant] }
+      end
+
+      def project_ids
+        flatten(nodes).map(&:id)
+      end
+
+      def flatten(level)
+        level.flat_map { |node| [node[:project], *flatten(node[:children])] }
+      end
+    end
+  end
+end

--- a/app/components/work_package_types/projects_tab/tree_component.rb
+++ b/app/components/work_package_types/projects_tab/tree_component.rb
@@ -53,7 +53,7 @@ module WorkPackageTypes
       def add_sub_tree(parent, level)
         level.each do |node|
           if node[:children].any?
-            parent.with_sub_tree(**item_options(node[:project])) do |sub_tree|
+            parent.with_sub_tree(select_strategy: :self, **item_options(node[:project])) do |sub_tree|
               add_sub_tree(sub_tree, node[:children])
             end
           else

--- a/app/controllers/concerns/work_package_types/type_deactivation_error_message.rb
+++ b/app/controllers/concerns/work_package_types/type_deactivation_error_message.rb
@@ -5,25 +5,29 @@ module WorkPackageTypes::TypeDeactivationErrorMessage
 
   private
 
-  def type_deactivation_error_messages(types, project_ids:)
-    types.map do |type|
-      type_deactivation_error_message(type, project_ids:)
+  def type_deactivation_error_messages(variants, project_ids:)
+    projects = visible_projects(project_ids)
+
+    messages = Array(variants).flat_map do |variant|
+      projects.map { |project| type_deactivation_error_message(variant, project:) }
     end
+
+    messages << I18n.t(:error_can_not_deactivate_type_invisible_projects) if hidden_any?(project_ids, projects)
+
+    messages
   end
 
-  def type_deactivation_error_message(type, project_ids:)
-    project_ids = Array(project_ids)
-    visible_project_ids = visible_project_ids(project_ids)
-
+  def type_deactivation_error_message(variant, project:)
     helpers.sanitize(
       I18n.t(:error_can_not_deactivate_type,
-             type: type.name,
+             name: variant.composite_name,
+             project: project.name,
              work_packages_link: helpers.link_to(
                I18n.t(:label_work_package_plural).downcase,
-               affected_work_packages_path(type, project_ids: visible_project_ids),
+               affected_work_packages_path(variant.type, project_ids: [project.id]),
                target: "_blank",
                rel: "noopener"
-             )) + invisible_projects_message(project_ids, visible_project_ids),
+             )),
       attributes: %w[href target rel]
     )
   end
@@ -35,16 +39,11 @@ module WorkPackageTypes::TypeDeactivationErrorMessage
     work_packages_path query_props: { f: filters }.to_json
   end
 
-  def visible_project_ids(project_ids)
-    Project
-      .visible
-      .where(id: project_ids)
-      .pluck(:id)
+  def visible_projects(project_ids)
+    Project.visible.where(id: Array(project_ids))
   end
 
-  def invisible_projects_message(project_ids, visible_project_ids)
-    return "" unless project_ids.size > visible_project_ids.size
-
-    " #{I18n.t(:error_can_not_deactivate_type_invisible_projects)}"
+  def hidden_any?(project_ids, visible)
+    Array(project_ids).size > visible.size
   end
 end

--- a/app/controllers/concerns/work_package_types/type_deactivation_error_message.rb
+++ b/app/controllers/concerns/work_package_types/type_deactivation_error_message.rb
@@ -19,7 +19,7 @@ module WorkPackageTypes::TypeDeactivationErrorMessage
 
   def type_deactivation_error_message(variant, project:)
     helpers.sanitize(
-      I18n.t(:error_can_not_deactivate_type,
+      I18n.t(:error_can_not_remove_type_from_project,
              name: variant.composite_name,
              project: project.name,
              work_packages_link: helpers.link_to(

--- a/app/controllers/projects/settings/work_packages/types/switches_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/switches_controller.rb
@@ -39,7 +39,7 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
 
   def new
     respond_with_dialog Projects::Settings::WorkPackages::Types::SwitchDialogComponent
-                          .new(project: @project, source: @source)
+                          .new(project: @project, source: @source, url: switch_path)
   end
 
   def create
@@ -78,9 +78,13 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
 
     update_via_turbo_stream(
       component: Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(
-        project: @project, source: @source, selected: target || @source, validation_message: message
+        project: @project, source: @source, url: switch_path, selected: target || @source, validation_message: message
       )
     )
+  end
+
+  def switch_path
+    project_settings_work_packages_type_switch_path(@project, @source.type)
   end
 
   # Reload so the repainted list no longer sees the association's cached types.

--- a/app/controllers/projects/settings/work_packages/types_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types_controller.rb
@@ -79,7 +79,7 @@ class Projects::Settings::WorkPackages::TypesController < Projects::SettingsCont
     result.on_failure do
       render_error_flash_message_via_turbo_stream(
         message: join_flash_messages(
-          type_deactivation_error_messages(::Type.where(id: variant.type_id), project_ids: [@project.id])
+          type_deactivation_error_messages(variant, project_ids: [@project.id])
         )
       )
     end
@@ -93,7 +93,7 @@ class Projects::Settings::WorkPackages::TypesController < Projects::SettingsCont
     if UpdateProjectsTypesService.new(@project).call(type_ids)
       flash[:notice] = success_message
     else
-      flash[:error] = type_deactivation_error_messages(types_missing_from(type_ids), project_ids: [@project.id])
+      flash[:error] = type_deactivation_error_messages(variants_missing_from(type_ids), project_ids: [@project.id])
     end
 
     redirect_to project_settings_types_path(@project.identifier)
@@ -121,9 +121,10 @@ class Projects::Settings::WorkPackages::TypesController < Projects::SettingsCont
     )
   end
 
-  def types_missing_from(type_ids)
+  def variants_missing_from(type_ids)
     @project
       .types_used_by_work_packages
       .where.not(id: type_ids.presence)
+      .map { |type| @project.type_variant(type) }
   end
 end

--- a/app/controllers/work_package_types/projects_tab_controller.rb
+++ b/app/controllers/work_package_types/projects_tab_controller.rb
@@ -40,8 +40,6 @@ module WorkPackageTypes
       :types
     end
 
-    helper_method :enabled_everywhere?, :enable_all_label
-
     def edit; end
 
     def update
@@ -122,22 +120,13 @@ module WorkPackageTypes
                end
 
       refresh_table
+      replace_via_turbo_stream(component: ProjectsTab::SubHeaderComponent.new(variant: @variant))
       result.on_failure { render_error_flash_message_via_turbo_stream(message: aggregate_refusal_message(result)) }
 
       respond_to_with_turbo_streams(status: result)
     end
 
     private
-
-    def enabled_everywhere?
-      return @enabled_everywhere unless @enabled_everywhere.nil?
-
-      @enabled_everywhere = @variant.projects.count == ::Project.count
-    end
-
-    def enable_all_label
-      enabled_everywhere? ? I18n.t("types.edit.projects.disable_all") : I18n.t("types.edit.projects.enable_all")
-    end
 
     def load_query
       @query = ProjectQuery.new(name: "work-package-type-variant-projects-#{@variant.id}") do |query|

--- a/app/controllers/work_package_types/projects_tab_controller.rb
+++ b/app/controllers/work_package_types/projects_tab_controller.rb
@@ -72,7 +72,7 @@ module WorkPackageTypes
       result = apply_to(projects)
 
       close_dialog_via_turbo_stream("##{ProjectsTab::AddFormComponent::DIALOG_ID}")
-      refresh_table
+      refresh_projects
 
       if result.success?
         render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
@@ -88,7 +88,7 @@ module WorkPackageTypes
                  .new(user: current_user, model: @linked_project)
                  .call(variant: @variant)
 
-      result.on_success { refresh_table }
+      result.on_success { refresh_projects }
       result.on_failure { render_error_flash_message_via_turbo_stream(message: removal_refusal_message(result)) }
 
       respond_to_with_turbo_streams(status: result)
@@ -119,8 +119,7 @@ module WorkPackageTypes
                  remove_from(@variant.projects)
                end
 
-      refresh_table
-      replace_via_turbo_stream(component: ProjectsTab::SubHeaderComponent.new(variant: @variant))
+      refresh_projects
       result.on_failure { render_error_flash_message_via_turbo_stream(message: aggregate_refusal_message(result)) }
 
       respond_to_with_turbo_streams(status: result)
@@ -191,7 +190,7 @@ module WorkPackageTypes
       close_dialog_via_turbo_stream(
         "##{::Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}"
       )
-      refresh_table
+      refresh_projects
       render_success_flash_message_via_turbo_stream(
         message: I18n.t("projects.settings.types.switch_dialog.success", type: target.composite_name)
       )
@@ -212,12 +211,13 @@ module WorkPackageTypes
       )
     end
 
-    def refresh_table
+    def refresh_projects
       update_via_turbo_stream(
         component: ProjectsTab::TableComponent.new(
           query: @query, params: params.merge(variant: @variant, url_for_action: :edit)
         )
       )
+      replace_via_turbo_stream(component: ProjectsTab::SubHeaderComponent.new(variant: @variant))
     end
 
     def refuse_empty_selection

--- a/app/controllers/work_package_types/projects_tab_controller.rb
+++ b/app/controllers/work_package_types/projects_tab_controller.rb
@@ -33,11 +33,14 @@ module WorkPackageTypes
     include OpTurbo::ComponentStream
     include TypeDeactivationErrorMessage
 
-    before_action :load_projects, only: %i[edit enable_all_projects]
+    before_action :load_query, only: %i[edit update link unlink switch enable_all_projects]
+    before_action :load_linked_project, only: %i[unlink new_switch switch]
 
     current_menu_item [:edit, :update] do
       :types
     end
+
+    helper_method :enabled_everywhere?, :enable_all_label
 
     def edit; end
 
@@ -47,91 +50,238 @@ module WorkPackageTypes
       if result.success?
         redirect_to edit_type_projects_path(**@variant.path_args), notice: I18n.t(:notice_successful_update)
       else
-        flash_error(result, desired_project_ids)
-        load_projects
+        flash.now[:error] = aggregate_refusal_message(result)
         render :edit, status: :unprocessable_entity
       end
     end
 
-    def enable_all_projects
-      desired = params[:value] == "1" ? @projects.pluck(:id) : []
-      result = sync_projects(desired)
+    def new_link
+      respond_with_dialog ProjectsTab::AddDialogComponent.new(variant: @variant)
+    end
+
+    def tree
+      render ProjectsTab::TreeComponent.new(variant: @variant,
+                                            nodes: ::Project.build_projects_hierarchy(candidate_projects),
+                                            builder: tree_form_builder,
+                                            form_name: params[:name]),
+             layout: false
+    end
+
+    def link
+      projects = ::Project.where(id: selected_project_ids)
+      return refuse_empty_selection if projects.empty?
+
+      result = apply_to(projects)
+
+      close_dialog_via_turbo_stream("##{ProjectsTab::AddFormComponent::DIALOG_ID}")
+      refresh_table
 
       if result.success?
-        replace_via_turbo_stream(component: ProjectsComponent.new(@type, variant: @variant, projects: @projects))
-        respond_with_turbo_streams
+        render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
       else
-        flash_error(result, desired)
-        render :edit, status: :unprocessable_entity
+        render_error_flash_message_via_turbo_stream(message: aggregate_refusal_message(result))
       end
+
+      respond_to_with_turbo_streams(status: result)
+    end
+
+    def unlink
+      result = ::Projects::Types::RemoveService
+                 .new(user: current_user, model: @linked_project)
+                 .call(variant: @variant)
+
+      result.on_success { refresh_table }
+      result.on_failure { render_error_flash_message_via_turbo_stream(message: removal_refusal_message(result)) }
+
+      respond_to_with_turbo_streams(status: result)
+    end
+
+    def new_switch
+      respond_with_dialog ::Projects::Settings::WorkPackages::Types::SwitchDialogComponent.new(
+        project: @linked_project, source: @variant, url: switch_path
+      )
+    end
+
+    def switch
+      target = @type.variants.find_by(id: params[:target_id])
+      result = ::Projects::Types::SwitchVariantService
+                 .new(user: current_user, model: @linked_project)
+                 .call(source: @variant, target:)
+
+      result.on_success { on_switched(target) }
+      result.on_failure { on_switch_refused(target, result) }
+
+      respond_to_with_turbo_streams(status: result)
+    end
+
+    def enable_all_projects
+      result = if params[:value] == "1"
+                 apply_to(::Project.where.not(id: @variant.projects.select(:id)))
+               else
+                 remove_from(@variant.projects)
+               end
+
+      refresh_table
+      result.on_failure { render_error_flash_message_via_turbo_stream(message: aggregate_refusal_message(result)) }
+
+      respond_to_with_turbo_streams(status: result)
     end
 
     private
 
-    # Updates one project at a time through Projects::Types
-    #
-    # A checked project is applying this variant, resulting in three cases:
-    # 1. Adding a new type with this variant
-    # 2. Switching another variant
-    # 3. Removing when unchecked (only possible if no work packages exist)
+    def enabled_everywhere?
+      return @enabled_everywhere unless @enabled_everywhere.nil?
+
+      @enabled_everywhere = @variant.projects.count == ::Project.count
+    end
+
+    def enable_all_label
+      enabled_everywhere? ? I18n.t("types.edit.projects.disable_all") : I18n.t("types.edit.projects.enable_all")
+    end
+
+    def load_query
+      @query = ProjectQuery.new(name: "work-package-type-variant-projects-#{@variant.id}") do |query|
+        query.where(:type_variant_id, "=", [@variant.id.to_s])
+        query.select(:name)
+        query.order("lft" => "asc")
+      end
+    end
+
+    def load_linked_project
+      @linked_project = ::Project.find(params.expect(:project_id))
+    end
+
+    def switch_path
+      switch_type_projects_path(**@variant.path_args, project_id: @linked_project.id)
+    end
+
     def sync_projects(desired)
       applying = @variant.projects.pluck(:id)
-      using_type = @type.projects.pluck(:id)
 
-      ServiceResult.success(result: @type).tap do |aggregated|
-        add_variant(aggregated, desired - using_type)
-        switch_variant(aggregated, (desired & using_type) - applying)
-        remove_type(aggregated, applying - desired)
+      new_aggregate.tap do |aggregated|
+        apply_to(::Project.where(id: desired - applying), into: aggregated)
+        remove_from(::Project.where(id: applying - desired), into: aggregated)
       end
     end
 
-    def add_variant(aggregated, project_ids)
-      apply(aggregated, project_ids) do |project|
+    def apply_to(projects, into: new_aggregate)
+      projects.find_each { |project| into.add_dependent!(add_or_switch(project)) }
+
+      into
+    end
+
+    def add_or_switch(project)
+      applied = applied_variant_of(project)
+
+      if applied.nil?
         ::Projects::Types::AddService.new(user: current_user, model: project).call(variant: @variant)
-      end
-    end
-
-    def switch_variant(aggregated, project_ids)
-      apply(aggregated, project_ids) do |project|
+      elsif applied == @variant
+        ServiceResult.success(result: project)
+      else
         ::Projects::Types::SwitchVariantService
           .new(user: current_user, model: project)
-          .call(source: project.type_variant(@type), target: @variant)
+          .call(source: applied, target: @variant)
       end
     end
 
-    def remove_type(aggregated, project_ids)
-      apply(aggregated, project_ids) do |project|
-        ::Projects::Types::RemoveService.new(user: current_user, model: project).call(variant: @variant)
+    def applied_variant_of(project)
+      project.project_types.find_by(type_id: @type.id)&.variant
+    end
+
+    def remove_from(projects, into: new_aggregate)
+      projects.find_each do |project|
+        into.add_dependent!(::Projects::Types::RemoveService.new(user: current_user, model: project).call(variant: @variant))
       end
+
+      into
     end
 
-    def apply(aggregated, project_ids)
-      Project.where(id: project_ids).find_each do |project|
-        aggregated.add_dependent!(yield(project))
-      end
+    def new_aggregate = ServiceResult.success(result: @variant)
+
+    def on_switched(target)
+      close_dialog_via_turbo_stream(
+        "##{::Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID}"
+      )
+      refresh_table
+      render_success_flash_message_via_turbo_stream(
+        message: I18n.t("projects.settings.types.switch_dialog.success", type: target.composite_name)
+      )
     end
 
-    def flash_error(result, project_ids)
-      deactivated_project_ids = deactivated_project_ids_with_work_packages(project_ids)
+    def on_switch_refused(target, result)
+      message = result.errors.messages_for(:types).first
+      return if message.blank?
 
-      flash.now[:error] = if deactivated_project_ids.any?
-                            type_deactivation_error_message(@type, project_ids: deactivated_project_ids)
-                          else
-                            project_error_messages(result)
-                          end
+      update_via_turbo_stream(
+        component: ::Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(
+          project: @linked_project,
+          source: @variant,
+          selected: target || @variant,
+          validation_message: message,
+          url: switch_path
+        )
+      )
     end
 
-    # The services report against the project they were called on, so the project has to be named
-    # for the message to be actionable when several were submitted at once.
-    def project_error_messages(result)
-      result.dependent_results
-            .reject(&:success?)
-            .map { |failed| "#{failed.result.name}: #{failed.errors.full_messages.to_sentence}" }
-            .to_sentence
+    def refresh_table
+      update_via_turbo_stream(
+        component: ProjectsTab::TableComponent.new(
+          query: @query, params: params.merge(variant: @variant, url_for_action: :edit)
+        )
+      )
     end
 
-    def load_projects
-      @projects = Project.all
+    def refuse_empty_selection
+      update_via_turbo_stream(
+        component: ProjectsTab::AddFormComponent.new(
+          variant: @variant,
+          validation_message: I18n.t("types.edit.projects.add_dialog.no_projects_selected")
+        ),
+        status: :bad_request
+      )
+      respond_with_turbo_streams
+    end
+
+    def tree_form_builder
+      ActionView::Helpers::FormBuilder.new("", nil, view_context, {})
+    end
+
+    def candidate_projects
+      scope = ::Project.order(:lft)
+      return scope.to_a if filter_term.blank?
+
+      matching = scope.where("LOWER(projects.name) LIKE LOWER(?)", "%#{sanitized_filter_term}%")
+      (matching.to_a + ancestors_of(matching)).uniq(&:id).sort_by(&:lft)
+    end
+
+    def ancestors_of(projects)
+      return [] if projects.empty?
+
+      ::Project.where(
+        "EXISTS (SELECT 1 FROM projects descendants WHERE descendants.id IN (:ids) " \
+        "AND projects.lft < descendants.lft AND projects.rgt > descendants.rgt)",
+        ids: projects.map(&:id)
+      ).to_a
+    end
+
+    def filter_term = params[:query].to_s.strip
+
+    def sanitized_filter_term = ActiveRecord::Base.sanitize_sql_like(filter_term)
+
+    def selected_project_ids
+      ids = Array(params[ProjectsTab::AddFormComponent::FIELD_NAME]).filter_map { |node| node_id_from(node) }
+
+      params[:include_sub_items] == "1" ? with_descendants(ids) : ids
+    end
+
+    def node_id_from(payload)
+      JSON.parse(payload)["nodeId"].presence&.to_i
+    rescue JSON::ParserError, TypeError
+      nil
+    end
+
+    def with_descendants(project_ids)
+      ::Project.where(id: project_ids).flat_map { |project| project.self_and_descendants.ids }.uniq
     end
 
     # TODO: once the input is correctly delivered, read params.expect(type: [:project_ids])
@@ -141,13 +291,29 @@ module WorkPackageTypes
         Array(JSON.parse(params.expect(type: [:project_ids])[:project_ids])).compact_blank.map(&:to_i)
     end
 
-    def deactivated_project_ids_with_work_packages(desired)
-      deactivated_project_ids = @variant.projects.pluck(:id) - desired
+    def aggregate_refusal_message(result)
+      refused = result.dependent_results.reject(&:success?)
+      blocked = blocked_project_ids(refused.map { |failed| failed.result.id })
 
-      WorkPackage
-        .where(type_id: @type.id, project_id: deactivated_project_ids)
-        .distinct
-        .pluck(:project_id)
+      return blocked_message(blocked) if blocked.any?
+
+      refused.map { |failed| "#{failed.result.name}: #{failed.errors.full_messages.to_sentence}" }.to_sentence
     end
+
+    def blocked_message(project_ids)
+      helpers.join_flash_messages(type_deactivation_error_messages(@variant, project_ids:))
+    end
+
+    def removal_refusal_message(result)
+      return type_deactivation_error_message(@variant, project: @linked_project) if blocked?(@linked_project)
+
+      "#{@linked_project.name}: #{result.errors.full_messages.to_sentence}"
+    end
+
+    def blocked_project_ids(project_ids)
+      WorkPackage.where(type_id: @type.id, project_id: project_ids).distinct.pluck(:project_id)
+    end
+
+    def blocked?(project) = WorkPackage.exists?(type_id: @type.id, project_id: project.id)
   end
 end

--- a/app/forms/work_package_types/projects_tab/add_projects_form.rb
+++ b/app/forms/work_package_types/projects_tab/add_projects_form.rb
@@ -28,41 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
-  module Settings
-    module WorkPackages
-      module Types
-        # The switch dialog's form. Separate from the dialog so a refused switch can replace
-        # it: replacing the dialog component would swap out the <dialog> element and close it.
-        class SwitchFormComponent < ApplicationComponent
-          include OpPrimer::ComponentHelpers
-          include OpTurbo::Streamable
+module WorkPackageTypes
+  module ProjectsTab
+    class AddProjectsForm < ApplicationForm
+      form do |form|
+        form.filterable_tree_view(
+          name: AddFormComponent::FIELD_NAME,
+          label: Project.model_name.human(count: 2),
+          visually_hide_label: true,
+          src: @tree_src,
+          filter_input_arguments: { placeholder: I18n.t("types.edit.projects.add_dialog.search_placeholder") },
+          no_results_node_arguments: { label: I18n.t("filterable_tree_view.no_results_text") }
+        )
+      end
 
-          # Two places switch a project's variant through the same service, so each names the
-          # route it posts to rather than one of them being the default.
-          def initialize(project:, source:, url:, selected: source, validation_message: nil)
-            super()
+      def initialize(tree_src:)
+        super()
 
-            @project = project
-            @source = source
-            @url = url
-            @selected = selected
-            @validation_message = validation_message
-          end
-
-          private
-
-          attr_reader :project, :source, :url, :selected, :validation_message
-
-          def available_targets
-            source.type.variants.in_display_order
-          end
-
-          # Constant lookup in a compiled template does not walk the enclosing modules.
-          def dialog_id
-            SwitchDialogComponent::DIALOG_ID
-          end
-        end
+        @tree_src = tree_src
       end
     end
   end

--- a/app/views/work_package_types/projects_tab/edit.html.erb
+++ b/app/views/work_package_types/projects_tab/edit.html.erb
@@ -31,4 +31,39 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, variant: @variant, tabs: types_tabs) %>
 
-<%= render WorkPackageTypes::ProjectsComponent.new(@type, variant: @variant, projects: @projects) %>
+<%= render(Primer::OpenProject::SubHeader.new(test_selector: "type-projects-sub-header")) do |sub_header| %>
+  <%
+    sub_header.with_action_button(
+      scheme: :primary,
+      leading_icon: :"op-include-projects",
+      label: t(:label_add_projects),
+      tag: :a,
+      href: new_link_type_projects_path(**@variant.path_args),
+      test_selector: "type-projects-add-button",
+      data: { controller: "async-dialog" }
+    ) { t(:label_add_projects) }
+  %>
+
+  <% if @variant.default? %>
+    <%
+      sub_header.with_action_button(
+        scheme: :secondary,
+        tag: :a,
+        label: enable_all_label,
+        leading_icon: enabled_everywhere? ? :"x-circle" : :"check-circle",
+        href: enable_all_type_projects_path(**@variant.path_args, value: enabled_everywhere? ? "0" : "1"),
+        test_selector: "type-projects-enable-all",
+        data: { turbo_method: :post, turbo_stream: true }
+      ) { enable_all_label }
+    %>
+  <% end %>
+<% end %>
+
+<%=
+  render(
+    WorkPackageTypes::ProjectsTab::TableComponent.new(
+      query: @query,
+      params: params.merge(variant: @variant, url_for_action: :edit)
+    )
+  )
+%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,6 +267,7 @@ en:
         templated_value:
           false: "unmarked as template"
           true: "marked as template"
+        type_variant: "Work package type variant"
         types: "Types"
         versions: "Versions"
         work_packages: "Work Packages"
@@ -2654,7 +2655,7 @@ en:
 
   error_auth_source_sso_failed: "Single Sign-On (SSO) for user '%{value}' failed"
   error_can_not_archive_project: "This project cannot be archived: %{errors}"
-  error_can_not_deactivate_type: "Unable to deactivate type %{type} because it's still in use by %{work_packages_link}"
+  error_can_not_deactivate_type: "Unable to remove \"%{name}\" from project \"%{project}\" because it's still in use by %{work_packages_link}"
   error_can_not_deactivate_type_invisible_projects: "There are also work packages in projects you cannot see."
   error_can_not_delete_custom_field: "Unable to delete custom field"
   error_can_not_delete_entry: "Unable to delete entry"
@@ -6300,6 +6301,16 @@ en:
         filter: "Search by section or name"
         tab: "Project attributes"
       projects:
+        actions:
+          confirm_remove: "Remove the type %{type} from %{project}?"
+          remove_from_project: "Remove from project"
+          switch_variant: "Change variant"
+        add_dialog:
+          no_projects_selected: "Please select at least one project."
+          search_placeholder: "Search projects"
+        disable_all: Disable for all projects
+        empty_state:
+          description: Add a project to use this configuration there.
         enable_all: Enable for all projects
         select_projects: Select projects
         select_projects_description: Select the projects in which you would like to use this type.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2655,7 +2655,6 @@ en:
 
   error_auth_source_sso_failed: "Single Sign-On (SSO) for user '%{value}' failed"
   error_can_not_archive_project: "This project cannot be archived: %{errors}"
-  error_can_not_deactivate_type: "Unable to remove \"%{name}\" from project \"%{project}\" because it's still in use by %{work_packages_link}"
   error_can_not_deactivate_type_invisible_projects: "There are also work packages in projects you cannot see."
   error_can_not_delete_custom_field: "Unable to delete custom field"
   error_can_not_delete_entry: "Unable to delete entry"
@@ -2666,6 +2665,7 @@ en:
   error_can_not_find_all_resources: "Could not find all related resources to this request."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."
+  error_can_not_remove_type_from_project: "Unable to remove \"%{name}\" from project \"%{project}\" because it's still in use by %{work_packages_link}"
   error_can_not_reopen_work_package_on_closed_version: "A work package assigned to a closed version cannot be reopened"
   error_can_not_unarchive_project: "This project cannot be unarchived: %{errors}"
   error_check_user_and_role: "Please choose a user and a role."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,9 +169,17 @@ Rails.application.routes.draw do
     # the type member rather than in front of it.
     nested do
       scope "(variants/:variant_id)" do
-        resource :projects, controller: "projects_tab", only: %i[update edit] do
+        resource :projects, controller: "projects_tab", only: %i[edit update] do
           collection do
             post :enable_all, to: "projects_tab#enable_all_projects"
+
+            get :new_link
+            get :tree
+            post :link
+            delete :unlink
+
+            get :new_switch
+            post :switch
           end
         end
 

--- a/spec/components/work_package_types/projects_tab/add_dialog_component_spec.rb
+++ b/spec/components/work_package_types/projects_tab/add_dialog_component_spec.rb
@@ -28,30 +28,37 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
-  module Settings
-    module WorkPackages
-      module Types
-        # Moves a project from the family member it uses now to another one.
-        class SwitchDialogComponent < ApplicationComponent
-          include OpPrimer::ComponentHelpers
-          include OpTurbo::Streamable
+require "rails_helper"
 
-          DIALOG_ID = "project-types-switch-dialog"
+RSpec.describe WorkPackageTypes::ProjectsTab::AddDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
 
-          def initialize(project:, source:, url:)
-            super()
+  shared_let(:type) { create(:type) }
 
-            @project = project
-            @source = source
-            @url = url
-          end
+  let(:variant) { type.default_variant }
 
-          private
+  before { render_inline(described_class.new(variant:)) }
 
-          attr_reader :project, :source, :url
-        end
-      end
-    end
+  it "keeps the form inside the body, with the footer outside it" do
+    expect(page).to have_css(".Overlay-body form##{WorkPackageTypes::ProjectsTab::AddFormComponent::FORM_ID}")
+    expect(page).to have_no_css(".Overlay-footer form")
+  end
+
+  it "submits that form from the footer by id" do
+    expect(page).to have_css(
+      ".Overlay-footer button[type=submit][form='#{WorkPackageTypes::ProjectsTab::AddFormComponent::FORM_ID}']"
+    )
+  end
+
+  it "posts to the variant's link action" do
+    expect(page).to have_css("form[action='#{link_type_projects_path(**variant.path_args)}']")
+  end
+
+  it "names the tree's form field after the field the controller expects" do
+    expect(page).to have_css(
+      "input[data-target='tree-view.formInputPrototype']" \
+      "[name='#{WorkPackageTypes::ProjectsTab::AddFormComponent::FIELD_NAME}[]']",
+      visible: :all
+    )
   end
 end

--- a/spec/components/work_package_types/projects_tab/tree_component_spec.rb
+++ b/spec/components/work_package_types/projects_tab/tree_component_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::ProjectsTab::TreeComponent, type: :component do
+  shared_let(:type) { create(:type) }
+  shared_let(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
+  shared_let(:other_variant) { create(:type_variant, type:, variant_name: "Firmware") }
+
+  let(:builder) { ActionView::Helpers::FormBuilder.new("", nil, vc_test_controller.view_context, {}) }
+
+  def render_tree(projects)
+    render_inline(
+      described_class.new(variant:,
+                          nodes: Project.build_projects_hierarchy(projects),
+                          builder:,
+                          form_name: "project_ids")
+    )
+  end
+
+  it "renders a node per project" do
+    parent = create(:project, name: "Parent")
+    child = create(:project, name: "Child", parent:)
+
+    render_tree([parent, child])
+
+    expect(page).to have_text("Parent")
+    expect(page).to have_text("Child")
+  end
+
+  context "when a project applies another variant of the type" do
+    let!(:project) { create(:project, name: "Bookshop", types: [other_variant]) }
+
+    it "labels the node with that variant" do
+      render_tree([project])
+
+      expect(page).to have_css(".Label", text: other_variant.composite_name)
+    end
+  end
+
+  context "when a project applies the variant being edited" do
+    let!(:project) { create(:project, name: "Bookshop", types: [variant]) }
+
+    it "carries no label" do
+      render_tree([project])
+
+      expect(page).to have_text("Bookshop")
+      expect(page).to have_no_css(".Label")
+    end
+
+    it "cannot be picked again" do
+      render_tree([project])
+
+      expect(page).to have_css("[aria-disabled='true']")
+    end
+  end
+
+  context "when a project does not use the type at all" do
+    let!(:project) { create(:project, name: "Bookshop", types: []) }
+
+    it "carries no label" do
+      render_tree([project])
+
+      expect(page).to have_text("Bookshop")
+      expect(page).to have_no_css(".Label")
+    end
+  end
+end

--- a/spec/components/work_package_types/projects_tab/tree_component_spec.rb
+++ b/spec/components/work_package_types/projects_tab/tree_component_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe WorkPackageTypes::ProjectsTab::TreeComponent, type: :component do
     expect(page).to have_text("Child")
   end
 
+  it "lets a parent be ticked without ticking its children" do
+    parent = create(:project, name: "Parent")
+    create(:project, name: "Child", parent:)
+
+    render_tree(Project.order(:lft))
+
+    expect(page).to have_css("[data-node-id='#{parent.id}'][data-select-strategy='self']", visible: :all)
+    expect(page).to have_no_css("[data-select-strategy='descendants']", visible: :all)
+  end
+
   context "when a project applies another variant of the type" do
     let!(:project) { create(:project, name: "Bookshop", types: [other_variant]) }
 

--- a/spec/controllers/projects/settings/work_packages/types_controller_spec.rb
+++ b/spec/controllers/projects/settings/work_packages/types_controller_spec.rb
@@ -52,8 +52,10 @@ RSpec.describe Projects::Settings::WorkPackages::TypesController do
     it { expect(response).to redirect_to(project_settings_types_path(project.identifier)) }
 
     it "shows an error message with a link to the affected work packages" do
-      expect(sanitize_string(flash[:error]))
-        .to include("Unable to deactivate type #{type.name} because it's still in use by work packages")
+      refusal = %(Unable to remove "#{type.name}" from project "#{project.name}" \
+because it's still in use by work packages)
+
+      expect(sanitize_string(flash[:error].first)).to include(refusal)
       expect(flash[:error].first)
         .to include(work_packages_path(query_props: { f: [
           { n: "type", o: "=", v: [type.id] },

--- a/spec/controllers/work_package_types/projects_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/projects_tab_controller_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe WorkPackageTypes::ProjectsTabController do
     login_as user
   end
 
+  def node_payload(project)
+    { path: [project.name], nodeId: project.id.to_s }.to_json
+  end
+
   context "without admin access" do
     let(:user) { create :user }
 
@@ -105,8 +109,10 @@ RSpec.describe WorkPackageTypes::ProjectsTabController do
         it { expect(response).to have_http_status(:unprocessable_entity) }
 
         it "shows an error message with a link to the affected work packages" do
-          expect(sanitize_string(flash[:error]))
-            .to include("Unable to deactivate type #{type.name} because it's still in use by work packages")
+          refusal = %(Unable to remove "#{type.name}" from project "#{project.name}" \
+because it's still in use by work packages)
+
+          expect(sanitize_string(flash[:error])).to include(refusal)
           expect(flash[:error])
             .to include(work_packages_path(query_props: { f: [
               { n: "type", o: "=", v: [type.id] },
@@ -209,6 +215,145 @@ RSpec.describe WorkPackageTypes::ProjectsTabController do
             expect(sibling_project.reload.type_variant(type)).to eq(other_variant)
           end
         end
+      end
+    end
+
+    describe "GET new_link" do
+      it "opens the add projects dialog" do
+        get :new_link, params: { type_id: type.id }, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(WorkPackageTypes::ProjectsTab::AddFormComponent::DIALOG_ID)
+      end
+    end
+
+    describe "GET tree" do
+      let!(:child) { create(:project, name: "Child", parent: project) }
+
+      it "renders the project tree the dialog picks from" do
+        get :tree, params: { type_id: type.id, name: "project_ids" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(project.name).and include(child.name)
+      end
+
+      it "narrows to the matches and the branches leading to them" do
+        get :tree, params: { type_id: type.id, name: "project_ids", query: "Child" }
+
+        expect(response.body).to include(child.name).and include(project.name)
+      end
+
+      it "leaves out projects that match nothing" do
+        other = create(:project, name: "Unrelated")
+
+        get :tree, params: { type_id: type.id, name: "project_ids", query: "Child" }
+
+        expect(response.body).not_to include(other.name)
+      end
+    end
+
+    describe "POST link" do
+      it "puts the chosen projects on the variant" do
+        post :link, params: { type_id: type.id, project_ids: [node_payload(project)] }, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(project.reload.type_variant(type)).to eq(type.default_variant)
+      end
+
+      it "reaches the descendants too when asked to include sub-items" do
+        child = create(:project, parent: project)
+
+        post :link,
+             params: { type_id: type.id, project_ids: [node_payload(project)], include_sub_items: "1" },
+             format: :turbo_stream
+
+        expect(child.reload.enabled_types).to include(type)
+      end
+
+      it "ignores a payload naming no project" do
+        post :link, params: { type_id: type.id, project_ids: ["not json"] }, format: :turbo_stream
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "refuses an empty selection" do
+        post :link, params: { type_id: type.id, project_ids: [] }, format: :turbo_stream
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to include(I18n.t("types.edit.projects.add_dialog.no_projects_selected"))
+      end
+
+      context "when a project already applies another variant", with_flag: { type_variants: true } do
+        let(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
+        let(:other_variant) { create(:type_variant, type:, variant_name: "Firmware") }
+
+        before { create(:project_type, project:, type:, variant: other_variant) }
+
+        it "switches it over rather than adding a second row" do
+          post :link,
+               params: { type_id: type.id, variant_id: variant.id, project_ids: [node_payload(project)] },
+               format: :turbo_stream
+
+          expect(project.project_types.where(type_id: type.id).count).to eq(1)
+          expect(project.reload.type_variant(type)).to eq(variant)
+        end
+      end
+    end
+
+    describe "DELETE unlink" do
+      before { create(:project_type, project:, type:) }
+
+      it "drops the type from the project" do
+        delete :unlink, params: { type_id: type.id, project_id: project.id }, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(project.reload.enabled_types).not_to include(type)
+      end
+
+      context "when the project holds work packages of the type" do
+        before { create(:work_package, project:, type:) }
+
+        it "refuses and names the affected work packages" do
+          delete :unlink, params: { type_id: type.id, project_id: project.id }, format: :turbo_stream
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(project.reload.enabled_types).to include(type)
+        end
+
+        it "links to the work packages standing in the way" do
+          delete :unlink, params: { type_id: type.id, project_id: project.id }, format: :turbo_stream
+
+          expect(response.body)
+            .to include(CGI.escapeHTML(work_packages_path(query_props: { f: [
+              { n: "type", o: "=", v: [type.id] },
+              { n: "project", o: "=", v: [project.id.to_s] }
+            ] }.to_json)))
+        end
+      end
+    end
+
+    describe "the switch flow", with_flag: { type_variants: true } do
+      let(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
+      let(:target) { create(:type_variant, type:, variant_name: "Firmware") }
+
+      before { create(:project_type, project:, type:, variant:) }
+
+      it "opens the switch dialog for the row's project" do
+        get :new_switch, params: { type_id: type.id, variant_id: variant.id, project_id: project.id },
+                         format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body)
+          .to include(Projects::Settings::WorkPackages::Types::SwitchDialogComponent::DIALOG_ID)
+      end
+
+      it "moves the project to the chosen variant" do
+        post :switch, params: { type_id: type.id, variant_id: variant.id,
+                                project_id: project.id, target_id: target.id },
+                      format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(project.reload.type_variant(type)).to eq(target)
       end
     end
 

--- a/spec/features/projects/settings/work_package_types_spec.rb
+++ b/spec/features/projects/settings/work_package_types_spec.rb
@@ -92,7 +92,10 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
     it "refuses the removal and explains why" do
       settings_page.remove_type(bug.default_variant)
 
-      expect_flash(type: :error, message: "Unable to deactivate type Bug because it's still in use by work packages")
+      refusal = %(Unable to remove "Bug" from project "#{project.name}" \
+because it's still in use by work packages)
+
+      expect_flash(type: :error, message: refusal)
       settings_page.expect_type_row(bug.default_variant)
       expect(project.enabled_types).to include(bug)
     end

--- a/spec/features/types/projects_spec.rb
+++ b/spec/features/types/projects_spec.rb
@@ -109,4 +109,20 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
     # Scoped to this type: the project factory enables the default types on every project.
     expect(inside.reload.project_types.where(type_id: type.id)).to be_empty
   end
+
+  it "flips the toggle label when the add dialog completes the set" do
+    lone_type = create(:type, name: "Chore")
+    Project.where.not(id: parent.id).find_each { |project| create(:project_type, project:, type: lone_type) }
+
+    visit edit_type_projects_path(type_id: lone_type.id)
+
+    expect(page).to have_test_selector("type-projects-enable-all",
+                                       text: I18n.t("types.edit.projects.enable_all"))
+
+    add_projects(parent, include_sub_items: false)
+
+    expect_flash(message: I18n.t(:notice_successful_update))
+    expect(page).to have_test_selector("type-projects-enable-all",
+                                       text: I18n.t("types.edit.projects.disable_all"))
+  end
 end

--- a/spec/features/types/projects_spec.rb
+++ b/spec/features/types/projects_spec.rb
@@ -68,4 +68,25 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
 
     expect(parent.reload.type_variant(type)).to eq(hardware)
   end
+  describe "enabling the type in all projects" do
+    shared_let(:elsewhere) { create(:project, name: "Warehouse") }
+
+    # The button posts the action derived from the current state, so if it is not repainted the
+    # next click offers to redo what just happened rather than undo it.
+    it "flips the button between enable and disable as it is clicked" do
+      visit edit_type_projects_path(type_id: type.id)
+
+      click_link_or_button I18n.t("types.edit.projects.enable_all")
+
+      expect(page).to have_test_selector("type-projects-enable-all",
+                                         text: I18n.t("types.edit.projects.disable_all"))
+      within("#project-table") { expect(page).to have_text(elsewhere.name) }
+
+      click_link_or_button I18n.t("types.edit.projects.disable_all")
+
+      expect(page).to have_test_selector("type-projects-enable-all",
+                                         text: I18n.t("types.edit.projects.enable_all"))
+      within("#project-table") { expect(page).to have_no_text(elsewhere.name) }
+    end
+  end
 end

--- a/spec/features/types/projects_spec.rb
+++ b/spec/features/types/projects_spec.rb
@@ -40,18 +40,20 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
 
   current_user { admin }
 
-  def add_projects_including_sub_items(project)
+  def add_projects(project, include_sub_items:)
     find_test_selector("type-projects-add-button").click
 
     within("##{WorkPackageTypes::ProjectsTab::AddFormComponent::DIALOG_ID}") do
-      check I18n.t("filterable_tree_view.include_sub_items")
+      check I18n.t("filterable_tree_view.include_sub_items") if include_sub_items
       find("[role='treeitem'][data-node-id='#{project.id}']").click
       click_link_or_button I18n.t(:button_add)
     end
   end
 
-  # The case from review. The child already applies this variant, so re-applying it is nothing
-  # to do; before the fix it was refused, leaving the banner behind the overlay and the list stale.
+  def add_projects_including_sub_items(project)
+    add_projects(project, include_sub_items: true)
+  end
+
   it "adds a parent with its sub-projects when one of them is already on the variant" do
     visit edit_type_projects_path(type_id: type.id, variant_id: hardware.id)
 
@@ -68,11 +70,10 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
 
     expect(parent.reload.type_variant(type)).to eq(hardware)
   end
+
   describe "enabling the type in all projects" do
     shared_let(:elsewhere) { create(:project, name: "Warehouse") }
 
-    # The button posts the action derived from the current state, so if it is not repainted the
-    # next click offers to redo what just happened rather than undo it.
     it "flips the button between enable and disable as it is clicked" do
       visit edit_type_projects_path(type_id: type.id)
 
@@ -88,5 +89,24 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
                                          text: I18n.t("types.edit.projects.enable_all"))
       within("#project-table") { expect(page).to have_no_text(elsewhere.name) }
     end
+  end
+
+  it "leaves sub-projects out unless they are asked for" do
+    outside = create(:project, name: "Warehouse")
+    inside = create(:project, name: "Annex", parent: outside)
+
+    visit edit_type_projects_path(type_id: type.id, variant_id: hardware.id)
+
+    add_projects(outside, include_sub_items: false)
+
+    expect_flash(message: I18n.t(:notice_successful_update))
+
+    within "#project-table" do
+      expect(page).to have_text(outside.name)
+      expect(page).to have_no_text(inside.name)
+    end
+
+    # Scoped to this type: the project factory enables the default types on every project.
+    expect(inside.reload.project_types.where(type_id: type.id)).to be_empty
   end
 end

--- a/spec/features/types/projects_spec.rb
+++ b/spec/features/types/projects_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:hardware) { create(:type_variant, type:, variant_name: "Hardware") }
+
+  shared_let(:parent) { create(:project, name: "Foundry") }
+  shared_let(:child) { create(:project, name: "Laboratory", parent:, types: [hardware]) }
+
+  current_user { admin }
+
+  def add_projects_including_sub_items(project)
+    find_test_selector("type-projects-add-button").click
+
+    within("##{WorkPackageTypes::ProjectsTab::AddFormComponent::DIALOG_ID}") do
+      check I18n.t("filterable_tree_view.include_sub_items")
+      find("[role='treeitem'][data-node-id='#{project.id}']").click
+      click_link_or_button I18n.t(:button_add)
+    end
+  end
+
+  # The case from review. The child already applies this variant, so re-applying it is nothing
+  # to do; before the fix it was refused, leaving the banner behind the overlay and the list stale.
+  it "adds a parent with its sub-projects when one of them is already on the variant" do
+    visit edit_type_projects_path(type_id: type.id, variant_id: hardware.id)
+
+    add_projects_including_sub_items(parent)
+
+    expect_flash(message: I18n.t(:notice_successful_update))
+
+    expect(page).to have_no_css("##{WorkPackageTypes::ProjectsTab::AddFormComponent::DIALOG_ID}", visible: :visible)
+
+    within "#project-table" do
+      expect(page).to have_text(parent.name)
+      expect(page).to have_text(child.name)
+    end
+
+    expect(parent.reload.type_variant(type)).to eq(hardware)
+  end
+end

--- a/spec/models/queries/projects/filters/type_variant_filter_spec.rb
+++ b/spec/models/queries/projects/filters/type_variant_filter_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe Queries::Projects::Filters::TypeVariantFilter do
       end
     end
 
+    context "with the base variant of a type" do
+      it "matches only the projects that enabled it" do
+        expect(filter("=", [bug.default_variant.id.to_s]).apply_to(Project))
+          .to contain_exactly(base_project)
+      end
+
+      it "leaves out a project that never enabled the type" do
+        never_enabled = create(:project, types: [])
+
+        expect(filter("=", [bug.default_variant.id.to_s]).apply_to(Project))
+          .not_to include(never_enabled)
+      end
+    end
+
     context 'for "!"' do
       it "returns the projects using another variant of the same type as well as those on other types" do
         expect(filter("!", values).apply_to(Project))

--- a/spec/requests/admin_types_smoke_spec.rb
+++ b/spec/requests/admin_types_smoke_spec.rb
@@ -53,6 +53,49 @@ RSpec.describe "Admin types UI smoke", :skip_csrf, type: :rails_request, with_fl
     expect(response).to have_http_status(:ok)
   end
 
+  it "renders the projects tab with a project applying the variant" do
+    project = create(:project, name: "Bookshop", types: [variant])
+
+    get edit_type_projects_path(type_id: type.id, variant_id: variant.id)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(project.name)
+  end
+
+  it "asks for confirmation before removing a project" do
+    project = create(:project, name: "Bookshop", types: [variant])
+
+    get edit_type_projects_path(type_id: type.id, variant_id: variant.id)
+
+    confirmation = I18n.t("types.edit.projects.actions.confirm_remove", project: project.name, type: type.name)
+
+    expect(response.body).to include(CGI.escapeHTML(confirmation))
+  end
+
+  it "renders the add projects dialog" do
+    get new_link_type_projects_path(type_id: type.id, variant_id: variant.id), as: :turbo_stream
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "renders the project tree the add dialog picks from" do
+    create(:project, name: "Bookshop")
+
+    get tree_type_projects_path(type_id: type.id, variant_id: variant.id, name: "project_ids")
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Bookshop")
+  end
+
+  it "renders the switch dialog for a listed project" do
+    project = create(:project, types: [variant])
+
+    get new_switch_type_projects_path(type_id: type.id, variant_id: variant.id, project_id: project.id),
+        as: :turbo_stream
+
+    expect(response).to have_http_status(:ok)
+  end
+
   it "creates a named variant" do
     post creation_wizard_types_path(type_id: type.id), params: { type_variant: { variant_name: "Hardware" } }
     expect(response).to have_http_status(:see_other)

--- a/spec/requests/work_package_types/projects_tab_enable_all_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_enable_all_spec.rb
@@ -72,8 +72,6 @@ RSpec.describe "Enabling a work package type in all projects", :skip_csrf,
       create(:work_package, project: blocked, type:)
     end
 
-    # The refusal stops the sweep with the earlier projects already changed, so both the list
-    # and the button have to catch up or the next click offers to redo what just happened.
     it "still repaints the list and the button" do
       toggle("0")
 

--- a/spec/requests/work_package_types/projects_tab_enable_all_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_enable_all_spec.rb
@@ -87,4 +87,36 @@ RSpec.describe "Enabling a work package type in all projects", :skip_csrf,
       expect(response.body).to include("Blocked")
     end
   end
+
+  describe "the toggle label after the project set changes some other way" do
+    def add(project)
+      post link_type_projects_path(type_id: type.id),
+           params: { project_ids: [{ nodeId: project.id.to_s }.to_json] },
+           as: :turbo_stream
+    end
+
+    def remove(project)
+      delete unlink_type_projects_path(type_id: type.id, project_id: project.id), as: :turbo_stream
+    end
+
+    it "offers to disable once the last remaining project has been added" do
+      create(:project_type, project: one, type:)
+
+      add(other)
+
+      expect(variant.reload.projects).to contain_exactly(one, other)
+      expect(response.body).to include(I18n.t("types.edit.projects.disable_all"))
+      expect(response.body).not_to include(I18n.t("types.edit.projects.enable_all"))
+    end
+
+    it "offers to enable again once one project has been removed from the full set" do
+      [one, other].each { |project| create(:project_type, project:, type:) }
+
+      remove(other)
+
+      expect(variant.reload.projects).to contain_exactly(one)
+      expect(response.body).to include(I18n.t("types.edit.projects.enable_all"))
+      expect(response.body).not_to include(I18n.t("types.edit.projects.disable_all"))
+    end
+  end
 end

--- a/spec/requests/work_package_types/projects_tab_enable_all_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_enable_all_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Enabling a work package type in all projects", :skip_csrf,
+               type: :rails_request, with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:one) { create(:project, name: "Foundry") }
+  shared_let(:other) { create(:project, name: "Laboratory") }
+
+  let(:variant) { type.default_variant }
+
+  before { login_as admin }
+
+  def toggle(value)
+    post enable_all_type_projects_path(type_id: type.id, value:), as: :turbo_stream
+  end
+
+  it "enables the type everywhere and offers to disable it next" do
+    toggle("1")
+
+    expect(response).to have_http_status(:ok)
+    expect(variant.projects).to contain_exactly(one, other)
+    expect(response.body).to include(I18n.t("types.edit.projects.disable_all"))
+    expect(response.body).not_to include(I18n.t("types.edit.projects.enable_all"))
+  end
+
+  it "disables it everywhere and offers to enable it next" do
+    create(:project_type, project: one, type:)
+    create(:project_type, project: other, type:)
+
+    toggle("0")
+
+    expect(variant.reload.projects).to be_empty
+    expect(response.body).to include(I18n.t("types.edit.projects.enable_all"))
+  end
+
+  context "when one project refuses" do
+    shared_let(:blocked) { create(:project, name: "Blocked") }
+
+    before do
+      [one, other, blocked].each { |project| create(:project_type, project:, type:) }
+      create(:work_package, project: blocked, type:)
+    end
+
+    # The refusal stops the sweep with the earlier projects already changed, so both the list
+    # and the button have to catch up or the next click offers to redo what just happened.
+    it "still repaints the list and the button" do
+      toggle("0")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(variant.reload.projects).to contain_exactly(blocked)
+      expect(response.body).to include("projects-table")
+      expect(response.body).to include(I18n.t("types.edit.projects.enable_all"))
+    end
+
+    it "reports which project stood in the way" do
+      toggle("0")
+
+      expect(response.body).to include("Blocked")
+    end
+  end
+end

--- a/spec/requests/work_package_types/projects_tab_link_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_link_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Adding projects to a work package type variant", :skip_csrf,
+               type: :rails_request, with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:hardware) { create(:type_variant, type:, variant_name: "Hardware") }
+  shared_let(:firmware) { create(:type_variant, type:, variant_name: "Firmware") }
+
+  before { login_as admin }
+
+  def link_projects(*projects, variant: hardware, include_sub_items: false)
+    post link_type_projects_path(type_id: type.id, variant_id: variant.id),
+         params: { project_ids: projects.map { { nodeId: it.id.to_s }.to_json },
+                   include_sub_items: include_sub_items ? "1" : "0" },
+         as: :turbo_stream
+  end
+
+  describe "a project that already applies the variant" do
+    # The case from review: adding a parent with sub-items reaches a child already on this
+    # variant. Re-applying it is nothing to do, not a conflict -- switching a project onto the
+    # variant it is already on is what SwitchVariantContract turns away as identical.
+    it "is nothing to do rather than a conflict" do
+      parent = create(:project)
+      child = create(:project, parent:, types: [hardware])
+
+      link_projects(parent, include_sub_items: true)
+
+      expect(response).to have_http_status(:ok)
+      expect(parent.reload.type_variant(type)).to eq(hardware)
+      expect(child.reload.type_variant(type)).to eq(hardware)
+    end
+
+    it "still moves a child sitting on another variant of the same type" do
+      parent = create(:project)
+      child = create(:project, parent:, types: [firmware])
+
+      link_projects(parent, include_sub_items: true)
+
+      expect(response).to have_http_status(:ok)
+      expect(child.reload.type_variant(type)).to eq(hardware)
+    end
+  end
+
+  describe "when part of the selection is refused" do
+    shared_let(:blocked) { create(:project, name: "Blocked") }
+    shared_let(:addable) { create(:project, name: "Addable") }
+
+    # Nothing reachable refuses an add today -- the identical-switch bug above was the way in,
+    # and it is fixed -- so the one project that must fail is made to fail directly.
+    before do
+      refusal = ServiceResult.failure(result: blocked)
+      refusal.errors.add(:base, "Refused for a reason")
+
+      allow(Projects::Types::AddService).to receive(:new).and_call_original
+      allow(Projects::Types::AddService)
+        .to receive(:new).with(user: anything, model: blocked)
+        .and_return(instance_double(Projects::Types::AddService, call: refusal))
+    end
+
+    # Leaving the dialog open would hide the message behind the overlay and show a list and a
+    # tree that no longer match the database, since the projects before the refusal did change.
+    it "closes the dialog anyway" do
+      link_projects(addable, blocked)
+
+      expect(response.body).to include("dialog").and include("closeDialog")
+    end
+
+    it "repaints the project list anyway" do
+      link_projects(addable, blocked)
+
+      expect(response.body).to include("projects-table")
+    end
+
+    it "reports the refusal" do
+      link_projects(addable, blocked)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Blocked")
+    end
+  end
+end

--- a/spec/requests/work_package_types/projects_tab_link_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_link_spec.rb
@@ -47,9 +47,6 @@ RSpec.describe "Adding projects to a work package type variant", :skip_csrf,
   end
 
   describe "a project that already applies the variant" do
-    # The case from review: adding a parent with sub-items reaches a child already on this
-    # variant. Re-applying it is nothing to do, not a conflict -- switching a project onto the
-    # variant it is already on is what SwitchVariantContract turns away as identical.
     it "is nothing to do rather than a conflict" do
       parent = create(:project)
       child = create(:project, parent:, types: [hardware])
@@ -76,8 +73,6 @@ RSpec.describe "Adding projects to a work package type variant", :skip_csrf,
     shared_let(:blocked) { create(:project, name: "Blocked") }
     shared_let(:addable) { create(:project, name: "Addable") }
 
-    # Nothing reachable refuses an add today -- the identical-switch bug above was the way in,
-    # and it is fixed -- so the one project that must fail is made to fail directly.
     before do
       refusal = ServiceResult.failure(result: blocked)
       refusal.errors.add(:base, "Refused for a reason")
@@ -88,8 +83,6 @@ RSpec.describe "Adding projects to a work package type variant", :skip_csrf,
         .and_return(instance_double(Projects::Types::AddService, call: refusal))
     end
 
-    # Leaving the dialog open would hide the message behind the overlay and show a list and a
-    # tree that no longer match the database, since the projects before the refusal did change.
     it "closes the dialog anyway" do
       link_projects(addable, blocked)
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/FND-220
https://community.openproject.org/work_packages/FND-221

Implements:

- Project selection through the standard table list we use in Project attributes and Storages
- Add dialog using a FilterableTreeView that shows a label
- Row action to switch the variant reusing the project based switching flow
- Row action to remove the variant/type from the project