### PR TITLE
[AGILE-396] Add a stacked preview for multi-card drags

### DIFF
--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -316,6 +316,15 @@
     .-browser-firefox &
       box-shadow: none
 
+  // The stack and the lift share the one box-shadow property, so both are
+  // declared here or one replaces the other.
+  &[data-preview].op-sortable-lists-drag-preview-stack
+    box-shadow: op-drag-stack-shadows(), var(--shadow-floating-medium)
+
+    // Blur-free and inside the reserved overhang, so only the lift has to go.
+    .-browser-firefox &
+      box-shadow: op-drag-stack-shadows()
+
 .Box--condensed .Box-card
   padding: var(--stack-padding-condensed) var(--stack-padding-normal)
 

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -318,12 +318,13 @@
 
   // The stack and the lift share the one box-shadow property, so both are
   // declared here or one replaces the other.
-  &[data-preview].op-sortable-lists-drag-preview-stack
-    box-shadow: op-drag-stack-shadows(), var(--shadow-floating-medium)
+  @for $layers from 1 through $op-drag-stack-max-layers
+    &[data-preview][data-stack-depth="#{$layers}"]
+      box-shadow: op-drag-stack-shadows($layers: $layers), var(--shadow-floating-medium)
 
-    // Blur-free and inside the reserved overhang, so only the lift has to go.
-    .-browser-firefox &
-      box-shadow: op-drag-stack-shadows()
+      // Blur-free and inside the reserved overhang, so only the lift has to go.
+      .-browser-firefox &
+        box-shadow: op-drag-stack-shadows($layers: $layers)
 
 .Box--condensed .Box-card
   padding: var(--stack-padding-condensed) var(--stack-padding-normal)

--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -318,11 +318,21 @@
 
   // The stack and the lift share the one box-shadow property, so both are
   // declared here or one replaces the other.
-  @for $layers from 1 through $op-drag-stack-max-layers
+  //
+  // The depth the preview writes is the batch's, uncapped: past four cards the
+  // added depth stops reading, so this default holds every deeper batch at the
+  // maximum and the shallow depths below override it.
+  &[data-preview][data-stack-depth]
+    box-shadow: op-drag-stack-shadows(), var(--shadow-floating-medium)
+
+    // Blur-free and inside the reserved overhang, so only the lift has to go.
+    .-browser-firefox &
+      box-shadow: op-drag-stack-shadows()
+
+  @for $layers from 1 through $op-drag-stack-max-layers - 1
     &[data-preview][data-stack-depth="#{$layers}"]
       box-shadow: op-drag-stack-shadows($layers: $layers), var(--shadow-floating-medium)
 
-      // Blur-free and inside the reserved overhang, so only the lift has to go.
       .-browser-firefox &
         box-shadow: op-drag-stack-shadows($layers: $layers)
 

--- a/frontend/src/global_styles/content/drag_and_drop.sass
+++ b/frontend/src/global_styles/content/drag_and_drop.sass
@@ -25,6 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
+@use "sass:list"
 
 // The intend for this file is to become the place where all drag&drop styles are placed.
 // As there will hopefully also be a shared style for resizing, and as those two will hopefully also share some styles
@@ -46,18 +47,45 @@
   &:active
     cursor: grabbing
 
