### PR TITLE
MCP: Refactor tools & condense work packages response

### DIFF
--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -30,6 +30,8 @@
 
 module McpTools
   class Base
+    include Dry::Monads::Result(String)
+
     RESPONSE_FORMATS = %i[full content_only structured_only].freeze
 
     class << self
@@ -59,69 +61,10 @@ module McpTools
         @name
       end
 
-      def pagination_enabled?
-        @pagination_enabled || false
-      end
-
-      def enable_pagination
-        @pagination_enabled = true
-      end
-
       def input_schema(schema = nil)
-        if schema.present?
-          if pagination_enabled?
-            page = {
-              type: "number",
-              default: 1,
-              description: "Page number for pagination. If no page is defined, the first result set is returned. " \
-                           "To get the rest of the results, use a page number of 2 or higher."
-            }
-
-            @input_schema = schema.deep_merge({ properties: { page: } })
-          else
-            @input_schema = schema
-          end
-        end
+        @input_schema = schema if schema
 
         @input_schema
-      end
-
-      ##
-      # Defines a filter for selecting results through input parameters. Only one of filter_proc and filter_class are allowed at
-      # the same time. If none is provided, a default where-based filter is created, using name as the filtered attribute name.
-      #
-      # Filters defined here can later be applied by the tool implementation using #apply_filters.
-      #
-      # @param name [Symbol] The name of the input parameter used for filtering.
-      # @param filter_class [String] Class name of a shared filter implementation to be used to perform filtering,
-      #                              inheriting from Queries::Filters::Base.
-      # @param operator [String] When using a filter_class, this is the operator that will be used for filtering. Default: "="
-      # @param filter_proc [Proc] A callback procedure used for filtering that must accept two arguments:
-      #                           The base scope that the filter applies to and the value that's used as a filter input.
-      # @example
-      #   filter :id
-      #
-      # @example
-      #   filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
-      #
-      # @example
-      #   filter :status, filter_proc: ->(scope, value) { scope.where(status_name: value) }
-      def filter(name, filter_class: nil, filter_proc: nil, operator: "=")
-        if filter_class && filter_proc
-          raise ArgumentError, "filter_proc and filter_class are mutually exclusive, please only specify one"
-        end
-
-        if filter_class
-          filter_proc = ->(scope, value) { filter_class.constantize.create!(operator:, values: Array(value)).apply_to(scope) }
-        elsif !filter_proc
-          filter_proc = ->(scope, value) { scope.where(name.to_sym => value) }
-        end
-
-        filters[name.to_sym] = filter_proc
-      end
-
-      def filters
-        @filters ||= {}
       end
 
       def output_filter(filter_class)
@@ -170,31 +113,37 @@ module McpTools
     def handle_request(**)
       result = call(**)
 
-      format_response(result)
+      response = result.either(
+        ->(r) { r },
+        ->(error) { { error: } }
+      )
+
+      format_response(response)
     end
 
     private
 
-    # Intended to be implemented by subclasses. It should return a structured result (e.g. a Hash or Array).
+    # Intended to be implemented by subclasses. It should return a success monad with structured result (e.g. a Hash or Array)
+    # or a failure monad with an error message.
     def call(**)
       raise SubclassResponsibilityError, "#{self.class} needs to implement #call method"
     end
 
-    def format_response(result)
-      result = self.class.output_filters.each_with_object(result.as_json) { |f, r| f.filter(r) }
-      plain = render_plain_content? ? format_content(result) : []
-      structured_content = render_structured_content? ? format_structured_content(result) : nil
+    def format_response(response)
+      response = self.class.output_filters.each_with_object(response.as_json) { |f, r| f.filter(r) }
+      plain = render_plain_content? ? format_content(response) : []
+      structured_content = render_structured_content? ? format_structured_content(response) : nil
       MCP::Tool::Response.new(plain, **{ structured_content: }.compact)
     end
 
-    def format_content(result)
-      [{ type: "text", text: result.to_json }]
+    def format_content(response)
+      [{ type: "text", text: response.to_json }]
     end
 
