### PR TITLE
[COMMS-986] Handle list view drag n drop when grouped by multi value fields

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/drag-and-drop/actions/group-by-drag-action.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/drag-and-drop/actions/group-by-drag-action.service.ts
@@ -64,7 +64,7 @@ export class GroupByDragActionService extends TableDragActionService {
 
   public handleDrop(workPackage:WorkPackageResource, el:HTMLElement):Promise<unknown> {
     const changeset = this.halEditing.changeFor(workPackage);
-    const groupedValue = this.getValueForGroup(el);
+    const groupedValue = this.getValueForGroup(workPackage, el);
 
     changeset.projectedResource[this.groupedAttribute!] = groupedValue;
     return this.halEditing
@@ -73,7 +73,7 @@ export class GroupByDragActionService extends TableDragActionService {
       .catch((e) => this.halNotification.handleRawError(e, workPackage));
   }
 
-  private getValueForGroup(el:HTMLElement):unknown|null {
+  private getValueForGroup(workPackage:WorkPackageResource, el:HTMLElement):unknown|null {
     const groupHeader = locatePredecessorBySelector(el, `.${rowGroupClassName}`)!;
     const match = this.groups.find((group) => groupIdentifier(group) === groupHeader.dataset.groupIdentifier);
 
@@ -83,6 +83,11 @@ export class GroupByDragActionService extends TableDragActionService {
 
     if (match._links && match._links.valueLink) {
       const links = match._links.valueLink;
+      const fieldSchema = this.schemaCache.of(workPackage).ofProperty(this.groupedAttribute!);
+
+      if (fieldSchema?.type?.startsWith('[]')) {
+        return links;
+      }
 
       // Unwrap single links to properly use them
       return links.length === 1 ? links[0] : links;

--- a/frontend/src/app/features/work-packages/components/wp-table/drag-and-drop/actions/group-by-drag-action.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/drag-and-drop/actions/group-by-drag-action.service.ts
@@ -73,7 +73,7 @@ export class GroupByDragActionService extends TableDragActionService {
       .catch((e) => this.halNotification.handleRawError(e, workPackage));
   }
 
-  private getValueForGroup(workPackage:WorkPackageResource, el:HTMLElement):unknown|null {
+  private getValueForGroup(workPackage:WorkPackageResource, el:HTMLElement):unknown {
     const groupHeader = locatePredecessorBySelector(el, `.${rowGroupClassName}`)!;
     const match = this.groups.find((group) => groupIdentifier(group) === groupHeader.dataset.groupIdentifier);
 
@@ -81,9 +81,10 @@ export class GroupByDragActionService extends TableDragActionService {
       return null;
     }
 
-    if (match._links && match._links.valueLink) {
+    if (match._links?.valueLink) {
       const links = match._links.valueLink;
-      const fieldSchema = this.schemaCache.of(workPackage).ofProperty(this.groupedAttribute!);
+      const schema = this.schemaCache.state(workPackage).value;
+      const fieldSchema = schema && this.schemaCache.proxied(workPackage, schema).ofProperty(this.groupedAttribute!);
 
       if (fieldSchema?.type?.startsWith('[]')) {
         return links;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-986/files

# What are you trying to accomplish?
Fix an issue where list views grouped by fields with multiple values (e.g. target versions) were not allowing drag and drop.

## Screenshots
[Screencast From 2026-08-27 12-37-20.webm](https://github.com/user-attachments/assets/18a8eb75-a104-44aa-86a5-c228a36c3673)

---

[Screencast From 2026-08-27 12-36-39.webm](https://github.com/user-attachments/assets/6eda0754-9321-4545-b643-b34c242028c4)