+// Ghost layers behind a multi-card drag preview. Composed into the card's own
+// shadow by the component that renders it (border_box_list_component.sass).
+$op-drag-stack-layers: 2 !default
+$op-drag-stack-step: 6px !default
+$op-drag-stack-ring: 1px !default
+$op-drag-stack-shade-blur: 4px !default
+$op-drag-stack-shade-color: rgba(37, 41, 46, 0.18) !default
+
+// Mirrored by BATCH_BADGE_OVERHANG_PX and DRAG_STACK_OVERHANG_PX (preview.ts).
+$op-drag-badge-overhang: 8px !default
+$op-drag-stack-overhang: $op-drag-stack-step * $op-drag-stack-layers + $op-drag-stack-shade-blur
+
+// Each depth emits shade, fill then ring: CSS paints a shadow list front to
+// back, so a depth's shade lands above its own fill, in the gap under the card
+// in front of it. The deepest shade reaches `step * layers + shade-blur` past
+// the right and bottom edges; the blur is under every offset, so nothing
+// reaches past the top or left.
+@function op-drag-stack-shadows($layers: $op-drag-stack-layers, $step: $op-drag-stack-step, $ring: $op-drag-stack-ring, $blur: $op-drag-stack-shade-blur, $shade: $op-drag-stack-shade-color)
+  $shadows: ()
+
+  @for $depth from 1 through $layers
+    $offset: $step * $depth
+    $shadows: list.append($shadows, $offset $offset $blur 0 $shade, comma)
+    $shadows: list.append($shadows, $offset $offset 0 0 var(--bgColor-default), comma)
+    $shadows: list.append($shadows, $offset $offset 0 $ring var(--borderColor-default), comma)
+
+  @return $shadows
+
 // Multi-card batch count badge on a drag preview, on Primer's Counter
 // contract plus the positioning Counter does not own and the accent skin the
 // drop indicator uses.
 //
-// top/right 0 places it in the container padding renderDragPreview writes
-// inline: the badge overlaps the card's corner while staying inside the
-// container's border box, which Firefox needs — it folds any paint past that
-// box into the drag snapshot and shifts its origin off the grab offset.
+// Paint past the container's border box lands in Firefox's drag snapshot and
+// shifts its origin off the grab offset, so the badge sits in the padding
+// renderDragPreview writes. The right offset keeps it on the card's corner.
 .op-sortable-lists-drag-preview-batch-badge
   position: absolute
   top: 0
-  right: 0
+  right: $op-drag-stack-overhang - $op-drag-badge-overhang
   min-width: 20px
   height: 20px
   padding: 0 6px

--- a/frontend/src/global_styles/content/drag_and_drop.sass
+++ b/frontend/src/global_styles/content/drag_and_drop.sass
@@ -56,9 +56,15 @@ $op-drag-stack-ring: 1px !default
 $op-drag-stack-shade-blur: 4px !default
 $op-drag-stack-shade-color: rgba(37, 41, 46, 0.18) !default
 
-// Mirrored by BATCH_BADGE_OVERHANG_PX and DRAG_STACK_OVERHANG_PX (preview.ts).
 $op-drag-badge-overhang: 8px !default
 $op-drag-stack-overhang: $op-drag-stack-step * $op-drag-stack-max-layers + $op-drag-stack-shade-blur
+
+// renderDragPreview reserves the overhangs as container padding, and can only
+// do so inline (Pragmatic inline-resets the container first), so they are
+// published as custom properties rather than duplicated as numbers there.
+:root
+  --op-drag-badge-overhang: #{$op-drag-badge-overhang}
+  --op-drag-stack-overhang: #{$op-drag-stack-overhang}
 
 // Each depth emits shade, fill then ring: CSS paints a shadow list front to
 // back, so a depth's shade lands above its own fill, in the gap under the card

--- a/frontend/src/global_styles/content/drag_and_drop.sass
+++ b/frontend/src/global_styles/content/drag_and_drop.sass
@@ -47,9 +47,10 @@
   &:active
     cursor: grabbing
 
-// Ghost layers behind a multi-card drag preview. Composed into the card's own
-// shadow by the component that renders it (border_box_list_component.sass).
-$op-drag-stack-layers: 2 !default
+// Ghost layers behind a multi-card drag preview, one per further card in the
+// batch up to the maximum. Composed into the card's own shadow by the
+// component that renders it (border_box_list_component.sass).
+$op-drag-stack-max-layers: 3 !default
 $op-drag-stack-step: 6px !default
 $op-drag-stack-ring: 1px !default
 $op-drag-stack-shade-blur: 4px !default
@@ -57,14 +58,14 @@ $op-drag-stack-shade-color: rgba(37, 41, 46, 0.18) !default
 
 // Mirrored by BATCH_BADGE_OVERHANG_PX and DRAG_STACK_OVERHANG_PX (preview.ts).
 $op-drag-badge-overhang: 8px !default