-    def format_structured_content(result)
-      # performing a useless JSON roundtrip to ensure that our representers get converted into proper Ruby hashes,
+    def format_structured_content(response)
+      # Ensure that our representers get converted into proper Ruby hashes,
       # because the mcp gem performs strict type checks on the structured content
-      JSON.parse(result.to_json)
+      response.as_json
     end
 
     def current_user
@@ -207,31 +156,6 @@ module McpTools
 
     def render_structured_content?
       %i[full structured_only].include?(Setting.mcp_tool_response_format)
-    end
-
-    # Usable by tool implementations. Takes a scope and filters it according to the passed params.
-    # Filtering happens based on the filters defined for the tool, see .filter.
-    def apply_filters(scope, params)
-      params.each do |name, value|
-        filter_proc = filter_proc_for(name)
-        scope = filter_proc.call(scope, value)
-      end
-
-      scope
-    end
-
-    def filter_proc_for(name)
-      self.class.filters[name] || raise(ArgumentError, "Don't know how to handle filter argument called #{name}")
-    end
-
-    def apply_pagination(scope, page)
-      total = scope.count
-      return [scope, total] unless self.class.pagination_enabled?
-
-      page_number = page || 1
-      page_size = self.class.page_size
-
-      [scope.offset((page_number - 1) * page_size).limit(page_size), total]
     end
   end
 end

--- a/app/services/mcp_tools/create_work_package.rb
+++ b/app/services/mcp_tools/create_work_package.rb
@@ -54,21 +54,25 @@ module McpTools
     )
 
     def call(data:)
-      attributes = parse_work_package(data).on_failure { |result| return { error: result.message } }.result
+      attributes = parse_work_package(data).on_failure { |result| return Failure(result.message) }.result
 
       result = WorkPackages::CreateService.new(user: current_user).call(**attributes)
 
-      if result.success?
-        API::V3::WorkPackages::WorkPackageRepresenter.create(result.result, current_user:)
-      else
-        { error: result.message }
-      end
+      format_result(result)
     end
 
     private
 
     def parse_work_package(data)
       ::API::V3::WorkPackages::ParseParamsService.new(current_user, model: WorkPackage).call(data.deep_stringify_keys)
+    end
+
+    def format_result(result)
+      if result.success?
+        Success(API::V3::WorkPackages::WorkPackageRepresenter.create(result.result, current_user:))
+      else
+        Failure(result.message)
+      end
     end
   end
 end

--- a/app/services/mcp_tools/create_work_package_comment.rb
+++ b/app/services/mcp_tools/create_work_package_comment.rb
@@ -58,14 +58,18 @@ module McpTools
 
     def call(work_package_id:, comment:, internal: false)
       work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
-      return { error: "The given work package could not be found." } if work_package.nil?
+      return Failure("The given work package could not be found.") if work_package.nil?
 
       result = AddWorkPackageNoteService.new(user: current_user, work_package:).call(comment, send_notifications: true, internal:)
 
+      format_result(result)
+    end
+
+    def format_result(result)
       if result.success?
-        API::V3::Activities::ActivityRepresenter.create(result.result, current_user:)
+        Success(API::V3::Activities::ActivityRepresenter.create(result.result, current_user:))
       else
-        { error: result.message }
+        Failure(result.message)
       end
     end
   end

--- a/app/services/mcp_tools/create_work_package_relation.rb
+++ b/app/services/mcp_tools/create_work_package_relation.rb
@@ -78,10 +78,12 @@ module McpTools
       }
     )
 
+    private
+
     def call(from_work_package_id:, to_work_package_id:, type: "relates", description: nil, lag: nil)
       from = WorkPackage.visible(current_user).find_by(id: from_work_package_id)
       to = WorkPackage.visible(current_user).find_by(id: to_work_package_id)
-      return { error: "The given work package could not be found." } if from.nil? || to.nil?
+      return Failure("The given work package could not be found.") if from.nil? || to.nil?
 
       result = Relations::CreateService.new(user: current_user).call(
         from:,
@@ -91,10 +93,14 @@ module McpTools
         lag:
       )
 
+      format_result(result)
+    end
+
+    def format_result(result)
       if result.success?
-        API::V3::Relations::RelationRepresenter.create(result.result, current_user:)
+        Success(API::V3::Relations::RelationRepresenter.create(result.result, current_user:))
       else
