### PR TITLE
[OP-19994] Allow displaying department, groups, projects and status in User Table

### DIFF
--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -70,6 +70,10 @@ module Users
       helpers.format_time user.created_at
     end
 
+    def consented_at
+      helpers.format_time user.consented_at unless user.consented_at.nil?
+    end
+
     def status
       helpers.full_user_status user
     end

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -101,19 +101,25 @@ module Users
     def column_value(column)
       return custom_field_column(column) if custom_field_column?(column)
 
-      send(column.respond_to?(:attribute) ? column.attribute : column)
+      attribute = column_attribute(column)
+
+      respond_to?(attribute) ? send(attribute) : user.public_send(attribute)
     end
 
     def column_css_class(column)
-      attr = column.respond_to?(:attribute) ? column.attribute : column
-      case attr
+      attribute = column_attribute(column)
+      case attribute
       when :mail then "email"
       when :login then "username"
-      else attr.to_s
+      else attribute.to_s
       end
     end
 
     private
+
+    def column_attribute(column)
+      column.respond_to?(:attribute) ? column.attribute : column
+    end
 
     def custom_field_column_subject
       user

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -74,6 +74,14 @@ module Users
       helpers.full_user_status user
     end
 
+    def member_of_group
+      joined_names user.regular_groups
+    end
+
+    def member_of_project
+      joined_names user.projects
+    end
+
     def button_links
       [status_link].compact
     end
@@ -119,6 +127,10 @@ module Users
 
     def column_attribute(column)
       column.respond_to?(:attribute) ? column.attribute : column
+    end
+
+    def joined_names(records)
+      records.map(&:name).sort.join(", ")
     end
 
     def custom_field_column_subject

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -74,6 +74,17 @@ module Users
       helpers.full_user_status user
     end
 
+    def department
+      return if user.department.nil?
+
+      safe_join(
+        [
+          render(Primer::Beta::Octicon.new(icon: :briefcase, color: :muted, mr: 1)),
+          user.department.name
+        ]
+      )
+    end
+
     def member_of_group
       joined_names user.regular_groups
     end

--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -65,7 +65,7 @@ module Queries::BaseQuery
 
   def results
     if valid?
-      apply_orders(apply_filters(default_scope))
+      apply_selects(apply_orders(apply_filters(default_scope)))
     else
       empty_scope
     end
@@ -191,6 +191,14 @@ module Queries::BaseQuery
   def apply_filters(query_scope)
     filters.inject(query_scope) do |scope, filter|
       filter.apply_to(scope)
+    end
+  end
+
+  def apply_selects(query_scope)
+    return query_scope unless respond_to?(:selects)
+
+    selects.inject(query_scope) do |scope, select|
+      select.apply_to(scope)
     end
   end
 

--- a/app/models/queries/selects/base.rb
+++ b/app/models/queries/selects/base.rb
@@ -61,4 +61,14 @@ class Queries::Selects::Base
   def available?
     true
   end
+
+  def apply_to(query_scope)
+    includes ? query_scope.includes(includes) : query_scope
+  end
+
+  private
+
+  def includes
+    nil
+  end
 end

--- a/app/models/queries/users/filters/consented_at_filter.rb
+++ b/app/models/queries/users/filters/consented_at_filter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Users::Filters::ConsentedAtFilter < Queries::Users::Filters::UserFilter
+  def type
+    :datetime_past
+  end
+
+  def available?
+    Setting.consent_required?
+  end
+end

--- a/app/models/queries/users/selects/consented_at.rb
+++ b/app/models/queries/users/selects/consented_at.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Users::Selects::ConsentedAt < Queries::Selects::Base
+  def self.key
+    :consented_at
+  end
+
+  def self.available?
+    Setting.consent_required?
+  end
+end

--- a/app/models/queries/users/selects/department.rb
+++ b/app/models/queries/users/selects/department.rb
@@ -28,35 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
-
-  def self.model
-    User
+class Queries::Users::Selects::Department < Queries::Selects::Base
+  def self.key
+    :department
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
-  end
+  private
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
-
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::CustomField
+  def includes
+    :departments
   end
 end

--- a/app/models/queries/users/selects/member_of_group.rb
+++ b/app/models/queries/users/selects/member_of_group.rb
@@ -28,38 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
-
-  def self.model
-    User
+class Queries::Users::Selects::MemberOfGroup < Queries::Selects::Base
+  def self.key
+    :member_of_group
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  def caption
+    I18n.t(:label_member_of_group)
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  private
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::MemberOfGroup
-    select Queries::Users::Selects::MemberOfProject
-    select Queries::Users::Selects::Status
-    select Queries::Users::Selects::CustomField
+  def includes
+    :regular_groups
   end
 end

