### PR TITLE
Cost Report Modernization [3/5]: Migrate existing `CostQuery` instances to `CostReport` + `CostReportQuery`

### DIFF
--- a/modules/reporting/app/models/cost_report.rb
+++ b/modules/reporting/app/models/cost_report.rb
@@ -57,6 +57,15 @@ class CostReport < PersistedView
     CostReportQuery.new(project:, principal:)
   end
 
+  # Replays the query into a reporting engine chain, laid out on this view's axes.
+  def engine_query
+    query.engine_query(rows: pivot_rows, columns: pivot_columns)
+  end
+
+  def results
+    engine_query.result
+  end
+
   # The axes are the user facing configuration; the query's group_bys are
   # derived from them so the two can never drift apart.
   def apply_pivot_configuration(rows:, columns:)

--- a/modules/reporting/app/models/cost_report.rb
+++ b/modules/reporting/app/models/cost_report.rb
@@ -28,11 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# A saved cost report: the presentation of a CostReportQuery.
-#
-# The query owns which dimensions are aggregated; this view owns how they are
-# laid out - which dimensions go on rows, which on columns - plus the selected
-# unit tab.
+# The query owns which dimensions a report aggregates by; this view owns how they
+# are laid out across rows and columns.
 class CostReport < PersistedView
   PIVOT_AXES = %i[pivot_rows pivot_columns].freeze
 
@@ -47,17 +44,23 @@ class CostReport < PersistedView
   store_attribute :options, :pivot_rows, :json, default: []
   store_attribute :options, :pivot_columns, :json, default: []
   store_attribute :options, :unit_id, :integer
+  store_attribute :options, :legacy_cost_query_id, :integer
+
+  scope :for_legacy_cost_query, ->(id) { where("options ->> 'legacy_cost_query_id' = ?", id.to_s) }
 
   validates :query, presence: true
   validate :pivot_axes_match_query_group_bys
 
   before_validation :set_category
 
+  def self.for_legacy_cost_query_id(id)
+    for_legacy_cost_query(id).first
+  end
+
   def build_default_query
     CostReportQuery.new(project:, principal:)
   end
 
-  # Replays the query into a reporting engine chain, laid out on this view's axes.
   def engine_query
     query.engine_query(rows: pivot_rows, columns: pivot_columns)
   end
@@ -66,8 +69,7 @@ class CostReport < PersistedView
     engine_query.result
   end
 
-  # The axes are the user facing configuration; the query's group_bys are
-  # derived from them so the two can never drift apart.
+  # The query's group_bys are derived from the axes so the two cannot drift apart.
   def apply_pivot_configuration(rows:, columns:)
     self.pivot_rows = Array(rows).map(&:to_s)
     self.pivot_columns = Array(columns).map(&:to_s)
@@ -75,11 +77,8 @@ class CostReport < PersistedView
     query.group_bys = (pivot_columns + pivot_rows).map { |name| query.group_by_for(name) }
   end
 
-  # Mirrors the CostReportsController: any of the four permissions that grant
-  # access to the report pages is enough to read a report, and a report is
-  # readable if it is public or the user's own. Note that there is deliberately
-  # no exception for admins - they cannot read somebody else's private report
-  # either.
+  # Deliberately without an exception for admins: they cannot read somebody
+  # else's private report either.
   def visible?(user)
     return false unless public? || principal == user
 

--- a/modules/reporting/app/models/cost_report_query.rb
+++ b/modules/reporting/app/models/cost_report_query.rb
@@ -52,19 +52,25 @@ class CostReportQuery < PersistedQuery
   end
 
   def results
-    engine_query.result
+    raise NotImplementedError, "Run a CostReport, which knows how to lay the results out" # rubocop:disable OpenProject/NoNotImplementedError
   end
 
   # Replays this definition into a reporting engine chain.
