### PR TITLE
Allow InsetBox to receive a scheme, and extract title and icon, actions

### DIFF
--- a/app/components/op_primer/inset_box_component.html.erb
+++ b/app/components/op_primer/inset_box_component.html.erb
@@ -27,16 +27,35 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%=
-  render(
-    Primer::Box.new(
-      border:,
-      border_radius: 2,
-      bg: :inset,
-      p: 3,
-      **system_arguments
-    )
-  ) do
-    content
-  end
-%>
+<%= render(
+      Primer::Box.new(
+        border:,
+        border_radius: 2,
+        p: 3,
+        **scheme_arguments,
+        **system_arguments
+      )
+    ) do %>
+  <% if title? || title_icon? %>
+    <%= render(Primer::Box.new(display: :flex, align_items: :center, mb: 2, classes: "gap-2")) do %>
+      <%= title_icon %>
+      <%= title %>
+    <% end %>
+  <% end %>
+  <%= content %>
+  <% if actions.any? %>
+    <%= render(
+          Primer::Box.new(
+            display: :flex,
+            align_items: :center,
+            flex_wrap: :wrap,
+            mt: 2,
+            classes: "gap-2"
+          )
+        ) do %>
+      <% actions.each do |action| %>
+        <%= action %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/op_primer/inset_box_component.rb
+++ b/app/components/op_primer/inset_box_component.rb
@@ -30,11 +30,36 @@
 
 module OpPrimer
   class InsetBoxComponent < Primer::Component
-    attr_reader :border, :system_arguments
+    DEFAULT_SCHEME = :default
+    SCHEME_MAPPINGS = {
+      DEFAULT_SCHEME => { bg: :inset },
+      info: { bg: :accent, border_color: :accent },
+      warning: { bg: :attention, border_color: :attention },
+      danger: { bg: :danger, border_color: :danger },
+      success: { bg: :success, border_color: :success }
+    }.freeze
 
-    def initialize(border: true, **system_arguments)
+    attr_reader :border, :scheme_arguments, :system_arguments
+
+    renders_one :title_icon, Primer::Beta::Octicon
+
+    renders_one :title, lambda { |tag: :h3, **system_arguments|
+      Primer::Beta::Heading.new(tag:, font_size: 5, font_weight: :semibold, **system_arguments)
+    }
+
+    renders_many :actions, types: {
+      button: lambda { |**system_arguments|
+        Primer::Beta::Button.new(**system_arguments)
+      },
+      menu: lambda { |**system_arguments|
+        Primer::Alpha::ActionMenu.new(**system_arguments)
+      }
+    }
+
+    def initialize(border: true, scheme: DEFAULT_SCHEME, **system_arguments)
       super()
       @border = border
+      @scheme_arguments = SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)]
       @system_arguments = system_arguments
     end
   end

--- a/lookbook/docs/components/inset-box.md.erb
+++ b/lookbook/docs/components/inset-box.md.erb
@@ -7,14 +7,17 @@ The Inset Box element is used to visually group content inside a container with 
 The Inset Box is made up of:
 
 1. The **container**, which provides consistent padding and background.
-2. The **content slot**, which renders any inner content (text, forms, tables, etc.).
-3. An optional **border**, which can be toggled off when not needed.
+2. An optional **title**, with an optional **title icon** in front of it.
+3. The **content slot**, which renders any inner content (text, forms, tables, etc.).
+4. Optional **actions**, rendered in a row below the content.
+5. An optional **border**, which can be toggled off when not needed.
+6. A **scheme**, which colors the background and the border.
 
 ## Default rendering
 
 - **Border:** enabled by default
 - **Border radius:** 2
-- **Background:** `:inset` (light grey)
+- **Background:** `:inset` (light grey), from the `:default` scheme
 - **Padding:** 3
 
 <%= embed OpPrimer::InsetBoxComponentPreview, :default %>
@@ -24,9 +27,58 @@ The Inset Box is made up of:
 The Inset Box supports the following options:
 
 - **Border** – can be disabled with `border: false`.