--- a/app/models/queries/users/selects/member_of_project.rb
+++ b/app/models/queries/users/selects/member_of_project.rb
@@ -28,38 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
-
-  def self.model
-    User
+class Queries::Users::Selects::MemberOfProject < Queries::Selects::Base
+  def self.key
+    :member_of_project
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  def caption
+    I18n.t(:label_member_of_project)
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  private
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::MemberOfGroup
-    select Queries::Users::Selects::MemberOfProject
-    select Queries::Users::Selects::Status
-    select Queries::Users::Selects::CustomField
+  def includes
+    :projects
   end
 end

--- a/app/models/queries/users/selects/status.rb
+++ b/app/models/queries/users/selects/status.rb
@@ -28,38 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
-
-  def self.model
-    User
+class Queries::Users::Selects::Status < Queries::Selects::Base
+  def self.key
+    :status
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
-  end
-
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
-
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::MemberOfGroup
-    select Queries::Users::Selects::MemberOfProject
-    select Queries::Users::Selects::Status
-    select Queries::Users::Selects::CustomField
+  def caption
+    I18n.t(:label_status)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,11 @@ class User < Principal
            -> { Group.organizational_units },
            through: :group_users,
            source: :group
+  # Departments are surfaced as their own attribute, so they are left out here.
+  has_many :regular_groups,
+           -> { Group.not_organizational_units },
+           through: :group_users,
+           source: :group
 
   has_many :watches, class_name: "Watcher",
                      dependent: :delete_all

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3453,6 +3453,7 @@ en:
   label_me: "me"
   label_member_all_admin: "(All roles due to admin status)"
   label_member_new: "New member"
+  label_member_of_group: "Member of group"
   label_member_of_project: "Member of project"
   label_member_plural: "Members"
   label_member_role: "Project role"

--- a/spec/components/users/table_component_spec.rb
+++ b/spec/components/users/table_component_spec.rb
@@ -32,12 +32,22 @@ require "rails_helper"
 
 RSpec.describe Users::TableComponent, type: :component do
   shared_let(:admin) { create(:admin) }
-  shared_let(:member_of_department) { create(:user, login: "with-department") }
-  shared_let(:without_department) { create(:user, login: "without-department") }
-  shared_let(:department) { create(:department, lastname: "Research", members: [member_of_department]) }
+  shared_let(:project) { create(:project, name: "Apple") }
+  shared_let(:other_project) { create(:project, name: "Banana") }
+  shared_let(:user) do
+    create(:user,
+           login: "connected",
+           status: :locked,
+           member_with_permissions: { project => [:view_project], other_project => [:view_project] })
+  end
+  shared_let(:lonely_user) { create(:user, login: "unconnected") }
+  shared_let(:department) { create(:department, lastname: "Research", members: [user]) }
+  shared_let(:group) { create(:group, lastname: "Reviewers", members: [user]) }
+
+  let(:selects) { %i[login department member_of_group member_of_project status] }
 
   let(:query) do
-    UserQuery.new(name: "Users").tap { it.select(:login, :department) }
+    UserQuery.new(name: "Users").tap { it.select(*selects) }
   end
 
   before do
@@ -47,12 +57,39 @@ RSpec.describe Users::TableComponent, type: :component do
     render_inline(described_class.new(rows: query, current_user: admin))
   end
 
-  it "renders the department column header" do
-    expect(page).to have_css("th", text: User.human_attribute_name(:department))
+  it "renders a header for every selected column" do
+    captions = [User.human_attribute_name(:login),
+                User.human_attribute_name(:department),
+                I18n.t(:label_member_of_group),
+                I18n.t(:label_member_of_project),
+                I18n.t(:label_status)]
+
+    captions.each { expect(page).to have_css("th", text: it) }
   end
 
-  it "renders the department of each user" do
+  it "renders the department" do
     expect(page).to have_css("td.department", text: department.name, count: 1)
