### PR TITLE
[OP-20014] Introduce optional daily limit for outbound mails

### DIFF
--- a/app/mailers/interceptors/rate_limit_emails.rb
+++ b/app/mailers/interceptors/rate_limit_emails.rb
@@ -28,13 +28,40 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+module Interceptors
+  module RateLimitEmails
+    module_function
+
+    def delivering_email(mail)
+      recipient_count = [mail.to, mail.cc, mail.bcc].flatten.compact.uniq.size
+
+      return if OpenProject::TokenBucketBasedRateLimiter::EmailLimitPerDay.consume!(recipient_count)
+
+      mail.perform_deliveries = false
+      report_dropped(mail, recipient_count)
+    end
+
+    def report_dropped(mail, recipient_count)
+      OpenProject.logger.warn(
+        "Dropped message due to daily email limit: '#{mail.subject}'",
+        reference: :daily_email_limit,
+        payload: {
+          recipient_count: recipient_count,
+          daily_limit: OpenProject::TokenBucketBasedRateLimiter::EmailLimitPerDay.limit,
+          host_name: Setting.host_name
+        }
+      )
+
+      OpenProject::OpenTelemetry.add_event(
+        "outbound_mail.message_dropped",
+        "openproject.mail.recipient_count" => recipient_count,
+        "openproject.mail.daily_limit" => OpenProject::TokenBucketBasedRateLimiter::EmailLimitPerDay.limit
+      )
+
+      OpenProject::Appsignal.increment_counter(
+        "outbound_mail.messages_dropped",
+        1
+      )
+    end
+  end
 end

--- a/app/models/token_bucket_state.rb
+++ b/app/models/token_bucket_state.rb
@@ -28,13 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+class TokenBucketState < ApplicationRecord
+  def self.with_instance(identifier)
+    transaction do
+      yield(lock.find_by!(identifier:))
+    end
+  end
 end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -481,6 +481,16 @@ module Settings
         default: nil,
         env_alias: "EMAIL_DELIVERY_METHOD"
       },
