### PR TITLE
Improve user guide clarity and navigation

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -23,7 +23,7 @@ This guide explains OpenProject's features from a user's perspective. If you are
 | Track time and costs | [Time and costs](time-and-costs/) |
 | Collaborate with my team | [Meetings](meetings/), [Wiki](wiki/) or [File management](file-management/) |
 
-## How OpenProject is organized
+## Overview of modules in OpenProject
 
 Your work in OpenProject can be organized into multiple projects. Each project has its own members and project roles. Projects can also be configured individually by enabling or disabling features called *modules*.
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -9,51 +9,92 @@ keywords: user guide
 
 Welcome to the OpenProject User guide.
 
-This guide covers all of OpenProject's functionalities from a user's perspective.
+This guide explains OpenProject's features from a user's perspective. If you are new to OpenProject, begin with the [Getting started guide](../getting-started/).
 
-## Overview of projects in OpenProject
+## Start with a task
 
-Your work within OpenProject can be organized into multiple projects, each with a distinct set of members and their respective roles in that project.  In turn, each project can be individually configured with regards to the enabled features, called _Modules_ in OpenProject. This distinction between projects provides you with a lot of flexibility to set up your work, and control what users are allowed to view and/or collaborate on in each individual project.
+| I want to... | Go to |
+| ------------ | ----- |
+| Configure my account | [Account settings](account-settings/) |
+| Create or manage a project | [Projects](projects/) |
+| Plan and manage work | [Work packages](work-packages/) |
+| Create a project schedule | [Gantt charts](gantt-chart/) |
+| Organize agile work | [Agile boards](agile-boards/) or [Backlogs (Scrum)](backlogs-scrum/) |
+| Track time and costs | [Time and costs](time-and-costs/) |
+| Collaborate with my team | [Meetings](meetings/), [Wiki](wiki/) or [File management](file-management/) |
 
-Both the Community edition and Enterprise edition allow you to create an unlimited number of projects to separate your work. To learn more about the creation and management of projects within OpenProject, [please visit our separate section on projects](projects/).
+## How OpenProject is organized
 
-## Overview of modules in OpenProject
+Your work in OpenProject can be organized into multiple projects. Each project has its own members and project roles. Projects can also be configured individually by enabling or disabling features called *modules*.
+
+Both the Community edition and Enterprise editions allow you to create an unlimited number of projects. To learn more, see [Projects](projects/).
 
 <div class="glossary">
 
-**Module** is defined as an independent unit of functionality that can be used to extend and improve the existing core functions.
+**Module** is a feature that can be enabled or disabled for an individual project.
 
 </div>
 
-Within a project Modules can be activated and deactivated under "Modules" in the project settings menu by project members who have sufficient permissions to adjust project settings. Which modules or single functionalities will be available within projects is controlled in the global Administration settings (please see [System admin guide](../system-admin-guide/projects) to see how this is done).
+Project members with the required permissions can activate or deactivate modules under **Project settings → Modules**. Administrators control which modules and features are available globally. For more information, see the [System admin guide](../system-admin-guide/projects/).
 
-Please choose the module or feature you want to learn more about.
+## Personal workspace and settings
 
