### PR TITLE
[COMMS-936] Project deletion fails in project hierarchy with semantic work package IDs

### DIFF
--- a/db/migrate/20260819090000_add_cascade_to_work_package_semantic_aliases_fk.rb
+++ b/db/migrate/20260819090000_add_cascade_to_work_package_semantic_aliases_fk.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddCascadeToWorkPackageSemanticAliasesFk < ActiveRecord::Migration[8.1]
+  def up
+    remove_foreign_key :work_package_semantic_aliases, :work_packages
+    add_foreign_key :work_package_semantic_aliases, :work_packages, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :work_package_semantic_aliases, :work_packages
+    add_foreign_key :work_package_semantic_aliases, :work_packages
+  end
+end

--- a/spec/models/work_package_semantic_alias_spec.rb
+++ b/spec/models/work_package_semantic_alias_spec.rb
@@ -113,5 +113,12 @@ RSpec.describe WorkPackageSemanticAlias do
       expect { work_package.destroy! }.not_to raise_error
       expect(described_class.where(work_package_id: work_package.id)).not_to exist
     end
+
+    it "cascades work package deletion to its semantic aliases at the database level" do
+      fk = ActiveRecord::Base.connection.foreign_keys(:work_package_semantic_aliases)
+                             .find { it.to_table == "work_packages" }
+
+      expect(fk.on_delete).to eq(:cascade)
+    end
   end
 end

--- a/spec/models/work_package_semantic_alias_spec.rb
+++ b/spec/models/work_package_semantic_alias_spec.rb
@@ -105,4 +105,13 @@ RSpec.describe WorkPackageSemanticAlias do
       end
     end
   end
+
+  describe "deletion of the work package (regression #COMMS-936)" do
+    it "does not raise a foreign key violation when the work package is destroyed directly" do
+      described_class.create!(identifier: "PROJ-1", work_package:)
+
+      expect { work_package.destroy! }.not_to raise_error
+      expect(described_class.where(work_package_id: work_package.id)).not_to exist
+    end
+  end
 end

--- a/spec/services/projects/delete_service_spec.rb
+++ b/spec/services/projects/delete_service_spec.rb
@@ -109,6 +109,17 @@ RSpec.describe Projects::DeleteService, type: :model do
       end
     end
 
+    context "with semantic work package identifiers (regression #COMMS-936)",
+         with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::SEMANTIC } do
+      let!(:child) { create(:project, parent: project) }
+      let!(:work_package) { create(:work_package, project: child) }
+
+      it "destroys the project hierarchy together with the semantic aliases of its work packages" do
+        expect { subject }.to change(Project, :count).by(-2)
+        expect(WorkPackageSemanticAlias.where(work_package_id: work_package.id)).not_to exist
+      end
+    end
+
     it "sends a message on destroy failure" do
       expect(project).to receive(:destroy).and_return false
 

--- a/spec/services/projects/delete_service_spec.rb
+++ b/spec/services/projects/delete_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Projects::DeleteService, type: :model do
     end
 
     context "with semantic work package identifiers (regression #COMMS-936)",
-         with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::SEMANTIC } do
+            with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::SEMANTIC } do
       let!(:child) { create(:project, parent: project) }
       let!(:work_package) { create(:work_package, project: child) }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/COMMS-936

# What are you trying to accomplish?

Fix project deletion failures when projects or subprojects contain work packages with semantic identifiers. Project hierarchies fail to delete because the foreign key from `work_package_semantic_aliases` to `work_packages` lacks cascade delete.

## What approach did you choose and why?

Add `ON DELETE CASCADE` to the foreign key on `work_package_semantic_aliases.work_package_id`. This ensures Postgres removes alias rows automatically when their work package is deleted. This approach works at the database level, not only through Rails associations, which is necessary when Postgres triggers deletion under cascades (for example, when `awesome_nested_set` or project delete jobs remove rows).

## Screenshots

N/A

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)