+      email_limit_per_day: {
+        format: :integer,
+        default: 0,
+        writable: false,
+        allowed: (0..),
+        description: "Number of emails which are allowed to be sent per day on average (may be up to 2x as much on " \
+                     "a single day). This can be used to address spam and abuse, but is just designed as a last " \
+                     "resort as it simply drops mails that are over the limit instead of sending them at a later " \
+                     "point in time or notifying the user."
+      },
       emails_salutation: {
         allowed: %i[firstname name],
         default: :firstname

--- a/db/migrate/20260820101109_add_token_bucket_states.rb
+++ b/db/migrate/20260820101109_add_token_bucket_states.rb
@@ -28,13 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+class AddTokenBucketStates < ActiveRecord::Migration[8.1]
+  def change
+    create_table :token_bucket_states do |t|
+      t.string :identifier, null: false, index: { unique: true }
+      t.bigint :microtokens, null: false
+      t.datetime :refilled_at, null: false
+
+      t.timestamps
+    end
+  end
 end

--- a/db/migrate/20260820101159_create_email_limit_per_day_token_bucket_state.rb
+++ b/db/migrate/20260820101159_create_email_limit_per_day_token_bucket_state.rb
@@ -28,13 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+class CreateEmailLimitPerDayTokenBucketState < ActiveRecord::Migration[8.1]
+  def up
+    TokenBucketState.create!(
+      identifier: :email_limit_per_day,
+      microtokens: 0,
+      refilled_at: Time.utc(2000, 1, 1)
+    )
+  end
+
+  def down
+    TokenBucketState.delete_all
+  end
 end

--- a/docs/installation-and-operations/configuration/environment/README.md
+++ b/docs/installation-and-operations/configuration/environment/README.md
@@ -116,7 +116,7 @@ For Docker installations:
 docker exec -it -e RAILS_ENV=production openproject-web-1 bundle exec rake setting:available_envs
 ```
 
-The default value is also visible for each variable in parentheses. 
+The default value is also visible for each variable in parentheses.
 
 <!-- Warning: Anything within the below lines will be overwritten by `rake docs:env_vars` -->
 <!-- BEGIN AUTOMATED SECTION -->
@@ -221,6 +221,7 @@ OPENPROJECT_EE__HIDE__BANNERS (default=false) Hide the Enterprise enterprise ban
 OPENPROJECT_EE__MANAGER__VISIBLE (default=true) Show the Enterprise configuration page
 OPENPROJECT_EMAIL__DELIVERY__CONFIGURATION (default="inapp")
 OPENPROJECT_EMAIL__DELIVERY__METHOD (default=nil) Email delivery method
+OPENPROJECT_EMAIL__LIMIT__PER__DAY (default=0) Number of emails which are allowed to be sent per day on average (may be up to 2x as much on a single day). This can be used to address spam and abuse, but is just designed as a last resort as it simply drops mails that are over the limit instead of sending them at a later point in time or notifying the user.
 OPENPROJECT_EMAIL__LOGIN (default=false) Use email as login
 OPENPROJECT_EMAILS__FOOTER (default={"en" => ""}) Emails footer
 OPENPROJECT_EMAILS__HEADER (default={"en" => ""}) Emails header

--- a/lib/open_project/token_bucket_based_rate_limiter/base.rb
+++ b/lib/open_project/token_bucket_based_rate_limiter/base.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module TokenBucketBasedRateLimiter
+    # Abstract class. Sub classes need to provide the upper limit of the bucket by implementing the `identifier` and
+    # `limit` instance methods.
+    class Base
+      MICROTOKENS_PER_TOKEN = 1_000_000
+      SECONDS_PER_DAY = 24 * 60 * 60
+
+      class NotImplemented < StandardError; end
+
+      def self.consume!(tokens = 1)
+        new.consume!(tokens)
+      end
+
+      def self.enabled?
+        new.enabled?
+      end
+
+      def self.limit
+        new.limit
+      end
+
+      def consume!(tokens = 1)
+        return true unless enabled?
+
+        now = Time.current
+        required_microtokens = tokens * MICROTOKENS_PER_TOKEN
+
+        TokenBucketState.with_instance(identifier) do |state|
+          available_microtokens = available_microtokens(state, now)
+
+          if available_microtokens >= required_microtokens
+            state.update!(
+              microtokens: available_microtokens - required_microtokens,
+              refilled_at: now
+            )
+
+            true
+          else
+            false
+          end
+        end
+      end
+
+      def enabled?
+        limit.positive?
+      end
+
+      # Maximum number of tokens (not microtokens) the bucket can hold.
+      def limit
+        raise NotImplemented, "Subclass responsibility"
+      end
+
+      private
+
+      # String used to identify the TokenBucketState instance which stores the number of available (micro) tokens.
+      def identifier
+        raise NotImplemented, "Subclass responsibility"
+      end
+
+      # Maximum number of microtokens the bucket can hold.
+      def capacity
+        @capacity ||= limit * MICROTOKENS_PER_TOKEN
+      end
+
+      # Number of microtokens, which should be added per second
+      #
+      # The default implementation assumes that `limit` is a daily limit, i.e. the refill rate is based on the number of
+      # seconds per day.  When implementing e.g. an hourly limit, then this method needs to be overwritten in a subclass
+      # to adjust the calculation accordingly.
+      def refill_rate
+        @refill_rate ||= capacity.to_f / SECONDS_PER_DAY
+      end
+
+      def available_microtokens(state, now)
+        seconds_since_last_refill = [now - state.refilled_at, 0].max
+
+        [
+          state.microtokens + (seconds_since_last_refill * refill_rate).floor,
+          capacity
+        ].min
+      end
+    end
+  end
+end

--- a/lib/open_project/token_bucket_based_rate_limiter/email_limit_per_day.rb
+++ b/lib/open_project/token_bucket_based_rate_limiter/email_limit_per_day.rb
@@ -28,13 +28,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+module OpenProject
+  module TokenBucketBasedRateLimiter
+    # Limits how many emails will be sent by the system on a daily basis on average.
+    class EmailLimitPerDay < OpenProject::TokenBucketBasedRateLimiter::Base
+      def limit
+        Setting.email_limit_per_day
+      end
+
+      private
+
+      def identifier
+        :email_limit_per_day
+      end
+    end
+  end
 end

--- a/spec/factories/token_bucket_state_factory.rb
+++ b/spec/factories/token_bucket_state_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,15 +26,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+FactoryBot.define do
+  factory :token_bucket_state do
+    microtokens { 0 }
+    refilled_at { Time.utc(2000, 1, 1) }
+
+    trait :email_limit_per_day do
+      identifier { :email_limit_per_day }
+    end
+  end
 end

--- a/spec/lib/open_project/token_bucket_based_rate_limiter/base_spec.rb
+++ b/spec/lib/open_project/token_bucket_based_rate_limiter/base_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::TokenBucketBasedRateLimiter::Base do
+  let!(:token_bucket_state) { create(:token_bucket_state, identifier: :sample, microtokens:, refilled_at:) }
+  let(:microtokens) { 0 }
+  let(:refilled_at) { Time.current }
+
+  context "when a limit is configured" do
+    let(:described_class) do
+      Class.new(OpenProject::TokenBucketBasedRateLimiter::Base) do
+        def limit
+          24
+        end
+
+        def identifier
+          :sample
+        end
+      end
+    end
+
+    describe "enabled?" do
+      subject(:enabled?) { described_class.enabled? }
+
+      it { is_expected.to be true }
+    end
+
+    describe "limit" do
+      subject(:limit) { described_class.limit }
+
+      it { is_expected.to eq 24 }
+    end
+
+    describe "consume!" do
+      subject(:consume!) { described_class.consume!(tokens) }
+
+      let(:tokens) { 1 }
+
+      context "with no tokens to consume" do
+        let(:microtokens) { 0 }
+
+        it { is_expected.to be false }
+      end
+
+      context "with tokens available" do
+        let(:microtokens) { 24_000_000 }
+
+        it { is_expected.to be true }
+
+        it "removes tokens from the state" do
+          consume!
+
+          expect(token_bucket_state.reload.microtokens).to eq 23_000_000
+        end
+      end
+
+      context "when tokens need refilling" do
+        let(:tokens) { 2 }
+
+        # 1 token left, but 2 tokens have been aquired in the mean time
+        let(:microtokens) { 1_000_000 }
+        let(:refilled_at) { 2.hours.ago }
+
+        it { is_expected.to be true }
+
+        it "refills and consumes tokens" do
+          consume!
+
+          expect(token_bucket_state.reload.microtokens).to eq 1_000_000
+        end
+      end
+
+      context "when too many tokens are to be consumed" do
+        let(:tokens) { 2 }
+
+        # 1 token left
+        let(:microtokens) { 1_000_000 }
+
+        it { is_expected.to be false }
+
+        it "does not consume tokens" do
+          consume!
+
+          expect(token_bucket_state.reload.microtokens).to eq 1_000_000
+        end
+      end
+    end
+  end
+
+  context "when limit is set to 0" do
+    let(:described_class) do
+      Class.new(OpenProject::TokenBucketBasedRateLimiter::Base) do
+        def limit
+          0
+        end
+
+        def identifier
+          :sample
+        end
+      end
+    end
+
+    describe "enabled?" do
+      subject(:enabled?) { described_class.enabled? }
+
+      it { is_expected.to be false }
+    end
+
+    describe "limit" do
+      subject(:limit) { described_class.limit }
+
+      it { is_expected.to eq 0 }
+    end
+
+    describe "consume!" do
+      subject(:consume!) { described_class.consume!(tokens) }
+
+      let(:tokens) { 1 }
+
+      context "with no tokens to consume" do
+        let(:microtokens) { 0 }
+
+        it { is_expected.to be true }
+      end
+
+      context "with tokens available" do
+        let(:microtokens) { 1_234_567_890 }
+
+        it { is_expected.to be true }
+
+        it "doesn't remove tokens from the state" do
+          consume!
+
+          expect(token_bucket_state.reload.microtokens).to eq 1_234_567_890
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/token_bucket_based_rate_limiter/email_limit_per_day_spec.rb
+++ b/spec/lib/open_project/token_bucket_based_rate_limiter/email_limit_per_day_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::TokenBucketBasedRateLimiter::EmailLimitPerDay do
+  context "when a limit is configured", with_settings: { email_limit_per_day: 24 } do
+    describe "enabled?" do
+      subject(:enabled?) { described_class.enabled? }
+
+      it { is_expected.to be true }
+    end
+
+    describe "limit" do
+      subject(:limit) { described_class.limit }
+
+      it { is_expected.to eq 24 }
+    end
+
+    describe "consume!" do
+      subject(:consume!) { described_class.consume!(tokens) }
+
+      let(:tokens) { 1 }
+      let(:state) { TokenBucketState.find_by!(identifier: :email_limit_per_day) }
+
+      it { is_expected.to be true }
+
+      context "with tokens available" do
+        before do
+          # Full bucket
+          state.update!(microtokens: 24_000_000, refilled_at: Time.current)
+        end
+
+        it { is_expected.to be true }
+
+        it "removes tokens from the state" do
+          consume!
+
+          expect(state.reload.microtokens).to eq 23_000_000
+        end
+      end
+    end
+  end
+
+  context "when no limit is configured" do
+    describe "enabled?" do
+      subject(:enabled?) { described_class.enabled? }
+
+      it { is_expected.to be false }
+    end
+
+    describe "limit" do
+      subject(:limit) { described_class.limit }
+
+      it { is_expected.to eq 0 }
+    end
+
+    describe "consume!" do
+      subject(:consume!) { described_class.consume!(tokens) }
+
+      let(:tokens) { 1 }
+      let(:state) { TokenBucketState.find_by!(identifier: :email_limit_per_day) }
+
+      it { is_expected.to be true }
+
+      context "with no tokens to consume" do
+        before do
+          state.update!(microtokens: 0, refilled_at: Time.current)
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+end

--- a/spec/mailers/interceptors/rate_limit_emails_spec.rb
+++ b/spec/mailers/interceptors/rate_limit_emails_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Interceptors::RateLimitEmails do
+  let(:to) { ["john@example.com"] }
+  let(:cc) { nil }
+  let(:bcc) { nil }
+  let(:mail) do
+    Mail.new({ from: "noreply@example.net", to:, cc:, bcc:, subject: "Notification", body: "Hi" }.compact)
+  end
+
+  let(:token_bucket_state) { TokenBucketState.with_instance(:email_limit_per_day) { it } }
+
+  def intercept!
+    described_class.delivering_email(mail)
+  end
+
+  context "when a limit is configured", with_settings: { email_limit_per_day: 10 } do
+    context "with no tokens to consume" do
+      before do
+        token_bucket_state.update!(microtokens: 0, refilled_at: Time.current)
+      end
+
+      it "drops the mail" do
+        intercept!
+
+        expect(mail.perform_deliveries).to be false
+      end
+    end
+
+    context "with tokens to consume" do
+      before do
+        token_bucket_state.update!(microtokens: 10 * 1_000_000, refilled_at: Time.current)
+      end
+
+      context "and one recipient" do
+        let(:to) { ["joe@example.org"] }
+
+        it "removes one token from the bucket" do
+          intercept!
+
+          expect(token_bucket_state.reload.microtokens).to eq(9 * 1_000_000)
+        end
+
+        it "keeps the mail" do
+          intercept!
+
+          expect(mail.perform_deliveries).to be true
+        end
+      end
+
+      context "and four recipients" do
+        let(:to) { ["joe@example.org", "jane@example.org"] }
+        let(:cc) { ["jim@example.org"] }
+        let(:bcc) { ["janet@example.org"] }
+
+        it "removes four tokens from the bucket" do
+          intercept!
+
+          expect(token_bucket_state.reload.microtokens).to eq(6 * 1_000_000)
+        end
+
+        it "keeps the mail" do
+          intercept!
+
+          expect(mail.perform_deliveries).to be true
+        end
+      end
+
+      context "and duplicate recipients" do
+        let(:to) { ["joe@example.org"] }
+        let(:cc) { ["joe@example.org"] }
+        let(:bcc) { ["joe@example.org"] }
+
+        it "removes just one token per uniq recipient from the bucket" do
+          intercept!
+
+          expect(token_bucket_state.reload.microtokens).to eq(9 * 1_000_000)
+        end
+
+        it "keeps the mail" do
+          intercept!
+
+          expect(mail.perform_deliveries).to be true
+        end
+      end
+    end
+  end
+
+  context "when NO limit is configured", with_settings: { email_limit_per_day: 0 } do
+    context "with no tokens to consume" do
+      before do
+        token_bucket_state.update!(microtokens: 0, refilled_at: Time.current)
+      end
+
+      it "still doesn't drop the mail" do
+        intercept!
+
+        expect(mail.perform_deliveries).to be true
+      end
+    end
+  end
+end

--- a/spec/models/token_bucket_state_spec.rb
+++ b/spec/models/token_bucket_state_spec.rb
@@ -28,13 +28,33 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Register interceptors defined in app/mailers/user_mailer.rb
-# Do this here, so they aren't registered multiple times due to reloading in development mode.
-Rails.application.reloader.to_prepare do
-  ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
-  ApplicationMailer.register_interceptor Interceptors::RemoveBlockedRecipients
-  ApplicationMailer.register_interceptor Interceptors::LimitDistinctRecipients
-  ApplicationMailer.register_interceptor Interceptors::RateLimitEmails
-  # following needs to be the last interceptor
-  ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient
+require "spec_helper"
+
+RSpec.describe TokenBucketState do
+  describe ".with_instance" do
+    # This is supposed to test that concurrent access to the singleton is blocked on DB level. However I wasn't able to
+    # get this to work in the tests, as transactional fixtures are messing with the semantics of transactions in the
+    # test context. Therefore, we're merely testing that `SELECT ... FOR UPDATE` is used.
+    it "uses PostgreSQL row locking" do
+      sql_queries = []
+
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        sql_queries << payload[:sql]
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        described_class.with_instance(:email_limit_per_day) {} # trigger action
+      end
+
+      expect(sql_queries).to include(
+        a_string_matching(/SELECT .* FROM "token_bucket_states" .* FOR UPDATE/i)
+      )
+    end
+
+    it "passes the singleton instance into the block" do
+      instance = described_class.with_instance(:email_limit_per_day) { it }
+
+      expect(instance.identifier).to eq "email_limit_per_day"
+    end
+  end
 end

--- a/spec/support/rspec_cleanup.rb
+++ b/spec/support/rspec_cleanup.rb
@@ -6,6 +6,9 @@ RSpec.configure do |config|
     # This happens automatically for :mailer specs
     ActionMailer::Base.delivery_method = :test
     ActionMailer::Base.deliveries.clear
+
+    TokenBucketState.delete_all
+    FactoryBot.create :token_bucket_state, :email_limit_per_day
   end
 
   config.append_after do


### PR DESCRIPTION
# Ticket

[OP-20014](https://community.openproject.org/projects/OP/work_packages/OP-20014)

# What are you trying to accomplish?

This feature introduces an optional upper bound of daily mails sent by the system. This can be used to minimize the potentially harmful effect of spam attacks or misuse of an otherwise open installation.

## Screenshots

n/a

# What approach did you choose and why?

Adding a mail interceptor which checks if enough mail tokens have been acquired before sending a mail.

The token management is located in the OpenProject::TokenBucketBasedRateLimiter. The token amount is stored in the TokenBucketState model, of which there will only be a single instance per type ever. That instance is created via a migration and never deleted nor a second one added. The latter is even ensured using a database constraint.

The main configuration for this feature is done using the EMAIL_LIMIT_PER_DAY setting. If that's set to `0`, then no throttling will be performed. Otherwise, the value will be considered the average daily limit. Throughout the day, the bucket will (virtually) continuously fill up with that many tokens. I.e. it will be EMAIL_LIMIT_PER_DAY tokens in 24 hours. Each outgoing mail removes tokens from the bucket - one token per recipient. If the bucket is empty, outgoing mails will be dropped silently.

### Token management

The token management is implemented in base class `OpenProject::TokenBucketBasedRateLimiter::Base`, which can be subclassed. Each subclass just needs to overwrite the `limit` and `identifier` methods and it's good to go.

The number of tokens will be computed lazily, i.e. only when the `TokenBucketState` is used. It's not updated automatically in the background. Also we're not storing the number of tokens, but the number of micro tokens so that we don't need to deal with decimal numbers and such, when continuously adding tokens to the bucket.

Access to each `TokenBucketState` is protected by a row-level lock. This should avoid that concurrent access may trigger a lost updates.

More details in the work package description.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)