### PR TITLE
Get rid of hardcoded IDs to provoke 404 errors, instead use `Model.maximum(:id) + 1`

### DIFF
--- a/modules/boards/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe "API v3 Grids resource for Board Grids", content_type: :json do
     end
 
     context "with the grid not existing" do
-      let(:path) { api_v3_paths.grid(1234) }
+      let(:path) { api_v3_paths.grid(not_existing_id(Boards::Grid)) }
 
       it "responds with 404 NOT FOUND" do
         expect(subject.status).to be 404

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe "API v3 file links resource" do
     end
 
     context "if no file link with that id exists" do
-      let(:path) { api_v3_paths.file_link(1337) }
+      let(:path) { api_v3_paths.file_link(not_existing_id(Storages::FileLink)) }
 
       it_behaves_like "not found"
     end
@@ -563,7 +563,7 @@ RSpec.describe "API v3 file links resource" do
     end
 
     context "if no file link with that id exists" do
-      let(:path) { api_v3_paths.file_link(1337) }
+      let(:path) { api_v3_paths.file_link(not_existing_id(Storages::FileLink)) }
 
       it_behaves_like "not found"
     end
@@ -594,7 +594,7 @@ RSpec.describe "API v3 file links resource" do
     end
 
     context "if no storage with that id exists" do
-      let(:path) { api_v3_paths.file_link(1337) }
+      let(:path) { api_v3_paths.file_link(not_existing_id(Storages::FileLink)) }
 
       it_behaves_like "not found"
     end

--- a/modules/storages/spec/requests/api/v3/storages/storages_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storages_api_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe "API v3 storages resource", :storage_server_helpers, :webmock, co
       end
 
       context "if no storage with that id exists" do
-        let(:path) { api_v3_paths.storage(1337) }
+        let(:path) { api_v3_paths.storage(not_existing_id(Storages::Storage)) }
 
         it_behaves_like "not found"
       end

--- a/spec/controllers/placeholder_users/memberships_controller_spec.rb
+++ b/spec/controllers/placeholder_users/memberships_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
       it "returns an error" do
         put :update, params: {
           placeholder_user_id: placeholder_user.id,
-          id: 1234
+          id: not_existing_id(Member)
         }
 
         expect(response).to have_http_status :not_found
@@ -91,7 +91,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
       it "returns an error" do
         delete :destroy, params: {
           placeholder_user_id: placeholder_user.id,
-          id: 1234
+          id: not_existing_id(Member)
         }
 
         expect(response).to have_http_status :not_found

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -147,10 +147,12 @@ RSpec.describe "Work package navigation", :js, :selenium do
   end
 
   it "loading an unknown work package ID" do
-    visit "/work_packages/999999999"
+    unknown_id = not_existing_id(WorkPackage)
+
+    visit "/work_packages/#{unknown_id}"
     expect_flash type: :error, message: I18n.t(:notice_file_not_found)
 
-    visit "/projects/#{project.identifier}/work_packages/999999999"
+    visit "/projects/#{project.identifier}/work_packages/#{unknown_id}"
     expect_flash type: :error, message: I18n.t(:notice_file_not_found)
   end
 

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe API::V3::Activities::ActivitiesAPI, content_type: :json do
       end
 
       context "requesting nonexistent activity" do
