### PR TITLE
[FND-226] Add variants tab to the Type edit page

### DIFF
--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -54,20 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% root.variants.non_default_variants.in_display_order.each do |child| %>
             <% list.with_item do |item| %>
               <% item.with_menu(menu_id: variant_menu_id(child), src: variant_menu_src(child)) %>
-              <%= flex_layout(align_items: :center, justify_content: :space_between) do |variant| %>
-                <% variant.with_column(display: :inline_flex, align_items: :center) do %>
-                  <%= render(
-                        Primer::Beta::Link.new(
-                          href: variant_path(child),
-                          font_weight: :bold
-                        )
-                      ) { child.variant_name } %>
-                  <%= render(Primer::Beta::Text.new(color: :muted, ml: 2)) { t("types.index.variant_label") } %>
-                <% end %>
-                <% if child.enabled_in_new_projects? %>
-                  <% variant.with_column(mr: 3) { render(Primer::Beta::Label.new) { t("types.index.enabled_in_new_projects") } } %>
-                <% end %>
-              <% end %>
+              <%= render(WorkPackageTypes::VariantRowComponent.new(variant: child, caption: t("types.index.variant_label"))) %>
             <% end %>
           <% end %>
 

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -70,7 +70,7 @@ module WorkPackageTypes
       end
 
       def add_variant_path(type)
-        new_creation_wizard_types_path(type_id: type.id)
+        new_creation_wizard_types_path(type_id: type.id, back_url: types_path)
       end
 
       def menu_id(type)

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -69,10 +69,6 @@ module WorkPackageTypes
         type.variants.detect(&:enabled_in_new_projects?)
       end
 
-      def variant_path(variant)
-        edit_type_details_path(type_id: variant.type_id, variant_id: variant.id)
-      end
-
       def add_variant_path(type)
         new_creation_wizard_types_path(type_id: type.id)
       end

--- a/app/components/work_package_types/types/type_actions_component.rb
+++ b/app/components/work_package_types/types/type_actions_component.rb
@@ -70,7 +70,7 @@ module WorkPackageTypes
 
       def add_variant_action(menu)
         menu.with_item(label: t("types.index.add_variant_action"),
-                       href: new_creation_wizard_types_path(type_id: type.id)) do |item|
+                       href: new_creation_wizard_types_path(type_id: type.id, back_url: types_path)) do |item|
           item.with_leading_visual_icon(icon: :plus)
         end
       end

--- a/app/components/work_package_types/types/variant_actions_component.rb
+++ b/app/components/work_package_types/types/variant_actions_component.rb
@@ -37,10 +37,11 @@ module WorkPackageTypes
         "variant-#{variant.id}-action-menu"
       end
 
-      def initialize(variant:)
+      def initialize(variant:, back_url: nil)
         super()
 
         @variant = variant
+        @back_url = back_url
       end
 
       def menu_id
@@ -49,7 +50,7 @@ module WorkPackageTypes
 
       private
 
-      attr_reader :variant
+      attr_reader :variant, :back_url
 
       def variant_actions(menu)
         configure_action(menu)
@@ -81,7 +82,7 @@ module WorkPackageTypes
       def make_default_action(menu)
         menu.with_item(
           label: t("types.index.make_default"),
-          href: make_default_type_variant_path(type_id: variant.type_id, id: variant.id),
+          href: make_default_type_variant_path(type_id: variant.type_id, id: variant.id, back_url:),
           form_arguments: { method: :post }
         ) do |item|
           item.with_leading_visual_icon(icon: :"check-circle")
@@ -91,7 +92,7 @@ module WorkPackageTypes
       def remove_default_action(menu)
         menu.with_item(
           label: t("types.index.remove_default"),
-          href: remove_default_type_variant_path(type_id: variant.type_id, id: variant.id),
+          href: remove_default_type_variant_path(type_id: variant.type_id, id: variant.id, back_url:),
           form_arguments: { method: :post }
         ) do |item|
           item.with_leading_visual_icon(icon: :"circle-slash")
@@ -102,7 +103,7 @@ module WorkPackageTypes
         menu.with_item(
           label: t(:button_delete),
           scheme: :danger,
-          href: type_variant_path(type_id: variant.type_id, id: variant.id),
+          href: type_variant_path(type_id: variant.type_id, id: variant.id, back_url:),
           form_arguments: { method: :delete, data: { turbo_confirm: t(:text_are_you_sure) } }
         ) do |item|
           item.with_leading_visual_icon(icon: :trash)

--- a/app/components/work_package_types/variant_row_component.html.erb
+++ b/app/components/work_package_types/variant_row_component.html.erb
@@ -1,0 +1,43 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= flex_layout(align_items: :center, justify_content: :space_between) do |row| %>
+  <% row.with_column(display: :inline_flex, align_items: :center) do %>
+    <%= render(Primer::Beta::Link.new(href: variant_path, font_weight: :bold)) { variant.variant_name } %>
+    <% if caption %>
+      <%= render(Primer::Beta::Text.new(color: :muted, ml: 2)) { caption } %>
+    <% end %>
+  <% end %>
+
+  <% if variant.enabled_in_new_projects? %>
+    <% row.with_column(mr: 3) do %>
+      <%= render(Primer::Beta::Label.new) { t("types.index.enabled_in_new_projects") } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/work_package_types/variant_row_component.rb
+++ b/app/components/work_package_types/variant_row_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  # The contents of one variant's row, as listed on the type's variants tab and inside the
+  # type's group on the types index. The row's action menu is not part of this: it hangs off
+  # the surrounding list item, and each list points it back at itself.
+  class VariantRowComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    # @param caption [String, nil] muted text after the name, telling rows apart where the
+    #   list mixes variants with other records.
+    def initialize(variant:, caption: nil)
+      super()
+
+      @variant = variant
+      @caption = caption
+    end
+
+    private
+
+    attr_reader :variant, :caption
+
+    def variant_path = edit_type_details_path(**variant.path_args)
+  end
+end

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -91,7 +91,7 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
     else
-      render(Primer::Beta::Blankslate.new(border: true, test_selector: "type-variants-blankslate")) do |blankslate|
+      render(Primer::Beta::Blankslate.new(border: true, spacious: true, test_selector: "type-variants-blankslate")) do |blankslate|
         blankslate.with_heading(tag: :h3) { I18n.t("types.edit.variants.blankslate.title") }
         blankslate.with_description { t("types.edit.variants.blankslate.description_html") }
         blankslate.with_primary_action(href: add_variant_path, test_selector: "add-type-variant") do

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -58,7 +58,7 @@ See COPYRIGHT and LICENSE files for more details.
         end
 
         page.with_row do