-  def engine_query
+  #
+  # Which dimension goes on which axis is view state rather than part of the
+  # query, so the axes have to be passed in - see CostReport#engine_query. The
+  # engine defaults a group by without a type to a column, so leaving them out
+  # would silently flatten a pivot into a single row of columns.
+  def engine_query(rows:, columns:)
     CostQuery.new(project:).tap do |query|
       filters.each do |filter|
         query.filter(filter.name, operator: filter.operator, values: filter.values)
       end
 
-      group_bys.each do |group_by|
-        query.group_by(group_by.name)
-      end
+      # Each one is prepended to the chain, so they are added in reverse of the
+      # order they should end up in, columns before rows.
+      columns.reverse_each { |attribute| query.column(attribute) }
+      rows.reverse_each { |attribute| query.row(attribute) }
     end
   end
 

--- a/modules/reporting/db/migrate/20260814153519_migrate_cost_queries_to_cost_reports.rb
+++ b/modules/reporting/db/migrate/20260814153519_migrate_cost_queries_to_cost_reports.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Converts the saved cost reports from the cost_queries table into a
+# CostReportQuery (the definition) plus a CostReport (its presentation).
+#
+# The old ids are not preserved, so links to a saved report have to be recreated.
+# The cost_queries table is left in place and can be dropped in a later release.
+class MigrateCostQueriesToCostReports < ActiveRecord::Migration[8.1]
+  # Filters and group bys the engine injects itself. They are serialized as part
+  # of the chain but are not part of the user's definition.
+  SYSTEM_FILTERS = %w[PermissionFilter NoFilter].freeze
+  SYSTEM_GROUP_BYS = %w[SingletonValue].freeze
+
+  CUSTOM_FIELD = /\ACustomField(\d+)\z/
+
+  PERMITTED_YAML_CLASSES = [Symbol, Date, Time, ActiveSupport::HashWithIndifferentAccess].freeze
+
+  # Local models, so that the migration does not depend on the real ones, whose
+  # serialization and validations are free to change.
+  class CostQuery < ApplicationRecord
+    self.table_name = "cost_queries"
+  end
+
+  # The type column is written directly rather than through single table
+  # inheritance, so that the migration does not have to know the classes.
+  class PersistedQuery < ApplicationRecord
+    self.table_name = "persisted_queries"
+    self.inheritance_column = nil
+  end
+
+  class PersistedView < ApplicationRecord
+    self.table_name = "persisted_views"
+    self.inheritance_column = nil
+  end
+
+  def up
+    CostQuery.order(:id).find_each do |cost_query|
+      definition = deserialize(cost_query.serialized)
+
+      if definition.nil?
+        say "Skipping cost query #{cost_query.id} (#{cost_query.name}): unreadable definition"
+        next
+      end
+
+      rows, columns = axes(definition)
+
+      query = create_query(cost_query, definition, rows, columns)
+      create_view(cost_query, query, rows, columns)
+    end
+  end
+
+  def down
+    PersistedView.where(type: "CostReport").delete_all
+    PersistedQuery.where(type: "CostReportQuery").delete_all
+  end
+
+  private
+
+  def create_query(cost_query, definition, rows, columns)
+    PersistedQuery.create!(
+      type: "CostReportQuery",
+      project_id: cost_query.project_id,
+      principal_id: cost_query.user_id,
+      filters: filters(definition),
+      # Columns before rows, matching the order the engine expects them in.
+      group_bys: columns + rows,
+      selects: [],
+      orders: [],
+      created_at: cost_query.created_at,
+      updated_at: cost_query.updated_at
+    )
+  end
+
+  def create_view(cost_query, query, rows, columns)
+    PersistedView.create!(
+      type: "CostReport",
+      name: cost_query.name,
+      project_id: cost_query.project_id,
+      principal_id: cost_query.user_id,
+      query_type: "PersistedQuery",
+      query_id: query.id,
+      public: cost_query.is_public,
+      category: "cost_report",
+      options: { "pivot_rows" => rows, "pivot_columns" => columns },
+      created_at: cost_query.created_at,
+      updated_at: cost_query.updated_at
+    )
+  end
+
+  def deserialize(serialized)
+    definition = YAML.safe_load(serialized.to_s, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
+
+    definition if definition.is_a?(Hash)
+  rescue Psych::Exception
+    nil
+  end
+
+  def filters(definition)
+    Array(definition[:filters]).filter_map do |name, options|
+      next if SYSTEM_FILTERS.include?(name)
+
+      options ||= {}
+      operator = options[:operator].to_s
+      next if operator.empty?
+
+      { "attribute" => attribute_for(name),
+        "operator" => operator,
+        "values" => Array(options[:values]) }
+    end
+  end
+
+  # Returns the row and column dimensions, each in the order the user sees them.
+  #
+  # The serialized group bys are stored in reverse chain order (see
+  # CostQuery#serialize), and within an axis the chain order is the order the
+  # user arranged them in.
+  def axes(definition)
+    dimensions = Array(definition[:group_bys]).reverse.filter_map do |name, options|
+      next if SYSTEM_GROUP_BYS.include?(name)
+
+      # The engine defaults a group by without a type to a column.
+      [attribute_for(name), (options || {})[:type].to_s]
+    end
+
+    rows, columns = dimensions.partition { |_attribute, type| type == "row" }
+
+    [rows.map(&:first), columns.map(&:first)]
+  end
+
+  # The engine names its classes after the attribute, e.g. WorkPackageId, and its
+  # custom field classes after the custom field id, e.g. CustomField7.
+  def attribute_for(name)
+    match = CUSTOM_FIELD.match(name.to_s)
+
+    if match
+      "cf_#{match[1]}"
+    else
+      name.to_s.underscore
+    end
+  end
+end

--- a/modules/reporting/db/migrate/20260814153519_migrate_cost_queries_to_cost_reports.rb
+++ b/modules/reporting/db/migrate/20260814153519_migrate_cost_queries_to_cost_reports.rb
@@ -109,7 +109,9 @@ class MigrateCostQueriesToCostReports < ActiveRecord::Migration[8.1]
       query_id: query.id,
       public: cost_query.is_public,
       category: "cost_report",
-      options: { "pivot_rows" => rows, "pivot_columns" => columns },
+      options: { "pivot_rows" => rows,
+                 "pivot_columns" => columns,
+                 "legacy_cost_query_id" => cost_query.id },
       created_at: cost_query.created_at,
       updated_at: cost_query.updated_at
     )

