### PR TITLE
[MEET-589] Journal is not clear when meeting is cancelled  

### DIFF
--- a/lib/open_project/journal_formatter/cause_meeting_rendering.rb
+++ b/lib/open_project/journal_formatter/cause_meeting_rendering.rb
@@ -53,11 +53,12 @@ module OpenProject::JournalFormatter::CauseMeetingRendering
 
   def meeting_message
     return I18n.t("journals.cause_descriptions.meeting_deleted") if @meeting.nil?
-    return I18n.t("journals.cause_descriptions.meeting_cancelled") if @meeting.cancelled?
     return meeting_template_message if @meeting.templated?
 
     label = "#{@meeting.title} – #{format_time(@meeting.start_time)}"
-    meeting_link(label)
+    return meeting_link(label) unless @meeting.cancelled?
+
+    "#{label} #{I18n.t('journals.cause_descriptions.meeting_cancelled')}"
   end
 
   def meeting_template_message

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -1047,11 +1047,30 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
         allow(meeting).to receive(:cancelled?).and_return(true)
       end
 
-      it "keeps the entry with a generic label" do
+      it "renders the meeting label as plain text with '(cancelled)'" do
+        label = "#{meeting.title} – #{format_time(meeting.start_time)}"
+        cancelled = I18n.t("journals.cause_descriptions.meeting_cancelled")
         expect(cause).to render_html_variant(
           I18n.t("journals.caused_changes.meeting_agenda_item_added_html",
-                 meeting_title_information: I18n.t("journals.cause_descriptions.meeting_cancelled"))
+                 meeting_title_information: "#{label} #{cancelled}")
         )
+      end
+
+      it "renders the meeting label with '(cancelled)' when rendering raw text" do
+        label = "#{meeting.title} – #{format_time(meeting.start_time)}"
+        cancelled = I18n.t("journals.cause_descriptions.meeting_cancelled")
+        expect(cause).to render_raw_variant(
+          ActionController::Base.helpers.strip_tags(
+            I18n.t("journals.caused_changes.meeting_agenda_item_added_html",
+                   meeting_title_information: "#{label} #{cancelled}")
+          )
+        )
+      end
+
+      it "escapes a malicious meeting title when rendering HTML" do
+        allow(meeting).to receive(:title).and_return("<script>alert('xss')</script>")
+        expect(cause).to render_html_variant(a_string_including("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"))
+        expect(cause).not_to render_html_variant(a_string_including("<script>alert('xss')</script>"))
       end
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-589

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
