### PR TITLE
[COMMS-891] Correctly render SMTP configuration fields

### DIFF
--- a/app/forms/admin/settings/mail_notifications_setting_form.rb
+++ b/app/forms/admin/settings/mail_notifications_setting_form.rb
@@ -60,6 +60,7 @@ module Admin
               name: :email_delivery_method,
               values: email_methods.map { |m| [m.to_s, m] },
               input_width: :small,
+              include_blank: I18n.t(:label_not_configured),
               data: {
                 show_when_value_selected_target: "cause",
                 target_name: "email_delivery_method_settings"
@@ -97,6 +98,21 @@ module Admin
           ) do |sendmail|
             sendmail.text_field(name: :sendmail_location)
             sendmail.text_field(name: :sendmail_arguments)
+          end
+
+          if Rails.env.development?
+            f.group(
+              hidden: Setting.email_delivery_method != :letter_opener,
+              data: {
+                show_when_value_selected_target: "effect",
+                target_name: "email_delivery_method_settings",
+                value: "letter_opener"
+              }
+            ) do |letter_opener|
+              letter_opener.html_content do
+                render(Primer::Beta::Text.new(tag: :p)) { I18n.t(:text_email_delivery_letter_opener) }
+              end
+            end
           end
         end
 

--- a/app/forms/admin/settings/mail_notifications_setting_form.rb
+++ b/app/forms/admin/settings/mail_notifications_setting_form.rb
@@ -68,7 +68,7 @@ module Admin
           end
 
           f.group(
-            hidden: { true => Setting.email_delivery_method != :smtp },
+            hidden: Setting.email_delivery_method != :smtp,
             data: {
               show_when_value_selected_target: "effect",
               target_name: "email_delivery_method_settings",
@@ -88,7 +88,7 @@ module Admin
           end
 
           f.group(
-            hidden: { true => Setting.email_delivery_method != :sendmail },
+            hidden: Setting.email_delivery_method != :sendmail,
             data: {
               show_when_value_selected_target: "effect",
               target_name: "email_delivery_method_settings",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6001,6 +6001,7 @@ en:
   text_destroy_what_to_do: "What do you want to do?"
   text_destroy_with_associated: "There are additional objects associated with the work package(s) that are to be deleted. Those objects are of the following types:"
   text_diff_truncated: "... This diff was truncated because it exceeds the maximum size that can be displayed."
+  text_email_delivery_letter_opener: "Letter opener is used to render emails as a file in your Rails tmp folder. Mails will automatically open in your browser if supported."
   text_email_delivery_not_configured: "Email delivery is not configured, and notifications are disabled.\nConfigure your SMTP server to enable them."
   text_enumeration_category_reassign_to: "Reassign them to this value:"
   text_enumeration_destroy_question: "%{count} objects are assigned to this value."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6001,7 +6001,7 @@ en:
   text_destroy_what_to_do: "What do you want to do?"
   text_destroy_with_associated: "There are additional objects associated with the work package(s) that are to be deleted. Those objects are of the following types:"
   text_diff_truncated: "... This diff was truncated because it exceeds the maximum size that can be displayed."
-  text_email_delivery_letter_opener: "Letter opener is used to render emails as a file in your Rails tmp folder. Mails will automatically open in your browser if supported."
+  text_email_delivery_letter_opener: "Letter opener is used to render emails as files in your Rails tmp folder. Emails will automatically open in your browser if supported."
   text_email_delivery_not_configured: "Email delivery is not configured, and notifications are disabled.\nConfigure your SMTP server to enable them."
   text_enumeration_category_reassign_to: "Reassign them to this value:"
   text_enumeration_destroy_question: "%{count} objects are assigned to this value."

--- a/spec/requests/admin/settings/mail_notifications_settings_spec.rb
+++ b/spec/requests/admin/settings/mail_notifications_settings_spec.rb
@@ -40,9 +40,8 @@ RSpec.describe "Mail Notifications Settings",
   end
 
   describe "GET /admin/settings/mail_notifications" do
-    context "when email_delivery_method is sendmail" do
+    context "when email_delivery_method is sendmail", with_settings: { email_delivery_method: :sendmail } do
       before do
-        allow(Setting).to receive(:email_delivery_method).and_return(:sendmail)
         get "/admin/settings/mail_notifications"
       end
 
@@ -53,22 +52,78 @@ RSpec.describe "Mail Notifications Settings",
       end
 
       it "shows the sendmail fields group and hides the smtp fields group" do
-        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :visible)
-        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :hidden)
+        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :visible, disabled: :all)
+        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :hidden, disabled: :all)
       end
     end
 
-    context "when email_delivery_method is smtp" do
+    context "when email_delivery_method is smtp", with_settings: { email_delivery_method: :smtp } do
       before do