--- a/modules/reporting/spec/migrations/migrate_cost_queries_to_cost_reports_spec.rb
+++ b/modules/reporting/spec/migrations/migrate_cost_queries_to_cost_reports_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe MigrateCostQueriesToCostReports, type: :model do
       expect(report.category).to eq("cost_report")
     end
 
+    it "keeps the original id so old report links still resolve" do
+      expect(CostReport.last.legacy_cost_query_id).to eq(cost_query.id)
+      expect(CostReport.for_legacy_cost_query_id(cost_query.id)).to eq(CostReport.last)
+    end
+
     it "links the view to its query" do
       expect(CostReport.last.query).to eq(CostReportQuery.last)
     end

--- a/modules/reporting/spec/migrations/migrate_cost_queries_to_cost_reports_spec.rb
+++ b/modules/reporting/spec/migrations/migrate_cost_queries_to_cost_reports_spec.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join(
+  "modules/reporting/db/migrate/20260814153519_migrate_cost_queries_to_cost_reports.rb"
+)
+
+RSpec.describe MigrateCostQueriesToCostReports, type: :model do
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+  shared_let(:user) { create(:user) }
+  shared_let(:project) { create(:project) }
+
+  # A filter carrying the "me" value only validates for a logged in user, which
+  # is always the case when a report is actually run.
+  current_user { create(:admin) }
+
+  # Builds a cost query through the engine, so the stored YAML is exactly what
+  # the old implementation produces rather than a hand written approximation.
+  def create_cost_query(name:, is_public: false, in_project: nil, &)
+    query = CostQuery.new(project: in_project)
+    yield(query) if block_given?
+
+    query.name = name
+    query.user_id = user.id
+    query.project_id = in_project&.id
+    query.is_public = is_public
+    query.save!
+    query
+  end
+
+  describe "a report with filters and both axes" do
+    let!(:cost_query) do
+      create_cost_query(name: "Spent per week", is_public: true, in_project: project) do |query|
+        query.filter(:spent_on, operator: ">d", values: ["2026-01-01"])
+        query.filter(:user_id, operator: "=", values: ["me"])
+        query.column(:week)
+        query.row(:project_id)
+      end
+    end
+
+    before { migrate }
+
+    it "creates one query and one view" do
+      expect(CostReportQuery.count).to eq(1)
+      expect(CostReport.count).to eq(1)
+    end
+
+    it "moves the name, ownership and publicity onto the view" do
+      report = CostReport.last
+
+      expect(report.name).to eq("Spent per week")
+      expect(report.principal).to eq(user)
+      expect(report.project).to eq(project)
+      expect(report).to be_public
+      expect(report.category).to eq("cost_report")
+    end
+
+    it "links the view to its query" do
+      expect(CostReport.last.query).to eq(CostReportQuery.last)
+    end
+
+    it "converts the filters, keeping operators and values" do
+      filters = CostReportQuery.last.filters.map { |f| [f.name, f.operator, f.values] }
+
+      expect(filters).to contain_exactly([:spent_on, ">d", ["2026-01-01"]],
+                                         [:user_id, "=", ["me"]])
+    end
+
+    it "splits the group bys onto the view's axes" do
+      report = CostReport.last
+
+      expect(report.pivot_columns).to eq(%w[week])
+      expect(report.pivot_rows).to eq(%w[project_id])
+    end
+
+    it "derives the query's group bys from the axes, columns first" do
+      expect(CostReportQuery.last.group_bys.map(&:name)).to eq(%i[week project_id])
+    end
+
+    it "produces a valid query and view" do
+      expect(CostReportQuery.last).to be_valid
+      expect(CostReport.last).to be_valid
+    end
+
+    it "keeps the timestamps of the original report" do
+      expect(CostReport.last.created_at).to be_within(1.second).of(cost_query.created_at)
+    end
+
+    it "leaves the original row in place" do
+      expect(CostQuery.count).to eq(1)
+    end
+  end
+
+  describe "the system filter the engine injects" do
+    let!(:cost_query) do
+      create_cost_query(name: "With permissions") do |query|
+        query.filter(:spent_on, operator: ">d", values: ["2026-01-01"])
+      end
+    end
+
+    it "serializes a permission filter in the original" do
+      expect(cost_query.serialized[:filters].map(&:first)).to include("PermissionFilter")
+    end
+
+    it "is not carried over" do
+      migrate
+
+      expect(CostReportQuery.last.filters.map(&:name)).to eq([:spent_on])
+    end
+  end
+
+  describe "nesting order within an axis" do
+    let!(:cost_query) do
+      create_cost_query(name: "Nested") do |query|
+        # The engine prepends, so the arguments are given in reverse of the
+        # order the user sees, exactly as CostReportsController#build_query does.
+        query.row(:work_package_id)
+        query.row(:project_id)
+        query.column(:tmonth)
+        query.column(:tyear)
+      end
+    end
+
+    it "keeps the order the user arranged the rows in" do
+      migrate
+
+      expect(CostReport.last.pivot_rows).to eq(%w[project_id work_package_id])
+    end
+
+    it "keeps the order the user arranged the columns in" do
+      migrate
+
+      expect(CostReport.last.pivot_columns).to eq(%w[tyear tmonth])
+    end
+
+    it "round trips through the engine unchanged, axes included" do
+      migrate
+
+      replayed = CostReport.last.engine_query.group_bys
+                           .map { |group_by| [group_by.class.name.demodulize, group_by.type] }
+      original = cost_query.group_bys
+                           .map { |group_by| [group_by.class.name.demodulize, group_by.type] }
+
+      expect(replayed).to eq(original)
+    end
+  end
+
+  describe "a report without any group by" do
+    let!(:cost_query) do
+      create_cost_query(name: "Flat list") do |query|
+        query.filter(:spent_on, operator: ">d", values: ["2026-01-01"])
+      end
+    end
+
+    it "leaves both axes empty" do
+      migrate
+
+      report = CostReport.last
+
+      expect(report.pivot_rows).to eq([])
+      expect(report.pivot_columns).to eq([])
+      expect(report.query.group_bys).to eq([])
+    end
+
+    it "produces a valid report" do
+      migrate
+
+      expect(CostReport.last).to be_valid
+    end
+  end
+
+  describe "a custom field filter and group by" do
+    shared_let(:custom_field) { create(:list_wp_custom_field, is_filter: true, is_for_all: true) }
+
+    let!(:cost_query) do
+      custom_field
+      CostQuery::Cache.reset!
+
+      # The engine generates a class per custom field, and add_chain looks the
+      # class up before the chain gets a chance to generate it - swallowing the
+      # NameError and dropping the group by. This is what the controller's
+      # load_all before_action exists for.
+      CostQuery::GroupBy.all
+      CostQuery::Filter.all
+
+      create_cost_query(name: "By custom field") do |query|
+        query.row(:"custom_field_#{custom_field.id}")
+      end
+    end
+
+    it "translates the engine's class name into the cf_<id> attribute" do
+      migrate
+
+      expect(CostReport.last.pivot_rows).to eq(["cf_#{custom_field.id}"])
+      expect(CostReportQuery.last.group_bys.map(&:name)).to eq([:"cf_#{custom_field.id}"])
+    end
+  end
+
+  describe "a global report" do
+    let!(:cost_query) { create_cost_query(name: "Everything", is_public: true) }
+
+    it "stays without a project" do
+      migrate
+
+      expect(CostReport.last.project).to be_nil
+      expect(CostReportQuery.last.project).to be_nil
+    end
+  end
+
+  describe "an unreadable definition" do
+    let!(:cost_query) { create_cost_query(name: "Broken") }
+
+    # Written through the migration's own model, which does not serialize the
+    # column, to get invalid YAML into the database at all.
+    before do
+      described_class::CostQuery.find(cost_query.id).update_column(:serialized, "{ not: valid: yaml")
+    end
+
+    it "does not raise" do
+      expect { migrate }.not_to raise_error
+    end
+
+    it "skips the report" do
+      migrate
+
+      expect(CostReport.count).to eq(0)
+    end
+  end
+
+  describe "reverting" do
+    let!(:cost_query) do
+      create_cost_query(name: "Spent per week") do |query|
+        query.column(:week)
+      end
+    end
+
+    it "removes what it created" do
+      migrate
+
+      expect { ActiveRecord::Migration.suppress_messages { described_class.new.down } }
+        .to change(CostReport, :count).from(1).to(0)
+        .and change(CostReportQuery, :count).from(1).to(0)
+    end
+  end
+end