-        { error: result.message }
+        Failure(result.message)
       end
     end
   end

--- a/app/services/mcp_tools/delete_work_package_relation.rb
+++ b/app/services/mcp_tools/delete_work_package_relation.rb
@@ -49,14 +49,14 @@ module McpTools
 
     def call(id:)
       relation = Relation.visible(current_user).find_by(id:)
-      return { error: "The given relation could not be found." } if relation.nil?
+      return Failure("The given relation could not be found.") if relation.nil?
 
       result = Relations::DeleteService.new(user: current_user, model: relation).call
 
       if result.success?
-        API::V3::Relations::RelationRepresenter.create(result.result, current_user:)
+        Success(API::V3::Relations::RelationRepresenter.create(result.result, current_user:))
       else
-        { error: result.message }
+        Failure(result.message)
       end
     end
   end

--- a/app/services/mcp_tools/list_work_package_comments.rb
+++ b/app/services/mcp_tools/list_work_package_comments.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class ListWorkPackageComments < Base
+  class ListWorkPackageComments < SearchTool
     default_title "List work package comments"
     default_description "List comments of the given work package."
 
@@ -52,26 +52,30 @@ module McpTools
     output_filter McpOutputFilters::RemoveFormattableHtml.new
     output_filter McpOutputFilters::RemoveLinks.new(%w[update addAttachment])
 
-    def call(work_package_id:, page: nil)
+    def scope_param_names
+      %i[work_package_id]
+    end
+
+    def base_scope(work_package_id:)
       work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
-      return { error: "Can't find given work package." } if work_package.nil?
+      return Failure("Can't find given work package.") if work_package.nil?
 
-      comments = work_package
-                  .journals
-                  .internal_visible
-                  .includes(:data,
-                            :customizable_journals,
-                            :attachable_journals,
-                            :storable_journals,
-                            :bcf_comment)
-                  .where.not(notes: "")
-                  .order(created_at: :desc)
+      Success(
+        work_package
+          .journals
+          .internal_visible
+          .includes(:data,
+                    :customizable_journals,
+                    :attachable_journals,
+                    :storable_journals,
+                    :bcf_comment)
+          .where.not(notes: "")
+          .order(created_at: :desc)
+      )
+    end
 
-      comments, total = apply_pagination(comments, page)
-      {
-        items: comments.map { |c| ::API::V3::Activities::ActivityRepresenter.new(c, current_user:, embed_emoji_reactions: true) },
-        total:
-      }
+    def format_item(item)
+      ::API::V3::Activities::ActivityRepresenter.new(item, current_user:, embed_emoji_reactions: true)
     end
   end
 end

--- a/app/services/mcp_tools/list_work_package_relations.rb
+++ b/app/services/mcp_tools/list_work_package_relations.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class ListWorkPackageRelations < Base
+  class ListWorkPackageRelations < SearchTool
     default_title "List work package relations"
     default_description "List relations of the given work package towards other work packages."
 
@@ -47,20 +47,25 @@ module McpTools
       }
     )
 
-    def call(work_package_id:)
+    def scope_param_names
+      %i[work_package_id]
+    end
+
+    def base_scope(work_package_id:)
       work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
-      return { error: "Can't find given work package." } if work_package.nil?
+      return Failure("Can't find given work package.") if work_package.nil?
 
-      relations = work_package
-        .relations
-        .visible(current_user)
-        .includes(::API::V3::Relations::RelationCollectionRepresenter.to_eager_load)
-        .to_a
+      Success(
+        work_package
+          .relations
+          .visible(current_user)
+          .includes(::API::V3::Relations::RelationCollectionRepresenter.to_eager_load)
+          .to_a
+      )
+    end
 
