### PR TITLE
Add missing GET /api/v3/reminders/:id endpoint

### DIFF
--- a/lib/api/v3/reminders/reminders_api.rb
+++ b/lib/api/v3/reminders/reminders_api.rb
@@ -52,6 +52,7 @@ module API
               end
             end
 
+            get(&API::V3::Utilities::Endpoints::Show.new(model: Reminder).mount)
             patch(&API::V3::Utilities::Endpoints::Update.new(model: Reminder).mount)
             delete(&API::V3::Utilities::Endpoints::Delete.new(model: Reminder).mount)
           end

--- a/spec/requests/api/v3/reminders/reminders_api_spec.rb
+++ b/spec/requests/api/v3/reminders/reminders_api_spec.rb
@@ -64,6 +64,70 @@ RSpec.describe API::V3::Reminders::RemindersAPI do
     it_behaves_like "handling anonymous user"
   end
 
+  describe "GET /api/v3/reminders/:id" do
+    let!(:reminder) { create(:reminder, remindable: work_package, creator: user_with_permissions) }
+    let!(:other_user_reminder) { create(:reminder, remindable: work_package, creator: other_user_without_permissions) }
+    let!(:completed_reminder) do
+      create(:reminder, :completed, remindable: work_package, creator: user_with_permissions)
+    end
+
+    def make_request
+      get path
+    end
+
+    context "with permissions viewing own reminder" do
+      let(:path) { api_v3_paths.reminder(reminder.id) }
+
+      current_user { user_with_permissions }
+
+      before { make_request }
+
+      it_behaves_like "successful response", 200, "Reminder" do
+        it "returns the reminder" do
+          expect(last_response.body)
+            .to be_json_eql(reminder.id.to_json)
+            .at_path("id")
+        end
+      end
+    end
+
+    context "with permissions viewing completed reminder" do
+      let(:path) { api_v3_paths.reminder(completed_reminder.id) }
+
+      current_user { user_with_permissions }
+
+      before { make_request }
+
+      it_behaves_like "error response",
+                      404, "NotFound",
+                      "The reminder you are looking for cannot be found or has been deleted."
+    end
+
+    context "with permissions viewing other user's reminder" do
+      let(:path) { api_v3_paths.reminder(other_user_reminder.id) }
+
+      current_user { user_with_permissions }
+
+      before { make_request }
+
+      it_behaves_like "error response",
+                      404, "NotFound",
+                      "The reminder you are looking for cannot be found or has been deleted."
+    end
+
+    context "with no permissions viewing own reminder" do
+      let(:path) { api_v3_paths.reminder(other_user_reminder.id) }
+
+      current_user { other_user_without_permissions }
+
+      before { make_request }
+
+      it_behaves_like "error response",
+                      404, "NotFound",
+                      "The reminder you are looking for cannot be found or has been deleted."
+    end
+  end
+
   describe "PATCH /api/v3/reminders/:id" do
     let(:headers) { { "CONTENT_TYPE" => "application/json" } }
 


### PR DESCRIPTION
## Ticket

n/a

## Summary

`route_param :id` under `resources :reminders` already looked up and authorized `@reminder` for `PATCH`/`DELETE`, but never mounted a `GET`, so there was no way to fetch a single reminder directly -- clients had to page through the whole collection (`GET /api/v3/reminders`) to find one by id.

## Change

Mount `GET &API::V3::Utilities::Endpoints::Show.new(model: Reminder).mount` alongside the existing `PATCH`/`DELETE` in the same `route_param :id` block, reusing the `@reminder` instance variable and authorization already in place.

## Test plan

- [x] Added regression request specs for the new endpoint: own reminder (200), completed reminder (404, matching the existing `PATCH`/`DELETE` behavior for completed reminders), another user's reminder (404), and no permissions (404)
- [x] Full `spec/requests/api/v3/reminders/reminders_api_spec.rb` run locally: 61 examples, 0 failures