-          helpers.turbo_frame_tag(FRAME_ID) do
+          helpers.turbo_frame_tag(FRAME_ID, target: "_top") do
             render(
               OpenProject::Common::BorderBoxListComponent.new(
                 container: "type-variants",

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -73,17 +73,7 @@ See COPYRIGHT and LICENSE files for more details.
                 list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
                   item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
 
-                  flex_layout(align_items: :center, justify_content: :space_between) do |row|
-                    row.with_column do
-                      render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
-                    end
-
-                    if variant.enabled_in_new_projects?
-                      row.with_column(mr: 3) do
-                        render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
-                      end
-                    end
-                  end
+                  render(WorkPackageTypes::VariantRowComponent.new(variant:))
                 end
               end
             end

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -29,65 +29,73 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper do
-    if variants.empty?
-      render(Primer::Beta::Blankslate.new(border: true, test_selector: "type-variants-blankslate")) do |blankslate|
-        blankslate.with_heading(tag: :h3) { I18n.t("types.edit.variants.blankslate.title") }
-        blankslate.with_description { t("types.edit.variants.blankslate.description_html") }
-        blankslate.with_primary_action(href: add_variant_path, test_selector: "add-type-variant") do
-          I18n.t("types.index.add_variant_action")
-        end
-      end
-    else
+    if any_variants?
       flex_layout do |page|
         page.with_row do
-          render(Primer::OpenProject::SubHeader.new(collapsed_search: false)) do |subheader|
-            subheader.with_filter_input(
-              name: "type-variants-filter",
-              label: I18n.t("types.edit.variants.filter"),
-              placeholder: I18n.t("types.edit.variants.filter"),
-              leading_visual: { icon: :search, size: :small }
-            )
+          form_tag(variants_path, method: :get, data: filter_form_data) do
+            render(Primer::OpenProject::SubHeader.new(collapsed_search: false)) do |subheader|
+              subheader.with_filter_input(
+                name: "query",
+                value: query,
+                label: I18n.t("types.edit.variants.filter"),
+                placeholder: I18n.t("types.edit.variants.filter"),
+                leading_visual: { icon: :search, size: :small },
+                data: { action: "input->auto-submit#submit" }
+              )
 
-            subheader.with_action_button(
-              scheme: :primary,
-              leading_icon: :plus,
-              label: I18n.t("types.index.add_variant_action"),
-              tag: :a,
-              href: add_variant_path,
-              test_selector: "add-type-variant"
-            ) do
-              I18n.t("types.index.variant_label")
+              subheader.with_action_button(
+                scheme: :primary,
+                leading_icon: :plus,
+                label: I18n.t("types.index.add_variant_action"),
+                tag: :a,
+                href: add_variant_path,
+                test_selector: "add-type-variant"
+              ) do
+                I18n.t("types.index.variant_label")
+              end
             end
           end
         end
 
         page.with_row do
-          render(
-            OpenProject::Common::BorderBoxListComponent.new(
-              container: "type-variants",
-              padding: :condensed,
-              mb: 3,
-              test_selector: "type-variants"
-            )
-          ) do |list|
-            variants.each do |variant|
-              list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
-                item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
+          helpers.turbo_frame_tag(FRAME_ID) do
+            render(
+              OpenProject::Common::BorderBoxListComponent.new(
+                container: "type-variants",
+                padding: :condensed,
+                mb: 3,
+                test_selector: "type-variants"
+              )
+            ) do |list|
+              list.with_empty_state(title: I18n.t("types.edit.variants.filter_no_results"), icon: :search)
 
-                flex_layout(align_items: :center, justify_content: :space_between) do |row|
-                  row.with_column do
-                    render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
-                  end
+              variants.each do |variant|
+                list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
+                  item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
 
-                  if variant.enabled_in_new_projects?
-                    row.with_column(mr: 3) do
-                      render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+                  flex_layout(align_items: :center, justify_content: :space_between) do |row|
+                    row.with_column do
+                      render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
+                    end
+
+                    if variant.enabled_in_new_projects?
+                      row.with_column(mr: 3) do
+                        render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+                      end
                     end
                   end
                 end
               end
             end
           end
+        end
+      end
+    else
+      render(Primer::Beta::Blankslate.new(border: true, test_selector: "type-variants-blankslate")) do |blankslate|
+        blankslate.with_heading(tag: :h3) { I18n.t("types.edit.variants.blankslate.title") }
+        blankslate.with_description { t("types.edit.variants.blankslate.description_html") }
+        blankslate.with_primary_action(href: add_variant_path, test_selector: "add-type-variant") do
+          I18n.t("types.index.add_variant_action")
         end
       end
     end

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -38,39 +38,52 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
     else
-      render(
-        OpenProject::Common::BorderBoxListComponent.new(
-          container: "type-variants",
-          mb: 3,
-          test_selector: "type-variants"
-        )
-      ) do |list|
-        list.with_header(title:, count: variants.size) do |header|
-          header.with_action_button(
-            tag: :a,
-            href: add_variant_path,
-            scheme: :invisible,
-            font_weight: :bold,
-            color: :subtle,
-            test_selector: "add-type-variant"
-          ) do |button|
-            button.with_leading_visual_icon(icon: :plus, color: :subtle)
-            I18n.t("types.index.add_variant_action")
+      flex_layout do |page|
+        page.with_row do
+          render(Primer::OpenProject::SubHeader.new(collapsed_search: false)) do |subheader|
+            subheader.with_filter_input(
+              name: "type-variants-filter",
+              label: I18n.t("types.edit.variants.filter"),
+              placeholder: I18n.t("types.edit.variants.filter"),
+              leading_visual: { icon: :search, size: :small }
+            )
+
+            subheader.with_action_button(
+              scheme: :primary,
+              leading_icon: :plus,
+              label: I18n.t("types.index.add_variant_action"),
+              tag: :a,
+              href: add_variant_path,
+              test_selector: "add-type-variant"
+            ) do
+              I18n.t("types.index.variant_label")
+            end
           end
         end
 
-        variants.each do |variant|
-          list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
-            item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
+        page.with_row do
+          render(
+            OpenProject::Common::BorderBoxListComponent.new(
+              container: "type-variants",
+              padding: :condensed,
+              mb: 3,
+              test_selector: "type-variants"
+            )
+          ) do |list|
+            variants.each do |variant|
+              list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
+                item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
 
-            flex_layout(align_items: :center, justify_content: :space_between) do |row|
-              row.with_column do
-                render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
-              end
+                flex_layout(align_items: :center, justify_content: :space_between) do |row|
+                  row.with_column do
+                    render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
+                  end
 
-              if variant.enabled_in_new_projects?
-                row.with_column(mr: 3) do
-                  render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+                  if variant.enabled_in_new_projects?
+                    row.with_column(mr: 3) do
+                      render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+                    end
+                  end
                 end
               end
             end

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -1,0 +1,81 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  component_wrapper do
+    render(
+      OpenProject::Common::BorderBoxListComponent.new(
+        container: "type-variants",
+        mb: 3,
+        test_selector: "type-variants"
+      )
+    ) do |list|
+      list.with_header(title:, count: variants.size) do |header|
+        header.with_action_button(
+          tag: :a,
+          href: add_variant_path,
+          scheme: :invisible,
+          font_weight: :bold,
+          color: :subtle,
+          test_selector: "add-type-variant"
+        ) do |button|
+          button.with_leading_visual_icon(icon: :plus, color: :subtle)
+          I18n.t("types.index.add_variant_action")
+        end
+      end
+
+      list.with_empty_state(
+        title: I18n.t("types.edit.variants.blankslate.title"),
+        description: I18n.t("types.edit.variants.blankslate.description"),
+        icon: :versions,
+        action_label: I18n.t("types.index.add_variant_action"),
+        action_icon: :plus,
+        action_arguments: { tag: :a, href: add_variant_path }
+      )
+
+      variants.each do |variant|
+        list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
+          item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
+
+          flex_layout(align_items: :center, justify_content: :space_between) do |row|
+            row.with_column do
+              render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
+            end
+
+            if variant.enabled_in_new_projects?
+              row.with_column(mr: 3) do
+                render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -29,48 +29,49 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper do
-    render(
-      OpenProject::Common::BorderBoxListComponent.new(
-        container: "type-variants",
-        mb: 3,
-        test_selector: "type-variants"
-      )
-    ) do |list|
-      list.with_header(title:, count: variants.size) do |header|
-        header.with_action_button(
-          tag: :a,
-          href: add_variant_path,
-          scheme: :invisible,
-          font_weight: :bold,
-          color: :subtle,
-          test_selector: "add-type-variant"
-        ) do |button|
-          button.with_leading_visual_icon(icon: :plus, color: :subtle)
+    if variants.empty?
+      render(Primer::Beta::Blankslate.new(border: true, test_selector: "type-variants-blankslate")) do |blankslate|
+        blankslate.with_heading(tag: :h3) { I18n.t("types.edit.variants.blankslate.title") }
+        blankslate.with_description { t("types.edit.variants.blankslate.description_html") }
+        blankslate.with_primary_action(href: add_variant_path, test_selector: "add-type-variant") do
           I18n.t("types.index.add_variant_action")
         end
       end
+    else
+      render(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "type-variants",
+          mb: 3,
+          test_selector: "type-variants"
+        )
+      ) do |list|
+        list.with_header(title:, count: variants.size) do |header|
+          header.with_action_button(
+            tag: :a,
+            href: add_variant_path,
+            scheme: :invisible,
+            font_weight: :bold,
+            color: :subtle,
+            test_selector: "add-type-variant"
+          ) do |button|
+            button.with_leading_visual_icon(icon: :plus, color: :subtle)
+            I18n.t("types.index.add_variant_action")
+          end
+        end
 
-      list.with_empty_state(
-        title: I18n.t("types.edit.variants.blankslate.title"),
-        description: I18n.t("types.edit.variants.blankslate.description"),
-        icon: :versions,
-        action_label: I18n.t("types.index.add_variant_action"),
-        action_icon: :plus,
-        action_arguments: { tag: :a, href: add_variant_path }
-      )
+        variants.each do |variant|
+          list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
+            item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
 
-      variants.each do |variant|
-        list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
-          item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
+            flex_layout(align_items: :center, justify_content: :space_between) do |row|
+              row.with_column do
+                render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
+              end
 
-          flex_layout(align_items: :center, justify_content: :space_between) do |row|
-            row.with_column do
-              render(Primer::Beta::Link.new(href: variant_path(variant), font_weight: :bold)) { variant.variant_name }
-            end
-
-            if variant.enabled_in_new_projects?
-              row.with_column(mr: 3) do
-                render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+              if variant.enabled_in_new_projects?
+                row.with_column(mr: 3) do
+                  render(Primer::Beta::Label.new) { I18n.t("types.index.enabled_in_new_projects") }
+                end
               end
             end
           end

--- a/app/components/work_package_types/variants_list_component.rb
+++ b/app/components/work_package_types/variants_list_component.rb
@@ -49,8 +49,6 @@ module WorkPackageTypes
       @variants ||= type.variants.non_default_variants.in_display_order
     end
 
-    def title = TypeVariant.model_name.human(count: 2)
-
     def variant_path(variant) = edit_type_details_path(**variant.path_args)
 
     def add_variant_path = new_creation_wizard_types_path(type_id: type.id, back_url: variants_path)

--- a/app/components/work_package_types/variants_list_component.rb
+++ b/app/components/work_package_types/variants_list_component.rb
@@ -53,10 +53,16 @@ module WorkPackageTypes
 
     def variant_path(variant) = edit_type_details_path(**variant.path_args)
 
-    def add_variant_path = new_creation_wizard_types_path(type_id: type.id)
+    def add_variant_path = new_creation_wizard_types_path(type_id: type.id, back_url: variants_path)
 
     def menu_id(variant) = Types::VariantActionsComponent.menu_id(variant)
 
-    def menu_src(variant) = menu_type_variant_path(type_id: variant.type_id, id: variant.id)
+    # The menu's actions are reachable from the types index too, so each one has to be told to
+    # come back here rather than to that list.
+    def menu_src(variant)
+      menu_type_variant_path(type_id: variant.type_id, id: variant.id, back_url: variants_path)
+    end
+
+    def variants_path = type_variants_path(type_id: type.id)
   end
 end

--- a/app/components/work_package_types/variants_list_component.rb
+++ b/app/components/work_package_types/variants_list_component.rb
@@ -33,20 +33,40 @@ module WorkPackageTypes
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(type:)
+    FRAME_ID = "type-variants-list"
+
+    def initialize(type:, query: nil)
       super()
 
       @type = type
+      @query = query.presence
     end
 
     private
 
-    attr_reader :type
+    attr_reader :type, :query
 
     # The base variant is the type itself, which the sibling tabs already configure, so only the
     # named ones are listed here.
+    def named_variants = type.variants.non_default_variants
+
     def variants
-      @variants ||= type.variants.non_default_variants.in_display_order
+      @variants ||= begin
+        scope = named_variants
+        scope = scope.with_name_like(query) if query
+        scope.in_display_order
+      end
+    end
+
+    def any_variants? = named_variants.exists?
+
+    def filter_form_data
+      {
+        controller: "auto-submit",
+        "auto-submit-delay-value": 300,
+        turbo_frame: FRAME_ID,
+        turbo_action: "replace"
+      }
     end
 
     def variant_path(variant) = edit_type_details_path(**variant.path_args)

--- a/app/components/work_package_types/variants_list_component.rb
+++ b/app/components/work_package_types/variants_list_component.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackageTypes
+  class VariantsListComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+
+    def initialize(type:)
+      super()
+
+      @type = type
+    end
+
+    private
+
+    attr_reader :type
+
+    # The base variant is the type itself, which the sibling tabs already configure, so only the
+    # named ones are listed here.
+    def variants
+      @variants ||= type.variants.non_default_variants.in_display_order
+    end
+
+    def title = TypeVariant.model_name.human(count: 2)
+
+    def variant_path(variant) = edit_type_details_path(**variant.path_args)
+
+    def add_variant_path = new_creation_wizard_types_path(type_id: type.id)
+
+    def menu_id(variant) = Types::VariantActionsComponent.menu_id(variant)
+
+    def menu_src(variant) = menu_type_variant_path(type_id: variant.type_id, id: variant.id)
+  end
+end

--- a/app/components/work_package_types/variants_list_component.rb
+++ b/app/components/work_package_types/variants_list_component.rb
@@ -69,8 +69,6 @@ module WorkPackageTypes
       }
     end
 
