### PR TITLE
[OP-19747] Required user custom fields interfere with LDAP group and department synchronisation

### DIFF
--- a/app/services/ldap/base_service.rb
+++ b/app/services/ldap/base_service.rb
@@ -83,9 +83,10 @@ module Ldap
       call
     end
 
-    def try_to_create(attrs)
+    def try_to_create(attrs) # rubocop:disable Metrics/AbcSize
+      # LDAP maps no custom fields, so a required one would make the sync permanently impossible.
       call = Users::CreateService
-        .new(user: User.system)
+        .new(user: User.system, contract_options: { skip_custom_field_validation: true })
         .call(attrs.merge(ldap_auth_source_id: ldap.id))
 
       if call.success?

--- a/modules/ldap_departments/app/services/ldap_departments/synchronize_members_service.rb
+++ b/modules/ldap_departments/app/services/ldap_departments/synchronize_members_service.rb
@@ -169,7 +169,10 @@ module LdapDepartments
     end
 
     def try_to_create(attrs)
-      call = Users::CreateService.new(user: User.system).call(attrs)
+      # LDAP maps no custom fields, so a required one would make the sync permanently impossible.
+      call = Users::CreateService
+        .new(user: User.system, contract_options: { skip_custom_field_validation: true })
+        .call(attrs)
       if call.success?
         Rails.logger.info("[LDAP departments] User '#{call.result.login}' created")
       else

--- a/modules/ldap_departments/spec/services/ldap_departments/synchronize_members_service_spec.rb
+++ b/modules/ldap_departments/spec/services/ldap_departments/synchronize_members_service_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe LdapDepartments::SynchronizeMembersService do
 
       expect(frontend.reload.user_ids).to include(User.find_by(login: "newbie").id)
     end
+
+    context "and a required user custom field" do
+      let!(:custom_field) { create(:user_custom_field, :string, name: "Employee ID", is_required: true) }
+
+      it "still creates the user, as LDAP cannot provide a value for the custom field" do
+        expect { service_call }.to change { User.where(login: "newbie").count }.from(0).to(1)
+
+        expect(frontend.reload.user_ids).to include(User.find_by(login: "newbie").id)
+      end
+
+      it "leaves the custom field empty" do
+        service_call
+
+        expect(User.find_by(login: "newbie").custom_value_for(custom_field).value).to be_nil
+      end
+    end
   end
 
   context "with a user directly under the base DN" do

--- a/modules/ldap_groups/app/services/ldap_groups/synchronize_groups_service.rb
+++ b/modules/ldap_groups/app/services/ldap_groups/synchronize_groups_service.rb
@@ -69,8 +69,9 @@ module LdapGroups
 
     # Try to create the user from attributes
     def try_to_create(attrs)
+      # LDAP maps no custom fields, so a required one would make the sync permanently impossible.
       call = Users::CreateService
-        .new(user: User.system)
+        .new(user: User.system, contract_options: { skip_custom_field_validation: true })
         .call(attrs)
 
       if call.success?

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -194,6 +194,25 @@ RSpec.describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do
               expect(group_foo.users).to contain_exactly(user_aa729)
               expect(group_bar.users).to contain_exactly(user_aa729, user_bb459, user_cc414)
             end
+
+            context "and a required user custom field" do
+              let!(:custom_field) { create(:user_custom_field, :string, name: "Employee ID", is_required: true) }
+
+              it "still creates the remaining users, as LDAP cannot provide a value for the custom field" do
+                subject
+                expect(synced_foo.users.count).to eq(1)
+                expect(synced_bar.users.count).to eq(3)
+
+                expect(group_foo.users).to contain_exactly(user_aa729)
+                expect(group_bar.users).to contain_exactly(user_aa729, user_bb459, user_cc414)
+              end
+
+              it "leaves the custom field empty" do
+                subject
+
+                expect(user_bb459.custom_value_for(custom_field).value).to be_nil
+              end
+            end
           end
 
           context "and users sync not enabled" do

--- a/spec/services/ldap/import_user_list_service_integration_spec.rb
+++ b/spec/services/ldap/import_user_list_service_integration_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe Ldap::ImportUsersFromListService do
     expect(user_cc414.lastname).to eq "Carpenter"
   end
 
+  context "with a required user custom field" do
+    let!(:custom_field) { create(:user_custom_field, :string, name: "Employee ID", is_required: true) }
+
+    it "still adds all three users, as LDAP cannot provide a value for the custom field" do
+      subject
+
+      expect(User.where(login: user_list).count).to eq 3
+    end
+
+    it "leaves the custom field empty" do
+      subject
+
+      expect(User.find_by(login: "aa729").custom_value_for(custom_field).value).to be_nil
+    end
+  end
+
   context "when two users already exist" do
     let!(:user_aa729) { create(:user, login: "aa729", firstname: "Foobar", lastname: "Bobbit", ldap_auth_source:) }
     let!(:user_bb459) { create(:user, login: "bb459", firstname: "Bla", lastname: "Bobbit", ldap_auth_source:) }

--- a/spec/services/ldap/post_login_sync_service_spec.rb
+++ b/spec/services/ldap/post_login_sync_service_spec.rb
@@ -91,5 +91,20 @@ RSpec.describe Ldap::PostLoginSyncService do
       expect(subject.result.mail).to eq "a.adam@example.com"
       expect(subject.result).to be_persisted
     end
+
+    context "with a required user custom field" do
+      let!(:custom_field) { create(:user_custom_field, :string, name: "Employee ID", is_required: true) }
+
+      it "still creates the user, as LDAP cannot provide a value for the custom field" do
+        expect(subject).to be_success
+        expect(subject.result).to be_persisted
+      end
+
+      it "leaves the custom field empty" do
+        subject
+
+        expect(User.find_by(login: "aa729").custom_value_for(custom_field).value).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19747

# What are you trying to accomplish?

A required user custom field made LDAP synchronisation fail to create users:

```
[LDAP groups] User 'mtester' could not be created: … Attribute can't be blank.
```

`LdapAuthSource#mapped_attributes` only maps login, firstname, lastname, mail and admin — never a custom field. So a required user CF is unsatisfiable by any LDAP-driven creation and blocks it permanently.

Fixed for all LDAP user-creation paths:

- group sync (`LdapGroups::SynchronizeGroupsService`)
- department sync (`LdapDepartments::SynchronizeMembersService`)
- user import from filter/list and first-login auto-provisioning (`Ldap::BaseService`)

# What approach did you choose and why?

- Pass the existing `contract_options: { skip_custom_field_validation: true }` to `Users::CreateService` rather than add a new mechanism.
- Split in two commits: the two sync services named in the ticket, then the remaining creation paths that share the same defect.

# Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [ ] ~Tested major browsers (Chrome, Firefox, Edge, ...)~
