### PR TITLE
[OP-19934] Communitiy version: Project list inconsistencies

### DIFF
--- a/app/controllers/header/projects_controller.rb
+++ b/app/controllers/header/projects_controller.rb
@@ -141,28 +141,22 @@ class Header::ProjectsController < ApplicationController
   # Builds a nested structure from a flat, lft-ordered list of projects.
   # Each level is sorted alphabetically by project name.
   def build_tree(projects)
-    nodes = Project.build_projects_hierarchy(projects)
-    mark_query_matches(nodes)
-    sort_nodes(nodes)
+    decorate_nodes(Project.build_projects_hierarchy(projects))
   end
 
-  def mark_query_matches(nodes)
+  def decorate_nodes(nodes)
     nodes.each do |node|
+      decorate_nodes(node[:children])
       node[:matches_query] = @matching_ids.nil? || @matching_ids.include?(node[:project].id)
-      mark_query_matches(node[:children])
-    end
-  end
-
-  def sort_nodes(nodes)
-    nodes.sort_by { |n| n[:project].name.downcase }.each do |node|
-      node[:children] = sort_nodes(node[:children])
       node[:expanded] = expanded_node?(node)
     end
   end
 
   def expanded_node?(node)
     filter_mode == "favorited" || node[:children].any? do |child|
-      child[:project].id == @current_project_id || child[:expanded]
+      child[:project].parent_id != node[:project].id ||
+        child[:project].id == @current_project_id ||
+        child[:expanded]
     end
   end
 end

--- a/app/controllers/header/projects_controller.rb
+++ b/app/controllers/header/projects_controller.rb
@@ -141,31 +141,28 @@ class Header::ProjectsController < ApplicationController
   # Builds a nested structure from a flat, lft-ordered list of projects.
   # Each level is sorted alphabetically by project name.
   def build_tree(projects)
-    nodes = projects.index_by(&:id).transform_values do |p|
-      { project: p, children: [], matches_query: @matching_ids.nil? || @matching_ids.include?(p.id) }
+    nodes = Project.build_projects_hierarchy(projects)
+    mark_query_matches(nodes)
+    sort_nodes(nodes)
+  end
+
+  def mark_query_matches(nodes)
+    nodes.each do |node|
+      node[:matches_query] = @matching_ids.nil? || @matching_ids.include?(node[:project].id)
+      mark_query_matches(node[:children])
     end
-
-    roots = []
-    projects.each do |project|
-      node   = nodes[project.id]
-      parent = nodes[project.parent_id]
-
-      if parent
-        parent[:children] << node
-      else
-        roots << node
-      end
-    end
-
-    sort_nodes(roots)
   end
 
   def sort_nodes(nodes)
     nodes.sort_by { |n| n[:project].name.downcase }.each do |node|
       node[:children] = sort_nodes(node[:children])
-      node[:expanded] = filter_mode == "favorited" || node[:children].any? do |c|
-        c[:project].id == @current_project_id || c[:expanded]
-      end
+      node[:expanded] = expanded_node?(node)
+    end
+  end
+
+  def expanded_node?(node)
+    filter_mode == "favorited" || node[:children].any? do |child|
+      child[:project].id == @current_project_id || child[:expanded]
     end
   end
 end

--- a/app/controllers/header/projects_controller.rb
+++ b/app/controllers/header/projects_controller.rb
@@ -138,8 +138,8 @@ class Header::ProjectsController < ApplicationController
     @user_project_favorites ||= Favorite.where(favorited_type: "Project", user_id: current_user.id)
   end
 
-  # Builds a nested structure from a flat, lft-ordered list of projects.
-  # Each level is sorted alphabetically by project name.
+  # Builds the nested tree from a flat, lft-ordered list of projects and
+  # decorates each node with its query-match and expansion state.
   def build_tree(projects)
     decorate_nodes(Project.build_projects_hierarchy(projects))
   end
@@ -152,6 +152,13 @@ class Header::ProjectsController < ApplicationController
     end
   end
 
+  # A node is expanded so its children are revealed when:
+  # - favorited mode is active (always expand to surface favorites), or
+  # - a child is grafted onto this node because its real parent is hidden
+  #   (child.parent_id != this node's id) and would otherwise be concealed
+  #   behind a collapsed ancestor, or
+  # - a child is the current project, or
+  # - a child is itself expanded, propagating expansion up the visible chain.
   def expanded_node?(node)
     filter_mode == "favorited" || node[:children].any? do |child|
       child[:project].parent_id != node[:project].id ||

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Header::ProjectsController do
 
         expect(assigns(:projects)).to include(visible_grandchild)
         expect(assigns(:projects)).not_to include(invisible_project)
+        expect(response.body).not_to include("Invisible")
         expect(tree.pluck(:project)).not_to include(visible_grandchild)
         expect(parent_node[:children].pluck(:project)).to include(visible_grandchild)
         expect(parent_node[:expanded]).to be(true)

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -99,6 +99,31 @@ RSpec.describe Header::ProjectsController do
       end
     end
 
