### PR TITLE
Fix time entry error messages

### DIFF
--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -80,14 +80,24 @@ en:
             project_ids:
               blank: "Please select a project."
         time_entry:
-          cannot_log_for_this_work_package: "Cannot log time for this work package."
-          duplicate_ongoing: "An ongoing time entry already exists for this user."
-          exceeds_user_working_hours: "cannot exceed the %{limit} hours available on the user's working day."
-          in_past_month: "is in a month that is closed. Time entries can only be added, changed or deleted from %{date} onwards."
-          invalid_time: "must be between 00:00 and 23:59."
-          max_hours_per_day_exceeded: "cannot exceed %{limit} hours logged in total for a single day."
-          max_hours_per_entry_exceeded: "cannot be more than %{limit} hours for a single time entry."
-          not_a_working_day: "is not a working day for the user."
+          attributes:
+            entity:
+              blank: "Logged for can't be blank."
+              cannot_log_for_this_work_package: "You don't have permissions to log time for this work package."
+              format: "%{message}"
+            hours:
+              exceeds_user_working_hours: "The logged hours cannot exceed the limit of %{limit} hours available on the user's working day."
+              format: "%{message}"
+              max_hours_per_day_exceeded: "The logged hours cannot exceed the limit of %{limit} hours for a single day defined by the administrator."
+              max_hours_per_entry_exceeded: "The logged hours cannot exceed the limit of %{limit} hours for a single time entry defined by the administrator."
+            spent_on:
+              format: "%{message}"
+              in_past_month: "You can't plan time into a past month. Time entries can only be added, changed or deleted from %{date} onwards."
+              not_a_working_day: "The selected day is a non-working day for this user."
+            start_time:
+              format: "%{message}"
+              invalid_time: "Invalid time. The time must be between 00:00 and 23:59."
+          duplicate_ongoing: "Another timer is already running. Only one timer can be active at the same time."
         work_package:
           is_not_a_valid_target_for_cost_entries: "Work package #%{id} is not a valid target for reassigning the cost entries."
           nullify_is_not_valid_for_cost_entries: "Cost entries can not be assigned to a project."

--- a/modules/costs/spec/features/time_entry_dialog_spec.rb
+++ b/modules/costs/spec/features/time_entry_dialog_spec.rb
@@ -278,7 +278,8 @@ RSpec.describe "time entry dialog", :js do
         end.not_to change(TimeEntry, :count)
 
         time_logging_modal.field_has_error("hours_display",
-                                           "Hours cannot be more than 2 hours for a single time entry.")
+                                           "The logged hours cannot exceed the limit of 2 hours for a single time " \
+                                           "entry defined by the administrator.")
       end
     end
 
@@ -292,7 +293,8 @@ RSpec.describe "time entry dialog", :js do
         end.not_to change(TimeEntry, :count)
 
         time_logging_modal.field_has_error("hours_display",
-                                           "Hours cannot exceed 2 hours logged in total for a single day.")
+                                           "The logged hours cannot exceed the limit of 2 hours for a single day " \
+                                           "defined by the administrator.")
       end
 
       it "takes hours already logged on that day into account" do
@@ -306,7 +308,8 @@ RSpec.describe "time entry dialog", :js do
         end.not_to change(TimeEntry, :count)
 
         time_logging_modal.field_has_error("hours_display",
-                                           "Hours cannot exceed 2 hours logged in total for a single day.")
+                                           "The logged hours cannot exceed the limit of 2 hours for a single day " \
+                                           "defined by the administrator.")
 
         time_logging_modal.update_field("hours_display", "0.5")
 

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe TimeEntry do
       it "does not allow times > 23:59" do
         time_entry.start_time = "26:00"
         expect(time_entry).not_to be_valid
-        expect(time_entry.errors.full_messages).to include("Start time must be between 00:00 and 23:59.")
+        expect(time_entry.errors.full_messages).to include("Invalid time. The time must be between 00:00 and 23:59.")
       end
 
       it "does not allow non integer values" do

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe "API v3 time_entry resource" do
           .to be(422)
 
         expect(subject.body)
-          .to be_json_eql("An ongoing time entry already exists for this user.".to_json)
+          .to be_json_eql("Another timer is already running. Only one timer can be active at the same time.".to_json)
                 .at_path("message")
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-20008/activity

# What are you trying to accomplish?
- Used the texts provided by @marcalcobe 
- Error messages here are just generated from the message. Rails would normally prefix the field name ending up in "Hours The logged hours cannot exceed the limit of %{limit} hours for a single day defined by the administrator."

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
