### PR TITLE
[COMMS-909] First headline not rendered correctly when opening a document

### DIFF
--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -41,7 +41,7 @@ import {
   workPackageSlashMenu,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import * as Y from 'yjs';
 import { useBlockNoteAttachments } from '../hooks/useBlockNoteAttachments';
 import { useBlockNoteLocale } from '../hooks/useBlockNoteLocale';
@@ -128,6 +128,23 @@ export function OpBlockNoteEditor({
   const editor = useCreateBlockNote(editorParams, []);
   type EditorType = typeof editor;
   const theme = useOpTheme();
+
+  // Works around a BlockNote/Yjs bootstrap race where the first block can render with
+  // stale transition-tracking CSS state (e.g. a heading rendering at body-text size)
+  // until the next transaction. Re-applying its own props once, before first paint,
+  // forces that state to recompute cleanly.
+  const forcedInitialBlockRefreshRef = useRef(false);
+  useLayoutEffect(() => {
+    if (!hocuspocusProvider || forcedInitialBlockRefreshRef.current) {
+      return;
+    }
+
+    forcedInitialBlockRefreshRef.current = true;
+    const firstBlock = editor.document[0];
+    if (firstBlock?.id === 'initialBlockId') {
+      editor.updateBlock(firstBlock, { props: { ...firstBlock.props } });
+    }
+  }, [editor, hocuspocusProvider]);
 
   const getCustomSlashMenuItems = useCallback((editorInstance:EditorType) => [
     ...getDefaultReactSlashMenuItems(editorInstance),

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -78,6 +78,31 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
     end
   end
 
+  context "when a heading is the very first block of a document (COMMS-909)" do
+    # A BlockNote/Yjs collaboration-bootstrap race leaves the first block rendered
+    # at the wrong font-size until the next transaction (e.g. a click) recomputes it.
+    # It only reproduces on a genuine fresh editor mount of an already-persisted
+    # document.
+    it "renders the heading at full size immediately on reload, without needing a click" do
+      visit document_path(document)
+      expect(page).to have_test_selector("blocknote-document-description")
+
+      editor.fill_in("# Test heading")
+      editor.element.send_keys(:enter)
+      editor.fill_in("Some text here")
+      wait_for { document.reload.content_binary }.to be_present
+
+      visit home_path
+      visit document_path(document)
+
+      expect(page).to have_test_selector("blocknote-document-description")
+      wait_for { editor.content }.to have_text("Test heading")
+
+      # No click between the reload and here, since a click would trigger re-rendering (and with that "fix" the font size).
+      wait_for { editor.heading_to_paragraph_font_size_ratio }.to be > 2
+    end
+  end
+
   context "when running with a relative_url_root and non-proxied frontend assets",
           js: false,
           with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => "1" } do

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -48,7 +48,7 @@ module FormFields
       def wait_for_shadow_content(text)
         page.evaluate_async_script(<<~JS)
           (function(done) {
-            var shadowRoot = #{shadow_root_query}
+            var shadowRoot = #{shadow_root_query};
             var textToFind = #{text.to_json};
             #{shadow_root_observe_js}
 
@@ -125,7 +125,7 @@ module FormFields
       # its editor div regardless of isTrusted.
       def undo
         page.execute_script(<<~JS)
-          var shadowRoot = #{shadow_root_query}
+          var shadowRoot = #{shadow_root_query};
           var element = shadowRoot.querySelector('div[role="textbox"]');
           element.focus();
           element.dispatchEvent(new KeyboardEvent('keydown', {
@@ -137,6 +137,16 @@ module FormFields
             composed: true
           }));
         JS
+      end
+
+      def heading_to_paragraph_font_size_ratio
+        heading_font_size, paragraph_font_size = page.evaluate_script(<<~JS)
+          [
+            getComputedStyle(#{shadow_root_query}.querySelector('[data-content-type="heading"]')).fontSize,
+            getComputedStyle(#{shadow_root_query}.querySelector('[data-content-type="paragraph"]')).fontSize,
+          ]
+        JS
+        heading_font_size.to_f / paragraph_font_size.to_i
       end
 
       private
@@ -215,7 +225,7 @@ module FormFields
       end
 
       def shadow_root_query
-        "document.querySelector('op-block-note').shadowRoot;"
+        "document.querySelector('op-block-note').shadowRoot"
       end
     end
   end


### PR DESCRIPTION
The problem only applies to a headline that is created in the very first line in a new document (and this line not heavily edited before or after). It always occurred with a headline in a div with data-id="initialBlockId". The data-id can be removed by BlockNote when editing, so it seemed like this bug was only triggered sometimes, while in fact it was very deterministic.

Details to the actual bug (which needs to be adressed in BlockNote) are here: https://github.com/TypeCellOS/BlockNote/issues/3013

# Ticket
https://community.openproject.org/wp/COMMS-909

# What are you trying to accomplish?
Workaround a bug that would wrongly render the first headline as paragraph in certain circumstances, until the first user interaction, which then would "expand" the headline to its actual size (see screencast attached to the work package: https://community.openproject.org/api/v3/attachments/922948/content )

# What approach did you choose and why?
Since the bug is deeply in BlockNote / yjs collaboration, it's out of scope to apply a real fix inside OpenProject. Rather, the symptom is fixed by forcing a refresh of the affected block after document load (instead of waiting for the first user interaction, which would then also trigger the refresh).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
