### PR TITLE
[MEET-590, OP-19670] Meetings filter fixes

### DIFF
--- a/modules/meeting/app/controllers/concerns/meetings/query_loading.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/query_loading.rb
@@ -44,8 +44,9 @@ module Meetings
       time_filter = query.filters.find { |f| f.name == :time }
 
       if time_filter.nil?
-        # Only default to upcoming on the initial, unfiltered view
-        query.where("time", Queries::Operators::Upcoming.symbol, []) unless params.key?(:filters)
+        # Meetings render and group differently for upcoming vs past,
+        # so a time filter needs to always be present
+        query.where("time", Queries::Operators::Upcoming.symbol, [])
         query.order(start_time: :asc)
       elsif time_filter.past? && query.orders.none?
         query.order(start_time: :desc)

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -29,6 +29,8 @@
 # ++
 module Meetings
   class Menu < Submenu
+    CROSS_FILTER_KEYS = %w[time project_id].freeze
+
     def initialize(params:, project: nil)
       super(view_type: nil, project:, params:)
     end
@@ -53,11 +55,14 @@ module Meetings
     def my_meetings_item
       return unless User.current.logged?
 
-      my_meetings_href = polymorphic_path([project, :meetings])
-      filters = params[:filters].to_s
-      menu_item(title: I18n.t(:label_my_meetings),
-                selected: params[:current_href] == my_meetings_href &&
-                  (filters.blank? || (filters.include?("invited_user_id") && filters.exclude?('"*"'))))
+      menu_item(title: I18n.t(:label_my_meetings), selected: my_meetings_selected?)
+    end
+
+    def my_meetings_selected?
+      return false unless params[:current_href] == polymorphic_path([project, :meetings])
+      return params[:filters].blank? if preset_filters.empty?
+
+      sole_preset_matches?("invited_user_id", "=", [User.current.id.to_s])
     end
 
     def templates_menu_item
@@ -77,19 +82,16 @@ module Meetings
       )
     end
 
-    def all_meetings_item # rubocop:disable Metrics/AbcSize
+    def all_meetings_item
       all_filter = [{ time: { operator: Queries::Operators::Upcoming.symbol, values: [] } }].to_json
-      my_meetings_href = polymorphic_path([project, :meetings])
-      query_params = { filters: all_filter }
 
-      if User.current.anonymous?
-        menu_item(title: I18n.t(:label_all_meetings),
-                  selected: params[:current_href] == my_meetings_href && (params[:filters].blank? || selected?(query_params)),
-                  query_params:)
-      else
-        menu_item(title: I18n.t(:label_all_meetings),
-                  query_params:)
-      end
+      menu_item(title: I18n.t(:label_all_meetings),
+                selected: all_meetings_selected?,
+                query_params: { filters: all_filter })
+    end
+
+    def all_meetings_selected?
+      preset_filters.empty? && (User.current.anonymous? || params[:filters].present?)
     end
 
     def meeting_series_menu_items # rubocop:disable Metrics/AbcSize
@@ -120,7 +122,31 @@ module Meetings
       ].to_json
 
       menu_item(title: I18n.t("label_recurring_meeting_plural"),
+                selected: recurring_meetings_selected?,
                 query_params: { filters: recurring_filter, sort: "start_time" })
+    end
+
+    def recurring_meetings_selected?
+      sole_preset_matches?("type", "=", [OpenProject::Database::DB_VALUE_TRUE])
+    end
+
+    def sole_preset_matches?(key, operator, values)
+      return false unless preset_filters.size == 1
+
+      filter = preset_filters.first[key]
+      filter.is_a?(Hash) && filter["operator"] == operator && filter["values"] == values
+    end
+
+    def preset_filters
+      parsed_filters.reject { |filter| filter.keys.intersect?(CROSS_FILTER_KEYS) }
+    end
+
+    def parsed_filters
+      return @parsed_filters if defined?(@parsed_filters)
+
+      @parsed_filters = JSON.parse(params[:filters].to_s)
+    rescue JSON::ParserError
+      @parsed_filters = []
     end
 
     def involvement_group

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Meetings", "Index", :js do
           meetings_page.set_quick_filter upcoming: true
         end
 
-        it "lets the quick filter enter an unselected state" do
+        it "re-applies the upcoming quick filter automatically" do
           meetings_page.expect_quick_filter_selected "Upcoming"
 
           meetings_page.open_filters
@@ -270,7 +270,7 @@ RSpec.describe "Meetings", "Index", :js do
 
           wait_for_network_idle
 
-          meetings_page.expect_quick_filter_unselected
+          meetings_page.expect_quick_filter_selected "Upcoming"
         end
       end
 

--- a/modules/meeting/spec/requests/meetings_index_spec.rb
+++ b/modules/meeting/spec/requests/meetings_index_spec.rb
@@ -301,6 +301,23 @@ RSpec.describe "Meeting index",
     end
   end
 