-    def variant_path(variant) = edit_type_details_path(**variant.path_args)
-
     def add_variant_path = new_creation_wizard_types_path(type_id: type.id, back_url: variants_path)
 
     def menu_id(variant) = Types::VariantActionsComponent.menu_id(variant)

--- a/app/components/work_package_types/wizard/footer_component.rb
+++ b/app/components/work_package_types/wizard/footer_component.rb
@@ -39,15 +39,16 @@ module WorkPackageTypes
 
       FORM_IDENTIFIER = "type-wizard-form"
 
-      def initialize(type:, current_step:)
+      def initialize(type:, current_step:, back_url: nil)
         super(type)
 
         @current_step = current_step
+        @back_url = back_url
       end
 
       private
 
-      attr_reader :current_step
+      attr_reader :current_step, :back_url
 
       def type = model
 
@@ -68,10 +69,12 @@ module WorkPackageTypes
 
       def back_href
         previous_step = Steps.previous_before(current_step)
-        type_creation_wizard_path(type, step: previous_step) if previous_step && type.persisted?
+        type_creation_wizard_path(type, step: previous_step, back_url:) if previous_step && type.persisted?
       end
 
       def cancel_href
+        return back_url if back_url.present?
+
         type.persisted? ? edit_type_details_path(type_id: type.id) : types_path
       end
     end