-      {
-        items: relations.map { |r| ::API::V3::Relations::RelationRepresenter.new(r, current_user:) },
-        total: relations.size
-      }
+    def format_item(item)
+      ::API::V3::Relations::RelationRepresenter.new(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/resource_proxy_tool.rb
+++ b/app/services/mcp_tools/resource_proxy_tool.rb
@@ -47,7 +47,7 @@ module McpTools
     private
 
     def call
-      McpResources.read_resource_content(self.class.resource.uri, resources_considered: McpResources.all)
+      Success(McpResources.read_resource_content(self.class.resource.uri, resources_considered: McpResources.all))
     end
 
     def format_content(result)

--- a/app/services/mcp_tools/search_custom_field_items.rb
+++ b/app/services/mcp_tools/search_custom_field_items.rb
@@ -68,10 +68,12 @@ module McpTools
     private
 
     def format_items(items)
-      {
-        items: items.map { |item| API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter.new(item, current_user:) },
-        total: items.size
-      }
+      Success(
+        {
+          items: items.map { |item| API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter.new(item, current_user:) },
+          total: items.size
+        }
+      )
     end
 
     def flatten_hierarchy(custom_field)

--- a/app/services/mcp_tools/search_custom_fields.rb
+++ b/app/services/mcp_tools/search_custom_fields.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchCustomFields < Base
+  class SearchCustomFields < SearchTool
     default_title "Search custom fields"
     default_description "Show details of the custom fields matching given criteria."
 
@@ -55,16 +55,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      custom_fields = apply_filters(CustomField.visible, filters)
-      custom_fields, total = apply_pagination(custom_fields, page)
+    def base_scope
+      Success(CustomField.visible)
+    end
 
-      {
-        items: custom_fields.map do |custom_field|
-          ::API::V3::CustomFields::CustomFieldRepresenter.create(custom_field, current_user:)
-        end,
-        total:
-      }
+    def format_item(item)
+      ::API::V3::CustomFields::CustomFieldRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_portfolios.rb
+++ b/app/services/mcp_tools/search_portfolios.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchPortfolios < Base
+  class SearchPortfolios < SearchTool
     default_title "Search portfolios"
     default_description "Search portfolios matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
@@ -53,14 +53,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      filtered = apply_filters(Project.portfolio.visible, filters)
-      portfolios, total = apply_pagination(filtered, page)
+    def base_scope
+      Success(Project.portfolio.visible)
+    end
 
-      {
-        items: portfolios.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) },
-        total:
-      }
+    def format_item(item)
+      API::V3::Projects::ProjectRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_programs.rb
+++ b/app/services/mcp_tools/search_programs.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchPrograms < Base
+  class SearchPrograms < SearchTool
     default_title "Search programs"
     default_description "Search programs matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
@@ -53,14 +53,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      filtered = apply_filters(Project.program.visible, filters)
-      programs, total = apply_pagination(filtered, page)
+    def base_scope
+      Success(Project.program.visible)
+    end
 
-      {
-        items: programs.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) },
-        total:
-      }
+    def format_item(item)
+      API::V3::Projects::ProjectRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchProjects < Base
+  class SearchProjects < SearchTool
     default_title "Search projects"
     default_description "Search projects matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
@@ -53,14 +53,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      filtered = apply_filters(Project.project.visible, filters)
-      projects, total = apply_pagination(filtered, page)
+    def base_scope
+      Success(Project.project.visible)
+    end
 
-      {
-        items: projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) },
-        total:
-      }
+    def format_item(item)
+      API::V3::Projects::ProjectRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_tool.rb
+++ b/app/services/mcp_tools/search_tool.rb
@@ -95,14 +95,14 @@ module McpTools
 
     private
 
-    def call(page: nil, **filters_and_scope_params)
+    def call(page: nil, level_of_detail: "condensed", **filters_and_scope_params)
       scope_params = filters_and_scope_params.slice(*scope_param_names)
       filters = filters_and_scope_params.except(*scope_param_names).reverse_merge(default_filters)
       base_scope(**scope_params).bind do |scope|
         filtered = apply_filters(scope, filters)
         items, total = apply_pagination(filtered, page)
 
-        Success({ items: items.map { |item| format_item(item) }, total: })
+        Success({ items: items.map { |item| apply_lod(format_item(item), level_of_detail:) }, total: })
       end
     end
 
@@ -129,6 +129,15 @@ module McpTools
       [scope.offset((page_number - 1) * page_size).limit(page_size), total]
     end
 