-| Topic                                                        | Content                                                      |
-| ------------------------------------------------------------ | :----------------------------------------------------------- |
-| [Activity](activity)                                         | How to find out about the latest activities in a project.    |
-| [Backlogs (Scrum)](backlogs-scrum)                           | How to manage a Scrum team in OpenProject with a product backlog and taskboard. |
-| [Baseline comparison](work-packages/baseline-comparison)     | View and compare changes in a work package table within a given period of time. |
-| [Boards](agile-boards)                                       | How to work with Agile boards for agile project management, e.g. Kanban. |
-| [Budgets](budgets)                                           | How to create and manage a project budget.                   |
-| [Calendar](calendar)                                         | How to display your work in a calendar in OpenProject.       |
-| [Documents](documents)                                       | How to upload and share documents in OpenProject.            |
-| [Forums](forums)                                             | How to manage forums to discuss and comment on topics.       |
-| [Gantt chart](gantt-chart)                                   | How to create and manage a project plan in a Gantt chart.    |
-| [GitHub](../system-admin-guide/integrations/github-integration/) | How to manage the GitHub integration.                        |
-| [GitLab](../system-admin-guide/integrations/gitlab-integration/) | How to manage the GitLab integration.                        |
-| [Meetings](meetings)                                         | How to manage meetings to create and share meeting agenda and meeting outcomes. |
-| [Members](members)                                           | How to manage Members in a project.                          |
-| [My time tracking](./time-and-costs/my-time-tracking)        | How to manage personal time entries in list and calendar views. |
-| [News](news)                                                 | How to create and manage News for your projects.             |
-| [Nextcloud integration](./file-management/nextcloud-integration) | How to link and use Nextcloud files and folders in OpenProject. |
-| [OneDrive integration](./file-management/one-drive-integration) | How to link and use OneDrive files and folders in OpenProject. |
-| [Portfolios](portfolios)                                     | How to create, edit and manage portfolios in OpenProject.    |
-| [Projects](./projects/)                                      | Edit, create, copy, delete projects and change project settings. |
-| [Project home page](./projects/project-home/)                | How to create a project overview dashboard with important project information. |
-| [Resource management](./resource-management)                 | How to manage resources and overview project capacities in your organization. |
-| [Roadmap](roadmap)                                           | How to create a product roadmap with OpenProject.            |
-| [Team planner](team-planner)                                 | How to use the team planner module.                          |
-| [Time and costs](time-and-costs)                             | How to track time and costs in OpenProject and report spent time and costs. |
-| [Wiki](wiki)                                                 | How to create and manage a wiki to collaboratively document and share information. |
-| [Work packages](work-packages)                               | How to manage your work in a project.                        |
+| Topic | Content |
+| ----- | ------- |
+| [Account settings](account-settings/) | Change your profile, language, security and notification preferences. |
+| [Home page](home/) | Understand the global OpenProject home page. |
+| [Notifications](notifications/) | View and manage in-app notifications. |
+| [Search](search/) | Find projects, work packages and other content. |
+| [Keyboard shortcuts and access keys](keyboard-shortcuts-access-keys/) | Navigate and work more efficiently with the keyboard. |
+| [Rich text editor](wysiwyg/) | Format text, add links and mention other users. |
+
+## Planning and delivering work
+
+| Topic | Content |
+| ----- | ------- |
+| [Portfolios](portfolios/) | Create, edit and manage portfolios. |
+| [Projects](projects/) | Create, copy, configure and delete projects. |
+| [Project home page](projects/project-home/) | Build a project dashboard with important project information. |
+| [Work packages](work-packages/) | Create, organize and update work in a project. |
+| [Gantt charts](gantt-chart/) | Create and maintain a visual project schedule. |
+| [Agile boards](agile-boards/) | Manage work visually with Kanban-style boards. |
+| [Backlogs (Scrum)](backlogs-scrum/) | Manage product backlogs, sprints and task boards. |
+| [Calendar](calendar/) | Display work packages in a calendar. |
+| [Roadmap](roadmap/) | Create and communicate a product roadmap. |
+| [Resource management](resource-management/) | Plan capacity and allocate work across projects. |
+| [Team planner](team-planner/) | Plan and review work by team member. |
+
+## Collaboration and communication
+
+| Topic | Content |
+| ----- | ------- |
+| [Activity](activity/) | Review the latest activity in a project. |
+| [Meetings](meetings/) | Prepare agendas, document outcomes and manage follow-up work. |
+| [Members](members/) | Add members and manage their project roles. |
+| [News](news/) | Publish and discuss project news. |
+| [Forums](forums/) | Discuss topics in project forums. |
+| [Wiki](wiki/) | Create and maintain collaborative documentation. |
+| [Documents](documents/) | Create and share project documents. |
+| [File management](file-management/) | Attach files or link external file storages. |
+| [Repository](repository/) | View repository revisions and related work packages. |
+
+## Time, costs and reporting
+
+| Topic | Content |
+| ----- | ------- |
+| [My time tracking](time-and-costs/my-time-tracking/) | Review and manage your own time entries. |
+| [Time and costs](time-and-costs/) | Log time and costs and create reports. |
+| [Budgets](budgets/) | Create and manage project budgets. |
+| [Baseline comparison](work-packages/baseline-comparison/) | Compare changes in a work package table over time. |
+
+## Integrations and specialized guides
+
+| Topic | Content |
+| ----- | ------- |
+| [Nextcloud integration](file-management/nextcloud-integration/) | Link Nextcloud files and folders to work packages. |
+| [OneDrive integration](file-management/one-drive-integration/) | Link OneDrive files and folders to work packages. |
+| [SharePoint integration](file-management/sharepoint-integration/) | Link SharePoint files and folders to work packages. |
+| [GitHub integration](../system-admin-guide/integrations/github-integration/) | Connect OpenProject with GitHub. |
+| [GitLab integration](../system-admin-guide/integrations/gitlab-integration/) | Connect OpenProject with GitLab. |
+| [BIM guide](../bim-guide/) | Use OpenProject for BIM issue management. |
+| [Mobile app guide](../mobile-app-guide/) | Use OpenProject on supported mobile devices. |