--- a/app/components/work_package_types/wizard/page_component.html.erb
+++ b/app/components/work_package_types/wizard/page_component.html.erb
@@ -46,6 +46,6 @@
   <% end %>
 
   <%= layout.with_footer do %>
-    <%= render(WorkPackageTypes::Wizard::FooterComponent.new(type:, current_step:)) %>
+    <%= render(WorkPackageTypes::Wizard::FooterComponent.new(type:, current_step:, back_url:)) %>
   <% end %>
 <% end %>

--- a/app/components/work_package_types/wizard/page_component.rb
+++ b/app/components/work_package_types/wizard/page_component.rb
@@ -33,10 +33,11 @@ module WorkPackageTypes
     class PageComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      def initialize(type:, current_step:, variant: nil)
+      def initialize(type:, current_step:, variant: nil, back_url: nil)
         super(type)
 
         @current_step = current_step
+        @back_url = back_url
         # Creating a type hands in the type itself, or nothing at all. Settle what the wizard is
         # editing once here, so nothing below has to ask what it was given.
         @variant = variant.is_a?(TypeVariant) ? variant : type.default_variant
@@ -44,7 +45,7 @@ module WorkPackageTypes
 
       private
 
-      attr_reader :current_step, :variant
+      attr_reader :current_step, :variant, :back_url
 
       def type = model
 
@@ -71,6 +72,7 @@ module WorkPackageTypes
       end
 
       def cancel_href
+        return back_url if back_url.present?
         return types_path unless type.persisted?
 
         edit_type_details_path(type_id: type.id)
@@ -78,7 +80,7 @@ module WorkPackageTypes
 
       def step_title = Steps.title(current_step)
 
-      def step_url = type_creation_wizard_path(**variant_path_args, step: current_step)
+      def step_url = type_creation_wizard_path(**variant_path_args, step: current_step, back_url:)
 
       # A type still being created has no variant to address yet.
       def variant_path_args = variant&.path_args || { type_id: type.id }
@@ -86,7 +88,7 @@ module WorkPackageTypes
       def step_form_url
         return step_url if record_persisted?
 
-        adding_variant? ? creation_wizard_types_path(type_id: type.id) : creation_wizard_types_path
+        adding_variant? ? creation_wizard_types_path(type_id: type.id, back_url:) : creation_wizard_types_path(back_url:)
       end
 
       def step_form_method

--- a/app/controllers/work_package_types/creation_wizard_controller.rb
+++ b/app/controllers/work_package_types/creation_wizard_controller.rb
@@ -43,6 +43,7 @@ module WorkPackageTypes
     before_action :find_type, only: %i[show update]
     before_action :find_variant, only: %i[show update]
     before_action :set_current_step, only: %i[show update]
+    before_action :set_back_url
 
     def show; end
 
@@ -173,10 +174,17 @@ module WorkPackageTypes
 
     def redirect_to_step(step)
       if step
-        redirect_to type_creation_wizard_path(**variant_path_args, step:), status: :see_other
+        redirect_to type_creation_wizard_path(**variant_path_args, step:, back_url: @back_url), status: :see_other
       else
-        redirect_to types_path, notice: t("types.creation_wizard.success"), status: :see_other
+        flash[:notice] = t("types.creation_wizard.success")
+        redirect_back_or_default(types_path, status: :see_other)
       end
+    end
+
+    # The wizard hands this straight to the cancel button, so it is validated here rather than
+    # where it is rendered.
+    def set_back_url
+      @back_url = RedirectPolicy.new(params[:back_url], hostname: request.host, default: nil).redirect_url
     end
 
     # @variant is the type itself while a type is being created until there is a variant to be used

--- a/app/controllers/work_package_types/variants_controller.rb
+++ b/app/controllers/work_package_types/variants_controller.rb
@@ -38,6 +38,8 @@ module WorkPackageTypes
       :types
     end
 
+    def index; end
+
     def menu
       render Types::VariantActionsComponent.new(variant: named_variant), layout: false
     end

--- a/app/controllers/work_package_types/variants_controller.rb
+++ b/app/controllers/work_package_types/variants_controller.rb
@@ -41,17 +41,20 @@ module WorkPackageTypes
     def index; end
 
     def menu
-      render Types::VariantActionsComponent.new(variant: named_variant), layout: false
+      render Types::VariantActionsComponent.new(variant: named_variant, back_url: params[:back_url]),
+             layout: false
     end
 
     def destroy
       service_call = DeleteVariantService.new(user: current_user, model: named_variant).call
 
       if service_call.success?
-        redirect_to types_path, notice: t(:notice_successful_delete), status: :see_other
+        flash[:notice] = t(:notice_successful_delete)
       else
