### PR TITLE
[DREAM-807] Update Lookbook config to enable page filtering, UI improvements

### DIFF
--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -36,24 +36,30 @@ Rails.application.configure do
 
   # Re-define snapshot to avoid warnings
   YARD::Tags::Library.define_tag("Snapshot preview (unused)", :snapshot)
+
+  # Branding
   config.lookbook.project_name = "OpenProject Lookbook"
   config.lookbook.project_logo = Rails.root.join("app/assets/images/icon_logo_white.svg").read
   config.lookbook.ui_favicon = Rails.root.join("app/assets/images/icon_logo.svg").read
-  config.lookbook.page_paths = [Rails.root.join("lookbook/docs").to_s]
+  config.lookbook.ui_theme = "blue"
 
+  # Previews: ours, plus the ones shipped by Primer
   config.lookbook.component_paths << Primer::ViewComponents::Engine.root.join("app/components").to_s
   config.view_component.previews.paths += [
     Rails.root.join("lookbook/previews").to_s,
     Primer::ViewComponents::Engine.root.join("previews").to_s
   ]
 
+  # Pages
+  config.lookbook.page_paths = [Rails.root.join("lookbook/docs").to_s]
+
+  # Inspector
   # Show pages first, then previews
   config.lookbook.preview_inspector.sidebar_panels = %i[pages previews]
   # Show notes first, all other panels next
   config.lookbook.preview_inspector.drawer_panels = [:notes, "*"]
-  config.lookbook.ui_theme = "blue"
 
-  # Add custom inputs
+  # Custom inputs
   Lookbook.add_input_type(:octicon, "lookbook/previews/inputs/octicon")
   Lookbook.add_input_type(:medium_octicon, "lookbook/previews/inputs/medium_octicon")
 end

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
   config.lookbook.project_logo = Rails.root.join("app/assets/images/icon_logo_white.svg").read
   config.lookbook.ui_favicon = Rails.root.join("app/assets/images/icon_logo.svg").read
   config.lookbook.ui_theme = "blue"
+  config.lookbook.ui_theme_overrides = {
+    header_bg: "#1A67A3"
+  }
 
   # Previews: ours, plus the ones shipped by Primer
   config.lookbook.component_paths << Primer::ViewComponents::Engine.root.join("app/components").to_s

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -52,6 +52,8 @@ Rails.application.configure do
 
   # Pages
   config.lookbook.page_paths = [Rails.root.join("lookbook/docs").to_s]
+  # Previews ship with a filter box (preview_nav_filter), pages do not
+  config.lookbook.page_nav_filter = true
 
   # Inspector
   # Show pages first, then previews


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-807

# What are you trying to accomplish?

Makes Lookbook pages findable and tidies the initializer.

- Enables `page_nav_filter` — previews already ship with a filter box, pages did not.
- Sets `ui_theme_overrides.header_bg` to the OpenProject blue.
- Groups the config by concern (branding, previews, pages, inspector, custom inputs). No behaviour change.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1274" height="1319" alt="Screenshot 2026-08-14 at 12 42 57" src="https://github.com/user-attachments/assets/aecf9122-d466-400e-81b7-169801d387af" /> | <img width="1277" height="1318" alt="Screenshot 2026-08-14 at 12 42 18" src="https://github.com/user-attachments/assets/467c387e-70a9-4a4c-ad78-232e120f42f3" /> | 


# What approach did you choose and why?

Config-only; both changes are stock Lookbook options. The regrouping is a separate commit so each functional change stays a one-liner in the diff.

# Merge checklist

- [ ] Added/updated tests
- [X] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
