### PR TITLE
[Dream-76] Primerise Interface tab of Admin/Design page

### DIFF
--- a/app/components/custom_styles/design_color_dialog_component.html.erb
+++ b/app/components/custom_styles/design_color_dialog_component.html.erb
@@ -1,0 +1,64 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  color_field_arguments = field_arguments
+
+  render(Primer::Alpha::Dialog.new(title: color_label, id: dialog_id)) do |dialog|
+    dialog.with_show_button(
+      icon: :pencil,
+      scheme: :invisible,
+      "aria-label": I18n.t("admin.custom_styles.edit_color", color: color_label),
+      data: { test_selector: "edit-design-color-#{variable}" }
+    )
+    dialog.with_header(variant: :large)
+
+    dialog.with_body do
+      primer_form_with(**form_arguments) do |form_builder|
+        render_inline_form(form_builder) do |form|
+          form.text_field(**color_field_arguments)
+        end
+      end
+    end
+
+    dialog.with_footer do
+      concat(render(Primer::Beta::Button.new(data: { close_dialog_id: dialog_id })) { I18n.t(:button_cancel) })
+      concat(
+        render(
+          Primer::Beta::Button.new(
+            type: :submit,
+            scheme: :primary,
+            form: form_id,
+            data: { test_selector: "save-design-color-#{variable}" }
+          )
+        ) { I18n.t(:button_save) }
+      )
+    end
+  end
+%>

--- a/app/components/custom_styles/design_color_dialog_component.rb
+++ b/app/components/custom_styles/design_color_dialog_component.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module CustomStyles
+  class DesignColorDialogComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :design_color, :color_label, :instruction, :hexcode
+
+    def initialize(design_color:, label:, instruction:, hexcode:)
+      super()
+
+      @design_color = design_color
+      @color_label = label
+      @instruction = instruction
+      @hexcode = hexcode
+    end
+
+    private
+
+    def variable = design_color.variable
+
+    def dialog_id = "design-color-#{variable}-dialog"
+
+    def form_id = "design-color-#{variable}-form"
+
+    def form_arguments
+      {
+        url: url_helpers.update_design_colors_path,
+        method: :post,
+        id: form_id,
+        data: { turbo: false }
+      }
+    end
+
+    def field_arguments
+      {
+        name: "design_colors[]#{variable}",
+        id: "design_colors_#{variable}",
+        label: color_label,
+        visually_hide_label: true,
+        caption: instruction,
+        value: design_color.hexcode,
+        placeholder: hexcode,
+        input_width: :medium,
+        scope_name_to_model: false,
+        data: { variable_name: variable }
+      }
+    end
+  end
+end

--- a/app/components/custom_styles/theme_selector_component.html.erb
+++ b/app/components/custom_styles/theme_selector_component.html.erb
@@ -27,23 +27,24 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= with_enterprise_banner_guard(
-      :define_custom_style,
-      inactive_guard: default_colors_tab?,
-      variant: :large,
-      video: "enterprise/custom-design.mp4"
-    ) do %>
-  <%= render(Admin::DesignHeaderComponent.new(tabs: design_tabs)) %>
-  <%= error_messages_for "custom_style" %>
-  <% if show_theme_selector? %>
-    <%= render(
-          CustomStyles::ThemeSelectorComponent.new(
-            theme_options: @theme_options,
-            current_theme: @current_theme,
-            selected_tab_name: selected_tab(design_tabs).fetch(:name)
-          )
-        ) %>
-  <% end %>
+<%=
+  options = theme_options
+  selected_theme = current_theme
+  theme_select_arguments = select_arguments
 
-  <%= render_tabs design_tabs %>
-<% end %>
+  primer_form_with(**form_arguments) do |form_builder|
+    render_inline_form(form_builder) do |form|
+      form.select_list(**theme_select_arguments) do |select|
+        options.each do |option|
+          option_label, value, attributes = option.is_a?(Array) ? option : [option, option, {}]
+          select.option(
+            label: option_label,
+            value:,
+            selected: attributes&.fetch(:selected, value == selected_theme),
+            disabled: attributes&.fetch(:disabled, false)
+          )
+        end
+      end
+    end
+  end
+%>

--- a/app/components/custom_styles/theme_selector_component.rb
+++ b/app/components/custom_styles/theme_selector_component.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module CustomStyles
+  class ThemeSelectorComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :theme_options, :current_theme, :selected_tab_name
+
+    def initialize(theme_options:, current_theme:, selected_tab_name:)
+      super()
+
+      @theme_options = theme_options
+      @current_theme = current_theme
+      @selected_tab_name = selected_tab_name
+    end
+
+    private
+
+    def form_arguments
+      {
+        url: url_helpers.update_design_themes_path(tab: selected_tab_name),
+        method: :post,
+        data: {
+          controller: "auto-submit",
+          turbo_confirm: (I18n.t("admin.custom_styles.theme_warning") if current_theme.blank?)
+        }
+      }
+    end
+
+    def select_arguments
+      {
+        name: :theme,
+        label: I18n.t("admin.custom_styles.color_theme"),
+        caption: I18n.t("admin.custom_styles.color_theme_caption"),
+        input_width: :medium,
+        scope_name_to_model: false,
+        data: {
+          action: "auto-submit#submit",
+          test_selector: "color-theme-select"
+        }
+      }
+    end
+  end
+end