+- **Scheme** – colors the box, see below.
 - **Other system arguments** – all `Primer::Box` arguments are passed through.
 
 <%= embed OpPrimer::InsetBoxComponentPreview, :borderless %>
+
+## Schemes
+
+`scheme:` mirrors the schemes of `Primer::Alpha::Banner`, with `:info` in place of
+`:upsell`. Each one sets the background and the border color:
+
+| Scheme | Use it for |
+| --- | --- |
+| `:default` | grouping related content. No status attached. |
+| `:info` | a neutral fact the reader has to know to understand the content. |
+| `:warning` | a consequence the reader has to weigh before acting. |
+| `:danger` | an action that destroys data or cannot be undone. |
+| `:success` | an outcome that has already happened. |
+
+Pick the icon yourself: unlike the Banner, the Inset Box does not imply one from the
+scheme. `:info` pairs with `info`, `:warning` with `alert`, `:danger` with `stop`, and
+`:success` with `check-circle`.
+
+A colored box carries the same weight as a banner, so use one only where the status is
+about the content of the box. For a page-level message, use `Primer::Alpha::Banner`.
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :info %>
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :warning %>
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :danger %>
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :success %>
+
+## Title
+
+Call `with_title` for a heading above the content. It renders an `h3` by default, which
+`tag:` overrides. Add `with_title_icon` for an Octicon in front of it.
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :with_title_icon %>
+
+## Actions
+
+Call `with_action_button` for each button that follows the content, or `with_action_menu`
+for an overflow menu. Both slots accept many entries, and they render in the order they
+are added.
+
+Use actions for what the box itself offers. An action that applies to the surrounding
+page belongs in the sub header, not here.
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :with_action_buttons %>
+
+<%= embed OpPrimer::InsetBoxComponentPreview, :with_action_menu %>
 
 ## Uses
 
@@ -38,8 +90,8 @@ Some places where we already use the Inset Box:
 
 It is useful whenever content should stand out from the page background while staying lightweight.
 
-If content needs more structure, such as headers, actions, or multiple items,
-consider using the Border Box List component instead.
+If the content is a list of many items, consider using the Border Box List component
+instead.
 
 ## Best practices
 
@@ -50,7 +102,7 @@ consider using the Border Box List component instead.
 
 **Don't**
 
-- Don’t apply arbitrary custom background colors in CSS — use the component’s options.
+- Don’t apply arbitrary custom background colors in CSS — use `scheme:`.
 - Don’t duplicate "grey box" styles manually; always use the Inset Box.
 - Don’t use Inset Box if a more structured component, such as Border Box List,
   is better suited.
@@ -59,4 +111,4 @@ consider using the Border Box List component instead.
 
 <%= embed OpPrimer::InsetBoxComponentPreview, :playground, panels: %i[params source] %>
 
-The Inset Box is implemented as a wrapper around `Primer::Box` with opinionated defaults for border, padding, border radius, and background. It passes through all other `system_arguments` to `Primer::Box`.
+The Inset Box is implemented as a wrapper around `Primer::Box` with opinionated defaults for border, padding and border radius, and a `scheme:` that resolves to `bg:` and `border_color:` arguments. It passes through all other `system_arguments` to `Primer::Box`. The title slots wrap `Primer::Beta::Heading` and `Primer::Beta::Octicon`, the action slots wrap `Primer::Beta::Button` and `Primer::Alpha::ActionMenu`.

--- a/lookbook/previews/op_primer/inset_box_component_preview.rb
+++ b/lookbook/previews/op_primer/inset_box_component_preview.rb
@@ -38,13 +38,21 @@ module OpPrimer
     end
 
     # @param border [Boolean]
+    # @param scheme [Symbol] select [default, info, warning, danger, success]
+    # @param title [String]
+    # @param title_icon [Symbol] select [none, info, alert, stop, check-circle, link, pencil, git-branch]
     # @param content [String]
