### PR TITLE
[COMMS-973] Adjust WP eager loader checksum to use observed_in_versions

### DIFF
--- a/lib/api/v3/work_packages/eager_loading/checksum.rb
+++ b/lib/api/v3/work_packages/eager_loading/checksum.rb
@@ -54,19 +54,15 @@ module API
 
             protected
 
-            # The target versions associated via work_package_versions are a
-            # has_many, which the left_joins/pluck design above cannot express
-            # (it would multiply rows), so they enter the checksum as an
-            # aggregated correlated subquery. This also covers versions beyond
-            # the first, which the deprecated version association could not see.
-            # Only "target" rows are folded in: they are what the representer
-            # renders (as `version` and `targetVersions`); observed_in versions
-            # do not appear in the representation and must not bust its cache.
+            # Versions are a has_many, which would multiply rows in the
+            # left_joins/pluck above, so they enter as an aggregated subquery.
+            # A version can attach under more than one kind, so the kind is part
+            # of the value and of the order.
             VERSIONS_CHECKSUM_SQL = <<~SQL.squish
-              (SELECT COALESCE(STRING_AGG(CONCAT(v.id, v.updated_at), ',' ORDER BY v.id), '')
+              (SELECT COALESCE(STRING_AGG(CONCAT(wpv.kind, v.id, v.updated_at), ',' ORDER BY wpv.kind, v.id), '')
                  FROM work_package_versions wpv
                  INNER JOIN versions v ON v.id = wpv.version_id
-                WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target')
+                WHERE wpv.work_package_id = work_packages.id)
             SQL
 
             def md5_concat

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -145,12 +145,19 @@ RSpec.describe API::V3::WorkPackages::EagerLoading::Checksum do
         .not_to eql orig_checksum
     end
 
-    it "produces the same checksum on changes to an observed_in version" do
+    it "produces a different checksum on changes to an additional observed_in version" do
       other_version = create(:version, project:)
       work_package.work_package_versions.create!(version: other_version, kind: "observed_in")
 
       expect(new_checksum)
-        .to eql orig_checksum
+        .not_to eql orig_checksum
+    end
+
+    it "produces a different checksum on moving a version between kinds" do
+      work_package.work_package_versions.where(kind: "target").update_all(kind: "observed_in")
+
+      expect(new_checksum)
+        .not_to eql orig_checksum
     end
 
     it "produces a different checksum on changes to the type id" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/projects/FND/work_packages/COMMS-973

# What are you trying to accomplish?
Follow-up to https://github.com/opf/openproject/pull/24349, this time for the `observed_in_versions` field.

The big danger here was the potential of mis-detecting the _kinds_ of linked versions. I added some tests and played around with checksumming in the console -- looks to be working well.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
