### PR TITLE
Use same pattern to define and apply quick filters to current filters

### DIFF
--- a/app/components/op_primer/quick_filter.rb
+++ b/app/components/op_primer/quick_filter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  module QuickFilter
+    def self.serialize(filters, except: nil)
+      filters
+        .reject { |filter| filter.name == except }
+        .map do |filter|
+          { filter.class.key.to_s => { "operator" => filter.operator.to_s, "values" => filter.values } }
+        end
+    end
+  end
+end

--- a/app/components/op_primer/quick_filter/segmented_control_component.rb
+++ b/app/components/op_primer/quick_filter/segmented_control_component.rb
@@ -77,9 +77,7 @@ module OpPrimer
       end
 
       def filters_params(value)
-        filters = @query.filters
-          .reject { |f| f.name == @filter_key }
-          .map { |f| { f.class.key.to_s => { "operator" => f.operator.to_s, "values" => f.values } } }
+        filters = OpPrimer::QuickFilter.serialize(@query.filters, except: @filter_key)
 
         filters << { @filter_key.to_s => { "operator" => "=", "values" => [value] } } if value
 

--- a/app/components/op_primer/quick_filter/select_panel_component.rb
+++ b/app/components/op_primer/quick_filter/select_panel_component.rb
@@ -135,9 +135,7 @@ module OpPrimer
       end
 
       def other_filters
-        @query.filters
-          .reject { |f| f.name == @filter_key }
-          .map { |f| { f.class.key.to_s => { "operator" => f.operator.to_s, "values" => f.values } } }
+        OpPrimer::QuickFilter.serialize(@query.filters, except: @filter_key)
       end
 
       def sort

--- a/app/components/work_package_types/projects_tab/sub_header_component.rb
+++ b/app/components/work_package_types/projects_tab/sub_header_component.rb
@@ -46,7 +46,8 @@ module WorkPackageTypes
         {
           controller: "filter--filters-form",
           "filter--filters-form-perform-turbo-requests-value": true,
-          "filter--filters-form-clear-button-id-value": clear_button_id
+          "filter--filters-form-clear-button-id-value": clear_button_id,
+          "filter--filters-form-current-filters-value": serialized_filters
         }
       end
 
@@ -60,6 +61,10 @@ module WorkPackageTypes
       end
 
       def name_filter_key = ::Queries::Projects::Filters::NameAndIdentifierFilter.key.to_s
+
+      def serialized_filters
+        OpPrimer::QuickFilter.serialize(query.filters).to_json
+      end
 
       def name_filter_value = query.find_active_filter(name_filter_key.to_sym)&.values&.first
 

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -45,6 +45,8 @@ export interface InternalFilterValue {
   value:string[];
 }
 