-    def playground(border: true, content: "Group some information here")
-      puts "border: "
-      puts border
-      puts border.class
-
-      render OpPrimer::InsetBoxComponent.new(border: ActiveModel::Type::Boolean.new.cast(border)) do
+    def playground(border: true,
+                   scheme: :default,
+                   title: "Inset box title",
+                   title_icon: :none,
+                   content: "Group some information here")
+      render OpPrimer::InsetBoxComponent.new(
+        border: ActiveModel::Type::Boolean.new.cast(border),
+        scheme: scheme.to_sym
+      ) do |box|
+        box.with_title_icon(icon: title_icon.to_sym) unless title_icon.to_s == "none"
+        box.with_title { title } if title.present?
         content
       end
     end
@@ -52,6 +60,76 @@ module OpPrimer
     def borderless
       render OpPrimer::InsetBoxComponent.new(border: false) do
         "I am a text inside InsetBox Component."
+      end
+    end
+
+    def info
+      render OpPrimer::InsetBoxComponent.new(scheme: :info) do |box|
+        box.with_title_icon(icon: :info)
+        box.with_title { "Good to know" }
+        "This variant inherits its configuration from another type."
+      end
+    end
+
+    def warning
+      render OpPrimer::InsetBoxComponent.new(scheme: :warning) do |box|
+        box.with_title_icon(icon: :alert)
+        box.with_title { "Careful" }
+        "Switching the mode overrides the current settings."
+      end
+    end
+
+    def danger
+      render OpPrimer::InsetBoxComponent.new(scheme: :danger) do |box|
+        box.with_title_icon(icon: :stop)
+        box.with_title { "This cannot be undone" }
+        "Deleting the variant releases every project that uses it."
+      end
+    end
+
+    def success
+      render OpPrimer::InsetBoxComponent.new(scheme: :success) do |box|
+        box.with_title_icon(icon: :"check-circle")
+        box.with_title { "All set" }
+        "The configuration was copied."
+      end
+    end
+
+    def with_title
+      render OpPrimer::InsetBoxComponent.new do |box|
+        box.with_title { "Reuse mode" }
+        "The configuration of this section is inherited from another type."
+      end
+    end
+
+    def with_title_icon
+      render OpPrimer::InsetBoxComponent.new do |box|
+        box.with_title_icon(icon: :link)
+        box.with_title { "Linked mode" }
+        "The configuration of this section is inherited from another type."
+      end
+    end
+
+    def with_action_buttons
+      render OpPrimer::InsetBoxComponent.new do |box|
+        box.with_title_icon(icon: :link)
+        box.with_title { "Linked mode" }
+        box.with_action_button { "Change source type" }
+        box.with_action_button(scheme: :primary) { "Switch to independent mode" }
+        "The configuration of this section is inherited from another type."
+      end
+    end
+
+    def with_action_menu
+      render OpPrimer::InsetBoxComponent.new do |box|
+        box.with_title_icon(icon: :"git-branch")
+        box.with_title { "Dependents" }
+        box.with_action_menu do |menu|
+          menu.with_show_button { "Actions" }
+          menu.with_item(label: "Show dependents", href: "#")
+          menu.with_item(label: "Unlink all", href: "#", scheme: :danger)
+        end
+        "Two types inherit this configuration."
       end
     end
   end

--- a/lookbook/previews/op_primer/inset_box_component_preview.rb
+++ b/lookbook/previews/op_primer/inset_box_component_preview.rb
@@ -41,11 +41,13 @@ module OpPrimer
     # @param scheme [Symbol] select [default, info, warning, danger, success]
     # @param title [String]
     # @param title_icon [Symbol] select [none, info, alert, stop, check-circle, link, pencil, git-branch]
+    # @param action [Symbol] select [none, button, buttons, menu]
     # @param content [String]
     def playground(border: true,
                    scheme: :default,
                    title: "Inset box title",
                    title_icon: :none,
+                   action: :none,
                    content: "Group some information here")
       render OpPrimer::InsetBoxComponent.new(
         border: ActiveModel::Type::Boolean.new.cast(border),
@@ -53,6 +55,7 @@ module OpPrimer
       ) do |box|
         box.with_title_icon(icon: title_icon.to_sym) unless title_icon.to_s == "none"
         box.with_title { title } if title.present?
