### PR TITLE
fixed per raw authorization in Work package collection HAL serialization

### DIFF
--- a/app/models/users/permission_checks.rb
+++ b/app/models/users/permission_checks.rb
@@ -79,6 +79,7 @@ module Users::PermissionChecks
            :allowed_in_any_project?,
            :allowed_in_entity?,
            :allowed_in_any_entity?,
+           :preload_entity_permissions,
            to: :user_permissible_service
 
   # Return user's roles for project

--- a/app/services/authorization/user_permissible_service.rb
+++ b/app/services/authorization/user_permissible_service.rb
@@ -86,14 +86,51 @@ module Authorization
       end
     end
 
+    def preload_entity_permissions(contexts)
+      contexts = Array(contexts)
+                   .filter_map { |context| permission_context(context) }
+                   .select { |context| Member.can_be_member_of?(context) }
+                   .uniq
+      return if contexts.empty? || user.admin?
+
+      contexts.group_by(&:class).each_value do |group|
+        preload_permissions_for_group(group)
+      end
+    end
+
     private
 
-    def cached_permissions(context)
-      @cached_permissions ||= Hash.new do |hash, context_key|
-        hash[context_key] = user.all_permissions_for(context_key)
-      end
+    def preload_permissions_for_group(contexts)
+      permissions_by_id = preloaded_permissions_by_id(contexts)
+      contexts.each { |context| cache_preloaded_permissions(context, permissions_by_id) }
+    end
 
-      @cached_permissions[context]
+    def preloaded_permissions_by_id(contexts)
+      Member
+        .where(user_id: user.id,
+               entity_type: contexts.first.class.name,
+               entity_id: contexts.map(&:id))
+        .joins(member_roles: { role: :role_permissions })
+        .pluck(:entity_id, "role_permissions.permission")
+        .group_by(&:first)
+    end
+
+    def cache_preloaded_permissions(context, permissions_by_id)
+      rows = permissions_by_id.fetch(context.id, [])
+      cached_permissions_by_context[context] = rows.filter_map { |_, permission| permission&.to_sym }.uniq
+    end
+
+    def cached_permissions(context)
+      context = permission_context(context)
+      cached_permissions_by_context[context] ||= user.all_permissions_for(context)
+    end
+
+    def cached_permissions_by_context
+      @cached_permissions_by_context ||= {}
+    end
+
+    def permission_context(context)
+      context.is_a?(SimpleDelegator) ? context.__getobj__ : context
     end
 
     def cached_in_any_project?(permissions)

--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -40,20 +40,20 @@ module API
           def wrap(ids_in_order, current_user, timestamps: nil, query: nil)
             work_packages = add_eager_loading(WorkPackage.where(id: ids_in_order), current_user).to_a
 
-            wrap_and_apply(work_packages, eager_loader_classes_all, timestamps:, query:)
+            wrap_and_apply(work_packages, eager_loader_classes_all, current_user:, timestamps:, query:)
               .sort_by { |wp| ids_in_order.index(wp.id) }
           end
 
-          def wrap_one(work_package, _current_user, timestamps: nil, query: nil)
+          def wrap_one(work_package, current_user, timestamps: nil, query: nil)
             return work_package if work_package.respond_to?(:wrapped?)
 
-            wrap_and_apply([work_package], eager_loader_classes_all, timestamps:, query:)
+            wrap_and_apply([work_package], eager_loader_classes_all, current_user:, timestamps:, query:)
               .first
           end
 
           private
 
-          def wrap_and_apply(work_packages, container_classes, timestamps:, query:)
+          def wrap_and_apply(work_packages, container_classes, current_user:, timestamps:, query:)
             containers = container_classes
                          .map { |klass| klass.new(work_packages, timestamps:, query:) }
 
@@ -66,6 +66,11 @@ module API
                 container.apply(work_package)
               end
             end
+
+            permission_contexts = work_packages.flat_map do |work_package|
+              [work_package, work_package.parent, *work_package.children]
+            end
+            current_user&.preload_entity_permissions(permission_contexts)
 
             work_packages
           end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -495,11 +495,8 @@ module API
                  as: :hasProjectAttributes,
                  writable: false,
                  uncacheable: true,
-                 getter: ->(*) do
-                   variant = type_variant
-
-                   (variant.present? && project&.available_custom_fields_for_variant(variant.id)&.any?) || false
-                 end
+                 exec_context: :decorator,
+                 getter: ->(*) { has_project_attributes? }
 
         associated_resource :category
 
