### PR TITLE
Allow throttling registration attempts

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -972,6 +972,21 @@ module Settings
           "en" => ""
         }
       },
+      registration_rate_limit: {
+        format: :integer,
+        default: 0,
+        writable: false,
+        allowed: (0..),
+        description: "Maximum unauthenticated POST /account/register requests per hour. " \
+                     "Counted per client IP by default, or per instance (host_name) when " \
+                     "registration_rate_limit_per_ip is false. 0 disables the limit."
+      },
+      registration_rate_limit_per_ip: {
+        format: :boolean,
+        default: true,
+        writable: false,
+        description: "Count registration rate limits per client IP. Set to false to count based on hostname itself."
+      },
       remote_storage_upload_host: {
         format: :string,
         default: nil,

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -701,6 +701,24 @@ Limits password-reset requests per email address to 3 per hour.
 OPENPROJECT_RATE_LIMITING_LOST__PASSWORD="true"
 ```
 
+##### Registration rate limiting (disabled by default)
+
+Limits unauthenticated `POST /account/register` requests per hour.
+`0` (the default) disables the limit. A positive value is the number of attempts allowed.
+
+The two counting modes target different attackers:
+
+- **Per client IP** (default): an unauthenticated outsider hitting the public registration form.
+  This does not stop someone who rotates addresses, and it will not freeze signups for everyone
+  behind a shared NAT.
+- **Per instance** (`host_name`): Set
+  `registration_rate_limit_per_ip` to `false` for this mode, which will restrict registrations altogether.
+
+```shell
+OPENPROJECT_REGISTRATION__RATE__LIMIT="10"
+OPENPROJECT_REGISTRATION__RATE__LIMIT__PER__IP="false"
+```
+
 ##### API v3 rate limiting (disabled by default)
 
 Limits API form endpoint requests per session to 6 per 3 seconds.

--- a/docs/installation-and-operations/configuration/environment/README.md
+++ b/docs/installation-and-operations/configuration/environment/README.md
@@ -345,6 +345,8 @@ OPENPROJECT_RATE__LIMITING (default={}) Configure rate limiting for various endp
 OPENPROJECT_REAL__TIME__TEXT__COLLABORATION__ENABLED (default=false) Enable real-time collaborative editing of text fields using BlockNoteJS and Hocuspocus server.
 OPENPROJECT_RECAPTCHA__VIA__HCAPTCHA (default=false)
 OPENPROJECT_REGISTRATION__FOOTER (default={"en" => ""}) Registration footer
+OPENPROJECT_REGISTRATION__RATE__LIMIT (default=0) Maximum unauthenticated POST /account/register requests per hour. Counted per client IP by default, or per instance (host_name) when registration_rate_limit_per_ip is false. 0 disables the limit.
+OPENPROJECT_REGISTRATION__RATE__LIMIT__PER__IP (default=true) Count registration rate limits per client IP. Set to false to count based on hostname itself.
 OPENPROJECT_REMOTE__STORAGE__DOWNLOAD__HOST (default=nil) Host the frontend uses to download files, which has to be added to the CSP.
 OPENPROJECT_REMOTE__STORAGE__UPLOAD__HOST (default=nil) Host the frontend uses to upload files to, which has to be added to the CSP.
 OPENPROJECT_REPORT__INCOMING__EMAIL__ERRORS (default=true) Respond to incoming mails with error details

--- a/lib/open_project/rate_limiting.rb
+++ b/lib/open_project/rate_limiting.rb
@@ -12,7 +12,8 @@ module OpenProject
       @default_rules ||= [
         LostPassword,
         APIV3,
-        Login
+        Login,
+        Registration
       ]
     end
 

--- a/lib/open_project/rate_limiting/base.rb
+++ b/lib/open_project/rate_limiting/base.rb
@@ -3,6 +3,8 @@
 module OpenProject
   module RateLimiting
     class Base
+      include RecognizedRoute
+
       class << self
         def rule_name
           name.demodulize.underscore

--- a/lib/open_project/rate_limiting/recognized_route.rb
+++ b/lib/open_project/rate_limiting/recognized_route.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module OpenProject
+  module RateLimiting
+    # Memoizes route recognition on the Rack env so every Attack rule can
+    # share one lookup per request. Prefers Rails' own path_parameters when
+    # the router has already run (e.g. a later controller hook).
+    module RecognizedRoute
+      ENV_KEY = "open_project.rate_limiting.recognized_route"
+
+      def recognized_route(req)
+        RecognizedRoute.fetch(req)
+      end
+
+      def recognized_route?(req, controller:, action:)
+        RecognizedRoute.matches?(req, controller:, action:)
+      end
+
+      class << self
+        def fetch(req)
+          env = req.env
+          return env[ENV_KEY] if env.key?(ENV_KEY)
+
+          env[ENV_KEY] = lookup(req)
+        end
+
+        def matches?(req, controller:, action:)
+          route = fetch(req)
+          route && route[:controller] == controller && route[:action] == action
+        end
+
+        private
+
+        def lookup(req)
+          params = req.env[ActionDispatch::Http::Parameters::PARAMETERS_KEY]
+          return params if params && params[:controller]
+
+          OpenProject::StaticRouting.recognize_route(req.path)
+        end
+      end
+    end
+  end
+end

--- a/lib/open_project/rate_limiting/registration.rb
+++ b/lib/open_project/rate_limiting/registration.rb
@@ -8,14 +8,13 @@ module OpenProject
     # Default bucket is the client IP
     # Set registration_rate_limit_per_ip to false to count per instance instead
     class Registration < Base
-      # Optional format suffix: Rails routes include (.:format), so
-      # POST /account/register.json still hits AccountController#register.
-      # No \A anchor: OpenProject may run under rails_relative_url_root.
-      REGISTER_PATH = %r{/account/register(?:\.\w+)?\z}
-
       class << self
         def enabled?
           Setting.registration_rate_limit.to_i.positive?
+        end
+
+        def registration_request?(req)
+          req.post? && RecognizedRoute.matches?(req, controller: "account", action: "register")
         end
       end
 
@@ -38,7 +37,7 @@ module OpenProject
       protected
 
       def discriminator(req)
-        return unless req.post? && req.path.match?(REGISTER_PATH)
+        return unless self.class.registration_request?(req)
 
         per_ip? ? client_ip(req) : Setting.host_name
       end

--- a/lib/open_project/rate_limiting/registration.rb
+++ b/lib/open_project/rate_limiting/registration.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module OpenProject
+  module RateLimiting
+    # Throttles unauthenticated POST /account/register.
+    # Disabled when registration_rate_limit is 0.
+    #
+    # Default bucket is the client IP
+    # Set registration_rate_limit_per_ip to false to count per instance instead
+    class Registration < Base
+      # Optional format suffix: Rails routes include (.:format), so
+      # POST /account/register.json still hits AccountController#register.
+      # No \A anchor: OpenProject may run under rails_relative_url_root.
+      REGISTER_PATH = %r{/account/register(?:\.\w+)?\z}
+
+      class << self
+        def enabled?
+          Setting.registration_rate_limit.to_i.positive?
+        end
+      end
+
+      def default_limit
+        Setting.registration_rate_limit.to_i
+      end
+
+      def default_period
+        1.hour.to_i
+      end
+
+      def response_body(retry_after:, **)
+        "Too many registration attempts. Try again at #{retry_after.seconds.from_now}.\n"
+      end
+
+      def per_ip?
+        Setting.registration_rate_limit_per_ip
+      end
+
+      protected
+
+      def discriminator(req)
+        return unless req.post? && req.path.match?(REGISTER_PATH)
+
+        per_ip? ? client_ip(req) : Setting.host_name
+      end
+
+      def client_ip(req)
+        req.env["HTTP_X_REAL_IP"].presence || req.ip
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/rate_limiting/recognized_route_spec.rb
+++ b/spec/lib/open_project/rate_limiting/recognized_route_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::RateLimiting::RecognizedRoute do
+  def request_for(path, method: "POST", path_parameters: nil)
+    env = Rack::MockRequest.env_for(path, method:)
+    env[ActionDispatch::Http::Parameters::PARAMETERS_KEY] = path_parameters if path_parameters
+    Rack::Attack::Request.new(env)
+  end
+
+  describe ".fetch" do
+    it "recognizes the route" do
+      route = described_class.fetch(request_for("/account/register"))
+
+      expect(route).to include(controller: "account", action: "register")
+    end
+
+    it "returns nil for an unknown path" do
+      expect(described_class.fetch(request_for("/this/does/not/exist"))).to be_nil
+    end
+
+    it "memoizes recognition on the request env" do
+      req = request_for("/account/register")
+      allow(OpenProject::StaticRouting).to receive(:recognize_route).and_call_original
+
+      2.times { described_class.fetch(req) }
+
+      expect(OpenProject::StaticRouting).to have_received(:recognize_route).once
+    end
+
+    it "memoizes a miss so unknown paths are not recognized twice" do
+      req = request_for("/this/does/not/exist")
+      allow(OpenProject::StaticRouting).to receive(:recognize_route).and_call_original
+
+      2.times { described_class.fetch(req) }
+
+      expect(OpenProject::StaticRouting).to have_received(:recognize_route).once
+    end
+
+    it "uses path_parameters when the router has already run" do
+      req = request_for(
+        "/ignored",
+        path_parameters: { controller: "account", action: "register" }
+      )
+      allow(OpenProject::StaticRouting).to receive(:recognize_route)
+
+      expect(described_class.fetch(req)).to include(controller: "account", action: "register")
+      expect(OpenProject::StaticRouting).not_to have_received(:recognize_route)
+    end
+  end
+
+  describe ".matches?" do
+    it "is true for the given controller and action" do
+      expect(described_class).to be_matches(request_for("/account/register"),
+                                            controller: "account",
+                                            action: "register")
+    end
+
+    it "is false for a different action" do
+      expect(described_class).not_to be_matches(request_for("/account/lost_password"),
+                                                controller: "account",
+                                                action: "register")
+    end
+  end
+end

--- a/spec/lib/open_project/rate_limiting/registration_spec.rb
+++ b/spec/lib/open_project/rate_limiting/registration_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::RateLimiting::Registration do
+  describe ".enabled?" do
+    it "is disabled when the limit is 0" do
+      expect(described_class).not_to be_enabled
+    end
+
+    context "with a positive limit", with_settings: { registration_rate_limit: 10 } do
+      it { expect(described_class).to be_enabled }
+    end
+  end
+
+  describe "#default_limit" do
+    context "with a positive limit", with_settings: { registration_rate_limit: 7 } do
+      it "uses the configured value" do
+        expect(described_class.new.default_limit).to eq 7
+      end
+    end
+  end
+
+  describe "#per_ip?" do
+    it "defaults to counting per client IP" do
+      expect(described_class.new).to be_per_ip
+    end
+
+    context "when disabled", with_settings: { registration_rate_limit_per_ip: false } do
+      it { expect(described_class.new).not_to be_per_ip }
+    end
+  end
+
+  describe "#discriminator" do
+    subject(:rule) { described_class.new }
+
+    def request_for(path, method: "POST", ip_address: "192.0.2.1")
+      env = Rack::MockRequest.env_for(path, method:, "REMOTE_ADDR" => ip_address)
+      Rack::Attack::Request.new(env)
+    end
+
+    it "matches the register path" do
+      expect(rule.send(:discriminator, request_for("/account/register"))).to eq "192.0.2.1"
+    end
+
+    it "matches an optional format suffix that still routes to register" do
+      expect(rule.send(:discriminator, request_for("/account/register.json"))).to eq "192.0.2.1"
+    end
+
+    it "matches under a relative URL root" do
+      expect(rule.send(:discriminator, request_for("/openproject/account/register"))).to eq "192.0.2.1"
+    end
+
+    it "does not match other paths" do
+      expect(rule.send(:discriminator, request_for("/account/lost_password"))).to be_nil
+    end
+
+    it "does not match GET" do
+      expect(rule.send(:discriminator, request_for("/account/register", method: "GET"))).to be_nil
+    end
+  end
+end

--- a/spec/lib/open_project/rate_limiting/registration_spec.rb
+++ b/spec/lib/open_project/rate_limiting/registration_spec.rb
@@ -75,12 +75,18 @@ RSpec.describe OpenProject::RateLimiting::Registration do
       expect(rule.send(:discriminator, request_for("/account/register.json"))).to eq "192.0.2.1"
     end
 
-    it "matches under a relative URL root" do
-      expect(rule.send(:discriminator, request_for("/openproject/account/register"))).to eq "192.0.2.1"
+    context "with a relative URL root", with_config: { rails_relative_url_root: "/openproject" } do
+      it "matches the register path under that prefix" do
+        expect(rule.send(:discriminator, request_for("/openproject/account/register"))).to eq "192.0.2.1"
+      end
     end
 
     it "does not match other paths" do
       expect(rule.send(:discriminator, request_for("/account/lost_password"))).to be_nil
+    end
+
+    it "does not match a path that merely ends with /account/register" do
+      expect(rule.send(:discriminator, request_for("/evil/account/register"))).to be_nil
     end
 
     it "does not match GET" do

--- a/spec/requests/rate_limiting/registration_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/registration_rate_limiting_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Rate limiting registration",
+               :with_rack_attack,
+               type: :rails_request do
+  before do
+    allow_any_instance_of(ActionController::Base) # rubocop:disable RSpec/AnyInstance
+      .to(receive(:protect_against_forgery?))
+      .and_return(false)
+  end
+
+  def register!(ip_address: "192.0.2.1")
+    post account_register_path,
+         params: {
+           user: {
+             login: "spam#{SecureRandom.hex(4)}",
+             mail: "#{SecureRandom.hex(4)}@example.com",
+             firstname: "Spam",
+             lastname: "User",
+             password: "adminADMIN!",
+             password_confirmation: "adminADMIN!"
+           }
+         },
+         headers: { "REMOTE_ADDR" => ip_address, "Content-Type": "multipart/form-data" }
+  end
+
+  context "when enabled per IP",
+          with_settings: { registration_rate_limit: 3 } do
+    before { OpenProject::RateLimiting.set_defaults! }
+
+    it "blocks the fourth attempt from the same IP" do
+      3.times do
+        register!
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      register!
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include "Too many registration attempts"
+    end
+
+    it "does not block a different IP" do
+      3.times { register!(ip: "192.0.2.1") }
+
+      register!(ip: "198.51.100.1")
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+  end
+
+  context "when enabled per instance",
+          with_settings: { registration_rate_limit: 3, registration_rate_limit_per_ip: false } do
+    before { OpenProject::RateLimiting.set_defaults! }
+
+    it "blocks the fourth attempt on the instance regardless of IP" do
+      3.times do
+        register!
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      register!(ip: "198.51.100.1")
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include "Too many registration attempts"
+    end
+
+    it "does not share the limit across host names" do
+      3.times { register! }
+
+      allow(Setting).to receive(:host_name).and_return("other.example.com")
+
+      register!
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+  end
+
+  context "when disabled" do
+    it "does not block repeated registrations" do
+      4.times do
+        register!
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+    end
+  end
+end

--- a/spec/requests/rate_limiting/registration_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/registration_rate_limiting_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Rate limiting registration",
     end
 
     it "does not block a different IP" do
-      3.times { register!(ip: "192.0.2.1") }
+      3.times { register!(ip_address: "192.0.2.1") }
 
-      register!(ip: "198.51.100.1")
+      register!(ip_address: "198.51.100.1")
       expect(response).not_to have_http_status(:too_many_requests)
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe "Rate limiting registration",
         expect(response).not_to have_http_status(:too_many_requests)
       end
 
-      register!(ip: "198.51.100.1")
+      register!(ip_address: "198.51.100.1")
       expect(response).to have_http_status(:too_many_requests)
       expect(response.body).to include "Too many registration attempts"
     end


### PR DESCRIPTION
Allow `/account/registration` to be rate limited per instance as an optional rule that is disabled by default. This can be opted into

https://community.openproject.org/work_packages/OP-19978