### PR TITLE
Run npm audit fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7409,14 +7409,15 @@
       }
     },
     "node_modules/@xeokit/xeokit-sdk": {
-      "version": "2.6.90",
-      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-sdk/-/xeokit-sdk-2.6.90.tgz",
-      "integrity": "sha512-wkZmsWr0fhefrKjlByUs+6j2mizbUQiQJ4nihYwcQrkuECy52e7ntBdpfWVVOXd1eIcV5R2a62AhqR/SjOP0Ww==",
+      "version": "2.6.112",
+      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-sdk/-/xeokit-sdk-2.6.112.tgz",
+      "integrity": "sha512-1N87LyvL1PMQvm0N4xw+ZmZHbVjmsXBo6vX1m6zyYvFK4DHWzACFt5b0DnBKwbasYhsnl/SO51ylgxsllahXiA==",
+      "license": "AGPL-3.0",
       "dependencies": {
-        "@loaders.gl/core": "^4.3.3",
-        "@loaders.gl/gltf": "^4.3.3",
-        "@loaders.gl/las": "^4.3.3",
-        "html2canvas": "^1.4.1"
+        "@loaders.gl/core": "4.3.4",
+        "@loaders.gl/gltf": "4.3.4",
+        "@loaders.gl/las": "4.3.4",
+        "html2canvas": "1.4.1"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -11101,6 +11102,18 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
@@ -12735,9 +12748,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -15414,17 +15427,6 @@
       },
       "bin": {
         "texture-compressor": "bin/texture-compressor.js"
-      }
-    },
-    "node_modules/texture-compressor/node_modules/image-size": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
-      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/ticky": {


### PR DESCRIPTION
Created by GitHub action.

## Impacted packages

### frontend
- `@loaders.gl/gltf` (high)
- `@loaders.gl/textures` (high)
- `@xeokit/xeokit-bim-viewer` (high)
- `@xeokit/xeokit-sdk` (high)
- `esbuild` (low)
- `image-size` (high)
- `nanoid` (high)
- `texture-compressor` (high)

## Replaced PRs

Replaces #24674
