### PR TITLE
Fix flaky frontend specs: don't assume `setTimeout` fires before rAF

### DIFF
--- a/frontend/src/stimulus/controllers/disable-when-clicked.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/disable-when-clicked.controller.spec.ts
@@ -26,6 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { waitFor } from '@testing-library/dom';
+
 import DisableWhenClickedController from './disable-when-clicked.controller';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 
@@ -50,10 +52,10 @@ describe('DisableWhenClickedController', () => {
     const button = ctx.screen.getByRole('button', { name: 'Submit' });
 
     button.click();
-    // setTimeout(fn) defers by one task; nextFrame (rAF) fires after
-    await ctx.nextFrame();
 
-    expect(button).toBeDisabled();
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
   });
 
   it('replaces button text when text value is set', async () => {
@@ -67,9 +69,10 @@ describe('DisableWhenClickedController', () => {
     const button = ctx.screen.getByRole('button', { name: 'Submit' });
 
     button.click();
-    await ctx.nextFrame();
 
-    expect(button).toHaveTextContent('Processing...');
+    await waitFor(() => {
+      expect(button).toHaveTextContent('Processing...');
+    });
     expect(button).toBeDisabled();
   });
 
@@ -105,10 +108,10 @@ describe('DisableWhenClickedController', () => {
     const link = ctx.screen.getByRole('link', { name: '+ Document' });
 
     link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-    // setTimeout(fn) defers by one task; nextFrame (rAF) fires after
-    await ctx.nextFrame();
 
-    expect(link).toHaveAttribute('aria-disabled', 'true');
+    await waitFor(() => {
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+    });
   });
 
   it('resets its state when the element is disconnected and reconnected', async () => {
@@ -123,8 +126,9 @@ describe('DisableWhenClickedController', () => {
     const parent = link.parentElement!;
 
     link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-    await ctx.nextFrame();
-    expect(link).toHaveAttribute('aria-disabled', 'true');
+    await waitFor(() => {
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+    });
 
     // Detach and reattach to trigger disconnect() then connect() again, as
     // would happen during a Turbo cache/restore.

--- a/frontend/src/stimulus/controllers/scroll-into-view.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/scroll-into-view.controller.spec.ts
@@ -26,6 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { waitFor } from '@testing-library/dom';
+
 import ScrollIntoViewController from './scroll-into-view.controller';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 
@@ -48,10 +50,10 @@ describe('ScrollIntoViewController', () => {
         Target element
       </div>
     `);
-    // One extra frame for the setTimeout(fn, 0)
-    await ctx.nextFrame();
 
-    expect(scrollSpy).toHaveBeenCalledWith({ block: 'center' });
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledWith({ block: 'center' });
+    });
 
     scrollSpy.mockRestore();
   });


### PR DESCRIPTION
# Ticket

No work package — CI hygiene, found while triaging frontend spec flakes.

# What are you trying to accomplish?

Two frontend unit specs go red intermittently in CI ([#24844](https://github.com/opf/openproject/actions/runs/32360499832/job/96398885108), [#24622](https://github.com/opf/openproject/actions/runs/32342815267/job/96345264178), [#24463](https://github.com/opf/openproject/actions/runs/30934232446/job/92076187897)). Both controllers defer their effect with `setTimeout(fn, 0)`; both specs awaited a single `requestAnimationFrame` and asserted, on the assumption that the timer task always runs before the next rendering opportunity. Nothing guarantees that. When the frame wins, the assertion reads the pre-click DOM.

Measured with a probe queueing both in one task, 300 rounds on an idle machine: rAF ran first 23/300 in WebKit and 38/300 in Chromium. So this is **not** WebKit-specific, despite the sample above skewing that way.

# What approach did you choose and why?

Wait for the effect with `waitFor` from `@testing-library/dom` — already the idiom in 29 spec files here — instead of guessing a frame count. Applied to all five click-then-assert sites in the two files, since the other three carry the identical race. Adding a second `nextFrame()` would only have made the race less likely, and bending the controllers to suit the tests would be the wrong direction: the deferral is deliberate production behaviour.

Verified: eslint clean; 12 consecutive WebKit runs of both specs green; full `src/stimulus` suite on WebKit 65 files / 550 tests passing.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a, test-only change
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — n/a, no user-facing change
