### PR TITLE
Test/COMMS-954: Cover the target version filter in the API filter hash mapping

### DIFF
--- a/spec/services/queries/filters_mapper_spec.rb
+++ b/spec/services/queries/filters_mapper_spec.rb
@@ -138,6 +138,24 @@ RSpec.describe Queries::Copy::FiltersMapper do
     end
   end
 
+  describe "with a filter hash array holding the target versions filter" do
+    let(:filters) do
+      [
+        { "targetVersion" => { "operator" => "=", "values" => ["3"] } }
+      ]
+    end
+
+    subject { instance.map_filters(filters) }
+
+    before do
+      state.version_id_lookup = { 3 => 33 }
+    end
+
+    it "maps the filter values" do
+      expect(subject[0]["targetVersion"]["values"]).to eq(["33"])
+    end
+  end
+
   describe "with a symbolized filter hash array" do
     let(:filters) do
       [


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-954

Follow-up to #24787: the copy filters mapper's APIv3 hash path had no example with the `targetVersion` key - only the live-query path exercised the `target_version_id` mapper entry. Adds one asserting the key maps through the version lookup.