--- a/app/helpers/custom_styles_helper.rb
+++ b/app/helpers/custom_styles_helper.rb
@@ -45,6 +45,23 @@ module CustomStylesHelper
     selected_tab(design_tabs)&.dig(:name) == "default_colors"
   end
 
+  def design_color_groups
+    colors = DesignColor.setables.index_by(&:variable)
+
+    {
+      base_colors: %w[primary-button-color accent-color],
+      top_header_colors: %w[header-bg-color],
+      main_menu: %w[main-menu-bg-color main-menu-bg-selected-background]
+    }.filter_map do |name, variables|
+      group_colors = variables.filter_map { |variable| colors[variable] }
+      [name, group_colors] if group_colors.any?
+    end
+  end
+
+  def effective_design_color(design_color, current_theme:)
+    design_color.hexcode.presence || color_theme(current_theme).fetch(:colors).fetch(design_color.variable)
+  end
+
   def design_tabs
     [
       {
@@ -81,6 +98,16 @@ module CustomStylesHelper
       }
     ]
   end
+
+  private
+
+  def color_theme(current_theme)
+    OpenProject::CustomStyles::ColorThemes.themes.find do |theme|
+      theme[:theme] == current_theme
+    end || OpenProject::CustomStyles::ColorThemes.themes.first
+  end
+
+  public
 
   def apply_custom_styles?(skip_ee_check: OpenProject::Configuration.bim?)
     # Apply custom styles either if EE allows OR we are on a BIM edition with the BIM theme active.

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -47,7 +47,6 @@ See COPYRIGHT and LICENSE files for more details.
       <% label = t("admin.custom_styles.colors.#{variable}") %>
       <% instruction = t("admin.custom_styles.instructions.#{variable}", default: "") %>
       <% hexcode = effective_design_color(design_color, current_theme: @current_theme) %>
