### PR TITLE
Fix undefined `sender_email` in attachment error logging

### DIFF
--- a/app/services/incoming_emails/handlers/base.rb
+++ b/app/services/incoming_emails/handlers/base.rb
@@ -91,7 +91,7 @@ module IncomingEmails::Handlers
         .call(container:, filename: attachment.filename, file:)
 
       call.on_failure do
-        log "Failed to add attachment #{attachment.filename} for [#{sender_email}]: #{call.message}"
+        log "Failed to add attachment #{attachment.filename} for [#{user.mail}]: #{call.message}"
       end
 
       call.result


### PR DESCRIPTION
# Ticket
No ticket — bug discovered during self-hosted installation testing.

# What are you trying to accomplish?

Fix a bug where attachments from incoming emails are silently dropped 
when creating work packages via IMAP. The root cause is a reference to 
`sender_email` in the error logging block of 
`IncomingEmails::Handlers::Base#create_attachment`, which is not defined 
in the handler context. This causes a NoMethodError that masks the 
original error and prevents the attachment from being saved.

After applying the fix (replacing `sender_email` with `user.mail`), 
attachments from incoming emails are correctly added to the created 
work package.

# What approach did you choose and why?

Replaced `sender_email` with `user.mail`, as `user` is already available 
in the handler context via `attr_reader :user` in the base class. 
This is the minimal, non-breaking fix that resolves the issue without 
any structural changes.

Alternative considered: passing `sender_email` from DispatchService 
to the handlers — discarded as it would require more invasive changes 
for a simple logging fix.

# Merge checklist

- [ ] Added/updated tests — not added; fix is a one-line change in error logging
