### PR TITLE
[TTP2-21] Project deletion fails in project hierarchy with semantic work package IDs

### DIFF
--- a/db/migrate/20260814120000_cascade_delete_work_package_semantic_aliases.rb
+++ b/db/migrate/20260814120000_cascade_delete_work_package_semantic_aliases.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CascadeDeleteWorkPackageSemanticAliases < ActiveRecord::Migration[8.1]
+  # Deleting a project cascades to its work_packages at the database level
+  # (work_packages.project_id has ON DELETE CASCADE). That database-level cascade
+  # bypasses the ActiveRecord `dependent: :delete_all` on the semantic_aliases
+  # association, so the restricting foreign key from work_package_semantic_aliases
+  # to work_packages blocked the delete. Cascade the aliases too.
+  def up
+    remove_foreign_key :work_package_semantic_aliases, :work_packages
+    add_foreign_key :work_package_semantic_aliases, :work_packages, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :work_package_semantic_aliases, :work_packages
+    add_foreign_key :work_package_semantic_aliases, :work_packages
+  end
+end

--- a/spec/models/work_package_semantic_alias_spec.rb
+++ b/spec/models/work_package_semantic_alias_spec.rb
@@ -105,4 +105,35 @@ RSpec.describe WorkPackageSemanticAlias do
       end
     end
   end
+
+  describe "work_package foreign key on delete",
+           with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::SEMANTIC } do
+    shared_let(:user) { create(:admin) }
+
+    # The path a user takes in the UI: Projects::DeleteProjectJob -> Projects::DeleteService.
+    it "deletes a parent project whose subproject holds a work package" do
+      parent_project = create(:project, identifier: "PARENT", name: "Parent")
+      child_project = create(:project, identifier: "CHILD", name: "Child", parent: parent_project)
+      child_work_package = create(:work_package, project: child_project, subject: "In the subproject")
+
+      expect(described_class.where(work_package_id: child_work_package.id).pluck(:identifier))
+        .to eq(["CHILD-1"])
+
+      service_call = Projects::DeleteService.new(user:, model: parent_project).call
+
+      expect(service_call).to be_success
+      expect(Project.where(id: [parent_project.id, child_project.id])).to be_empty
+    end
+
+    # Any caller that destroys a project without going through Projects::DeleteService,
+    # e.g. the console, seeders, or awesome_nested_set destroying descendants.
+    it "destroys a project holding a work package" do
+      project = create(:project, identifier: "SOLO", name: "Solo")
+      create(:work_package, project:, subject: "In the project")
+
+      project.destroy!
+
+      expect(Project.where(id: project.id)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
<!-- chomper:banner -->
🤖 This is an AI-generated prototype.

* To ask for a change, write a comment to @op-chomper on this PR.
* To ship the PR, first make it yours: run `gh adopt 24761` ([setup guide](https://github.com/opf/openproject-chomper#adopting-a-chomper-pr)).
<!-- /chomper:banner -->

📋 **Implementation plan:** https://gist.github.com/op-chomper/20ff7e42f5680037e3737f56df3bb207

# Ticket

hxxps://qa.openproject-edge.com/work_packages/TTP2-21

# What are you trying to accomplish?

Deleting a project failed when a work package in the project or a subproject had a semantic identifier. The database cascade removed the `work_packages` rows, but the foreign key from `work_package_semantic_aliases` to `work_packages` restricted the delete. The result was a `PG::ForeignKeyViolation`, and the projects stayed in the database. This change makes that foreign key cascade, so the delete succeeds.

# What approach did you choose and why?

A new migration replaces the foreign key with an `on_delete: :cascade` variant. The `work_packages.project_id` foreign key already cascades at the database level, which bypasses the ActiveRecord `dependent: :delete_all` on the association. A matching database cascade on the alias foreign key is the reliable fix. I did not edit the original create migration, because it has already run on development and staging databases.

## Screenshots

No visual changes.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)