### PR TITLE
[fix] Add missing seeders to BIM module

### DIFF
--- a/app/seeders/basic_data_seeder.rb
+++ b/app/seeders/basic_data_seeder.rb
@@ -29,7 +29,26 @@
 #++
 class BasicDataSeeder < CompositeSeeder
   def data_seeder_classes
-    raise SubclassResponsibilityError
+    [
+      ::BasicData::BuiltinUsersSeeder,
+      ::BasicData::ProjectRoleSeeder,
+      ::BasicData::WorkPackageRoleSeeder,
+      ::BasicData::ProjectQueryRoleSeeder,
+      ::BasicData::GlobalRoleSeeder,
+      ::BasicData::TimeEntryActivitySeeder,
+      ::BasicData::ColorSeeder,
+      ::BasicData::ColorSchemeSeeder,
+      ::BasicData::PluginAuthProviderSeeder,
+      ::BasicData::ProjectPhaseColorSeeder,
+      ::BasicData::ProjectPhaseDefinitionSeeder,
+      ::BasicData::StatusSeeder,
+      ::BasicData::TypeSeeder,
+      ::BasicData::WorkflowSeeder,
+      ::BasicData::PrioritySeeder,
+      ::BasicData::SettingSeeder,
+      ::BasicData::ProjectCustomFieldSectionSeeder,
+      ::BasicData::UserCustomFieldSectionSeeder
+    ]
   end
 
   def namespace

--- a/app/seeders/standard/basic_data_seeder.rb
+++ b/app/seeders/standard/basic_data_seeder.rb
@@ -28,28 +28,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 module Standard
-  class BasicDataSeeder < ::BasicDataSeeder
-    def data_seeder_classes
-      [
-        ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::ProjectRoleSeeder,
-        ::BasicData::WorkPackageRoleSeeder,
-        ::BasicData::ProjectQueryRoleSeeder,
-        ::BasicData::GlobalRoleSeeder,
-        ::BasicData::TimeEntryActivitySeeder,
-        ::BasicData::ColorSeeder,
-        ::BasicData::ColorSchemeSeeder,
-        ::BasicData::PluginAuthProviderSeeder,
-        ::BasicData::ProjectPhaseColorSeeder,
-        ::BasicData::ProjectPhaseDefinitionSeeder,
-        ::BasicData::StatusSeeder,
-        ::BasicData::TypeSeeder,
-        ::BasicData::WorkflowSeeder,
-        ::BasicData::PrioritySeeder,
-        ::BasicData::SettingSeeder,
-        ::BasicData::ProjectCustomFieldSectionSeeder,
-        ::BasicData::UserCustomFieldSectionSeeder
-      ]
-    end
-  end
+  class BasicDataSeeder < ::BasicDataSeeder; end
 end

--- a/modules/bim/app/seeders/bim/basic_data_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data_seeder.rb
@@ -28,25 +28,7 @@
 module Bim
   class BasicDataSeeder < ::BasicDataSeeder
     def data_seeder_classes
-      [
-        ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::ProjectRoleSeeder,
-        ::BasicData::WorkPackageRoleSeeder,
-        ::BasicData::GlobalRoleSeeder,
-        ::BasicData::ProjectQueryRoleSeeder,
-        ::BasicData::TimeEntryActivitySeeder,
-        ::BasicData::ColorSeeder,
-        ::BasicData::ColorSchemeSeeder,
-        ::BasicData::ProjectPhaseColorSeeder,
-        ::BasicData::ProjectPhaseDefinitionSeeder,
-        ::BasicData::StatusSeeder,
-        ::BasicData::TypeSeeder,
-        ::BasicData::WorkflowSeeder,
-        ::BasicData::PrioritySeeder,
-        ::Bim::BasicData::SettingSeeder,
-        ::Bim::BasicData::ThemeSeeder
-
-      ]
+      super - [::BasicData::SettingSeeder] + [::Bim::BasicData::SettingSeeder, ::Bim::BasicData::ThemeSeeder]
     end
   end
 end


### PR DESCRIPTION
# Ticket
[BIM-81](https://community.openproject.org/wp/BIM-81)

# What are you trying to accomplish?
- BIM trials should have user custom field sections seeded

# What approach did you choose and why?
- the BIM basic data seeder duplicates the data seeder definitions
- with latest changes to the standard basic data seeder, BIM was forgotten
- missing seeder were added
