### PR TITLE
Bug/COMMS-985: Add remediation task for stale target versions

### DIFF
--- a/app/services/work_packages/stale_target_version_remediation.rb
+++ b/app/services/work_packages/stale_target_version_remediation.rb
@@ -43,7 +43,8 @@ class WorkPackages::StaleTargetVersionRemediation
     skip_manual_change: "skipped %d (manual change since)",
     skip_no_prior_version: "skipped %d (no prior version)",
     skip_anomaly: "skipped %d (anomaly - needs human review)",
-    already_corrected: "already corrected %d"
+    already_corrected: "already corrected %d",
+    failed: "failed %d (rolled back)"
   }.freeze
 
   Finding = Struct.new(:work_package, :journal, :stale_version, :action, :reason, keyword_init: true)
@@ -73,9 +74,17 @@ class WorkPackages::StaleTargetVersionRemediation
 
   def apply(out: $stdout)
     results = findings
+    failures = []
 
-    results.select { it.action == :remove }.each { |finding| remove_stale_version(finding, out:) }
+    results.select { it.action == :remove }.each do |finding|
+      remove_stale_version(finding, out:)
+    rescue StandardError => e
+      finding.action = :failed
+      failures << [finding, e]
+    end
+
     print_summary(results, out, remove_label: "fixed %d work packages")
+    print_failures(failures, out)
 
     results
   end
@@ -202,14 +211,21 @@ class WorkPackages::StaleTargetVersionRemediation
         .where(work_package_id: work_package.id, version_id: finding.stale_version.id, kind: "target")
         .delete_all
 
-      Journal::NotificationConfiguration.with(false) do
-        Journals::CreateService.new(work_package, User.system).call(
-          cause: Journal::CausedBySystemUpdate.new(feature: CORRECTIVE_CAUSE_FEATURE)
-        )
-      end
+      create_corrective_journal!(work_package)
     end
 
     out.puts "WP##{work_package.id}: removed stale target version #{finding.stale_version.name}"
+  end
+
+  def create_corrective_journal!(work_package)
+    Journal::NotificationConfiguration.with(false) do
+      result = Journals::CreateService.new(work_package, User.system).call(
+        cause: Journal::CausedBySystemUpdate.new(feature: CORRECTIVE_CAUSE_FEATURE)
+      )
+      # The journal service reports success even when no journal row was written;
+      # raising rolls back the removal so it never lands without its audit journal.
+      raise "corrective journal was not created" if result.result.nil?
+    end
   end
 
   def describe_finding(finding)
@@ -233,6 +249,16 @@ class WorkPackages::StaleTargetVersionRemediation
     end
 
     print_anomalies(results, out)
+  end
+
+  def print_failures(failures, out)
+    return if failures.empty?
+
+    out.puts
+    out.puts "Failures (rolled back, unchanged in the database):"
+    failures.each do |finding, error|
+      out.puts "  WP##{finding.work_package.id}: #{error.message}"
+    end
   end
 
   def print_anomalies(results, out)

--- a/app/services/work_packages/stale_target_version_remediation.rb
+++ b/app/services/work_packages/stale_target_version_remediation.rb
@@ -63,19 +63,17 @@ class WorkPackages::StaleTargetVersionRemediation
     out.puts "[REPORT ONLY - DRY RUN]"
     out.puts
 
-    # Findings print as they are classified so a tailed run shows progress.
-    results = stale_repair_journals.filter_map do |journal|
-      classify(journal)&.tap { |finding| out.puts describe_finding(finding) }
-    end
+    results = classified_findings(out)
     print_summary(results, out, remove_label: "would fix %d work packages")
 
     results
   end
 
   def apply(out: $stdout)
-    results = findings
+    results = classified_findings(out)
     failures = []
 
+    out.puts
     results.select { it.action == :remove }.each do |finding|
       remove_stale_version(finding, out:)
     rescue StandardError => e
@@ -90,6 +88,13 @@ class WorkPackages::StaleTargetVersionRemediation
   end
 
   private
+
+  # Findings print as they are classified so a tailed run shows progress.
+  def classified_findings(out)
+    stale_repair_journals.filter_map do |journal|
+      classify(journal)&.tap { |finding| out.puts describe_finding(finding) }
+    end
+  end
 
   def stale_repair_journals
     scope = Journal

--- a/app/services/work_packages/stale_target_version_remediation.rb
+++ b/app/services/work_packages/stale_target_version_remediation.rb
@@ -49,10 +49,12 @@ class WorkPackages::StaleTargetVersionRemediation
 
   Finding = Struct.new(:work_package, :journal, :stale_version, :action, :reason, keyword_init: true)
 
-  # Optionally scopes the run to the given work packages, for a sanity check
-  # on a few items before touching the whole dataset.
-  def initialize(work_package_ids: nil)
+  # Optionally scopes the run to the given work packages or to repair journals
+  # created within the given time range, for a sanity check on a few items or a
+  # smaller blast radius before touching the whole dataset.
+  def initialize(work_package_ids: nil, created_between: nil)
     @work_package_ids = work_package_ids.presence
