### PR TITLE
remove hazardous type position specification in factory

### DIFF
--- a/spec/factories/type_factory.rb
+++ b/spec/factories/type_factory.rb
@@ -30,13 +30,11 @@
 
 FactoryBot.define do
   factory :type do
-    # Offset past the named seed types' hard-coded 1..4 (and past types.position's DB default of
-    # 1, which acts_as_list reads as "append me at the bottom"). Without the offset the position a
-    # type gets depends on how many types the whole rspec process built before it, so an unrelated
-    # spec creating a type shifts this one ahead of :type_task and silently becomes
-    # project.enabled_types.first / the work_package factory's type fallback.
-    sequence(:position) { |n| n + 100 }
-    name { |a| "Type No. #{a.position}" }
+    # No position: it is acts_as_list's to assign, which appends on create. Sequencing it here
+    # made the value depend on how many types the whole rspec process had built before this one,
+    # so an unrelated spec creating a type could shift this one ahead of :type_task and silently
+    # become project.enabled_types.first / the work_package factory's type fallback.
+    sequence(:name) { |n| "Type No. #{n}" }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
 


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Remove the position specification from the type factory as that field is part of the acts_as_list internals