--- a/modules/reporting/spec/models/cost_report_query_spec.rb
+++ b/modules/reporting/spec/models/cost_report_query_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe CostReportQuery do
 
   describe "#engine_query" do
     let(:project) { create(:project) }
+    let(:engine_query) { instance.engine_query(rows: %w[project_id], columns: %w[week]) }
 
     before do
       instance.project = project
@@ -127,33 +128,41 @@ RSpec.describe CostReportQuery do
     end
 
     it "replays the definition into a reporting engine query" do
-      expect(instance.engine_query).to be_a(CostQuery)
+      expect(engine_query).to be_a(CostQuery)
     end
 
     it "replays the filters" do
-      names = instance.engine_query.filters.map { |filter| filter.class.name.demodulize }
-
-      expect(names).to include("SpentOn")
+      expect(engine_query.filters.map { |filter| filter.class.name.demodulize }).to include("SpentOn")
     end
 
-    it "replays the group bys" do
-      names = instance.engine_query.group_bys.map { |group_by| group_by.class.name.demodulize }
+    it "replays the group bys onto the axes it is given" do
+      replayed = engine_query.group_bys.map { |group_by| [group_by.class.name.demodulize, group_by.type] }
 
-      expect(names).to contain_exactly("Week", "ProjectId")
+      expect(replayed).to eq([["ProjectId", :row], ["Week", :column]])
     end
 
     it "passes the project on" do