-        redirect_to types_path, alert: service_call.errors.full_messages.to_sentence, status: :see_other
+        flash[:error] = service_call.errors.full_messages.to_sentence
       end
+
+      redirect_back_or_default(types_path, status: :see_other)
     end
 
     def make_default
@@ -82,7 +85,7 @@ module WorkPackageTypes
         flash[:error] = service_call.errors.full_messages
       end
 
-      redirect_to types_path, status: :see_other
+      redirect_back_or_default(types_path, status: :see_other)
     end
 
     def named_variant

--- a/app/controllers/work_package_types/variants_controller.rb
+++ b/app/controllers/work_package_types/variants_controller.rb
@@ -38,7 +38,13 @@ module WorkPackageTypes
       :types
     end
 
-    def index; end
+    # The filter input drives the list's turbo frame, so a frame request only needs the list
+    # component: Turbo picks the frame out of it and drops the rest.
+    def index
+      return unless turbo_frame_request?
+
+      render VariantsListComponent.new(type: @type, query: params[:query]), layout: false
+    end
 
     def menu
       render Types::VariantActionsComponent.new(variant: named_variant, back_url: params[:back_url]),

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -46,6 +46,7 @@ module ::TypesHelper
         path: edit_type_defaults_path(**variant_args),
         label: I18n.t("types.edit.defaults.tab")
       },
+      *variants_tab,
       {
         name: "form_configuration",
         path: edit_type_form_configuration_path(**variant_args),
@@ -77,6 +78,17 @@ module ::TypesHelper
 
   def type_variant_tab_args
     @variant&.path_args || { type_id: @type.id }
+  end
+
+  def variants_tab
+    return [] unless OpenProject::FeatureDecisions.type_variants_active?
+    return [] if @variant.present? && !@variant.is_default_variant?
+
+    [{
+      name: "variants",
+      path: type_variants_path(type_id: @type.id),
+      label: TypeVariant.model_name.human(count: 2)
+    }]
   end
   # rubocop:enable Rails/HelperInstanceVariable
 

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -32,7 +32,7 @@ module ::TypesHelper
   include CustomFieldsHelper
 
   # rubocop:disable Rails/HelperInstanceVariable
-  def types_tabs
+  def types_tabs # rubocop:disable Metrics/AbcSize
     variant_args = type_variant_tab_args
 
     [
@@ -46,7 +46,7 @@ module ::TypesHelper
         path: edit_type_defaults_path(**variant_args),
         label: I18n.t("types.edit.defaults.tab")
       },
-      *variants_tab,
+      variants_tab,
       {
         name: "form_configuration",
         path: edit_type_form_configuration_path(**variant_args),
@@ -73,7 +73,7 @@ module ::TypesHelper
         label: I18n.t("types.edit.export_configuration.tab"),
         view_component: WorkPackageTypes::ExportConfigurationComponent
       }
-    ]
+    ].compact
   end
 
   def type_variant_tab_args
@@ -81,14 +81,14 @@ module ::TypesHelper
   end
 
   def variants_tab
-    return [] unless OpenProject::FeatureDecisions.type_variants_active?
-    return [] if @variant.present? && !@variant.is_default_variant?
+    return unless OpenProject::FeatureDecisions.type_variants_active?
+    return if @variant.present? && !@variant.is_default_variant?
 
-    [{
+    {
       name: "variants",
       path: type_variants_path(type_id: @type.id),
       label: TypeVariant.model_name.human(count: 2)
-    }]
+    }
   end
   # rubocop:enable Rails/HelperInstanceVariable
 

--- a/app/models/type_variant.rb
+++ b/app/models/type_variant.rb
@@ -107,6 +107,10 @@ class TypeVariant < ApplicationRecord
   # Base variants first, then the named ones alphabetically. Named variants have no user defined order
   scope :in_display_order, -> { order(is_default_variant: :desc, variant_name: :asc) }
 
+  scope :with_name_like, ->(query) {
+    where("variant_name ILIKE :query", query: "%#{sanitize_sql_like(query.to_s.strip)}%")
+  }
+
   delegate :name, :color, :color_id, :is_milestone, :is_milestone?, :is_in_roadmap, :is_in_roadmap?,
            to: :type
 

--- a/app/views/work_package_types/creation_wizard/show.html.erb
+++ b/app/views/work_package_types/creation_wizard/show.html.erb
@@ -1,4 +1,11 @@
 <% html_title t(:label_administration),
               adding_variant? ? t("types.creation_wizard.create_variant") : t("types.creation_wizard.create_type") %>
 
-<%= render(WorkPackageTypes::Wizard::PageComponent.new(type: @type, variant: @variant, current_step: @current_step)) %>
+<%= render(
+      WorkPackageTypes::Wizard::PageComponent.new(
+        type: @type,
+        variant: @variant,
+        current_step: @current_step,
+        back_url: @back_url
+      )
+    ) %>

--- a/app/views/work_package_types/variants/index.html.erb
+++ b/app/views/work_package_types/variants/index.html.erb
@@ -31,4 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
 
-<%= render WorkPackageTypes::VariantsListComponent.new(type: @type) %>
+<%= render WorkPackageTypes::VariantsListComponent.new(type: @type, query: params[:query]) %>

--- a/app/views/work_package_types/variants/index.html.erb
+++ b/app/views/work_package_types/variants/index.html.erb
@@ -30,3 +30,5 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+
+<%= render WorkPackageTypes::VariantsListComponent.new(type: @type) %>

--- a/app/views/work_package_types/variants/index.html.erb
+++ b/app/views/work_package_types/variants/index.html.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
+
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6384,8 +6384,11 @@ en:
         parent_suffix: " (parent)"
       variants:
         blankslate:
-          description: "Variants let you configure different flavors of this type."
-          title: "This type has no variants yet."
+          description_html: >
+            You can create variants to offer versions of this type to different projects.<br>
+            Each variant can inherit, copy or have its own custom configuration for the default
+            template, custom fields, workflows and preferences.
+          title: "No variants exist for this type"
       workflow:
         tab: "Workflows"
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6390,6 +6390,7 @@ en:
             template, custom fields, workflows and preferences.
           title: "No variants exist for this type"
         filter: "Filter by text"
+        filter_no_results: "No variants match this filter."
       workflow:
         tab: "Workflows"
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6389,6 +6389,7 @@ en:
             Each variant can inherit, copy or have its own custom configuration for the default
             template, custom fields, workflows and preferences.
           title: "No variants exist for this type"
+        filter: "Filter by text"
       workflow:
         tab: "Workflows"
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6390,7 +6390,7 @@ en:
             template, custom fields, workflows and preferences.
           title: "No variants exist for this type"
         filter: "Filter by text"