+  context "when the time filter is not present" do
+    let(:request) do
+      filters = [{ "author_id" => { "operator" => "=", "values" => [user.id.to_s] } }].to_json
+      get "/projects/#{project.id}/meetings", params: { filters: }
+    end
+
+    it "defaults to the upcoming view and excludes past meetings" do
+      expect(subject).to have_http_status(:ok)
+
+      today = page.find("[data-test-selector='meetings-table-today']")
+      expect(today).to have_text "meeting starting soon"
+      expect(today).to have_text "meeting starting tonight"
+
+      expect(page).to have_no_text "an earlier meeting"
+    end
+  end
+
   describe "POST #refresh_form (add WP to meeting)" do
     let(:wp_project) do
       create(:project, enabled_module_names: %w[meetings work_package_tracking])

--- a/modules/meeting/spec/requests/meetings_menu_spec.rb
+++ b/modules/meeting/spec/requests/meetings_menu_spec.rb
@@ -86,4 +86,99 @@ RSpec.describe "Meeting index menu",
       end
     end
   end
+
+  describe "with the past time filter active" do
+    let(:meetings_href) { "/projects/#{project.identifier}/meetings" }
+    let(:project_filter) { { project_id: { operator: "=", values: [project.id.to_s] } } }
+    let(:time_filter) { { time: { operator: "past", values: [] } } }
+
+    context "in the 'All meetings' view" do
+      let(:all_past_filter) { [project_filter, time_filter].to_json }
+      let(:request) do
+        get "/projects/#{project.id}/meetings/menu",
+            params: { current_href: meetings_href, filters: all_past_filter }
+      end
+
+      it "keeps 'All meetings' selected instead of falling back to 'My meetings'" do
+        request
+
+        expect(page).to have_css(".op-submenu--item-action.selected", text: "All meetings")
+        expect(page).to have_no_css(".op-submenu--item-action.selected", text: "My meetings")
+      end
+    end
+
+    context "in the 'Recurring meetings' view" do
+      let(:recurring_past_filter) do
+        [{ type: { operator: "=", values: ["t"] } }, project_filter, time_filter].to_json
+      end
+      let(:request) do
+        get "/projects/#{project.id}/meetings/menu",
+            params: { current_href: meetings_href, filters: recurring_past_filter }
+      end
+
+      it "keeps 'Recurring meetings' selected instead of falling back to 'My meetings'" do
+        request
+
+        expect(page).to have_css(".op-submenu--item-action.selected", text: "Recurring meetings")
+        expect(page).to have_no_css(".op-submenu--item-action.selected", text: "My meetings")
+      end
+    end
+  end
+
+  describe "with a 'part of a meeting series' filter" do
+    let(:meetings_href) { "/projects/#{project.identifier}/meetings" }
+
+    context "when set to 'no'" do
+      let(:not_recurring_filter) { [{ type: { operator: "=", values: ["f"] } }].to_json }
+      let(:request) do
+        get "/projects/#{project.id}/meetings/menu",
+            params: { current_href: meetings_href, filters: not_recurring_filter }
+      end
+
+      it "does not select the 'Recurring meetings' option" do
+        request
+
+        expect(page).to have_no_css(".op-submenu--item-action.selected", text: "Recurring meetings")
+      end
+    end
+
+    context "when added on top of the 'My meetings' filter" do
+      let(:my_recurring_filter) do
+        [
+          { invited_user_id: { operator: "=", values: [user.id.to_s] } },
+          { type: { operator: "=", values: ["t"] } }
+        ].to_json
+      end
+      let(:request) do
+        get "/projects/#{project.id}/meetings/menu",
+            params: { current_href: meetings_href, filters: my_recurring_filter }
+      end
+
+      # No single preset matches the combined filters, so nothing is selected
+      it "selects neither 'My meetings' nor 'Recurring meetings'" do
+        request
+
+        expect(page).to have_no_css(".op-submenu--item-action.selected", text: "My meetings")
+        expect(page).to have_no_css(".op-submenu--item-action.selected", text: "Recurring meetings")
+      end
+    end
+  end
+
+  describe "with the 'My meetings' filter" do
+    let(:meetings_href) { "/projects/#{project.identifier}/meetings" }
+
+    context "when it is the sole filter" do
+      let(:my_filter) { [{ invited_user_id: { operator: "=", values: [user.id.to_s] } }].to_json }
+      let(:request) do
+        get "/projects/#{project.id}/meetings/menu",
+            params: { current_href: meetings_href, filters: my_filter }
+      end
+
+      it "selects 'My meetings'" do
+        request
+
+        expect(page).to have_css(".op-submenu--item-action.selected", text: "My meetings")
+      end
+    end
+  end
 end

--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -155,13 +155,6 @@ module Pages::Meetings
       end
     end
 
-    def expect_quick_filter_unselected
-      within "#content-body" do
-        expect(page).to have_css("segmented-control")
-        expect(page).to have_no_css("segmented-control .SegmentedControl-item--selected")
-      end
-    end
-
     def set_project_filter(*projects)
       find_test_selector("quick-filter-select-panel-button").click
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-590
https://community.openproject.org/wp/OP-19670

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

## MEET-590

- Update filter highlighting criteria

## OP-19670

- Always add a default 'upcoming' time filter if it is removed manually from the filters component, since a time filter-less meetings index page does not work currently

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
