### PR TITLE
TokenFetcher: Replace optimistic locking with pessimistic locking

### DIFF
--- a/app/services/oauth_clients/token_fetcher.rb
+++ b/app/services/oauth_clients/token_fetcher.rb
@@ -49,16 +49,18 @@ module OAuthClients
     # Obtains an access token for the given OAuthClient, refreshing it beforehand if necessary.
     def access_token_for(oauth_client:)
       log_debug("Obtaining token at client #{oauth_client&.id}.")
-      token = OAuthClientToken.find_by(user:, oauth_client:)
-      if token.nil?
-        log_warn("Could not find an existing token.")
-        return Failure(SimpleError.new(source: self.class, code: :missing_token))
-      end
+      OAuthClientToken.transaction do
+        token = OAuthClientToken.lock("FOR UPDATE").find_by(user:, oauth_client:)
+        if token.nil?
+          log_warn("Could not find an existing token.")
+          return Failure(SimpleError.new(source: self.class, code: :missing_token))
+        end
 
-      if expired?(token)
-        refresh(token)
-      else
-        Success(token.access_token)
+        if expired?(token)
+          refresh(token)
+        else
+          Success(token.access_token)
+        end
       end
     end
 
@@ -73,13 +75,7 @@ module OAuthClients
           return Failure(SimpleError.new(source: self.class, code: :token_refresh_response_invalid))
         end
 
-        begin
-          token.update!(access_token:, refresh_token:, expires_in:)
-        rescue ActiveRecord::StaleObjectError
-          log_info("Access token was already refreshed in background. Reloading from database.")
-          token.reload
-        end
-
+        token.update!(access_token:, refresh_token:, expires_in:)
         Success(token.access_token)
       end
     end

--- a/spec/services/oauth_clients/token_fetcher_spec.rb
+++ b/spec/services/oauth_clients/token_fetcher_spec.rb
@@ -110,33 +110,63 @@ RSpec.describe OAuthClients::TokenFetcher, :webmock do
       )
     end
 
-    context "and when the token was concurrently refreshed in the background" do
-      let(:changed_access_token) { "changed-access-token" }
-      let(:changed_refresh_token) { "changed-refresh-token" }
+    context "and when the token is concurrently being refreshed in the background" do
+      subject(:fetch_token) do
+        concurrency_semaphore.release
+        described_class.new(user:).access_token_for(oauth_client:)
+      end
 
-      before do
-        allow(OAuthClientToken).to receive(:find_by) do |user:, oauth_client:|
-          result = OAuthClientToken.where(user:, oauth_client:).first
+      # Semaphore used to ensure that the background thread performs the first request
+      let(:startup_semaphore) { Concurrent::Semaphore.new(0) }
 
-          # changing the token in the background, without reflecting the result back into the returned value
-          OAuthClientToken.where(user:, oauth_client:).update_all(
-            access_token: changed_access_token,
-            refresh_token: changed_refresh_token,
-            lock_version: result.lock_version + 1 # lock_version needs manual update during update_all
-          )
+      # Semaphore used to slow down response of background thread enough to ensure that the foreground
+      # thread had to wait for the background thread
+      let(:concurrency_semaphore) { Concurrent::Semaphore.new(0) }
 
-          result
+      let(:token_request) do
+        instance_double(OAuthClients::TokenRequest).tap do |request|
+          # RSpec seems to have multi-threading limits, calculating refresh_response while the main thread is locked up does
+          # not seem to work. Thus we assign it outside of the mocked response block below
+          response = refresh_response
+          main_thread = Thread.current
+          first_request = true
+          allow(request).to receive(:refresh) do
+            unless first_request
+              next Success(
+                { "access_token" => "wrong-access-token", "refresh_token" => "wrong-refresh-token", "expires_in" => new_ttl }
+              )
+            end
+            first_request = false
+            startup_semaphore.release
+            concurrency_semaphore.acquire
+            # our test locking is imperfect: we want to continue here, once the foreground thread ran into the SQL lock
+            # we are testing. So we give the foreground thread additional time to acquire the lock-under-test
+            loop do
+              sleep(0.5)
+              break if main_thread.status == "sleep"
+            end
+
+            response
+          end
         end
       end
 
-      it "keeps the originally refreshed value" do
-        fetch_token
-        expect(existing_token.reload).to have_attributes(access_token: changed_access_token, refresh_token: changed_refresh_token)
+      before do
+        Thread.new do
+          described_class.new(user:).access_token_for(oauth_client:)
+        end
+
+        startup_semaphore.acquire
       end
 
-      it "returns the refreshed access token" do
+      it "refreshes the token only once (in the background)" do
+        fetch_token
+        expect(token_request).to have_received(:refresh).once
+      end
+
+      it "returns the previously refreshed token on the foreground request" do
         expect(fetch_token).to be_success
-        expect(fetch_token.value!).to eq(changed_access_token)
+        expect(fetch_token.value!).to eq(new_access_token)
       end
     end
 


### PR DESCRIPTION
Changing locking mode in the TokenFetcher. Instead of locking optimistically around the update of the stored values, we'll lock pessimistically around the entire fetching of an access token — even if no refresh happens.

This avoids concurrent refreshes of the same token entirely, which can be beneficial if the OAuth server invalidates a refresh token after using it. The old approach may have led to rejected refreshes in such cases, while the new approach ensures that exactly one refresh will happen.

# Ticket
https://community.openproject.org/wp/SI-238