-        allow(Setting).to receive(:email_delivery_method).and_return(:smtp)
         get "/admin/settings/mail_notifications"
       end
 
       it "shows the smtp fields group and hides the sendmail fields group" do
         expect(response).to have_http_status(:success)
 
-        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :visible)
-        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :hidden)
+        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :visible, disabled: :all)
+        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :hidden, disabled: :all)
+      end
+
+      it "marks smtp as the selected option" do
+        select = page.find_field(I18n.t(:setting_email_delivery_method), visible: :all, disabled: :all)
+
+        expect(select).to have_css("option[selected][value='smtp']", visible: :all)
+      end
+    end
+
+    context "when email_delivery_method is not configured", with_settings: { email_delivery_method: nil } do
+      before do
+        get "/admin/settings/mail_notifications"
+      end
+
+      it "hides both delivery method field groups" do
+        expect(response).to have_http_status(:success)
+
+        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :hidden, disabled: :all)
+        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :hidden, disabled: :all)
+      end
+
+      it "offers a blank option instead of displaying an unsaved delivery method" do
+        select = page.find_field(I18n.t(:setting_email_delivery_method), visible: :all, disabled: :all)
+
+        expect(select).to have_css("option[value='']", text: I18n.t(:label_not_configured), visible: :all)
+        expect(select).to have_no_css("option[selected]", visible: :all)
+      end
+    end
+
+    context "when email_delivery_method is letter_opener",
+            with_settings: { email_delivery_method: :letter_opener } do
+      context "in development" do
+        before do
+          allow(Rails.env).to receive(:development?).and_return(true)
+          get "/admin/settings/mail_notifications"
+        end
+
+        it "explains letter_opener and hides the smtp and sendmail field groups" do
+          expect(response).to have_http_status(:success)
+
+          expect(page).to have_text(I18n.t(:text_email_delivery_letter_opener))
+          expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :hidden, disabled: :all)
+          expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :hidden, disabled: :all)
+        end
+      end
+
+      context "when not in development" do
+        before do
+          get "/admin/settings/mail_notifications"
+        end
+
+        it "does not offer letter_opener at all" do
+          expect(response).to have_http_status(:success)
+
+          expect(page).to have_no_text(I18n.t(:text_email_delivery_letter_opener))
+          expect(page).to have_no_css("option[value='letter_opener']", visible: :all)
+        end
       end
     end
   end

--- a/spec/requests/admin/settings/mail_notifications_settings_spec.rb
+++ b/spec/requests/admin/settings/mail_notifications_settings_spec.rb
@@ -51,6 +51,25 @@ RSpec.describe "Mail Notifications Settings",
 
         expect(page).to have_field(I18n.t(:setting_sendmail_location), disabled: true, visible: :all)
       end
+
+      it "shows the sendmail fields group and hides the smtp fields group" do
+        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :visible)
+        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :hidden)
+      end
+    end
+
+    context "when email_delivery_method is smtp" do
+      before do
+        allow(Setting).to receive(:email_delivery_method).and_return(:smtp)
+        get "/admin/settings/mail_notifications"
+      end
+
+      it "shows the smtp fields group and hides the sendmail fields group" do
+        expect(response).to have_http_status(:success)
+
+        expect(page).to have_field(I18n.t(:setting_smtp_address), visible: :visible)
+        expect(page).to have_field(I18n.t(:setting_sendmail_location), visible: :hidden)
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-891

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix the SMTP configuration form, which had some problems ever since the Primerization done in https://github.com/opf/openproject/pull/22341 (and possibly even before):

* The default state showed selected `smtp` + _no form elements_. Only clicking away to another option and back to `smtp` forced rendering of those elements. 
* The `letter_opener` option showed no form content (as it was removed in that previous PR).

## Screenshots
Before (Default)
<img width="359" height="221" alt="Screenshot 2026-08-18 at 22 46 30" src="https://github.com/user-attachments/assets/c7b4a2e5-677f-4ccf-9d66-f466de1f174e" />
Before (`letter_opener`)
<img width="313" height="215" alt="Screenshot 2026-08-18 at 22 46 40" src="https://github.com/user-attachments/assets/5b64fa45-61fa-4e48-9efe-2e1c6b578682" />

After (Default)
<img width="311" height="225" alt="Screenshot 2026-08-18 at 22 45 09" src="https://github.com/user-attachments/assets/b9809795-ecc4-40ae-9981-d0badbecc689" />
After (`letter_opener`)
<img width="691" height="285" alt="Screenshot 2026-08-18 at 22 56 17" src="https://github.com/user-attachments/assets/01e23859-9828-4dce-b296-a13c527e8db8" />



# What approach did you choose and why?
* Fix an odd copy-paste artifact (?) that generated a truthy hash for the `hidden` key in form
* Add a default blank option to the form, so that it doesn't erroneously default to `smtp`
* Put back the `letter_opener` form description which got removed during primerization

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