+    @created_between = created_between
   end
 
   def findings
@@ -62,6 +64,7 @@ class WorkPackages::StaleTargetVersionRemediation
   def report(out: $stdout)
     out.puts "[REPORT ONLY - DRY RUN]"
     out.puts
+    print_scope(out)
 
     results = classified_findings(out)
     print_summary(results, out, remove_label: "would fix %d work packages")
@@ -70,6 +73,7 @@ class WorkPackages::StaleTargetVersionRemediation
   end
 
   def apply(out: $stdout)
+    print_scope(out)
     results = classified_findings(out)
     failures = []
 
@@ -102,7 +106,31 @@ class WorkPackages::StaleTargetVersionRemediation
       .where("cause ->> 'feature' = ?", CAUSE_FEATURE)
       .order(:journable_id, :version)
     scope = scope.where(journable_id: @work_package_ids) if @work_package_ids
+    scope = scope.where(created_at: @created_between) if @created_between
     scope
+  end
+
+  def print_scope(out)
+    return if @work_package_ids.nil? && @created_between.nil?
+
+    out.puts "This run is limited to:"
+    out.puts "  - work packages #{@work_package_ids.join(', ')}" if @work_package_ids
+    out.puts "  - repair journals created #{humanized_time_range}" if @created_between
+    out.puts "Everything outside this scope is left untouched."
+    out.puts
+  end
+
+  def humanized_time_range
+    from = @created_between.begin&.strftime("%Y-%m-%d %H:%M %Z")
+    to = @created_between.end&.strftime("%Y-%m-%d %H:%M %Z")
+
+    if from && to
+      "between #{from} and #{to}"
+    elsif from
+      "after #{from}"
+    else
+      "before #{to}"
+    end
   end
 
   def classify(journal)

