### PR TITLE
[OP-19968] Fix 500 when writing end_time on a time entry

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -118,16 +118,13 @@ module API
                            },
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
+        # end_time is derived (start_time + hours), never its own column.
         date_time_property :end_time,
                            exec_context: :decorator,
                            getter: ->(*) {
                              datetime_formatter.format_datetime(represented.end_timestamp, allow_nil: true)
                            },
-                           setter: ->(*) {
-                             # end_time is derived (start_time + hours), never its own column --
-                             # silently accept a write attempt without touching the record, same
-                             # as any other purely-computed read-only API property.
-                           },
+                           setter: ->(*) {}, # ignored
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         associated_resource :activity,

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -123,6 +123,11 @@ module API
                            getter: ->(*) {
                              datetime_formatter.format_datetime(represented.end_timestamp, allow_nil: true)
                            },
+                           setter: ->(*) {
+                             # end_time is derived (start_time + hours), never its own column --
+                             # silently accept a write attempt without touching the record, same
+                             # as any other purely-computed read-only API property.
+                           },
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         associated_resource :activity,

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -124,7 +124,7 @@ module API
                            getter: ->(*) {
                              datetime_formatter.format_datetime(represented.end_timestamp, allow_nil: true)
                            },
-                           setter: ->(*) {},
+                           writable: false,
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         associated_resource :activity,

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -124,7 +124,7 @@ module API
                            getter: ->(*) {
                              datetime_formatter.format_datetime(represented.end_timestamp, allow_nil: true)
                            },
-                           setter: ->(*) {}, # ignored
+                           setter: ->(*) {},
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         associated_resource :activity,

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -224,12 +224,21 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "parsing" do
             must_track_start_and_end_time?: false
           )
 
-          hash["endTime"] = "2017-07-28T17:30:00Z"
+          # Deliberately a different value than what start_time + hours would derive
+          # (12:30 + 5h = 17:30) -- proves the sent endTime is actually ignored, not
+          # coincidentally equal to the derived value.
+          hash["endTime"] = "2017-07-28T23:00:00Z"
         end
 
-        it "does not raise and does not set end_time as its own attribute" do
-          expect { representer.from_hash(hash) }.not_to raise_error
-          expect(time_entry).not_to respond_to(:end_time=)
+        it "does not raise and ignores the sent endTime, keeping the derived value" do
+          parsed = nil
+          expect { parsed = representer.from_hash(hash) }.not_to raise_error
+
+          # timezone would normally be set via the SetAttribute service -- set it manually here,
+          # same as the analogous startTime spec above, so end_timestamp can be computed.
+          parsed.time_zone = "UTC"
+
+          expect(parsed.end_timestamp).to eq(DateTime.parse("2017-07-28T17:30:00Z"))
         end
       end
     end

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -211,6 +211,29 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "parsing" do
       end
     end
 
+    describe "endTime" do
+      # Regression test: end_time is purely derived (start_time + hours) and
+      # has no setter of its own on TimeEntry. Representable used to fall
+      # through to a raw `send(:end_time=, value)` when a client sent
+      # endTime on write, crashing with NoMethodError instead of silently
+      # ignoring the unwritable field.
+      context "when tracking start and end time" do
+        before do
+          allow(TimeEntry).to receive_messages(
+            can_track_start_and_end_time?: true,
+            must_track_start_and_end_time?: false
+          )
+
+          hash["endTime"] = "2017-07-28T17:30:00Z"
+        end
+
+        it "does not raise and does not set end_time as its own attribute" do
+          expect { representer.from_hash(hash) }.not_to raise_error
+          expect(time_entry).not_to respond_to(:end_time=)
+        end
+      end
+    end
+
     describe "hours" do
       it "updates hours" do
         time_entry = representer.from_hash(hash)

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -212,11 +212,6 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "parsing" do
     end
 
     describe "endTime" do
-      # Regression test: end_time is purely derived (start_time + hours) and
-      # has no setter of its own on TimeEntry. Representable used to fall
-      # through to a raw `send(:end_time=, value)` when a client sent
-      # endTime on write, crashing with NoMethodError instead of silently
-      # ignoring the unwritable field.
       context "when tracking start and end time" do
         before do
           allow(TimeEntry).to receive_messages(
@@ -224,9 +219,8 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "parsing" do
             must_track_start_and_end_time?: false
           )
 
-          # Deliberately a different value than what start_time + hours would derive
-          # (12:30 + 5h = 17:30) -- proves the sent endTime is actually ignored, not
-          # coincidentally equal to the derived value.
+          # Different from the start_time + hours derived value (17:30), so a match would
+          # prove the sent endTime was actually ignored, not coincidentally equal.
           hash["endTime"] = "2017-07-28T23:00:00Z"
         end
 
@@ -234,8 +228,8 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "parsing" do
           parsed = nil
           expect { parsed = representer.from_hash(hash) }.not_to raise_error
 
-          # timezone would normally be set via the SetAttribute service -- set it manually here,
-          # same as the analogous startTime spec above, so end_timestamp can be computed.
+          # Normally set via the SetAttribute service; set manually here so end_timestamp
+          # can be computed, same as the analogous startTime spec above.
           parsed.time_zone = "UTC"
 
           expect(parsed.end_timestamp).to eq(DateTime.parse("2017-07-28T17:30:00Z"))


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/OP-19968

## Summary

`end_time` is derived (`start_time` + `hours`) and has no setter of its own -- the `date_time_property` declaration had a custom getter but no setter, so Representable fell through to its default `send(:end_time=, value)` when a client included `endTime` in a write payload, crashing with `NoMethodError` since `TimeEntry` defines no such method.

## Change

Add an explicit no-op setter, matching how other purely-computed read-only representer properties in this codebase already handle a write attempt.

## Test plan

- [x] Added a regression parsing spec asserting no error is raised when `endTime` is included in a write payload
- [x] Verified live against a real 17.7.1 instance (with "Allow start and finish times" enabled): before the fix, `POST` with `endTime` set → 500; after the fix → 201, entry created successfully