-    expect(page).to have_css("tr.user td.department", count: 3)
+  end
+
+  it "renders the groups without the department" do
+    expect(page).to have_css("td.member_of_group", text: group.name, count: 1)
+    expect(page).to have_no_css("td.member_of_group", text: department.name)
+  end
+
+  it "renders the projects in alphabetical order" do
+    expect(page).to have_css("td.member_of_project", text: "Apple, Banana", count: 1)
+  end
+
+  it "renders the status" do
+    expect(page).to have_css("td.status", text: I18n.t(:status_locked), count: 1)
+    expect(page).to have_css("td.status", text: I18n.t(:status_active), count: 2)
+  end
+
+  it "leaves the cells of an unconnected user empty" do
+    row = page.find("tr.user", text: lonely_user.login)
+
+    expect(row.find("td.department").text).to be_blank
+    expect(row.find("td.member_of_group").text).to be_blank
+    expect(row.find("td.member_of_project").text).to be_blank
   end
 end

--- a/spec/components/users/table_component_spec.rb
+++ b/spec/components/users/table_component_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Users::TableComponent, type: :component do
     create(:user,
            login: "connected",
            status: :locked,
+           consented_at: Time.zone.parse("2026-03-04T10:00:00Z"),
            member_with_permissions: { project => [:view_project], other_project => [:view_project] })
   end
   shared_let(:lonely_user) { create(:user, login: "unconnected") }
@@ -84,6 +85,23 @@ RSpec.describe Users::TableComponent, type: :component do
   it "renders the status" do
     expect(page).to have_css("td.status", text: I18n.t(:status_locked), count: 1)
     expect(page).to have_css("td.status", text: I18n.t(:status_active), count: 2)
+  end
+
+  context "with the consent column", with_settings: { consent_required: true } do
+    let(:selects) { %i[login consented_at] }
+
+    it "renders the formatted consent time of a user who consented" do
+      expect(page).to have_css("th", text: User.human_attribute_name(:consented_at))
+      expect(page).to have_css("td.consented_at",
+                               text: ApplicationController.helpers.format_time(user.consented_at),
+                               count: 1)
+    end
+
+    it "leaves the cell empty for a user who never consented" do
+      row = page.find("tr.user", text: lonely_user.login)
+
+      expect(row.find("td.consented_at").text).to be_blank
+    end
   end
 
   it "leaves the cells of an unconnected user empty" do

--- a/spec/components/users/table_component_spec.rb
+++ b/spec/components/users/table_component_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe Users::TableComponent, type: :component do
     captions.each { expect(page).to have_css("th", text: it) }
   end
 
-  it "renders the department" do
+  it "renders the department with a briefcase icon" do
     expect(page).to have_css("td.department", text: department.name, count: 1)
+    expect(page).to have_css("td.department .octicon-briefcase", count: 1)
   end
 
   it "renders the groups without the department" do

--- a/spec/components/users/table_component_spec.rb
+++ b/spec/components/users/table_component_spec.rb
@@ -28,35 +28,31 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
+require "rails_helper"
 
-  def self.model
-    User
+RSpec.describe Users::TableComponent, type: :component do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:member_of_department) { create(:user, login: "with-department") }
+  shared_let(:without_department) { create(:user, login: "without-department") }
+  shared_let(:department) { create(:department, lastname: "Research", members: [member_of_department]) }
+
+  let(:query) do
+    UserQuery.new(name: "Users").tap { it.select(:login, :department) }
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  before do
+    login_as(admin)
+    vc_test_controller.action_name = "index"
+    vc_test_controller.request.path_parameters = { controller: "users", action: "index" }
+    render_inline(described_class.new(rows: query, current_user: admin))
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  it "renders the department column header" do
+    expect(page).to have_css("th", text: User.human_attribute_name(:department))
+  end
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::CustomField
+  it "renders the department of each user" do
+    expect(page).to have_css("td.department", text: department.name, count: 1)
+    expect(page).to have_css("tr.user td.department", count: 3)
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -760,6 +760,14 @@ RSpec.describe UsersController do
       end
     end
 
+    context "with the department column requested" do
+      let(:params) { { columns: "login department" } }
+
+      it "assigns a query selecting the department" do
+        expect(assigns(:query).selects.map(&:attribute)).to eq(%i[login department])
+      end
+    end
+
     context "with a user scheduled for deletion present" do
       let!(:deleted_user) { create(:user_marked_for_deletion) }
 

