### PR TITLE
[COMMS-964] - exclude observed in versions from default form configuration

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -49,7 +49,8 @@ module Type::AttributeGroups
         remaining_time: :estimates_and_progress,
         percentage_done: :estimates_and_progress,
         spent_time: :estimates_and_progress,
-        priority: :details
+        priority: :details,
+        observed_in_versions: :versions
       }
     end
 
@@ -195,8 +196,6 @@ module Type::AttributeGroups
   # Custom fields should not get included into the default form configuration.
   # This method might get patched by modules.
   def default_attribute?(active_cfs, key)
-    return false if key == "observed_in_versions"
-
     !(CustomField.custom_field_attribute?(key) && active_cfs.exclude?(key))
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/COMMS-964/activity

# What are you trying to accomplish?
`observed_in_versions` field was being included by default in all work package types, because it had "details" type. All details are included by default. So to exclude the field - make it an opt in field where the admin needs to manually add it to a type - I added an `if` check which was not nice.

Now I have a nicer looking solution. By making `observed_in_versions` something other than `:details` it does not get included automatically