### PR TITLE
Use `effective hours` wording consistently

### DIFF
--- a/app/components/users/working_hours/availability_factor_form.rb
+++ b/app/components/users/working_hours/availability_factor_form.rb
@@ -55,7 +55,7 @@ class Users::WorkingHours::AvailabilityFactorForm < ApplicationForm
                     trailing_visual: { text: { text: "%" } }
 
     form.text_field name: :total_factored_hours,
-                    label: I18n.t("users.working_hours.form.total_available_hours"),
+                    label: I18n.t("users.working_hours.form.effective_hours"),
                     input_width: :large,
                     readonly: true,
                     data: { "users--working-hours-form-target": "totalAvailableHoursDisplay" },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6288,7 +6288,7 @@ en:
           success: "The configuration was copied."
         exclusions:
           not_linked: "This type owns its configuration for this section, so there is nothing to exclude. Edit the configuration directly instead."
-          unknown_aspect: "Unknown configuration section \"%{aspect}\"."
+          unknown_aspect: 'Unknown configuration section "%{aspect}".'
         independent:
           confirm_dialog:
             check_box: "I understand that this will override the current settings"
@@ -6508,6 +6508,7 @@ en:
         availability_description: "The availability factor represents the actual percentage of your working time dedicated to project tasks. This accounts for meetings, emails, administrative work, and other non-project activities."
         availability_factor: "Availability factor"
         availability_factor_caption: "Define the percentage of your working time dedicated to project work."
+        effective_hours: "Effective work hours"
         hours_mode_label: "Hours mode"
         hours_per_day: "Hours per day"
         individual_hours_mode: "Individual hours per day"
@@ -6521,7 +6522,6 @@ en:
         title_current: "Edit current work schedule"
         title_days_and_hours: "Days and hours"
         title_future_dates: "Future dates"
-        total_available_hours: "Total available work hours"
         total_work_hours: "Total work hours"
         work_days: "Work days"
         work_hours: "Work hours"

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -295,7 +295,7 @@ en:
   setting_enforce_tracking_start_and_end_times_caption: "Makes entering start and finish times mandatory when logging time."
   setting_enforce_without_allow: "Requiring start and finish times is not possible without allowing them"
   setting_time_entries_limit_to_user_working_hours: "Limit to the user's working hours"
-  setting_time_entries_limit_to_user_working_hours_caption: "Limits the number of hours that can be logged to that user’s capacity for that day. Users without defined working times will not be restricted."
+  setting_time_entries_limit_to_user_working_hours_caption: "Limits the total hours that can be logged per day to that user’s effective working hours. Users without defined working times will not be restricted."
   setting_time_entries_max_hours_per_day: "Maximum number of hours per day"
   setting_time_entries_max_hours_per_day_caption: "Limits the total number of hours a user can log in a single day. A value of 0 means there are no restrictions."
   setting_time_entries_max_hours_per_entry: "Maximum number of hours per time entry"


### PR DESCRIPTION
Use `effective hours` wording consistently in working times and settings for time entries.