+    def apply_lod(item, level_of_detail:)
+      return item if level_of_detail == "full" || (condensed_attributes.empty? && condensed_links.empty?)
+
+      hash = item.as_json
+      hash.delete_if { |attr| condensed_attributes.exclude?(attr) }
+      hash["_links"]&.delete_if { |l| condensed_links.exclude?(l) }
+      hash
+    end
+
     ### Methods intended for overwriting in subclasses ###
 
     # Must return a scope that's used to list items of the given search. The result of this will be passed down
@@ -143,5 +152,13 @@ module McpTools
 
     # Defines formatting of each item returned from the search. Must return something that responds to #as_json.
     def format_item(_item) = raise SubclassResponsibilityError
+
+    # List of attributes that shall be returned in the condensed level-of-detail.
+    # If neither #condensed_attributes nor #condensed links are present, only full level-of-detail will be rendered.
+    def condensed_attributes = []
+
+    # List of links that shall be returned in the condensed level-of-detail.
+    # If neither #condensed_attributes nor #condensed links are present, only full level-of-detail will be rendered.
+    def condensed_links = []
   end
 end

--- a/app/services/mcp_tools/search_tool.rb
+++ b/app/services/mcp_tools/search_tool.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class SearchTool < Base
+    class << self
+      def pagination_enabled?
+        @pagination_enabled || false
+      end
+
+      def enable_pagination
+        @pagination_enabled = true
+      end
+
+      def input_schema(schema = nil)
+        if schema && pagination_enabled?
+          page = {
+            type: "number",
+            default: 1,
+            description: "Page number for pagination. If no page is defined, the first result set is returned. " \
+                         "To get the rest of the results, use a page number of 2 or higher."
+          }
+
+          return super(schema.deep_merge({ properties: { page: } }))
+        end
+
+        super
+      end
+
+      ##
+      # Defines a filter for selecting results through input parameters. Only one of filter_proc and filter_class are allowed at
+      # the same time. If none is provided, a default where-based filter is created, using name as the filtered attribute name.
+      #
+      # Filters defined here can later be applied by the tool implementation using #apply_filters.
+      #
+      # @param name [Symbol] The name of the input parameter used for filtering.
+      # @param filter_class [String] Class name of a shared filter implementation to be used to perform filtering,
+      #                              inheriting from Queries::Filters::Base.
+      # @param operator [String] When using a filter_class, this is the operator that will be used for filtering. Default: "="
+      # @param filter_proc [Proc] A callback procedure used for filtering that must accept two arguments:
+      #                           The base scope that the filter applies to and the value that's used as a filter input.
+      # @example
+      #   filter :id
+      #
+      # @example
+      #   filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
+      #
+      # @example
+      #   filter :status, filter_proc: ->(scope, value) { scope.where(status_name: value) }
+      def filter(name, filter_class: nil, filter_proc: nil, operator: "=")
+        if filter_class && filter_proc
+          raise ArgumentError, "filter_proc and filter_class are mutually exclusive, please only specify one"
+        end
+
+        if filter_class
+          filter_proc = ->(scope, value) { filter_class.constantize.create!(operator:, values: Array(value)).apply_to(scope) }
+        elsif !filter_proc
+          filter_proc = ->(scope, value) { scope.where(name.to_sym => value) }
+        end
+
+        filters[name.to_sym] = filter_proc
+      end
+
+      def filters
+        @filters ||= {}
+      end
+    end
+
+    private
+
+    def call(page: nil, **filters_and_scope_params)
+      scope_params = filters_and_scope_params.slice(*scope_param_names)
+      filters = filters_and_scope_params.except(*scope_param_names).reverse_merge(default_filters)
+      base_scope(**scope_params).bind do |scope|
+        filtered = apply_filters(scope, filters)
+        items, total = apply_pagination(filtered, page)
+
+        Success({ items: items.map { |item| format_item(item) }, total: })
+      end
+    end
+
+    def apply_filters(scope, params)
+      params.each do |name, value|
+        filter_proc = filter_proc_for(name)
+        scope = filter_proc.call(scope, value)
+      end
+
+      scope
+    end
+
+    def filter_proc_for(name)
+      self.class.filters[name] || raise(ArgumentError, "Don't know how to handle filter argument called #{name}")
+    end
+
+    def apply_pagination(scope, page)
+      total = scope.count
+      return [scope, total] unless self.class.pagination_enabled?
+
+      page_number = page || 1
+      page_size = self.class.page_size
+
+      [scope.offset((page_number - 1) * page_size).limit(page_size), total]
+    end
+
+    ### Methods intended for overwriting in subclasses ###
+
+    # Must return a scope that's used to list items of the given search. The result of this will be passed down
+    # to the filtering and pagination.
+    def base_scope = raise SubclassResponsibilityError
+
+    # Names of tool call parameters that need to be forwarded to the #base_scope method, if any.
+    def scope_param_names = []
+
+    # Hash of default values that filters should assume, if they are not explicitly provided.
+    def default_filters = {}
+
+    # Defines formatting of each item returned from the search. Must return something that responds to #as_json.
+    def format_item(_item) = raise SubclassResponsibilityError
+  end
+end