-      expect(instance.engine_query.project).to eq(project)
+      expect(engine_query.project).to eq(project)
     end
 
     it "builds a chain that produces SQL" do
-      expect(instance.engine_query.sql_statement.to_s).to be_present
+      expect(engine_query.sql_statement.to_s).to be_present
+    end
+
+    it "requires the axes, because the engine would silently make everything a column" do
+      expect { instance.engine_query }.to raise_error(ArgumentError)
     end
   end
 
   describe "#default_scope" do
     it "raises, because the engine computes the results" do
       expect { instance.default_scope }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#results" do
+    it "raises, pointing at the view that knows the layout" do
+      expect { instance.results }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/modules/reporting/spec/models/cost_report_spec.rb
+++ b/modules/reporting/spec/models/cost_report_spec.rb
@@ -123,6 +123,28 @@ RSpec.describe CostReport do
     end
   end
 
+  describe "#engine_query" do
+    before do
+      instance.query.where("spent_on", ">d", ["2026-01-01"])
+      instance.apply_pivot_configuration(rows: %i[project_id work_package_id], columns: [:week])
+    end
+
+    it "lays the dimensions out on the axes this view holds" do
+      replayed = instance.engine_query.group_bys.map { |group_by| [group_by.class.name.demodulize, group_by.type] }
+
+      expect(replayed).to eq([["ProjectId", :row], ["WorkPackageId", :row], ["Week", :column]])
+    end
+
+    it "replays the query's filters" do
+      expect(instance.engine_query.filters.map { |filter| filter.class.name.demodulize })
+        .to include("SpentOn")
+    end
+
+    it "builds a chain that produces SQL" do
+      expect(instance.engine_query.sql_statement.to_s).to be_present
+    end
+  end
+
   describe "#build_default_query" do
     let(:instance) { described_class.new(name: "Costs", project:, principal: user) }
 