-      <% form_id = "design-color-#{variable}-form" %>
 
       <% list.with_item do %>
         <%= flex_layout(
@@ -68,59 +67,13 @@ See COPYRIGHT and LICENSE files for more details.
 
           <% row.with_column(ml: 2) do %>
             <%= render(
-                  Primer::Alpha::Dialog.new(
-                    title: label,
-                    id: "design-color-#{variable}-dialog"
+                  CustomStyles::DesignColorDialogComponent.new(
+                    design_color:,
+                    label:,
+                    instruction:,
+                    hexcode:
                   )
-                ) do |dialog| %>
-              <% dialog.with_show_button(
-                   icon: :pencil,
-                   scheme: :invisible,
-                   "aria-label": t("admin.custom_styles.edit_color", color: label),
-                   data: { test_selector: "edit-design-color-#{variable}" }
-                 ) %>
-              <% dialog.with_header(variant: :large) %>
-              <% dialog.with_body do %>
-                <%=
-                  primer_form_with(
-                    url: update_design_colors_path,
-                    method: :post,
-                    id: form_id,
-                    data: { turbo: false }
-                  ) do |form_builder|
-                    render_inline_form(form_builder) do |form|
-                      form.text_field(
-                        name: "design_colors[]#{variable}",
-                        id: "design_colors_#{variable}",
-                        label:,
-                        visually_hide_label: true,
-                        caption: instruction,
-                        value: design_color.hexcode,
-                        placeholder: hexcode,
-                        input_width: :medium,
-                        scope_name_to_model: false,
-                        data: { variable_name: variable }
-                      )
-                    end
-                  end
-                %>
-              <% end %>
-              <% dialog.with_footer do %>
-                <%= render(Primer::Beta::Button.new(data: { close_dialog_id: "design-color-#{variable}-dialog" })) do %>
-                  <%= t(:button_cancel) %>
-                <% end %>
-                <%= render(
-                      Primer::Beta::Button.new(
-                        type: :submit,
-                        scheme: :primary,
-                        form: form_id,
-                        data: { test_selector: "save-design-color-#{variable}" }
-                      )
-                    ) do %>
-                  <%= t(:button_save) %>
-                <% end %>
-              <% end %>
-            <% end %>
+                ) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -70,8 +70,7 @@ See COPYRIGHT and LICENSE files for more details.
             <%= render(
                   Primer::Alpha::Dialog.new(
                     title: label,
-                    id: "design-color-#{variable}-dialog",
-                    visually_hide_title: true
+                    id: "design-color-#{variable}-dialog"
                   )
                 ) do |dialog| %>
               <% dialog.with_show_button(
@@ -82,20 +81,29 @@ See COPYRIGHT and LICENSE files for more details.
                  ) %>
               <% dialog.with_header(variant: :large) %>
               <% dialog.with_body do %>
-                <%= form_tag update_design_colors_path, method: :post, id: form_id, data: { turbo: false } do %>
-                  <%= render(
-                        Primer::Alpha::TextField.new(
-                          name: "design_colors[]#{variable}",
-                          id: "design_colors_#{variable}",
-                          label:,
-                          caption: instruction,
-                          value: design_color.hexcode,
-                          placeholder: hexcode,
-                          input_width: :medium,
-                          data: { variable_name: variable }
-                        )
-                      ) %>
-                <% end %>
+                <%=
+                  primer_form_with(
+                    url: update_design_colors_path,
+                    method: :post,
+                    id: form_id,
+                    data: { turbo: false }
+                  ) do |form_builder|
+                    render_inline_form(form_builder) do |form|
+                      form.text_field(
+                        name: "design_colors[]#{variable}",
+                        id: "design_colors_#{variable}",
+                        label:,
+                        visually_hide_label: true,
+                        caption: instruction,
+                        value: design_color.hexcode,
+                        placeholder: hexcode,
+                        input_width: :medium,
+                        scope_name_to_model: false,
+                        data: { variable_name: variable }
+                      )
+                    end
+                  end
+                %>
               <% end %>
               <% dialog.with_footer do %>
                 <%= render(Primer::Beta::Button.new(data: { close_dialog_id: "design-color-#{variable}-dialog" })) do %>

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -50,12 +50,10 @@ See COPYRIGHT and LICENSE files for more details.
       <% form_id = "design-color-#{variable}-form" %>
 
       <% list.with_item do %>
-        <%= render(
-              Primer::OpenProject::FlexLayout.new(
-                align_items: :center,
-                flex_wrap: :wrap,
-                justify_content: :space_between
-              )
+        <%= flex_layout(
+              align_items: :center,
+              flex_wrap: :wrap,
+              justify_content: :space_between
             ) do |row| %>
           <% row.with_column(flex: 1, mr: 3) do %>
             <%= render(Primer::Beta::Text.new(font_weight: :bold)) { label } %>
@@ -65,56 +63,53 @@ See COPYRIGHT and LICENSE files for more details.
           <% end %>
 
           <% row.with_column do %>
-            <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center)) do |value| %>
-              <% value.with_column do %>
-                <%= render(Colors::SwatchComponent.new(hexcode:, show_value: true)) %>
+            <%= render(Colors::SwatchComponent.new(hexcode:, show_value: true)) %>
+          <% end %>
+
+          <% row.with_column(ml: 2) do %>
+            <%= render(
+                  Primer::Alpha::Dialog.new(
+                    title: label,
+                    id: "design-color-#{variable}-dialog",
+                    visually_hide_title: true
+                  )
+                ) do |dialog| %>
+              <% dialog.with_show_button(
+                   icon: :pencil,
+                   scheme: :invisible,
+                   "aria-label": t("admin.custom_styles.edit_color", color: label),
+                   data: { test_selector: "edit-design-color-#{variable}" }
+                 ) %>
+              <% dialog.with_header(variant: :large) %>
+              <% dialog.with_body do %>
+                <%= form_tag update_design_colors_path, method: :post, id: form_id, data: { turbo: false } do %>
+                  <%= render(
+                        Primer::Alpha::TextField.new(
+                          name: "design_colors[]#{variable}",
+                          id: "design_colors_#{variable}",
+                          label:,
+                          caption: instruction,
+                          value: design_color.hexcode,
+                          placeholder: hexcode,
+                          input_width: :medium,
+                          data: { variable_name: variable }
+                        )
+                      ) %>
+                <% end %>
               <% end %>