--- a/spec/models/queries/users/filters/consented_at_filter_spec.rb
+++ b/spec/models/queries/users/filters/consented_at_filter_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Users::Filters::ConsentedAtFilter do
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :consented_at }
+    let(:type) { :datetime_past }
+    let(:model) { User }
+    let(:attribute) { :consented_at }
+    let(:values) { ["3"] }
+    let(:human_name) { User.human_attribute_name(:consented_at) }
+
+    describe "#available?" do
+      it "is true when consent is required", with_settings: { consent_required: true } do
+        expect(instance).to be_available
+      end
+
+      it "is false when consent is not required", with_settings: { consent_required: false } do
+        expect(instance).not_to be_available
+      end
+    end
+  end
+
+  describe "being offered by the query" do
+    current_user { create(:admin) }
+
+    it "is offered when consent is required", with_settings: { consent_required: true } do
+      expect(UserQuery.new.available_filters.map(&:name)).to include(:consented_at)
+    end
+
+    it "is not offered when consent is not required", with_settings: { consent_required: false } do
+      expect(UserQuery.new.available_filters.map(&:name)).not_to include(:consented_at)
+    end
+  end
+
+  describe "#apply_to" do
+    shared_let(:consented_recently) { create(:user, consented_at: 2.days.ago) }
+    shared_let(:consented_long_ago) { create(:user, consented_at: 2.years.ago) }
+    shared_let(:never_consented) { create(:user, consented_at: nil) }
+
+    let(:instance) do
+      described_class.create!(name: :consented_at, operator: ">t-", values: ["7"])
+    end
+
+    it "keeps only the users who consented within the given number of days" do
+      expect(instance.apply_to(User.user).to_a).to contain_exactly(consented_recently)
+    end
+  end
+end

--- a/spec/models/queries/users/selects/consented_at_spec.rb
+++ b/spec/models/queries/users/selects/consented_at_spec.rb
@@ -28,40 +28,42 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
+require "spec_helper"
 
-  def self.model
-    User
+RSpec.describe Queries::Users::Selects::ConsentedAt do
+  describe ".key" do
+    it "is :consented_at" do
+      expect(described_class.key).to eq(:consented_at)
+    end
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  describe "#caption" do
+    it "is the user attribute name" do
+      expect(described_class.new(:consented_at).caption).to eq(User.human_attribute_name(:consented_at))
+    end
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::ConsentedAtFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  context "when consent is required", with_settings: { consent_required: true } do
+    it "is available" do
+      expect(UserQuery.new.available_selects).to include(an_instance_of(described_class))
+    end
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
+    it "is selectable" do
+      query = UserQuery.new(name: "Users").tap { it.select(:consented_at) }
 
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::ConsentedAt
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::MemberOfGroup
-    select Queries::Users::Selects::MemberOfProject
-    select Queries::Users::Selects::Status
-    select Queries::Users::Selects::CustomField
+      expect(query.selects.last).to be_a(described_class)
+    end
+  end
+
+  context "when consent is not required", with_settings: { consent_required: false } do
+    it "is not available" do
+      expect(UserQuery.new.available_selects).not_to include(an_instance_of(described_class))
+    end
+
+    it "does not resolve to the select" do
+      query = UserQuery.new(name: "Users").tap { it.select(:consented_at) }
+
+      expect(query.selects.last).to be_a(Queries::Selects::NotExistingSelect)
+    end
   end
 end

--- a/spec/models/queries/users/selects/department_spec.rb
+++ b/spec/models/queries/users/selects/department_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Users::Selects::Department do
+  describe ".key" do
+    it "is :department" do
+      expect(described_class.key).to eq(:department)
+    end
+  end
+
+  describe "#caption" do
+    it "is the user attribute name" do
+      expect(described_class.new(:department).caption).to eq(User.human_attribute_name(:department))
+    end
+  end
+
+  describe "selecting it on a UserQuery" do
+    shared_let(:user) { create(:user) }
+    shared_let(:department) { create(:department, members: [user]) }
+
+    let(:query) { UserQuery.new(name: "Users") }
+
+    current_user { create(:admin) }
+
+    it "is available" do
+      expect(UserQuery.new.available_selects).to include(an_instance_of(described_class))
+    end
+
+    it "resolves to the select" do
+      query.select(:department)
+
+      expect(query.selects.last).to be_a(described_class)
+    end
+
+    it "eager loads the departments" do
+      query.select(:department)
+
+      expect(query.results.to_a.map { it.association(:departments) }).to all(be_loaded)
+    end
+
+    it "does not eager load them when not selected" do
+      associations = query.results.to_a.map { it.association(:departments) }
+
+      expect(associations).to be_present
+      expect(associations.none?(&:loaded?)).to be(true)
+    end
+  end
+end

--- a/spec/models/queries/users/selects/member_of_group_spec.rb
+++ b/spec/models/queries/users/selects/member_of_group_spec.rb
@@ -28,38 +28,33 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
+require "spec_helper"
 