--- a/docs/user-guide/account-settings/notification-and-email/README.md
+++ b/docs/user-guide/account-settings/notification-and-email/README.md
@@ -6,9 +6,9 @@ description: Learn how to configure notifications and email alerts in OpenProjec
 keywords: my account, account settings, notifications, email, alert, update, reminder, email reminder
 ---
 
-#  Notification and email
+# Notification and email
 
-To configure the notification settings which you receive from the system, navigate to **Account settings** and choose **Notification and email** from the menu.
+To configure the notifications and email reminders you receive from OpenProject, open **Account settings** and choose **Notification and email**.
 
 ## Notification settings
 
@@ -16,13 +16,11 @@ To configure the notification settings which you receive from the system, naviga
 
 ![More notification settings in OpenProject account settings](openproject_account_settings_more_notification_settings.png)
 
-In-app notifications can be configured and customized various ways. For a detailed guide, [click here](../../notifications/notification-settings/).
-
-Please also see our detailed [in-app notifications](../../notifications/) guide to gain a general understanding.
+To learn how the Notification center works, see [In-app notifications](../../notifications/). To choose which events notify you, see [Notification settings](../../notifications/notification-settings/).
 
 ## Email reminders
 
-To configure the email reminders which you receive from the system, switch to the **email reminders tab.** Your system administrator can also set them for you or change the global default settings.
+To configure email reminders, switch to the **Email reminders** tab. Your system administrator can also configure these settings for you or change the global defaults.
 
 ![Email reminders section in OpenProject account settings](openproject_account_settings_email_reminders.png)
 
@@ -30,7 +28,7 @@ To configure the email reminders which you receive from the system, switch to th
 
 You can choose between several email reminders.
 
-Default: Enable daily email reminders: 2am, Monday - Friday.
+By default, daily email reminders are enabled at 2:00 a.m., Monday through Friday.
 
 You can choose to receive emails immediately, or only on certain days and times, temporarily pause reminder emails, or opt for no reminders at all.
 
