### PR TITLE
Add test for form loading, output block notification once

### DIFF
--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.spec.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.spec.ts
@@ -1,0 +1,90 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { FormResource } from 'core-app/features/hal/resources/form-resource';
+import { vi } from 'vitest';
+
+class TestResourceChangeset extends ResourceChangeset {
+  public refresh():Promise<FormResource> {
+    return this.updateForm();
+  }
+}
+
+function deferred<T>() {
+  let resolve:(value:T) => void;
+  let reject:(reason?:unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
+describe('ResourceChangeset', () => {
+  it('returns the latest form when requests finish out of order', async () => {
+    const firstRequest = deferred<FormResource>();
+    const secondRequest = deferred<FormResource>();
+    const update = vi.fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    const resource = {
+      id: 1,
+      lockVersion: 1,
+      $source: { _links: {} },
+      $links: { update },
+      injector: {
+        get: vi.fn().mockReturnValue({ of: vi.fn() }),
+      },
+    } as unknown as HalResource;
+    const cachedForm = {
+      payload: { $source: { _links: {} } },
+      schema: {},
+    } as unknown as FormResource;
+    const currentForm = {
+      payload: {},
+      schema: {},
+    } as unknown as FormResource;
+    const staleForm = {
+      payload: {},
+      schema: {},
+    } as unknown as FormResource;
+    const changeset = new TestResourceChangeset(resource, undefined, cachedForm);
+
+    const firstResult = changeset.refresh();
+    const secondResult = changeset.refresh();
+    firstRequest.resolve(staleForm);
+    secondRequest.resolve(currentForm);
+
+    await expect(firstResult).resolves.toBe(currentForm);
+    await expect(secondResult).resolves.toBe(currentForm);
+    await expect(changeset.getForm()).resolves.toBe(currentForm);
+  });
+});

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -63,6 +63,11 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
   /** Reference and load promise for the current form */
   protected form$ = input<FormResource>();
 
+  /** The latest form request, if one is currently running */
+  private formRequest:Promise<FormResource>|null = null;
+
+  private formRequestId = 0;
+
   /** Request cache for objects within the changeset for the current form */
   protected cache:Record<string, Promise<unknown>> = {};
 
@@ -148,7 +153,11 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
    * Returns the cached form or loads it if necessary.
    */
   public getForm(reload = false):Promise<FormResource> {
-    if ((this.form$.isPristine() || reload) && !this.form$.hasActivePromiseRequest()) {
+    if (this.formRequest) {
+      return this.formRequest;
+    }
+
+    if (this.form$.isPristine() || reload) {
       return this.updateForm();
     }
 
@@ -173,18 +182,37 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const promise = this.pristineResource
+    const formRequest = this.pristineResource
       .$links
-      .update(payload)
-      .then((form:FormResource) => {
-        this.cache = {};
-        this.form$.putValue(form);
-        this.setNewDefaults(form);
-        this.push();
-        return form;
-      }) as Promise<FormResource>;
+      .update(payload) as Promise<FormResource>;
+    const requestId = ++this.formRequestId;
 
-    this.form$.putFromPromiseIfPristine(() => promise);
+    const promise = formRequest.then((form:FormResource) => {
+      if (this.formRequestId !== requestId) {
+        return this.getForm();
+      }
+
+      this.cache = {};
+      this.form$.putValue(form);
+      this.setNewDefaults(form);
+      this.push();
+      return form;
+    });
+
+    this.formRequest = promise;
+    void promise.then(
+      () => {
+        if (this.formRequestId === requestId) {
+          this.formRequest = null;
+        }
+      },
+      () => {
+        if (this.formRequestId === requestId) {
+          this.formRequest = null;
+        }
+      },
+    );
+
     return promise;
   }
 

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.spec.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.spec.ts
@@ -29,11 +29,15 @@
 import { ApplicationRef, Injector } from '@angular/core';
 import { EditForm } from 'core-app/shared/components/fields/edit/edit-form/edit-form';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
+import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
 import { afterEach, vi } from 'vitest';
 import type { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 
 class TestEditForm extends EditForm<HalResource> {
+  public changeValue?:ResourceChangeset<HalResource>;
+
   constructor(injector:Injector, private readonly requireVisibleSpy:(fieldName:string) => Promise<void>, private readonly resetSpy:(fieldName:string, focus?:boolean) => void) {
     super(injector);
   }
@@ -52,14 +56,99 @@ class TestEditForm extends EditForm<HalResource> {
     this.resetSpy(fieldName, focus);
   }
 
+  public loadSchema(fieldName:string):Promise<IFieldSchema> {
+    return this.loadFieldSchema(fieldName);
+  }
+
+  public override get change():ResourceChangeset<HalResource> {
+    return this.changeValue ?? super.change;
+  }
+
   protected focusOnFirstError():void {
     return undefined;
   }
 }
 
 describe('EditForm', () => {
+  const buildSchemaForm = (change:object) => {
+    const notification = {
+      handleRawError: vi.fn(),
+      showEditingBlockedError: vi.fn(),
+    };
+    const injector = {
+      get: vi.fn().mockImplementation((token:unknown) => (
+        token === HalResourceNotificationService ? notification : null
+      )),
+    } as Injector;
+    const form = new TestEditForm(injector, vi.fn(), vi.fn());
+
+    form.resource = { id: 1 } as unknown as HalResource;
+    form.changeValue = change as unknown as ResourceChangeset<HalResource>;
+
+    return { form, notification };
+  };
+
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('waits for the current form before using a cached field schema', async () => {
+    const staleSchema = { writable: true, name: 'Stale' } as IFieldSchema;
+    const currentSchema = { writable: true, name: 'Current' } as IFieldSchema;
+    let schema = staleSchema;
+    const getForm = vi.fn().mockImplementation(() => {
+      schema = currentSchema;
+      return Promise.resolve({});
+    });
+    const change = {
+      getForm,
+      schema: {
+        ofProperty: vi.fn().mockImplementation(() => schema),
+      },
+    };
+    const { form } = buildSchemaForm(change);
+
+    await expect(form.loadSchema('foo')).resolves.toBe(currentSchema);
+    expect(getForm).toHaveBeenCalledOnce();
+  });
+
+  it('reloads the form once when its schema does not contain the field', async () => {
+    const currentSchema = { writable: true, name: 'Current' } as IFieldSchema;
+    let schema:IFieldSchema|null = null;
+    const getForm = vi.fn().mockImplementation((reload = false) => {
+      if (reload) {
+        schema = currentSchema;
+      }
+      return Promise.resolve({});
+    });
+    const change = {
+      getForm,
+      schema: {
+        ofProperty: vi.fn().mockImplementation(() => schema),
+      },
+    };
+    const { form } = buildSchemaForm(change);
+
+    await expect(form.loadSchema('foo')).resolves.toBe(currentSchema);
+    expect(getForm).toHaveBeenNthCalledWith(1);
+    expect(getForm).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it('shows one notification when the current schema is not writable', async () => {
+    const reset = vi.fn();
+    const change = {
+      getForm: vi.fn().mockResolvedValue({}),
+      reset,
+      schema: {
+        ofProperty: vi.fn().mockReturnValue({ writable: false, name: 'Blocked' }),
+      },
+    };
+    const { form, notification } = buildSchemaForm(change);
+
+    await form.activate('foo').catch(() => undefined);
+
+    expect(notification.showEditingBlockedError).toHaveBeenCalledExactlyOnceWith('Blocked');
+    expect(reset).toHaveBeenCalledWith('foo');
   });
 
   it('does not require visibility twice for newly erroneous inactive fields', async () => {

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
@@ -125,6 +125,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
       .then((schema:IFieldSchema) => {
         if (!schema.writable && !noWarnings) {
           this.halNotification.showEditingBlockedError(schema.name || fieldName);
+          this.closeEditFields([fieldName]);
           return Promise.reject();
         }
 
@@ -294,17 +295,12 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    * values loaded.
    * @param fieldName
    */
-  protected loadFieldSchema(fieldName:string, noWarnings = false):Promise<IFieldSchema> {
+  protected loadFieldSchema(fieldName:string, _noWarnings = false):Promise<IFieldSchema> {
     return this.getFormFieldSchema(fieldName).then((fieldSchema) => {
       if (!fieldSchema) {
         this.closeEditFields([fieldName]);
 
         throw new Error();
-      }
-
-      if (!fieldSchema.writable && !noWarnings) {
-        this.halNotification.showEditingBlockedError(fieldSchema.name || fieldName);
-        this.closeEditFields([fieldName]);
       }
 
       return fieldSchema;
@@ -318,30 +314,6 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    * @param fieldName
    */
   private getFormFieldSchema(fieldName:string):Promise<IFieldSchema|null> {
-    // Sync fast path: whatever schema the changeset currently exposes (form-derived if
-    // loaded, otherwise the pristine resource's cached schema) usually contains the
-    // field. Returning it synchronously lets the field activate without waiting on the
-    // form request — required by Capybara specs whose activate! check has a tight
-    // timeout, and by tests that intentionally disable AJAX before activating a field.
-    const cachedSchema = (this.change.schema as ISchemaProxy).ofProperty(fieldName);
-    if (cachedSchema) {
-      // Still kick off the form load (or piggy-back on an in-flight one) so the form's
-      // defaults, allowed values, and projected payload are populated for subsequent
-      // edits/submissions. We don't await it, but we do surface any error (e.g. a 409
-      // lock-version conflict when the resource was modified elsewhere) through the
-      // same notification path the awaited code-path uses — otherwise the user would
-      // open the editor without ever being told their copy is stale.
-      this.change.getForm().catch((error:unknown) => {
-        console.error('Background form load failed for %s: %o', fieldName, error);
-        this.halNotification.handleRawError(error, this.resource);
-      });
-      return Promise.resolve(cachedSchema);
-    }
-
-    // Cached schema doesn't know about this field. Either the form hasn't been loaded
-    // at all, or the cached form is stale (e.g. the work package type was just changed
-    // and the new type's custom fields aren't in the cached form yet). Load the form,
-    // then retry; if still missing, force a full reload once.
     return this.change.getForm()
       .then(():Promise<IFieldSchema|null> => {
         const fieldSchema:IFieldSchema|null = (this.change.schema as ISchemaProxy).ofProperty(fieldName);


### PR DESCRIPTION
- The edit form now waits for the latest form request
- An old request is prevented from replacing a newer form
- The editor uses the current field schema, and only warns once for a blocked field
- Added specs for these changes