### PR TITLE
[OP-19932] Ckeditor toolbar is partially offscreen on work package description

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -224,34 +224,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     });
   }
 
-  private constrainGroupedDropdownToEditorWidth(_editor:ICKEditorInstance) {
-    const host = this.elementRef.nativeElement;
-
-    const editorWidth = () => {
-      const editorEl = host.querySelector<HTMLElement>('.ck-editor') ?? host;
-      return Math.floor(editorEl.getBoundingClientRect().width);
-    };
-
-    const apply = () => {
-      const width = editorWidth();
-
-      const panels = Array.from(
-        document.querySelectorAll<HTMLElement>(
-          '.ck.ck-dropdown__panel'
-        )
-      );
-
-      for (const panel of panels) {
-        panel.style.maxWidth = `${width - 8}px`;
-
-      }
-    };
-
-    fromEvent(host, 'click')
-      .pipe(this.untilDestroyed())
-      .subscribe(() => setTimeout(apply));
-  }
-
   public setup(editor:ICKEditorInstance) {
     this.setupMarkingReadonlyWhenTextareaIsDisabled(editor);
 
@@ -268,8 +240,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     editor.ui.focusTracker.on('change:isFocused', (_evt:unknown, _name:string, _isFocused:boolean) => {
       this.setLabel();
     });
-    this.constrainGroupedDropdownToEditorWidth(editor);
-
     return editor;
   }
 

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -87,6 +87,21 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
 .ck.ck-sticky-panel__content
   position: unset !important
 
+// Keep the grouped toolbar dropdown within the editor when surrounding split
+// panes reduce its available width.
+.ck.ck-toolbar.ck-toolbar_grouping
+  container-type: inline-size
+
+  > .ck-toolbar__grouped-dropdown > .ck-dropdown__panel
+    max-width: calc(100cqw - 8px)
+
+    > .ck-toolbar
+      max-width: 100%
+
+      > .ck-toolbar__items
+        max-width: 100%
+        flex-wrap: wrap
+
 // Mentions autocomplete
 .ck-list__item .mention-list-item
   display: block


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19932

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix the CKEditor grouped toolbar overflowing the work package description when the surrounding split panes reduce the editor width.
The grouped dropdown is now constrained relative to the toolbar container using CSS container-query units. It keeps its natural width when only a few controls overflow and wraps controls when additional space is required.

