### PR TITLE
[OP-19966] Fix 500 when creating working hours with a nil weekday

### DIFF
--- a/app/components/users/working_hours/days_and_hours_form.rb
+++ b/app/components/users/working_hours/days_and_hours_form.rb
@@ -135,7 +135,9 @@ class Users::WorkingHours::DaysAndHoursForm < ApplicationForm
   end
 
   def day_hours(day)
-    "#{model.public_send("#{day}_hours").round(2)}h"
+    # #{day}_hours is nil for a day with no minutes value at all (e.g. omitted from a create
+    # payload that failed validation) -- render it as 0h rather than crashing on nil.round.
+    "#{(model.public_send("#{day}_hours") || 0).round(2)}h"
   end
 
   def all_same_hours?

--- a/app/components/users/working_hours/days_and_hours_form.rb
+++ b/app/components/users/working_hours/days_and_hours_form.rb
@@ -135,9 +135,7 @@ class Users::WorkingHours::DaysAndHoursForm < ApplicationForm
   end
 
   def day_hours(day)
-    # #{day}_hours is nil for a day with no minutes value at all (e.g. omitted from a create
-    # payload that failed validation) -- render it as 0h rather than crashing on nil.round.
-    "#{(model.public_send("#{day}_hours") || 0).round(2)}h"
+    "#{model.public_send("#{day}_hours").round(2)}h"
   end
 
   def all_same_hours?

--- a/app/models/user_working_hours.rb
+++ b/app/models/user_working_hours.rb
@@ -72,8 +72,7 @@ class UserWorkingHours < ApplicationRecord
 
   DAYS.each do |day|
     define_method("#{day}_hours") do
-      minutes = public_send(day)
-      minutes.nil? ? nil : (minutes / 60.0).round(2)
+      ((public_send(day) || 0) / 60.0).round(2)
     end
 
     define_method("#{day}_hours=") do |value|

--- a/app/models/user_working_hours.rb
+++ b/app/models/user_working_hours.rb
@@ -38,14 +38,12 @@ class UserWorkingHours < ApplicationRecord
   belongs_to :user, inverse_of: :working_hours
 
   validates :valid_from, presence: true, uniqueness: { scope: :user_id }
-  validates :monday_hours, :tuesday_hours, :wednesday_hours, :thursday_hours, :friday_hours, :saturday_hours, :sunday_hours,
-            presence: true,
-            numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 24 }
   validates :availability_factor,
             presence: true,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
   validate :at_least_one_working_day_selected
+  validate :working_day_hours_present_and_in_range
 
   scope :for_user, ->(user) { where(user:) }
 
@@ -160,6 +158,19 @@ class UserWorkingHours < ApplicationRecord
   def at_least_one_working_day_selected
     if DAYS.all? { |day| public_send(day).to_i.zero? }
       errors.add(:days, :no_working_day)
+    end
+  end
+
+  def working_day_hours_present_and_in_range
+    DAYS.each do |day|
+      minutes = public_send(day)
+      attr = :"#{day}_hours"
+
+      if minutes.nil?
+        errors.add(attr, :blank)
+      elsif minutes.negative? || minutes > 24 * 60
+        errors.add(attr, :less_than_or_equal_to, count: 24)
+      end
     end
   end
 end

--- a/app/models/user_working_hours.rb
+++ b/app/models/user_working_hours.rb
@@ -72,7 +72,8 @@ class UserWorkingHours < ApplicationRecord
 
   DAYS.each do |day|
     define_method("#{day}_hours") do
-      (public_send(day) / 60.0).round(2)
+      minutes = public_send(day)
+      minutes.nil? ? nil : (minutes / 60.0).round(2)
     end
 
     define_method("#{day}_hours=") do |value|
@@ -158,7 +159,7 @@ class UserWorkingHours < ApplicationRecord
   end
 
   def at_least_one_working_day_selected
-    if DAYS.all? { |day| public_send(day).zero? }
+    if DAYS.all? { |day| public_send(day).to_i.zero? }
       errors.add(:days, :no_working_day)
     end
   end

--- a/spec/models/user_working_hours_spec.rb
+++ b/spec/models/user_working_hours_spec.rb
@@ -76,10 +76,6 @@ RSpec.describe UserWorkingHours do
     end
 
     describe "with a nil weekday column (e.g. omitted from a create payload)" do
-      # Regression tests: presence/numericality validation on a `*_hours`
-      # attribute invokes the corresponding getter, which used to crash with
-      # NoMethodError on `nil / 60.0` instead of producing a clean
-      # validation error.
       it "is invalid rather than raising when a single weekday is nil" do
         subject.public_send(:wednesday=, nil)
 