--- a/modules/reporting/spec/models/cost_report_spec.rb
+++ b/modules/reporting/spec/models/cost_report_spec.rb
@@ -222,4 +222,26 @@ RSpec.describe CostReport do
       expect(described_class.find(instance.id).unit_id).to eq(3)
     end
   end
+
+  describe ".for_legacy_cost_query_id" do
+    it "finds the report converted from that cost query" do
+      instance.legacy_cost_query_id = 42
+      instance.save!
+
+      expect(described_class.for_legacy_cost_query_id(42)).to eq(instance)
+    end
+
+    it "accepts the id as a string" do
+      instance.legacy_cost_query_id = 42
+      instance.save!
+
+      expect(described_class.for_legacy_cost_query_id("42")).to eq(instance)
+    end
+
+    it "is nil for a report that was not converted" do
+      instance.save!
+
+      expect(described_class.for_legacy_cost_query_id(42)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COSTS/work_packages/COSTS-18
https://community.openproject.org/projects/COSTS/work_packages/COSTS-43

# What are you trying to accomplish?
- Adds a link to the previous `cost_query.id`, so we can still support old links
- Makes sure the query is always started from the `CostReport` view model, because it knows about the pivot axes
- Runs a database migration that builds the new models for every existing `CostQuery`

> [!NOTE]
> This adds a test for the migration (as it moves data around). The migration will be deleted in step 5 (#24818) as it will no longer be possible to test the migration with the `cost_queries` table gone.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