@@ -41,9 +39,9 @@ You can also opt-in to receive **email alerts for other items (that are not work
 
 - **News added** - ...adds or updates news in the [News Page](../../news/)
 - **Comment on a news item** - ...adds a comment on a news item
-- **Documents added** - ...adds a document somewhere in the project (i.e. a work package)
+- **Documents added** - ...adds a document to the project
 - **New forum message** - ...sends a new message into the [Forum](../../forums/)
 - **Wiki page added** - ...adds a new [Wiki page](../../wiki/)
 - **Wiki page updated** - ...updates a [Wiki page](../../wiki/)
-- **Membership added** - ...adds you to a new [Work package](../../../getting-started/work-packages-introduction/)
-- **Membership updated** - ...updates your membership associations
+- **Membership added** - ...adds you as a [member of a project](../../members/)
+- **Membership updated** - ...updates your project membership

--- a/docs/user-guide/file-management/README.md
+++ b/docs/user-guide/file-management/README.md
@@ -30,14 +30,14 @@ Please refer to [Nextcloud integration user guide](./nextcloud-integration) for 
 
 For the initial setup please refer to the [Nextcloud integration setup guide](../../system-admin-guide/integrations/nextcloud/).
 
+## OneDrive integration (Enterprise add-on)
+
 [feature: one_drive_sharepoint_file_storage]
 
 > [!NOTE]
-> This feature includes using both OneDrive and SharePoint integrations.
+> This Enterprise add-on includes both the OneDrive and SharePoint integrations.
 
-## OneDrive integration (Enterprise add-on)
-
-You can also use OneDrive integration to link OpenProject work packages directly to the files stored in your OneDrive repository.
+You can use the OneDrive integration to link OpenProject work packages directly to the files stored in your OneDrive repository.
 
 Please refer to [OneDrive integration user guide](./one-drive-integration) for further instructions on using the integration.
 

--- a/docs/user-guide/keyboard-shortcuts-access-keys/README.md
+++ b/docs/user-guide/keyboard-shortcuts-access-keys/README.md
@@ -1,13 +1,13 @@
 ---
 sidebar_navigation:
-  title: Keyboard Shortcuts and Access Keys
+  title: Keyboard shortcuts and access keys
   priority: 450
-description: Keyboard Shortcuts and Access Keys in OpenProject.
-keywords: keyboard shortcuts and access keys
+description: Keyboard shortcuts and access keys in OpenProject.
+keywords: keyboard shortcuts, access keys, navigation
 ---
-# Keyboard Shortcuts and Access Keys
+# Keyboard shortcuts and access keys
 
-OpenProject (since version 3.0) offers useful keyboard shortcuts to  enhance your productivity. We use both access keys and regular  shortcuts. When using access keys, press the modifier keys and the  access key number. For the regular shortcuts just type the listed keys  on any OpenProject page.
+OpenProject offers keyboard shortcuts and access keys to help you navigate and work more efficiently. To use an access key, press the browser-specific modifier keys together with the access key number. To use a regular shortcut, type the listed keys on an OpenProject page.
 
 ## Shortcuts
 
@@ -17,14 +17,14 @@ OpenProject (since version 3.0) offers useful keyboard shortcuts to  enhance you
 - Project Search: p
 - Go to: My page: g m
 - Open Help Page: –
-- Open regular shortcuts List: ?
+- Open regular shortcuts list: ?
 - Go to: Overview: g o
 - Go to: Work Packages: g w p
 - Go to: Wiki: g w i
 - Go to: Activity: g a
 - Go to: Calendar: g c
 - Go to: News: g n
-- Go to: Timelines: g t
+- Go to: Gantt charts: g t
 - New: Work Package: n w p
 - Go to: Edit (only on certain detail pages): g e
 - Open ‘More’ Menu (only on certain detail pages): m
@@ -45,7 +45,7 @@ OpenProject (since version 3.0) offers useful keyboard shortcuts to  enhance you
 - Go to: Activity: –
 - Go to: Calendar: –
 - Go to: News: –
-- Go to: Timelines: –
+- Go to: Gantt charts: –
 - New: Work Package: 2
 - Go to: Edit (only on certain detail pages): 3
 - Open ‘More’ Menu (only on certain detail pages): 7
@@ -59,10 +59,9 @@ OpenProject (since version 3.0) offers useful keyboard shortcuts to  enhance you
 
 ### Windows
 
-- Internet Explorer: Alt + &lt;access key number&gt;
 - Firefox: Alt + Shift + &lt;access key number&gt;
 - Google Chrome: Alt + &lt;access key number&gt;
-- Safari: Alt + &lt;access key number&gt;
+- Microsoft Edge: Alt + &lt;access key number&gt;
 
 ------
 
@@ -89,4 +88,4 @@ To quickly save changes in a rich text editor (for example a work package descri
 | -------------------------- | -------------- | ------------------------------------------------------------ |
 | CTRL + ENTER               | CMD + ENTER    | **Save changes.**<br>For inline-editable fields, save the field and close it.<br>For pages with a full WYSIWYG (meetings, wiki pages), submit the form. |
 
-Please also refer to documentation  on [working in Rich text editor in OpenProject](../wysiwyg).
+Please also refer to the documentation on [working in Rich text editor in OpenProject](../wysiwyg).

--- a/docs/user-guide/notifications/README.md
+++ b/docs/user-guide/notifications/README.md
@@ -2,7 +2,7 @@
 sidebar_navigation:
   title: Notifications
   priority: 590
-description: An over view of how in-app notifications work in OpenProject and how to manage them.
+description: An overview of how in-app notifications work in OpenProject and how to manage them.
 keywords: notifications, alert, activity, updates
 ---
 # Notifications
@@ -31,7 +31,7 @@ To view the notifications, click the bell icon at the top right of the header.  
 
 ![A screenshot of the Notification center with a number of unread notifications](openproject-notification-center-inbox.png)
 
-Each row in Notification center is a work package that has generated a notification. It is possible that you have received multiple notifications for the same work package (if, for example, the date of a work package you are watching was changed by one person and then the status later change by another, that would generate two notifications). A blue badge on the right edge of each row displays the number of unread notifications concerning that particular work package.
+Each row in Notification center is a work package that has generated a notification. It is possible that you have received multiple notifications for the same work package (if, for example, the date of a work package you are watching was changed by one person and then the status was later changed by another, that would generate two notifications). A blue badge on the right edge of each row displays the number of unread notifications concerning that particular work package.
 
 The work packages are listed in order of freshness. The work packages on top of the list have the "newest" notifications. This means if there is a new update to a work package that was further down in your notification list, it will be moved to the top since that is now the newest notification.
 
@@ -39,23 +39,23 @@ The work packages are listed in order of freshness. The work packages on top of 
 >
 > If multiple notifications exist for a single work package, the [work package reminder](../work-packages/edit-work-package/#work-package-reminders) will take precedence, showing the reminder note at the bottom of the page if one exists. 
 >
-> In case a work package has both a reminder and a date alert notification set up, then the date alert is combined with the reminder note such that that both are visible in the last line. If there are additional reasons for the notification (watcher, mentioned, assignee), those will continue to be displayed in first line of the notification.
+> In case a work package has both a reminder and a date alert notification set up, then the date alert is combined with the reminder note so that both are visible in the last line. If there are additional reasons for the notification (watcher, mentioned, assignee), those will continue to be displayed in the first line of the notification.
 
 ## Manage notifications
 
 Click on a notification to open the Activity tab of this work package in split screen. If you double click on a notification, it will open the full view of a work package. 
 
 > [!TIP]
-> You can adjust the split screen by moving the resizer on the left side of the split screen, it will be stored locally and used for other split screen layouts.
+> You can adjust the split screen by moving the resizer on its left side. The selected width is stored locally and used for other split-screen layouts.
 
-The Activity tab will auto-scroll to the last event that generated a notification. Badges next to the tabs  indicate number of content, e.g. number 1 next to the tab _Relations_ indicates that current work package is related to one more work package. 
+The Activity tab will auto-scroll to the last event that generated a notification. Badges next to the tabs indicate the amount of related content. For example, the number 1 next to the _Relations_ tab indicates that the current work package has one relation. 
 
 > [!TIP]
-> Not all work package activity generate notifications. For example, if you received a notification because you were mentioned, there might be other activities on that work package after that, even though the _Activity_ tab will auto-scroll to highlight the mention when you click on the notification, since the mention was originally what triggered the notification.
+> Not all work package activity generates notifications. For example, if you received a notification because you were mentioned, there might be other activities on that work package after that, even though the _Activity_ tab will auto-scroll to highlight the mention when you click on the notification, since the mention was originally what triggered the notification.
 
 ![OpenProject notification center split screen view explained](openproject_user_guide_notification_center_split_screen.png)
 
-You can filter or group notifications by using the two sets of predefined filters on the left-hand menu:
+You can filter, group and manage notifications using the controls in the left-hand menu:
 
 (Area 1) You can filter by the **reason** you were notified: because you were mentioned (_@mention_), because you are either the assignee or accountable for that work package, because it concerns a work package you are watching or because you have an active reminder or a date alert.
 
@@ -63,17 +63,17 @@ You can filter or group notifications by using the two sets of predefined filter
 
 (Area 3) You can also affect which notifications are visible on the screen:
 
-- You can also choose to view either only **Unread** notification or **All**, which will also display notifications previously marked as read.
+- You can also choose to view either only **Unread** notifications or **All** notifications, which will also display notifications previously marked as read.
 - You can also **Mark all as read** if you want to clean your notification inbox in one click.
 
 > [!TIP]
 > The **Mark all as read** button clears all _visible_ notification rows. If you have a very large number unread notifications, the oldest ones might not be visible on the page. In this case, you might have to click the button multiple times to clear your inbox completely.
 
-(Area 4) If you would like to view your current notification preferences or modify them, click on the [Notification settings](./notification-settings) button. You can also access your settings via your Avatar in the top right corner > _Account settings_> _Notification settings_.
+(Area 4) If you would like to view your current notification preferences or modify them, click on the [Notification settings](./notification-settings) button. You can also access your settings via your Avatar in the top right corner > _Account settings_ > _Notification settings_.
 
 (Area 5) The split screen view lets you not only view work package activity as previously described, but also lets you access all other work package tabs, including overview, files, relations and watchers.
 
-In addition to the in-app notifications, you will also get a once-a-day summary of all notifications by email. To learn more about Email reminders, [click here](../../user-guide/notifications/notification-settings/#email-reminders).
+Depending on your email reminder settings, OpenProject can also send notification summaries by email. See [Email reminders](./notification-settings/#email-reminders) for details.
 
 ## Mark notifications as read
 
@@ -87,7 +87,7 @@ Additionally, you can mark notifications as read in the work package full screen
 
 ## Notifications outside of Notification Center
 
-In-app notifications are also visible directly on work packages, in both full screen and in split-screen views. If there are unread notifications related to the currently-open work package, a small blue badge next to the Activity tab will display indicate this, along with the number of unread notifications.
+In-app notifications are also visible directly on work packages, in both full-screen and split-screen views. If there are unread notifications related to the currently-open work package, a small blue badge next to the Activity tab will indicate this, along with the number of unread notifications.
 
 ![Notifications in the activity tab of work package in OpenProject](openproject_user_guide_notification_activity_tab.png)
 

--- a/docs/user-guide/notifications/notification-settings/README.md
+++ b/docs/user-guide/notifications/notification-settings/README.md
@@ -1,13 +1,13 @@
 ---
 sidebar_navigation:
-  title: Notifications settings
+  title: Notification settings
   priority: 580
-description: In-app notification settings in OpenProject
-keywords: notifications settings
+description: Configure in-app notification settings in OpenProject.
+keywords: notification settings, email reminders, date alerts
 ---
 # Notification settings
 
-You can configure how and for what events you wish to be notified through notifications. To access these settings, you can either click on your avatar on the top right corner > _Account settings_ > _Notification settings_ or click on **Settings** on the top right corner of the notifications inbox.
+You can choose which work package events trigger in-app notifications. To access these settings, you can either click on your avatar on the top right corner > _Account settings_ > _Notification settings_ or click on **Settings** on the top right corner of the notifications inbox.
 
 ![A screenshot of Notification center with the Notification settings button highlighted](Notification-settings-12.4-fromNotificationCenter.png)
 
@@ -15,7 +15,7 @@ Notification settings are divided into four sections:
 
 | Topic                                               | Description                                                                                                                          |
 |-----------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| [Participating](#participating)                     | Be notified of activities on some or all of the work packages in which you are participating (as assignee, responsible or watcher).  |
+| [Participating](#participating)                     | Be notified of activities on some or all of the work packages in which you are participating (as assignee, accountable or watcher).  |
 | [Date alerts](#date-alerts-enterprise-add-on)       | Be notified of approaching start or end dates, and when things are overdue.                                                          |
 | [Non-participating](#non-participating)             | Be notified of activities on work packages in which you are not participating.                                                       |
 | [Project-specific](#project-specific-notifications) | Fine-tune your notification settings at the level of individual projects.                                                            |
@@ -37,9 +37,7 @@ You cannot disable notifications for when you are mentioned since the goal of me
 
 ## Date alerts (Enterprise add-on)
 
-Starting with 12.4, OpenProject offers notification for date alerts.
-
-[feature: date_alerts ]
+[feature: date_alerts]
 
 Date alerts allow you to receive a notification when a start date or a finish date is approaching for a work package you are participating in (that is, for which you are assignee, accountable or a watcher).
 
@@ -48,9 +46,9 @@ Date alerts allow you to receive a notification when a start date or a finish da
 For **start** and **finish dates**, you can choose to be alerted the same day, 1 day before, 3 days before or a week before.
 
 > [!NOTE]
-> Please note that these are natural days and not working days. For a work package starting on a Monday, "3 days before" would be Friday.
-> Date alerts are generated once a day at 1am local time.
-> Please note that when you activate a date alert, work packages that are due earlier than the duration selected will not generate notifications (for example, if you choose to be notified "3 days before" the finish date, work packages that are due in 2 days at that point in time will not generate a date alert.
+> Date alerts use calendar days, not working days. For a work package starting on a Monday, "3 days before" is Friday.
+> Date alerts are generated once a day at 1:00 a.m. local time.
+> When you activate a date alert, work packages that are due sooner than the selected interval do not generate that alert. For example, choosing "3 days before" does not create an alert for a work package that is already due in 2 days.
 
 For **overdue dates**, you can also choose to receive a recurring notification (every day, every 3 days or every week).
 
@@ -61,7 +59,7 @@ Date alerts notifications appear in [Notification center](../#access-in-app-noti
 
 ## Non-participating
 
-You can also chose to receive additional notifications for specific events in all projects concerning work packages in which you are not participating.
+You can also choose to receive additional notifications for specific events in all projects concerning work packages in which you are not participating.
 
 You can be notified of:
 
@@ -74,11 +72,11 @@ You can be notified of:
 ![A screenshot of options for non-participating work packages](Notification-settings-12.4-nonPartipating.png)
 
 > [!NOTE]
-> Please note that these apply to _all_ work packages in _all_ of your projects. If you enable many of them, you may receive too many irrelevant notifications. Please use this feature with parsimony.
+> Please note that these apply to _all_ work packages in _all_ of your projects. If you enable many of them, you may receive too many irrelevant notifications. Enable only the events that are relevant to you.
 
 ## Project-specific notifications
 
-In some cases, you may wish to fine-tune your notification settings at a project-level.
+In some cases, you may wish to fine-tune your notification settings at the project level.
 
 This might be because you are more active in certain projects than others or because certain activities (like date alerts or the creation of new work packages) might be more important to you than others.
 
@@ -92,7 +90,7 @@ Then select a project from the overlay form that will appear and specify notific
 
 Once you do so, you will see a list of projects, for which project-specific notification settings were defined. You can modify these settings at any later point.
 
-![Text](Notification-settings-12.4-projectSpecific.png)
+![A list of projects with project-specific notification settings](Notification-settings-12.4-projectSpecific.png)
 
 > [!NOTE]
 > These project-specific settings will override any global settings above. You can use these settings if you find that you receive too many or not enough notifications for a particular project.

--- a/docs/user-guide/time-and-costs/README.md
+++ b/docs/user-guide/time-and-costs/README.md
@@ -8,17 +8,20 @@ keywords: Time tracking, cost tracking, cost reporting
 
 # Time tracking and cost reporting
 
-Time and costs functionality in OpenProject allows keeping track of the resources,  both in terms of labor and budgets. With OpenProject you can always keep control of the time and costs planned for and spent on the projects.
+The time and costs functionality in OpenProject helps you track labor and budgets. You can compare the time and costs planned for a project with what was actually spent.
 
 Create budgets, log time and costs on specific work packages and create time and cost reports based on your needs.
 
 | Topic                                | Content                                     |
 |--------------------------------------|:--------------------------------------------|
-| [Progress tracking](progress-tracking)| How to track progress for work packages     |
-| [Time tracking](time-tracking)       | How to log time to work packages.           |
-| [My time tracking module](my-time-tracking) | How to log time in my tracking module |
-| [Cost tracking](cost-tracking)       | How to track unit costs spent in a project. |
-| [Time and cost reporting](reporting) | How to create time and cost reports.        |
+| [Progress tracking](progress-tracking) | Track progress for work packages. |
+| [Time tracking](time-tracking) | Log time from a work package or with the timer. |
+| [My time tracking](my-time-tracking) | Review and manage your own time entries across projects in list or calendar view. |
+| [Cost tracking](cost-tracking) | Track unit costs spent in a project. |
+| [Time and cost reporting](reporting) | Create time and cost reports. |
+
+> [!TIP]
+> Use **Time tracking** to log time for a specific work package. Use **My time tracking** to review and edit your own time entries across projects.
 
 ## Time tracking, cost tracking and reporting video tutorial
 


### PR DESCRIPTION
## What changed

- Reorganize the User Guide landing page around common tasks and feature groups
- Add missing entry points for account settings, notifications, search, keyboard shortcuts, rich text editing, file management, SharePoint, BIM, and the mobile app
- Correct misleading notification and membership links
- Clarify OneDrive and SharePoint availability
- Standardize notification terminology and fix copy and alt-text issues
- Replace outdated shortcut terminology and browser references
- Distinguish Time tracking from My time tracking

## Why

The current guide mixes modules, integrations, and global features, omits several important entry points, and contains a number of misleading links, outdated labels, and editorial inconsistencies. These changes make the documentation easier to scan and reduce ambiguity in common user journeys.

## User impact

Users can reach the right documentation faster, understand related features more clearly, and avoid several misleading instructions.

## Root causes

The affected pages evolved independently over time, which led to duplicated notification guidance, stale UI terminology, a misplaced feature note, and inconsistent descriptions.

## Validation

- Rebased onto `release/17.7`: two commits ahead, zero behind
- Reviewed the complete seven-file diff
- Verified the new member, notification settings, BIM, and mobile guide link targets
- Internal documentation links, YAML headers, and README case checks passed before the rebase
- Documentation-only change; no application tests required
