### PR TITLE
[AGILE-406] Add sprint.started_at and completed_at

### DIFF
--- a/docs/api/apiv3/components/schemas/sprint_model.yml
+++ b/docs/api/apiv3/components/schemas/sprint_model.yml
@@ -33,6 +33,22 @@ properties:
       - "string"
       - "null"
     format: date
+  startedAt:
+    type:
+      - "string"
+      - "null"
+    format: date-time
+    description: |-
+      The time when the sprint was started. This is an explicit action performed by users, the date can thus divert
+      from the (planned) sprint start_date.
+  completedAt:
+    type:
+      - "string"
+      - "null"
+    format: date-time
+    description: |-
+      The time when the sprint was completed. This is an explicit action performed by users, the date can thus divert
+      from the (planned) sprint finish_date.
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/tags/sprints.yml
+++ b/docs/api/apiv3/tags/sprints.yml
@@ -23,8 +23,10 @@ description: |-
   | id          | Sprint id                                     | Integer     | x > 0          | READ                 |
   | name        | Sprint name                                   | String      | not null       | READ                 |
   | description |                                               | Formattable |                | READ                 |
-  | startDate   |                                               | Date        |                | READ                 |
-  | finishDate  |                                               | Date        |                | READ                 |
+  | startDate   | Date when the sprint is planned to start      | Date        |                | READ                 |
+  | finishDate  | Date when the sprint is planned to end        | Date        |                | READ                 |
+  | startedAt   | Time when the sprint actually started         | DateTime    |                | READ                 |
+  | completedAt | Time when the sprint actually ended           | DateTime    |                | READ                 |
   | createdAt   | Time of creation                              | DateTime    | not null       | READ                 |
   | updatedAt   | Time of the most recent change to the sprint  | DateTime    | not null       | READ                 |
 name: Sprints

--- a/modules/backlogs/app/services/backlogs/sprints/finish_service.rb
+++ b/modules/backlogs/app/services/backlogs/sprints/finish_service.rb
@@ -51,7 +51,7 @@ class Backlogs::Sprints::FinishService < BaseServices::BaseContracted
   end
 
   def persist(service_call)
-    model.completed!
+    model.update!(status: "completed", completed_at: Time.zone.now)
     service_call
   end
 

--- a/modules/backlogs/app/services/backlogs/sprints/start_service.rb
+++ b/modules/backlogs/app/services/backlogs/sprints/start_service.rb
@@ -48,7 +48,7 @@ class Backlogs::Sprints::StartService < BaseServices::BaseContracted
     ensure_task_boards(service_call)
     return service_call if service_call.failure?
 
-    unless model.update(status: "active")
+    unless model.update(status: "active", started_at: Time.zone.now)
       service_call.success = false
       service_call.errors = model.errors
     end

--- a/modules/backlogs/db/migrate/20260824132100_add_started_at_and_completed_at_to_sprints.rb
+++ b/modules/backlogs/db/migrate/20260824132100_add_started_at_and_completed_at_to_sprints.rb
@@ -28,48 +28,9 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "roar/decorator"
-require "roar/json/hal"
-
-module API
-  module V3
-    module Sprints
-      class SprintRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::V3::Workspaces::LinkedResource
-        include API::Decorators::DateProperty
-
-        self_link
-
-        link :status do
-          {
-            href: "#{::API::V3::URN_PREFIX}sprints:status:#{represented.status}",
-            title: I18n.t("activerecord.attributes.sprint.statuses.#{represented.status}")
-          }
-        end
-
-        associated_project as: :definingWorkspace
-
-        property :id,
-                 render_nil: true
-
-        property :name,
-                 render_nil: true
-
-        date_property :start_date
-
-        date_property :finish_date
-
-        date_time_property :started_at
-        date_time_property :completed_at
-
-        date_time_property :created_at
-        date_time_property :updated_at
-
-        def _type
-          "Sprint"
-        end
-      end
-    end
+class AddStartedAtAndCompletedAtToSprints < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sprints, :started_at, :datetime
+    add_column :sprints, :completed_at, :datetime
   end
 end

--- a/modules/backlogs/db/migrate/20260825103847_backfill_sprint_started_and_completed_at.rb
+++ b/modules/backlogs/db/migrate/20260825103847_backfill_sprint_started_and_completed_at.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class BackfillSprintStartedAndCompletedAt < ActiveRecord::Migration[8.1]
+  def up
+    say_with_time "Backfilling started_at for active and completed sprints from start_date" do
+      execute <<~SQL.squish
+        UPDATE sprints
+        SET started_at = start_date::timestamptz
+        WHERE status IN ('active', 'completed')
+          AND started_at IS NULL
+          AND start_date IS NOT NULL
+      SQL
+    end
+
+    say_with_time "Backfilling completed_at for completed sprints from finish_date" do
+      execute <<~SQL.squish
+        UPDATE sprints
+        SET completed_at = finish_date::timestamptz
+        WHERE status = 'completed'
+          AND completed_at IS NULL
+          AND finish_date IS NOT NULL
+      SQL
+    end
+  end
+
+  def down; end
+end