+    context "when a hidden project sits mid-way in a visible chain" do
+      shared_let(:visible_root) { create(:project, name: "Root Visible") }
+      shared_let(:visible_mid)  { create(:project, name: "Mid Visible", parent: visible_root) }
+      shared_let(:hidden_middle) { create(:private_project, name: "Hidden Middle", parent: visible_mid) }
+      shared_let(:visible_leaf) { create(:project, name: "Leaf Visible", parent: hidden_middle) }
+
+      before do
+        create(:member, principal: current_user, project: visible_root, roles: [role])
+        create(:member, principal: current_user, project: visible_mid,  roles: [role])
+        create(:member, principal: current_user, project: visible_leaf, roles: [role])
+      end
+
+      it "expands every visible ancestor down to the grafted leaf", :aggregate_failures do
+        make_request
+
+        tree = assigns(:tree)
+        root_node = tree.find { |node| node[:project] == visible_root }
+        mid_node = root_node[:children].find { |node| node[:project] == visible_mid }
+
+        expect(root_node[:expanded]).to be(true)
+        expect(mid_node[:expanded]).to be(true)
+        expect(mid_node[:children].pluck(:project)).to include(visible_leaf)
+      end
+    end
+
     context "when searching by query" do
       subject(:make_request) { get :index, params: { query: "Beta" } }
 

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe Header::ProjectsController do
       expect(response).to render_template(layout: false)
     end
 
+    it "keeps ordinary parent projects collapsed by default" do
+      make_request
+
+      parent_node = assigns(:tree).find { |node| node[:project] == parent_project }
+      expect(parent_node[:expanded]).to be(false)
+    end
+
     context "when an invisible project is between two visible projects" do
       shared_let(:invisible_project) { create(:private_project, name: "Invisible", parent: parent_project) }
       shared_let(:visible_grandchild) { create(:project, name: "Visible Grandchild", parent: invisible_project) }
@@ -87,6 +94,7 @@ RSpec.describe Header::ProjectsController do
         expect(assigns(:projects)).not_to include(invisible_project)
         expect(tree.pluck(:project)).not_to include(visible_grandchild)
         expect(parent_node[:children].pluck(:project)).to include(visible_grandchild)
+        expect(parent_node[:expanded]).to be(true)
       end
     end
 

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -69,6 +69,27 @@ RSpec.describe Header::ProjectsController do
       expect(response).to render_template(layout: false)
     end
 
+    context "when an invisible project is between two visible projects" do
+      shared_let(:invisible_project) { create(:private_project, name: "Invisible", parent: parent_project) }
+      shared_let(:visible_grandchild) { create(:project, name: "Visible Grandchild", parent: invisible_project) }
+
+      before do
+        create(:member, principal: current_user, project: visible_grandchild, roles: [role])
+      end
+
+      it "nests the grandchild below its nearest visible ancestor", :aggregate_failures do
+        make_request
+
+        tree = assigns(:tree)
+        parent_node = tree.find { |node| node[:project] == parent_project }
+
+        expect(assigns(:projects)).to include(visible_grandchild)
+        expect(assigns(:projects)).not_to include(invisible_project)
+        expect(tree.pluck(:project)).not_to include(visible_grandchild)
+        expect(parent_node[:children].pluck(:project)).to include(visible_grandchild)
+      end
+    end
+
     context "when searching by query" do
       subject(:make_request) { get :index, params: { query: "Beta" } }
 

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -191,6 +191,25 @@ RSpec.describe "Projects autocomplete page", :js do
     top_menu.expect_current_project project2.name
   end
 
+  it "nests projects below their nearest visible ancestor" do
+    visible_grandparent = create(:project, name: "Visible Grandparent", members: { user => role })
+    invisible_parent = create(:private_project, name: "Invisible Parent", parent: visible_grandparent)
+    visible_grandchild = create(:project,
+                                name: "Visible Grandchild",
+                                parent: invisible_parent,
+                                members: { user => role })
+
+    retry_block do
+      top_menu.toggle unless top_menu.open?
+      top_menu.expect_open
+
+      top_menu.expect_result visible_grandparent.name
+      top_menu.expect_no_result invisible_parent.name
+      top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
+                                                item_name: visible_grandchild.name
+    end
+  end
+
   it "displays workspace type badges for portfolios and programs" do
     retry_block do
       top_menu.toggle unless top_menu.open?


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19934

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The project selector now uses the existing project hierarchy builder, which places visible projects below their nearest visible ancestor without exposing inaccessible projects. Query matching and hierarchy expansion are applied recursively to the resulting tree.

## Screenshots
**Before:**
Admin:
<img width="1118" height="564" alt="Screenshot 2026-08-14 at 10 44 35" src="https://github.com/user-attachments/assets/c0a109cc-1b12-4f53-9399-23f4acb02aa4" />

Restricted User:
<img width="1013" height="362" alt="Screenshot 2026-08-14 at 11 44 45" src="https://github.com/user-attachments/assets/13c77d63-8e22-49f9-b86d-cf7c4473eba5" />

**After:**
Admin:
<img width="1118" height="564" alt="Screenshot 2026-08-14 at 10 44 35" src="https://github.com/user-attachments/assets/5a65156f-aea5-498c-a95c-e3d211775bcf" />

Restricted User:
<img width="1022" height="551" alt="Screenshot 2026-08-14 at 10 44 18" src="https://github.com/user-attachments/assets/89d1fdf3-11b1-45af-b418-3bda9e490450" />