--- a/app/services/work_packages/stale_target_version_remediation.rb
+++ b/app/services/work_packages/stale_target_version_remediation.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# One-off remediation for target versions the deleted
+# WorkPackages::EnableMultipleVersionsJob reinstated from the frozen
+# work_packages.version_id column. That column stopped being written once target
+# versions moved to work_package_versions, so any value it still held was either
+# stale (superseded or removed since) or, for work packages that never went
+# through the new write path, still legitimate. This class tells the two apart
+# and removes only the stale rows.
+class WorkPackages::StaleTargetVersionRemediation
+  CAUSE_FEATURE = "target_versions_repaired"
+  CORRECTIVE_CAUSE_FEATURE = "stale_target_versions_removed"
+
+  SUMMARY_LABELS = {
+    skip_manual_change: "skipped %d (manual change since)",
+    skip_no_prior_version: "skipped %d (no prior version)",
+    skip_anomaly: "skipped %d (anomaly - needs human review)",
+    already_corrected: "already corrected %d"
+  }.freeze
+
+  Finding = Struct.new(:work_package, :journal, :stale_version, :action, :reason, keyword_init: true)
+
+  # Optionally scopes the run to the given work packages, for a sanity check
+  # on a few items before touching the whole dataset.
+  def initialize(work_package_ids: nil)
+    @work_package_ids = work_package_ids.presence
+  end
+
+  def findings
+    stale_repair_journals.filter_map { |journal| classify(journal) }
+  end
+
+  def report(out: $stdout)
+    out.puts "[REPORT ONLY - DRY RUN]"
+    out.puts
+
+    # Findings print as they are classified so a tailed run shows progress.
+    results = stale_repair_journals.filter_map do |journal|
+      classify(journal)&.tap { |finding| out.puts describe_finding(finding) }
+    end
+    print_summary(results, out, remove_label: "would fix %d work packages")
+
+    results
+  end
+
+  def apply(out: $stdout)
+    results = findings
+
+    results.select { it.action == :remove }.each { |finding| remove_stale_version(finding, out:) }
+    print_summary(results, out, remove_label: "fixed %d work packages")
+
+    results
+  end
+
+  private
+
+  def stale_repair_journals
+    scope = Journal
+      .where(data_type: "Journal::WorkPackageJournal")
+      .where("cause ->> 'feature' = ?", CAUSE_FEATURE)
+      .order(:journable_id, :version)
+    scope = scope.where(journable_id: @work_package_ids) if @work_package_ids
+    scope
+  end
+
+  def classify(journal)
+    work_package = journal.journable
+    return nil if work_package.nil?
+
+    return corrected_finding(work_package, journal) if corrected_after?(journal)
+
+    snapshot = target_version_ids(journal)
+    added = added_target_version_ids(journal, snapshot)
+
+    return classify_no_change(work_package, journal) if added.empty?
+    return classify_mismatch(work_package, journal, added) if added != Set[work_package.version_id]
+
+    classify_candidate(work_package, journal, snapshot, added.first)
+  end
+
+  # A later journal carrying the corrective cause means this work package was
+  # already fixed by a previous remediation run, even though the correction
+  # itself also changed the target snapshot.
+  def corrected_after?(journal)
+    later_journals(journal).any? { |later| later.cause["feature"] == CORRECTIVE_CAUSE_FEATURE }
+  end
+
+  def corrected_finding(work_package, journal)
+    build_finding(work_package, journal, action: :already_corrected,
+                                         reason: "already corrected by a previous remediation run")
+  end
+
+  def added_target_version_ids(journal, snapshot)
+    previous_snapshot = journal.previous ? target_version_ids(journal.previous) : Set.new
+
+    snapshot - previous_snapshot
+  end
+
+  def classify_no_change(work_package, journal)
+    build_finding(work_package, journal, action: :skip_anomaly,
+                                         reason: "repair journal recorded no target version change")
+  end
+
+  def classify_mismatch(work_package, journal, added)
+    reason = "journal delta #{format_ids(added)} does not match the frozen column value " \
+             "#{work_package.version_id.inspect}"
+    build_finding(work_package, journal, action: :skip_anomaly, reason:)
+  end
+
+  def classify_candidate(work_package, journal, snapshot, stale_version_id)
+    if no_prior_target_version?(journal)
+      return build_finding(work_package, journal, action: :skip_no_prior_version, stale_version_id:,
+                                                  reason: "work package never had a target version before " \
+                                                          "this journal")
+    end
+
+    if manual_change_after?(journal, snapshot)
+      return build_finding(work_package, journal, action: :skip_manual_change, stale_version_id:,
+                                                  reason: "target versions changed again after this journal")
+    end
+
+    current = current_target_version_ids(work_package)
+    if current != snapshot
+      reason = "current target set #{format_ids(current)} differs from the repair-journal snapshot " \
+               "#{format_ids(snapshot)}"
+      return build_finding(work_package, journal, action: :skip_anomaly, reason:)
+    end
+
+    build_finding(work_package, journal, action: :remove, stale_version_id:,
+                                         reason: "reinstated by the frozen version_id column; safe to remove")
+  end
+
+  def build_finding(work_package, journal, action:, reason:, stale_version_id: nil)
+    Finding.new(
+      work_package:,
+      journal:,
+      stale_version: stale_version_id && Version.find_by(id: stale_version_id),
+      action:,
+      reason:
+    )
+  end
+
+  def format_ids(ids) = "[#{ids.to_a.sort.join(', ')}]"
+
+  def target_version_ids(journal)
+    journal.target_version_journals.pluck(:version_id).to_set
+  end
+
+  def current_target_version_ids(work_package)
+    WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id).to_set
+  end
+
+  def no_prior_target_version?(journal)
+    earlier_journals(journal).none? { |earlier| target_version_ids(earlier).any? }
+  end
+
+  def manual_change_after?(journal, snapshot)
+    later_journals(journal).any? { |later| target_version_ids(later) != snapshot }
+  end
+
+  def earlier_journals(journal)
+    journal.journable.journals.where(version: ...journal.version)
+  end
+
+  def later_journals(journal)
+    journal.journable.journals.where(version: (journal.version + 1)...)
+  end
+
+  def remove_stale_version(finding, out:)
+    work_package = finding.work_package
+
+    ActiveRecord::Base.transaction do
+      WorkPackageVersion
+        .where(work_package_id: work_package.id, version_id: finding.stale_version.id, kind: "target")
+        .delete_all
+
+      Journal::NotificationConfiguration.with(false) do
+        Journals::CreateService.new(work_package, User.system).call(
+          cause: Journal::CausedBySystemUpdate.new(feature: CORRECTIVE_CAUSE_FEATURE)
+        )
+      end
+    end
+
+    out.puts "WP##{work_package.id}: removed stale target version #{finding.stale_version.name}"
+  end
+
+  def describe_finding(finding)
+    work_package = finding.work_package
+    current = work_package.target_versions.map(&:name).join(", ").presence || "(none)"
+    stale = finding.stale_version&.name || "(none)"
+
+    "WP##{work_package.id}: current target versions [#{current}], " \
+      "stale [#{stale}] -> #{finding.action} (#{finding.reason})"
+  end
+
+  def print_summary(results, out, remove_label:)
+    grouped = results.group_by(&:action)
+
+    out.puts
+    out.puts "Summary:"
+    { remove: remove_label, **SUMMARY_LABELS }.each do |action, label|
+      findings = grouped.fetch(action, [])
+      ids = findings.map { it.work_package.id }.join(", ")
+      out.puts "  #{format(label, findings.size)}#{": #{ids}" if ids.present?}"
+    end
+
+    print_anomalies(results, out)
+  end
+
+  def print_anomalies(results, out)
+    anomalies = results.select { it.action == :skip_anomaly }
+    return if anomalies.empty?
+
+    out.puts
+    out.puts "Anomalies needing manual review:"
+    anomalies.each do |finding|
+      out.puts "  WP##{finding.work_package.id}: #{finding.reason}"
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3011,6 +3011,9 @@ en:
         scheduling_mode_adjusted: >-
           Scheduling mode automatically adjusted with version update.
         sprint_migration: "Version '%{version_name}' has been copied as a sprint."
