### PR TITLE
[COMMS-956] Fix showing groups of target versions on gantt chart exports

### DIFF
--- a/app/models/exports/pdf/components/gantt/gantt_builder.rb
+++ b/app/models/exports/pdf/components/gantt/gantt_builder.rb
@@ -140,17 +140,39 @@ module Exports::PDF::Components::Gantt
     # @param [Array<GanttDataEntry>] entries
     # @return [Array<GanttDataEntry>]
     def insert_work_package_group_placeholders(entries)
-      last_group = nil
+      last_group_key = nil
       result = []
       entries.each do |entry|
-        wp_group = @query.group_by_column.value(entry.work_package)
-        if last_group != wp_group
-          last_group = wp_group
-          result << GanttDataEntry.new("group_#{wp_group}", wp_group.to_s, nil)
+        wp_group = group_value(@query, entry.work_package)
+        if last_group_key != wp_group
+          last_group_key = wp_group
+          result << GanttDataEntry.new("group_#{wp_group}", group_label(wp_group), nil)
         end
         result << entry
       end
       result
+    end
+
+    # Normalizes the value when it's a ActiveRecord::Relation into an array
+    # @param [Query] query
+    # @param [WorkPackage] work_package
+    # @return [Object]
+    def group_value(query, work_package)
+      value = query.group_by_column.value(work_package)
+      value.is_a?(ActiveRecord::Relation) ? value.to_a : value
+    end
+
+    # Handles names when the group is different kinds of objects
+    # @param [Object] group
+    # @return [String]
+    def group_label(group)
+      if group.blank?
+        I18n.t(:label_none_parentheses)
+      elsif group.is_a?(Array)
+        group.join(", ")
+      else
+        group.to_s
+      end
     end
 
     # Builds all page groups for the given work packages

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
@@ -422,6 +422,30 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
     end
   end
 
+  describe "with a request for a PDF gantt grouped by target versions" do
+    let(:query_attributes) { { group_by: "target_versions" } }
+    let(:version_one) { create(:version, project:, name: "1.0") }
+    let(:version_two) { create(:version, project:, name: "2.0") }
+    let(:work_packages) do
+      work_package_task.target_version_ids_replacements = [version_one.id, version_two.id]
+      work_package_task.save!
+      [work_package_task, work_package_milestone]
+    end
+
+    context "with multiple versions active",
+            with_settings: { work_package_multiple_versions: true } do
+      it "joins the several target versions of a work package into one group, " \
+         "and groups work packages without a target version under a none placeholder" do
+        expect(pdf[:strings]).to eq [query.name, "2024 Apr 21 22 23", # header columns
+                                     "1.0, 2.0",
+                                     wp_title_column(work_package_task),
+                                     I18n.t(:label_none_parentheses),
+                                     wp_title_column(work_package_milestone),
+                                     "1/1", export_date_formatted, query.name].join(" ").squeeze(" ")
+      end
+    end
+  end
+
   describe "with a request for a PDF gantt with too long date range" do
     let(:work_packages) { [work_package_task_far_future] }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-956/activity

# What are you trying to accomplish?
Exporting gantt charts while grouping by target_version was rendering the object id instead of the group name. Fixing it.

## Screenshots

:arrow_left: BEFORE (not good)
<img width="677" height="653" alt="image" src="https://github.com/user-attachments/assets/601c4a7e-0452-4ed8-9cac-3886b8fd4e84" />

AFTER (beautiful) :arrow_right:
<img width="2283" height="1573" alt="image" src="https://github.com/user-attachments/assets/50f181e8-b488-40b9-ae3e-3508c7e81fd3" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
