### PR TITLE
Pass allowed_clock_drift from UI/settings into RubySAML

### DIFF
--- a/docs/system-admin-guide/authentication/saml/README.md
+++ b/docs/system-admin-guide/authentication/saml/README.md
@@ -58,7 +58,7 @@ If you have used the metadata exchange, the next form will be pre-filled like in
 
 If some of the required fields (marked with an asterisk) are missing, fill them out with the information from your identity provider. OpenProject assumes you're using the URL of your OpenProject instance as the Service entity ID by default. If your provider expects a different format, this can be an arbitrary string.
 
-The optional **Allowed clock drift** field relaxes the validation of the timestamps contained in the identity provider response by the given number of seconds. Leave it empty unless authentication fails because the clocks of OpenProject and the identity provider are out of sync, and prefer synchronizing the clocks over raising this value: a large tolerance weakens the protection against replayed assertions.
+The optional **Allowed clock drift** field relaxes the validation of the timestamps contained in the identity provider response by the given number of seconds, fractions of a second included. Leave it empty unless authentication fails because the clocks of OpenProject and the identity provider are out of sync, and prefer synchronizing the clocks over raising this value: a large tolerance weakens the protection against replayed assertions.
 
 Once you verified the configuration with your settings from the identity provider, click on **Continue**.
 
@@ -261,6 +261,8 @@ The timestamps in the identity provider response are validated against the clock
 ```shell
 OPENPROJECT_SAML_SAML_ALLOWED__CLOCK__DRIFT="5"
 ```
+
+Fractions of a second are accepted as well, for example `"0.5"`.
 
 Prefer synchronizing the clocks over setting this value, and keep it as low as possible. A large tolerance weakens the protection against replayed assertions. Note that the tolerance applies to the login response only, not to logout requests initiated by the identity provider.
 

--- a/docs/system-admin-guide/authentication/saml/README.md
+++ b/docs/system-admin-guide/authentication/saml/README.md
@@ -58,6 +58,8 @@ If you have used the metadata exchange, the next form will be pre-filled like in
 
 If some of the required fields (marked with an asterisk) are missing, fill them out with the information from your identity provider. OpenProject assumes you're using the URL of your OpenProject instance as the Service entity ID by default. If your provider expects a different format, this can be an arbitrary string.
 
+The optional **Allowed clock drift** field relaxes the validation of the timestamps contained in the identity provider response by the given number of seconds. Leave it empty unless authentication fails because the clocks of OpenProject and the identity provider are out of sync, and prefer synchronizing the clocks over raising this value: a large tolerance weakens the protection against replayed assertions.
+
 Once you verified the configuration with your settings from the identity provider, click on **Continue**.
 
 ### Step 4: Signatures and Encryption
@@ -251,6 +253,16 @@ The default behavior would be to use the email Address like so:
 ```shell
 OPENPROJECT_SAML_SAML_NAME__IDENTIFIER__FORMAT="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 ```
+
+#### Optional: Allow for a clock drift
+
+The timestamps in the identity provider response are validated against the clock of the OpenProject server. If both clocks are out of sync, valid responses may be rejected. You can allow for a tolerance, given in seconds:
+
+```shell
+OPENPROJECT_SAML_SAML_ALLOWED__CLOCK__DRIFT="5"
+```
+
+Prefer synchronizing the clocks over setting this value, and keep it as low as possible. A large tolerance weakens the protection against replayed assertions. Note that the tolerance applies to the login response only, not to logout requests initiated by the identity provider.
 
 ### Applying the configuration
 

