### PR TITLE
[OP-19969] Round instead of truncate when formatting a duration from hours

### DIFF
--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -108,7 +108,11 @@ module API
         def format_duration_from_days(days, allow_nil: false)
           return nil if days.nil? && allow_nil
 
-          Duration.new(seconds: days * 3600 * 24).iso8601
+          # Duration.new truncates its :seconds argument via Float#to_i
+          # (ruby-duration gem) rather than rounding -- round explicitly
+          # here first, same as format_duration_from_hours above, so a
+          # fractional-day value doesn't silently lose up to ~1s of precision.
+          Duration.new(seconds: (days * 3600 * 24).round).iso8601
         end
 
         def parse_duration_to_days(duration, property_name, allow_nil: false)

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -85,7 +85,11 @@ module API
         def format_duration_from_hours(hours, allow_nil: false)
           return nil if hours.nil? && allow_nil
 
-          Duration.new(seconds: hours * 3600).iso8601
+          # Duration.new truncates its :seconds argument via Float#to_i
+          # (ruby-duration gem) rather than rounding -- round explicitly
+          # here first so e.g. 3600.9 seconds (1h 0.9s) serializes as
+          # PT1H1S, not silently dropped to PT1H.
+          Duration.new(seconds: (hours * 3600).round).iso8601
         end
 
         def parse_duration_to_hours(duration, property_name, allow_nil: false)

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -85,10 +85,8 @@ module API
         def format_duration_from_hours(hours, allow_nil: false)
           return nil if hours.nil? && allow_nil
 
-          # Duration.new truncates its :seconds argument via Float#to_i
-          # (ruby-duration gem) rather than rounding -- round explicitly
-          # here first so e.g. 3600.9 seconds (1h 0.9s) serializes as
-          # PT1H1S, not silently dropped to PT1H.
+          # Duration.new (ruby-duration gem) truncates :seconds via Float#to_i rather than
+          # rounding -- round explicitly first.
           Duration.new(seconds: (hours * 3600).round).iso8601
         end
 
@@ -108,10 +106,7 @@ module API
         def format_duration_from_days(days, allow_nil: false)
           return nil if days.nil? && allow_nil
 
-          # Duration.new truncates its :seconds argument via Float#to_i
-          # (ruby-duration gem) rather than rounding -- round explicitly
-          # here first, same as format_duration_from_hours above, so a
-          # fractional-day value doesn't silently lose up to ~1s of precision.
+          # Same Duration.new truncation caveat as format_duration_from_hours above.
           Duration.new(seconds: (days * 3600 * 24).round).iso8601
         end
 

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -232,6 +232,12 @@ RSpec.describe API::V3::Utilities::DateTimeFormatter do
       expect(subject.format_duration_from_days(5.501)).to eq("P5DT12H1M26S")
     end
 
+    it "rounds rather than truncates seconds" do
+      # 5.5006 days == 475251.84s -- rounds up to 475252s (P5DT12H52S), not
+      # truncated down to 475251s (P5DT12H51S).
+      expect(subject.format_duration_from_days(5.5006)).to eq("P5DT12H52S")
+    end
+
     it "formats ints" do
       expect(subject.format_duration_from_days(5)).to eq("P5D")
     end

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -180,8 +180,10 @@ RSpec.describe API::V3::Utilities::DateTimeFormatter do
       expect(subject.format_duration_from_hours(5.5)).to eq("PT5H30M")
     end
 
-    it "includes seconds" do
-      expect(subject.format_duration_from_hours(5.501)).to eq("PT5H30M3S")
+    it "includes seconds, rounded rather than truncated" do
+      # 5.501h == 19803.6s -- rounds up to 19804s (PT5H30M4S), not
+      # truncated down to 19803s (PT5H30M3S).
+      expect(subject.format_duration_from_hours(5.501)).to eq("PT5H30M4S")
     end
 
     it "formats ints" do

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -181,8 +181,6 @@ RSpec.describe API::V3::Utilities::DateTimeFormatter do
     end
 
     it "includes seconds, rounded rather than truncated" do
-      # 5.501h == 19803.6s -- rounds up to 19804s (PT5H30M4S), not
-      # truncated down to 19803s (PT5H30M3S).
       expect(subject.format_duration_from_hours(5.501)).to eq("PT5H30M4S")
     end
 
@@ -233,8 +231,6 @@ RSpec.describe API::V3::Utilities::DateTimeFormatter do
     end
 
     it "rounds rather than truncates seconds" do
-      # 5.5006 days == 475251.84s -- rounds up to 475252s (P5DT12H52S), not
-      # truncated down to 475251s (P5DT12H51S).
       expect(subject.format_duration_from_days(5.5006)).to eq("P5DT12H52S")
     end
 


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/OP-19969

## Summary

`format_duration_from_hours` passed its computed seconds value straight into `Duration.new(seconds: ...)`, whose hash-based constructor (in the `ruby-duration` gem) truncates via `Float#to_i` rather than rounding -- e.g. 5.501 hours (19803.6 seconds) silently serialized as `"PT5H30M3S"` instead of the correctly rounded `"PT5H30M4S"`, losing up to just under a second of precision on any value with a fractional-second remainder. This affects every caller of this shared formatter (work packages, meetings, time entries), not just time entries.

## Change

Round the seconds value explicitly before constructing the `Duration`.

## Test plan

- [x] Updated the existing spec assertion that encoded the old truncating behavior as expected
- [x] Verified live against a real 17.7.1 instance, both server-side and through the full REST API: before the fix, `format_duration_from_hours(5.501)` → `"PT5H30M3S"`; after the fix → `"PT5H30M4S"`, and `POST /api/v3/time_entries` with `hours: "PT5H30M3.6S"` correctly returns `"hours":"PT5H30M4S"`