-        filter_no_results: "No variants match this filter."
+        filter_no_results: "No variants match this filter"
       workflow:
         tab: "Workflows"
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6382,6 +6382,10 @@ en:
           switch_to_independent: "Switch to independent mode"
           title: "Linked mode"
         parent_suffix: " (parent)"
+      variants:
+        blankslate:
+          description: "Variants let you configure different flavors of this type."
+          title: "This type has no variants yet."
       workflow:
         tab: "Workflows"
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,7 +155,7 @@ Rails.application.routes.draw do
   get "/roles/workflow/:id/:role_id/:type_id" => "roles#workflow"
 
   resources :types, module: "work_package_types", except: [:update] do
-    resources :variants, controller: "variants", only: %i[destroy] do
+    resources :variants, controller: "variants", only: %i[index destroy] do
       member do
         get :menu
         post :make_default

--- a/spec/components/work_package_types/variant_row_component_spec.rb
+++ b/spec/components/work_package_types/variant_row_component_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::VariantRowComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
+
+  subject(:rendered_component) { render_inline(described_class.new(variant:, caption:)) }
+
+  let(:caption) { nil }
+
+  it "links the variant to its settings page" do
+    expect(rendered_component)
+      .to have_link("Hardware", href: edit_type_details_path(type_id: type.id, variant_id: variant.id))
+  end
+
+  it "leaves out the caption unless one is given" do
+    expect(rendered_component).to have_no_text(I18n.t("types.index.variant_label"))
+  end
+
+  it "says nothing about new projects while the variant is not the one they start with" do
+    expect(rendered_component).to have_no_text(I18n.t("types.index.enabled_in_new_projects"))
+  end
+
+  context "with a caption" do
+    let(:caption) { I18n.t("types.index.variant_label") }
+
+    it "renders it next to the name" do
+      expect(rendered_component).to have_text(caption)
+    end
+  end
+
+  context "when new projects start with this variant" do
+    before { variant.update!(enabled_in_new_projects: true) }
+
+    it "labels the row" do
+      expect(rendered_component).to have_text(I18n.t("types.index.enabled_in_new_projects"))
+    end
+  end
+end

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -71,9 +71,13 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
       end
     end
 
-    it "offers to add another variant from the header" do
+    it "offers to add another variant from the sub header" do
       expect(rendered_component)
-        .to have_link(I18n.t("types.index.add_variant_action"), href: add_variant_href)
+        .to have_link(I18n.t("types.index.variant_label"), href: add_variant_href)
+    end
+
+    it "renders the filter input, not yet wired to anything" do
+      expect(rendered_component).to have_field(I18n.t("types.edit.variants.filter"))
     end
 
     it "marks the variant new projects start with" do

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
 
   shared_let(:type) { create(:type, name: "Bug") }
 
-  subject(:rendered_component) { render_inline(described_class.new(type:)) }
+  subject(:rendered_component) { render_inline(described_class.new(type:, query:)) }
+
+  let(:query) { nil }
 
   # The wizard is reachable from the types index too, so it has to be told to come back here.
   let(:add_variant_href) do
@@ -76,14 +78,37 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
         .to have_link(I18n.t("types.index.variant_label"), href: add_variant_href)
     end
 
-    it "renders the filter input, not yet wired to anything" do
+    it "submits the filter input to the list's turbo frame" do
       expect(rendered_component).to have_field(I18n.t("types.edit.variants.filter"))
+      expect(rendered_component)
+        .to have_css("form[action='#{type_variants_path(type_id: type.id)}'][data-turbo-frame='#{described_class::FRAME_ID}']")
+      expect(rendered_component).to have_css("turbo-frame##{described_class::FRAME_ID}", visible: :all)
     end
 
     it "marks the variant new projects start with" do
       alfa.update!(enabled_in_new_projects: true)
 
       expect(rendered_component).to have_text(I18n.t("types.index.enabled_in_new_projects"))
+    end
+
+    context "with a query matching one of them" do
+      let(:query) { "alf" }
+
+      it "lists only the matches and keeps the query in the input" do
+        expect(rendered_component).to have_link("Alfa")
+        expect(rendered_component).to have_no_link("Zeta")
+        expect(rendered_component).to have_field(I18n.t("types.edit.variants.filter"), with: "alf")
+      end
+    end
+
+    context "with a query matching none of them" do
+      let(:query) { "nothing like it" }
+
+      it "keeps the filter around and says so, rather than falling back to the blankslate" do
+        expect(rendered_component).to have_text(I18n.t("types.edit.variants.filter_no_results"))
+        expect(rendered_component).to have_field(I18n.t("types.edit.variants.filter"))
+        expect(rendered_component).to have_no_css("[data-test-selector='type-variants-blankslate']")
+      end
     end
   end
 

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:type) { create(:type, name: "Bug") }
+
+  subject(:rendered_component) { render_inline(described_class.new(type:)) }
+
+  context "with named variants" do
+    let!(:zeta) { create(:type_variant, type:, variant_name: "Zeta") }
+    let!(:alfa) { create(:type_variant, type:, variant_name: "Alfa") }
+
+    it "links every named variant to its settings page" do
+      expect(rendered_component).to have_link("Alfa", href: edit_type_details_path(type_id: type.id, variant_id: alfa.id))
+      expect(rendered_component).to have_link("Zeta", href: edit_type_details_path(type_id: type.id, variant_id: zeta.id))
+    end
+
+    it "lists them in display order" do
+      names = rendered_component.css("[data-test-selector^='type-variant-'] a").map { it.text.strip }
+
+      expect(names).to eq(%w[Alfa Zeta])
+    end
+
+    it "leaves out the base variant: that is the type itself" do
+      expect(rendered_component).to have_no_link(type.name)
+      expect(rendered_component.css("[data-test-selector^='type-variant-']").size).to eq(2)
+    end
+
+    it "loads each variant's action menu from the variants controller" do
+      [alfa, zeta].each do |variant|
+        expect(rendered_component)
+          .to have_css("[src='#{menu_type_variant_path(type_id: type.id, id: variant.id)}']", visible: :all)
+      end
+    end
+
+    it "offers to add another variant from the header" do
+      expect(rendered_component)
+        .to have_link(I18n.t("types.index.add_variant_action"), href: new_creation_wizard_types_path(type_id: type.id))
+    end
+
+    it "marks the variant new projects start with" do
+      alfa.update!(enabled_in_new_projects: true)
+
+      expect(rendered_component).to have_text(I18n.t("types.index.enabled_in_new_projects"))
+    end
+  end
+
+  context "without named variants" do
+    it "renders a blankslate offering to add one" do
+      expect(rendered_component).to have_text(I18n.t("types.edit.variants.blankslate.title"))
+      expect(rendered_component)
+        .to have_link(I18n.t("types.index.add_variant_action"), href: new_creation_wizard_types_path(type_id: type.id))
+    end
+  end
+end

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -84,8 +84,12 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
   end
 
   context "without named variants" do
