### PR TITLE
Fix project attribute text/integer fields not saving on blur

### DIFF
--- a/app/components/open_project/common/inplace_edit_fields/text_input_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/text_input_component.rb
@@ -52,7 +52,9 @@ module OpenProject
             {
               data: { controller: "inplace-edit",
                       inplace_edit_url_value: reset_url,
-                      action: "keydown.esc->inplace-edit#request",
+                      action: "keydown.esc->inplace-edit#request " \
+                              "keydown.enter->inplace-edit#submitForm " \
+                              "change->inplace-edit#submitForm",
                       test_selector: }
             }
           else

--- a/spec/components/open_project/common/inplace_edit_fields/text_input_component_spec.rb
+++ b/spec/components/open_project/common/inplace_edit_fields/text_input_component_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe OpenProject::Common::InplaceEditFields::TextInputComponent,
 
     expect(rendered_content).to have_field("project[name]", type: "text")
     expect(rendered_content).to include("keydown.esc-&gt;inplace-edit#request")
+    expect(rendered_content).to include("keydown.enter-&gt;inplace-edit#submitForm")
+    expect(rendered_content).to include("change-&gt;inplace-edit#submitForm")
   end
 
   it "does not add a submit-on-change Stimulus action whe show_action_buttons is false" do
@@ -65,5 +67,7 @@ RSpec.describe OpenProject::Common::InplaceEditFields::TextInputComponent,
     end
 
     expect(rendered_content).not_to include("keydown.esc-&gt;inplace-edit#request")
+    expect(rendered_content).not_to include("keydown.enter-&gt;inplace-edit#submitForm")
+    expect(rendered_content).not_to include("change-&gt;inplace-edit#submitForm")
   end
 end


### PR DESCRIPTION
## What's wrong

Project attributes (project-level custom fields) of format **string** or **integer** silently fail to save when editing them inline from the project overview page, unless the user happens to press Enter. Clicking away to edit another attribute, or tabbing out, discards the typed value with no error shown.

`IntegerInputComponent` inherits directly from `TextInputComponent` without overriding the relevant method, so it has the exact same gap.

## Why

`TextInputComponent#additional_arguments` only wires:

```ruby
action: "keydown.esc->inplace-edit#request"
```

`DateInputComponent`, right next to it, correctly wires:

```ruby
action: "keydown.esc->inplace-edit#request " \
        "keydown.enter->inplace-edit#submitForm " \
        "change->inplace-edit#submitForm"
```

`TextInputComponent` is missing both the `keydown.enter` and, more importantly, the `change` binding. Pressing Enter appears to work today, but only by accident: the edit form contains a single visible text input, so the browser's native implicit-submission-on-Enter kicks in regardless of application JS. Any interaction other than Enter (blur, Tab, clicking another field) never sends a request at all.

Interestingly, `text_input_component_spec.rb` already had a test titled *"does not add a submit-on-change Stimulus action whe show_action_buttons is false"* (same title, same typo, as the equivalent test in `date_input_component_spec.rb`), but its assertion only checked for `keydown.esc`, never for `change->inplace-edit#submitForm`. Looks like the spec was copied over when this component was written, but the matching implementation and assertion were not.

## What this changes

- Adds the same `keydown.enter->inplace-edit#submitForm` and `change->inplace-edit#submitForm` bindings that `DateInputComponent` already has, to `TextInputComponent#additional_arguments`.
- Updates `text_input_component_spec.rb` to actually assert the new bindings are present (and absent when `show_action_buttons: false`), matching `date_input_component_spec.rb`'s coverage.

## Testing

- Reproduced the bug live against a running 17.7.0 instance: confirmed via network inspection that no request was sent on blur/tab, and confirmed via direct DB query that the value was never persisted.
- Built and ran a local instance with this fix applied: confirmed the field now saves on blur (`PATCH .../update` fires, value persists after reload).
- Verified the bug is still present on `dev` as of this writing (checked before opening this PR).
- I did not have a full local test environment set up to run the RSpec suite before opening this PR, the spec change follows the exact structure and assertions of the passing `date_input_component_spec.rb`, and I'd appreciate a check from CI on that.
