### PR TITLE
[OP-19965] Fix 500 when initializing an occurrence on a draft recurring meeting template

### DIFF
--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -62,7 +62,8 @@ module RecurringMeetings
     end
 
     def draft_template_failure
-      ServiceResult.failure(message: I18n.t("recurring_meeting.occurrence.error_template_draft"))
+      recurring_meeting.errors.add(:base, I18n.t("recurring_meeting.occurrence.error_template_draft"))
+      ServiceResult.failure(errors: recurring_meeting.errors)
     end
 
     def validate_contract

--- a/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/init_occurrence_service_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe RecurringMeetings::InitOccurrenceService, type: :model do
         expect(created_meeting).to be_nil
       end
 
+      it "carries a non-empty errors object usable by the API layer" do
+        # Regression test: draft_template_failure used to return only a
+        # message with no errors:, which crashed
+        # API::Errors::ErrorBase.create_and_merge_errors(call.errors) with an
+        # ArgumentError ("expected at least one error") when the API route
+        # tried to build a MultipleErrors response from an empty error list.
+        expect(service_result.errors).not_to be_empty
+      end
+
       it "does not add an occurrence" do
         expect { instance.call(**params) }
           .not_to change { series.meetings.not_templated.count }


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/OP-19965

## Summary

`InitOccurrenceService#draft_template_failure` returned only a message with no `errors:`, which crashed the API layer's `ErrorBase.create_and_merge_errors(call.errors)` with an `ArgumentError` ("expected at least one error") when it tried to build a `MultipleErrors` response from an empty error list. Every recurring meeting's template is in draft state right after creation, so initializing its first occurrence before moving the template out of draft always hit this 500 instead of a clean 422.

## Change

Populate the recurring meeting's own errors object before returning failure, matching the `errors:` shape used elsewhere in this service and across the codebase.

## Test plan

- [x] Added a regression spec asserting `service_result.errors` is non-empty on the draft-template path, alongside the existing `message`/`result` expectations
- [x] Verified live against a real 17.7.1 instance: before the fix, init on a fresh recurring meeting's draft template → 500; after the fix → 422 ("The meeting series template is still in draft mode.")