+        stale_target_versions_removed: >-
+          Outdated target version automatically removed. It had been incorrectly re-added when multiple target
+          versions were enabled.
         target_versions_repaired: >-
           Target versions automatically synchronized with the Version field before enabling multiple target versions.
         totals_removed_from_childless_work_packages: >-

--- a/lib/tasks/target_versions.rake
+++ b/lib/tasks/target_versions.rake
@@ -45,7 +45,8 @@ namespace :target_versions do
     }
 
     remediation = ->(args) {
-      ids, times = [args[:scope], *args.extras].compact.map { it.to_s.strip }
+      ids, times = [args[:scope], *args.extras].map { it.to_s.strip }
+                                               .compact_blank
                                                .partition { it.match?(/\A\d+\z/) }
       from, to, overflow = times.map { parse_time.call(it) }
       raise ArgumentError, "at most two time bounds (from, to) are supported" if overflow

--- a/lib/tasks/target_versions.rake
+++ b/lib/tasks/target_versions.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+namespace :target_versions do
+  namespace :stale do
+    # Both tasks take optional work package ids, e.g. rake "target_versions:stale:report[15,16]",
+    # to sanity-check a few items; without arguments the run covers everything.
+    remediation = ->(args) {
+      ids = ([args[:work_package_ids]] + args.extras).compact.map { it.to_s.strip.to_i }
+      WorkPackages::StaleTargetVersionRemediation.new(work_package_ids: ids)
+    }
+
+    desc "Report target versions stale-reinstated by the frozen version_id column"
+    task :report, [:work_package_ids] => :environment do |_task, args|
+      $stdout.sync = true
+      remediation.call(args).report
+    end
+
+    desc "Remove target versions stale-reinstated by the frozen version_id column"
+    task :fix, [:work_package_ids] => :environment do |_task, args|
+      $stdout.sync = true
+      remediation.call(args).apply
+    end
+  end
+end

--- a/lib/tasks/target_versions.rake
+++ b/lib/tasks/target_versions.rake
@@ -30,21 +30,41 @@
 
 namespace :target_versions do
   namespace :stale do
-    # Both tasks take optional work package ids, e.g. rake "target_versions:stale:report[15,16]",
-    # to sanity-check a few items; without arguments the run covers everything.
+    # Both tasks take optional arguments to narrow the run; without any, it covers everything.
+    # Numeric arguments are work package ids, anything else is parsed as a time and bounds the
+    # repair journals' creation time (first = from, second = to). Examples:
+    #   rake "target_versions:stale:report[15,16]"
+    #   rake "target_versions:stale:fix[2026-08-27T08:00:00+02:00,2026-08-27T09:00:00+02:00]"
+    #   rake "target_versions:stale:fix[15,2026-08-27T08:00:00+02:00,2026-08-27T09:00:00+02:00]"
+    parse_time = ->(raw) {
+      unless raw.match?(/\A\d{4}-\d{2}-\d{2}/)
+        raise ArgumentError, "unrecognized argument: #{raw} (work package id or ISO8601 time expected)"
+      end
+
+      Time.zone.parse(raw) || raise(ArgumentError, "unparsable time: #{raw}")
+    }
+
     remediation = ->(args) {
-      ids = ([args[:work_package_ids]] + args.extras).compact.map { it.to_s.strip.to_i }
-      WorkPackages::StaleTargetVersionRemediation.new(work_package_ids: ids)
+      ids, times = [args[:scope], *args.extras].compact.map { it.to_s.strip }
+                                               .partition { it.match?(/\A\d+\z/) }
+      from, to, overflow = times.map { parse_time.call(it) }
+      raise ArgumentError, "at most two time bounds (from, to) are supported" if overflow
+      raise ArgumentError, "the from time must come before the to time" if from && to && from > to
+
+      WorkPackages::StaleTargetVersionRemediation.new(
+        work_package_ids: ids.map(&:to_i),
+        created_between: (from || to) && Range.new(from, to)
+      )
     }
 
     desc "Report target versions stale-reinstated by the frozen version_id column"
-    task :report, [:work_package_ids] => :environment do |_task, args|
+    task :report, [:scope] => :environment do |_task, args|
       $stdout.sync = true
       remediation.call(args).report
     end
 
     desc "Remove target versions stale-reinstated by the frozen version_id column"
-    task :fix, [:work_package_ids] => :environment do |_task, args|
+    task :fix, [:scope] => :environment do |_task, args|
       $stdout.sync = true
       remediation.call(args).apply
     end

--- a/spec/rake/task_target_versions_spec.rb
+++ b/spec/rake/task_target_versions_spec.rb
@@ -76,6 +76,28 @@ RSpec.describe Rake::Task do
       expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
         .to contain_exactly(version_a.id, version_b.id)
     end
+
+    it "treats a single time bound as an open-ended from" do
+      work_package, = build_stale_target_version
+      repair_time = work_package.journals.reload.last.created_at
+
+      expect { subject.invoke((repair_time + 1.hour).iso8601) }
+        .to output(/journals created after .*would fix 0 work packages/m).to_stdout
+    end
+
+    it "rejects an argument that is neither a work package id nor an ISO8601 time" do
+      expect { subject.invoke("15.5") }.to raise_error(ArgumentError, /unrecognized argument/)
+    end
+
+    it "rejects a from bound that comes after the to bound" do
+      expect { subject.invoke("2026-08-28", "2026-08-27") }
+        .to raise_error(ArgumentError, /from time must come before/)
+    end
+
+    it "rejects more than two time bounds" do
+      expect { subject.invoke("2026-08-27", "2026-08-28", "2026-08-29") }
+        .to raise_error(ArgumentError, /at most two time bounds/)
+    end
   end
 
   describe "target_versions:stale:fix" do
@@ -87,6 +109,28 @@ RSpec.describe Rake::Task do
       work_package, _version_a, version_b = build_stale_target_version
 
       subject.invoke
+
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_b.id)
+    end
+
+    it "treats numeric arguments as work package ids and other arguments as time bounds" do
+      work_package, version_a, version_b = build_stale_target_version
+      repair_time = work_package.journals.reload.last.created_at
+
+      expect do
+        subject.invoke(work_package.id.to_s,
+                       (repair_time + 1.hour).iso8601,
+                       (repair_time + 2.hours).iso8601)
+      end.to output(/This run is limited to:.*work packages #{work_package.id}.*journals created between/m).to_stdout
+
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_a.id, version_b.id)
+
+      subject.reenable
+      subject.invoke(work_package.id.to_s,
+                     (repair_time - 1.minute).iso8601,
+                     (repair_time + 1.minute).iso8601)
 
       expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
         .to contain_exactly(version_b.id)

