### PR TITLE
[chore] Report correct offset for file link collections

### DIFF
--- a/modules/storages/lib/api/v3/file_links/work_packages_file_links_api.rb
+++ b/modules/storages/lib/api/v3/file_links/work_packages_file_links_api.rb
@@ -76,6 +76,7 @@ module API
 
             FileLinkCollectionRepresenter.new(
               relation,
+              page: params[:offset],
               per_page: params[:pageSize],
               self_link: api_v3_paths.file_links(@work_package.id),
               current_user:

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
@@ -219,7 +219,6 @@ RSpec.describe "API v3 file links resource" do
 
     context "if a collection with an offset is requested" do
       let(:path) { "#{api_v3_paths.file_links(work_package.id)}?pageSize=2&offset=2" }
-      # let(:path) { api_v3_paths.file_links(work_package.id) }
       let(:second_file_link) { create(:file_link, creator: current_user, container: work_package, storage:) }
       let(:third_file_link) { create(:file_link, creator: current_user, container: work_package, storage:) }
       let(:initialize_file_links) { [file_link, second_file_link, third_file_link] }

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
@@ -190,11 +190,10 @@ RSpec.describe "API v3 file links resource" do
 
   describe "GET /api/v3/work_packages/:work_package_id/file_links" do
     let(:path) { api_v3_paths.file_links(work_package.id) }
+    let(:initialize_file_links) { [file_link, file_link_of_other_work_package, file_link_of_another_storage] }
 
     before do
-      file_link
-      file_link_of_other_work_package
-      file_link_of_another_storage
+      initialize_file_links
       get path
     end
 
@@ -216,6 +215,20 @@ RSpec.describe "API v3 file links resource" do
       it_behaves_like "API V3 collection response", 0, 0, "FileLink", "Collection" do
         let(:elements) { [] }
       end
+    end
+
+    context "if a collection with an offset is requested" do
+      let(:path) { "#{api_v3_paths.file_links(work_package.id)}?pageSize=2&offset=2" }
+      # let(:path) { api_v3_paths.file_links(work_package.id) }
+      let(:second_file_link) { create(:file_link, creator: current_user, container: work_package, storage:) }
+      let(:third_file_link) { create(:file_link, creator: current_user, container: work_package, storage:) }
+      let(:initialize_file_links) { [file_link, second_file_link, third_file_link] }
+
+      it_behaves_like "API V3 collection response", 3, 1, "FileLink", "Collection" do
+        let(:elements) { [third_file_link] }
+      end
+
+      it { expect(response.body).to be_json_eql(2).at_path("offset") }
     end
 
     describe "with filter by storage" do


### PR DESCRIPTION
# What are you trying to accomplish?
- page offset was missing in the representer and thus it always showed 1, even when results of page 2 or greater were shown