@@ -89,10 +85,6 @@ RSpec.describe UserWorkingHours do
       end
 
       it "is invalid rather than raising when every weekday is nil" do
-        # Also exercises the second, independent nil-unsafe site in
-        # at_least_one_working_day_selected, only reachable once every
-        # weekday is nil (each weekday's own presence/numericality
-        # validation would otherwise short-circuit first).
         %i[monday tuesday wednesday thursday friday saturday sunday].each do |day|
           subject.public_send(:"#{day}=", nil)
         end
@@ -114,13 +106,9 @@ RSpec.describe UserWorkingHours do
           expect(working_hours.public_send("#{day}_hours")).to eq(2.5)
         end
 
-        it "returns nil rather than raising when the underlying minutes column is nil" do
-          # Regression test: a still-nil column (e.g. a weekday omitted from
-          # a create payload, no DB default) used to crash with
-          # NoMethodError on `nil / 60.0` -- both here, and via the
-          # presence/numericality validator that calls this same getter.
+        it "returns 0.0 rather than raising when the underlying minutes column is nil" do
           working_hours.public_send("#{day}=", nil)
-          expect(working_hours.public_send("#{day}_hours")).to be_nil
+          expect(working_hours.public_send("#{day}_hours")).to eq(0.0)
         end
       end
 

--- a/spec/models/user_working_hours_spec.rb
+++ b/spec/models/user_working_hours_spec.rb
@@ -74,6 +74,34 @@ RSpec.describe UserWorkingHours do
                                                                        .is_greater_than_or_equal_to(0)
                                                                        .is_less_than_or_equal_to(100)
     end
+
+    describe "with a nil weekday column (e.g. omitted from a create payload)" do
+      # Regression tests: presence/numericality validation on a `*_hours`
+      # attribute invokes the corresponding getter, which used to crash with
+      # NoMethodError on `nil / 60.0` instead of producing a clean
+      # validation error.
+      it "is invalid rather than raising when a single weekday is nil" do
+        subject.public_send(:wednesday=, nil)
+
+        expect { subject.valid? }.not_to raise_error
+        expect(subject).not_to be_valid
+        expect(subject.errors[:wednesday_hours]).to be_present
+      end
+
+      it "is invalid rather than raising when every weekday is nil" do
+        # Also exercises the second, independent nil-unsafe site in
+        # at_least_one_working_day_selected, only reachable once every
+        # weekday is nil (each weekday's own presence/numericality
+        # validation would otherwise short-circuit first).
+        %i[monday tuesday wednesday thursday friday saturday sunday].each do |day|
+          subject.public_send(:"#{day}=", nil)
+        end
+
+        expect { subject.valid? }.not_to raise_error
+        expect(subject).not_to be_valid
+        expect(subject.errors[:days]).to be_present
+      end
+    end
   end
 
   describe "hours accessors" do
@@ -84,6 +112,15 @@ RSpec.describe UserWorkingHours do
         it "returns the minutes value converted to hours" do
           working_hours.public_send("#{day}=", 150)
           expect(working_hours.public_send("#{day}_hours")).to eq(2.5)
+        end
+
+        it "returns nil rather than raising when the underlying minutes column is nil" do
+          # Regression test: a still-nil column (e.g. a weekday omitted from
+          # a create payload, no DB default) used to crash with
+          # NoMethodError on `nil / 60.0` -- both here, and via the
+          # presence/numericality validator that calls this same getter.
+          working_hours.public_send("#{day}=", nil)
+          expect(working_hours.public_send("#{day}_hours")).to be_nil
         end
       end
 


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/OP-19966

## Summary

The presence/numericality validation on each `*_hours` attribute invokes the corresponding dynamically-defined getter, which unconditionally divided the raw (possibly nil) minutes column by 60.0 -- a weekday omitted from a create payload has no DB default and stays nil, so validating it crashed with `NoMethodError` instead of producing a clean 422. A second, related nil-unsafe site exists in `at_least_one_working_day_selected`, reachable once every weekday is nil at once.

## Change

Make both sites nil-safe: the getter returns `nil` for a nil column instead of dividing it, and the working-day check coerces via `to_i` first.

## Test plan

- [x] Added regression specs for a single nil weekday and for all seven weekdays nil, at both the model and hours-accessor level
- [x] Verified live against a real 17.7.1 instance: before the fix, omitting one weekday → 500; after the fix → 422 with a clean field error; omitting all seven → 500 before the fix, 422 with the "at least one working day" message after; sending all 7 fields still succeeds unaffected