-              <% value.with_column(ml: 2) do %>
+              <% dialog.with_footer do %>
+                <%= render(Primer::Beta::Button.new(data: { close_dialog_id: "design-color-#{variable}-dialog" })) do %>
+                  <%= t(:button_cancel) %>
+                <% end %>
                 <%= render(
-                      Primer::Alpha::Dialog.new(
-                        title: label,
-                        id: "design-color-#{variable}-dialog",
-                        visually_hide_title: true
+                      Primer::Beta::Button.new(
+                        type: :submit,
+                        scheme: :primary,
+                        form: form_id,
+                        data: { test_selector: "save-design-color-#{variable}" }
                       )
-                    ) do |dialog| %>
-                  <% dialog.with_show_button(
-                       icon: :pencil,
-                       scheme: :invisible,
-                       "aria-label": t("admin.custom_styles.edit_color", color: label),
-                       data: { test_selector: "edit-design-color-#{variable}" }
-                     ) %>
-                  <% dialog.with_header(variant: :large) %>
-                  <% dialog.with_body do %>
-                    <%= form_tag update_design_colors_path, method: :post, id: form_id, data: { turbo: false } do %>
-                      <%= render(
-                            Primer::Alpha::TextField.new(
-                              name: "design_colors[]#{variable}",
-                              id: "design_colors_#{variable}",
-                              label:,
-                              caption: instruction,
-                              value: design_color.hexcode,
-                              placeholder: hexcode,
-                              input_width: :medium,
-                              data: { variable_name: variable }
-                            )
-                          ) %>
-                    <% end %>
-                  <% end %>
-                  <% dialog.with_footer do %>
-                    <%= render(Primer::Beta::Button.new(data: { close_dialog_id: "design-color-#{variable}-dialog" })) do %>
-                      <%= t(:button_cancel) %>
-                    <% end %>
-                    <%= render(
-                          Primer::Beta::Button.new(
-                            type: :submit,
-                            scheme: :primary,
-                            form: form_id,
-                            data: { test_selector: "save-design-color-#{variable}" }
-                          )
-                        ) do %>
-                      <%= t(:button_save) %>
-                    <% end %>
-                  <% end %>
+                    ) do %>
+                  <%= t(:button_save) %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -46,12 +46,14 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% design_color_groups.each do |group_name, design_colors| %>
-  <%= render(Primer::Beta::BorderBox.new(mb: 3, test_selector: "design-color-group-#{group_name}")) do |box| %>
-    <% box.with_header do %>
-      <%= render(Primer::Beta::Text.new(font_weight: :bold)) do %>
-        <%= t("admin.custom_styles.color_groups.#{group_name}") %>
-      <% end %>
-    <% end %>
+  <%= render(
+        OpenProject::Common::BorderBoxListComponent.new(
+          container: "design-color-group-#{group_name}",
+          mb: 3,
+          test_selector: "design-color-group-#{group_name}"
+        )
+      ) do |list| %>
+    <% list.with_header(title: t("admin.custom_styles.color_groups.#{group_name}")) %>
 
     <% design_colors.each do |design_color| %>
       <% variable = design_color.variable %>
@@ -60,7 +62,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% hexcode = effective_design_color(design_color, current_theme: @current_theme) %>
       <% form_id = "design-color-#{variable}-form" %>
 
