### PR TITLE
Fix 500 when every wiki page link fails to resolve

### DIFF
--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -65,6 +65,8 @@ module Wikis
     end
 
     def enrich_models(metadata)
+      return relation.select("wiki_page_links.*, NULL as title") if metadata.empty?
+
       variable_placeholders = Array.new(metadata.size, "(?,?)").join(",")
       join_string = <<~SQL.squish
         LEFT JOIN (VALUES #{variable_placeholders}) AS metadata(page_link_id, title)

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -74,6 +74,34 @@ module Wikis
       expect(page_links.first.title).to eq("Wikis, now with more cheese! Part #{page_links.first.identifier}")
     end
 
+    context "when every page link fails to resolve" do
+      # Regression test: when every link's identifier fails to resolve,
+      # metadata ends up empty, and building a `LEFT JOIN (VALUES )` (no
+      # placeholders) is invalid SQL that used to raise a Postgres syntax
+      # error instead of returning the links with a nil title.
+      before do
+        build_inputs.each do |input|
+          allow(query_double).to receive(:call).with(input_data: input, auth_strategy: anything)
+                                                .and_return(Failure(:not_found))
+        end
+      end
+
+      it "returns the relation without raising, instead of crashing on an empty VALUES clause" do
+        expect { service.call }.not_to raise_error
+
+        service_result = service.call
+        expect(service_result).to be_success
+      end
+
+      it "returns every link with a nil title rather than dropping them" do
+        service_result = service.call
+        returned_links = service_result.result
+
+        expect(returned_links.count).to eq(page_links.count)
+        expect(returned_links.map(&:title)).to all(be_nil)
+      end
+    end
+
     context "when page links have the same identifier but different providers" do
       shared_let(:xwiki_provider) { create(:xwiki_provider) }
       let(:new_page_links) do

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -87,9 +87,9 @@ module Wikis
       end
 
       it "returns the relation without raising, instead of crashing on an empty VALUES clause" do
-        expect { service.call }.not_to raise_error
+        service_result = nil
+        expect { service_result = service.call }.not_to raise_error
 
-        service_result = service.call
         expect(service_result).to be_success
       end
 

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -91,9 +91,9 @@ module Wikis
 
       it "returns every link with a nil title rather than dropping them" do
         service_result = service.call
-        returned_links = service_result.result
+        returned_links = service_result.result.to_a
 
-        expect(returned_links.count).to eq(page_links.count)
+        expect(returned_links.size).to eq(page_links.count)
         expect(returned_links.map(&:title)).to all(be_nil)
       end
     end

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -75,10 +75,6 @@ module Wikis
     end
 
     context "when every page link fails to resolve" do
-      # Regression test: when every link's identifier fails to resolve,
-      # metadata ends up empty, and building a `LEFT JOIN (VALUES )` (no
-      # placeholders) is invalid SQL that used to raise a Postgres syntax
-      # error instead of returning the links with a nil title.
       before do
         build_inputs.each do |input|
           allow(query_double).to receive(:call).with(input_data: input, auth_strategy: anything)


### PR DESCRIPTION
## Ticket

n/a

## Summary

Fixes the crash described in OP-19928 (points 2 and 3 of that report -- point 1's original framing about identifier semantics has been corrected in a follow-up comment there and does not apply to this fix).

When every link's identifier fails to resolve via the page-info query, `metadata` ends up empty. `enrich_models` still tried to build a `LEFT JOIN (VALUES #{placeholders})` with zero placeholders, producing the invalid SQL fragment `LEFT JOIN (VALUES )` and crashing with a Postgres syntax error, instead of returning the links with a nil title (which is what already happens for any individual link whose resolution fails when at least one other link in the same request succeeds).

## Change

Return the relation directly with a `NULL` title column when `metadata` is empty, matching the shape callers already get from the non-empty path.

## Test plan

- [x] Added a regression spec covering the case where every page link fails to resolve
- [x] Verified live against a real 17.7.1 instance: before the fix, `GET` on a work package with one unresolvable-identifier link returned 500; after the fix, it returns 200 with the link's title absent