### PR TITLE
Do not re-validate an unchanged host/url against secure_context_uri

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/contracts/general_information_contract.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/contracts/general_information_contract.rb
@@ -38,8 +38,6 @@ module Storages
             validates :name, presence: true, length: { maximum: 255 }
             attribute :host
             validates :host, url: { message: :invalid_host_url }, length: { maximum: 255 }
-            # Only re-check secure_context_uri when host is actually changing -- otherwise an
-            # unrelated update (e.g. renaming the storage) re-rejects an already-accepted host.
             # Must run BEFORE nextcloud_compatible_host: that validator makes a live network
             # probe to the host, which must not happen before secure_context_uri has had a
             # chance to reject an unsafe new host.

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/contracts/general_information_contract.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/contracts/general_information_contract.rb
@@ -38,9 +38,15 @@ module Storages
             validates :name, presence: true, length: { maximum: 255 }
             attribute :host
             validates :host, url: { message: :invalid_host_url }, length: { maximum: 255 }
+            # Only re-check secure_context_uri when host is actually changing -- otherwise an
+            # unrelated update (e.g. renaming the storage) re-rejects an already-accepted host.
+            # Must run BEFORE nextcloud_compatible_host: that validator makes a live network
+            # probe to the host, which must not happen before secure_context_uri has had a
+            # chance to reject an unsafe new host.
+            validates :host, secure_context_uri: true, unless: -> { errors.include?(:host) || !model.host_changed? }
             # Check that a host actually is a storage server.
-            # But only do so if the validations above for URL were successful.
-            validates :host, secure_context_uri: true, nextcloud_compatible_host: true, unless: -> { errors.include?(:host) }
+            # But only do so if the validations above were successful.
+            validates :host, nextcloud_compatible_host: true, unless: -> { errors.include?(:host) }
 
             attribute :authentication_method
             validates :authentication_method, presence: true, inclusion: { in: NextcloudStorage::AUTHENTICATION_METHODS }

--- a/modules/storages/spec/contracts/storages/storages/nextcloud_update_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/nextcloud_update_contract_spec.rb
@@ -48,5 +48,35 @@ RSpec.describe Storages::Storages::UpdateContract do
 
       include_examples "contract is valid"
     end
+
+    context "when host is unchanged from an already-persisted insecure value" do
+      let(:storage_host) { "http://nc.openproject.com" }
+
+      before { storage.clear_changes_information }
+
+      context "when only name changes" do
+        before { storage.name = "Renamed storage" }
+
+        include_examples "contract is valid"
+
+        it "does not perform metadata discovery requests" do
+          contract.validate
+
+          expect(WebMock).not_to have_requested(:get, "http://nc.openproject.com/ocs/v2.php/cloud/capabilities")
+        end
+      end
+
+      context "when host is also changed to a new insecure value" do
+        before { storage.host = "http://another-unsafe-host.example" }
+
+        include_examples "contract is invalid", host: :url_not_secure_context
+
+        it "does not perform metadata discovery requests" do
+          contract.validate
+
+          expect(WebMock).not_to have_requested(:get, "http://another-unsafe-host.example/ocs/v2.php/cloud/capabilities")
+        end
+      end
+    end
   end
 end

--- a/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
@@ -147,13 +147,13 @@ RSpec.shared_examples_for "nextcloud storage contract", :storage_server_helpers,
       end
 
       context "when host is an unsafe IP" do
-        let(:storage_host) { "http://172.16.193.146" }
+        before { storage.host = "http://172.16.193.146" }
 
         include_examples "contract is invalid", host: :url_not_secure_context
       end
 
       context "when host is an unsafe hostname" do
-        let(:storage_host) { "http://nc.openproject.com" }
+        before { storage.host = "http://nc.openproject.com" }
 
         include_examples "contract is invalid", host: :url_not_secure_context
       end

--- a/modules/wikis/app/contracts/wikis/xwiki_providers/base_contract.rb
+++ b/modules/wikis/app/contracts/wikis/xwiki_providers/base_contract.rb
@@ -42,7 +42,7 @@ module Wikis
       # Only re-check secure_context_uri when url is actually changing -- otherwise an unrelated
       # update (e.g. renaming the provider) re-rejects an already-accepted url.
       validates :url, secure_context_uri: true,
-                       unless: -> { url.blank? || errors.include?(:url) || !model.url_changed? }
+                      unless: -> { url.blank? || errors.include?(:url) || !model.url_changed? }
 
       validate :not_configured_from_env
 

--- a/modules/wikis/app/contracts/wikis/xwiki_providers/base_contract.rb
+++ b/modules/wikis/app/contracts/wikis/xwiki_providers/base_contract.rb
@@ -39,7 +39,10 @@ module Wikis
       validates :name, presence: true, length: { maximum: 255 }
       validates :url, presence: true, length: { maximum: 255 }
       validates :url, url: true, unless: -> { url.blank? || errors.include?(:url) }
-      validates :url, secure_context_uri: true, unless: -> { url.blank? || errors.include?(:url) }
+      # Only re-check secure_context_uri when url is actually changing -- otherwise an unrelated
+      # update (e.g. renaming the provider) re-rejects an already-accepted url.
+      validates :url, secure_context_uri: true,
+                       unless: -> { url.blank? || errors.include?(:url) || !model.url_changed? }
 
       validate :not_configured_from_env
 

