### PR TITLE
Reduce repeated type-variant queries while serializing API v3 work pa…

### DIFF
--- a/app/models/projects/enabled_types.rb
+++ b/app/models/projects/enabled_types.rb
@@ -46,7 +46,13 @@ module Projects::EnabledTypes
     def type_variant(type)
       return if type.nil?
 
-      project_types.find_by(type_id: type.id)&.variant || type.default_variant
+      project_type = if association(:project_types).loaded?
+                       project_types.find { |candidate| candidate.type_id == type.id }
+                     else
+                       project_types.find_by(type_id: type.id)
+                     end
+
+      project_type&.variant || type.default_variant
     end
 
     def type_variants(*types)

--- a/lib/api/v3/work_packages/eager_loading/project.rb
+++ b/lib/api/v3/work_packages/eager_loading/project.rb
@@ -48,10 +48,10 @@ module API
 
           def projects_by_id
             @projects_by_id ||= ::Project
-                .includes(:enabled_modules, phases: :definition)
+                .includes(:enabled_modules, { project_types: :variant, phases: :definition})
                 .where(id: project_ids)
                 .to_a
-                .index_by { |p| p.id }
+                .index_by(&:id)
           end
 
           def project_ids

--- a/lib/api/v3/work_packages/eager_loading/project.rb
+++ b/lib/api/v3/work_packages/eager_loading/project.rb
@@ -48,7 +48,7 @@ module API
 
           def projects_by_id
             @projects_by_id ||= ::Project
-                .includes(:enabled_modules, { project_types: :variant, phases: :definition})
+                .includes(:enabled_modules, { project_types: :variant, phases: :definition })
                 .where(id: project_ids)
                 .to_a
                 .index_by(&:id)

--- a/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe API::V3::WorkPackages::EagerLoading::Project do
   let!(:project) { create(:project) }
   let!(:parent_project) { create(:project) }
   let!(:child_project) { create(:project) }
+  let!(:unused_type) { create(:type) }
+  let!(:unused_project_type) { create(:project_type, project:, type: unused_type) }
 
   describe ".apply" do
     it "preloads the projects of the work packages, their parents and children" do
@@ -50,6 +52,10 @@ RSpec.describe API::V3::WorkPackages::EagerLoading::Project do
           .to be_loaded
 
         expect(w.project).to eql project
+        expect(w.project.association(:project_types)).to be_loaded
+        expect(w.project.project_types.map(&:type_id)).to contain_exactly(w.type_id, unused_type.id)
+        expect(w.project.project_types).to all(satisfy { |project_type| project_type.association(:variant).loaded? })
+        expect { w.project.type_variant(w.type) }.to have_a_query_limit(0)
 
         expect(w.parent.association(:project))
           .to be_loaded

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -250,6 +250,15 @@ RSpec.describe Project do
       it "resolves the type to that variant" do
         expect(project.type_variant(type)).to eq(variant)
       end
+
+      it "uses preloaded project types and variants" do
+        preloaded_project = described_class.preload(project_types: :variant).find(project.id)
+        expected_variant = variant
+        resolved_type = type
+
+        expect { expect(preloaded_project.type_variant(resolved_type)).to eq(expected_variant) }
+          .to have_a_query_limit(0)
+      end
     end
 
     context "when the project uses the type without choosing a variant" do


### PR DESCRIPTION
Reduce repeated type-variant queries while serializing API v3 work package collections.

Serializing `GET /api/v3/work_packages` repeatedly calls `Project#type_variant` while building work package resources, schemas, and links. For collections containing repeated project/type combinations, this resulted in the same queries being issued many times:

- Looking up `project_types` by `project_id` and `type_id`
- Loading the associated `type_variant` by ID

In the profiled workload, each query pattern occurred 381 times for a page containing 20 work packages.

## Changes

1. The work package collection eager loader now preloads each project's `project_types` and the variant associated with every project type

2. Optimized type_variant lookup in `app/models/projects/enabled_types.rb` so that it will not search the db again if `project_types` association is already loaded

## Performance

Measured using Rack Mini Profiler against:

`GET /api/v3/work_packages?pageSize=20&offset=1`

 The observed values are from docker in my machine using Admin API Key;

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Median server duration | 2,277 ms | 1,009 ms | -55.7% |
| Median SQL duration | 149.81 ms | 92.79 ms | -38.1% |
| SQL events | 922 | 148 | -83.9% |
| Cached SQL events | 827 | 64 | -92.3% |
| Duplicate query fingerprints | 865 | 91 | -89.5% |
| Project/type lookups | 381 | 0 | -100% |
| Variant-by-ID lookups | 381 | 0 | -100% |

The server-duration measurements come from a development environment and are subject to runtime variance. The query counts remained stable across the measured requests and directly demonstrate the removal of the targeted N+1 queries.

Response contents and size were unchanged.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
