### PR TITLE
[OP-19884] Long WP name or timespan doesn't wrap in planner cell

### DIFF
--- a/frontend/src/global_styles/openproject/_generic.sass
+++ b/frontend/src/global_styles/openproject/_generic.sass
@@ -134,3 +134,6 @@ a
 
 :focus-visible
   @include focus
+
+.white-space-normal
+  white-space: normal

--- a/modules/resource_management/app/components/resource_planner_views/work_package_timeline/resource_cell_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_timeline/resource_cell_component.rb
@@ -58,6 +58,7 @@ module ResourcePlannerViews
           Primer::Beta::Link.new(
             href: helpers.url_for(controller: "/work_packages", action: "show", id: @work_package),
             font_weight: :bold,
+            classes: "white-space-normal",
             underline: false
           )
         ) { @work_package.subject }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19884

# What are you trying to accomplish?
Wrap long WP titles in the resource view