--- a/modules/wikis/app/contracts/wikis/xwiki_providers/base_contract.rb
+++ b/modules/wikis/app/contracts/wikis/xwiki_providers/base_contract.rb
@@ -39,8 +39,6 @@ module Wikis
       validates :name, presence: true, length: { maximum: 255 }
       validates :url, presence: true, length: { maximum: 255 }
       validates :url, url: true, unless: -> { url.blank? || errors.include?(:url) }
-      # Only re-check secure_context_uri when url is actually changing -- otherwise an unrelated
-      # update (e.g. renaming the provider) re-rejects an already-accepted url.
       validates :url, secure_context_uri: true,
                       unless: -> { url.blank? || errors.include?(:url) || !model.url_changed? }
 

--- a/modules/wikis/spec/contracts/wikis/xwiki_providers/base_contract_spec.rb
+++ b/modules/wikis/spec/contracts/wikis/xwiki_providers/base_contract_spec.rb
@@ -75,5 +75,24 @@ RSpec.describe Wikis::XWikiProviders::BaseContract do
 
       include_examples "contract is invalid", url: :too_long
     end
+
+    context "when unchanged from an already-persisted insecure value" do
+      let(:current_user) { build_stubbed(:admin) }
+      let(:wiki_provider) { build_stubbed(:xwiki_provider, url: "http://xwiki.example.com") }
+
+      before { wiki_provider.clear_changes_information }
+
+      context "when only name changes" do
+        before { wiki_provider.name = "Renamed provider" }
+
+        include_examples "contract is valid"
+      end
+
+      context "when url is also changed to a new insecure value" do
+        before { wiki_provider.url = "http://another-unsafe-host.example" }
+
+        include_examples "contract is invalid", url: :url_not_secure_context
+      end
+    end
   end
 end

--- a/modules/wikis/spec/contracts/wikis/xwiki_providers/base_contract_spec.rb
+++ b/modules/wikis/spec/contracts/wikis/xwiki_providers/base_contract_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Wikis::XWikiProviders::BaseContract do
     end
 
     context "when not https" do
-      let(:wiki_provider) { build_stubbed(:xwiki_provider, url: "http://xwiki.example.com") }
+      let(:wiki_provider) { build(:xwiki_provider, url: "http://xwiki.example.com") }
 
       include_examples "contract is invalid", url: :url_not_secure_context
     end


### PR DESCRIPTION
https://community.openproject.org/wp/OP-19970


## Summary

`SecureContextUriValidator`, applied to Storages::NextcloudStorage#host and Wikis::XWikiProvider#url, does not guard on whether the field actually changed — unlike its sibling `NextcloudCompatibleHostValidator` on the same `host` attribute, which already checks `contract.model.changed_attributes.include?(attribute)`. As a result, every contract validation run re-checks the field's *current* value, even when an update leaves it untouched.

Once a storage's `host` (or an XWiki provider's `url`) predates this check or otherwise fails it, **every subsequent update that doesn't even touch that field** — a rename, or any other unrelated-field change — is permanently rejected with the same "Secure Context" error.

Fixes the bug reported at OP-19970.

## Changes

- Splits the combined `validates :host, secure_context_uri: true, nextcloud_compatible_host: true` declaration in `Storages::Adapters::Providers::Nextcloud::Contracts::GeneralInformationContract`, adding a `model.host_changed?` guard to `secure_context_uri` specifically. Order is preserved (`secure_context_uri` still runs before the network-probing `nextcloud_compatible_host`), so a newly-set unsafe host is still rejected before any live request is made to it.
- Adds the same `model.url_changed?` guard to `Wikis::XWikiProviders::BaseContract`'s `secure_context_uri` validation.
- Adds RSpec regression coverage in both contracts' specs for: (a) an unrelated field change with an already-persisted insecure value → valid, no network probe; (b) the same value being changed to a *new* insecure value → still invalid, no network probe attempted before rejection.

## Verification

Verified live against a running OpenProject 17.7.1 instance (could not run the RSpec suite locally — no working Ruby/bundler setup in this environment; the new spec files were only syntax-checked with `ruby -c`, please verify on CI):

- Renaming a Nextcloud storage whose `host` was `http://nc.openproject.com` (unchanged, insecure) — before: HTTP 422 "Secure Context" error; after: succeeds, `host` unchanged.
- Updating that same storage's `host` to a new insecure value (`http://another-unsafe-host.example`) — still correctly rejected, confirmed no network probe was attempted before rejection (rejection returned in ~0.07s).
- The analogous XWiki provider case (rename with unchanged insecure `url`; newly-set insecure `url`) verified the same way via a direct contract call.
- A storage whose host genuinely needs live-reachability validation (new host, or an existing host actually being changed) still triggers `nextcloud_compatible_host`'s probe exactly as before.

## Test plan

- [ ] CI passes the new/existing specs in `modules/storages/spec/contracts/storages/storages/nextcloud_update_contract_spec.rb` and `modules/wikis/spec/contracts/wikis/xwiki_providers/base_contract_spec.rb`
- [ ] Reviewer confirms the validator ordering (secure_context_uri before nextcloud_compatible_host) is preserved as intended