+        playground_actions(box, action.to_sym)
         content
       end
     end
@@ -130,6 +133,24 @@ module OpPrimer
           menu.with_item(label: "Unlink all", href: "#", scheme: :danger)
         end
         "Two types inherit this configuration."
+      end
+    end
+
+    private
+
+    def playground_actions(box, action)
+      case action
+      when :button
+        box.with_action_button { "Primary action" }
+      when :buttons
+        box.with_action_button { "Secondary action" }
+        box.with_action_button(scheme: :primary) { "Primary action" }
+      when :menu
+        box.with_action_menu do |menu|
+          menu.with_show_button { "Actions" }
+          menu.with_item(label: "First action", href: "#")
+          menu.with_item(label: "Second action", href: "#")
+        end
       end
     end
   end

--- a/spec/components/op_primer/inset_box_component_preview_spec.rb
+++ b/spec/components/op_primer/inset_box_component_preview_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe OpPrimer::InsetBoxComponentPreview, type: :component do
     expect(page).to have_css(".color-bg-attention .octicon-alert + h3", text: "Careful")
   end
 
+  it "renders the playground with a single action button" do
+    render_preview(:playground, from: described_class, params: { action: :button })
+
+    expect(page).to have_button("Primary action")
+  end
+
+  it "renders the playground with two action buttons" do
+    render_preview(:playground, from: described_class, params: { action: :buttons })
+
+    expect(page).to have_button("Secondary action")
+    expect(page).to have_button("Primary action")
+  end
+
+  it "renders the playground with an action menu" do
+    render_preview(:playground, from: described_class, params: { action: :menu })
+
+    expect(page).to have_button("Actions")
+    expect(page).to have_text("First action")
+  end
+
+  it "renders the playground without an action" do
+    render_preview(:playground, from: described_class, params: { action: :none })
+
+    expect(page).to have_no_button
+  end
+
   it "renders the playground without a title icon" do
     render_preview(:playground, from: described_class, params: { title_icon: :none })
 

--- a/spec/components/op_primer/inset_box_component_preview_spec.rb
+++ b/spec/components/op_primer/inset_box_component_preview_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "rails_helper"
+require Rails.root.join("lookbook/previews/op_primer/inset_box_component_preview").to_s
+
+RSpec.describe OpPrimer::InsetBoxComponentPreview, type: :component do
+  # Lookbook is disabled in the test environment, so its preview path is not registered.
+  # Register it for these examples, then restore the original paths.
+  around do |example|
+    path = Rails.root.join("lookbook/previews").to_s
+    paths = ViewComponent::Base.previews.paths
+    added = paths.exclude?(path)
+    paths << path if added
+    begin
+      example.run
+    ensure
+      paths.delete(path) if added
+    end
+  end
+
+  it "renders the playground with a title icon" do
+    render_preview(:playground, from: described_class,
+                                params: { scheme: :warning, title_icon: :alert, title: "Careful" })
+
+    expect(page).to have_css(".color-bg-attention .octicon-alert + h3", text: "Careful")
+  end
+
+  it "renders the playground without a title icon" do
+    render_preview(:playground, from: described_class, params: { title_icon: :none })
+
+    expect(page).to have_css("h3", text: "Inset box title")
+    expect(page).to have_no_css(".octicon")
+  end
+
+  it "renders the scheme previews" do
+    render_preview(:warning, from: described_class)
+
+    expect(page).to have_css(".color-bg-attention.color-border-attention")
+    expect(page).to have_css(".octicon-alert + h3", text: "Careful")
+  end
+
+  it "renders the info preview" do
+    render_preview(:info, from: described_class)
+
+    expect(page).to have_css(".color-bg-accent.color-border-accent")
+  end
+
+  it "renders the title preview" do
+    render_preview(:with_title, from: described_class)
+
+    expect(page).to have_css("h3", text: "Reuse mode")
+  end
+
+  it "renders the title icon preview" do
+    render_preview(:with_title_icon, from: described_class)
+
+    expect(page).to have_css(".octicon-link + h3", text: "Linked mode")
+  end
+
+  it "renders the action buttons preview" do
+    render_preview(:with_action_buttons, from: described_class)
+
+    expect(page).to have_button("Change source type")
+    expect(page).to have_button("Switch to independent mode")
+  end
+
+  it "renders the action menu preview" do
+    render_preview(:with_action_menu, from: described_class)
+
+    expect(page).to have_button("Actions")
+    expect(page).to have_text("Show dependents")
+  end
+end

