### PR TITLE
Drop old project_types table if it existed

### DIFF
--- a/db/migrate/20260804123419_create_project_types.rb
+++ b/db/migrate/20260804123419_create_project_types.rb
@@ -30,6 +30,9 @@
 
 class CreateProjectTypes < ActiveRecord::Migration[8.1]
   def up
+    # Old installations of OpenProject used ProjectType
+    drop_table :project_types, if_exists: true
+
     create_table :project_types do |t|
       t.references :project, null: false, foreign_key: { on_delete: :cascade }, index: false
       t.references :type, null: false, foreign_key: { to_table: :types, on_delete: :cascade }


### PR DESCRIPTION
Until OpenProject 8.0., we had a ProjectType model that was not really useful, but provided categories of projects. This prevents the migration of the new project types to succeed for old instances.

https://github.com/opf/openproject/commit/b08a5874f5946e5cfae3d65d7253fea7948ed226