### PR TITLE
Limit the list of filters for Resource Management to a sane list

### DIFF
--- a/modules/resource_management/app/components/resource_planner_views/configure_step/form_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/configure_step/form_component.html.erb
@@ -63,7 +63,7 @@
                 ::Filters::FilterFormComponent.new(
                   builder: f,
                   query: @filter_query,
-                  excluded_filters:,
+                  allowed_filters:,
                   wrap_with_controller: true,
                   hidden_input_name: "filters",
                   output_format: :json,

--- a/modules/resource_management/app/components/resource_planner_views/configure_step/form_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/configure_step/form_component.rb
@@ -72,10 +72,10 @@ module ResourcePlannerViews
         @filter_query.present?
       end
 
-      # Filters the view withholds from configuration (e.g. the project filter
-      # for work-package views, which must not override the project scoping).
-      def excluded_filters
-        @view.try(:excluded_configuration_filters) || []
+      # The filters the view offers for configuration. Falls back to the query's
+      # full set for views that do not curate one.
+      def allowed_filters
+        @view.try(:configuration_filters, @filter_query)
       end
 
       # ::ResourceUserCard disambiguates from the ResourcePlannerViews::ResourceUserCard contracts namespace.

--- a/modules/resource_management/app/models/concerns/resource_management/user_selection.rb
+++ b/modules/resource_management/app/models/concerns/resource_management/user_selection.rb
@@ -32,6 +32,22 @@ module ResourceManagement
   module UserSelection
     extend ActiveSupport::Concern
 
+    # `AnyNameAttributeFilter` is absent because it exists to back autocompleter
+    # searches rather than human filtering; `NameFilter` covers that case in the
+    # picker.
+    CONFIGURATION_FILTERS = [
+      ::Queries::Users::Filters::CustomFieldFilter,
+      ::Queries::Users::Filters::GroupFilter,
+      ::Queries::Users::Filters::LoginFilter,
+      ::Queries::Users::Filters::MemberFilter,
+      ::Queries::Users::Filters::NameFilter,
+      ::Queries::Users::Filters::StatusFilter
+    ].freeze
+
+    # The custom field filter's key is a `cf_<id>` pattern rather than a single
+    # name, hence the `===` match rather than a set lookup.
+    CONFIGURATION_FILTER_KEYS = CONFIGURATION_FILTERS.map(&:key).freeze
+
     included do
       validate :query_must_be_user_query
     end
@@ -59,10 +75,19 @@ module ResourceManagement
       nil
     end
 
-    # No filters are withheld when configuring a user view; the project scoping
-    # is applied outside the filter set (`results.in_project`).
-    def excluded_configuration_filters
-      []
+    # The filters offered when configuring the view, alphabetically as they
+    # appear in the picker. The project scoping is applied outside the filter set
+    # (`results.in_project`), so no filter can override it.
+    def configuration_filters(query)
+      return [] if query.nil?
+
+      query.available_advanced_filters
+           .select { |filter| configuration_filter?(filter.name) }
+           .sort_by(&:human_name)
+    end
+
+    def configuration_filter?(name)
+      CONFIGURATION_FILTER_KEYS.any? { |key| key === name.to_sym }
     end
 
     def build_default_query
@@ -99,11 +124,10 @@ module ResourceManagement
       end
     end
 
+    # Drops anything the configuration UI does not offer, so a hand-crafted
+    # payload cannot smuggle in a withheld filter.
     def allowed_configuration_filters(filters)
-      excluded = excluded_configuration_filters.map(&:to_s)
-      return filters if excluded.empty?
-
-      filters.reject { |filter| excluded.include?(filter[:attribute].to_s) }
+      filters.select { |filter| configuration_filter?(filter[:attribute]) }
     end
 
     def parse_filters(filters_json)

--- a/modules/resource_management/app/models/concerns/resource_management/work_package_selection.rb
+++ b/modules/resource_management/app/models/concerns/resource_management/work_package_selection.rb
@@ -35,6 +35,45 @@ module ResourceManagement
     # The "ow" (ordered work packages) filter restricts results to a hand-picked set.
     MANUAL_FILTER_NAME = "manual_sort"
 
+    # Work package queries advertise roughly fifty filters, most of which exist
+    # to back autocompleters, full-text search, storage integrations or relation
+    # lookups rather than resource planning. Only the attributes a planner
+    # allocates by are offered, plus custom fields.
+    #
+    # `ProjectFilter` is deliberately absent: the view is always scoped to its
+    # planner's project and a configured filter must not override that scoping.
+    CONFIGURATION_FILTERS = [
+      ::Queries::WorkPackages::Filter::CustomFieldFilter,
+      ::Queries::WorkPackages::Filter::AncestorFilter,
+      ::Queries::WorkPackages::Filter::AssignedToFilter,
+      ::Queries::WorkPackages::Filter::AssigneeOrGroupFilter,
+      ::Queries::WorkPackages::Filter::AuthorFilter,
+      ::Queries::WorkPackages::Filter::CategoryFilter,
+      ::Queries::WorkPackages::Filter::CreatedAtFilter,
+      ::Queries::WorkPackages::Filter::DatesIntervalFilter,
+      ::Queries::WorkPackages::Filter::DoneRatioFilter,
+      ::Queries::WorkPackages::Filter::DueDateFilter,
+      ::Queries::WorkPackages::Filter::DurationFilter,
+      ::Queries::WorkPackages::Filter::EstimatedHoursFilter,
+      ::Queries::WorkPackages::Filter::GroupFilter,
+      ::Queries::WorkPackages::Filter::IdFilter,
+      ::Queries::WorkPackages::Filter::ParentFilter,
+      ::Queries::WorkPackages::Filter::PriorityFilter,
+      ::Queries::WorkPackages::Filter::ProjectPhaseFilter,
+      ::Queries::WorkPackages::Filter::ResponsibleFilter,
+      ::Queries::WorkPackages::Filter::RoleFilter,
+      ::Queries::WorkPackages::Filter::StartDateFilter,
+      ::Queries::WorkPackages::Filter::StatusFilter,
+      ::Queries::WorkPackages::Filter::SubjectFilter,
+      ::Queries::WorkPackages::Filter::TargetVersionsFilter,
+      ::Queries::WorkPackages::Filter::TypeFilter,
+      ::Queries::WorkPackages::Filter::UpdatedAtFilter
+    ].freeze
+
+    # The custom field filter's key is a `cf_<id>` pattern rather than a single
+    # name, hence the `===` match rather than a set lookup.
+    CONFIGURATION_FILTER_KEYS = CONFIGURATION_FILTERS.map(&:key).freeze
+
     included do
       validate :query_must_be_work_package_query
     end
@@ -87,11 +126,19 @@ module ResourceManagement
       nil
     end
 
-    # Filters never offered when configuring the view. The view is always scoped
-    # to its planner's project, so a project filter must not be added on top of
-    # (and override) that built-in scoping.
-    def excluded_configuration_filters
-      %i[project_id]
+    # The filters offered when configuring the view, alphabetically as they
+    # appear in the picker. Takes the query rather than reading `effective_query`
+    # so the new-view dialog can advertise them before the view has one.
+    def configuration_filters(query)
+      return [] if query.nil?
+
+      query.available_advanced_filters
+           .select { |filter| configuration_filter?(filter.name) }
+           .sort_by(&:human_name)
+    end
+
+    def configuration_filter?(name)
+      CONFIGURATION_FILTER_KEYS.any? { |key| key === name.to_sym }
     end
 
     private
@@ -132,11 +179,11 @@ module ResourceManagement
       end
     end
 
-    # Drops any excluded filter that slipped into the payload so it can never
-    # override the built-in project scoping, regardless of the form.
+    # Drops anything the configuration UI does not offer, so a hand-crafted
+    # payload cannot smuggle in a withheld filter — the project filter in
+    # particular, which would override the built-in project scoping.
     def allowed_configuration_filters(filters)
-      excluded = excluded_configuration_filters.map(&:to_s)
-      filters.reject { |filter| excluded.include?(filter[:attribute].to_s) }
+      filters.select { |filter| configuration_filter?(filter[:attribute]) }
     end
 
     def parse_filters(filters_json)

--- a/modules/resource_management/spec/models/resource_user_card_spec.rb
+++ b/modules/resource_management/spec/models/resource_user_card_spec.rb
@@ -70,12 +70,55 @@ RSpec.describe ResourceUserCard do
     end
   end
 
+  describe "#configuration_filters" do
+    shared_let(:custom_field) { create(:user_custom_field, field_format: "string") }
+    shared_let(:group) { create(:group) }
+
+    subject(:offered) { view.configuration_filters(view.build_default_query).map(&:name) }
+
+    before do
+      login_as(user)
+    end
+
+    it "offers the attributes a planner picks team members by" do
+      expect(offered).to include(:name, :login, :status, :group, :member, :"cf_#{custom_field.id}")
+    end
+
+    it "withholds the name attribute filter that only backs autocompleter searches" do
+      expect(offered).not_to include(:any_name_attribute)
+    end
+
+    it "withholds the blocked filter" do
+      expect(offered).not_to include(:blocked)
+    end
+
+    it "sorts them by their human name so the picker reads alphabetically" do
+      names = view.configuration_filters(view.build_default_query).map(&:human_name)
+
+      expect(names).to eq(names.sort)
+    end
+
+    it "returns nothing without a query" do
+      expect(view.configuration_filters(nil)).to be_empty
+    end
+  end
+
   describe "#apply_query_configuration" do
     context "in automatic mode" do
       it "replaces the query filters with the automatic selection" do
         view.apply_query_configuration(
           filter_mode: "automatic",
           filters_json: filters_json({ status: { operator: "=", values: ["active"] } })
+        )
+
+        expect(view.query.filters.map(&:name)).to contain_exactly(:status)
+      end
+
+      it "ignores a filter the configuration UI does not offer" do
+        view.apply_query_configuration(
+          filter_mode: "automatic",
+          filters_json: filters_json({ blocked: { operator: "t", values: [] } },
+                                     { status: { operator: "=", values: ["active"] } })
         )
 
         expect(view.query.filters.map(&:name)).to contain_exactly(:status)

--- a/modules/resource_management/spec/models/resource_work_package_list_spec.rb
+++ b/modules/resource_management/spec/models/resource_work_package_list_spec.rb
@@ -54,6 +54,71 @@ RSpec.describe ResourceWorkPackageList do
     end
   end
 
+  describe "#configuration_filters" do
+    # A filter only shows up once it reports itself `available?`, so the
+    # attributes it depends on have to exist for the positive assertions.
+    shared_let(:status) { create(:status) }
+    shared_let(:priority) { create(:issue_priority) }
+
+    subject(:offered) { view.configuration_filters(view.build_default_query).map(&:name) }
+
+    before do
+      login_as(user)
+    end
+
+    it "offers the attributes a planner allocates by" do
+      expect(offered).to include(:type_id, :status_id, :priority_id, :assigned_to_id, :responsible_id,
+                                 :start_date, :due_date, :dates_interval, :estimated_hours, :done_ratio,
+                                 :target_version_id)
+    end
+
+    it "withholds the project filter so it cannot override the planner's project scoping" do
+      expect(offered).not_to include(:project_id)
+    end
+
+    it "withholds the filters that back autocompleters and full-text search" do
+      expect(offered).not_to include(:typeahead, :search, :subject_or_id, :relatable,
+                                     :attachment_content, :attachment_file_name,
+                                     :description, :comment)
+    end
+
+    it "withholds the storage integration filters" do
+      expect(offered).not_to include(:storage_id, :storage_url, :linkable_to_storage_id,
+                                     :linkable_to_storage_url, :file_link_origin_id)
+    end
+
+    it "withholds the relation filters" do
+      expect(offered).not_to include(:precedes, :follows, :relates, :blocks, :blocked,
+                                     :duplicates, :duplicated, :partof, :includes,
+                                     :requires, :required)
+    end
+
+    it "sorts them by their human name so the picker reads alphabetically" do
+      names = view.configuration_filters(view.build_default_query).map(&:human_name)
+
+      expect(names).to eq(names.sort)
+    end
+
+    it "returns nothing without a query" do
+      expect(view.configuration_filters(nil)).to be_empty
+    end
+
+    context "with an active work package custom field" do
+      shared_let(:custom_field) do
+        create(:work_package_custom_field, field_format: "string", is_for_all: true, is_filter: true)
+      end
+
+      before do
+        project.work_package_custom_fields << custom_field
+        project.types.each { |type| type.custom_fields << custom_field }
+      end
+
+      it "offers it alongside the built-in attributes" do
+        expect(offered).to include(:"cf_#{custom_field.id}")
+      end
+    end
+  end
+
   describe "#apply_query_configuration" do
     context "in automatic mode" do
       it "replaces the query filters with the serialized selection" do
@@ -84,10 +149,21 @@ RSpec.describe ResourceWorkPackageList do
         expect(view).not_to be_manually_picked
       end
 
-      it "ignores excluded filters so the project scoping cannot be overridden" do
+      it "ignores a withheld project filter so the project scoping cannot be overridden" do
         view.apply_query_configuration(
           filter_mode: "automatic",
           filters_json: filters_json({ project_id: { operator: "=", values: ["999"] } },
+                                     { assigned_to_id: { operator: "=", values: [user.id.to_s] } })
+        )
+
+        expect(view.query.filters.map(&:name)).to contain_exactly(:assigned_to_id)
+      end
+
+      it "ignores any other filter the configuration UI does not offer" do
+        view.apply_query_configuration(
+          filter_mode: "automatic",
+          filters_json: filters_json({ watcher_id: { operator: "=", values: [user.id.to_s] } },
+                                     { linkable_to_storage_id: { operator: "=", values: ["1"] } },
                                      { assigned_to_id: { operator: "=", values: [user.id.to_s] } })
         )
 

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -126,8 +126,17 @@ RSpec.describe "Projects autocomplete page", :js do
     # Expect hierarchy
     top_menu.clear_search
 
+    # The unfiltered tree collapses back to its initial state, so the child is
+    # hidden until its ancestor is expanded. Waiting for it to disappear also
+    # keeps the assertions below from reading the still-filtered tree, which
+    # lingers for the duration of the search debounce.
+    top_menu.expect_no_result "Plain other project"
+
     top_menu.expect_result "Plain project"
-    top_menu.expect_result "<strong>foobar</strong>", disabled: true
+    # Nothing is filtered out without a query, so the ancestor is selectable.
+    top_menu.expect_result "<strong>foobar</strong>"
+
+    top_menu.expand_node_for "<strong>foobar</strong>"
     top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
                                               item_name: "Plain other project"
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-20002/activity

# What are you trying to accomplish?
- We just added all filters for the filter component when creating resource planner views
- Instead we now only show a handpicked list.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
