### PR TITLE
[AGILE-397] Restore header description row gap

### DIFF
--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -25,14 +25,11 @@
 .op-border-box-list
   --op-border-box-list-header-row-gap: calc(var(--stack-gap-condensed) / 2)
 
-  &.Box--condensed
-    --op-border-box-list-header-row-gap: 0
-
   &.Box--spacious
     --op-border-box-list-header-row-gap: var(--stack-gap-condensed)
 
   &.op-border-box-list_header-padding-condensed
-    --op-border-box-list-header-row-gap: 0
+    --op-border-box-list-header-row-gap: calc(var(--stack-gap-condensed) / 2)
 
     > .Box-header
       padding-block: var(--stack-padding-condensed)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-397

# What are you trying to accomplish?

Restoring the gap between a BorderBox list header's title line and its description row.

`aa54da849b6` (#24456) moved the backlogs list components to `header_padding: :condensed`. That tier set `--op-border-box-list-header-row-gap: 0`, and the header's description area takes its `margin-top` from that property, so sprint headers lost the separation between the title/`Start sprint` line and the status/points/date row.

## Screenshots

Sprint headers in the Agile Backlogs page.

| Before | After |
| --- | --- |
| <img alt="Sprint headers with no gap below the title line" src="https://github.com/user-attachments/assets/a501780e-f4d2-4ccc-bf8d-f4f2fd9fb311" /> | <img alt="Sprint headers with a 4px gap below the title line" src="https://github.com/user-attachments/assets/5bc6702e-2ddc-408f-8b4f-49edefa897e5" /> |

# What approach did you choose and why?

Flooring the gap at 4px for every variant, rather than reverting `header_padding` on the backlogs components, so that no `padding:`/`header_padding:` combination can zero it out again. `spacious` tiers keep 8px.

The `.Box--condensed` block goes away entirely: it sat directly after the base declaration carrying the same value, so it could never win over a later rule of equal specificity.

Removing the `header_padding:` option altogether is agreed as a follow-up: [DREAM-812](https://community.openproject.org/wp/DREAM-812).

# Merge checklist

- [ ] Added/updated tests — a CSS custom property value is not assertable from a component or feature spec; verified in Lookbook across all `padding` × `header_padding` combinations instead
- [x] Added/updated documentation in Lookbook (patterns, previews, etc) — the playground preview already exposes both `padding` and `header_padding`
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — Chrome only so far
