### PR TITLE
Run npm audit fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7409,9 +7409,9 @@
       }
     },
     "node_modules/@xeokit/xeokit-sdk": {
-      "version": "2.6.112",
-      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-sdk/-/xeokit-sdk-2.6.112.tgz",
-      "integrity": "sha512-1N87LyvL1PMQvm0N4xw+ZmZHbVjmsXBo6vX1m6zyYvFK4DHWzACFt5b0DnBKwbasYhsnl/SO51ylgxsllahXiA==",
+      "version": "2.6.113",
+      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-sdk/-/xeokit-sdk-2.6.113.tgz",
+      "integrity": "sha512-MjYGlu5qxbBrkZ0Z7ayieYx3xJA7mZKPh/Cw8OVdbKqvRaxp9R7N1oOYcTH9ilC8f+4ajsK9FZpTBxJpHYqlZg==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@loaders.gl/core": "4.3.4",


### PR DESCRIPTION
Created by GitHub action.

## Impacted packages

### frontend
- `@loaders.gl/gltf` (high)
- `@loaders.gl/textures` (high)
- `@xeokit/xeokit-bim-viewer` (high)
- `@xeokit/xeokit-sdk` (high)
- `esbuild` (low)
- `image-size` (high)
- `texture-compressor` (high)
