### PR TITLE
[MEET-458] Make meeting default date today. Time now (rounded)  

### DIFF
--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -91,10 +91,15 @@ module Meeting::VirtualStartTime
   end
 
   def set_initial_values
-    # set defaults
-    # Start date is set to tomorrow at 10 AM (Current users local time)
-    self[:start_time] = time_zone.now.at_midnight + 34.hours if start_time.nil?
+    self[:start_time] = default_start_time if start_time.nil?
     update_derived_fields
+  end
+
+  ##
+  # Defaults to now, rounded up to the next half hour
+  def default_start_time
+    now = time_zone.now.change(sec: 0)
+    now + ((30 - (now.min % 30)) % 30).minutes
   end
 
   ##

--- a/modules/meeting/spec/features/meeting_notifications_spec.rb
+++ b/modules/meeting/spec/features/meeting_notifications_spec.rb
@@ -97,6 +97,9 @@ RSpec.describe "Meeting notifications", :js do
     include_examples "notification checkbox behaviour"
 
     it "sets and toggles the calendar updates state" do
+      # a time comfortably away from the now-based default start time, so editing is a real change
+      edit_start_time = 4.hours.from_now.strftime("%H:00")
+
       # check if the default is set correctly
       expect(meeting.notify).to be false
 
@@ -129,7 +132,7 @@ RSpec.describe "Meeting notifications", :js do
 
       page.within(".Overlay") do
         expect(page).to have_test_selector("notifications-banner")
-        show_page.set_start_time "12:00"
+        show_page.set_start_time edit_start_time
         click_on "Save"
       end
 
@@ -168,7 +171,7 @@ RSpec.describe "Meeting notifications", :js do
 
       page.within(".Overlay") do
         expect(page).to have_test_selector("notifications-banner")
-        show_page.set_start_time "12:00"
+        show_page.set_start_time edit_start_time
         click_on "Save"
       end
 
@@ -260,6 +263,10 @@ RSpec.describe "Meeting notifications", :js do
     end
 
     it "can set and toggle the calendar updates state for the template and occurrences" do
+      # times comfortably away from the now-based default start time, so each edit is a real change
+      template_start_time = 4.hours.from_now.strftime("%H:00")
+      occurrence_start_time = 5.hours.from_now.strftime("%H:00")
+
       template_page.visit!
 
       expect(meeting.template.notify).to be false
@@ -291,7 +298,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within(".Overlay") do
         expect(page).to have_test_selector("notifications-banner")
         expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
-        template_page.set_start_time "12:00"
+        template_page.set_start_time template_start_time
         wait_for_network_idle
         click_on "Save"
       end
@@ -322,7 +329,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within(".Overlay") do
         expect(page).to have_test_selector("notifications-banner")
         expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
-        occurrence_page.set_start_time "13:00"
+        occurrence_page.set_start_time occurrence_start_time
         wait_for_network_idle
         click_on "Save"
       end

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe Meeting do
         expect(meeting.start_time).to eq(Time.zone.today + 10.hours)
       end
     end
+
+    describe "default start_time" do
+      let(:meeting) { described_class.new(project:) }
+
+      it "defaults to today, now, rounded up to the next half hour" do
+        travel_to(Time.zone.local(2026, 8, 20, 9, 12)) do
+          expect(meeting.start_time).to eq(Time.zone.local(2026, 8, 20, 9, 30))
+        end
+      end
+
+      it "keeps the time when already on a half-hour boundary" do
+        travel_to(Time.zone.local(2026, 8, 20, 9, 30)) do
+          expect(meeting.start_time).to eq(Time.zone.local(2026, 8, 20, 9, 30))
+        end
+      end
+    end
   end
 
   describe "participants and author as watchers" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-458

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