-$op-drag-stack-overhang: $op-drag-stack-step * $op-drag-stack-layers + $op-drag-stack-shade-blur
+$op-drag-stack-overhang: $op-drag-stack-step * $op-drag-stack-max-layers + $op-drag-stack-shade-blur
 
 // Each depth emits shade, fill then ring: CSS paints a shadow list front to
 // back, so a depth's shade lands above its own fill, in the gap under the card
 // in front of it. The deepest shade reaches `step * layers + shade-blur` past
 // the right and bottom edges; the blur is under every offset, so nothing
 // reaches past the top or left.
-@function op-drag-stack-shadows($layers: $op-drag-stack-layers, $step: $op-drag-stack-step, $ring: $op-drag-stack-ring, $blur: $op-drag-stack-shade-blur, $shade: $op-drag-stack-shade-color)
+@function op-drag-stack-shadows($layers: $op-drag-stack-max-layers, $step: $op-drag-stack-step, $ring: $op-drag-stack-ring, $blur: $op-drag-stack-shade-blur, $shade: $op-drag-stack-shade-color)
   $shadows: ()
 
   @for $depth from 1 through $layers

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -1106,10 +1106,10 @@ describe('Sortable lists item controller', () => {
         y: 0,
         top: 0,
         left: 0,
-        right: 328,
-        bottom: 72,
-        width: 328,
-        height: 72,
+        right: 336,
+        bottom: 88,
+        width: 336,
+        height: 88,
         toJSON: vi.fn(),
       });
 

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/item.controller.spec.ts
@@ -1100,6 +1100,9 @@ describe('Sortable lists item controller', () => {
       const container = document.createElement('div');
       // getComputedStyle resolves empty on a detached element.
       document.body.appendChild(container);
+      // The overhang the preview pads with comes from drag_and_drop.sass,
+      // which no spec loads, so the token is declared here to resolve.
+      container.style.setProperty('--op-drag-badge-overhang', '8px');
 
       vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
         x: 0,

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
@@ -258,14 +258,16 @@ describe('sortable lists drag preview', () => {
 
         expect(container.style.position).toEqual('relative');
         expect(container.style.paddingTop).toEqual('8px');
-        expect(container.style.paddingRight).toEqual('16px');
-        expect(container.style.paddingBottom).toEqual('16px');
+        expect(container.style.paddingRight).toEqual('22px');
+        expect(container.style.paddingBottom).toEqual('22px');
         expect(container.style.paddingLeft).toEqual('0px');
       });
     });
 
     describe('batch stack', () => {
-      const stackClass = 'op-sortable-lists-drag-preview-stack';
+      const stackDepth = (container:HTMLElement) => container
+        .querySelector('[data-preview]')
+        ?.getAttribute('data-stack-depth');
 
       it('leaves the clone unstacked for a single-card drag (the default)', () => {
         const target = withWidth(previewTarget(), 320);
@@ -273,9 +275,7 @@ describe('sortable lists drag preview', () => {
 
         renderDragPreview({ previewTarget: target, sourceElement: target, container });
 
-        const preview = container.querySelector('[data-preview]');
-
-        expect(preview?.classList.contains(stackClass)).toBe(false);
+        expect(stackDepth(container)).toBeNull();
       });
 
       it('leaves the clone unstacked when batchSize is explicitly 1', () => {
@@ -286,9 +286,33 @@ describe('sortable lists drag preview', () => {
           previewTarget: target, sourceElement: target, container, batchSize: 1,
         });
 
-        const preview = container.querySelector('[data-preview]');
+        expect(stackDepth(container)).toBeNull();
+      });
 
-        expect(preview?.classList.contains(stackClass)).toBe(false);
+      it.each([
+        [2, '1'],
+        [3, '2'],
+        [4, '3'],
+      ])('gives a batch of %i a layer per card behind the front one', (batchSize, depth) => {
+        const target = withWidth(previewTarget(), 320);
+        const container = document.createElement('div');
+
+        renderDragPreview({
+          previewTarget: target, sourceElement: target, container, batchSize,
+        });
+
+        expect(stackDepth(container)).toEqual(depth);
+      });
+
+      it('caps the depth so a large batch stacks no deeper than four cards', () => {
+        const target = withWidth(previewTarget(), 320);
+        const container = document.createElement('div');
+
+        renderDragPreview({
+          previewTarget: target, sourceElement: target, container, batchSize: 27,
+        });
+
+        expect(stackDepth(container)).toEqual('3');
       });
 
       it('stacks the clone for a multi-card drag without disturbing its own classes', () => {
@@ -300,10 +324,8 @@ describe('sortable lists drag preview', () => {
           previewTarget: target, sourceElement: target, container, batchSize: 3,
         });
 
-        const preview = container.querySelector('[data-preview]');
-
-        expect(preview?.classList.contains(stackClass)).toBe(true);
-        expect(preview?.classList.contains('op-card')).toBe(true);
+        expect(stackDepth(container)).toEqual('2');
+        expect(container.querySelector('[data-preview]')?.classList.contains('op-card')).toBe(true);
       });
 
       it('adds no element for the layers, so the container holds only the clone and the badge', () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
@@ -246,7 +246,9 @@ describe('sortable lists drag preview', () => {
 
       // The padding holds the badge's overhang inside the container's border
       // box. It has to be written inline and after Pragmatic's own popover
-      // reset (padding: 0), which the pre-zeroed padding here reproduces.
+      // reset (padding: 0), which the pre-zeroed padding here reproduces. The
+      // widths stay in drag_and_drop.sass, so what is written is a reference
+      // to its tokens rather than a length.
       it('pads the container inline past Pragmatic popover reset for a multi-card drag', () => {
         const target = withWidth(previewTarget(), 320);
         const container = document.createElement('div');
@@ -257,9 +259,9 @@ describe('sortable lists drag preview', () => {
         });
 
         expect(container.style.position).toEqual('relative');
-        expect(container.style.paddingTop).toEqual('8px');
-        expect(container.style.paddingRight).toEqual('22px');
-        expect(container.style.paddingBottom).toEqual('22px');
+        expect(container.style.paddingTop).toEqual('var(--op-drag-badge-overhang)');
+        expect(container.style.paddingRight).toEqual('var(--op-drag-stack-overhang)');
+        expect(container.style.paddingBottom).toEqual('var(--op-drag-stack-overhang)');
         expect(container.style.paddingLeft).toEqual('0px');
       });
     });
@@ -304,7 +306,9 @@ describe('sortable lists drag preview', () => {
         expect(stackDepth(container)).toEqual(depth);
       });
 
-      it('caps the depth so a large batch stacks no deeper than four cards', () => {
+      // Capping how deep the stack draws belongs to the stylesheet, which
+      // holds every depth past its layers at the deepest one it has.
+      it('passes a large batch through uncapped', () => {
         const target = withWidth(previewTarget(), 320);
         const container = document.createElement('div');
 
@@ -312,7 +316,7 @@ describe('sortable lists drag preview', () => {
           previewTarget: target, sourceElement: target, container, batchSize: 27,
         });
 
-        expect(stackDepth(container)).toEqual('3');
+        expect(stackDepth(container)).toEqual('26');
       });
 
       it('stacks the clone for a multi-card drag without disturbing its own classes', () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.spec.ts
@@ -181,6 +181,7 @@ describe('sortable lists drag preview', () => {
         expect(container.querySelector(badgeSelector)).toBeNull();
         expect(container.style.paddingTop).toEqual('');
         expect(container.style.paddingRight).toEqual('');
+        expect(container.style.paddingBottom).toEqual('');
       });
 
       it('adds no badge when batchSize is explicitly 1', () => {
@@ -257,7 +258,64 @@ describe('sortable lists drag preview', () => {
 
         expect(container.style.position).toEqual('relative');
         expect(container.style.paddingTop).toEqual('8px');
-        expect(container.style.paddingRight).toEqual('8px');
+        expect(container.style.paddingRight).toEqual('16px');
+        expect(container.style.paddingBottom).toEqual('16px');
+        expect(container.style.paddingLeft).toEqual('0px');
+      });
+    });
+
+    describe('batch stack', () => {
+      const stackClass = 'op-sortable-lists-drag-preview-stack';
+
+      it('leaves the clone unstacked for a single-card drag (the default)', () => {
+        const target = withWidth(previewTarget(), 320);
+        const container = document.createElement('div');
+
+        renderDragPreview({ previewTarget: target, sourceElement: target, container });
+
+        const preview = container.querySelector('[data-preview]');
+
+        expect(preview?.classList.contains(stackClass)).toBe(false);
+      });
+
+      it('leaves the clone unstacked when batchSize is explicitly 1', () => {
+        const target = withWidth(previewTarget(), 320);
+        const container = document.createElement('div');
+
+        renderDragPreview({
+          previewTarget: target, sourceElement: target, container, batchSize: 1,
+        });
+
+        const preview = container.querySelector('[data-preview]');
+
+        expect(preview?.classList.contains(stackClass)).toBe(false);
+      });
+
+      it('stacks the clone for a multi-card drag without disturbing its own classes', () => {
+        const target = withWidth(previewTarget(), 320);
+        target.classList.add('op-card');
+        const container = document.createElement('div');
+
+        renderDragPreview({
+          previewTarget: target, sourceElement: target, container, batchSize: 3,
+        });
+
+        const preview = container.querySelector('[data-preview]');
+
+        expect(preview?.classList.contains(stackClass)).toBe(true);
+        expect(preview?.classList.contains('op-card')).toBe(true);
+      });
+
+      it('adds no element for the layers, so the container holds only the clone and the badge', () => {
+        const target = withWidth(previewTarget(), 320);
+        const container = document.createElement('div');
+
+        renderDragPreview({
+          previewTarget: target, sourceElement: target, container, batchSize: 3,
+        });
+
+        expect(container.querySelectorAll('[data-preview]')).toHaveLength(1);
+        expect(container.children).toHaveLength(2);
       });
     });
   });

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
@@ -62,21 +62,16 @@ const BOX_DENSITY_VARIANT_CLASSES = ['Box--condensed', 'Box--spacious'] as const
 // element would have painted, so it cannot be a custom element.
 const BATCH_BADGE_CLASS = 'op-sortable-lists-drag-preview-batch-badge';
 
-// Ghost layers drawn behind the clone, one per further card in the batch, so
-// the stack itself carries the magnitude the badge spells out. Past four cards
-// the added depth stops reading, so the layers stop too.
-const DRAG_STACK_MAX_LAYERS = 3;
-
 // Reserved as container padding so nothing paints past the border box: Firefox
 // folds such overflow into the drag snapshot and shifts its origin off the grab
 // offset. Written inline because Pragmatic inline-resets the container before
 // render(), and only a later inline write outranks that; the item controller
 // reads the top padding back to compensate the grab offset. Reserved for the
-// deepest stack whatever the batch size, so the badge keeps one offset.
-// Mirrors `$op-drag-badge-overhang` and `$op-drag-stack-overhang` in
-// drag_and_drop.sass.
-const BATCH_BADGE_OVERHANG_PX = 8;
-const DRAG_STACK_OVERHANG_PX = 22;
+// deepest stack whatever the batch size, so the badge keeps one offset. The
+// widths themselves stay in drag_and_drop.sass, which derives the stack one
+// from the layer geometry.
+const BATCH_BADGE_OVERHANG = 'var(--op-drag-badge-overhang)';
+const DRAG_STACK_OVERHANG = 'var(--op-drag-stack-overhang)';
 
 export function renderDragPreview({
   previewTarget,
@@ -116,14 +111,17 @@ export function renderDragPreview({
   container.append(preview);
 
   if (batchSize > 1) {
-    preview.setAttribute('data-stack-depth', `${Math.min(batchSize - 1, DRAG_STACK_MAX_LAYERS)}`);
+    // How many of the further cards the stack can show is the stylesheet's
+    // call, so the depth goes out unclamped and the deepest rule catches
+    // anything past the layers it draws.
+    preview.setAttribute('data-stack-depth', `${batchSize - 1}`);
 
     // Anchors the badge to the container rather than whatever ancestor
     // Pragmatic mounts it under. Nothing paints past the card's left edge.
     container.style.position = 'relative';
-    container.style.paddingTop = `${BATCH_BADGE_OVERHANG_PX}px`;
-    container.style.paddingRight = `${DRAG_STACK_OVERHANG_PX}px`;
-    container.style.paddingBottom = `${DRAG_STACK_OVERHANG_PX}px`;
+    container.style.paddingTop = BATCH_BADGE_OVERHANG;
+    container.style.paddingRight = DRAG_STACK_OVERHANG;
+    container.style.paddingBottom = DRAG_STACK_OVERHANG;
     renderBatchBadge(container, batchSize);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
@@ -62,13 +62,16 @@ const BOX_DENSITY_VARIANT_CLASSES = ['Box--condensed', 'Box--spacious'] as const
 // element would have painted, so it cannot be a custom element.
 const BATCH_BADGE_CLASS = 'op-sortable-lists-drag-preview-batch-badge';
 
-// The badge's overhang as container padding, so nothing paints past the
-// border box: Firefox folds such overflow into the drag snapshot and shifts
-// its origin off the grab offset. Inline because Pragmatic inline-resets the
-// popover container (padding: 0 among others) before handing it to render(),
-// and only a later inline write outranks that. The item controller reads the
-// padding back off the container to compensate the grab offset.
+const BATCH_STACK_CLASS = 'op-sortable-lists-drag-preview-stack';
+
+// Reserved as container padding so nothing paints past the border box: Firefox
+// folds such overflow into the drag snapshot and shifts its origin off the grab
+// offset. Written inline because Pragmatic inline-resets the container before
+// render(), and only a later inline write outranks that; the item controller
+// reads the top padding back to compensate the grab offset. Mirrors
+// `$op-drag-badge-overhang` and `$op-drag-stack-overhang` in drag_and_drop.sass.
 const BATCH_BADGE_OVERHANG_PX = 8;
+const DRAG_STACK_OVERHANG_PX = 16;
 
 export function renderDragPreview({
   previewTarget,
@@ -108,11 +111,14 @@ export function renderDragPreview({
   container.append(preview);
 
   if (batchSize > 1) {
+    preview.classList.add(BATCH_STACK_CLASS);
+
     // Anchors the badge to the container rather than whatever ancestor
-    // Pragmatic mounts it under, and pads it for the overhang.
+    // Pragmatic mounts it under. Nothing paints past the card's left edge.
     container.style.position = 'relative';
     container.style.paddingTop = `${BATCH_BADGE_OVERHANG_PX}px`;
-    container.style.paddingRight = `${BATCH_BADGE_OVERHANG_PX}px`;
+    container.style.paddingRight = `${DRAG_STACK_OVERHANG_PX}px`;
+    container.style.paddingBottom = `${DRAG_STACK_OVERHANG_PX}px`;
     renderBatchBadge(container, batchSize);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists/preview.ts
@@ -62,16 +62,21 @@ const BOX_DENSITY_VARIANT_CLASSES = ['Box--condensed', 'Box--spacious'] as const
 // element would have painted, so it cannot be a custom element.
 const BATCH_BADGE_CLASS = 'op-sortable-lists-drag-preview-batch-badge';
 
-const BATCH_STACK_CLASS = 'op-sortable-lists-drag-preview-stack';
+// Ghost layers drawn behind the clone, one per further card in the batch, so
+// the stack itself carries the magnitude the badge spells out. Past four cards
+// the added depth stops reading, so the layers stop too.
+const DRAG_STACK_MAX_LAYERS = 3;
 
 // Reserved as container padding so nothing paints past the border box: Firefox
 // folds such overflow into the drag snapshot and shifts its origin off the grab
 // offset. Written inline because Pragmatic inline-resets the container before
 // render(), and only a later inline write outranks that; the item controller
-// reads the top padding back to compensate the grab offset. Mirrors
-// `$op-drag-badge-overhang` and `$op-drag-stack-overhang` in drag_and_drop.sass.
+// reads the top padding back to compensate the grab offset. Reserved for the
+// deepest stack whatever the batch size, so the badge keeps one offset.
+// Mirrors `$op-drag-badge-overhang` and `$op-drag-stack-overhang` in
+// drag_and_drop.sass.
 const BATCH_BADGE_OVERHANG_PX = 8;
-const DRAG_STACK_OVERHANG_PX = 16;
+const DRAG_STACK_OVERHANG_PX = 22;
 
 export function renderDragPreview({
   previewTarget,
@@ -111,7 +116,7 @@ export function renderDragPreview({
   container.append(preview);
 
   if (batchSize > 1) {
-    preview.classList.add(BATCH_STACK_CLASS);
+    preview.setAttribute('data-stack-depth', `${Math.min(batchSize - 1, DRAG_STACK_MAX_LAYERS)}`);
 
     // Anchors the badge to the container rather than whatever ancestor
     // Pragmatic mounts it under. Nothing paints past the card's left edge.


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #24778  ([AGILE-278](https://community.openproject.org/wp/AGILE-278)).

# Ticket

https://community.openproject.org/wp/AGILE-396

# What are you trying to accomplish?

A batch drag looked identical to a single-card drag apart from a count badge in the corner. Ghost layers now sit behind the dragged card, so a multi-card drag reads as more than one card before the count is read. A single-card drag is unchanged.

The stack also carries the magnitude: its depth follows the batch, one layer per further card, up to four cards in all. Two cards get one ghost, three get two, and anything from four upward gets three — past that the added depth stops reading, and the badge is what carries the exact number.

## Screenshots

| Before (AGILE-278: count badge only) | After (this PR) |
| --- | --- |
| <img alt="Batch drag preview before: count badge only" src="https://github.com/user-attachments/assets/d8ddf3c3-4f0e-4669-a11a-2754596c5725" /> | <img alt="Batch drag preview after: two ghost layers stacked behind the card" src="https://github.com/user-attachments/assets/75e03695-ff09-4e29-9304-ea52c9e2bc29" /> |

<img width="1122" height="1402" alt="ChatGPT - Stack preview (real cards) 2" src="https://github.com/user-attachments/assets/73062c6f-64ab-4433-8518-959be8cc8c51" />


# What approach did you choose and why?

The layers are zero-blur `box-shadow`s on the card clone rather than extra DOM nodes, so they inherit its radius and geometry and cost nothing per layer — a 40-card selection renders what a 3-card one does. A Sass `@function` builds the list from the `$op-drag-stack-*` variables, emitting shade, fill then ring per depth: CSS paints a shadow list front to back, so each shade lands in the gap under the card in front of it.

Depth comes from a `data-stack-depth` attribute on the clone, written uncapped — a catch-all rule holds anything past the drawn layers at the deepest one, and a Sass `@for` emits the shallower depths over it. A custom property could not select depth on its own: the layers are entries in a build-time `box-shadow` list, and gating a fixed-length one means wrapping every colour in `color-mix`, which appears nowhere else here and leaves a unit test asserting the variable rather than the layer.

The overhang is reserved at the deepest stack whatever the batch size, so the badge keeps one offset and the grab-offset compensation — which reads only `padding-top` — is untouched. Both widths are custom properties (`--op-drag-badge-overhang` and `--op-drag-stack-overhang`) the preview references from its inline padding, so the space it reserves cannot drift from the shadows Sass paints into it. The cost is transparent padding beside a shallow stack, which the drag image does not show.

The composition lives in `border_box_list_component.sass` rather than the generic `drag_and_drop.sass`: that component already owns the clone's lift shadow, and `box-shadow` is a single property — declared apart, one silently replaces the other. A generic rule also loses the cascade, tying at (0,2,0) through the Angular-scoped sheet's `_ngcontent` attribute and losing on source order.

Considered and dropped: ghost layers as real DOM elements, and pseudo-elements on the clone (consumer markup may use its own).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

## Note for reviewers

The specs assert the depth attribute lands on the clone, which stayed true through an earlier revision where the CSS resolved to nothing. They do not cover the cascade.

