### PR TITLE
Be sparse with comments when using AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,26 @@ Run `rake copyright:update_typescript` to add or repair headers in `.ts` and
 `.tsx` files. Run `rake copyright:update_js` for `.js`, `.mjs`, and `.cjs`
 files. Both commands accept an optional path argument.
 
+## Code Comments
+
+Readers are domain experts who know Ruby, Rails, TypeScript, and the patterns used here.
+Write self-explanatory code instead of comments.
+
+- Default to zero comments. Sparse is the goal, not thorough coverage.
+- Never restate what the code plainly does (`# increments the counter` above `counter += 1`).
+  These get flagged in review.
+- Never justify the chosen approach. If a comment names a rejected alternative
+  ("EXISTS rather than a join because…"), delete it — that reasoning belongs in the commit
+  message or PR description, not the source.
+- Do comment to explain a constraint the code cannot express itself: a workaround for an
+  upstream bug, a non-obvious edge case, an ordering requirement, an invariant the caller
+  must uphold. Link the work package or upstream issue when there is one.
+- Don't add YARD/JSDoc headers to self-descriptive methods. Only where generated
+  documentation is actually consumed.
+- More than a handful of comments in a file is a smell: extract better-named methods,
+  variables, and objects so the code explains itself.
+- When in doubt, delete the comment rather than shortening it.
+
 ## Commit Messages
 - First line: < 72 characters, then blank line, then detailed description
 - Reference work packages when applicable

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -16,7 +16,8 @@
 - Use service objects for complex business logic (return `ServiceResult`)
 - Use contracts for validation and authorization
 - Keep controllers thin, models focused
-- Document with [YARD](https://yardoc.org/)
+- Where documentation is warranted, use [YARD](https://yardoc.org/) syntax — but see
+  "Code Comments" in the root `AGENTS.md`: self-descriptive methods get no docblock
 - Write RSpec tests for all new features
 - **Work package identifiers**: `WorkPackage.find("PROJ-42")` resolves semantic identifiers transparently. Use `find_by_display_id` only when input could legitimately be numeric OR semantic (controllers, URL-driven components, macro resolvers). Low-level code (queries, filters, services) should stick to `find_by(id:)` with primary keys. See `app/models/work_package/semantic_identifier/finder_methods.rb`.
 


### PR DESCRIPTION
In the recent months AI tools have added thousands of lines of comments in the codebase, that simply re-state what the following lines in the code will be doing. This leads not only to comment fatigue, not reading them anymore, but also it's super easy for them to get out of date and them stating wrong things.

We are all domain experts here. The code should speak for itself. Where the code needs to make assumptions or non-obvious stuff is happening, this warrants for a comment. A comment should also not be an explanation, why a certain path was chosen. That should go in the commit messages or the PR description.