### PR TITLE
Reduce repeated favorite queries while serializing API v3 project collections. 

### DIFF
--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -38,6 +38,7 @@ module API
       end
 
       def initialize(models, self_link:, current_user:, query_params: {}, page: nil, per_page: nil, groups: nil)
+        @current_user = current_user
         @self_link_base = self_link
         @query_params = query_params
         @page = page.to_i > 0 ? page.to_i : 1

--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -66,7 +66,11 @@ module API
         end
 
         def eager_loaded_paged_models(models)
-          ::API::V3::Projects::ProjectEagerLoadingWrapper.wrap(models)
+          ::API::V3::Projects::ProjectEagerLoadingWrapper.wrap(models, favorite_user: current_user)
+        end
+
+        def eager_load_for_element_decorator?
+          true
         end
       end
     end

--- a/lib/api/v3/projects/project_eager_loading_wrapper.rb
+++ b/lib/api/v3/projects/project_eager_loading_wrapper.rb
@@ -35,15 +35,39 @@ module API
         # delegate class check to wrapped object, as there are cases where the type is checked explicitly.
         delegate :is_a?, to: :__getobj__
 
+        def favorited_by?(user)
+          return super unless favorite_preloaded_for?(user)
+
+          @preloaded_favorite
+        end
+
+        def favorite_preloaded_for?(user)
+          defined?(@preloaded_favorite_user) && user == @preloaded_favorite_user
+        end
+        private :favorite_preloaded_for?
+
         class << self
-          def wrap(projects, eager_loaded: %i[custom_fields ancestors])
+          def wrap(projects, favorite_user: nil, eager_loaded: %i[custom_fields ancestors favorites])
             super(projects).tap do |wrapped_projects|
               eager_load_custom_fields(wrapped_projects) if eager_loaded.include?(:custom_fields)
               eager_load_ancestors(wrapped_projects) if eager_loaded.include?(:ancestors)
+              eager_load_favorites(wrapped_projects, favorite_user) if favorite_user && eager_loaded.include?(:favorites)
             end
           end
 
           private
+
+          def eager_load_favorites(projects, favorite_user)
+            favorite_project_ids = Favorite
+              .where(user: favorite_user, favorited_type: Project.base_class.name, favorited_id: projects.map(&:id))
+              .pluck(:favorited_id)
+              .index_with { true }
+
+            projects.each do |project|
+              project.instance_variable_set(:@preloaded_favorite_user, favorite_user)
+              project.instance_variable_set(:@preloaded_favorite, favorite_project_ids.fetch(project.id, false))
+            end
+          end
 
           def eager_load_custom_fields(projects)
             custom_fields_by_project_id = custom_fields_from_projects(projects)

--- a/spec/lib/api/v3/projects/project_collection_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_collection_representer_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe API::V3::Projects::ProjectCollectionRepresenter do
     subject(:collection) { representer.to_json }
 
     it_behaves_like "offset-paginated APIv3 collection", 3, "projects", "Project"
+
+    it "eager loads project data for the page" do
+      allow(API::V3::Projects::ProjectEagerLoadingWrapper).to receive(:wrap).and_call_original
+
+      collection
+
+      expect(API::V3::Projects::ProjectEagerLoadingWrapper)
+        .to have_received(:wrap).with(kind_of(ActiveRecord::Relation), favorite_user: current_user)
+    end
   end
 
   describe "representation formats" do

--- a/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
+++ b/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
@@ -50,6 +50,46 @@ RSpec.describe API::V3::Projects::ProjectEagerLoadingWrapper do
       end
     end
 
+    context "with favorites" do
+      let(:current_user) { create(:user) }
+      let!(:favorite) { create(:favorite, user: current_user, favorited: projects.first) }
+
+      subject(:loaded_projects) { described_class.wrap(projects, favorite_user: current_user) }
+
+      it "loads the favorite state once for all projects" do
+        allow(Favorite).to receive(:where).and_call_original
+
+        favorite_states = loaded_projects.map { |project| project.favorited_by?(current_user) }
+
+        expect(Favorite).to have_received(:where).once
+        expect(favorite_states).to eq([true, false, false])
+      end
+
+      it "falls back to the model favorite state for another user" do
+        other_user = create(:user)
+        create(:favorite, user: other_user, favorited: projects.second)
+
+        favorite_states = loaded_projects.map { |project| project.favorited_by?(other_user) }
+
+        expect(favorite_states).to eq([false, true, false])
+      end
+    end
+
+    context "without a favorite user" do
+      subject(:loaded_projects) { described_class.wrap(projects, favorite_user: nil, eager_loaded: [:favorites]) }
+
+      it "does not preload favorites and delegates favorite checks" do
+        allow(Favorite).to receive(:where).and_call_original
+        allow(projects.first).to receive(:favorited_by?).with(nil).and_return(false)
+
+        favorite_state = loaded_projects.first.favorited_by?(nil)
+
+        expect(Favorite).not_to have_received(:where)
+        expect(projects.first).to have_received(:favorited_by?).with(nil)
+        expect(favorite_state).to be(false)
+      end
+    end
+
     context "with available custom fields" do
       let!(:text_project_custom_field) do
         create :text_project_custom_field, projects: [projects.second, projects.third]


### PR DESCRIPTION
Serializing `GET /api/v3/projects` calls `Project#favorited_by?` while building each project’s favorite links and favorited property. This resulted in a separate favorite existence query for every project in the collection.

In the profiled workload, 50 favorite existence queries were issued for a page containing 50+ projects.

### Changes                                                                                                               
                                                                                                                       
 1. The project collection eager-loading wrapper now loads the current user’s favorite project IDs in one query for the complete page.
 2. `favorited_by?` uses the preloaded value when called for that user. Calls for another user, or without preloaded     
    data, continue to delegate to the underlying project model.
 3. The project collection representer now always invokes its project-specific eager-loading wrapper and passes the    
    current user to it.
 4. The offset-paginated collection makes the current user available while paginated records are being prepared. 
 5. Added tests covering bulk loading, favorite-state accuracy, fallback behavior for other users, and collection integration. 

### Performance                                                                                                           
                                                                                                                       
 Measured in production mode against: 
 ```
 GET /api/v3/projects?pageSize=50&offset=1
 ```
 The dataset contained 62 active projects, with 50 returned per request. The observed values are medians from five runs per state in a local environment using a system-admin API key
                                        
| Metric | Before | After | Change |
|---|---|---|---|
|Median server duration|139.49 ms|89.86 ms|-35.6%|
|Median SQL duration|16.18 ms|5.76 ms|-64.4%|
|SQL events|58|9|-84.5%|
Non-cached SQL events |58|9|-84.5%|
Duplicate query fingerprints|49|0|-100.0%|
Per-project favorite existence checks|50|0|-100.0%|

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