-    it "renders a blankslate offering to add one" do
+    it "renders a blankslate offering to add one, instead of an empty list" do
+      expect(rendered_component).to have_css("[data-test-selector='type-variants-blankslate']")
+      expect(rendered_component).to have_no_css("[data-test-selector='type-variants']")
       expect(rendered_component).to have_text(I18n.t("types.edit.variants.blankslate.title"))
+      expect(rendered_component)
+        .to have_css("[data-test-selector='type-variants-blankslate'] p br")
       expect(rendered_component)
         .to have_link(I18n.t("types.index.add_variant_action"), href: add_variant_href)
     end

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
 
   subject(:rendered_component) { render_inline(described_class.new(type:)) }
 
+  # The wizard is reachable from the types index too, so it has to be told to come back here.
+  let(:add_variant_href) do
+    new_creation_wizard_types_path(type_id: type.id, back_url: type_variants_path(type_id: type.id))
+  end
+
   context "with named variants" do
     let!(:zeta) { create(:type_variant, type:, variant_name: "Zeta") }
     let!(:alfa) { create(:type_variant, type:, variant_name: "Alfa") }
@@ -57,16 +62,18 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
       expect(rendered_component.css("[data-test-selector^='type-variant-']").size).to eq(2)
     end
 
-    it "loads each variant's action menu from the variants controller" do
+    it "loads each variant's action menu, telling it to come back to this tab" do
       [alfa, zeta].each do |variant|
-        expect(rendered_component)
-          .to have_css("[src='#{menu_type_variant_path(type_id: type.id, id: variant.id)}']", visible: :all)
+        src = menu_type_variant_path(type_id: type.id, id: variant.id,
+                                     back_url: type_variants_path(type_id: type.id))
+
+        expect(rendered_component).to have_css("[src='#{src}']", visible: :all)
       end
     end
 
     it "offers to add another variant from the header" do
       expect(rendered_component)
-        .to have_link(I18n.t("types.index.add_variant_action"), href: new_creation_wizard_types_path(type_id: type.id))
+        .to have_link(I18n.t("types.index.add_variant_action"), href: add_variant_href)
     end
 
     it "marks the variant new projects start with" do
@@ -80,7 +87,7 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
     it "renders a blankslate offering to add one" do
       expect(rendered_component).to have_text(I18n.t("types.edit.variants.blankslate.title"))
       expect(rendered_component)
-        .to have_link(I18n.t("types.index.add_variant_action"), href: new_creation_wizard_types_path(type_id: type.id))
+        .to have_link(I18n.t("types.index.add_variant_action"), href: add_variant_href)
     end
   end
 end

