### PR TITLE
[XWI-159] Allow parent and wiki selection

### DIFF
--- a/modules/wikis/app/components/wikis/search_pages_result_component.rb
+++ b/modules/wikis/app/components/wikis/search_pages_result_component.rb
@@ -37,7 +37,7 @@ module Wikis
 
     attr_reader :builder, :form_name, :wikis_selectable
 
-    def initialize(model = [], builder:, form_name:, wikis_selectable: false, **)
+    def initialize(model = [], builder:, form_name:, wikis_selectable:, **)
       @builder = builder
       @form_name = form_name
       @wikis_selectable = wikis_selectable

--- a/modules/wikis/app/components/wikis/search_pages_result_component.rb
+++ b/modules/wikis/app/components/wikis/search_pages_result_component.rb
@@ -35,11 +35,12 @@ module Wikis
 
     alias_method :tree_nodes, :model
 
-    attr_reader :builder, :form_name
+    attr_reader :builder, :form_name, :wikis_selectable
 
-    def initialize(model = [], builder:, form_name:, **)
+    def initialize(model = [], builder:, form_name:, wikis_selectable: false, **)
       @builder = builder
       @form_name = form_name
+      @wikis_selectable = wikis_selectable
       super(model, **)
     end
 
@@ -68,10 +69,14 @@ module Wikis
       {
         label: node.name,
         select_variant: :single,
-        disabled: !node.enabled,
+        disabled: !selectable?(node),
         expanded: true,
-        data: { node_id: node.identifier }
+        data: { node_id: node.key.to_s }
       }
+    end
+
+    def selectable?(node)
+      wikis_selectable || node.type != :wiki
     end
 
     def item_icon(node)

--- a/modules/wikis/app/contracts/wikis/adapters/input/create_page_contract.rb
+++ b/modules/wikis/app/contracts/wikis/adapters/input/create_page_contract.rb
@@ -35,9 +35,10 @@ module Wikis
         params do
           required(:title).filled(:string)
 
-          # TODO: This only works for pages as parents right now, we'll need to change some things around to support
-          # creating "root" pages that are direct children of a wiki. E.g. right now there is no data type to represent a wiki
+          # A page is either created below another page, or as a "root" page directly below a wiki. The identifier
+          # alone does not tell the two apart, hence the type is required as well.
           required(:parent_identifier).filled(:string)
+          required(:parent_type).filled(:symbol, included_in?: Results::PageSearchTreeNode::TYPES)
         end
       end
     end

