### PR TITLE
[OP-19967] Fix wiki_page_links pagination silently ignoring offset

### DIFF
--- a/modules/wikis/lib/api/v3/page_links/page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_links_api.rb
@@ -65,6 +65,7 @@ module API
 
             PageLinkCollectionRepresenter.new(
               enrich_models_with_wiki_metadata(relation).result,
+              page: params[:offset],
               per_page: params[:pageSize],
               self_link: api_v3_paths.wiki_page_links,
               current_user:

--- a/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
@@ -55,6 +55,7 @@ module API
 
             PageLinkCollectionRepresenter.new(
               enrich_models_with_wiki_metadata(relation).result,
+              page: params[:offset],
               per_page: params[:pageSize],
               self_link: api_v3_paths.work_package_page_links(@work_package.id),
               current_user:

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -81,6 +81,26 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
         let(:elements) { Wikis::PageLink.where(linkable: work_package, provider: internal_wiki).order(id: :desc).all }
       end
     end
+
+    context "when paginated with an offset beyond the first page" do
+      # Regression test: the offset param used to be silently dropped
+      # (never forwarded into the collection representer's page: option),
+      # so every page request rendered page 1 regardless of offset.
+      let(:all_ids) { Wikis::PageLink.where(linkable: work_package).order(id: :desc).pluck(:id) }
+
+      before { get "#{path}?pageSize=2&offset=2" }
+
+      it "returns the second page, distinct from the first page" do
+        expect(last_response.status).to eq(200)
+
+        body = JSON.parse(last_response.body)
+        expect(body["offset"]).to eq(2)
+
+        returned_ids = body["_embedded"]["elements"].pluck("id")
+        expect(returned_ids).to eq(all_ids[2, 2])
+        expect(returned_ids).not_to eq(all_ids[0, 2])
+      end
+    end
   end
 
   describe "GET /api/v3/wiki_page_links" do
@@ -108,6 +128,32 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
 
       it_behaves_like "API V3 collection response", 6, 6, "WikiPageLink", "WikiPageLinkCollection" do
         let(:elements) { Wikis::PageLink.where(provider: internal_wiki).order(id: :desc).all }
+      end
+    end
+
+    context "when paginated with an offset beyond the first page" do
+      # Regression test, independent of the work-package-scoped endpoint's
+      # own analogous coverage above -- the same bug existed in this
+      # global handler too.
+      let(:all_ids) do
+        ids = unaccessible_links.pluck(:id) + same_identifier_page_links.pluck(:id)
+        Wikis::PageLink.where.not(id: ids).order(id: :desc).pluck(:id)
+      end
+
+      before do
+        unaccessible_links
+        get "#{path}?pageSize=2&offset=2"
+      end
+
+      it "returns the second page, distinct from the first page" do
+        expect(last_response.status).to eq(200)
+
+        body = JSON.parse(last_response.body)
+        expect(body["offset"]).to eq(2)
+
+        returned_ids = body["_embedded"]["elements"].pluck("id")
+        expect(returned_ids).to eq(all_ids[2, 2])
+        expect(returned_ids).not_to eq(all_ids[0, 2])
       end
     end
 

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -83,9 +83,6 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
     end
 
     context "when paginated with an offset beyond the first page" do
-      # Regression test: the offset param used to be silently dropped
-      # (never forwarded into the collection representer's page: option),
-      # so every page request rendered page 1 regardless of offset.
       let(:all_ids) { Wikis::PageLink.where(linkable: work_package).order(id: :desc).pluck(:id) }
 
       before { get "#{path}?pageSize=2&offset=2" }
@@ -132,9 +129,6 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
     end
 
     context "when paginated with an offset beyond the first page" do
-      # Regression test, independent of the work-package-scoped endpoint's
-      # own analogous coverage above -- the same bug existed in this
-      # global handler too.
       let(:all_ids) do
         ids = unaccessible_links.pluck(:id) + same_identifier_page_links.pluck(:id)
         Wikis::PageLink.where.not(id: ids).order(id: :desc).pluck(:id)

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
       before { get "#{path}?pageSize=2&offset=2" }
 
       it "returns the second page, distinct from the first page" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(200)
 
         body = JSON.parse(last_response.body)
         expect(body["offset"]).to eq(2)
@@ -146,7 +146,7 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
       end
 
       it "returns the second page, distinct from the first page" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(200)
 
         body = JSON.parse(last_response.body)
         expect(body["offset"]).to eq(2)


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/OP-19967

## Summary

Both the work-package-scoped and the global GET handlers only passed `per_page:` into `PageLinkCollectionRepresenter.new`, never `page:`. `API::Decorators::OffsetPaginatedCollection` defaults `page` to 1 whenever it's not explicitly given, so every request to either endpoint always rendered (and reported) page 1 of the underlying relation, silently ignoring the client's `offset` query parameter -- `total` was reported correctly, but `offset` itself always echoed back 1 and results never advanced past the first page.

## Change

Pass `params[:offset]` through as `page:` at both call sites.

## Test plan

- [x] Added regression request specs on both endpoints asserting the second page returns distinct elements from the first, and that `offset` is correctly reported
- [x] Verified live against a real 17.7.1 instance: before the fix, `offset=2` returned the same elements as `offset=1` on both endpoints; after the fix, each returns distinct, correct results independently