### PR TITLE
Indicate _links object in WP modification schemas

### DIFF
--- a/app/services/mcp_tools/create_work_package.rb
+++ b/app/services/mcp_tools/create_work_package.rb
@@ -40,7 +40,13 @@ module McpTools
       properties: {
         data: {
           type: %w[object],
-          description: "JSON Representation of the work package to be created. The format is the same as accepted by APIv3."
+          description: "JSON Representation of the work package to be created. The format is the same as accepted by APIv3.",
+          properties: {
+            _links: {
+              description: "Contains related resources, such as projects, statuses, types, etc. They are represented as links, " \
+                           "i.e. objects with an 'href' property."
+            }
+          }
         }
       }
     )

--- a/app/services/mcp_tools/update_work_package.rb
+++ b/app/services/mcp_tools/update_work_package.rb
@@ -54,6 +54,10 @@ module McpTools
               description: "The lock version as indicated by the work package when reading it. This value is used for " \
                            "optimistic locking, if a change is rejected because of a conflict, " \
                            "re-read the work package and apply changes based on its new state."
+            },
+            _links: {
+              description: "Contains related resources, such as projects, statuses, types, etc. They are represented as links, " \
+                           "i.e. objects with an 'href' property."
             }
           }
         }


### PR DESCRIPTION
This is intended as an additional helper for MCP clients, pointing them towards the fact that related entities should be mapped through _links, rather than *_id attributes or similar.

Anecdotal testing shows that this can help, but let's see.

# Ticket
https://community.openproject.org/wp/AI-118