### PR TITLE
Bug/COMMS-963: Versions PG::UndefinedTable during a query

### DIFF
--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -108,8 +108,7 @@ class Query::Results
 
   def work_package_scope
     WorkPackage
-      .includes(all_includes)
-      .references(:projects)
+      .eager_load(all_includes)
   end
 
   def all_includes

--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -51,7 +51,6 @@ module ::Query::Results::GroupBy
       .joins(query.group_by_join_statement)
       .group(group_by_for_count)
       .visible
-      .references(:statuses, :projects)
       .where(query.statement)
       .order(order_for_count)
       .pluck(*pluck_for_count)
@@ -60,7 +59,7 @@ module ::Query::Results::GroupBy
 
   def work_packages_with_includes_for_count
     WorkPackage
-      .includes(all_includes)
+      .eager_load(all_includes)
       .joins(all_filter_joins)
   end
 

--- a/modules/backlogs/spec/models/query/results_backlog_bucket_sort_integration_spec.rb
+++ b/modules/backlogs/spec/models/query/results_backlog_bucket_sort_integration_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Grouping or sorting by backlog bucket adds a raw SQL join whose permission
+# subquery mentions the projects table. That mention must not stop the
+# associations of other sort columns (e.g. category) from being joined, or
+# their ORDER BY expressions reference tables missing from the query.
+RSpec.describe Query::Results, "sorting by backlog bucket and an association column" do
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+  shared_let(:role) do
+    create(:project_role, permissions: %i[view_work_packages view_sprints])
+  end
+  shared_let(:user) { create(:user, member_with_roles: { project => role }) }
+  shared_let(:bucket) { create(:backlog_bucket, project:) }
+  shared_let(:category) { create(:category, project:) }
+  shared_let(:work_package) do
+    create(:work_package, project:, backlog_bucket: bucket, category:, estimated_hours: 5)
+  end
+
+  let(:query) do
+    build(:query, project: nil, user:).tap do |q|
+      q.group_by = "backlog_bucket"
+      q.sort_criteria = [%w[category asc]]
+      q.column_names = %i[id subject estimated_hours]
+      q.display_sums = true
+    end
+  end
+  let(:results) { described_class.new(query) }
+
+  current_user { user }
+
+  it "lists the work packages" do
+    expect(results.work_packages.to_a).to eq [work_package]
+  end
+
+  it "counts by group" do
+    expect(results.work_package_count_by_group).to eq(bucket => 1)
+  end
+
+  it "computes total sums" do
+    expect(results.all_total_sums.values).to include(5.0)
+  end
+
+  it "computes group sums" do
+    expect(results.all_group_sums).to be_present
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-963

<img width="1259" height="788" alt="Screenshot 2026-08-29 at 6 50 55 PM" src="https://github.com/user-attachments/assets/af024b2c-56a1-4aee-a595-d61a3089c97c" />

Grouping or sorting by a select with a raw SQL join (backlog bucket, sprint, project phase) crashed queries that also sort by an association-based column, with `PG::UndefinedTable: missing FROM-clause entry`. [_See AppSignal trace_](https://appsignal.com/openproject-gmbh/sites/674718f1d2a5e4a7cb8b2298/exceptions/incidents/1047/traces/last).

Rails decides whether to eager load included associations by scanning raw join strings for referenced table names; the permission subquery inside those joins mentions the projects table, so Rails considered the reference satisfied and silently skipped eager loading altogether, leaving the ORDER BY pointing at tables that were never joined. This hit the work package list, group counts, and the sums query reported in the ticket.

`Query::Results` now uses `eager_load` instead of `includes` + `references`, which guarantees the joins regardless of what the raw join SQL happens to mention.
