### PR TITLE
[OP-9533] Translation error in "add work package" macro in WYSWIG

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3941,7 +3941,6 @@ en:
         invalid_type: "No type found with name '%{type}' in project '%{project}'."
         no_project_context: "Calling create_work_package_link macro from outside project context."
       link_name: "New work package"
-      link_name_type: "New %{type_name}"
     errors:
       missing_or_invalid_parameter: "Missing or invalid macro parameter."
     include_wiki_page:

--- a/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
+++ b/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
@@ -64,7 +64,7 @@ module OpenProject::TextFormatting::Filters::Macros
         end
 
         ApplicationController.helpers.link_to(
-          I18n.t("macros.create_work_package_link.link_name_type", type_name:),
+          "+ #{type_name}",
           new_project_work_packages_path(project_id: project.identifier, type: type.id),
           class: class_name
         )

--- a/spec/lib/open_project/text_formatting/markdown/work_package_buttons_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/work_package_buttons_macro_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe OpenProject::TextFormatting,
       let(:expected) do
         <<~EXPECTED
           <p class="op-uc-p">
-            <a class="op-uc-link" target="_top" href="/projects/my-project/work_packages/new?type=#{type.id}">New MyTaskName</a>
+            <a class="op-uc-link" target="_top" href="/projects/my-project/work_packages/new?type=#{type.id}">+ MyTaskName</a>
           </p>
         EXPECTED
       end
@@ -125,7 +125,7 @@ RSpec.describe OpenProject::TextFormatting,
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              <a class="button op-uc-link" target="_top" href="/projects/my-project/work_packages/new?type=#{type.id}">New MyTaskName</a>
+              <a class="button op-uc-link" target="_top" href="/projects/my-project/work_packages/new?type=#{type.id}">+ MyTaskName</a>
             </p>
           EXPECTED
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-9533

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The label now uses the language-neutral format + TypeName