--- a/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
+++ b/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
@@ -127,6 +127,36 @@ RSpec.describe WorkPackageTypes::CreationWizardController, with_flag: { type_var
 
         it { expect(flash[:notice]).to eq(I18n.t("types.creation_wizard.success")) }
       end
+
+      describe "returning to where the wizard was entered from" do
+        let(:back_url) { type_variants_path(type_id: type.id) }
+
+        it "carries the back_url from step to step" do
+          patch :update, params: { type_id: type.id, step: :details, type: { name: "Blocker" }, back_url: }
+
+          expect(response).to redirect_to(type_creation_wizard_path(type, step: :defaults, back_url:))
+        end
+
+        it "returns there once the wizard finishes" do
+          patch :update, params: { type_id: type.id, step: WorkPackageTypes::Wizard::Steps.last, back_url: }
+
+          expect(response).to redirect_to(back_url)
+          expect(flash[:notice]).to eq(I18n.t("types.creation_wizard.success"))
+        end
+
+        it "offers the cancel button the same target" do
+          get :show, params: { type_id: type.id, step: :details, back_url: }
+
+          expect(response.body).to include(CGI.escapeHTML(back_url))
+        end
+
+        it "drops a back_url pointing at another host" do
+          patch :update, params: { type_id: type.id, step: WorkPackageTypes::Wizard::Steps.last,
+                                   back_url: "https://evil.example.com/types" }
+
+          expect(response).to redirect_to(types_path)
+        end
+      end
     end
   end
 

--- a/spec/controllers/work_package_types/variants_controller_spec.rb
+++ b/spec/controllers/work_package_types/variants_controller_spec.rb
@@ -41,11 +41,16 @@ RSpec.describe WorkPackageTypes::VariantsController, with_flag: { type_variants:
     let(:user) { admin }
 
     describe "GET index" do
+      let!(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
+
       before { get :index, params: { type_id: type.id } }
 
-      it "renders the tab" do
+      render_views
+
+      it "renders the tab, listing the type's named variants" do
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:index)
+        expect(response.body).to include("Hardware")
       end
 
       context "with the type_variants feature disabled", with_flag: { type_variants: false } do

--- a/spec/controllers/work_package_types/variants_controller_spec.rb
+++ b/spec/controllers/work_package_types/variants_controller_spec.rb
@@ -106,6 +106,46 @@ RSpec.describe WorkPackageTypes::VariantsController, with_flag: { type_variants:
         expect(variant.reload).not_to be_enabled_in_new_projects
       end
     end
+
+    describe "DELETE destroy" do
+      let!(:variant) { create(:type_variant, type:) }
+
+      before { delete :destroy, params: { type_id: type.id, id: variant.id } }
+
+      it "deletes it and falls back to the types index" do
+        expect(response).to redirect_to(types_path)
+        expect(TypeVariant).not_to exist(id: variant.id)
+      end
+    end
+
+    describe "returning to where the action was triggered" do
+      let!(:variant) { create(:type_variant, type:) }
+      let(:back_url) { type_variants_path(type_id: type.id) }
+
+      it "sends make_default back to the variants tab" do
+        post :make_default, params: { type_id: type.id, id: variant.id, back_url: }
+
+        expect(response).to redirect_to(back_url)
+      end
+
+      it "sends remove_default back to the variants tab" do
+        post :remove_default, params: { type_id: type.id, id: variant.id, back_url: }
+
+        expect(response).to redirect_to(back_url)
+      end
+
+      it "sends destroy back to the variants tab" do
+        delete :destroy, params: { type_id: type.id, id: variant.id, back_url: }
+
+        expect(response).to redirect_to(back_url)
+      end
+
+      it "ignores a back_url pointing at another host" do
+        post :make_default, params: { type_id: type.id, id: variant.id, back_url: "https://evil.example.com/types" }
+
+        expect(response).to redirect_to(types_path)
+      end
+    end
   end
 
   context "without admin access" do

--- a/spec/controllers/work_package_types/variants_controller_spec.rb
+++ b/spec/controllers/work_package_types/variants_controller_spec.rb
@@ -60,6 +60,26 @@ RSpec.describe WorkPackageTypes::VariantsController, with_flag: { type_variants:
       end
     end
 
+    describe "GET index as a turbo frame request" do
+      let!(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
+      let!(:other_variant) { create(:type_variant, type:, variant_name: "Software") }
+
+      render_views
+
+      before do
+        request.headers["Turbo-Frame"] = WorkPackageTypes::VariantsListComponent::FRAME_ID
+
+        get :index, params: { type_id: type.id, query: "hard" }
+      end
+
+      it "renders the filtered list on its own, without the surrounding page" do
+        expect(response).to have_http_status(:ok)
+        expect(response).not_to render_template(:index)
+        expect(response.body).to include("Hardware")
+        expect(response.body).not_to include("Software")
+      end
+    end
+
     describe "POST make_default" do
       context "for the base variant" do
         let(:variant) { type.default_variant }

--- a/spec/controllers/work_package_types/variants_controller_spec.rb
+++ b/spec/controllers/work_package_types/variants_controller_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe WorkPackageTypes::VariantsController, with_flag: { type_variants:
   context "with admin access" do
     let(:user) { admin }
 
+    describe "GET index" do
+      before { get :index, params: { type_id: type.id } }
+
+      it "renders the tab" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:index)
+      end
+
+      context "with the type_variants feature disabled", with_flag: { type_variants: false } do
+        it "is not found" do
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
     describe "POST make_default" do
       context "for the base variant" do
         let(:variant) { type.default_variant }

--- a/spec/features/types/variants_index_spec.rb
+++ b/spec/features/types/variants_index_spec.rb
@@ -149,6 +149,20 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
       .to contain_exactly("Alpha variant", "Zeta variant", "Hardware")
   end
 
+  it "returns to the index when the add-variant wizard is cancelled" do
+    visit types_path(expand: bug_type.id)
+
+    within("[data-draggable-id='#{bug_type.id}']") do
+      click_on I18n.t("types.index.add_variant", name: bug_type.name)
+    end
+
+    expect(page).to have_text(I18n.t("types.creation_wizard.add_variant", name: bug_type.name))
+
+    click_on I18n.t(:button_cancel), match: :first
+
+    expect(page).to have_current_path(types_path)
+  end
+
   it "duplicates a type from its action menu" do
     visit types_path
 

--- a/spec/features/types/variants_tab_spec.rb
+++ b/spec/features/types/variants_tab_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Work package type variants tab", :js, with_flag: { type_variants
   end
 
   it "returns to the tab when the add-variant wizard is cancelled" do
-    click_on I18n.t("types.index.add_variant_action")
+    find_test_selector("add-type-variant").click
 
     expect(page).to have_text(I18n.t("types.creation_wizard.add_variant", name: bug_type.name))
 

--- a/spec/features/types/variants_tab_spec.rb
+++ b/spec/features/types/variants_tab_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package type variants tab", :js, with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:bug_type) { create(:type, name: "Bug") }
+
+  let!(:hardware) { create(:type_variant, type: bug_type, variant_name: "Hardware") }
+
+  let(:tab_path) { type_variants_path(type_id: bug_type.id) }
+
+  before do
+    login_as(admin)
+    visit tab_path
+  end
+
+  def open_variant_menu
+    within(".Box-row", text: hardware.variant_name) { find("action-menu > button").click }
+  end
+
+  it "lists the type's variants" do
+    expect(page).to have_link(hardware.variant_name,
+                              href: edit_type_details_path(type_id: bug_type.id, variant_id: hardware.id))
+  end
+
+  it "stays on the tab after activating a variant in new projects" do
+    open_variant_menu
+    click_on I18n.t("types.index.make_default")
+
+    expect(page).to have_current_path(tab_path)
+    expect(page).to have_text(I18n.t("types.index.enabled_in_new_projects"))
+    expect(hardware.reload).to be_enabled_in_new_projects
+  end
+
+  it "stays on the tab after deactivating a variant in new projects" do
+    hardware.update!(enabled_in_new_projects: true)
+    refresh
+
+    open_variant_menu
+    click_on I18n.t("types.index.remove_default")
+
+    expect(page).to have_current_path(tab_path)
+    expect(hardware.reload).not_to be_enabled_in_new_projects
+  end
+
+  it "stays on the tab after deleting a variant" do
+    open_variant_menu
+    accept_confirm { click_on I18n.t(:button_delete) }
+
+    expect(page).to have_current_path(tab_path)
+    expect(page).to have_text(I18n.t("types.edit.variants.blankslate.title"))
+    expect(TypeVariant).not_to exist(id: hardware.id)
+  end
+
+  it "returns to the tab when the add-variant wizard is cancelled" do
+    click_on I18n.t("types.index.add_variant_action")
+
+    expect(page).to have_text(I18n.t("types.creation_wizard.add_variant", name: bug_type.name))
+
+    click_on I18n.t(:button_cancel), match: :first
+
+    expect(page).to have_current_path(tab_path)
+  end
+end

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -34,6 +34,50 @@ RSpec.describe TypesHelper do
   let(:type) { build_stubbed(:type) }
   let(:variant) { build_stubbed(:type_variant, type:) }
 
+  describe "#types_tabs" do
+    subject(:tab_names) { helper.types_tabs.pluck(:name) }
+
+    before do
+      helper.instance_variable_set(:@type, type)
+      helper.instance_variable_set(:@variant, addressed_variant)
+    end
+
+    context "with the type_variants feature enabled", with_flag: { type_variants: true } do
+      context "when no variant is addressed" do
+        let(:addressed_variant) { nil }
+
+        it "offers the variants tab right after the defaults tab" do
+          expect(tab_names).to include("variants")
+          expect(tab_names.index("variants")).to eq(tab_names.index("defaults") + 1)
+        end
+      end
+
+      context "when the base variant is addressed" do
+        let(:addressed_variant) { build_stubbed(:type_variant, type:, is_default_variant: true) }
+
+        it "offers the variants tab: the URL is about the type itself" do
+          expect(tab_names).to include("variants")
+        end
+      end
+
+      context "when a named variant is addressed" do
+        let(:addressed_variant) { variant }
+
+        it "omits the variants tab" do
+          expect(tab_names).not_to include("variants")
+        end
+      end
+    end
+
+    context "with the type_variants feature disabled", with_flag: { type_variants: false } do
+      let(:addressed_variant) { nil }
+
+      it "omits the variants tab" do
+        expect(tab_names).not_to include("variants")
+      end
+    end
+  end
+
   describe "#form_configuration_groups" do
     it "returns a Hash with the keys :actives and :inactives Arrays" do
       expect(helper.form_configuration_groups(variant)[:actives]).to be_an Array


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/FND-226/activity

# What are you trying to accomplish?
- Add a Variants tab to the Type edit flow to list all existing variants
- Update the wizard, make/unmake default, delete actions so that they can also redirect back to the variants tab, not just the types index
