### PR TITLE
Forbid additional properties in MCP input schema

### DIFF
--- a/app/services/mcp_tools/create_work_package.rb
+++ b/app/services/mcp_tools/create_work_package.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: false, idempotent: false, destructive: false
 
     input_schema(
+      additionalProperties: false,
       properties: {
         data: {
           type: %w[object],

--- a/app/services/mcp_tools/create_work_package.rb
+++ b/app/services/mcp_tools/create_work_package.rb
@@ -38,6 +38,7 @@ module McpTools
 
     input_schema(
       additionalProperties: false,
+      required: %i[data],
       properties: {
         data: {
           type: %w[object],

--- a/app/services/mcp_tools/create_work_package_comment.rb
+++ b/app/services/mcp_tools/create_work_package_comment.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: false, idempotent: false, destructive: false
 
     input_schema(
+      additionalProperties: false,
       required: %i[work_package_id comment],
       properties: {
         work_package_id: {

--- a/app/services/mcp_tools/create_work_package_relation.rb
+++ b/app/services/mcp_tools/create_work_package_relation.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: false, idempotent: false, destructive: false
 
     input_schema(
+      additionalProperties: false,
       required: %i[from_work_package_id to_work_package_id],
       properties: {
         from_work_package_id: {

--- a/app/services/mcp_tools/delete_work_package_relation.rb
+++ b/app/services/mcp_tools/delete_work_package_relation.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: false, idempotent: true, destructive: true
 
     input_schema(
+      additionalProperties: false,
       required: %i[id],
       properties: {
         id: {

--- a/app/services/mcp_tools/list_work_package_comments.rb
+++ b/app/services/mcp_tools/list_work_package_comments.rb
@@ -38,6 +38,7 @@ module McpTools
     enable_pagination
 
     input_schema(
+      additionalProperties: false,
       required: %i[work_package_id],
       properties: {
         work_package_id: {

--- a/app/services/mcp_tools/list_work_package_relations.rb
+++ b/app/services/mcp_tools/list_work_package_relations.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
 
     input_schema(
+      additionalProperties: false,
       required: %i[work_package_id],
       properties: {
         work_package_id: {

--- a/app/services/mcp_tools/search_custom_field_items.rb
+++ b/app/services/mcp_tools/search_custom_field_items.rb
@@ -38,6 +38,7 @@ module McpTools
     annotations read_only: true, idempotent: true, destructive: false
 
     input_schema(
+      additionalProperties: false,
       required: %i[custom_field_id],
       properties: {
         custom_field_id: {

--- a/app/services/mcp_tools/search_custom_fields.rb
+++ b/app/services/mcp_tools/search_custom_fields.rb
@@ -41,6 +41,7 @@ module McpTools
     filter :name, filter_proc: ->(cfs, v) { cfs.where("name ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(v)}%'") }
 
     input_schema(
+      additionalProperties: false,
       properties: {
         id: {
           type: %i[number array],

--- a/app/services/mcp_tools/search_portfolios.rb
+++ b/app/services/mcp_tools/search_portfolios.rb
@@ -45,7 +45,7 @@ module McpTools
     filter :status_code
 
     input_schema(
-      type: :object,
+      additionalProperties: false,
       properties: {
         name: { type: "string", description: "Name of the portfolio. Accepts partial names, not case-sensitive." },
         identifier: { type: "string", description: "Portfolio identifier. Case-sensitive, matching exactly." },

--- a/app/services/mcp_tools/search_programs.rb
+++ b/app/services/mcp_tools/search_programs.rb
@@ -45,7 +45,7 @@ module McpTools
     filter :status_code
 
     input_schema(
-      type: :object,
+      additionalProperties: false,
       properties: {
         name: { type: "string", description: "Name of the program. Accepts partial names, not case-sensitive." },
         identifier: { type: "string", description: "Program identifier. Case-sensitive, matching exactly." },

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -45,7 +45,7 @@ module McpTools
     filter :status_code
 
     input_schema(
-      type: :object,
+      additionalProperties: false,
       properties: {
         name: { type: "string", description: "Name of the project. Accepts partial project names, not case-sensitive." },
         identifier: { type: "string", description: "Project identifier. Case-sensitive, matching exactly." },

--- a/app/services/mcp_tools/search_users.rb
+++ b/app/services/mcp_tools/search_users.rb
@@ -42,6 +42,7 @@ module McpTools
     filter :search_term, filter_class: "Queries::Users::Filters::AnyNameAttributeFilter", operator: "~"
 
     input_schema(
+      additionalProperties: false,
       properties: {
         search_term: {
           type: "string",

--- a/app/services/mcp_tools/search_versions.rb
+++ b/app/services/mcp_tools/search_versions.rb
@@ -44,7 +44,7 @@ module McpTools
     filter :sharing
 
     input_schema(
-      type: :object,
+      additionalProperties: false,
       properties: {
         name: { type: "string", description: "Name of the version. Accepts partial version names, not case-sensitive." },
         sharing: {

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -62,6 +62,7 @@ module McpTools
     filter :subject, filter_proc: ->(wps, v) { wps.where("subject ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(v)}%'") }
 
     input_schema(
+      additionalProperties: false,
       properties: {
         assigned_to_id: {
           type: %w[number null],

--- a/app/services/mcp_tools/update_work_package.rb
+++ b/app/services/mcp_tools/update_work_package.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: false, idempotent: true, destructive: false
 
     input_schema(
+      additionalProperties: false,
       required: %w[id data],
       properties: {
         id: {

--- a/app/services/mcp_tools/update_work_package_relation.rb
+++ b/app/services/mcp_tools/update_work_package_relation.rb
@@ -37,6 +37,7 @@ module McpTools
     annotations read_only: false, idempotent: true, destructive: false
 
     input_schema(
+      additionalProperties: false,
       required: %i[id],
       properties: {
         id: {


### PR DESCRIPTION
The top-level objects of our input schemas are exhaustively specified and nothing else is allowed there. Reject some guess-working from LLMs there.

This has to specified on every object in the schema, so having open-ended `data` objects, as we use them for create-tools is still possible. These objects don't receive the `additionalProperties: false` annotation.

# Ticket
https://appsignal.com/openproject-gmbh/sites/673aff9f83eb6776b27e7743/exceptions/incidents/2011