### PR TITLE
[COMMS-959] Fix typo on Administration -> work packages -> Versions and categories

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1573,7 +1573,7 @@ en:
           planned_changes:
             heading: Planned changes in a future release
             renamed: The “Version” field will be renamed “Target versions”.
-            single_value: This field is currently single-value. It will also be converted to allow multiple values.
+            single_value: This field is currently single-value. It will be converted to allow multiple values.
           recent_changes:
             documentation_html: For more information on this change and how to update API clients, please refer to <a href="%{link}" target="_blank" rel="noopener">our documentation</a>.
             heading: Recent changes

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -69,8 +69,10 @@ RSpec.describe "Versions and categories admin settings" do
     it "shows the planned changes for target versions" do
       expect(page).to have_text("The “Version” field will be renamed “Target versions”.")
       expect(page).to have_text(
-        "This field is currently single-value. It will also be converted to allow multiple values.",
-        count: 2
+        "This field is currently single-value. It will be converted to allow multiple values."
+      )
+      expect(page).to have_text(
+        "This field is currently single-value. It will also be converted to allow multiple values."
       )
       expect(page).to have_text(
         "You can choose to manually run the conversion to enable multiple values before this automatic migration happens."


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-959

# What are you trying to accomplish?
Fix a string (only the second of those two strings should contain "also")

## Screenshots
BEFORE
<img width="1097" height="328" alt="image" src="https://github.com/user-attachments/assets/06572724-97d7-4a6c-b4b5-ff1a2f1e5f10" />


AFTER
<img width="1097" height="328" alt="image" src="https://github.com/user-attachments/assets/6f925324-6f84-4cee-b330-b6b6baac34aa" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