-  def self.model
-    User
+RSpec.describe Queries::Users::Selects::MemberOfGroup do
+  shared_let(:user) { create(:user) }
+  shared_let(:group) { create(:group, members: [user]) }
+  shared_let(:department) { create(:department, members: [user]) }
+
+  let(:query) { UserQuery.new(name: "Users").tap { it.select(:member_of_group) } }
+
+  current_user { create(:admin) }
+
+  describe ".key" do
+    it "is :member_of_group" do
+      expect(described_class.key).to eq(:member_of_group)
+    end
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  describe "#caption" do
+    it "is the member of group label" do
+      expect(described_class.new(:member_of_group).caption).to eq(I18n.t(:label_member_of_group))
+    end
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  it "eager loads the group memberships without the departments" do
+    result = query.results.to_a.detect { it == user }
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::MemberOfGroup
-    select Queries::Users::Selects::MemberOfProject
-    select Queries::Users::Selects::Status
-    select Queries::Users::Selects::CustomField
+    expect(result.association(:regular_groups)).to be_loaded
+    expect(result.regular_groups).to contain_exactly(group)
   end
 end

--- a/spec/models/queries/users/selects/member_of_project_spec.rb
+++ b/spec/models/queries/users/selects/member_of_project_spec.rb
@@ -28,38 +28,32 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
+require "spec_helper"
 
-  def self.model
-    User
+RSpec.describe Queries::Users::Selects::MemberOfProject do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:user, member_with_permissions: { project => [:view_project] }) }
+
+  let(:query) { UserQuery.new(name: "Users").tap { it.select(:member_of_project) } }
+
+  current_user { create(:admin) }
+
+  describe ".key" do
+    it "is :member_of_project" do
+      expect(described_class.key).to eq(:member_of_project)
+    end
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user.visible
+  describe "#caption" do
+    it "is the member of project label" do
+      expect(described_class.new(:member_of_project).caption).to eq(I18n.t(:label_member_of_project))
+    end
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::MemberFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+  it "eager loads the projects" do
+    result = query.results.to_a.detect { it == user }
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::Department
-    select Queries::Users::Selects::MemberOfGroup
-    select Queries::Users::Selects::MemberOfProject
-    select Queries::Users::Selects::Status
-    select Queries::Users::Selects::CustomField
+    expect(result.association(:projects)).to be_loaded
+    expect(result.projects).to contain_exactly(project)
   end
 end

--- a/spec/models/user_query_spec.rb
+++ b/spec/models/user_query_spec.rb
@@ -284,5 +284,13 @@ RSpec.describe UserQuery do
         Queries::Users::Orders::GroupOrder
       )
     end
+
+    it "registers selects as a side-effect of loading the class" do
+      expect(Queries::Register.selects[described_class]).to include(
+        Queries::Users::Selects::Default,
+        Queries::Users::Selects::Department,
+        Queries::Users::Selects::CustomField
+      )
+    end
   end
 end

--- a/spec/models/user_query_spec.rb
+++ b/spec/models/user_query_spec.rb
@@ -273,7 +273,8 @@ RSpec.describe UserQuery do
       expect(Queries::Register.filters[described_class]).to include(
         Queries::Users::Filters::NameFilter,
         Queries::Users::Filters::StatusFilter,
-        Queries::Users::Filters::GroupFilter
+        Queries::Users::Filters::GroupFilter,
+        Queries::Users::Filters::ConsentedAtFilter
       )
     end
 

--- a/spec/models/user_query_spec.rb
+++ b/spec/models/user_query_spec.rb
@@ -289,6 +289,9 @@ RSpec.describe UserQuery do
       expect(Queries::Register.selects[described_class]).to include(
         Queries::Users::Selects::Default,
         Queries::Users::Selects::Department,
+        Queries::Users::Selects::MemberOfGroup,
+        Queries::Users::Selects::MemberOfProject,
+        Queries::Users::Selects::Status,
         Queries::Users::Selects::CustomField
       )
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-19994/activity

# What are you trying to accomplish?
- Allow selects in a `BaseQuery` to modify the query (here: includes)
- Add `Department`, `MemberOfProject`, `MemberOfGroup` and `Status` selects
- Make sure everything is properly displayed in the Table

## Screenshots
<img width="2287" height="1245" alt="image" src="https://github.com/user-attachments/assets/216a5210-d057-488f-8c5c-523f89b23b0c" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
