### PR TITLE
Drop redundant vitest imports from turbo specs

### DIFF
--- a/frontend/src/turbo/action-menu-morph-remount.spec.ts
+++ b/frontend/src/turbo/action-menu-morph-remount.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it,
-} from 'vitest';
 import { registerActionMenuMorphRemount } from './action-menu-morph-remount';
 
 describe('registerActionMenuMorphRemount', () => {

--- a/frontend/src/turbo/csp-script-nonce.spec.ts
+++ b/frontend/src/turbo/csp-script-nonce.spec.ts
@@ -26,7 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { vi } from 'vitest';
 import { readScriptNonce, scrubScriptElements } from './csp-script-nonce';
 
 describe('readScriptNonce', () => {

--- a/frontend/src/turbo/dispatch-event-stream-action.spec.ts
+++ b/frontend/src/turbo/dispatch-event-stream-action.spec.ts
@@ -26,7 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { vi } from 'vitest';
 import { StreamActions } from '@hotwired/turbo';
 import { registerDispatchEventStreamAction } from './dispatch-event-stream-action';
 

--- a/frontend/src/turbo/flash-stream-action.spec.ts
+++ b/frontend/src/turbo/flash-stream-action.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it,
-} from 'vitest';
 import { StreamActions } from '@hotwired/turbo';
 import { registerFlashStreamAction } from './flash-stream-action';
 

--- a/frontend/src/turbo/input-caption-stream-action.spec.ts
+++ b/frontend/src/turbo/input-caption-stream-action.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it,
-} from 'vitest';
 import { StreamActions } from '@hotwired/turbo';
 import { registerInputCaptionStreamAction } from './input-caption-stream-action';
 

--- a/frontend/src/turbo/live-region-stream-action.spec.ts
+++ b/frontend/src/turbo/live-region-stream-action.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it, vi,
-} from 'vitest';
 import { StreamActions } from '@hotwired/turbo';
 import { LiveRegionElement } from '@primer/live-region-element';
 import { registerLiveRegionStreamAction } from './live-region-stream-action';

--- a/frontend/src/turbo/turbo-angular-wrapper.spec.ts
+++ b/frontend/src/turbo/turbo-angular-wrapper.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it, vi,
-} from 'vitest';
 import type { ApplicationRef, ComponentRef } from '@angular/core';
 import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import { addTurboAngularWrapper } from './turbo-angular-wrapper';

--- a/frontend/src/turbo/turbo-event-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-event-listeners.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it, vi,
-} from 'vitest';
 import { addTurboEventListeners } from './turbo-event-listeners';
 
 describe('addTurboEventListeners — dialog close on turbo:submit-end', () => {

--- a/frontend/src/turbo/turbo-global-listeners.spec.ts
+++ b/frontend/src/turbo/turbo-global-listeners.spec.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  afterEach, beforeEach, describe, expect, it,
-} from 'vitest';
 import { addTurboGlobalListeners } from './turbo-global-listeners';
 
 describe('addTurboGlobalListeners — OPCE custom element morph guard', () => {

--- a/frontend/src/turbo/turbo-navigation-patch.spec.ts
+++ b/frontend/src/turbo/turbo-navigation-patch.spec.ts
@@ -27,9 +27,6 @@
 //++
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  afterAll, describe, expect, it,
-} from 'vitest';
 import * as Turbo from '@hotwired/turbo';
 import { applyTurboNavigationPatch } from './turbo-navigation-patch';
 


### PR DESCRIPTION
# Ticket

None — housekeeping, no behaviour change.

# What are you trying to accomplish?

Removes the `from 'vitest'` imports from the ten specs in `frontend/src/turbo/` that still carried one. Deletion only: 10 files, 26 lines, no insertions.

The imports never did anything. The Angular unit-test builder sets `globals: true` unconditionally (`@angular/build/src/builders/unit-test/runners/vitest/plugins.js`), and `tsconfig.spec.json` already includes the `vitest/globals` types, so `describe`, `it`, `expect`, the hooks and `vi` are all in scope without them. Nothing in `eslint.config.mjs` asks for the explicit form either.

The folder was already inconsistent: four of its fourteen specs omitted the import. This settles it on the shorter form.

# What approach did you choose and why?

Scoped to `frontend/src/turbo/` rather than sweeping the whole suite. 65 spec files across the repo import Vitest globals; changing all of them in one go would be a large, hard-to-review diff for zero behaviour change. This folder is the one being actively worked on, so it is where the inconsistency actually gets in the way.

Stacked behind #24269, which adds a spec to this same folder — a `dev`-based branch would miss that file and then conflict.

# Merge checklist

- [x] Added/updated tests — no new tests; the existing 14 turbo specs pass unchanged
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — not applicable
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) — the turbo specs run in chromium, firefox and webkit: 42/42 files, 192/192 tests
