### PR TITLE
[FND-203] Confirmation text is cut off on danger dialog

### DIFF
--- a/app/components/work_package_types/configuration_independence/confirm_dialog_component.html.erb
+++ b/app/components/work_package_types/configuration_independence/confirm_dialog_component.html.erb
@@ -31,6 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
       Primer::OpenProject::DangerDialog.new(
         id: DIALOG_ID,
         test_selector: DIALOG_ID,
+        size: :medium_portrait,
         title: t("types.edit.reuse_mode.independent.confirm_dialog.title"),
         confirm_button_text: t(:button_confirm),
         cancel_button_text: t(:button_close),
@@ -42,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
       )
     ) do |dialog| %>
   <% dialog.with_confirmation_message do |message| %>
-    <% message.with_heading(tag: :h2) { t("types.edit.reuse_mode.independent.confirm_dialog.title") } %>
+    <% message.with_heading(tag: :h2) { t("types.edit.reuse_mode.independent.confirm_dialog.heading") } %>
     <% message.with_description_content(t("types.edit.reuse_mode.independent.confirm_dialog.description")) %>
   <% end %>
 

--- a/app/components/work_package_types/configuration_links/confirm_dialog_component.html.erb
+++ b/app/components/work_package_types/configuration_links/confirm_dialog_component.html.erb
@@ -32,6 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
         id: DIALOG_ID,
         test_selector: DIALOG_ID,
         title:,
+        size: :medium_portrait,
         confirm_button_text: t(:button_confirm),
         cancel_button_text: t(:button_close),
         form_arguments: {
@@ -42,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
       )
     ) do |dialog| %>
   <% dialog.with_confirmation_message do |message| %>
-    <% message.with_heading(tag: :h2) { title } %>
+    <% message.with_heading(tag: :h2) { heading } %>
     <% if changing_source? %>
       <% message.with_description_content(
            t(

--- a/app/components/work_package_types/configuration_links/confirm_dialog_component.rb
+++ b/app/components/work_package_types/configuration_links/confirm_dialog_component.rb
@@ -63,6 +63,14 @@ module WorkPackageTypes
         end
       end
 
+      def heading
+        if changing_source?
+          t("types.edit.reuse_mode.linked.confirm_dialog.change_source.heading")
+        else
+          t("types.edit.reuse_mode.linked.confirm_dialog.from_independent.heading")
+        end
+      end
+
       def switch_path
         type_configuration_link_switch_path(type_id: type.id, aspect:)
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6293,7 +6293,8 @@ en:
           confirm_dialog:
             check_box: "I understand that this will override the current settings"
             description: "All the current selected settings will be overridden and might affect existing information on the work packages of this type."
-            title: "Switch configuration mode?"
+            heading: "Switch configuration mode?"
+            title: "Switch configuration mode"
           copy_from_type: "Copy from type"
           description: "No settings are inherited. If desired you can still one-time copy settings from another type."
           dialog:
@@ -6318,11 +6319,13 @@ en:
           confirm_dialog:
             change_source:
               description_html: "By changing the source type to %{source_name} you will overwrite the current settings and might affect existing information on the work packages of this type."
-              title: "Change source type?"
+              heading: "Change source type?"
+              title: "Change source type"
             check_box: "I understand that this will override the current settings"
             from_independent:
               description: "All the current selected settings will be overridden and might affect existing information on the work packages of this type."
-              title: "Switch configuration mode?"
+              heading: "Switch configuration mode?"
+              title: "Switch configuration mode"
           description: "This configuration is linked and inheriting its settings from the source type [%{source_name}](source_url)%{source_suffix}."
           dialog:
             description: "Copy and inherit this settings from a source. Any new configuration added to the source will also be added here."


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/FND-203

# What are you trying to accomplish?
Correct DangerDialog heading, titles and sizes