--- a/spec/rake/task_target_versions_spec.rb
+++ b/spec/rake/task_target_versions_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Rake::Task do
+  shared_let(:project) { create(:project) }
+
+  # Reinstates a stale target version the same way the deleted repair job did:
+  # a direct target row insert followed by a system journal carrying its cause.
+  def build_stale_target_version
+    version_a = create(:version, project:, name: "A")
+    version_b = create(:version, project:, name: "B")
+
+    work_package = create(:work_package, project:)
+    travel(6.minutes)
+
+    work_package.add_journal(user: create(:user))
+    work_package.target_version_ids_replacements = [version_a.id]
+    work_package.save!
+    travel(6.minutes)
+
+    work_package.add_journal(user: create(:user))
+    work_package.target_version_ids_replacements = [version_b.id]
+    work_package.save!
+
+    work_package.update_column(:version_id, version_a.id)
+    travel(6.minutes)
+
+    WorkPackageVersion.create!(work_package:, version: version_a, kind: "target")
+    Journal::NotificationConfiguration.with(false) do
+      Journals::CreateService.new(work_package, User.system).call(
+        cause: Journal::CausedBySystemUpdate.new(feature: "target_versions_repaired")
+      )
+    end
+
+    [work_package, version_a, version_b]
+  end
+
+  describe "target_versions:stale:report" do
+    include_context "rake" do
+      let(:task_name) { "target_versions:stale:report" }
+    end
+
+    it "prints the finding without removing the stale target version" do
+      work_package, version_a, version_b = build_stale_target_version
+
+      expect { subject.invoke }.to output(/##{work_package.id}/).to_stdout
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_a.id, version_b.id)
+    end
+  end
+
+  describe "target_versions:stale:fix" do
+    include_context "rake" do
+      let(:task_name) { "target_versions:stale:fix" }
+    end
+
+    it "removes the stale target version" do
+      work_package, _version_a, version_b = build_stale_target_version
+
+      subject.invoke
+
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_b.id)
+    end
+  end
+end

--- a/spec/rake/task_target_versions_spec.rb
+++ b/spec/rake/task_target_versions_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe Rake::Task do
         .to output(/journals created after .*would fix 0 work packages/m).to_stdout
     end
 
+    it "ignores blank arguments, such as one left by a trailing comma" do
+      work_package, = build_stale_target_version
+      repair_time = work_package.journals.reload.last.created_at
+
+      expect { subject.invoke((repair_time + 1.hour).iso8601, "") }
+        .to output(/journals created after .*would fix 0 work packages/m).to_stdout
+    end
+
     it "rejects an argument that is neither a work package id nor an ISO8601 time" do
       expect { subject.invoke("15.5") }.to raise_error(ArgumentError, /unrecognized argument/)
     end

--- a/spec/services/work_packages/stale_target_version_remediation_spec.rb
+++ b/spec/services/work_packages/stale_target_version_remediation_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe WorkPackages::StaleTargetVersionRemediation, type: :model do
       expect(scoped.findings.map(&:work_package)).to contain_exactly(scoped_work_package)
     end
 
