### PR TITLE
[XWI-158] update UI texts for project wikis

### DIFF
--- a/modules/wikis/app/models/wikis/internal_provider.rb
+++ b/modules/wikis/app/models/wikis/internal_provider.rb
@@ -47,7 +47,7 @@ module Wikis
     end
 
     def name
-      model_name.human
+      I18n.t("wikis.provider_types.internal.name")
     end
   end
 end

--- a/modules/wikis/app/views/wikis/admin/health_status/show.html.erb
+++ b/modules/wikis/app/views/wikis/admin/health_status/show.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% page_title = t(".title") %>
 
-<% html_title(t(:label_administration), t(:project_module_wiki_platforms), @provider.name, page_title) -%>
+<% html_title(t(:label_administration), t("menus.admin.external_wiki_providers"), @provider.name, page_title) -%>
 
 <%= turbo_frame_tag "health_status_report", refresh: :morph do %>
   <%=
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
       header.with_breadcrumbs(
         [
           { href: admin_index_path, text: t("label_administration") },
-          { href: admin_settings_wiki_providers_path, text: t(:project_module_wiki_platforms) },
+          { href: admin_settings_wiki_providers_path, text: t("menus.admin.external_wiki_providers") },
           { href: edit_admin_settings_wiki_provider_path(@provider), text: @provider.name },
           page_title
         ]

--- a/modules/wikis/app/views/wikis/admin/internal_wiki_provider/show.html.erb
+++ b/modules/wikis/app/views/wikis/admin/internal_wiki_provider/show.html.erb
@@ -27,16 +27,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), Wikis::InternalProvider.model_name.human(count: :other) %>
+<% html_title t(:label_administration), t("menus.admin.internal_wiki_provider") %>
 
 <% content_for :content_header do %>
   <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
-    <% header.with_title { Wikis::InternalProvider.model_name.human(count: :other) } %>
+    <% header.with_title { t("menus.admin.internal_wiki_provider") } %>
     <% header.with_description { t(".description") } %>
     <% header.with_breadcrumbs([
       { href: admin_index_path, text: t(:label_administration) },
       { href: admin_settings_wiki_providers_path, text: t("menus.admin.wikis") },
-      Wikis::InternalProvider.model_name.human(count: :other)
+      t("menus.admin.internal_wiki_provider")
     ]) %>
   <% end %>
 <% end %>

--- a/modules/wikis/app/views/wikis/admin/wiki_providers/edit.html.erb
+++ b/modules/wikis/app/views/wikis/admin/wiki_providers/edit.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% page_title = @wiki_provider.name.presence || t("wikis.admin.wiki_providers.label_edit") %>
 
-<% html_title t(:label_administration), t(:project_module_wiki_platforms), page_title %>
+<% html_title t(:label_administration), t("menus.admin.external_wiki_providers"), page_title %>
 
 <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
   <% header.with_title do %>
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
       [
         { href: admin_index_path, text: t(:label_administration) },
         { href: admin_settings_wiki_providers_path, text: t("menus.admin.wikis") },
-        { href: admin_settings_wiki_providers_path, text: t(:project_module_wiki_platforms) },
+        { href: admin_settings_wiki_providers_path, text: t("menus.admin.external_wiki_providers") },
         page_title
       ]
     )

--- a/modules/wikis/app/views/wikis/admin/wiki_providers/index.html.erb
+++ b/modules/wikis/app/views/wikis/admin/wiki_providers/index.html.erb
@@ -27,17 +27,17 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), t(:project_module_wiki_platforms) %>
+<% html_title t(:label_administration), t("menus.admin.external_wiki_providers") %>
 
 <% content_for :content_header do %>
   <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
-    <% header.with_title { t(:project_module_wiki_platforms) } %>
+    <% header.with_title { t("menus.admin.external_wiki_providers") } %>
     <% header.with_description { t("wikis.admin.wiki_providers.index_description") } %>
     <% header.with_breadcrumbs(
          [
            { href: admin_index_path, text: t(:label_administration) },
            { href: admin_settings_wiki_providers_path, text: t("menus.admin.wikis") },
-           t(:project_module_wiki_platforms)
+           t("menus.admin.external_wiki_providers")
          ]
        ) %>
   <% end %>

--- a/modules/wikis/app/views/wikis/admin/wiki_providers/new.html.erb
+++ b/modules/wikis/app/views/wikis/admin/wiki_providers/new.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), t(:project_module_wiki_platforms), t("wikis.admin.wiki_providers.label_new_provider") %>
+<% html_title t(:label_administration), t("menus.admin.external_wiki_providers"), t("wikis.admin.wiki_providers.label_new_provider") %>
 
 <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
   <% header.with_title(test_selector: "wiki-provider-new-page-header--title") do %>
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% header.with_breadcrumbs([
     { href: admin_index_path, text: t(:label_administration) },
     { href: admin_settings_wiki_providers_path, text: t("menus.admin.wikis") },
-    { href: admin_settings_wiki_providers_path, text: t(:project_module_wiki_platforms) },
+    { href: admin_settings_wiki_providers_path, text: t("menus.admin.external_wiki_providers") },
     t("wikis.admin.wiki_providers.label_new_provider")
   ]) %>
 

--- a/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
+++ b/modules/wikis/app/views/wikis/project_settings/wiki/show.html.erb
@@ -29,11 +29,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { I18n.t("projects_settings_wiki.title") }
+    header.with_title { I18n.t("menus.project_settings.wiki") }
     header.with_breadcrumbs(
       [{ href: project_overview_path(@project.id), text: @project.name },
        { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
-       I18n.t("projects_settings_wiki.title")]
+       I18n.t("menus.project_settings.wiki")]
     )
   end
 %>

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -28,8 +28,8 @@ en:
         one: Inline page link
         other: Inline page links
       wikis/internal_provider:
-        one: Project wiki
-        other: Project wikis
+        one: Internal provider
+        other: Internal providers
       wikis/provider:
         one: Wiki provider
         other: Wiki providers
@@ -44,11 +44,9 @@ en:
       external_wiki_providers: External wiki providers
       internal_wiki_provider: Project wikis
       wikis: Wikis
+    project_settings:
+      wiki: Project wiki
   permission_manage_wiki_page_links: Manage wiki page links
-  project_module_wiki_internal: Project wiki
-  project_module_wiki_platforms: External wiki providers
-  projects_settings_wiki:
-    title: Project wiki
   wikis:
     admin:
       destroy_confirmation_dialog_component:
@@ -223,6 +221,8 @@ en:
           that are stored in OpenProject.
         enable: Enable the OpenProject wiki for this project
     provider_types:
+      internal:
+        name: OpenProject
       xwiki:
         name: XWiki
     relation_page_links_component:

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -195,7 +195,7 @@ module OpenProject::Wikis
            { controller: "/wikis/project_settings/wiki", action: :show },
            parent: :settings,
            after: :settings_backlogs,
-           caption: :project_module_wiki_internal
+           caption: :"menus.project_settings.wiki"
     end
 
     patch_with_namespace :WikiPages, :CreateService


### PR DESCRIPTION
# Ticket
[XWI-158](https://community.openproject.org/wp/XWI-158)

# What are you trying to accomplish?

- Improve naming for internal wiki menu entrys, pages, titles, and selection options

# What approach did you choose and why?

- use "OpenProject" as a name for the internal provider when used in modals and tabs
- use "Project wiki" to indicate menus where settings for those wikis can be configured
