### PR TITLE
[COMMS-955] Adjust target version groups for table pdf exports

### DIFF
--- a/app/models/exports/pdf/components/wp_table.rb
+++ b/app/models/exports/pdf/components/wp_table.rb
@@ -48,12 +48,21 @@ module Exports::PDF::Components::WpTable
 
   def write_grouped!(work_packages, query, columns)
     groups_with_work_packages = work_packages.group_by do |work_package|
-      query.group_by_column.value(work_package)
+      group_value(query, work_package)
     end
-    sums = transformed_sum_group(query)
+    sums = transformed_sum_group(query).transform_keys { |group| group_sums_key(group) }
     groups_with_work_packages.each do |group, grouped_work_packages|
-      write_group!(group, grouped_work_packages, query, columns, sums[group] || {})
+      write_group!(group, grouped_work_packages, query, columns, sums[group_sums_key(group)] || {})
     end
+  end
+
+  def group_value(query, work_package)
+    value = query.group_by_column.value(work_package)
+    value.is_a?(ActiveRecord::Relation) ? value.to_a : value
+  end
+
+  def group_sums_key(group)
+    group.is_a?(Array) ? group.map(&:to_s).sort : group
   end
 
   # -- start workaround

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
@@ -262,6 +262,46 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
           expect(strings).to eq(expected_pdf_strings.join(" "))
         end
       end
+
+      context "when grouped by target versions", with_settings: { work_package_multiple_versions: true } do
+        let!(:version_two) { create(:version, project:, name: "2.0") }
+        let!(:version_one) { create(:version, project:, name: "1.0") }
+        let(:query_attributes) { { group_by: "target_versions" } }
+
+        before do
+          [work_package_parent, work_package_child].each do |work_package|
+            create(:work_package_version, work_package:, version: version_two)
+            create(:work_package_version, work_package:, version: version_one)
+          end
+        end
+
+        it "writes work packages sharing the same target versions into a single group" do
+          strings = pdf_strings_without_footers(1)
+          expect(strings).to eq [
+            query.name,
+            "2.0, 1.0",
+            *column_titles,
+            *work_package_columns(work_package_parent),
+            *work_package_columns(work_package_child)
+          ].join(" ")
+        end
+
+        context "with sums" do
+          let(:query_attributes) { { group_by: "target_versions", display_sums: true } }
+
+          it "writes the group sums although the versions are ordered by name in the sums" do
+            strings = pdf_strings_without_footers(1)
+            expect(strings).to eq [
+              query.name,
+              "2.0, 1.0",
+              *column_titles,
+              *work_package_columns(work_package_parent),
+              *work_package_columns(work_package_child),
+              I18n.t("js.label_sum"), work_packages_sum.to_s, "38%"
+            ].join(" ")
+          end
+        end
+      end
     end
 
     describe "grouped with sums" do


### PR DESCRIPTION
# Ticket
[COMMS-955](https://community.openproject.org/projects/COMMS/work_packages/COMMS-955/activity)

# What are you trying to accomplish?
PDF exports of work package lists were wrongly rendering the target_version fields as ruby objects.

## Screenshots

:arrow_left: BEFORE
<img width="1337" height="579" alt="image" src="https://github.com/user-attachments/assets/eb63ab0d-6e46-49c0-9473-dd6188059245" />

AFTER :arrow_right:
<img width="2276" height="1589" alt="image" src="https://github.com/user-attachments/assets/ea821496-6de6-4a03-bc4e-a5f1a4ac3e79" />


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