-        let(:get_path) { api_v3_paths.activity 9999 }
+        let(:get_path) { api_v3_paths.activity(not_existing_id(Journal)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -248,7 +248,7 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
       end
 
       context "requesting nonexistent attachment" do
-        let(:get_path) { api_v3_paths.attachment 9999 }
+        let(:get_path) { api_v3_paths.attachment(not_existing_id(Attachment)) }
 
         it_behaves_like "not found"
       end
@@ -396,7 +396,7 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
       it_behaves_like "deletes the attachment"
 
       context "for a non-existent attachment" do
-        let(:path) { api_v3_paths.attachment 1337 }
+        let(:path) { api_v3_paths.attachment(not_existing_id(Attachment)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/custom_fields/hierarchy/item_api_spec.rb
+++ b/spec/requests/api/v3/custom_fields/hierarchy/item_api_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "API v3 custom field items", :webmock, content_type: :json, with_
       end
 
       context "if custom field does not exist" do
-        let(:path) { api_v3_paths.custom_field_item(1337) }
+        let(:path) { api_v3_paths.custom_field_item(not_existing_id(CustomField::Hierarchy::Item)) }
 
         it_behaves_like "not found"
       end
@@ -100,7 +100,7 @@ RSpec.describe "API v3 custom field items", :webmock, content_type: :json, with_
       end
 
       context "if custom field does not exist" do
-        let(:path) { api_v3_paths.custom_field_items(1337) }
+        let(:path) { api_v3_paths.custom_field_items(not_existing_id(CustomField)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/custom_fields/hierarchy/items_api_spec.rb
+++ b/spec/requests/api/v3/custom_fields/hierarchy/items_api_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "API v3 custom field hierarchy items", :webmock, content_type: :j
       end
 
       context "if custom field does not exist" do
-        let(:path) { api_v3_paths.custom_field_items(1337) }
+        let(:path) { api_v3_paths.custom_field_items(not_existing_id(CustomField)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
     end
 
     context "requesting nonexistent group" do
-      let(:get_path) { api_v3_paths.group 9999 }
+      let(:get_path) { api_v3_paths.group(not_existing_id(Group)) }
 
       it_behaves_like "not found"
     end
@@ -766,7 +766,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
       end
 
       context "for a non-existent group" do
-        let(:path) { api_v3_paths.group 11111337 }
+        let(:path) { api_v3_paths.group(not_existing_id(Group)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -1208,7 +1208,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
       end
 
       context "for a non-existent version" do
-        let(:path) { api_v3_paths.membership 1337 }
+        let(:path) { api_v3_paths.membership(not_existing_id(Member)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/news/news_api_delete_spec.rb
+++ b/spec/requests/api/v3/news/news_api_delete_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe API::V3::News::NewsAPI, "delete" do
     end
 
     context "with a non-existent news" do
-      let(:path) { api_v3_paths.news 1337 }
+      let(:path) { api_v3_paths.news(not_existing_id(News)) }
 
       it_behaves_like "not found"
     end

--- a/spec/requests/api/v3/portfolios/show_resource_spec.rb
+++ b/spec/requests/api/v3/portfolios/show_resource_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "API v3 Portfolios resource show", content_type: :json do
     end
 
     context "when requesting nonexistent portfolio" do
-      let(:get_path) { api_v3_paths.portfolio 9999 }
+      let(:get_path) { api_v3_paths.portfolio(not_existing_id(Project)) }
 
       before do
         response

--- a/spec/requests/api/v3/programs/show_resource_spec.rb
+++ b/spec/requests/api/v3/programs/show_resource_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "API v3 Programs resource show", content_type: :json do
     end
 
     context "when requesting nonexistent program" do
-      let(:get_path) { api_v3_paths.program 9999 }
+      let(:get_path) { api_v3_paths.program(not_existing_id(Project)) }
 
       before do
         response

--- a/spec/requests/api/v3/projects/show_resource_spec.rb
+++ b/spec/requests/api/v3/projects/show_resource_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "API v3 Project resource show", content_type: :json do
     end
 
     context "when requesting nonexistent project" do
-      let(:get_path) { api_v3_paths.project 9999 }
+      let(:get_path) { api_v3_paths.project(not_existing_id(Project)) }
 
       before do
         response

--- a/spec/requests/api/v3/queries/query_resource_spec.rb
+++ b/spec/requests/api/v3/queries/query_resource_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe "API v3 Query resource",
         end
 
         context "when trying to star nonexistent query" do
-          let(:star_path) { api_v3_paths.query_star 999 }
+          let(:star_path) { api_v3_paths.query_star(not_existing_id(Query)) }
 
           it_behaves_like "not found"
         end
@@ -469,7 +469,7 @@ RSpec.describe "API v3 Query resource",
         end
 
         context "when trying to unstar nonexistent query" do
-          let(:unstar_path) { api_v3_paths.query_unstar 999 }
+          let(:unstar_path) { api_v3_paths.query_unstar(not_existing_id(Query)) }
 
           before do
             patch unstar_path

--- a/spec/requests/api/v3/repositories/revisions_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_resource_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "API v3 Revisions resource" do
       end
 
       context "requesting nonexistent revision" do
-        let(:get_path) { api_v3_paths.revision 909090 }
+        let(:get_path) { api_v3_paths.revision(not_existing_id(Changeset)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
     end
 
     context "with a non existing id" do
-      let(:path) { api_v3_paths.user_form(12345) }
+      let(:path) { api_v3_paths.user_form(not_existing_id(User)) }
 
       it "returns 404 Not found" do
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe API::V3::Users::UsersAPI do
 
     describe "unknown user" do
       let(:parameters) { { login: "new.login" } }
-      let(:path) { api_v3_paths.user(666) }
+      let(:path) { api_v3_paths.user(not_existing_id(User)) }
 
       it "responds with 404" do
         send_request

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe "API v3 User resource", content_type: :json do
       end
 
       context "requesting nonexistent user" do
-        let(:get_path) { api_v3_paths.user 9999 }
+        let(:get_path) { api_v3_paths.user(not_existing_id(User)) }
 
         it_behaves_like "not found"
       end
@@ -279,7 +279,7 @@ RSpec.describe "API v3 User resource", content_type: :json do
       end
 
       context "with a non-existent user" do
-        let(:path) { api_v3_paths.user 1337 }
+        let(:path) { api_v3_paths.user(not_existing_id(User)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/user/userlock_resource_spec.rb
+++ b/spec/requests/api/v3/user/userlock_resource_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "API v3 UserLock resource", content_type: :json do
     end
 
     context "requesting nonexistent user" do
-      let(:lock_path) { api_v3_paths.user_lock 9999 }
+      let(:lock_path) { api_v3_paths.user_lock(not_existing_id(User)) }
 
       before { response }
 

--- a/spec/requests/api/v3/version_resource_spec.rb
+++ b/spec/requests/api/v3/version_resource_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe "API v3 Version resource", content_type: :json do
       end
 
       context "for a non-existent version" do
-        let(:path) { api_v3_paths.version 1337 }
+        let(:path) { api_v3_paths.version(not_existing_id(Version)) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "API v3 Watcher resource", content_type: :json do
     end
 
     context "when the work package does not exist" do
-      let(:post_path) { api_v3_paths.work_package_watchers 9999 }
+      let(:post_path) { api_v3_paths.work_package_watchers(not_existing_id(WorkPackage)) }
 
       it_behaves_like "not found",
                       I18n.t("api_v3.errors.not_found.work_package")
@@ -161,7 +161,7 @@ RSpec.describe "API v3 Watcher resource", content_type: :json do
     context "when the user does not exist" do
       let(:post_body) do
         {
-          user: { href: api_v3_paths.user(99999) }
+          user: { href: api_v3_paths.user(not_existing_id(User)) }
         }.to_json
       end
 
@@ -236,7 +236,7 @@ RSpec.describe "API v3 Watcher resource", content_type: :json do
       end
 
       context "when removing nonexistent user" do
-        let(:delete_path) { api_v3_paths.watcher 9999, work_package.id }
+        let(:delete_path) { api_v3_paths.watcher(not_existing_id(User), work_package.id) }
 
         it_behaves_like "not found"
       end

--- a/spec/requests/api/v3/work_packages/delete_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/delete_resource_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "API v3 Work package resource",
       end
 
       context "for a non-existent work package" do
-        let(:path) { api_v3_paths.work_package 1337 }
+        let(:path) { api_v3_paths.work_package(not_existing_id(WorkPackage)) }
 
         it_behaves_like "not found",
                         I18n.t("api_v3.errors.not_found.work_package")

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe "API v3 Work package form resource" do
 
                 context "invalid #{property}" do
                   context "for non-existing user" do
-                    let(:user_link) { api_v3_paths.user 4200 }
+                    let(:user_link) { api_v3_paths.user(not_existing_id(User)) }
 
                     include_context "with post request"
 
@@ -775,7 +775,7 @@ RSpec.describe "API v3 Work package form resource" do
             end
 
             describe "multiple errors" do
-              let(:user_link) { api_v3_paths.user 4200 }
+              let(:user_link) { api_v3_paths.user(not_existing_id(User)) }
               let(:status_link) { api_v3_paths.status -1 }
               let(:links) do
                 {

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "API v3 Work package resource",
       end
 
       context "when requesting nonexistent work package" do
-        let(:get_path) { api_v3_paths.work_package 909090 }
+        let(:get_path) { api_v3_paths.work_package(not_existing_id(WorkPackage)) }
 
         it_behaves_like "not found",
                         I18n.t("api_v3.errors.not_found.work_package")

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -564,7 +564,7 @@ RSpec.describe "API v3 Work package resource",
             include_context "patch request"
 
             context "user doesn't exist" do
-              let(:user_href) { api_v3_paths.user 909090 }
+              let(:user_href) { api_v3_paths.user(not_existing_id(User)) }
 
               it_behaves_like "constraint violation" do
                 let(:message) do

--- a/spec/requests/my/auto_login_tokens_spec.rb
+++ b/spec/requests/my/auto_login_tokens_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "My::AutoLoginTokensController",
 
     it "handles non-existent token gracefully" do
       expect do
-        delete "/my/auto_login_tokens/99999"
+        delete "/my/auto_login_tokens/#{not_existing_id(Token::AutoLogin)}"
       end.not_to change(Token::AutoLogin, :count)
 
       expect(response).to have_http_status(:not_found)

--- a/spec/support/not_existing_id.rb
+++ b/spec/support/not_existing_id.rb
@@ -26,30 +26,19 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
+#++
 
-RSpec.shared_examples "deletion allowed" do
-  it "responds with 202" do
-    expect(last_response).to have_http_status :accepted
-  end
+module NotExistingId
+  # An id no record holds, for specs that need to provoke a "not found".
+  # Resolves the STI base class, so `not_existing_id(User)` also clears the ids of
+  # the groups and placeholder users sharing the `users` table.
+  def not_existing_id(model)
+    base_class = model.base_class
 
-  it "marks user as deleted and enqueues a deletion job" do
-    expect(Principals::DeleteJob).to have_been_enqueued.with(placeholder)
-    expect(placeholder.reload).to be_deleted
-  end
-
-  context "with a non-existent user" do
-    let(:path) { api_v3_paths.placeholder_user(not_existing_id(PlaceholderUser)) }
-
-    it_behaves_like "not found"
+    base_class.maximum(base_class.primary_key).to_i + 1
   end
 end
 
-RSpec.shared_examples "deletion is not allowed" do
-  it "responds with 403" do
-    expect(last_response).to have_http_status :forbidden
-  end
-
-  it "does not delete the user" do
-    expect(PlaceholderUser).to exist(placeholder.id)
-  end
+RSpec.configure do |config|
+  config.include NotExistingId
 end


### PR DESCRIPTION
In some cases, our tests have caught up to the hard coded 666 or 1337 IDs. So instead of hardcoding some arbitrary values (even though 9999 might be very safe), properly detect an ID that will not be found.

https://community.openproject.org/projects/OP/work_packages/OP-20009/activity