--- a/modules/wikis/app/controllers/wikis/page_link_macro_controller.rb
+++ b/modules/wikis/app/controllers/wikis/page_link_macro_controller.rb
@@ -88,7 +88,8 @@ module Wikis
       provider = Provider.visible.enabled.find(parameters[:provider_id])
       result = CreatePageService.new(provider:, user: current_user)
                                 .create_page(title: parameters[:page_title],
-                                             parent_identifier: parameters[:parent_page_identifier])
+                                             parent_identifier: parameters[:parent_identifier],
+                                             parent_type: parameters[:parent_type])
 
       result.either(
         ->(info) do
@@ -128,7 +129,7 @@ module Wikis
     def inline_existing_params
       if params.key?(:wikis_forms_inline_existing_wiki_page_form_model)
         params.expect(wikis_forms_inline_existing_wiki_page_form_model: %i[provider_id])
-              .merge(page_identifier: parse_identifier(params[:wiki_page_selection]))
+              .merge(page_identifier: parse_page_identifier(params[:wiki_page_selection]))
       else
         params
       end
@@ -136,8 +137,10 @@ module Wikis
 
     def inline_new_params
       if params.key?(:wikis_forms_inline_new_wiki_page_form_model)
+        parent = parse_selected_node(params[:wiki_page_selection])
+
         params.expect(wikis_forms_inline_new_wiki_page_form_model: %i[provider_id page_title])
-              .merge(parent_page_identifier: parse_identifier(params[:wiki_page_selection]))
+              .merge(parent_identifier: parent&.identifier, parent_type: parent&.type)
       else
         params
       end

--- a/modules/wikis/app/controllers/wikis/page_selection_form_input.rb
+++ b/modules/wikis/app/controllers/wikis/page_selection_form_input.rb
@@ -30,13 +30,22 @@
 
 module Wikis
   module PageSelectionFormInput
-    def parse_identifier(wiki_page_selection)
+    # The tree view submits the key of the selected node, i.e. its type and identifier.
+    def parse_selected_node(wiki_page_selection)
       case wiki_page_selection
-      in [selected_page]
-        MultiJson.load(selected_page, symbolize_keys: true)[:nodeId]
+      in [selected_node]
+        Adapters::Results::PageSearchTreeNode::Key.parse(
+          MultiJson.load(selected_node, symbolize_keys: true)[:nodeId]
+        )
       else
         nil
       end
+    end
+
+    def parse_page_identifier(wiki_page_selection)
+      node = parse_selected_node(wiki_page_selection)
+
+      node.identifier if node&.page?
     end
   end
 end

--- a/modules/wikis/app/controllers/wikis/pages_controller.rb
+++ b/modules/wikis/app/controllers/wikis/pages_controller.rb
@@ -49,7 +49,8 @@ module Wikis
         .new(provider:, user: current_user)
         .create_page_and_link(
           title: parameters[:page_title],
-          parent_identifier: parameters[:parent_page_identifier],
+          parent_identifier: parameters[:parent_identifier],
+          parent_type: parameters[:parent_type],
           linkable_type: parameters[:linkable_type],
           linkable_id: parameters[:linkable_id]
         )
@@ -78,7 +79,9 @@ module Wikis
       search_result = search_pages(query, fetch_provider)
 
       search_result.either(
-        ->(pages) { render(Wikis::SearchPagesResultComponent.new(pages, form_name:, builder:), layout: false) },
+        ->(pages) do
+          render(Wikis::SearchPagesResultComponent.new(pages, form_name:, builder:, wikis_selectable:), layout: false)
+        end,
         ->(failure) { render "search_error", layout: false, locals: { message: humanize_error_message(failure) } }
       )
     end
@@ -87,6 +90,10 @@ module Wikis
 
     def fetch_provider
       Provider.visible.enabled.find(params.expect(:provider_id))
+    end
+
+    def wikis_selectable
+      ActiveModel::Type::Boolean.new.cast(params[:wikis_selectable]) || false
     end
 
     def form_builder
@@ -98,8 +105,10 @@ module Wikis
     end
 
     def create_new_page_params
+      parent = parse_selected_node(params[:wiki_page_selection])
+
       params.expect(wikis_forms_create_new_wiki_page_form_model: %i[provider_id linkable_type linkable_id page_title])
-            .merge(parent_page_identifier: parse_identifier(params[:wiki_page_selection]))
+            .merge(parent_identifier: parent&.identifier, parent_type: parent&.type)
     end
   end
 end

--- a/modules/wikis/app/controllers/wikis/relation_page_links_controller.rb
+++ b/modules/wikis/app/controllers/wikis/relation_page_links_controller.rb
@@ -79,7 +79,7 @@ module Wikis
 
     def relation_page_link_params
       permitted = params.expect(wikis_relation_page_link: %i[provider_id linkable_type linkable_id identifier])
-      permitted[:identifier] = permitted[:identifier].presence || parse_identifier(params[:wiki_page_selection])
+      permitted[:identifier] = permitted[:identifier].presence || parse_page_identifier(params[:wiki_page_selection])
       permitted.merge(author_id: current_user.id)
     end
   end

--- a/modules/wikis/app/forms/wikis/create_new_wiki_page_form.rb
+++ b/modules/wikis/app/forms/wikis/create_new_wiki_page_form.rb
@@ -43,7 +43,9 @@ module Wikis
         f.filterable_tree_view(
           name: "wiki_page_selection",
           label: I18n.t("wikis.page_link_forms.labels.parent"),
-          src: helpers.search_wiki_pages_path(provider_id: model.provider_id, name: "wiki_page_selection"),
+          src: helpers.search_wiki_pages_path(provider_id: model.provider_id,
+                                              name: "wiki_page_selection",
+                                              wikis_selectable: true),
           filter_mode_control_arguments: { hidden: true },
           filter_input_arguments: { placeholder: I18n.t("wikis.page_link_forms.search.placeholder") },
           include_sub_items_check_box_arguments: { hidden: true },

--- a/modules/wikis/app/forms/wikis/inline_new_wiki_page_form.rb
+++ b/modules/wikis/app/forms/wikis/inline_new_wiki_page_form.rb
@@ -38,7 +38,9 @@ module Wikis
         f.filterable_tree_view(
           name: "wiki_page_selection",
           label: I18n.t("wikis.page_link_forms.labels.parent"),
-          src: helpers.search_wiki_pages_path(provider_id: model.provider_id, name: "wiki_page_selection"),
+          src: helpers.search_wiki_pages_path(provider_id: model.provider_id,
+                                              name: "wiki_page_selection",
+                                              wikis_selectable: true),
           filter_mode_control_arguments: { hidden: true },
           filter_input_arguments: { placeholder: I18n.t("wikis.page_link_forms.search.placeholder") },
           include_sub_items_check_box_arguments: { hidden: true },

--- a/modules/wikis/app/models/wikis/adapters/input/create_page.rb
+++ b/modules/wikis/app/models/wikis/adapters/input/create_page.rb
@@ -29,11 +29,13 @@
 #++
 
 module Wikis::Adapters::Input
-  CreatePage = Data.define(:title, :parent_identifier) do
+  CreatePage = Data.define(:title, :parent_identifier, :parent_type) do
     private_class_method :new
 
-    def self.build(title:, parent_identifier:, contract: CreatePageContract.new)
-      contract.call(title:, parent_identifier:).to_monad.fmap { new(**it.to_h) }
+    def self.build(title:, parent_identifier:, parent_type:, contract: CreatePageContract.new)
+      contract.call(title:, parent_identifier:, parent_type:).to_monad.fmap { new(**it.to_h) }
     end
+
+    def wiki_parent? = parent_type == :wiki
   end
 end

--- a/modules/wikis/app/models/wikis/adapters/results/page_search_tree_node.rb
+++ b/modules/wikis/app/models/wikis/adapters/results/page_search_tree_node.rb
@@ -42,8 +42,6 @@ module Wikis::Adapters::Results
 
       def to_s = "#{type}:#{identifier}"
 
-      def wiki? = type == :wiki
-
       def page? = type == :page
     end
 

--- a/modules/wikis/app/models/wikis/adapters/results/page_search_tree_node.rb
+++ b/modules/wikis/app/models/wikis/adapters/results/page_search_tree_node.rb
@@ -30,18 +30,32 @@
 
 module Wikis::Adapters::Results
   class PageSearchTreeNode
-    attr_accessor :enabled
+    TYPES = %i[wiki page].freeze
+
+    Key = Data.define(:type, :identifier) do
+      def self.parse(string)
+        type, identifier = string.to_s.split(":", 2)
+        return if identifier.blank? || TYPES.exclude?(type&.to_sym)
+
+        new(type: type.to_sym, identifier:)
+      end
+
+      def to_s = "#{type}:#{identifier}"
+
+      def wiki? = type == :wiki
+
+      def page? = type == :page
+    end
 
     attr_reader :identifier, :type, :name, :children
 
-    def initialize(identifier:, type:, name:, children:, enabled:)
+    def initialize(identifier:, type:, name:, children:)
       @identifier = identifier
       @type = type
       @name = name
       @children = children
-      @enabled = enabled
     end
 
-    def key = "#{type}:#{identifier}"
+    def key = Key.new(type:, identifier:)
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/commands/create_page.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/commands/create_page.rb
@@ -36,23 +36,32 @@ module Wikis
           class CreatePage < BaseCommand
             def call(input_data:, auth_strategy:)
               Adapters::Authentication[auth_strategy].call do |user|
-                parent = find_parent(input_data.parent_identifier, user:)
-                return failure(code: :not_found) if parent.nil?
-
-                service_result_to_monad(
-                  ::WikiPages::CreateService.new(user:).call(
-                    title: input_data.title,
-                    parent:,
-                    wiki: parent.wiki
-                  )
-                )
+                if input_data.wiki_parent?
+                  create_root_page(input_data, user:)
+                else
+                  create_child_page(input_data, user:)
+                end
               end
             end
 
             private
 
-            def find_parent(identifier, user:)
-              WikiPage.visible(user).find_by(id: identifier)
+            def create_root_page(input_data, user:)
+              wiki = Wiki.find_by(id: input_data.parent_identifier)
+              return failure(code: :not_found) unless wiki&.visible?(user)
+
+              create_page(title: input_data.title, wiki:, parent: nil, user:)
+            end
+
+            def create_child_page(input_data, user:)
+              parent = WikiPage.visible(user).find_by(id: input_data.parent_identifier)
+              return failure(code: :not_found) if parent.nil?
+
+              create_page(title: input_data.title, wiki: parent.wiki, parent:, user:)
+            end
+
+            def create_page(title:, wiki:, parent:, user:)
+              service_result_to_monad(::WikiPages::CreateService.new(user:).call(title:, parent:, wiki:))
             end
 
             def service_result_to_monad(result)

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/commands/create_page.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/commands/create_page.rb
@@ -44,9 +44,8 @@ module Wikis
             end
 
             def call(input_data:, auth_strategy:)
-              parent_result = fetch_canonical_parent(identifier: input_data.parent_identifier, auth_strategy:)
-              parent_result.bind do |canonical_parent|
-                identifier = "#{canonical_parent}.#{self.class.derive_page_id(input_data.title)}.WebHome"
+              parent_reference(input_data, auth_strategy:).bind do |reference_prefix|
+                identifier = "#{reference_prefix}#{self.class.derive_page_id(input_data.title)}.WebHome"
 
                 create_page_request(identifier, title: input_data.title, auth_strategy:) do |data|
                   success(Queries::StablePageInfo.json_to_page_info(data, provider:))
@@ -55,6 +54,12 @@ module Wikis
             end
 
             private
+
+            def parent_reference(input_data, auth_strategy:)
+              return success("#{input_data.parent_identifier}:") if input_data.wiki_parent?
+
+              fetch_canonical_parent(identifier: input_data.parent_identifier, auth_strategy:).fmap { "#{it}." }
+            end
 
             def fetch_canonical_parent(identifier:, auth_strategy:)
               ref = StablePageReference.parse(identifier)

--- a/modules/wikis/app/services/wikis/create_page_service.rb
+++ b/modules/wikis/app/services/wikis/create_page_service.rb
@@ -39,14 +39,14 @@ module Wikis
       @user = user
     end
 
-    def create_page_and_link(title:, parent_identifier:, linkable_type:, linkable_id:)
-      create_page(title:, parent_identifier:)
+    def create_page_and_link(title:, parent_identifier:, parent_type:, linkable_type:, linkable_id:)
+      create_page(title:, parent_identifier:, parent_type:)
         .bind { link_page(identifier: it.identifier, linkable_type:, linkable_id:) }
     end
 
-    def create_page(title:, parent_identifier:)
+    def create_page(title:, parent_identifier:, parent_type:)
       provider.auth_strategy_for(user).bind do |auth_strategy|
-        Adapters::Input::CreatePage.build(title:, parent_identifier:).bind do |input_data|
+        Adapters::Input::CreatePage.build(title:, parent_identifier:, parent_type:).bind do |input_data|
           provider.resolve("commands.create_page").call(input_data:, auth_strategy:)
         end
       end

--- a/modules/wikis/app/services/wikis/page_search_service.rb
+++ b/modules/wikis/app/services/wikis/page_search_service.rb
@@ -44,7 +44,7 @@ module Wikis
 
       if url?(query)
         search_by_url(query).either(
-          ->(page) { Success([to_tree_node(page:, enabled: true)]) },
+          ->(page) { Success([to_tree_node(page:)]) },
           ->(failure) { failure.code == :not_found ? Success([]) : Failure(failure) }
         )
       else
@@ -88,26 +88,22 @@ module Wikis
       provider.resolve("queries.search_wikis").call(input_data:, auth_strategy:)
     end
 
-    def to_tree_node(page:, enabled:)
+    def to_tree_node(page:)
       Adapters::Results::PageSearchTreeNode.new(identifier: page.identifier,
                                                 type: :page,
                                                 name: page.title,
-                                                children: [],
-                                                enabled:)
+                                                children: [])
     end
 
+    # Wikis matched by their own name are inserted first, so that they are listed above the wikis that only
+    # appear as the container of a matching page. A wiki matched in both ways is inserted only once.
     def build_result_tree(pages:, wikis:)
-      root = Adapters::Results::PageSearchTreeNode.new(identifier: "root",
-                                                       type: :root,
-                                                       name: "root",
-                                                       children: [],
-                                                       enabled: false)
-      accumulator = { root:, all_nodes: [root] }
+      accumulator = { wiki_nodes: [], all_nodes: [] }
 
       wikis.each { insert_wiki_node(accumulator, it) }
       pages.each { insert_page_hierarchy(accumulator, it) }
 
-      root.children
+      accumulator[:wiki_nodes]
     end
 
     def insert_page_hierarchy(accumulator, page_hierarchy)
@@ -123,10 +119,9 @@ module Wikis
       wiki_node = Adapters::Results::PageSearchTreeNode.new(identifier: wiki.identifier,
                                                             type: :wiki,
                                                             name: wiki.name,
-                                                            children: [],
-                                                            enabled: false)
+                                                            children: [])
       accumulator[:all_nodes] << wiki_node
-      accumulator[:root].children << wiki_node
+      accumulator[:wiki_nodes] << wiki_node
     end
 
     def insert_ancestor_nodes(accumulator, page) # rubocop:disable Metrics/AbcSize
@@ -139,7 +134,7 @@ module Wikis
       ancestors.reverse_each do |ancestor|
         ancestor_node = accumulator[:all_nodes].find { it.key == node_key(type: :page, identifier: ancestor.identifier) }
         if ancestor_node.nil?
-          ancestor_node = to_tree_node(page: ancestor, enabled: false)
+          ancestor_node = to_tree_node(page: ancestor)
           previous_ancestor_node.children << ancestor_node
           accumulator[:all_nodes] << ancestor_node
         end
@@ -151,10 +146,10 @@ module Wikis
     def insert_page_node(accumulator, page_hierarchy)
       page_hierarchy => { page:, ancestors:, wiki: }
 
-      return if enable_if_node_exists(accumulator, page)
+      return if node_exists?(accumulator, page)
 
       parent_node = find_parent(accumulator, ancestors, wiki)
-      new_node = to_tree_node(page:, enabled: true)
+      new_node = to_tree_node(page:)
       parent_node.children << new_node
       accumulator[:all_nodes] << new_node
     end
@@ -170,16 +165,12 @@ module Wikis
       end
     end
 
-    def enable_if_node_exists(accumulator, page) # rubocop:disable Naming/PredicateMethod
-      node = accumulator[:all_nodes].find { it.key == node_key(type: :page, identifier: page.identifier) }
-      return false if node.nil?
-
-      node.enabled = true
-      true
+    def node_exists?(accumulator, page)
+      accumulator[:all_nodes].any? { it.key == node_key(type: :page, identifier: page.identifier) }
     end
 
     def node_key(type:, identifier:)
-      "#{type}:#{identifier}"
+      Adapters::Results::PageSearchTreeNode::Key.new(type:, identifier:)
     end
   end
 end

--- a/modules/wikis/spec/components/wikis/search_pages_result_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/search_pages_result_component_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::SearchPagesResultComponent, type: :component do
+  subject do
+    render_inline(described_class.new(tree_nodes, builder:, form_name: "wiki_page_selection", **options))
+    page
+  end
+
+  let(:builder) { ActionView::Helpers::FormBuilder.new("", nil, vc_test_controller.view_context, {}) }
+  let(:options) { {} }
+
+  let(:page_node) do
+    Wikis::Adapters::Results::PageSearchTreeNode.new(identifier: "42", type: :page, name: "A page", children: [])
+  end
+  let(:wiki_node) do
+    Wikis::Adapters::Results::PageSearchTreeNode.new(identifier: "1", type: :wiki, name: "A wiki",
+                                                     children: [page_node])
+  end
+  let(:tree_nodes) { [wiki_node] }
+
+  it "identifies every node by its type and identifier" do
+    expect(subject).to have_css("[data-node-id='wiki:1']")
+    expect(subject).to have_css("[data-node-id='page:42']")
+  end
+
+  it "does not allow selecting the wiki" do
+    expect(subject).to have_css("[data-node-id='wiki:1'][aria-disabled='true']")
+  end
+
+  it "allows selecting the page" do
+    expect(subject).to have_no_css("[data-node-id='page:42'][aria-disabled='true']")
+  end
+
+  context "when wikis are selectable" do
+    let(:options) { { wikis_selectable: true } }
+
+    it "allows selecting the wiki" do
+      expect(subject).to have_no_css("[data-node-id='wiki:1'][aria-disabled='true']")
+    end
+  end
+end

--- a/modules/wikis/spec/components/wikis/search_pages_result_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/search_pages_result_component_spec.rb
@@ -33,12 +33,12 @@ require_module_spec_helper
 
 RSpec.describe Wikis::SearchPagesResultComponent, type: :component do
   subject do
-    render_inline(described_class.new(tree_nodes, builder:, form_name: "wiki_page_selection", **options))
+    render_inline(described_class.new(tree_nodes, builder:, form_name: "wiki_page_selection", wikis_selectable:))
     page
   end
 
   let(:builder) { ActionView::Helpers::FormBuilder.new("", nil, vc_test_controller.view_context, {}) }
-  let(:options) { {} }
+  let(:wikis_selectable) { false }
 
   let(:page_node) do
     Wikis::Adapters::Results::PageSearchTreeNode.new(identifier: "42", type: :page, name: "A page", children: [])
@@ -63,7 +63,7 @@ RSpec.describe Wikis::SearchPagesResultComponent, type: :component do
   end
 
   context "when wikis are selectable" do
-    let(:options) { { wikis_selectable: true } }
+    let(:wikis_selectable) { true }
 
     it "allows selecting the wiki" do
       expect(subject).to have_no_css("[data-node-id='wiki:1'][aria-disabled='true']")

--- a/modules/wikis/spec/controllers/wikis/page_selection_form_input_spec.rb
+++ b/modules/wikis/spec/controllers/wikis/page_selection_form_input_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::PageSelectionFormInput do
+  subject(:consumer) { Class.new { include Wikis::PageSelectionFormInput }.new }
+
+  let(:wiki_page_selection) { [{ path: ["A wiki", "A page"], nodeId: node_id }.to_json] }
+  let(:node_id) { "page:42" }
+
+  describe "#parse_selected_node" do
+    subject { consumer.parse_selected_node(wiki_page_selection) }
+
+    it { is_expected.to eq(Wikis::Adapters::Results::PageSearchTreeNode::Key.new(type: :page, identifier: "42")) }
+
+    context "when a wiki is selected" do
+      let(:node_id) { "wiki:7" }
+
+      it { is_expected.to eq(Wikis::Adapters::Results::PageSearchTreeNode::Key.new(type: :wiki, identifier: "7")) }
+    end
+
+    context "when the opaque identifier contains colons itself" do
+      let(:node_id) { "page:xwiki:VCR.Incredible space.WebHome" }
+
+      it "keeps the identifier intact" do
+        expect(subject.identifier).to eq("xwiki:VCR.Incredible space.WebHome")
+      end
+    end
+
+    context "when the node type is unknown" do
+      let(:node_id) { "project:42" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when nothing is selected" do
+      let(:wiki_page_selection) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the payload carries no node id" do
+      let(:wiki_page_selection) { [{ path: ["A wiki"] }.to_json] }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#parse_page_identifier" do
+    subject { consumer.parse_page_identifier(wiki_page_selection) }
+
+    it { is_expected.to eq("42") }
+
+    context "when a wiki is selected" do
+      let(:node_id) { "wiki:7" }
+
+      it "returns nothing, because a wiki can not be linked to" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end

--- a/modules/wikis/spec/models/wikis/adapters/results/page_search_tree_node_spec.rb
+++ b/modules/wikis/spec/models/wikis/adapters/results/page_search_tree_node_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Wikis::Adapters::Results::PageSearchTreeNode do
 
         it { is_expected.to eq(described_class.new(type: :wiki, identifier: "7")) }
 
-        it { is_expected.to be_wiki }
+        it { is_expected.not_to be_page }
       end
 
       context "when the opaque identifier contains colons itself" do

--- a/modules/wikis/spec/models/wikis/adapters/results/page_search_tree_node_spec.rb
+++ b/modules/wikis/spec/models/wikis/adapters/results/page_search_tree_node_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::Adapters::Results::PageSearchTreeNode do
+  describe "#key" do
+    subject { described_class.new(identifier: "42", type: :page, name: "A page", children: []).key }
+
+    it "consists of the node's type and identifier" do
+      expect(subject).to eq(described_class::Key.new(type: :page, identifier: "42"))
+      expect(subject.to_s).to eq("page:42")
+    end
+  end
+
+  describe described_class::Key do
+    describe ".parse" do
+      subject { described_class.parse(string) }
+
+      let(:string) { "page:42" }
+
+      it { is_expected.to eq(described_class.new(type: :page, identifier: "42")) }
+
+      it { is_expected.to be_page }
+
+      context "when the key refers to a wiki" do
+        let(:string) { "wiki:7" }
+
+        it { is_expected.to eq(described_class.new(type: :wiki, identifier: "7")) }
+
+        it { is_expected.to be_wiki }
+      end
+
+      context "when the opaque identifier contains colons itself" do
+        let(:string) { "page:xwiki:VCR.Incredible space.WebHome" }
+
+        it "only splits off the type" do
+          expect(subject).to eq(described_class.new(type: :page, identifier: "xwiki:VCR.Incredible space.WebHome"))
+        end
+      end
+
+      context "when there is no identifier" do
+        let(:string) { "page" }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when there is no type" do
+        let(:string) { ":42" }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the key is nil" do
+        let(:string) { nil }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end

--- a/modules/wikis/spec/services/wikis/adapters/providers/internal/commands/create_page_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/internal/commands/create_page_spec.rb
@@ -36,11 +36,12 @@ RSpec.describe Wikis::Adapters::Providers::Internal::Commands::CreatePage do
 
   let(:provider) { create(:internal_wiki_provider) }
   let(:auth_strategy) { Wikis::Adapters::Input::AuthStrategy.build(key: :internal, user:, provider:).value! }
-  let(:input_data) { Wikis::Adapters::Input::CreatePage.build(title:, parent_identifier:).value! }
+  let(:input_data) { Wikis::Adapters::Input::CreatePage.build(title:, parent_identifier:, parent_type:).value! }
   let(:user) { create(:user) }
 
   let(:title) { "A page automatically created during a create_page test" }
   let(:parent_identifier) { existing_page.id.to_s }
+  let(:parent_type) { :page }
 
   let(:existing_page) { create(:wiki_page) }
   let(:project) { existing_page.project }
@@ -104,6 +105,47 @@ RSpec.describe Wikis::Adapters::Providers::Internal::Commands::CreatePage do
 
     it "does not create a page" do
       expect { subject }.not_to change(WikiPage, :count)
+    end
+  end
+
+  context "when a wiki is the parent" do
+    let(:parent_identifier) { existing_page.wiki.id.to_s }
+    let(:parent_type) { :wiki }
+
+    it { is_expected.to be_success }
+
+    it "creates the page as a root page of that wiki" do
+      expect { subject }.to change(WikiPage, :count).by(1)
+
+      expect(WikiPage.last.title).to eq(title)
+      expect(WikiPage.last.wiki).to eq(existing_page.wiki)
+      expect(WikiPage.last.parent).to be_nil
+    end
+
+    context "when the wiki does not exist" do
+      let(:parent_identifier) { (existing_page.wiki.id * 10).to_s }
+
+      it "returns a :not_found error" do
+        expect(result).to be_failure
+        expect(result.failure.code).to eq(:not_found)
+      end
+
+      it "does not create a page" do
+        expect { subject }.not_to change(WikiPage, :count)
+      end
+    end
+
+    context "when the wiki is not visible to the user" do
+      let(:permissions) { %i[edit_wiki_pages] }
+
+      it "returns a :not_found error" do
+        expect(result).to be_failure
+        expect(result.failure.code).to eq(:not_found)
+      end
+
+      it "does not create a page" do
+        expect { subject }.not_to change(WikiPage, :count)
+      end
     end
   end
 end

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/commands/create_page_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/commands/create_page_spec.rb
@@ -37,9 +37,10 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Commands::CreatePage, :disable
 
     let(:provider) { create(:xwiki_provider, :for_local_connection, connected_user: user) }
     let(:auth_strategy) { Wikis::Adapters::Input::AuthStrategy.build(key: :bearer_token, user:, provider:).value! }
-    let(:input_data) { Wikis::Adapters::Input::CreatePage.build(title:, parent_identifier:).value! }
+    let(:input_data) { Wikis::Adapters::Input::CreatePage.build(title:, parent_identifier:, parent_type:).value! }
     let(:user) { create(:user) }
 
+    let(:parent_type) { :page }
     let(:title) { "A page automatically created during a create_page test" }
     # To record a VCR cassette, make sure to set parent_identifier to the stable ID of an existing wiki page
     # and parent_title to that wiki page's title.
@@ -82,6 +83,24 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Commands::CreatePage, :disable
         result
 
         expect(WebMock).not_to have_requested(:put, %r{https://xwiki.local/rest/openproject/documents})
+      end
+    end
+
+    context "when a wiki is the parent", vcr: "xwiki/create_root_page" do
+      let(:parent_identifier) { "xwiki" }
+      let(:parent_type) { :wiki }
+
+      it "creates the page as a root page of that wiki" do
+        expect(result).to be_success
+
+        expect(WebMock).to have_requested(:put, "https://xwiki.local/rest/openproject/documents")
+          .with(query: hash_including(docRef: "xwiki:#{title}.WebHome"))
+      end
+
+      it "does not look the parent up first" do
+        result
+
+        expect(WebMock).not_to have_requested(:get, %r{https://xwiki.local/rest/openproject/documents/})
       end
     end
 

--- a/modules/wikis/spec/services/wikis/create_page_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/create_page_service_spec.rb
@@ -40,6 +40,7 @@ module Wikis
                      .create_page_and_link(
                        title:,
                        parent_identifier:,
+                       parent_type:,
                        linkable_type: linkable.class.name,
                        linkable_id: linkable.id
                      )
@@ -49,6 +50,7 @@ module Wikis
     let(:linkable) { build_stubbed(:work_package) }
     let(:title) { "My Page" }
     let(:parent_identifier) { "MySpace.Parent" }
+    let(:parent_type) { :page }
     let(:page_identifier) { "#{parent_identifier}.MyPage" }
     let(:provider) { instance_double(Provider, id: 1) }
     let(:auth_strategy) { instance_double(Adapters::AuthenticationStrategies::BearerToken) }

--- a/modules/wikis/spec/services/wikis/page_search_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_search_service_spec.rb
@@ -107,40 +107,49 @@ RSpec.describe Wikis::PageSearchService do
       expect(search_results.first).to be_a(Wikis::Adapters::Results::PageSearchTreeNode)
     end
 
-    it "has disabled wiki root nodes" do
+    it "has wiki root nodes" do
       expect(subject).to be_success
       search_results = subject.value!
 
       expect(search_results.size).to eq(2)
       expect(search_results[0].type).to eq(:wiki)
-      expect(search_results[0].enabled).to be_falsey
+      expect(search_results[0].identifier).to eq(page_hierarchies[0].wiki.identifier)
       expect(search_results[1].type).to eq(:wiki)
-      expect(search_results[1].enabled).to be_falsey
+      expect(search_results[1].identifier).to eq(page_hierarchies[1].wiki.identifier)
     end
 
-    it "has disabled ancestor nodes" do
+    it "has ancestor nodes" do
       expect(subject).to be_success
       search_results = subject.value!
 
       ancestor_page = search_results[0].children[0]
       expect(ancestor_page.type).to eq(:page)
       expect(ancestor_page.identifier).to eq(page_hierarchies[0].ancestors[0].identifier)
-      expect(ancestor_page.enabled).to be_falsey
     end
 
-    it "has enabled search result nodes" do
+    it "has the search result nodes below their ancestors" do
       expect(subject).to be_success
       search_results = subject.value!
 
       first_page = search_results[0].children[0].children[0]
       expect(first_page.type).to eq(:page)
       expect(first_page.identifier).to eq(page_hierarchies[0].page.identifier)
-      expect(first_page.enabled).to be_truthy
 
       second_page = search_results[1].children[0]
       expect(second_page.type).to eq(:page)
       expect(second_page.identifier).to eq(page_hierarchies[1].page.identifier)
-      expect(second_page.enabled).to be_truthy
+    end
+
+    it "identifies every node by its type and identifier" do
+      expect(subject).to be_success
+      search_results = subject.value!
+
+      key = Wikis::Adapters::Results::PageSearchTreeNode::Key
+
+      expect(search_results[0].key)
+        .to eq(key.new(type: :wiki, identifier: page_hierarchies[0].wiki.identifier))
+      expect(search_results[1].children[0].key)
+        .to eq(key.new(type: :page, identifier: page_hierarchies[1].page.identifier))
     end
 
     context "if the search results contains an ancestor of another contained page" do
@@ -155,19 +164,28 @@ RSpec.describe Wikis::PageSearchService do
         ]
       end
 
-      it "enables the ancestor" do
+      it "inserts the ancestor only once" do
         expect(subject).to be_success
         search_results = subject.value!
+
+        expect(search_results[0].children.size).to eq(1)
 
         ancestor_node = search_results[0].children[0]
         expect(ancestor_node.type).to eq(:page)
         expect(ancestor_node.identifier).to eq(ancestor.identifier)
-        expect(ancestor_node.enabled).to be_truthy
 
-        page_node = search_results[0].children[0].children[0]
+        page_node = ancestor_node.children[0]
         expect(page_node.type).to eq(:page)
         expect(page_node.identifier).to eq(page.identifier)
-        expect(page_node.enabled).to be_truthy
+      end
+    end
+
+    context "if the search result is empty" do
+      let(:page_hierarchies) { [] }
+
+      it "returns an empty array" do
+        expect(subject).to be_success
+        expect(subject.value!).to be_empty
       end
     end
 
@@ -222,15 +240,6 @@ RSpec.describe Wikis::PageSearchService do
         expect(subject).to eq(search_wikis_result)
       end
     end
-
-    context "if the search result is empty" do
-      let(:page_hierarchies) { [] }
-
-      it "returns an empty array" do
-        expect(subject).to be_success
-        expect(subject.value!).to be_empty
-      end
-    end
   end
 
   context "when the query is a URL" do
@@ -252,7 +261,6 @@ RSpec.describe Wikis::PageSearchService do
       expect(search_results.first.type).to eq(:page)
       expect(search_results.first.name).to eq(page_info.title)
       expect(search_results.first.children).to be_empty
-      expect(search_results.first.enabled).to be_truthy
     end
 
     it "passes the URL along" do

--- a/spec/support/fixtures/vcr_cassettes/xwiki/create_root_page.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/create_root_page.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:A%20page%20automatically%20created%20during%20a%20create_page%20test.WebHome
+    body:
+      encoding: UTF-8
+      string: '{"title":"A page automatically created during a create_page test"}'
+    headers:
+      User-Agent:
+      - OpenProject 17.8.0 HTTPX Client
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '66'
+      Authorization:
+      - Bearer <SECRET>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Language:
+      - en
+      Content-Script-Type:
+      - text/javascript
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 04 Aug 2026 08:18:35 GMT
+      Set-Cookie:
+      - JSESSIONID=52C99E4B4A3B5DA467BFCB9FA359BF4F; Path=/; HttpOnly
+      Xwiki-Form-Token:
+      - e1AB7c2nsUPfoDbpYxYFbA
+      Xwiki-User:
+      - xwiki:XWiki.admin
+      Xwiki-Version:
+      - 18.3.0
+      Content-Length:
+      - '2499'
+    body:
+      encoding: UTF-8
+      string: '{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test","rel":"http://www.xwiki.org/rel/space","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/A%20page%20automatically%20created%20during%20a%20create_page%20test/pages/WebHome/history","rel":"http://www.xwiki.org/rel/history","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/syntaxes","rel":"http://www.xwiki.org/rel/syntaxes","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/openproject/documents","rel":"self","type":null,"hrefLang":null},{"href":"https://xwiki.local/rest/wikis/xwiki/classes/A%20page%20automatically%20created%20during%20a%20create_page%20test.WebHome","rel":"http://www.xwiki.org/rel/class","type":null,"hrefLang":null}],"id":"78f41","fullName":"A
+        page automatically created during a create_page test.WebHome","wiki":"xwiki","space":"A
+        page automatically created during a create_page test","name":"WebHome","title":"A
+        page automatically created during a create_page test","rawTitle":"A page automatically
+        created during a create_page test","parent":"","parentId":"","version":"1.1","author":"XWiki.admin","authorName":null,"xwikiRelativeUrl":"https://xwiki.local/bin/view/A%20page%20automatically%20created%20during%20a%20create_page%20test/","xwikiAbsoluteUrl":"https://xwiki.local/bin/view/A%20page%20automatically%20created%20during%20a%20create_page%20test/","translations":{"links":[],"translations":[],"default":""},"syntax":"xwiki/2.1","language":"","majorVersion":1,"minorVersion":1,"hidden":false,"enforceRequiredRights":false,"created":1785831515000,"creator":"XWiki.admin","creatorName":null,"modified":1785831515000,"modifier":"XWiki.admin","modifierName":null,"originalMetadataAuthor":"xwiki:XWiki.admin","originalMetadataAuthorName":null,"comment":"","content":"","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"A
+        page automatically created during a create_page test","name":"A page automatically
+        created during a create_page test","type":"space","url":"https://xwiki.local/bin/view/A%20page%20automatically%20created%20during%20a%20create_page%20test/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/A%20page%20automatically%20created%20during%20a%20create_page%20test/"}]},"rights":[],"renderedContent":null}'
+  recorded_at: Tue, 04 Aug 2026 08:18:35 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
# Ticket
[XWI-159](https://community.openproject.org/projects/XWI/work_packages/XWI-159)

# What are you trying to accomplish?
This is the second part of the issue. 

This ticket implements:
- allows selecting not only pages, but also by their parents

## Screenshots
<img width="667" height="432" alt="Screenshot 2026-08-11 at 16 41 07" src="https://github.com/user-attachments/assets/66be1a1f-60b1-4d63-9041-905e7be14feb" />
<img width="677" height="430" alt="Screenshot 2026-08-11 at 16 41 24" src="https://github.com/user-attachments/assets/e6b46e01-a918-444c-a72c-a8537d8160e1" />
<img width="660" height="453" alt="Screenshot 2026-08-11 at 16 41 50" src="https://github.com/user-attachments/assets/564969e9-a1d6-4878-bcdd-ad58b3a14fe6" />
<img width="668" height="431" alt="Screenshot 2026-08-11 at 16 42 07" src="https://github.com/user-attachments/assets/0c24e444-d1e2-4a0d-b316-0e979130df4c" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