--- a/spec/components/op_primer/inset_box_component_spec.rb
+++ b/spec/components/op_primer/inset_box_component_spec.rb
@@ -56,11 +56,102 @@ RSpec.describe OpPrimer::InsetBoxComponent, type: :component do
     end
   end
 
+  context "with a scheme" do
+    it "keeps the inset background by default" do
+      expect(render_component).to have_css(".color-bg-inset")
+    end
+
+    it "renders the info scheme in accent colors" do
+      rendered = render_component(scheme: :info)
+
+      expect(rendered).to have_css(".color-bg-accent.color-border-accent")
+    end
+
+    it "renders the warning scheme in attention colors" do
+      rendered = render_component(scheme: :warning)
+
+      expect(rendered).to have_css(".color-bg-attention.color-border-attention")
+    end
+
+    it "renders the danger scheme in danger colors" do
+      rendered = render_component(scheme: :danger)
+
+      expect(rendered).to have_css(".color-bg-danger.color-border-danger")
+    end
+
+    it "renders the success scheme in success colors" do
+      rendered = render_component(scheme: :success)
+
+      expect(rendered).to have_css(".color-bg-success.color-border-success")
+    end
+  end
+
   context "when custom classes are passed" do
     subject(:rendered) { render_component(classes: "my-extra-class") }
 
     it "applies custom classes" do
       expect(rendered).to have_css(".my-extra-class")
+    end
+  end
+
+  context "with a title" do
+    it "renders the title in a heading at body size" do
+      rendered = render_inline(described_class.new) do |box|
+        box.with_title { "Reuse mode" }
+      end
+
+      expect(rendered).to have_css("h3.f5.text-semibold", text: "Reuse mode")
+      expect(rendered).to have_no_css(".octicon")
+    end
+
+    it "renders the title icon in front of the title" do
+      rendered = render_inline(described_class.new) do |box|
+        box.with_title_icon(icon: :link)
+        box.with_title { "Linked mode" }
+      end
+
+      expect(rendered).to have_css(".octicon-link + h3", text: "Linked mode")
+    end
+
+    it "honours a custom heading tag" do
+      rendered = render_inline(described_class.new) do |box|
+        box.with_title(tag: :h2) { "Dependents" }
+      end
+
+      expect(rendered).to have_css("h2", text: "Dependents")
+    end
+  end
+
+  context "with actions" do
+    it "renders several action buttons after the content" do
+      rendered = render_inline(described_class.new) do |box|
+        box.with_action_button { "Change source" }
+        box.with_action_button(scheme: :primary) { "Switch mode" }
+        "Some content"
+      end
+
+      expect(rendered).to have_button("Change source")
+      expect(rendered).to have_button("Switch mode")
+      expect(rendered.text.index("Some content")).to be < rendered.text.index("Change source")
+    end
+
+    it "renders an action menu" do
+      rendered = render_inline(described_class.new) do |box|
+        box.with_action_menu do |menu|
+          menu.with_show_button { "Actions" }
+          menu.with_item(label: "Unlink")
+        end
+      end
+
+      expect(rendered).to have_button("Actions")
+      expect(rendered).to have_css("action-menu")
+      expect(rendered).to have_text("Unlink")
+    end
+
+    it "renders no action container without actions" do
+      rendered = render_inline(described_class.new) { "Only content" }
+
+      expect(rendered).to have_no_css(".d-flex")
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/FND-242

- Add a new title slot with an optional icon
- Add a new action slot for action_button or menu, possibly more than one
- Actions will collapse to separate lines if not enough space
- Add a scheme argument for default, info, warning, danger and success
  - Default scheme remains gray