-      <% box.with_row do %>
+      <% list.with_item do %>
         <%= render(
               Primer::OpenProject::FlexLayout.new(
                 align_items: :center,

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -27,22 +27,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(
-      Primer::Beta::Heading.new(
-        tag: :h2,
-        font_size: 3,
-        font_weight: :normal,
-        mt: 4,
-        mb: 2,
-        pb: 2,
-        border: :bottom
-      )
-    ) do %>
-  <%= t(:label_interface_colors) %>
-<% end %>
-
-<%= render(Primer::Beta::Text.new(tag: :p, mb: 3)) do %>
-  <%= t(:label_interface_colors_description) %>
+<%= render(Primer::Beta::Subhead.new(mt: 4, mb: 3)) do |subhead| %>
+  <% subhead.with_heading(tag: :h2, size: :medium) { t(:label_interface_colors) } %>
+  <% subhead.with_description { t(:label_interface_colors_description) } %>
 <% end %>
 
 <% design_color_groups.each do |group_name, design_colors| %>

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -1,48 +1,121 @@
-<%= form_tag update_design_colors_path, method: :post, class: "form", data: { turbo: false } do %>
-  <section class="form--section">
-    <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= I18n.t(:label_interface_colors) %></legend>
-      <p> <%= t("label_interface_colors_description") %> </p>
-      <% DesignColor.setables.each do |design_color| %>
-        <div class="form--field -required">
-          <label class="form--label"><%= I18n.t("admin.custom_styles.colors.#{design_color.variable}") %>:</label>
-          <span class="form--field-container">
-            <div class="form--field-affix">
-              <%= icon_for_color(
-                    Color.new(
-                      hexcode: design_color.hexcode
-                    ),
-                    data: { target: "#design_colors_" + design_color.variable }
-                  ) %>
-            </div>
-            <span class="form--text-field-container">
-              <%= styled_text_field_tag "design_colors[]" + design_color.variable,
-                                        design_color.hexcode,
-                                        class: "design-color--variable-input",
-                                        data: { "variable-name": design_color.variable } %>
-            </span>
-          </span>
-          <div class="form--field-instructions">
-            <% instruction_key = "admin.custom_styles.instructions.#{design_color.variable}" %>
-            <% if I18n.exists?(instruction_key, :en) %>
-              <%= I18n.t(instruction_key) %>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-      <button type="submit" class="button -hide-when-collapsed" data-test-selector="interface-colors-button"><%= I18n.t(:button_save) %></button>
-    </fieldset>
-  </section>
-  <%# Fill in the computed css variables in the inputs as their defaults %>
-  <%= nonced_javascript_tag do %>
-    var computedStyle = getComputedStyle(document.documentElement);
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
 
-    document
-        .querySelectorAll('.design-color--variable-input')
-        .forEach(function(el) {
-            if (!el.value || el.value === '') {
-                el.placeholder = computedStyle.getPropertyValue('--' + el.dataset.variableName).trim();
-            }
-        });
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(Primer::Beta::Heading.new(tag: :h2, font_size: 3, font_weight: :normal, mt: 4, mb: 2)) do %>
+  <%= t(:label_interface_colors) %>
+<% end %>
+
+<%= render(Primer::Beta::Text.new(tag: :p, mb: 3)) do %>
+  <%= t(:label_interface_colors_description) %>
+<% end %>
+
+<% design_color_groups.each do |group_name, design_colors| %>
+  <%= render(Primer::Beta::BorderBox.new(mb: 3, test_selector: "design-color-group-#{group_name}")) do |box| %>
+    <% box.with_header do %>
+      <%= render(Primer::Beta::Text.new(font_weight: :bold)) do %>
+        <%= t("admin.custom_styles.color_groups.#{group_name}") %>
+      <% end %>
+    <% end %>
+
+    <% design_colors.each do |design_color| %>
+      <% variable = design_color.variable %>
+      <% label = t("admin.custom_styles.colors.#{variable}") %>
+      <% instruction = t("admin.custom_styles.instructions.#{variable}", default: "") %>
+      <% hexcode = effective_design_color(design_color, current_theme: @current_theme) %>
+      <% form_id = "design-color-#{variable}-form" %>
+
+      <% box.with_row do %>
+        <%= render(
+              Primer::OpenProject::FlexLayout.new(
+                align_items: :center,
+                flex_wrap: :wrap,
+                justify_content: :space_between
+              )
+            ) do |row| %>
+          <% row.with_column(flex: 1, mr: 3) do %>
+            <%= render(Primer::Beta::Text.new(font_weight: :bold)) { label } %>
+            <% if instruction.present? %>
+              <%= render(Primer::Beta::Text.new(font_size: :small, color: :subtle, ml: 1)) { instruction } %>
+            <% end %>
+          <% end %>
+
+          <% row.with_column do %>
+            <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center)) do |value| %>
+              <% value.with_column do %>
+                <%= render(Colors::SwatchComponent.new(hexcode:, show_value: true)) %>
+              <% end %>
+              <% value.with_column(ml: 2) do %>
+                <%= render(Primer::Alpha::Dialog.new(title: label, id: "design-color-#{variable}-dialog")) do |dialog| %>
+                  <% dialog.with_show_button(
+                       icon: :pencil,
+                       scheme: :invisible,
+                       "aria-label": t("admin.custom_styles.edit_color", color: label),
+                       data: { test_selector: "edit-design-color-#{variable}" }
+                     ) %>
+                  <% dialog.with_header(variant: :large) %>
+                  <% dialog.with_body do %>
+                    <%= form_tag update_design_colors_path, method: :post, id: form_id, data: { turbo: false } do %>
+                      <%= render(
+                            Primer::Alpha::TextField.new(
+                              name: "design_colors[]#{variable}",
+                              id: "design_colors_#{variable}",
+                              label:,
+                              caption: instruction,
+                              value: design_color.hexcode,
+                              placeholder: hexcode,
+                              input_width: :medium,
+                              data: { variable_name: variable }
+                            )
+                          ) %>
+                    <% end %>
+                  <% end %>
+                  <% dialog.with_footer do %>
+                    <%= render(Primer::Beta::Button.new(data: { close_dialog_id: "design-color-#{variable}-dialog" })) do %>
+                      <%= t(:button_cancel) %>
+                    <% end %>
+                    <%= render(
+                          Primer::Beta::Button.new(
+                            type: :submit,
+                            scheme: :primary,
+                            form: form_id,
+                            data: { test_selector: "save-design-color-#{variable}" }
+                          )
+                        ) do %>
+                      <%= t(:button_save) %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/custom_styles/_interface.html.erb
+++ b/app/views/custom_styles/_interface.html.erb
@@ -27,7 +27,17 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(Primer::Beta::Heading.new(tag: :h2, font_size: 3, font_weight: :normal, mt: 4, mb: 2)) do %>
+<%= render(
+      Primer::Beta::Heading.new(
+        tag: :h2,
+        font_size: 3,
+        font_weight: :normal,
+        mt: 4,
+        mb: 2,
+        pb: 2,
+        border: :bottom
+      )
+    ) do %>
   <%= t(:label_interface_colors) %>
 <% end %>
 
