### PR TITLE
fix: Apply default ordering to WP Observed in versions

### DIFF
--- a/app/models/work_package/versions.rb
+++ b/app/models/work_package/versions.rb
@@ -38,7 +38,7 @@ module WorkPackage::Versions
              -> { where(work_package_versions: { kind: "target" }).order(:id) },
              through: :work_package_versions, source: :version
     has_many :observed_in_versions,
-             -> { where(work_package_versions: { kind: "observed_in" }) },
+             -> { where(work_package_versions: { kind: "observed_in" }).order(:id) },
              through: :work_package_versions, source: :version
 
     scope :with_target_version, ->(version_id) {

--- a/spec/models/work_package/work_package_versions_spec.rb
+++ b/spec/models/work_package/work_package_versions_spec.rb
@@ -61,3 +61,18 @@ RSpec.describe WorkPackage, "target versions" do
     expect(work_package.reload.target_versions).to be_empty
   end
 end
+
+RSpec.describe WorkPackage, "observed in versions" do
+  let(:project) { create(:project) }
+  let!(:lower_version) { create(:version, project:) }
+  let!(:higher_version) { create(:version, project:) }
+  let(:work_package) { create(:work_package, project:) }
+
+  it "returns observed in versions in id order even when preloaded" do
+    work_package.observed_in_version_ids_replacements = [higher_version.id, lower_version.id]
+    work_package.save!
+
+    preloaded = described_class.where(id: work_package.id).includes(:observed_in_versions).first
+    expect(preloaded.observed_in_versions.map(&:id)).to eq([lower_version.id, higher_version.id])
+  end
+end


### PR DESCRIPTION
This should mirror the logic already applied to `target_versions`.