### PR TITLE
Use pkgr action with local toolchain builds

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -53,7 +53,7 @@ jobs:
             echo "channel=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
           fi
       - name: Package
-        uses: pkgr/action/package@c5666febcd31750da6428042193fc5b2fb765435 # main
+        uses: pkgr/action/package@72711239e8f309a29f078b90bd269af6c7db3f70 # v1
         id: package
         with:
           target: ${{ matrix.target }}
@@ -63,7 +63,7 @@ jobs:
           env: |
             DATABASE_URL=postgres://app:p4ssw0rd@127.0.0.1:5432/app
       - name: Publish
-        uses: pkgr/action/publish@c5666febcd31750da6428042193fc5b2fb765435 # main
+        uses: pkgr/action/publish@72711239e8f309a29f078b90bd269af6c7db3f70 # v1
         with:
           target: ${{ matrix.target }}
           token: ${{ secrets.PACKAGER_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Context

OpenProject packaging jobs can fail while bootstrapping Ruby because the pinned package action still depends on the hosted buildcurl service. The current `pkgr/action` v1 release builds missing toolchains locally and caches them with the workflow.

## What changed

- Pin `pkgr/action/package` to v1 revision `72711239e8f309a29f078b90bd269af6c7db3f70`.
- Pin `pkgr/action/publish` to the same immutable revision.
- Keep the existing targets, inputs, permissions, triggers, and publishing behavior unchanged.

Triggered a test job here: https://github.com/opf/openproject/actions/runs/33055654947/job/98461672827, and it passed.