@@ -71,7 +81,13 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= render(Colors::SwatchComponent.new(hexcode:, show_value: true)) %>
               <% end %>
               <% value.with_column(ml: 2) do %>
-                <%= render(Primer::Alpha::Dialog.new(title: label, id: "design-color-#{variable}-dialog")) do |dialog| %>
+                <%= render(
+                      Primer::Alpha::Dialog.new(
+                        title: label,
+                        id: "design-color-#{variable}-dialog",
+                        visually_hide_title: true
+                      )
+                    ) do |dialog| %>
                   <% dialog.with_show_button(
                        icon: :pencil,
                        scheme: :invisible,

--- a/app/views/custom_styles/show.html.erb
+++ b/app/views/custom_styles/show.html.erb
@@ -36,25 +36,36 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render(Admin::DesignHeaderComponent.new(tabs: design_tabs)) %>
   <%= error_messages_for "custom_style" %>
   <% if show_theme_selector? %>
-    <%= form_tag update_design_themes_path, method: :post, class: "form" do %>
-      <section class="form--section">
-        <fieldset class="form--fieldset">
-          <legend class="form--fieldset-legend"><%= I18n.t("admin.custom_styles.color_theme") %></legend>
-          <div class="form--field">
-            <div class="form--field-container">
-              <%= styled_select_tag "theme",
-                                    options_for_select(@theme_options, @current_theme),
-                                    container_class: "-slim" %>
-            </div>
-          </div>
-
-          <%= styled_button_tag t(:button_save),
-                                data: {
-                                  test_selector: "color-theme-button",
-                                  turbo_confirm: (t("admin.custom_styles.theme_warning") if @current_theme.blank?)
-                                } %>
-        </fieldset>
-      </section>
+    <%= form_tag(
+          update_design_themes_path,
+          method: :post,
+          data: {
+            controller: "auto-submit",
+            turbo_confirm: (t("admin.custom_styles.theme_warning") if @current_theme.blank?)
+          }
+        ) do %>
+      <%= render(
+            Primer::Alpha::Select.new(
+              name: "theme",
+              label: t("admin.custom_styles.color_theme"),
+              caption: t("admin.custom_styles.color_theme_caption"),
+              input_width: :large,
+              data: {
+                action: "auto-submit#submit",
+                test_selector: "color-theme-select"
+              }
+            )
+          ) do |select| %>
+        <% @theme_options.each do |option| %>
+          <% label, value, attributes = option.is_a?(Array) ? option : [option, option, {}] %>
+          <% select.option(
+               label:,
+               value:,
+               selected: attributes&.fetch(:selected, value == @current_theme),
+               disabled: attributes&.fetch(:disabled, false)
+             ) %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/custom_styles/show.html.erb
+++ b/app/views/custom_styles/show.html.erb
@@ -36,37 +36,42 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render(Admin::DesignHeaderComponent.new(tabs: design_tabs)) %>
   <%= error_messages_for "custom_style" %>
   <% if show_theme_selector? %>
-    <%= form_tag(
-          update_design_themes_path,
-          method: :post,
-          data: {
-            controller: "auto-submit",
-            turbo_confirm: (t("admin.custom_styles.theme_warning") if @current_theme.blank?)
-          }
-        ) do %>
-      <%= render(
-            Primer::Alpha::Select.new(
-              name: "theme",
-              label: t("admin.custom_styles.color_theme"),
-              caption: t("admin.custom_styles.color_theme_caption"),
-              input_width: :large,
-              data: {
-                action: "auto-submit#submit",
-                test_selector: "color-theme-select"
-              }
-            )
-          ) do |select| %>
-        <% @theme_options.each do |option| %>
-          <% label, value, attributes = option.is_a?(Array) ? option : [option, option, {}] %>
-          <% select.option(
-               label:,
-               value:,
-               selected: attributes&.fetch(:selected, value == @current_theme),
-               disabled: attributes&.fetch(:disabled, false)
-             ) %>
-        <% end %>
-      <% end %>
-    <% end %>
+    <% theme_options = @theme_options %>
+    <% current_theme = @current_theme %>
+    <%=
+      primer_form_with(
+        url: update_design_themes_path,
+        method: :post,
+        data: {
+          controller: "auto-submit",
+          turbo_confirm: (t("admin.custom_styles.theme_warning") if @current_theme.blank?)
+        }
+      ) do |form_builder|
+        render_inline_form(form_builder) do |form|
+          form.select_list(
+            name: :theme,
+            label: helpers.t("admin.custom_styles.color_theme"),
+            caption: helpers.t("admin.custom_styles.color_theme_caption"),
+            input_width: :medium,
+            scope_name_to_model: false,
+            data: {
+              action: "auto-submit#submit",
+              test_selector: "color-theme-select"
+            }
+          ) do |select|
+            theme_options.each do |option|
+              label, value, attributes = option.is_a?(Array) ? option : [option, option, {}]
+              select.option(
+                label:,
+                value:,
+                selected: attributes&.fetch(:selected, value == current_theme),
+                disabled: attributes&.fetch(:disabled, false)
+              )
+            end
+          end
+        end
+      end
+    %>
   <% end %>
 
   <%= render_tabs design_tabs %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1379,14 +1379,13 @@ en:
     banners:
       environment_configured_readonly: "These values are configured via environment variables and cannot be edited here."
     custom_styles:
-      color_theme: "Color theme"
-      color_theme_caption: "Use one of the default OpenProject themes or create your own theme with your colors by selecting Custom theme."
-      color_theme_custom: "(Custom)"
       color_groups:
         base_colors: "Base colors"
         main_menu: "Main lateral menu"
         top_header_colors: "Top header colors"
-      edit_color: "Edit %{color}"
+      color_theme: "Color theme"
+      color_theme_caption: "Use one of the default OpenProject themes or create your own theme with your colors by selecting Custom theme."
+      color_theme_custom: "(Custom)"
       colors:
         accent-color: "Accent"
         header-bg-color: "Header background"
@@ -1394,6 +1393,7 @@ en:
         main-menu-bg-selected-background: "Main menu when selected"
         primary-button-color: "Primary button"
       custom_colors: "Custom colors"
+      edit_color: "Edit %{color}"
       fonts:
         file_is_invalid: "is not a valid TTF font file."
         file_too_large: "is too large (maximum size is %{count} MB)."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1380,7 +1380,13 @@ en:
       environment_configured_readonly: "These values are configured via environment variables and cannot be edited here."
     custom_styles:
       color_theme: "Color theme"
+      color_theme_caption: "Use one of the default OpenProject themes or create your own theme with your colors by selecting Custom theme."
       color_theme_custom: "(Custom)"
+      color_groups:
+        base_colors: "Base colors"
+        main_menu: "Main lateral menu"
+        top_header_colors: "Top header colors"
+      edit_color: "Edit %{color}"
       colors:
         accent-color: "Accent"
         header-bg-color: "Header background"
@@ -1393,7 +1399,9 @@ en:
         file_too_large: "is too large (maximum size is %{count} MB)."
       instructions:
         accent-color: "Color for links and other decently highlighted elements."
+        header-bg-color: "Default background color of the app header."
         main-menu-bg-color: "Left side menu's background color."
+        main-menu-bg-selected-background: "Background color of menu items when selected."
         primary-button-color: "Strong accent color, used for the most important button on a screen."
       manage_colors: "Edit color select options"
       tab_branding: "Branding"

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -713,6 +713,20 @@ RSpec.describe CustomStylesController do
       end
     end
 
+    describe "#update_themes", with_ee: %i[define_custom_style] do
+      let!(:custom_style) { create(:custom_style) }
+
+      before do
+        post :update_themes, params: { theme: "OpenProject Gray", tab: :branding }
+      end
+
+      it "updates the theme and redirects to the selected tab" do
+        expect(custom_style.reload.theme).to eq("OpenProject Gray")
+        expect(flash[:notice]).to eq(I18n.t(:notice_successful_update))
+        expect(response).to redirect_to(action: :show, tab: :branding)
+      end
+    end
+
     describe "update with export font uploads", with_ee: %i[define_custom_style] do
       let(:custom_style) { create(:custom_style) }
       let(:font_file) { Rack::Test::UploadedFile.new(Rails.public_path.join("fonts/noto-emoji/NotoEmoji.ttf"), "font/ttf") }

--- a/spec/features/custom_styles/tabs_navigation_spec.rb
+++ b/spec/features/custom_styles/tabs_navigation_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       find_test_selector("edit-design-color-accent-color").click
       fill_in "design_colors[]accent-color", with: "#333333"
       find_test_selector("save-design-color-accent-color").click
-      expect(page).to have_css("#design_colors_accent-color", value: "#333333")
+
+      expect(page).to have_text("#333333")
+      expect(DesignColor.find_by(variable: "accent-color").hexcode).to eq("#333333")
       expect(page).to have_current_path custom_style_path(tab: "interface")
     end
 

--- a/spec/features/custom_styles/tabs_navigation_spec.rb
+++ b/spec/features/custom_styles/tabs_navigation_spec.rb
@@ -57,19 +57,53 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
     it "shows interface tab" do
       expect(page).to have_current_path custom_style_path(tab: "interface")
       expect(page).to have_text I18n.t(:label_interface_colors)
+      %i[base_colors top_header_colors main_menu].each do |group_name|
+        expect(page).to have_test_selector("design-color-group-#{group_name}")
+      end
+      %w[
+        primary-button-color
+        accent-color
+        header-bg-color
+        main-menu-bg-color
+        main-menu-bg-selected-background
+      ].each do |variable|
+        expect(page).to have_test_selector("edit-design-color-#{variable}")
+      end
     end
 
-    it "selects a color theme and redirect to the interface tab" do
+    it "renders an auto-submitting theme selector on the interface tab" do
+      selector = find_test_selector("color-theme-select")
+
+      expect(selector["data-action"]).to eq("auto-submit#submit")
+      expect(selector.find(:xpath, "ancestor::form")["data-controller"]).to eq("auto-submit")
+    end
+
+    it "selects a color theme", :js do
       select("OpenProject Gray", from: "theme")
-      find("[data-test-selector='color-theme-button']").click
+
       expect_flash(message: I18n.t(:notice_successful_update))
+      expect(page).to have_select("theme", selected: "OpenProject Gray")
       expect(page).to have_current_path custom_style_path(tab: "interface")
+      expect(custom_style.reload.theme).to eq("OpenProject Gray")
     end
 
     it "changes accent color and redirects to interface tab" do
+      find_test_selector("edit-design-color-accent-color").click
       fill_in "design_colors[]accent-color", with: "#333333"
-      find("[data-test-selector='interface-colors-button']").click
+      find_test_selector("save-design-color-accent-color").click
       expect(page).to have_css("#design_colors_accent-color", value: "#333333")
+      expect(page).to have_current_path custom_style_path(tab: "interface")
+    end
+
+    it "restores the inherited color by clearing an override" do
+      create(:design_color, variable: "accent-color", hexcode: "#333333")
+      visit custom_style_path(tab: "interface")
+
+      find_test_selector("edit-design-color-accent-color").click
+      fill_in "design_colors[]accent-color", with: ""
+      find_test_selector("save-design-color-accent-color").click
+
+      expect(DesignColor.find_by(variable: "accent-color")).to be_nil
       expect(page).to have_current_path custom_style_path(tab: "interface")
     end
 
@@ -77,11 +111,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       click_on "Branding"
       expect(page).to have_current_path custom_style_path(tab: "branding")
 
-      # select a color theme and redirect to the branding tab
-      select("OpenProject Navy Blue", from: "theme")
-      find("[data-test-selector='color-theme-button']").click
-      expect_flash(message: I18n.t(:notice_successful_update))
-      expect(page).to have_current_path custom_style_path(tab: "branding")
+      expect(page).to have_test_selector("color-theme-select")
 
       # remove the logo and redirect to the branding tab
       custom_style.send :remove_logo!
@@ -95,7 +125,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
 
       # change export cover text color and redirect to the PDF export styles tab
       fill_in "export_cover_text_color", with: "#333"
-      find("[data-test-selector='text-color-change']").click
+      find_test_selector("text-color-change").click
       expect(page).to have_css("#export_cover_text_color", value: "#333")
       expect(page).to have_current_path custom_style_path(tab: "pdf_export_styles")
     end

--- a/spec/features/custom_styles/tabs_navigation_spec.rb
+++ b/spec/features/custom_styles/tabs_navigation_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       expect(custom_style.reload.theme).to eq("OpenProject Gray")
     end
 
-    it "changes accent color and redirects to interface tab" do
+    it "changes accent color and redirects to interface tab", :js do
       find_test_selector("edit-design-color-accent-color").click
       fill_in "design_colors[]accent-color", with: "#333333"
       find_test_selector("save-design-color-accent-color").click
@@ -95,7 +95,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       expect(page).to have_current_path custom_style_path(tab: "interface")
     end
 
-    it "restores the inherited color by clearing an override" do
+    it "restores the inherited color by clearing an override", :js do
       create(:design_color, variable: "accent-color", hexcode: "#333333")
       visit custom_style_path(tab: "interface")
 

--- a/spec/features/custom_styles/tabs_navigation_spec.rb
+++ b/spec/features/custom_styles/tabs_navigation_spec.rb
@@ -107,11 +107,15 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       expect(page).to have_current_path custom_style_path(tab: "interface")
     end
 
-    it "redirects to branding tab" do
+    it "redirects to branding tab", :js do
       click_on "Branding"
       expect(page).to have_current_path custom_style_path(tab: "branding")
-
       expect(page).to have_test_selector("color-theme-select")
+
+      # select a color theme and redirect to the branding tab
+      select("OpenProject Navy Blue", from: "theme")
+      expect_flash(message: I18n.t(:notice_successful_update))
+      expect(page).to have_current_path custom_style_path(tab: "branding")
 
       # remove the logo and redirect to the branding tab
       custom_style.send :remove_logo!


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-76

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Primerise interface tab in admin->design(interface)

## Screenshots
<img width="1397" height="1127" alt="Screenshot 2026-08-20 at 13 51 33" src="https://github.com/user-attachments/assets/53c97a00-0bcd-4509-9196-06d5ebe187e3" />