### PR TITLE
Default frontend tests to Chromium only

### DIFF
--- a/docs/development/testing/running-tests-locally/README.md
+++ b/docs/development/testing/running-tests-locally/README.md
@@ -51,6 +51,12 @@ You can run all frontend tests with the standard npm command:
 npm test
 ```
 
+This runs the suite in headless Chromium. CI additionally runs Firefox and WebKit; to reproduce that locally, pass the browsers explicitly:
+
+```shell
+npm test -- --browsers chromium --browsers firefox --browsers webkit
+```
+
 Alternatively, when in the `frontend/` folder, you can also use the watch mode of Angular to automatically run tests after you changed a file in the frontend.
 
 ```shell

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -144,7 +144,7 @@
             "runnerConfig": true,
             "providersFile": "src/test-providers.ts",
             "setupFiles": ["src/test-browser-polyfills.ts", "src/test-setup.ts"],
-            "browsers": ["chromium", "firefox", "webkit"],
+            "browsers": ["chromium"],
             "reporters": ["dot"]
           }
         },


### PR DESCRIPTION
# Ticket

No work package — frontend test-runtime hygiene.

# What are you trying to accomplish?

`npm test` in `frontend/` currently runs the whole Vitest suite three times in sequence — Chromium, Firefox, WebKit — which takes about three minutes on a laptop. This makes it the default for one engine only, so a local full run takes under a minute (measured: 2:52 → 0:47 for 169 files / 1493 tests).

CI is unaffected: `test-frontend-unit.yml` already passes `--browsers ${{ matrix.browser }}` per job, and a CLI `--browsers` value overrides the `angular.json` default. The docs gain a one-liner for reproducing the full three-engine run locally.

# What approach did you choose and why?

I first investigated reintroducing a jsdom (or happy-dom) lane as the local fast path. The numbers argued against it: with `isolate: true` (needed so specs mocking `@atlaskit` modules do not poison the ones driving the real adapters) every spec file gets a fresh DOM environment, and jsdom came out *slower* than a single Chromium run (1:10 vs 0:47), with happy-dom only marginally faster (0:39). Both also left 20–24 spec files red after polyfilling `IntersectionObserver`, `DataTransfer`/`DragEvent` (via `@atlaskit/pragmatic-drag-and-drop-unit-testing`), the popover API, `elementFromPoint`, `innerText` and `requestAnimationFrame` under fake timers — the remainder being drag-and-drop geometry specs that need real layout and would have had to be marked browser-only. Trading one fidelity surface for two, plus ~14 silently skipped spec files locally, was not worth nine seconds.

Single-spec iteration is ~8–10s in every mode because the Angular esbuild step dominates, so the environment choice does not matter there either.

# Merge checklist

- [x] Added/updated tests — config only; full suite green in Chromium (169 files / 1493 tests)
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — n/a
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) — three-engine run still green via explicit `--browsers` (507 files)