+type SerializedFilter = Record<string, { operator:string; values:unknown[] }>;
+
 type FilterFunc<T> = (_value:T) => boolean;
 
 export default class FiltersFormController extends Controller {
@@ -85,6 +87,7 @@ export default class FiltersFormController extends Controller {
     performTurboRequests: { type: Boolean, default: false },
     clearButtonId: String,
     urlPathName: String,
+    currentFilters: Array,
   };
 
   declare displayFiltersValue:boolean;
@@ -92,6 +95,7 @@ export default class FiltersFormController extends Controller {
   declare performTurboRequestsValue:boolean;
   declare readonly clearButtonIdValue:string;
   declare urlPathNameValue:string;
+  declare currentFiltersValue:SerializedFilter[];
   declare hasFilterFormTarget:boolean;
 
   private formLoadedResolver:(() => void)|null = () => null;
@@ -102,6 +106,7 @@ export default class FiltersFormController extends Controller {
 
   private boundListener:() => void;
   private boundClearListener:(event:MouseEvent) => void;
+  private sentFilters:string|null = null;
 
   initialize() {
     // Initialize runs anytime an element with a controller connected to the DOM for the first time
@@ -391,11 +396,31 @@ export default class FiltersFormController extends Controller {
     }
   }
 
-  // Serialize the current DOM filter selection in this form's output format,
-  // ignoring anything in except while adding additions.
   serializedFiltersWith(additions:InternalFilterValue[] = [], { except }:{ except?:string } = {}):string {
-    const filters = this.parseFilters().filter((filter) => filter.name !== except);
+    const filters = this.currentFilters().filter((filter) => filter.name !== except);
     return this.buildFiltersParam([...filters, ...additions]);
+  }
+
+  private currentFilters():InternalFilterValue[] {
+    // Owned filters are filters that we see in this form,
+    // and those we want to update with the actual value present in the filter form
+    const ownedFilterNames = new Set(
+      [...this.simpleFilterTargets, ...this.filterTargets]
+        .map((filter) => filter.getAttribute('data-filter-name'))
+        .filter((name):name is string => name !== null),
+    );
+
+    // Unowned filter might be additional information, keys, params that we do not know in this form
+    // we will simply reflect them again so they do not change.
+    const unownedFilters = this.currentFiltersValue.flatMap((filter) => (
+      Object.entries(filter).map(([name, options]) => ({
+        name,
+        operator: options.operator,
+        value: options.values.map(String),
+      }))
+    )).filter((filter) => !ownedFilterNames.has(filter.name));
+
+    return [...unownedFilters, ...this.parseFilters()];
   }
 
   sendForm() {
@@ -411,9 +436,9 @@ export default class FiltersFormController extends Controller {
     }
 
     const params = new URLSearchParams(window.location.search);
-    const newFilters = this.buildFiltersParam(this.parseFilters());
+    const newFilters = this.buildFiltersParam(this.currentFilters());
 
-    if (newFilters === params.get('filters')) {
+    if (newFilters === (this.sentFilters ?? params.get('filters'))) {
       // Some fields may be triggered via the input event and the change event too.
       // This early return will prevent firing request when the filter params are not changed.
       return;
@@ -421,14 +446,23 @@ export default class FiltersFormController extends Controller {
 
     // Remove the page parameter when changing filters, so that pagination resets
     params.delete('page');
-    params.set('filters', newFilters);
+    if (newFilters) {
+      params.set('filters', newFilters);
+    } else {
+      params.delete('filters');
+    }
     const loadingIndicator = document.querySelector<HTMLElement>('#global-loading-indicator')!;
     showElement(loadingIndicator);
 
     const pathName = this.urlPathNameValue || window.location.pathname;
-    const url = `${pathName}?${params.toString()}`;
+    const search = params.toString();
+    const url = `${pathName}${search ? `?${search}` : ''}`;
+    const browserUrl = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
 
     if (this.performTurboRequestsValue) {
+      const previousFilters = this.sentFilters;
+      this.sentFilters = newFilters;
+
       fetch(url, {
         headers: {
           Accept: 'text/vnd.turbo-stream.html',
@@ -437,9 +471,13 @@ export default class FiltersFormController extends Controller {
         .then((response:Response) => response.text())
         .then((html:string) => {
           renderStreamMessage(html);
+          if (this.sentFilters === newFilters) {
+            window.history.replaceState(window.history.state, '', browserUrl);
+          }
           hideElement(loadingIndicator);
         })
         .catch((error:Error) => {
+          this.sentFilters = previousFilters;
           console.error('Error:', error);
           hideElement(loadingIndicator);
         });
@@ -449,7 +487,7 @@ export default class FiltersFormController extends Controller {
   }
 
   private writeFiltersToHiddenInput() {
-    this.filtersInputTarget.value = this.buildFiltersParam(this.parseFilters());
+    this.filtersInputTarget.value = this.buildFiltersParam(this.currentFilters());
   }
 
   private parseFilters():InternalFilterValue[] {

--- a/spec/features/types/projects_spec.rb
+++ b/spec/features/types/projects_spec.rb
@@ -76,6 +76,10 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
     end
   end
 
+  def current_url_filters
+    Rack::Utils.parse_query(URI(page.current_url).query).fetch("filters", "")
+  end
+
   it "lists every variant's projects at type level and narrows to one inside a variant" do
     visit edit_type_projects_path(type_id: type.id)
     expect_listed(on_base, on_hardware, on_firmware)
@@ -91,6 +95,7 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
     search_projects("Labor")
 
     expect_listed(on_firmware)
+    expect(current_url_filters).to include("name_and_identifier")
   end
 
   it "narrows the table to the variants picked in the quick filter" do
@@ -99,19 +104,55 @@ RSpec.describe "Work package type projects tab", :js, with_flag: { type_variants
     keep_only(firmware)
 
     expect_listed(on_firmware)
+    expect(current_url_filters).to include("type_variant_id")
   end
 
-  # The two controls write the one filters param, so typing must not drop the picked variant.
-  it "keeps the picked variant while a name is typed" do
+  # The two controls write the one filters param, so each has to narrow what the other left rather
+  # than replacing it.
+  it "cannot reach a project outside the picked variants by typing its name" do
     visit edit_type_projects_path(type_id: type.id)
 
     keep_only(hardware, firmware)
 
-    expect_listed(on_hardware, on_firmware)
+    search_projects("Book")
 
-    search_projects("Found")
+    within "#project-table" do
+      expect(page).to have_text(I18n.t("types.edit.projects.empty_state.no_results"))
+    end
+    expect_listed
+    expect(current_url_filters).to include("name_and_identifier", "type_variant_id")
+  end
+
+  it "keeps the typed name when a variant is picked afterwards" do
+    visit edit_type_projects_path(type_id: type.id)
+
+    # Matches Bookshop on the base variant and Laboratory on the firmware one.
+    search_projects("bo")
+
+    expect_listed(on_base, on_firmware)
+
+    keep_only(firmware)
+
+    expect_listed(on_firmware)
+    expect(current_url_filters).to include("name_and_identifier", "type_variant_id")
+  end
+
+  it "keeps the picked variants when the name is cleared again" do
+    visit edit_type_projects_path(type_id: type.id)
+
+    keep_only(hardware)
+
+    search_projects("nothing matches this")
+
+    within "#project-table" do
+      expect(page).to have_text(I18n.t("types.edit.projects.empty_state.no_results"))
+    end
+
+    find_by_id("type-projects-filters-clear-button").click
 
     expect_listed(on_hardware)
+    expect(current_url_filters).to include("type_variant_id")
+    expect(current_url_filters).not_to include("name_and_identifier")
   end
 
   it "says nothing matched rather than inviting an add, once a search has been made" do


### PR DESCRIPTION
Previously, the text filter rebuilt filters only from its own inputs, and the variant quick filter did not belong to this filter form. That means if a variant quick filter is selected, the search text will reset that state.

This PR replaces this with:
- The server rendering the form a complete parsed query
- On changes to the form, it replaces filters it detects in that query and updates the URL with that "combined" set again.

I also noticed that we use the same serialization logic in all three places that use this currently, and introduced `OpPrimer::QuickFilter.serialize` as a helper