### PR TITLE
[TTP2-12] Unable to delete wiki page if it is a parent of another page

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -313,14 +313,17 @@ class WikiController < ApplicationController
       when "reassign"
         # Reassign children to another parent page
         reassign_to = @wiki.pages.find_by(id: params[:reassign_to_id].presence)
-        return unless reassign_to
+        if reassign_to.nil?
+          @reassignable_to = @wiki.pages - @page.self_and_descendants
+          return render(action: :destroy, status: :unprocessable_entity)
+        end
 
         @page.children.each do |child|
           child.update_attribute(:parent, reassign_to)
         end
       else
         @reassignable_to = @wiki.pages - @page.self_and_descendants
-        return
+        return render(action: :destroy, status: :unprocessable_entity)
       end
     end
     @page.destroy!

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -542,14 +542,26 @@ RSpec.describe WikiController do
           { project_id: project, id: parent_page }
         end
 
-        it "responds with success" do
+        it "responds with unprocessable entity" do
           expect(subject)
-            .to have_http_status(:ok)
+            .to have_http_status(:unprocessable_entity)
         end
 
-        it "destroys the page" do
+        it "does not destroy the page" do
           expect { subject }
             .not_to change(WikiPage, :count)
+        end
+
+        it "assigns the reassignable pages" do
+          subject
+
+          expect(assigns(:reassignable_to))
+            .to match_array(@wiki.pages - parent_page.self_and_descendants)
+        end
+
+        it "renders the destroy template" do
+          expect(subject)
+            .to render_template(:destroy)
         end
       end
 
@@ -618,6 +630,34 @@ RSpec.describe WikiController do
 
           expect(child_page.parent_id)
             .to eq existing_page.id
+        end
+      end
+
+      context "when destroying a parent with reassign without a valid reassign_to_id" do
+        let(:params) do
+          { project_id: project, id: parent_page, todo: "reassign", reassign_to_id: nil }
+        end
+
+        it "responds with unprocessable entity" do
+          expect(subject)
+            .to have_http_status(:unprocessable_entity)
+        end
+
+        it "does not destroy the page" do
+          expect { subject }
+            .not_to change(WikiPage, :count)
+        end
+
+        it "assigns the reassignable pages" do
+          subject
+
+          expect(assigns(:reassignable_to))
+            .to match_array(@wiki.pages - parent_page.self_and_descendants)
+        end
+
+        it "renders the destroy template" do
+          expect(subject)
+            .to render_template(:destroy)
         end
       end
     end


### PR DESCRIPTION
<!-- opilot:banner -->
🤖 This is an AI-generated prototype.

* To ask for a change, write a comment to @op-chomper on this PR.
* To ship the PR, first make it yours: run `gh adopt 24799` ([setup guide](https://github.com/opf/openproject-opilot#adopting-a-opilot-pr)).
<!-- /opilot:banner -->

📋 **Implementation plan:** https://gist.github.com/op-chomper/07e44603a668e2a191c5ad9b650764f1

# Ticket
TTP2-12

# What are you trying to accomplish?

Fix wiki page deletion when the page is a parent of one or more child pages. The delete action now renders the child reassignment form with HTTP 422 (Unprocessable Entity) instead of returning 200 (OK), so Turbo Drive displays it to the user.

# What approach did you choose and why?

The controller renders the reassignment form with `status: :unprocessable_entity` when the user does not specify what to do with child pages or selects an invalid reassignment target. This matches the pattern already used in the `create` and `update` actions. Turbo Drive treats 422 responses as page visits and displays the form body.

## Screenshots

N/A

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)