--- a/modules/backlogs/spec/factories/sprint_factory.rb
+++ b/modules/backlogs/spec/factories/sprint_factory.rb
@@ -35,5 +35,16 @@ FactoryBot.define do
     status { "in_planning" }
     start_date { Time.zone.today }
     finish_date { Time.zone.today + 14.days }
+
+    trait :active do
+      status { "active" }
+      started_at { Time.zone.now }
+    end
+
+    trait :completed do
+      status { "completed" }
+      started_at { 1.week.ago }
+      completed_at { Time.zone.now }
+    end
   end
 end

--- a/modules/backlogs/spec/lib/api/v3/sprints/sprint_representer_rendering_spec.rb
+++ b/modules/backlogs/spec/lib/api/v3/sprints/sprint_representer_rendering_spec.rb
@@ -37,13 +37,17 @@ RSpec.describe API::V3::Sprints::SprintRepresenter, "rendering" do
   let(:start_date) { Date.new(2024, 1, 1) }
   let(:finish_date) { Date.new(2024, 1, 10) }
   let(:status) { "in_planning" }
+  let(:started_at) { Time.zone.local(2024, 1, 1, 9, 0) }
+  let(:completed_at) { Time.zone.local(2024, 1, 10, 17, 0) }
   let(:sprint) do
     build_stubbed(:sprint,
                   project: workspace,
                   status:,
                   name: "Sprint 1",
                   start_date:,
-                  finish_date:)
+                  finish_date:,
+                  started_at:,
+                  completed_at:)
   end
   let(:current_user) { build_stubbed(:user) }
   let(:embed_links) { true }
@@ -134,6 +138,20 @@ RSpec.describe API::V3::Sprints::SprintRepresenter, "rendering" do
       it_behaves_like "has ISO 8601 date only" do
         let(:date) { finish_date }
         let(:json_path) { "finishDate" }
+      end
+    end
+
+    describe "startedAt" do
+      it_behaves_like "has UTC ISO 8601 date and time" do
+        let(:date) { started_at }
+        let(:json_path) { "startedAt" }
+      end
+    end
+
+    describe "completedAt" do
+      it_behaves_like "has UTC ISO 8601 date and time" do
+        let(:date) { completed_at }
+        let(:json_path) { "completedAt" }
       end
     end
 

--- a/modules/backlogs/spec/migrations/backfill_sprint_started_and_completed_at_spec.rb
+++ b/modules/backlogs/spec/migrations/backfill_sprint_started_and_completed_at_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("modules/backlogs/db/migrate/20260825103847_backfill_sprint_started_and_completed_at")
+
+RSpec.describe BackfillSprintStartedAndCompletedAt, type: :model do
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
+
+  let!(:in_planning) { create(:sprint, status: "in_planning") }
+
+  let!(:active) do
+    create(:sprint, status: "active", start_date: Date.new(2026, 1, 5), finish_date: Date.new(2026, 1, 20))
+  end
+
+  let!(:completed) do
+    create(:sprint, status: "completed", start_date: Date.new(2026, 2, 1), finish_date: Date.new(2026, 2, 14))
+  end
+
+  let!(:active_without_dates) do
+    build(:sprint, status: "active", start_date: nil, finish_date: nil).tap { |s| s.save!(validate: false) }
+  end
+
+  let!(:already_started) do
+    create(:sprint, status: "active", start_date: Date.new(2026, 3, 1), finish_date: Date.new(2026, 3, 14)).tap do |s|
+      s.update_column(:started_at, Time.zone.parse("2026-03-01 09:17:42 UTC"))
+    end
+  end
+
+  let!(:already_started_and_completed) do
+    create(:sprint, status: "completed", start_date: Date.new(2026, 4, 1), finish_date: Date.new(2026, 4, 14)).tap do |s|
+      s.update_columns(
+        started_at: Time.zone.parse("2026-04-01 09:17:42 UTC"),
+        completed_at: Time.zone.parse("2026-04-14 16:03:11 UTC")
+      )
+    end
+  end
+
+  it "leaves sprints that are still in planning untouched" do
+    migrate
+    expect(in_planning.reload).to have_attributes(started_at: nil, completed_at: nil)
+  end
+
+  it "backfills started_at from start_date for active sprints" do
+    migrate
+    expect(active.reload.started_at).to eq(Time.zone.parse("2026-01-05 00:00:00 UTC"))
+    expect(active.completed_at).to be_nil
+  end
+
+  it "backfills started_at from start_date and completed_at from finish_date for completed sprints" do
+    migrate
+    expect(completed.reload.started_at).to eq(Time.zone.parse("2026-02-01 00:00:00 UTC"))
+    expect(completed.completed_at).to eq(Time.zone.parse("2026-02-14 00:00:00 UTC"))
+  end
+
+  it "does not fabricate a timestamp for legacy sprints with no start_date/finish_date" do
+    migrate
+    expect(active_without_dates.reload).to have_attributes(started_at: nil, completed_at: nil)
+  end
+
+  it "does not overwrite a started_at that was already set" do
+    migrate
+    expect(already_started.reload.started_at).to eq(Time.zone.parse("2026-03-01 09:17:42 UTC"))
+  end
+
+  it "does not overwrite a started_at and completed_at that were already set" do
+    migrate
+    expect(already_started_and_completed.reload).to have_attributes(
+      started_at: Time.zone.parse("2026-04-01 09:17:42 UTC"),
+      completed_at: Time.zone.parse("2026-04-14 16:03:11 UTC")
+    )
+  end
+end