--- a/app/services/mcp_tools/search_users.rb
+++ b/app/services/mcp_tools/search_users.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchUsers < Base
+  class SearchUsers < SearchTool
     default_title "Search users"
     default_description "Search users matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum of #{page_size} users. " \
@@ -52,14 +52,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      users = apply_filters(User.visible.not_builtin, filters)
-      users, total = apply_pagination(users, page)
+    def base_scope
+      Success(User.visible.not_builtin)
+    end
 
-      {
-        items: users.map { |user| API::V3::Users::UserRepresenter.create(user, current_user:) },
-        total:
-      }
+    def format_item(item)
+      API::V3::Users::UserRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_versions.rb
+++ b/app/services/mcp_tools/search_versions.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchVersions < Base
+  class SearchVersions < SearchTool
     default_title "Search versions"
     default_description "Search versions matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
@@ -55,14 +55,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      filtered = apply_filters(Version.visible, filters)
-      versions, total = apply_pagination(filtered, page)
+    def base_scope
+      Success(Version.visible)
+    end
 
-      {
-        items: versions.map { |v| API::V3::Versions::VersionRepresenter.create(v, current_user:) },
-        total:
-      }
+    def format_item(item)
+      API::V3::Versions::VersionRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchWorkPackages < Base
+  class SearchWorkPackages < SearchTool
     default_title "Search work packages"
     default_description "Search work packages matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
@@ -94,14 +94,12 @@ module McpTools
     output_filter McpOutputFilters::RemoveFormattableHtml.new
     output_filter McpOutputFilters::RemoveWorkPackageActionLinks.new
 
-    def call(page: nil, **filters)
-      filtered = apply_filters(WorkPackage.visible, filters)
-      work_packages, total = apply_pagination(filtered, page)
+    def base_scope
+      Success(WorkPackage.visible)
+    end
 