@@ -784,6 +781,15 @@ module API
           return @add_work_packages_allowed if defined?(@add_work_packages_allowed)
 
           @add_work_packages_allowed = current_user.allowed_in_project?(:add_work_packages, represented.project)
+        end
+
+        def has_project_attributes?
+          variant = represented.type_variant
+          return false unless variant && represented.project
+
+          RequestStore.fetch("work_package_has_project_attributes/#{represented.project_id}/#{variant.id}") do
+            represented.project.available_custom_fields_for_variant(variant.id).any?
+          end
         end
 
         def project_phase

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -228,6 +228,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           expect(subject).to be_json_eql(true.to_json).at_path("hasProjectAttributes")
         end
       end
+
+      it "reuses the result for the same project and variant" do
+        2.times { expect(representer.has_project_attributes?).to eq(variant_fields_exist) }
+
+        expect(workspace).to have_received(:available_custom_fields_for_variant)
+          .with(type_variant.id)
+          .once
+      end
     end
 
     describe "startDate" do

--- a/spec/services/authorization/user_permissible_service_spec.rb
+++ b/spec/services/authorization/user_permissible_service_spec.rb
@@ -498,6 +498,31 @@ RSpec.describe Authorization::UserPermissibleService do
     end
   end
 
+  describe "#preload_entity_permissions" do
+    let(:permission) { :view_work_packages }
+    let!(:other_work_package) { create(:work_package, project:) }
+    let(:role) { create(:work_package_role, permissions: [permission]) }
+
+    before do
+      create(:work_package_member, user:, project:, entity: work_package, roles: [role])
+    end
+
+    it "loads entity permissions in bulk" do
+      expect do
+        service.preload_entity_permissions([SimpleDelegator.new(work_package), other_work_package])
+      end.to have_a_query_limit(1)
+
+      allow(user).to receive(:all_permissions_for).and_call_original
+
+      expect(service).to be_allowed_in_entity(permission, work_package, WorkPackage)
+      expect(service).not_to be_allowed_in_entity(permission, other_work_package, WorkPackage)
+      expect { service.allowed_in_entity?(permission, [work_package, other_work_package], WorkPackage) }
+        .to have_a_query_limit(0)
+      expect(user).not_to have_received(:all_permissions_for).with(work_package)
+      expect(user).not_to have_received(:all_permissions_for).with(other_work_package)
+    end
+  end
+
   describe "#allowed_in_any_entity?" do
     context "when asking for a permission that is not defined" do
       let(:permission) { :not_defined }


### PR DESCRIPTION
This is a continuation of  #24894, But here instead of admin token, I called API requests as member-readonly. 

Serializing GET /api/v3/work_packages performs authorization checks for work packages, parents, and children while constructing action links. For regular users, these checks repeatedly loaded entity-scoped permissions for each work package.  The representer also repeatedly checked whether project custom fields existed for the same project/type-variant combination.

### Changes

1. Preload entity-scoped permissions for all work packages, parents, and children in the collection using one bulk query
2. Reuse the preloaded permissions in UserPermissibleService instead of querying permissions separately for each entity
3. Cache project custom-field existence checks per project/type-variant combination for the duration of the request

### Performance

Measured using Rack Mini Profiler against: 

```
 GET /api/v3/work_packages?pageSize=20&offset=1
```

The observed values are from Docker on my machine:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Server duration (ms) | 473.89 | 372.35 | -21.4% |
| SQL duration (ms) | 127.80 | 105.93 | -17.1% |
| SQL events | 139 | 94 | -32.4% |
| Cached SQL events | 37 | 11 | -70.3% |
| Non-cached SQL events | 102 | 83 | -18.6% |
| Duplicate fingerprints | 80 | 35 | -56.2% |
| Per-project/type lookups | 0 | 0 | n/a |
| Per-ID variant lookups | 0 | 0 | n/a |
| Custom-field existence checks | 20 | 7 | -65.0% |
| Per-entity permission lookups | 33 | 0 | -100.0% |

The optimization scales with larger collections. With pageSize=100, SQL events decreased from 190 to 111, and duplicate query fingerprints decreased from 130 to 51. #24894 focused on admin users and removed the project/type-variant N+1 queries. This PR profiles a regular user after those changes, which is why the “before” SQL event count is 139 rather than the previous PR's “after” count of 148. The values are not directly comparable because different user types exercise different authorization paths. Server-duration measurements come from a development environment and are subject to runtime variance. Query counts remained stable across the measured requests and directly demonstrate the removal of the targeted repeated queries.

# Merge Checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc.)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) 