### PR TITLE
[OP-19982] Change Automatic artefact export settings does not work

### DIFF
--- a/app/controllers/work_package_types/pdf_export_template_controller.rb
+++ b/app/controllers/work_package_types/pdf_export_template_controller.rb
@@ -47,7 +47,7 @@ module WorkPackageTypes
     def edit; end
 
     def update_artefact_export
-      mode = params.dig(:type, :artefact_export_mode)
+      mode = params.dig(@variant.model_name.param_key.to_sym, :artefact_export_mode)
       unless Type::ArtefactExport::MODES.include?(mode)
         render_error_flash_message_via_turbo_stream(
           message: I18n.t("types.edit.export_configuration.artefact_export.invalid_mode")

--- a/spec/controllers/work_package_types/pdf_export_template_controller_spec.rb
+++ b/spec/controllers/work_package_types/pdf_export_template_controller_spec.rb
@@ -133,9 +133,11 @@ RSpec.describe WorkPackageTypes::PdfExportTemplateController do
     end
 
     describe "#update_artefact_export" do
+      let(:param_key) { variant.model_name.param_key.to_sym }
+
       it "stores a valid artefact export mode and responds with a turbo stream" do
         put :update_artefact_export,
-            params: { type_id: wp_type.id, type: { artefact_export_mode: Type::ArtefactExport::FILE_LINK } },
+            params: { type_id: wp_type.id, param_key => { artefact_export_mode: Type::ArtefactExport::FILE_LINK } },
             as: :turbo_stream
 
         expect(response).to have_http_status(:ok)
@@ -145,7 +147,16 @@ RSpec.describe WorkPackageTypes::PdfExportTemplateController do
 
       it "rejects an invalid mode" do
         put :update_artefact_export,
-            params: { type_id: wp_type.id, type: { artefact_export_mode: "bogus" } },
+            params: { type_id: wp_type.id, param_key => { artefact_export_mode: "bogus" } },
+            as: :turbo_stream
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(variant.reload.artefact_export_mode).to eq(Type::ArtefactExport::OFF)
+      end
+
+      it "rejects a request that nests the mode under an unrelated params key" do
+        put :update_artefact_export,
+            params: { type_id: wp_type.id, type: { artefact_export_mode: Type::ArtefactExport::FILE_LINK } },
             as: :turbo_stream
 
         expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19982

# What are you trying to achieve?

Fix a bug that has been introduced by the latest changes to Types.

# What approach did you choose and why?

Make sure the parameters are parsed correctly by using the same model as the form sender.

# Merge checklist

- [x] Added/updated tests
