### PR TITLE
[OP-18663] WP search dropdown: wp created by deleted user has a weird layout with missing avatar

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -155,9 +155,12 @@
         } @else {
           <span
             class="op-autocompleter--option-principal op-autocompleter--option-principal-fallback op-avatar op-avatar--fallback"
-            aria-hidden="true"
+            role="img"
+            [attr.title]="item.author?.name || null"
+            [attr.aria-label]="item.author?.name || null"
+            [attr.aria-hidden]="item.author?.name ? null : 'true'"
           >
-            <op-icon icon-classes="icon-user" />
+            <op-icon icon-classes="icon-user" aria-hidden="true" />
           </span>
         }
         <span

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -152,6 +152,13 @@
             [principal]="item.author"
             [hideName]="true"
            />
+        } @else {
+          <span
+            class="op-autocompleter--option-principal op-autocompleter--option-principal-fallback op-avatar op-avatar--fallback"
+            aria-hidden="true"
+          >
+            <op-icon icon-classes="icon-user" />
+          </span>
         }
         <span
           class="op-autocompleter--wp-subject"

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
@@ -18,6 +18,11 @@
     grid-row-start: 1
     grid-row-end: 3
 
+  &--option-principal-fallback
+    background-color: var(--bgColor-neutral-muted)
+    border-color: var(--borderColor-default)
+    color: var(--fgColor-muted)
+
   &--wp-content
     display: grid
     grid-template-columns: 50% 1fr auto

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -79,8 +79,8 @@ describe('autocompleter', () => {
       name: 'Workpackage 2',
       formattedId: 'PROJ-2',
       author: {
-        href: '/api/v3/users/2',
-        name: 'Author2',
+        href: null,
+        name: 'Deleted user',
       },
       type: { id: 2, name: 'Bug' },
       status: { id: 2, name: 'Closed' },
@@ -233,6 +233,42 @@ describe('autocompleter', () => {
         const renderedIds = Array.from(wpIdElements).map(el => el.textContent?.trim());
 
         expect(renderedIds).toContain('#1');
+      }
+      finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should display a fallback avatar and keep the content aligned without an author avatar', () => {
+      vi.useFakeTimers();
+      try {
+        fixture.detectChanges();
+        vi.advanceTimersByTime(1000);
+        fixture.detectChanges();
+        const select = fixture.componentInstance.ngSelectInstance;
+
+        select.open();
+        select.focus();
+
+        const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+        const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+
+        inputElement.value = 'package 2';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        vi.advanceTimersByTime(0);
+        fixture.detectChanges();
+
+        expect(document.querySelector('op-principal.op-autocompleter--option-principal')).toBeNull();
+        expect(document.querySelector('.op-autocompleter--option-principal-fallback')).not.toBeNull();
+
+        const subject = document.querySelector<HTMLElement>('.op-autocompleter--wp-subject')!;
+        const content = document.querySelector<HTMLElement>('.op-autocompleter--wp-content')!;
+
+        expect(getComputedStyle(subject).gridColumnStart).toBe('2');
+        expect(getComputedStyle(subject).gridRowStart).toBe('1');
+        expect(getComputedStyle(content).gridColumnStart).toBe('2');
+        expect(getComputedStyle(content).gridRowStart).toBe('2');
       }
       finally {
         vi.useRealTimers();

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -239,7 +239,7 @@ describe('autocompleter', () => {
       }
     });
 
-    it('should display a fallback avatar and keep the content aligned without an author avatar', () => {
+    it('should display a fallback avatar when the author has been deleted', () => {
       vi.useFakeTimers();
       try {
         fixture.detectChanges();
@@ -261,14 +261,6 @@ describe('autocompleter', () => {
 
         expect(document.querySelector('op-principal.op-autocompleter--option-principal')).toBeNull();
         expect(document.querySelector('.op-autocompleter--option-principal-fallback')).not.toBeNull();
-
-        const subject = document.querySelector<HTMLElement>('.op-autocompleter--wp-subject')!;
-        const content = document.querySelector<HTMLElement>('.op-autocompleter--wp-content')!;
-
-        expect(getComputedStyle(subject).gridColumnStart).toBe('2');
-        expect(getComputedStyle(subject).gridRowStart).toBe('1');
-        expect(getComputedStyle(content).gridColumnStart).toBe('2');
-        expect(getComputedStyle(content).gridRowStart).toBe('2');
       }
       finally {
         vi.useRealTimers();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-18663

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show an avatar with user icon for deleted user

## Screenshots
<img width="650" height="415" alt="Screenshot 2026-08-17 at 08 19 03" src="https://github.com/user-attachments/assets/7d95f3d9-6654-4a17-b159-ae503b292e7f" />
<img width="632" height="423" alt="Screenshot 2026-08-17 at 08 32 26" src="https://github.com/user-attachments/assets/6ac84edc-781b-4262-8a0f-e0c9aae951c4" />