--- a/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
@@ -73,7 +73,6 @@ module Saml
       attribute :allowed_clock_drift
       validates :allowed_clock_drift,
                 numericality: {
-                  only_integer: true,
                   allow_nil: true,
                   greater_than_or_equal_to: 0,
                   less_than_or_equal_to: MAX_ALLOWED_CLOCK_DRIFT

--- a/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
@@ -32,6 +32,8 @@ module Saml
     class BaseContract < ModelContract
       include RequiresAdminGuard
 
+      MAX_ALLOWED_CLOCK_DRIFT = 5.minutes.to_i
+
       def self.model
         Saml::Provider
       end
@@ -67,6 +69,16 @@ module Saml
 
       attribute :authn_requests_signed
       validate :valid_certificate_key_pair
+
+      attribute :allowed_clock_drift
+      validates :allowed_clock_drift,
+                numericality: {
+                  only_integer: true,
+                  allow_nil: true,
+                  greater_than_or_equal_to: 0,
+                  less_than_or_equal_to: MAX_ALLOWED_CLOCK_DRIFT
+                },
+                if: -> { model.allowed_clock_drift_changed? }
 
       attribute :limit_self_registration
 

--- a/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
@@ -76,6 +76,17 @@ module Saml
             list.option(label: format, value: format)
           end
         end
+        f.text_field(
+          name: :allowed_clock_drift,
+          type: :number,
+          min: 0,
+          max: Saml::Providers::BaseContract::MAX_ALLOWED_CLOCK_DRIFT,
+          label: I18n.t("activerecord.attributes.saml/provider.allowed_clock_drift"),
+          caption: I18n.t("saml.instructions.allowed_clock_drift"),
+          disabled: provider.seeded_from_env?,
+          required: false,
+          input_width: :xsmall
+        )
         f.check_box(
           name: :limit_self_registration,
           label: I18n.t("activerecord.attributes.saml/provider.limit_self_registration"),

--- a/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
@@ -81,6 +81,7 @@ module Saml
           type: :number,
           min: 0,
           max: Saml::Providers::BaseContract::MAX_ALLOWED_CLOCK_DRIFT,
+          step: "any",
           label: I18n.t("activerecord.attributes.saml/provider.allowed_clock_drift"),
           caption: I18n.t("saml.instructions.allowed_clock_drift"),
           disabled: provider.seeded_from_env?,

--- a/modules/auth_saml/app/models/saml/provider.rb
+++ b/modules/auth_saml/app/models/saml/provider.rb
@@ -27,7 +27,7 @@ module Saml
     store_attribute :options, :want_assertions_encrypted, :boolean
     store_attribute :options, :digest_method, :string
     store_attribute :options, :signature_method, :string
-    store_attribute :options, :allowed_clock_drift, :integer
+    store_attribute :options, :allowed_clock_drift, :float
 
     store_attribute :options, :mapping_login, :string
     store_attribute :options, :mapping_mail, :string

--- a/modules/auth_saml/app/models/saml/provider.rb
+++ b/modules/auth_saml/app/models/saml/provider.rb
@@ -27,6 +27,7 @@ module Saml
     store_attribute :options, :want_assertions_encrypted, :boolean
     store_attribute :options, :digest_method, :string
     store_attribute :options, :signature_method, :string
+    store_attribute :options, :allowed_clock_drift, :integer
 
     store_attribute :options, :mapping_login, :string
     store_attribute :options, :mapping_mail, :string

--- a/modules/auth_saml/app/models/saml/provider/hash_builder.rb
+++ b/modules/auth_saml/app/models/saml/provider/hash_builder.rb
@@ -78,7 +78,8 @@ module Saml
         limit_self_registration:,
         attribute_statements: formatted_attribute_statements,
         request_attributes: formatted_request_attributes,
-        uid_attribute: mapping_uid.presence
+        uid_attribute: mapping_uid.presence,
+        allowed_clock_drift:
       }
         .merge(idp_cert_options_hash)
         .merge(security: security_options_hash)

--- a/modules/auth_saml/config/locales/en.yml
+++ b/modules/auth_saml/config/locales/en.yml
@@ -47,8 +47,8 @@ en:
     instructions:
       allowed_clock_drift: >
         Tolerance in seconds applied when validating the timestamps of the identity provider response.
-        Use this only if the clocks of OpenProject and the identity provider are known to be out of sync,
-        and keep the value as low as possible (Default: 0).
+        Fractions of a second are accepted. Use this only if the clocks of OpenProject and the identity
+        provider are known to be out of sync, and keep the value as low as possible (Default: 0).
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       certificate: >

--- a/modules/auth_saml/config/locales/en.yml
+++ b/modules/auth_saml/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activerecord:
     attributes:
       saml/provider:
+        allowed_clock_drift: Allowed clock drift
         assertion_consumer_service_url: ACS (Assertion consumer service) URL
         authn_requests_signed: Sign SAML AuthnRequests
         certificate: Certificate used by OpenProject for SAML requests
@@ -44,6 +45,10 @@ en:
         Use these parameters to configure your identity provider connection to OpenProject.
       title: "SAML Protocol Configuration Parameters"
     instructions:
+      allowed_clock_drift: >
+        Tolerance in seconds applied when validating the timestamps of the identity provider response.
+        Use this only if the clocks of OpenProject and the identity provider are known to be out of sync,
+        and keep the value as low as possible (Default: 0).
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       certificate: >

--- a/modules/auth_saml/spec/contracts/saml/providers/create_contract_spec.rb
+++ b/modules/auth_saml/spec/contracts/saml/providers/create_contract_spec.rb
@@ -29,23 +29,10 @@
 #++
 
 require "spec_helper"
-require "contracts/shared/model_contract_shared_context"
+require_relative "shared_contract_examples"
 
 RSpec.describe Saml::Providers::CreateContract do
-  include_context "ModelContract shared context"
-
   let(:provider) { build(:saml_provider) }
-  let(:contract) { described_class.new provider, current_user }
 
-  context "when admin" do
-    let(:current_user) { build_stubbed(:admin) }
-
-    it_behaves_like "contract is valid"
-  end
-
-  context "when non-admin" do
-    let(:current_user) { build_stubbed(:user) }
-
-    it_behaves_like "contract is invalid", base: :error_unauthorized
-  end
+  include_context "as saml provider contract"
 end

--- a/modules/auth_saml/spec/contracts/saml/providers/shared_contract_examples.rb
+++ b/modules/auth_saml/spec/contracts/saml/providers/shared_contract_examples.rb
@@ -28,18 +28,48 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
-require_relative "shared_contract_examples"
+require "contracts/shared/model_contract_shared_context"
 
-RSpec.describe Saml::Providers::UpdateContract do
-  let(:provider) { build_stubbed(:saml_provider) }
+RSpec.shared_context "as saml provider contract" do
+  include_context "ModelContract shared context"
 
-  include_context "as saml provider contract"
+  let(:contract) { described_class.new provider, current_user }
 
-  describe "allowed_clock_drift persisted out of bounds" do
+  context "when admin" do
     let(:current_user) { build_stubbed(:admin) }
-    let(:provider) { build_stubbed(:saml_provider, allowed_clock_drift: -1) }
 
     it_behaves_like "contract is valid"
+  end
+
+  context "when non-admin" do
+    let(:current_user) { build_stubbed(:user) }
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+
+  describe "allowed_clock_drift" do
+    let(:current_user) { build_stubbed(:admin) }
+
+    before do
+      provider.allowed_clock_drift = value
+    end
+
+    context "with a positive number of seconds" do
+      let(:value) { 5 }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "with a negative number of seconds" do
+      let(:value) { -1 }
+
+      it_behaves_like "contract is invalid", allowed_clock_drift: :greater_than_or_equal_to
+    end
+
+    context "with a value exceeding the maximum" do
+      let(:value) { Saml::Providers::BaseContract::MAX_ALLOWED_CLOCK_DRIFT + 1 }
+
+      it_behaves_like "contract is invalid", allowed_clock_drift: :less_than_or_equal_to
+    end
   end
 end

--- a/modules/auth_saml/spec/contracts/saml/providers/shared_contract_examples.rb
+++ b/modules/auth_saml/spec/contracts/saml/providers/shared_contract_examples.rb
@@ -60,14 +60,26 @@ RSpec.shared_context "as saml provider contract" do
       it_behaves_like "contract is valid"
     end
 
+    context "with a fraction of a second" do
+      let(:value) { 0.5 }
+
+      it_behaves_like "contract is valid"
+    end
+
     context "with a negative number of seconds" do
       let(:value) { -1 }
 
       it_behaves_like "contract is invalid", allowed_clock_drift: :greater_than_or_equal_to
     end
 
+    context "with a negative fraction of a second" do
+      let(:value) { -0.5 }
+
+      it_behaves_like "contract is invalid", allowed_clock_drift: :greater_than_or_equal_to
+    end
+
     context "with a value exceeding the maximum" do
-      let(:value) { Saml::Providers::BaseContract::MAX_ALLOWED_CLOCK_DRIFT + 1 }
+      let(:value) { Saml::Providers::BaseContract::MAX_ALLOWED_CLOCK_DRIFT + 0.5 }
 
       it_behaves_like "contract is invalid", allowed_clock_drift: :less_than_or_equal_to
     end

--- a/modules/auth_saml/spec/contracts/saml/providers/update_contract_spec.rb
+++ b/modules/auth_saml/spec/contracts/saml/providers/update_contract_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Saml::Providers::UpdateContract do
 
   describe "allowed_clock_drift persisted out of bounds" do
     let(:current_user) { build_stubbed(:admin) }
-    let(:provider) { build_stubbed(:saml_provider, allowed_clock_drift: -1) }
+    let(:provider) { build_stubbed(:saml_provider, allowed_clock_drift: -0.5) }
 
     it_behaves_like "contract is valid"
   end

--- a/modules/auth_saml/spec/models/saml/provider_spec.rb
+++ b/modules/auth_saml/spec/models/saml/provider_spec.rb
@@ -308,5 +308,22 @@ RSpec.describe Saml::Provider do
         expect(provider.to_h).not_to include(:uid_attribute)
       end
     end
+
+    context "when allowed_clock_drift is set" do
+      before do
+        provider.allowed_clock_drift = 5
+      end
+
+      it "outputs it as a top-level option for the ruby-saml response validation" do
+        expect(provider.to_h).to include(allowed_clock_drift: 5)
+        expect(provider.to_h[:security]).not_to include(:allowed_clock_drift)
+      end
+    end
+
+    context "when allowed_clock_drift is not set" do
+      it "does not output it, leaving the ruby-saml default in place" do
+        expect(provider.to_h).not_to include(:allowed_clock_drift)
+      end
+    end
   end
 end

--- a/modules/auth_saml/spec/models/saml/provider_spec.rb
+++ b/modules/auth_saml/spec/models/saml/provider_spec.rb
@@ -315,8 +315,18 @@ RSpec.describe Saml::Provider do
       end
 
       it "outputs it as a top-level option for the ruby-saml response validation" do
-        expect(provider.to_h).to include(allowed_clock_drift: 5)
+        expect(provider.to_h).to include(allowed_clock_drift: 5.0)
         expect(provider.to_h[:security]).not_to include(:allowed_clock_drift)
+      end
+    end
+
+    context "when allowed_clock_drift is set to a fraction of a second" do
+      before do
+        provider.allowed_clock_drift = 0.5
+      end
+
+      it "keeps the fraction" do
+        expect(provider.to_h).to include(allowed_clock_drift: 0.5)
       end
     end
 

--- a/modules/auth_saml/spec/services/saml/configuration_mapper_spec.rb
+++ b/modules/auth_saml/spec/services/saml/configuration_mapper_spec.rb
@@ -142,6 +142,14 @@ RSpec.describe Saml::ConfigurationMapper, type: :model do
     end
   end
 
+  describe "allowed_clock_drift" do
+    let(:configuration) { { allowed_clock_drift: 5 } }
+
+    subject { result["options"] }
+
+    it { is_expected.to include("allowed_clock_drift" => 5) }
+  end
+
   describe "idp_cert" do
     let(:idp_cert) { File.read(Rails.root.join("modules/auth_saml/spec/fixtures/idp_cert_plain.txt").to_s) }
 

--- a/modules/auth_saml/spec/services/saml/configuration_mapper_spec.rb
+++ b/modules/auth_saml/spec/services/saml/configuration_mapper_spec.rb
@@ -143,11 +143,11 @@ RSpec.describe Saml::ConfigurationMapper, type: :model do
   end
 
   describe "allowed_clock_drift" do
-    let(:configuration) { { allowed_clock_drift: 5 } }
+    let(:configuration) { { allowed_clock_drift: 0.5 } }
 
     subject { result["options"] }
 
-    it { is_expected.to include("allowed_clock_drift" => 5) }
+    it { is_expected.to include("allowed_clock_drift" => 0.5) }
   end
 
   describe "idp_cert" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-20015

# What are you trying to accomplish?

- Allow configuring the allowed_clock_drift within the SAML configuration
- Allow passing in the allowed_clock_drift to a SAML via ENV
- Pass the configured [allowed_clock_drift to RubySAML used for authentication](https://github.com/SAML-Toolkits/ruby-saml#clock-drift)

## Screenshots

<img width="643" height="295" alt="image" src="https://github.com/user-attachments/assets/62d0055e-9cd1-42f8-bb7d-e3287fa1651a" />

# What approach did you choose and why?

The RubySAML gem supports the `allowed_clock_drift` configuration option. This PR just needs to allow setting and storing the option via the UI or ENV. The value is then passed to the RubySAML gem.

As such, the PR just follows the patterns already established for the rest of the configuration options. Whether the chosen spot it the UI is the right one can be discusssed.

The contracts only checks the value if the allowed_clock_drift value changed. This is in line with most of the other values in the contract. I personally don't see the benefit of doing it in this case.

# Merge checklist

- [x] Added/updated tests
