### PR TITLE
[BNE-130] Hand the document's project to the BlockNote editor

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -118,6 +118,7 @@ class BlockNoteElement extends HTMLElement {
           openProjectUrl: this.getAttribute('open-project-url') ?? '',
           attachmentsUploadUrl: this.getAttribute('attachments-upload-url') ?? '',
           attachmentsCollectionKey: this.getAttribute('attachments-collection-key') ?? '',
+          projectId: this.getAttribute('project-id') ?? '',
           captureExternalLinks: document.body.dataset.externalLinksEnabledValue === 'true',
           hocuspocusProvider,
         }

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -40,6 +40,7 @@ export interface OpBlockNoteContainerProps {
   openProjectUrl:string;
   attachmentsUploadUrl:string;
   attachmentsCollectionKey:string;
+  projectId:string;
   captureExternalLinks:boolean;
   hocuspocusProvider:HocuspocusProvider;
 }
@@ -50,6 +51,7 @@ export default function OpBlockNoteContainer({
   openProjectUrl,
   attachmentsUploadUrl,
   attachmentsCollectionKey,
+  projectId,
   captureExternalLinks,
   hocuspocusProvider,
 }:OpBlockNoteContainerProps) {
@@ -84,6 +86,7 @@ export default function OpBlockNoteContainer({
       openProjectUrl={openProjectUrl}
       attachmentsUploadUrl={attachmentsUploadUrl}
       attachmentsCollectionKey={attachmentsCollectionKey}
+      projectId={projectId}
       captureExternalLinks={captureExternalLinks}
       hocuspocusProvider={hocuspocusProvider}
       doc={doc}

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -58,6 +58,7 @@ export interface OpBlockNoteEditorProps {
   openProjectUrl:string;
   attachmentsUploadUrl:string;
   attachmentsCollectionKey:string;
+  projectId:string;
   captureExternalLinks:boolean;
   hocuspocusProvider?:HocuspocusProvider;
   doc:Y.Doc;
@@ -82,6 +83,7 @@ export function OpBlockNoteEditor({
   openProjectUrl,
   attachmentsUploadUrl,
   attachmentsCollectionKey,
+  projectId,
   captureExternalLinks,
   hocuspocusProvider,
   doc,
@@ -90,8 +92,8 @@ export function OpBlockNoteEditor({
   const { enabled: attachmentsEnabled, uploadFile } = useBlockNoteAttachments(attachmentsCollectionKey, attachmentsUploadUrl);
 
   useEffect(() => {
-    initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString });
-  }, [openProjectUrl, localeString]);
+    initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString, projectId });
+  }, [openProjectUrl, localeString, projectId]);
 
   const editorParams = useMemo<Partial<BlockNoteEditorOptions<typeof schema.blockSchema, typeof schema.inlineContentSchema, typeof schema.styleSchema>>>(() => {
     return {

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -39,6 +39,7 @@
       "open-project-url": root_url,
       "attachments-upload-url": attachments_upload_url,
       "attachments-collection-key": attachments_collection_key,
+      "project-id": project_id,
       "blocknote-stylesheet-url": blocknote_stylesheet_url,
       "shadow-dom-stylesheet-url": shadow_dom_stylesheet_url,
       "browser-specific-classes": browser_specific_classes.join(" ").presence,

--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -43,13 +43,15 @@ module Primer
                     :active_user,
                     :attachments_upload_url,
                     :attachments_collection_key,
+                    :project_id,
                     :blocknote_stylesheet_url,
                     :shadow_dom_stylesheet_url,
                     :collaboration_enabled
 
         delegate :name, to: :@input
 
-        def initialize(input:, value:, readonly:, attachments_upload_url: "", attachments_collection_key: "")
+        def initialize(input:, value:, readonly:, attachments_upload_url: "", attachments_collection_key: "",
+                       project_id: nil)
           super()
           @input = input
           @value = value
@@ -60,6 +62,7 @@ module Primer
           }
           @attachments_upload_url = attachments_upload_url
           @attachments_collection_key = attachments_collection_key
+          @project_id = project_id
           @blocknote_stylesheet_url = raw_variable_asset_path("blocknote.css")
           @shadow_dom_stylesheet_url = raw_variable_asset_path("styles.css")
 

--- a/lib/primer/open_project/forms/dsl/block_note_editor_input.rb
+++ b/lib/primer/open_project/forms/dsl/block_note_editor_input.rb
@@ -39,7 +39,8 @@ module Primer
                       :readonly,
                       :classes,
                       :attachments_upload_url,
-                      :attachments_collection_key
+                      :attachments_collection_key,
+                      :project_id
 
           ##
           # @param name [String] The name of the input field.
@@ -47,8 +48,9 @@ module Primer
           # @param value [String] The initial value of the input in base64 format.
           # @param attachments_upload_url [String] The URL to which attachments will be uploaded.
           # @param attachments_collection_key [String] The collection key for attachments.
+          # @param project_id [Integer] The project the edited document belongs to.
           def initialize(name:, label:, value:, readonly: false, attachments_upload_url: "", attachments_collection_key: "",
-                         **system_arguments)
+                         project_id: nil, **system_arguments)
             @name = name
             @label = label
             @value = value
@@ -56,12 +58,14 @@ module Primer
             @classes = system_arguments[:classes]
             @attachments_upload_url = attachments_upload_url
             @attachments_collection_key = attachments_collection_key
+            @project_id = project_id
 
             super(**system_arguments)
           end
 
           def to_component
-            BlockNoteEditor.new(input: self, value:, readonly:, attachments_upload_url:, attachments_collection_key:)
+            BlockNoteEditor.new(input: self, value:, readonly:, attachments_upload_url:, attachments_collection_key:,
+                                project_id:)
           end
 
           def type

--- a/modules/documents/app/forms/documents/block_note_editor_form.rb
+++ b/modules/documents/app/forms/documents/block_note_editor_form.rb
@@ -38,7 +38,8 @@ module Documents
         visually_hide_label: true,
         value: model.content_binary,
         attachments_upload_url:,
-        attachments_collection_key:
+        attachments_collection_key:,
+        project_id: model.project_id
       )
     end
 

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
     expect(editor.content).to include("Heading")
   end
 
+  it "hands the project of the document to the editor, so a work package can be created in it" do
+    visit document_path(document)
+
+    expect(page).to have_test_selector("blocknote-document-description")
+    expect(find("op-block-note", visible: false)["project-id"]).to eq(document.project_id.to_s)
+  end
+
   context "when real time text collaboration is disabled",
           with_settings: { real_time_text_collaboration_enabled: false } do
     it "does not render the BlockNote editor" do

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -260,5 +260,43 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         end
       end
     end
+
+    context "when creating a work package from the document" do
+      let(:type) { create(:type_task) }
+      let(:project) { create(:project, name: "Documented project", types: [create(:type_bug), type]) }
+      let(:document) { create(:document, :collaborative, project:) }
+      let!(:release_note) do
+        create(:string_wp_custom_field, name: "Release note", is_required: true, types: [type], projects: [project])
+      end
+      let!(:default_status) { create(:status, is_default: true) }
+      let!(:default_priority) { create(:priority, is_default: true) }
+      let!(:other_project) { create(:project, name: "Another project", types: [type]) }
+
+      it "creates it in the project of the document, with the fields the chosen type requires" do
+        visit document_path(document)
+        expect(page).to have_test_selector("blocknote-document-description")
+
+        editor.open_create_work_package_dialog
+
+        within editor.create_work_package_form do
+          expect(page).to have_field("Project", with: project.name)
+
+          select type.name, from: "Type"
+          fill_in "Subject", with: "Write the release notes"
+          fill_in "Release note", with: "16.0"
+
+          click_on "Create"
+        end
+
+        expect(page).to have_no_css("[data-testid='create-wp-modal']")
+        expect(editor.element).to have_text("Write the release notes")
+
+        work_package = WorkPackage.last
+        expect(work_package.project).to eq(project)
+        expect(work_package.type).to eq(type)
+        expect(work_package.subject).to eq("Write the release notes")
+        expect(work_package.custom_value_for(release_note).value).to eq("16.0")
+      end
+    end
   end
 end

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -19,6 +19,15 @@ module FormFields
         send_keys(:enter)
       end
 
+      def open_create_work_package_dialog
+        send_keys_to_editor("/create")
+        send_keys(:enter)
+      end
+
+      def create_work_package_form
+        page.find("[data-testid='create-wp-modal']")
+      end
+
       def fill_in(content)
         send_keys_to_editor(content)
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/BNE/work_packages/BNE-130

# What are you trying to accomplish?
Creating a work package from a document asked for the project every time, even though the document already belongs to one. This hands that project to the BlockNote editor, so the create form opens on it and only asks for what is genuinely new.

# What approach did you choose and why?

The project id travels the same way the editor's other context does: the document form puts it on the `op-block-note` element, and the element passes it to `initializeOpBlockNoteExtensions`, which takes a new optional `projectId` (see opf/op-blocknote-extensions#214).

Passing the document's project explicitly rather than reading the `current_project` meta tag: the meta tag holds the project of the *page*, which happens to be the same today, but would be absent or wrong wherever the editor
is rendered outside a project route. Optional on both sides, so an editor rendered without a project keeps working exactly as before - and a library version that does not know the attribute yet simply ignores it.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