--- a/modules/backlogs/spec/services/backlogs/sprints/finish_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/sprints/finish_service_spec.rb
@@ -54,9 +54,10 @@ RSpec.describe Backlogs::Sprints::FinishService do
   subject(:result) { instance.call(**call_params) }
 
   context "when the sprint has no unfinished work packages" do
-    it "completes the sprint", :aggregate_failures do
+    it "completes the sprint", :aggregate_failures, :freeze_time do
       expect(result).to be_success
       expect(sprint.reload).to be_completed
+      expect(sprint.completed_at).to equal_time_without_usec(Time.zone.now)
     end
   end
 
@@ -65,9 +66,10 @@ RSpec.describe Backlogs::Sprints::FinishService do
       create(:work_package, project:, sprint:, status: closed_status)
     end
 
-    it "completes the sprint ignoring the closed work package", :aggregate_failures do
+    it "completes the sprint ignoring the closed work package", :aggregate_failures, :freeze_time do
       expect(result).to be_success
       expect(sprint.reload).to be_completed
+      expect(sprint.completed_at).to equal_time_without_usec(Time.zone.now)
       expect(closed_wp.reload).to have_attributes(sprint:)
     end
   end
@@ -100,6 +102,7 @@ RSpec.describe Backlogs::Sprints::FinishService do
         expect(result).not_to be_success
         expect(result.includes_error?(:base, :unfinished_work_packages)).to be true
         expect(sprint.reload).to be_active
+        expect(sprint.completed_at).to be_nil
         expect(open_wp.reload).to have_attributes(sprint:)
       end
     end

--- a/modules/backlogs/spec/services/backlogs/sprints/start_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/sprints/start_service_spec.rb
@@ -47,9 +47,10 @@ RSpec.describe Backlogs::Sprints::StartService do
   end
 
   context "when no task board exists yet" do
-    it "creates the board and starts the sprint", :aggregate_failures do
+    it "creates the board and starts the sprint", :aggregate_failures, :freeze_time do
       expect(result).to be_success
       expect(sprint.reload).to be_active
+      expect(sprint.started_at).to equal_time_without_usec(Time.zone.now)
       expect(sprint.task_board_for(project)).to be_present
     end
   end
@@ -69,10 +70,11 @@ RSpec.describe Backlogs::Sprints::StartService do
   context "when a task board already exists" do
     let!(:existing_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
-    it "starts the sprint without creating another board", :aggregate_failures do
+    it "starts the sprint without creating another board", :aggregate_failures, :freeze_time do
       expect { result }.not_to change(Boards::Grid, :count)
       expect(result).to be_success
       expect(sprint.reload).to be_active
+      expect(sprint.started_at).to equal_time_without_usec(Time.zone.now)
       expect(sprint.task_board_for(project)).to eq(existing_board)
     end
   end
@@ -81,10 +83,11 @@ RSpec.describe Backlogs::Sprints::StartService do
     let!(:other_project) { create(:project) }
     let!(:other_board) { create(:board_grid_with_query, project: other_project, linked: sprint) }
 
-    it "creates a board for the sprint project", :aggregate_failures do
+    it "creates a board for the sprint project", :aggregate_failures, :freeze_time do
       expect { result }.to change(Boards::Grid, :count).by(1)
       expect(result).to be_success
       expect(sprint.reload).to be_active
+      expect(sprint.started_at).to equal_time_without_usec(Time.zone.now)
       expect(sprint.task_board_for(project)).to be_present
       expect(sprint.task_board_for(project)).not_to eq(other_board)
       expect(sprint.task_board_for(other_project)).to eq(other_board)
@@ -105,6 +108,7 @@ RSpec.describe Backlogs::Sprints::StartService do
     it "returns failure and leaves the sprint in planning", :aggregate_failures do
       expect(result).not_to be_success
       expect(sprint.reload).to be_in_planning
+      expect(sprint.started_at).to be_nil
       expect(sprint.task_board_for(project)).to be_nil
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-406

# What are you trying to accomplish?
When starting a sprint, set a `started_at` date. Likewise, when completing, set a `completed_at` date.

## Caveats

* There is a backfill migration for existing sprints to have approximate sane values for the new fields.
* The date is set, but not visible anywhere in the UI at this point.
* Since the user cannot _see_ these dates, validating them strictly could cause confusion. Apart from starting and completing a sprint, there's also no way of modifying these invisible dates from the UI. So even if there were validations (and error messages), the user would only have very limited capabilities to do something about it. I have thus decided to strip validation for the time being.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
