### PR TITLE
Run frontend unit tests in Playwright container

### DIFF
--- a/.github/workflows/test-frontend-unit.yml
+++ b/.github/workflows/test-frontend-unit.yml
@@ -35,10 +35,11 @@ jobs:
     outputs:
       version: ${{ steps.lockfile.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: frontend/package-lock.json
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - id: lockfile
         run: echo "version=$(jq -r '.packages["node_modules/playwright"].version' package-lock.json)" >> "$GITHUB_OUTPUT"
@@ -57,11 +58,12 @@ jobs:
         browser: [chromium, firefox, webkit]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.18.0'
           package-manager-cache: false

--- a/.github/workflows/test-frontend-unit.yml
+++ b/.github/workflows/test-frontend-unit.yml
@@ -10,6 +10,7 @@ on:
       - '**/frontend/**/*.ts'
       - '**/frontend/**/*.js'
       - '**/frontend/**/*.json'
+      - '.github/workflows/test-frontend-unit.yml'
 
   pull_request:
     types: [opened, reopened, synchronize]
@@ -17,6 +18,7 @@ on:
       - '**/frontend/**/*.ts'
       - '**/frontend/**/*.js'
       - '**/frontend/**/*.json'
+      - '.github/workflows/test-frontend-unit.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/test-frontend-unit.yml
+++ b/.github/workflows/test-frontend-unit.yml
@@ -26,9 +26,28 @@ defaults:
     working-directory: ./frontend
 
 jobs:
+  playwright-version:
+    name: Resolve Playwright version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.lockfile.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: frontend/package-lock.json
+          sparse-checkout-cone-mode: false
+
+      - id: lockfile
+        run: echo "version=$(jq -r '.packages["node_modules/playwright"].version' package-lock.json)" >> "$GITHUB_OUTPUT"
+
   unit:
     name: Units (${{ matrix.browser }})
+    needs: playwright-version
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
+      options: --ipc=host
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -51,13 +70,10 @@ jobs:
       - name: Register plugins
         run: npm run ci:plugins:register_frontend
 
-      - name: Install Playwright dependencies
-        timeout-minutes: 5
-        run: npx playwright install-deps ${{ matrix.browser }}
-
-      - name: Install Playwright Browser
-        timeout-minutes: 5
-        run: npx playwright install --only-shell ${{ matrix.browser }}
+      - name: Take ownership of HOME
+        # Actions points HOME at /github/home, owned by the image's pwuser, and
+        # firefox refuses to launch as root under a home it does not own.
+        run: chown root:root "$HOME"
 
       - name: Test
         run: npm test -- --browsers ${{ matrix.browser }} --reporters dot --reporters github-actions


### PR DESCRIPTION
# Ticket

None — unplanned CI fix.

# What are you trying to accomplish?

`playwright install-deps` shells out to apt, and the runner's `azure.archive.ubuntu.com` mirror is unreachable, so the step burns its 5-minute timeout retrying. The browser it kills is random, leaving nearly every PR touching `frontend/**` red on `Install Playwright dependencies`. [Example run.](https://github.com/opf/openproject/actions/runs/32275404437/job/96141536151)

# What approach did you choose and why?

Run the job in the official Playwright image — deps and browsers baked in — and drop both install steps. Nothing touches apt any more.

A `playwright-version` job reads the tag out of `frontend/package-lock.json`, so the image can't drift from the `playwright` dependency.

Container details: `--ipc=host` for chromium, and a `chown` of `$HOME`, because Actions points `HOME` at `/github/home`, owned by the image's `pwuser`, and firefox won't launch as root under a home it doesn't own.

Rejected retrying `install-deps` behind a per-attempt `timeout`: smaller diff, still hostage to Ubuntu mirrors.

Separate commits add the workflow to its own `paths:` filters and correct the action pin comments.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