-      {
-        items: work_packages.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) },
-        total:
-      }
+    def format_item(item)
+      API::V3::WorkPackages::WorkPackageRepresenter.create(item, current_user:)
     end
   end
 end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -64,6 +64,12 @@ module McpTools
     input_schema(
       additionalProperties: false,
       properties: {
+        level_of_detail: {
+          type: :string,
+          enum: %w[reduced full],
+          description: "Defines how much information is returned per work package. By default a reduced representation " \
+                       "is returned, but passing 'full' can return all information."
+        },
         assigned_to_id: {
           type: %w[number null],
           description: "The ID of the user or group that is assigned to this work package. " \
@@ -100,6 +106,33 @@ module McpTools
 
     def format_item(item)
       API::V3::WorkPackages::WorkPackageRepresenter.create(item, current_user:)
+    end
+
+    def condensed_attributes
+      @condensed_attributes ||= %w[
+        _links
+        id
+        displayId
+        subject
+        lockVersion
+        date
+        startDate
+        dueDate
+        derivedStartDate
+        derivedDueDate
+        createdAt
+        updatedAt
+      ].to_set
+    end
+
+    def condensed_links
+      @condensed_links ||= %w[
+        project
+        status
+        type
+        author
+        assignee
+      ].to_set
     end
   end
 end

--- a/app/services/mcp_tools/update_work_package.rb
+++ b/app/services/mcp_tools/update_work_package.rb
@@ -67,22 +67,26 @@ module McpTools
 
     def call(id:, data:)
       work_package = WorkPackage.visible(current_user).find_by(id:)
-      return { error: "The given work package could not be found." } if work_package.nil?
+      return Failure("The given work package could not be found.") if work_package.nil?
 
-      attributes = parse_work_package(data).on_failure { |result| return { error: result.message } }.result
+      attributes = parse_work_package(data).on_failure { |result| return Failure(result.message) }.result
       result = WorkPackages::UpdateService.new(user: current_user, model: work_package).call(**attributes)
 
-      if result.success?
-        API::V3::WorkPackages::WorkPackageRepresenter.create(result.result, current_user:)
-      else
-        { error: result.message }
-      end
+      format_result(result)
     end
 
     private
 
     def parse_work_package(data)
       ::API::V3::WorkPackages::ParseParamsService.new(current_user, model: WorkPackage).call(data.deep_stringify_keys)
+    end
+
+    def format_result(result)
+      if result.success?
+        Success(API::V3::WorkPackages::WorkPackageRepresenter.create(result.result, current_user:))
+      else
+        Failure(result.message)
+      end
     end
   end
 end

--- a/app/services/mcp_tools/update_work_package_relation.rb
+++ b/app/services/mcp_tools/update_work_package_relation.rb
@@ -76,15 +76,11 @@ module McpTools
 
     def call(id:, **attributes)
       relation = Relation.visible(current_user).find_by(id:)
-      return { error: "The given relation could not be found." } if relation.nil?
+      return Failure("The given relation could not be found.") if relation.nil?
 
       result = Relations::UpdateService.new(user: current_user, model: relation).call(map_attributes(attributes))
 
-      if result.success?
-        API::V3::Relations::RelationRepresenter.create(result.result, current_user:)
-      else
-        { error: result.message }
-      end
+      format_result(result)
     end
 
     private
@@ -93,6 +89,14 @@ module McpTools
       attributes = attributes.slice(:type, :description, :lag)
       attributes[:relation_type] = attributes.delete(:type) if attributes.key?(:type)
       attributes
+    end
+
+    def format_result(result)
+      if result.success?
+        Success(API::V3::Relations::RelationRepresenter.create(result.result, current_user:))
+      else
+        Failure(result.message)
+      end
     end
   end
 end

--- a/modules/costs/app/services/mcp_tools/create_time_entry.rb
+++ b/modules/costs/app/services/mcp_tools/create_time_entry.rb
@@ -74,21 +74,25 @@ module McpTools
     )
 
     def call(data:)
-      parsed = parse_time_entry(data).on_failure { |result| return { error: result.message } }.result
+      parsed = parse_time_entry(data).on_failure { |result| return Failure(result.message) }.result
       parsed = parsed.reverse_merge(user_id: current_user.id, spent_on: Date.current)
       result = TimeEntries::CreateService.new(user: current_user).call(**parsed)
 
-      if result.success?
-        API::V3::TimeEntries::TimeEntryRepresenter.create(result.result, current_user:)
-      else
-        { error: result.message }
-      end
+      format_result(result)
     end
 
     private
 
     def parse_time_entry(data)
       ::API::V3::ParseResourceParamsService.new(current_user, model: TimeEntry).call(data.deep_stringify_keys)
+    end
+
+    def format_result(result)
+      if result.success?
+        Success(API::V3::TimeEntries::TimeEntryRepresenter.create(result.result, current_user:))
+      else
+        Failure(result.message)
+      end
     end
   end
 end

--- a/modules/costs/app/services/mcp_tools/delete_time_entry.rb
+++ b/modules/costs/app/services/mcp_tools/delete_time_entry.rb
@@ -49,14 +49,14 @@ module McpTools
 
     def call(id:)
       time_entry = TimeEntry.visible(current_user).find_by(id:)
-      return { error: "The given time entry could not be found." } if time_entry.nil?
+      return Failure("The given time entry could not be found.") if time_entry.nil?
 
       result = TimeEntries::DeleteService.new(user: current_user, model: time_entry).call
 
       if result.success?
-        API::V3::TimeEntries::TimeEntryRepresenter.create(result.result, current_user:)
+        Success(API::V3::TimeEntries::TimeEntryRepresenter.create(result.result, current_user:))
       else
-        { error: result.message }
+        Failure(result.message)
       end
     end
   end

--- a/modules/costs/app/services/mcp_tools/search_time_entries.rb
+++ b/modules/costs/app/services/mcp_tools/search_time_entries.rb
@@ -29,7 +29,7 @@
 #++
 
 module McpTools
-  class SearchTimeEntries < Base
+  class SearchTimeEntries < SearchTool
     default_title "Search time entries"
     default_description "Search time entries matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
@@ -65,15 +65,12 @@ module McpTools
       }
     )
 
