### PR TITLE
[COMMS-960] Fix PATCH /documents/:id corrupting the description field

### DIFF
--- a/modules/documents/lib/api/v3/documents/documents_api.rb
+++ b/modules/documents/lib/api/v3/documents/documents_api.rb
@@ -71,6 +71,18 @@ module API
               doc = document
               request_body = JSON.parse(request.body.read)
 
+              # `description` arrives as the nested {format:, raw:, html:} HAL
+              # shape every formattable property uses on write -- extract only
+              # `raw` before handing off to the Service, matching how every
+              # other formattable-property-backed domain's payload representer
+              # already does this (API::Decorators::FormattableProperty's
+              # setter). Passing the raw nested hash through unfiltered
+              # corrupts the stored description into a literal, hash-shaped
+              # string.
+              if request_body["description"].is_a?(Hash)
+                request_body["description"] = request_body["description"]["raw"]
+              end
+
               result = ::Documents::UpdateService
                 .new(user: current_user, model: doc)
                 .call(request_body)

--- a/modules/documents/lib/api/v3/documents/documents_api.rb
+++ b/modules/documents/lib/api/v3/documents/documents_api.rb
@@ -71,14 +71,9 @@ module API
               doc = document
               request_body = JSON.parse(request.body.read)
 
-              # `description` arrives as the nested {format:, raw:, html:} HAL
-              # shape every formattable property uses on write -- extract only
-              # `raw` before handing off to the Service, matching how every
-              # other formattable-property-backed domain's payload representer
-              # already does this (API::Decorators::FormattableProperty's
-              # setter). Passing the raw nested hash through unfiltered
-              # corrupts the stored description into a literal, hash-shaped
-              # string.
+              # description arrives as the nested {format:, raw:, html:} HAL shape every
+              # formattable property uses on write -- extract raw, as
+              # API::Decorators::FormattableProperty's setter does for every other domain.
               if request_body["description"].is_a?(Hash)
                 request_body["description"] = request_body["description"]["raw"]
               end

--- a/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
+++ b/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
@@ -163,6 +163,29 @@ RSpec.describe "API v3 documents resource" do
         .at_path("contentBinary")
     end
 
+    context "when updating the description" do
+      # Regression test: the request body was previously passed unfiltered
+      # to Documents::UpdateService, so the raw {format:, raw:, html:} hash
+      # ended up stored verbatim as the description's raw text instead of
+      # extracting just the raw string, corrupting it into a literal
+      # hash-shaped string on every update.
+      let(:request_body) do
+        {
+          description: { format: "markdown", raw: "An updated description" }
+        }
+      end
+
+      it "stores and returns the plain description text, not the raw HAL hash" do
+        expect(subject.status).to be(200)
+
+        expect(subject.body)
+          .to be_json_eql("An updated description".to_json)
+          .at_path("description/raw")
+
+        expect(document.reload.description).to eq("An updated description")
+      end
+    end
+
     context "when lacking edit permissions" do
       let(:permissions) { %i(view_documents) }
 

--- a/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
+++ b/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
@@ -164,11 +164,6 @@ RSpec.describe "API v3 documents resource" do
     end
 
     context "when updating the description" do
-      # Regression test: the request body was previously passed unfiltered
-      # to Documents::UpdateService, so the raw {format:, raw:, html:} hash
-      # ended up stored verbatim as the description's raw text instead of
-      # extracting just the raw string, corrupting it into a literal
-      # hash-shaped string on every update.
       let(:request_body) do
         {
           description: { format: "markdown", raw: "An updated description" }


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/COMMS-960

## Summary

`PATCH /api/v3/documents/:id` parsed the raw JSON request body and passed it unfiltered to `Documents::UpdateService`, instead of extracting only `description.raw` the way every other formattable-property-backed domain does via the `FormattableProperty` decorator's setter. Every update therefore corrupted the stored description into a literal Ruby-hash-shaped string.

## Change

Extract `description.raw` from the request body before handing it off to the service, when `description` is present as the nested HAL shape (`{format:, raw:, html:}`).

## Test plan

- [x] Added a regression request spec asserting the description round-trips as plain text, not the raw HAL hash
- [x] Verified live against a real 17.7.1 instance: before the fix, `description.raw` became the literal string `'{format: "markdown", raw: "..."}'`; after the fix, it's the clean string as sent