+    it "covers only repair journals created within the given time range" do
+      work_package, = build_reinstated_corruption
+      repair_time = work_package.journals.reload.last.created_at
+
+      covering = described_class.new(created_between: (repair_time - 1.minute)..(repair_time + 1.minute))
+      expect(covering.findings.map(&:work_package)).to contain_exactly(work_package)
+
+      outside = described_class.new(created_between: (repair_time + 1.hour)..(repair_time + 2.hours))
+      expect(outside.findings).to be_empty
+    end
+
+    it "announces an upper-bound-only time scope as created before that time" do
+      out = StringIO.new
+      described_class.new(created_between: ..Time.zone.now).report(out:)
+
+      expect(out.string).to include("repair journals created before")
+    end
+
     it "flags a version that was reinstated after being replaced" do
       work_package, version_a, version_b = build_reinstated_corruption
 

--- a/spec/services/work_packages/stale_target_version_remediation_spec.rb
+++ b/spec/services/work_packages/stale_target_version_remediation_spec.rb
@@ -327,5 +327,55 @@ RSpec.describe WorkPackages::StaleTargetVersionRemediation, type: :model do
       expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
         .to contain_exactly(version_b.id)
     end
+
+    it "rolls back the removal and reports a failure when the corrective journal is not written" do
+      work_package, version_a, version_b = build_reinstated_corruption
+
+      silent_service = instance_double(Journals::CreateService,
+                                       call: ServiceResult.success(result: nil))
+      allow(Journals::CreateService).to receive(:new).and_return(silent_service)
+
+      out = StringIO.new
+      results = remediation.apply(out:)
+
+      expect(results.sole.action).to eq(:failed)
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_a.id, version_b.id)
+
+      output = out.string
+      expect(output).to include("failed 1 (rolled back): #{work_package.id}")
+      expect(output).to include("WP##{work_package.id}: corrective journal was not created")
+    end
+
+    it "continues with the remaining work packages when one of them fails" do
+      failing_work_package, failing_version_a, failing_version_b = build_reinstated_corruption
+
+      # Journals are stamped with database now(), which time travel cannot reach, so a
+      # work package created while the clock is traveled ahead would order its journals
+      # backwards. Return to real time before building the second corruption.
+      travel_back
+      healthy_work_package, _healthy_version_a, healthy_version_b = build_reinstated_corruption
+
+      allow(Journals::CreateService).to receive(:new).and_call_original
+      silent_service = instance_double(Journals::CreateService,
+                                       call: ServiceResult.success(result: nil))
+      allow(Journals::CreateService).to receive(:new)
+        .with(failing_work_package, User.system).and_return(silent_service)
+
+      out = StringIO.new
+      results = remediation.apply(out:)
+
+      expect(results.map { [it.work_package, it.action] })
+        .to contain_exactly([failing_work_package, :failed], [healthy_work_package, :remove])
+
+      expect(WorkPackageVersion.where(work_package_id: failing_work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(failing_version_a.id, failing_version_b.id)
+      expect(WorkPackageVersion.where(work_package_id: healthy_work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(healthy_version_b.id)
+
+      output = out.string
+      expect(output).to include("fixed 1 work packages: #{healthy_work_package.id}")
+      expect(output).to include("failed 1 (rolled back): #{failing_work_package.id}")
+    end
   end
 end

--- a/spec/services/work_packages/stale_target_version_remediation_spec.rb
+++ b/spec/services/work_packages/stale_target_version_remediation_spec.rb
@@ -1,0 +1,331 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::StaleTargetVersionRemediation, type: :model do
+  subject(:remediation) { described_class.new }
+
+  shared_let(:project) { create(:project) }
+
+  def repair_cause
+    Journal::CausedBySystemUpdate.new(feature: "target_versions_repaired")
+  end
+
+  # Mirrors the writes the deleted WorkPackages::EnableMultipleVersionsJob made: a direct
+  # target row insert followed by a system journal carrying the same cause.
+  def stale_repair!(work_package, stale_version, user: User.system)
+    WorkPackageVersion.create!(work_package:, version: stale_version, kind: "target")
+
+    Journal::NotificationConfiguration.with(false) do
+      Journals::CreateService.new(work_package, user).call(cause: repair_cause)
+    end
+  end
+
+  # Builds the flavor-1 corruption: version A was replaced by version B through the normal
+  # update path, then the frozen version_id column (still holding A) got reinserted as a
+  # second target row.
+  def build_reinstated_corruption
+    version_a = create(:version, project:)
+    version_b = create(:version, project:)
+
+    work_package = create(:work_package, project:)
+    travel(6.minutes)
+
+    work_package.add_journal(user: create(:user))
+    work_package.target_version_ids_replacements = [version_a.id]
+    work_package.save!
+    travel(6.minutes)
+
+    work_package.add_journal(user: create(:user))
+    work_package.target_version_ids_replacements = [version_b.id]
+    work_package.save!
+
+    work_package.update_column(:version_id, version_a.id)
+    travel(6.minutes)
+
+    stale_repair!(work_package, version_a)
+
+    [work_package, version_a, version_b]
+  end
+
+  describe "#findings" do
+    it "covers only the given work packages when scoped, and everything otherwise" do
+      other_work_package = create(:work_package, project:)
+      other_version = create(:version, project:)
+      other_work_package.update_column(:version_id, other_version.id)
+      stale_repair!(other_work_package, other_version)
+
+      scoped_work_package, = build_reinstated_corruption
+
+      expect(remediation.findings.map(&:work_package))
+        .to contain_exactly(scoped_work_package, other_work_package)
+
+      scoped = described_class.new(work_package_ids: [scoped_work_package.id])
+      expect(scoped.findings.map(&:work_package)).to contain_exactly(scoped_work_package)
+    end
+
+    it "flags a version that was reinstated after being replaced" do
+      work_package, version_a, version_b = build_reinstated_corruption
+
+      finding = remediation.findings.sole
+
+      expect(finding.work_package).to eq(work_package)
+      expect(finding.action).to eq(:remove)
+      expect(finding.stale_version).to eq(version_a)
+      expect(work_package.target_versions.reload).to contain_exactly(version_a, version_b)
+    end
+
+    it "flags a version that was reinstated after being removed entirely" do
+      version_a = create(:version, project:, name: "A")
+
+      work_package = create(:work_package, project:)
+      travel(6.minutes)
+
+      work_package.add_journal(user: create(:user))
+      work_package.target_version_ids_replacements = [version_a.id]
+      work_package.save!
+      travel(6.minutes)
+
+      work_package.add_journal(user: create(:user))
+      work_package.target_version_ids_replacements = []
+      work_package.save!
+
+      work_package.update_column(:version_id, version_a.id)
+      travel(6.minutes)
+
+      stale_repair!(work_package, version_a)
+
+      finding = remediation.findings.sole
+
+      expect(finding.work_package).to eq(work_package)
+      expect(finding.action).to eq(:remove)
+      expect(finding.stale_version).to eq(version_a)
+    end
+
+    it "skips a work package whose target versions were corrected again after the repair" do
+      work_package, version_a, version_b = build_reinstated_corruption
+
+      travel(6.minutes)
+      work_package.add_journal(user: create(:user))
+      work_package.target_version_ids_replacements = [version_b.id]
+      work_package.save!
+
+      finding = remediation.findings.sole
+
+      expect(finding.work_package).to eq(work_package)
+      expect(finding.action).to eq(:skip_manual_change)
+      expect(finding.stale_version).to eq(version_a)
+    end
+
+    it "still flags the stale version when a later journal leaves target versions untouched" do
+      work_package, version_a, = build_reinstated_corruption
+
+      travel(6.minutes)
+      work_package.add_journal(user: create(:user))
+      work_package.subject = "Renamed after the repair"
+      work_package.save!
+
+      finding = remediation.findings.sole
+
+      expect(finding.action).to eq(:remove)
+      expect(finding.stale_version).to eq(version_a)
+    end
+
+    it "leaves alone a work package that never had a target version before the repair" do
+      version_a = create(:version, project:, name: "A")
+
+      work_package = create(:work_package, project:)
+      work_package.update_column(:version_id, version_a.id)
+      travel(6.minutes)
+
+      stale_repair!(work_package, version_a)
+
+      finding = remediation.findings.sole
+
+      expect(finding.work_package).to eq(work_package)
+      expect(finding.action).to eq(:skip_no_prior_version)
+      expect(finding.stale_version).to eq(version_a)
+    end
+
+    it "flags an anomaly when the added version does not match the frozen column value" do
+      version_a = create(:version, project:, name: "A")
+      version_b = create(:version, project:, name: "B")
+      version_c = create(:version, project:, name: "C")
+
+      work_package = create(:work_package, project:)
+      travel(6.minutes)
+
+      work_package.add_journal(user: create(:user))
+      work_package.target_version_ids_replacements = [version_b.id]
+      work_package.save!
+
+      work_package.update_column(:version_id, version_a.id)
+      travel(6.minutes)
+
+      stale_repair!(work_package, version_c)
+
+      finding = remediation.findings.sole
+
+      expect(finding.work_package).to eq(work_package)
+      expect(finding.action).to eq(:skip_anomaly)
+      expect(finding.stale_version).to be_nil
+    end
+
+    it "flags an anomaly instead of crashing when the stale version was later deleted" do
+      work_package, version_a, = build_reinstated_corruption
+
+      version_a.destroy!
+
+      finding = remediation.findings.sole
+
+      expect(finding.work_package).to eq(work_package)
+      expect(finding.action).to eq(:skip_anomaly)
+      expect(finding.stale_version).to be_nil
+    end
+
+    it "skips a journal whose work package was deleted, without crashing" do
+      work_package, = build_reinstated_corruption
+
+      WorkPackage.where(id: work_package.id).delete_all
+
+      expect(remediation.findings).to be_empty
+    end
+  end
+
+  describe "#report" do
+    it "prints one line per finding and a summary, without changing any data" do
+      work_package, version_a, version_b = build_reinstated_corruption
+
+      out = StringIO.new
+      expect { remediation.report(out:) }.not_to change {
+        WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id).sort
+      }.from([version_a.id, version_b.id].sort)
+      expect { remediation.report(out:) }.not_to change(Journal, :count)
+
+      output = out.string
+      expect(output).to include("##{work_package.id}")
+      expect(output).to include(version_a.name)
+      expect(output).to include("remove")
+      expect(output).to include("would fix 1 work packages: #{work_package.id}")
+      expect(output).to include("skipped 0 (manual change since)")
+      expect(output).to include("skipped 0 (no prior version)")
+      expect(output).to include("skipped 0 (anomaly - needs human review)")
+      expect(output).to include("already corrected 0")
+    end
+
+    it "lists anomalies with the work package and the concrete mismatch, for human review" do
+      version_a = create(:version, project:, name: "A")
+      version_b = create(:version, project:, name: "B")
+      version_c = create(:version, project:, name: "C")
+
+      work_package = create(:work_package, project:)
+      travel(6.minutes)
+
+      work_package.add_journal(user: create(:user))
+      work_package.target_version_ids_replacements = [version_b.id]
+      work_package.save!
+
+      work_package.update_column(:version_id, version_a.id)
+      travel(6.minutes)
+
+      stale_repair!(work_package, version_c)
+
+      out = StringIO.new
+      remediation.report(out:)
+      output = out.string
+
+      expect(output).to include("skipped 1 (anomaly - needs human review)")
+      expect(output).to include("Anomalies needing manual review:")
+      expect(output).to include("WP##{work_package.id}")
+      expect(output).to include("[#{version_c.id}]")
+      expect(output).to include(version_a.id.to_s)
+    end
+  end
+
+  describe "#apply" do
+    it "removes exactly the stale target row and journals the correction, under a dedicated " \
+       "cause, without notifying" do
+      work_package, version_a, version_b = build_reinstated_corruption
+      create(:work_package_version, work_package:, version: version_a, kind: "observed_in")
+
+      repair_journal = work_package.journals.reload.last
+      notifications_before = Notification.count
+
+      out = StringIO.new
+      results = remediation.apply(out:)
+
+      expect(Notification.count).to eq(notifications_before)
+      expect(results.sole.action).to eq(:remove)
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_b.id)
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "observed_in").pluck(:version_id))
+        .to contain_exactly(version_a.id)
+
+      corrective_journal = work_package.journals.reload.order(:version).last
+      expect(corrective_journal.id).not_to eq(repair_journal.id)
+      expect(corrective_journal.version).to eq(repair_journal.version + 1)
+      expect(corrective_journal.cause_type).to eq("system_update")
+      expect(corrective_journal.cause["feature"]).to eq("stale_target_versions_removed")
+      expect(corrective_journal.target_version_journals.pluck(:version_id)).to contain_exactly(version_b.id)
+
+      output = out.string
+      expect(output).to include("fixed 1 work packages: #{work_package.id}")
+    end
+
+    it "creates a journal separate from the repair journal even when applied immediately after " \
+       "it, because the differing cause blocks aggregation" do
+      work_package, = build_reinstated_corruption
+      repair_journal = work_package.journals.reload.last
+
+      expect { remediation.apply }.to change { work_package.journals.reload.count }.by(1)
+
+      expect(work_package.journals.exists?(id: repair_journal.id)).to be true
+      corrective_journal = work_package.journals.order(:version).last
+      expect(corrective_journal.id).not_to eq(repair_journal.id)
+      expect(corrective_journal.user).to eq(repair_journal.user)
+      expect(corrective_journal.cause["feature"]).to eq("stale_target_versions_removed")
+    end
+
+    it "is idempotent: a second pass sees the correction and does nothing" do
+      work_package, _version_a, version_b = build_reinstated_corruption
+      remediation.apply
+
+      second_pass = described_class.new.findings
+
+      expect(second_pass.sole.action).to eq(:already_corrected)
+      expect(second_pass.sole.work_package).to eq(work_package)
+
+      expect { described_class.new.apply }.not_to change { work_package.journals.count }
+      expect(WorkPackageVersion.where(work_package_id: work_package.id, kind: "target").pluck(:version_id))
+        .to contain_exactly(version_b.id)
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-985

Adds a one-off remediation as a  corrective system journal with cause `target_versions_repaired`

It intentionally ships with the release in case the issue recurs- and customer support needs a diagnosis.

## Running it

```
# read-only, prints every finding plus a summary (would-fix/skipped/anomalies)
# pipe to a file to keep the audit trail: ... | tee comms985_report.txt
bundle exec rake target_versions:stale:report

# applies the :remove findings, prints the same summary with fixed WP ids
bundle exec rake target_versions:stale:fix
```

See Runbook: https://github.com/opf/openproject/pull/24987#issuecomment-5449391515

Both tasks take optional work package ids to sanity-check a few items first, e.g. `rake "target_versions:stale:fix[15,16]"`; without arguments the run covers everything. Run `report` first and hand the "Anomalies needing manual review" list to a human; `fix` is safe to re-run. Finding lines stream as they are classified, so a tailed tee file shows progress. 

<img width="874" height="403" alt="target-versions-journal-correction" src="https://github.com/user-attachments/assets/96fea18e-047e-46e0-9b03-a0f4890bd4a6" />