-    def call(page: nil, **filters)
-      filters = filters.reverse_merge(spent_since: Date.current, spent_until: Date.current)
-      filtered = apply_filters(TimeEntry.visible, filters)
-      time_entries, total = apply_pagination(filtered, page)
+    def base_scope = Success(TimeEntry.visible)
 
-      {
-        items: time_entries.map { |entry| API::V3::TimeEntries::TimeEntryRepresenter.create(entry, current_user:) },
-        total:
-      }
+    def default_filters = { spent_since: Date.current, spent_until: Date.current }
+
+    def format_item(item)
+      API::V3::TimeEntries::TimeEntryRepresenter.create(item, current_user:)
     end
   end
 end

--- a/modules/costs/app/services/mcp_tools/update_time_entry.rb
+++ b/modules/costs/app/services/mcp_tools/update_time_entry.rb
@@ -79,22 +79,26 @@ module McpTools
 
     def call(id:, data:)
       time_entry = TimeEntry.visible(current_user).find_by(id:)
-      return { error: "The given time entry could not be found." } if time_entry.nil?
+      return Failure("The given time entry could not be found.") if time_entry.nil?
 
-      attributes = parse_time_entry(data).on_failure { |result| return { error: result.message } }.result
+      attributes = parse_time_entry(data).on_failure { |result| return Failure(result.message) }.result
       result = TimeEntries::UpdateService.new(user: current_user, model: time_entry).call(**attributes)
 
-      if result.success?
-        API::V3::TimeEntries::TimeEntryRepresenter.create(result.result, current_user:)
-      else
-        { error: result.message }
-      end
+      format_result(result)
     end
 
     private
 
     def parse_time_entry(data)
       ::API::V3::ParseResourceParamsService.new(current_user, model: TimeEntry).call(data.deep_stringify_keys)
+    end
+
+    def format_result(result)
+      if result.success?
+        Success(API::V3::TimeEntries::TimeEntryRepresenter.create(result.result, current_user:))
+      else
+        Failure(result.message)
+      end
     end
   end
 end

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe McpTools::SearchWorkPackages do
       }
     }
   end
-  let(:call_args) { {} }
+  let(:call_args) { { level_of_detail: "full" } }
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
   let(:result_items) { parsed_results.dig("structuredContent", "items") }
 
@@ -122,6 +122,25 @@ RSpec.describe McpTools::SearchWorkPackages do
 
         # ... but rejects links that merely tell the client "what's possible to do" (non-exhaustive examples)
         expect(work_package.fetch("_links").keys).not_to include("logTime", "generate_pdf", "copy")
+      end
+    end
+
+    context "when not requesting a full representation" do
+      let(:call_args) { {} }
+
+      it "finds all work packages" do
+        mcp_request
+        expect(result_items.size).to eq(2)
+      end
+
+      it "removes lots of attributes" do
+        subject
+        result_items.each do |work_package|
+          expect(work_package.keys.size).to be < 15
+
+          links = work_package.fetch("_links")
+          expect(links.keys.size).to be < 10
+        end
       end
     end
 


### PR DESCRIPTION
Allowing to pass `level_of_detail` to choose how many attributes the items in `search_work_packages` have. By default they will be shortened.

# Ticket
https://community.openproject.org/wp/AI-123

# Approach chosen

This PR offers a third alternative to https://github.com/opf/openproject/pull/24923, after doing additional code separation on the MCP tools first.

The parameters feel to be all in the right place to me now. Level of detail is a concept that more tools can opt into, however for practical reasons (see my concerns of the second solution) it has also not been implemented as an output filter. However, it was now implemented in a reusable way.
