### PR TITLE
[AGILE-219] 1st iteration of filters within the backlog

### DIFF
--- a/app/components/admin/settings/project_reserved_identifiers/sub_header_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/sub_header_component.rb
@@ -44,7 +44,7 @@ module Admin::Settings::ProjectReservedIdentifiers
     def sub_header_data_attributes
       {
         controller: "filter--filters-form",
-        "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-turbo-stream-request-value": true,
         "filter--filters-form-output-format-value": "json",
         "filter--filters-form-url-path-name-value": helpers.search_admin_settings_project_reserved_identifiers_path,
         "filter--filters-form-clear-button-id-value": clear_button_id

--- a/app/components/filter/filter_button_component.html.erb
+++ b/app/components/filter/filter_button_component.html.erb
@@ -8,7 +8,14 @@
           test_selector: "filter-component-toggle"
         )
       ) do |button| %>
-    <% button.with_trailing_visual_counter(count: filters_count, test_selector: "filters-button-counter") %>
+    <%
+      button.with_trailing_visual_counter(
+        count: filters_count,
+        hide_if_zero: true,
+        test_selector: "filters-button-counter",
+        data: { "filter--filters-form-target": "filterCount" }
+      )
+    %>
     <% button.with_leading_visual_icon(icon: :filter) %>
     <%= t(:button_all_filters) %>
   <% end %>

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -36,9 +36,10 @@ module Filter
     # If none is provided, the filters are rendered right away.
     options lazy_loaded_path: false
     options initially_expanded: false
+    options excluded_filters: []
 
     def filter_form(form)
-      Filters::FilterFormComponent.new(builder: form, query:, allowed_filters:)
+      Filters::FilterFormComponent.new(builder: form, query:, allowed_filters:, excluded_filters:)
     end
 
     def allowed_filters

--- a/app/components/portfolios/index_sub_header_component.rb
+++ b/app/components/portfolios/index_sub_header_component.rb
@@ -51,7 +51,7 @@ module Portfolios
     def sub_header_data_attributes
       {
         controller: "filter--filters-form",
-        "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-turbo-stream-request-value": true,
         "filter--filters-form-clear-button-id-value": clear_button_id,
         "filter--filters-form-display-filters-value": filters_expanded?
       }

--- a/app/components/projects/index_sub_header_component.rb
+++ b/app/components/projects/index_sub_header_component.rb
@@ -53,7 +53,7 @@ module Projects
     def sub_header_data_attributes
       {
         controller: "filter--filters-form",
-        "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-turbo-stream-request-value": true,
         "filter--filters-form-clear-button-id-value": clear_button_id,
         "filter--filters-form-display-filters-value": filters_expanded?
       }

--- a/app/components/work_package_types/projects_tab/sub_header_component.rb
+++ b/app/components/work_package_types/projects_tab/sub_header_component.rb
@@ -45,7 +45,7 @@ module WorkPackageTypes
       def filters_form_attributes
         {
           controller: "filter--filters-form",
-          "filter--filters-form-perform-turbo-requests-value": true,
+          "filter--filters-form-turbo-stream-request-value": true,
           "filter--filters-form-clear-button-id-value": clear_button_id,
           "filter--filters-form-current-filters-value": serialized_filters
         }

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -226,8 +226,15 @@ class Query < ApplicationRecord
   # `Filters::FilterFormComponent` builds. Mirrors how
   # `Queries::Filters::AvailableFilters#available_advanced_filters` already
   # excludes the inline `name_and_identifier` quick-filter on projects.
+  #
+  # The relation-type filters (blocks, precedes, duplicates, etc.) and the
+  # generic relatable filter are also not supposed to be user selectable filters.
   def available_advanced_filters
-    super.grep_v(::Queries::WorkPackages::Filter::ManualSortFilter)
+    super
+      .grep_v(::Queries::WorkPackages::Filter::ManualSortFilter)
+      .grep_v(::Queries::WorkPackages::Filter::FilterOnDirectedRelationsMixin)
+      .grep_v(::Queries::WorkPackages::Filter::FilterOnUndirectedRelationsMixin)
+      .grep_v(::Queries::WorkPackages::Filter::RelatableFilter)
   end
 
   def normalized_name

--- a/frontend/src/global_styles/content/modules/_backlogs.sass
+++ b/frontend/src/global_styles/content/modules/_backlogs.sass
@@ -39,10 +39,6 @@
     #content-body
       padding-right: 0
 
-  @media screen and (max-width: $breakpoint-sm)
-    #content-body
-      padding-right: 15px
-
 .op-backlogs-page
   display: block
   height: 100%
@@ -82,6 +78,7 @@
     height: unset
     overflow: auto
     flex-direction: column
+    padding-right: 5px
 
   .op-sprint-planning-lists
     padding-top: 0

--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -121,6 +121,8 @@ $left-side-min-width: 300px
   padding-right: $right-space
   padding-top: $top-space
   padding-left: $left-space
+  // Limit the width of the header to the container around it
+  overflow-x: hidden
 
 #content-body
   grid-area: body

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
@@ -1,0 +1,147 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import type FiltersFormControllerType from './filters-form.controller';
+
+const ASSIGNEE_FILTER_ROW = `
+  <div data-filter-name="assignee" data-filter-type="text" hidden data-filter--filters-form-target="filter">
+    <select data-filter-name="assignee" data-filter--filters-form-target="operator">
+      <option value="=">is</option>
+      <option value="!*" data-no-value>is not set</option>
+    </select>
+    <div data-filter-name="assignee" data-filter--filters-form-target="filterValueContainer">
+      <input data-filter-name="assignee" data-filter--filters-form-target="simpleValue">
+    </div>
+  </div>
+`;
+
+describe('Filters form controller - filter count badge', () => {
+  let ctx:StimulusTestContext;
+  let FiltersFormController:typeof FiltersFormControllerType;
+
+  beforeAll(async () => {
+    ({ default: FiltersFormController } = await import('./filters-form.controller'));
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  async function mountForm(filterRow:string) {
+    ctx = await setupStimulusTest({
+      controllers: { 'filter--filters-form': FiltersFormController },
+    });
+
+    await ctx.mount(`
+      <div data-controller="filter--filters-form">
+        <button data-filter--filters-form-target="filterFormToggle">Filter</button>
+        <span data-filter--filters-form-target="filterCount" hidden>0</span>
+        <span data-filter--filters-form-target="filterCount" hidden>0</span>
+        <input type="hidden" data-filter--filters-form-target="filtersInput">
+        <select data-filter--filters-form-target="addFilterSelect">
+          <option value=""></option>
+          <option value="assignee">Assignee</option>
+        </select>
+        ${filterRow}
+      </div>
+    `);
+
+    const controller = ctx.getController<FiltersFormControllerType>('filter--filters-form');
+    const counters = Array.from(ctx.container.querySelectorAll<HTMLElement>('[data-filter--filters-form-target="filterCount"]'));
+
+    return { controller, counters };
+  }
+
+  function enterSimpleValue(value:string) {
+    const valueInput = ctx.container.querySelector<HTMLInputElement>('[data-filter--filters-form-target="simpleValue"]')!;
+    valueInput.value = value;
+    valueInput.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  it('leaves the count unchanged when a filter is added with no value yet', async () => {
+    const { controller, counters } = await mountForm(ASSIGNEE_FILTER_ROW);
+
+    controller.addFilterByName('assignee');
+    await ctx.nextFrame();
+
+    counters.forEach((counter) => {
+      expect(counter.textContent).toBe('0');
+      expect(counter.hidden).toBe(true);
+    });
+  });
+
+  it('increments the count once a value is entered', async () => {
+    const { controller, counters } = await mountForm(ASSIGNEE_FILTER_ROW);
+
+    controller.addFilterByName('assignee');
+    await ctx.nextFrame();
+    enterSimpleValue('john');
+
+    counters.forEach((counter) => {
+      expect(counter.textContent).toBe('1');
+      expect(counter.hidden).toBe(false);
+    });
+  });
+
+  it('decrements the count when an active filter is removed', async () => {
+    const { controller, counters } = await mountForm(ASSIGNEE_FILTER_ROW);
+
+    controller.addFilterByName('assignee');
+    enterSimpleValue('john');
+
+    counters.forEach((counter) => {
+      expect(counter.textContent).toBe('1');
+      expect(counter.hidden).toBe(false);
+    });
+
+    controller.removeFilter({ params: { filterName: 'assignee' } });
+    await ctx.nextFrame();
+
+    // Not just re-hidden -- the text itself must be updated back to 0 too,
+    // rather than staying stale at the last visible count while hidden.
+    counters.forEach((counter) => {
+      expect(counter.textContent).toBe('0');
+      expect(counter.hidden).toBe(true);
+    });
+  });
+
+  it('counts a data-no-value operator immediately, without a value', async () => {
+    const { controller, counters } = await mountForm(ASSIGNEE_FILTER_ROW);
+    const operatorSelect = ctx.container.querySelector<HTMLSelectElement>('[data-filter--filters-form-target="operator"]')!;
+    operatorSelect.value = '!*';
+
+    controller.addFilterByName('assignee');
+    await ctx.nextFrame();
+
+    counters.forEach((counter) => {
+      expect(counter.textContent).toBe('1');
+      expect(counter.hidden).toBe(false);
+    });
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { waitFor } from '@testing-library/dom';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type FiltersFormControllerType from './filters-form.controller';
 
@@ -103,9 +104,13 @@ describe('Filters form controller - filter count badge', () => {
     await ctx.nextFrame();
     enterSimpleValue('john');
 
-    counters.forEach((counter) => {
-      expect(counter.textContent).toBe('1');
-      expect(counter.hidden).toBe(false);
+    // The counter update is debounced together with the network request, so
+    // it lands asynchronously rather than right after the input event.
+    await waitFor(() => {
+      counters.forEach((counter) => {
+        expect(counter.textContent).toBe('1');
+        expect(counter.hidden).toBe(false);
+      });
     });
   });
 
@@ -115,9 +120,13 @@ describe('Filters form controller - filter count badge', () => {
     controller.addFilterByName('assignee');
     enterSimpleValue('john');
 
-    counters.forEach((counter) => {
-      expect(counter.textContent).toBe('1');
-      expect(counter.hidden).toBe(false);
+    // The counter update is debounced together with the network request, so
+    // it lands asynchronously rather than right after the input event.
+    await waitFor(() => {
+      counters.forEach((counter) => {
+        expect(counter.textContent).toBe('1');
+        expect(counter.hidden).toBe(false);
+      });
     });
 
     controller.removeFilter({ params: { filterName: 'assignee' } });

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -27,7 +27,7 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
-import { renderStreamMessage } from '@hotwired/turbo';
+import { renderStreamMessage, visit } from '@hotwired/turbo';
 import { debounce } from 'lodash-es';
 import {
   hideElement,
@@ -64,9 +64,12 @@ export default class FiltersFormController extends Controller {
     'dateRange',
     'simpleValue',
     'filtersInput',
+    'filterCount',
   ];
 
   declare readonly filterFormToggleTarget:HTMLButtonElement;
+  // The filter button has 2 counters, one is displayed and the other is for screen readers.
+  declare readonly filterCountTargets:HTMLElement[];
   declare readonly filterFormTarget:HTMLFormElement;
   declare readonly simpleFilterTargets:HTMLElement[];
   declare readonly filterTargets:HTMLElement[];
@@ -85,7 +88,8 @@ export default class FiltersFormController extends Controller {
   static values = {
     displayFilters: { type: Boolean, default: false },
     outputFormat: { type: String, default: 'params' },
-    performTurboRequests: { type: Boolean, default: false },
+    turboStreamRequest: { type: Boolean, default: false },
+    turboFrameRequest: String,
     clearButtonId: String,
     urlPathName: String,
     currentFilters: Array,
@@ -93,7 +97,9 @@ export default class FiltersFormController extends Controller {
 
   declare displayFiltersValue:boolean;
   declare outputFormatValue:string;
-  declare performTurboRequestsValue:boolean;
+  declare turboStreamRequestValue:boolean;
+  declare readonly turboFrameRequestValue:string;
+  declare readonly hasTurboFrameRequestValue:boolean;
   declare readonly clearButtonIdValue:string;
   declare urlPathNameValue:string;
   declare currentFiltersValue:SerializedFilter[];
@@ -111,7 +117,8 @@ export default class FiltersFormController extends Controller {
 
   initialize() {
     // Initialize runs anytime an element with a controller connected to the DOM for the first time
-    this.boundListener = debounce(this.sendForm.bind(this), 300);
+    this.boundListener = debounce(this.sendFormLive.bind(this), 300);
+
     this.boundClearListener = (event:MouseEvent) => this.clearInputWithButton(event);
   }
 
@@ -257,7 +264,7 @@ export default class FiltersFormController extends Controller {
   }
 
   private get liveUpdatesEnabled():boolean {
-    return this.performTurboRequestsValue || this.hasFiltersInputTarget;
+    return this.turboStreamRequestValue || this.hasTurboFrameRequestValue || this.hasFiltersInputTarget;
   }
 
   private addChangeListener(target:HTMLElement) {
@@ -295,9 +302,7 @@ export default class FiltersFormController extends Controller {
 
     this.focusFilterValueIfPossible(selectedFilter);
 
-    if (this.liveUpdatesEnabled) {
-      this.sendForm();
-    }
+    this.sendFormLive();
   }
 
   // Takes an Element and tries to find the next input or select child element. This should be the filter value.
@@ -337,9 +342,7 @@ export default class FiltersFormController extends Controller {
     const removedFilterOption = selectOptions.find((option) => option.value === filterName);
     removedFilterOption?.removeAttribute('disabled');
 
-    if (this.liveUpdatesEnabled) {
-      this.sendForm();
-    }
+    this.sendFormLive();
   }
 
   clearInputWithButton(event:MouseEvent) {
@@ -355,6 +358,14 @@ export default class FiltersFormController extends Controller {
       cancelable: true,
     });
     inputElement.dispatchEvent(inputEvent);
+  }
+
+  private updateFilterCounter() {
+    const filterCount = this.parseFilters().length;
+    this.filterCountTargets.forEach((counter) => {
+      counter.textContent = `${filterCount}`;
+      counter.hidden = filterCount === 0;
+    });
   }
 
   private readonly daysOperators = ['>t-', '<t-', 't-', '<t+', '>t+', 't+'];
@@ -391,12 +402,6 @@ export default class FiltersFormController extends Controller {
     }
   }
 
-  autocompleteSendForm() {
-    if (this.liveUpdatesEnabled) {
-      this.sendForm();
-    }
-  }
-
   serializedFiltersWith(additions:InternalFilterValue[] = [], { except }:{ except?:string } = {}):string {
     const filters = this.currentFilters().filter((filter) => filter.name !== except);
     return this.buildFiltersParam([...filters, ...additions]);
@@ -424,6 +429,21 @@ export default class FiltersFormController extends Controller {
     return [...unownedFilters, ...this.parseFilters()];
   }
 
+  // Public entrypoint for the autocomplete/list filter hidden fields
+  autocompleteSendForm() {
+    this.sendFormLive();
+  }
+
+  // Only for change/input listeners that stay bound regardless of whether live updates are
+  // enabled (e.g. the "add filter"/"remove filter" buttons). The plain form submit action
+  // must always call sendForm() directly.
+  private sendFormLive() {
+    if (this.liveUpdatesEnabled) {
+      this.updateFilterCounter();
+      this.sendForm();
+    }
+  }
+
   sendForm() {
     // When we want the filter content to be written to a hidden input, do this.
     // When we do not also want the turbo requests, we can exit early here. Otherwise the automatic redirect
@@ -431,7 +451,7 @@ export default class FiltersFormController extends Controller {
     if (this.hasFiltersInputTarget) {
       this.writeFiltersToHiddenInput();
 
-      if (!this.performTurboRequestsValue) {
+      if (!this.turboStreamRequestValue) {
         return;
       }
     }
@@ -447,20 +467,29 @@ export default class FiltersFormController extends Controller {
 
     // Remove the page parameter when changing filters, so that pagination resets
     params.delete('page');
+
     if (newFilters) {
       params.set('filters', newFilters);
     } else {
       params.delete('filters');
     }
-    const loadingIndicator = document.querySelector<HTMLElement>('#global-loading-indicator')!;
-    showElement(loadingIndicator);
 
     const pathName = this.urlPathNameValue || window.location.pathname;
     const search = params.toString();
     const url = `${pathName}${search ? `?${search}` : ''}`;
     const browserUrl = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
 
-    if (this.performTurboRequestsValue) {
+    if (this.hasTurboFrameRequestValue) {
+      // Turbo Drive shows its own progress bar for visits, so there is no need to
+      // toggle the global loading indicator here as the other branches below do.
+      visit(url, { frame: this.turboFrameRequestValue });
+      return;
+    }
+
+    const loadingIndicator = document.querySelector<HTMLElement>('#global-loading-indicator')!;
+    showElement(loadingIndicator);
+
+    if (this.turboStreamRequestValue) {
       const previousFilters = this.sentFilters;
       this.sentFilters = newFilters;
 

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -482,7 +482,7 @@ export default class FiltersFormController extends Controller {
     if (this.hasTurboFrameRequestValue) {
       // Turbo Drive shows its own progress bar for visits, so there is no need to
       // toggle the global loading indicator here as the other branches below do.
-      visit(url, { frame: this.turboFrameRequestValue });
+      visit(url, { frame: this.turboFrameRequestValue, action: 'advance' });
       return;
     }
 

--- a/lookbook/previews/open_project/filter/filters_component_preview/default.html.erb
+++ b/lookbook/previews/open_project/filter/filters_component_preview/default.html.erb
@@ -1,6 +1,6 @@
 <div
   data-controller="filter--filters-form"
-  data-filter--filters-form-perform-turbo-requests-value="true"
+  data-filter--filters-form-turbo-stream-request-value="true"
   data-filter--filters-form-clear-button-id-value="the_button"
   data-filter--filters-form-display-filters-value="true">
   <%= render(::Projects::ProjectsFiltersComponent.new(query:, initially_expanded: true)) %>

--- a/modules/backlogs/app/components/backlogs/backlog_filter_button_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_button_component.rb
@@ -30,7 +30,6 @@
 
 module Backlogs
   class BacklogFilterButtonComponent < Filter::FilterButtonComponent
-
     def filters_count
       @filters_count ||= query.filters.count do |filter|
         Backlogs::BacklogFiltersComponent::PICKER_CONTROLLED_FILTER_NAMES.exclude?(filter.name)

--- a/modules/backlogs/app/components/backlogs/backlog_filter_button_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filter_button_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,49 +26,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Users
-  class IndexSubHeaderComponent < ApplicationComponent
-    include ApplicationHelper
+module Backlogs
+  class BacklogFilterButtonComponent < Filter::FilterButtonComponent
 
-    def initialize(query:)
-      super
-      @query = query
-    end
-
-    def filter_input_value
-      @query.find_active_filter(:any_name_attribute)&.values&.first
-    end
-
-    def sub_header_data_attributes
-      {
-        controller: "filter--filters-form",
-        "filter--filters-form-turbo-stream-request-value": true,
-        "filter--filters-form-clear-button-id-value": clear_button_id,
-        "filter--filters-form-display-filters-value": filters_expanded?
-      }
-    end
-
-    def filter_input_data_attributes
-      {
-        "filter-name": "any_name_attribute",
-        "filter-type": "string",
-        "filter-operator": "~",
-        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
-      }
-    end
-
-    def clear_button_id
-      "user-filters-form-clear-button"
-    end
-
-    def collapsed_search?
-      filter_input_value.blank?
-    end
-
-    def filters_expanded?
-      params[:filters].present?
+    def filters_count
+      @filters_count ||= query.filters.count do |filter|
+        Backlogs::BacklogFiltersComponent::PICKER_CONTROLLED_FILTER_NAMES.exclude?(filter.name)
+      end
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/backlog_filters_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_filters_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,49 +26,27 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Users
-  class IndexSubHeaderComponent < ApplicationComponent
-    include ApplicationHelper
+module Backlogs
+  class BacklogFiltersComponent < Filter::FilterComponent
+    # Controlled by their own dedicated pickers (sprint/bucket/inbox/project selects),
+    # so they don't belong in the generic advanced filter panel.
+    PICKER_CONTROLLED_FILTER_NAMES = %i[sprint_id backlog_bucket_id backlog_inbox project_id].freeze
+    # Has its own permanent quick-search input in the subheader, so it doesn't belong
+    # in the generic advanced filter panel either, but unlike the picker-controlled
+    # ones above, it still counts as a filter the user applied (see
+    # Backlogs::BacklogFilterButtonComponent#filters_count).
+    QUICK_SEARCH_FILTER_NAME = :subject
 
-    def initialize(query:)
-      super
-      @query = query
+    EXCLUDED_FILTER_NAMES = (PICKER_CONTROLLED_FILTER_NAMES + [QUICK_SEARCH_FILTER_NAME]).freeze
+
+    options excluded_filters: EXCLUDED_FILTER_NAMES
+
+    def allowed_filters
+      super.sort_by(&:human_name)
     end
 
-    def filter_input_value
-      @query.find_active_filter(:any_name_attribute)&.values&.first
-    end
-
-    def sub_header_data_attributes
-      {
-        controller: "filter--filters-form",
-        "filter--filters-form-turbo-stream-request-value": true,
-        "filter--filters-form-clear-button-id-value": clear_button_id,
-        "filter--filters-form-display-filters-value": filters_expanded?
-      }
-    end
-
-    def filter_input_data_attributes
-      {
-        "filter-name": "any_name_attribute",
-        "filter-type": "string",
-        "filter-operator": "~",
-        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
-      }
-    end
-
-    def clear_button_id
-      "user-filters-form-clear-button"
-    end
-
-    def collapsed_search?
-      filter_input_value.blank?
-    end
-
-    def filters_expanded?
-      params[:filters].present?
-    end
+    def turbo_requests? = true
   end
 end

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -76,8 +76,8 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       list.with_empty_state(
-        title: t(".blankslate_title"),
-        description: t(".blankslate_description"),
+        title: backlog_filters.filtered? ? t("backlogs.blankslate_filtered_title") : t(".blankslate_title"),
+        description: backlog_filters.filtered? ? nil : t(".blankslate_description"),
         drop_target_label: t(".drop_zone_label")
       )
     end

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -60,8 +60,8 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       list.with_empty_state(
-        title: t(".blankslate_title"),
-        description: t(".blankslate_description"),
+        title: backlog_filters.filtered? ? t("backlogs.blankslate_filtered_title") : t(".blankslate_title"),
+        description: backlog_filters.filtered? ? nil : t(".blankslate_description"),
         icon: :"op-backlogs",
         drop_target_label: t(".drop_zone_label"),
         spacious: true

--- a/modules/backlogs/app/components/backlogs/index_subheader_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/index_subheader_component.html.erb
@@ -1,0 +1,65 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  component_wrapper do
+    render(
+      Primer::OpenProject::SubHeader.new(
+        collapsed_search: false,
+        data: sub_header_data_attributes,
+        mb: 0,
+        pb: 3,
+        classes: "border-bottom"
+      )
+    ) do |subheader|
+      subheader.with_filter_input(
+        name: "subject_or_id",
+        label: t(".label_search_by_subject"),
+        placeholder: t(".label_search_by_subject"),
+        value: filter_input_value,
+        clear_button_id:,
+        data: filter_input_data_attributes
+      )
+
+      subheader.with_filter_component do
+        render(Backlogs::BacklogFilterButtonComponent.new(query: @query))
+      end
+
+      subheader.with_bottom_pane_component(mt: 0) do
+        render(
+          Backlogs::BacklogFiltersComponent.new(
+            query: @query,
+            lazy_loaded_path: :project_backlogs_filters_path,
+            initially_expanded: filters_expanded?
+          )
+        )
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/index_subheader_component.rb
+++ b/modules/backlogs/app/components/backlogs/index_subheader_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,25 +26,32 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Users
-  class IndexSubHeaderComponent < ApplicationComponent
-    include ApplicationHelper
+module Backlogs
+  class IndexSubheaderComponent < ApplicationComponent
+    include OpTurbo::Streamable
 
-    def initialize(query:)
+    def initialize(query:, project:)
       super
       @query = query
+      @project = project
+    end
+
+    def self.wrapper_key
+      "backlogs-index-sub-header"
     end
 
     def filter_input_value
-      @query.find_active_filter(:any_name_attribute)&.values&.first
+      @query.find_active_filter(:subject)&.values&.first
     end
 
     def sub_header_data_attributes
       {
         controller: "filter--filters-form",
-        "filter--filters-form-turbo-stream-request-value": true,
+        "filter--filters-form-output-format-value": "params",
+        "filter--filters-form-turbo-frame-request-value": "backlogs_container",
+        "filter--filters-form-url-path-name-value": helpers.project_backlogs_backlog_path(@project),
         "filter--filters-form-clear-button-id-value": clear_button_id,
         "filter--filters-form-display-filters-value": filters_expanded?
       }
@@ -52,23 +59,19 @@ module Users
 
     def filter_input_data_attributes
       {
-        "filter-name": "any_name_attribute",
-        "filter-type": "string",
+        "filter-name": "subject",
+        "filter-type": "text",
         "filter-operator": "~",
         "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
       }
     end
 
     def clear_button_id
-      "user-filters-form-clear-button"
-    end
-
-    def collapsed_search?
-      filter_input_value.blank?
+      "backlog-filters-form-clear-button"
     end
 
     def filters_expanded?
-      params[:filters].present?
+      @query.filters.any? { |filter| Backlogs::BacklogFiltersComponent::EXCLUDED_FILTER_NAMES.exclude?(filter.name) }
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -145,8 +145,8 @@ See COPYRIGHT and LICENSE files for more details.
 
     <%
       list.with_empty_state(
-        title: t(".blankslate_title", name: sprint.name),
-        description: t(".blankslate_description"),
+        title: backlog_filters.filtered? ? t("backlogs.blankslate_filtered_title") : t(".blankslate_title", name: sprint.name),
+        description: backlog_filters.filtered? ? nil : t(".blankslate_description"),
         drop_target_label: t(".drop_zone_label")
       )
     %>

--- a/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
@@ -29,14 +29,15 @@
 #++
 
 module Backlogs
-  BacklogFilters = Data.define(:bucket_ids, :sprint_ids, :show_all) do
+  BacklogFilters = Data.define(:bucket_ids, :sprint_ids, :show_all, :filters_string) do
     def self.from_params(params)
       new(
         bucket_ids: Array(params[:bucket_ids]).filter_map do |id|
                       id == "inbox" ? "inbox" : id.to_i.nonzero?
                     end.presence,
         sprint_ids: Array(params[:sprint_ids]).filter_map { |id| id.to_i.nonzero? }.presence,
-        show_all: ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
+        show_all: ActiveRecord::Type::Boolean.new.cast(params[:all]) || false,
+        filters_string: params[:filters].presence
       )
     end
 
@@ -44,10 +45,15 @@ module Backlogs
       bucket_ids.nil? || bucket_ids.include?("inbox")
     end
 
+    def bucket_ids_without_inbox
+      bucket_ids&.excluding("inbox")
+    end
+
     def to_h
       result = show_all? ? { all: true } : {}
       result[:bucket_ids] = bucket_ids if bucket_ids
       result[:sprint_ids] = sprint_ids if sprint_ids
+      result[:filters] = filters_string if filters_string
       result
     end
 

--- a/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
@@ -45,6 +45,10 @@ module Backlogs
       bucket_ids.nil? || bucket_ids.include?("inbox")
     end
 
+    def filtered?
+      filters_string.present?
+    end
+
     def bucket_ids_without_inbox
       bucket_ids&.excluding("inbox")
     end

--- a/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_filters.rb
@@ -30,7 +30,7 @@
 
 module Backlogs
   BacklogFilters = Data.define(:bucket_ids, :sprint_ids, :show_all, :filters_string) do
-    def self.from_params(params)
+    def self.from_params(params) # rubocop:disable Metrics/AbcSize
       new(
         bucket_ids: Array(params[:bucket_ids]).filter_map do |id|
                       id == "inbox" ? "inbox" : id.to_i.nonzero?

--- a/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
+++ b/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
@@ -44,7 +44,8 @@ module Backlogs::Concerns
       # @project, which would still block starting a sprint it owns.
       @active_sprints = Sprint.active.where(project_id: @sprints.map(&:project_id).uniq)
 
-      @work_packages_by_sprint_id = filtered_sprint_work_packages
+      @work_packages_by_sprint_id = backlog_query_builder
+                                      .build_sprint_work_packages(sprint_ids: @sprints.map { |s| s.id.to_s })
                                       .includes(:type, :status, :assigned_to, :priority, :parent)
                                       .order_by_position
                                       .group_by(&:sprint_id)
@@ -57,43 +58,17 @@ module Backlogs::Concerns
       # This has the drawback of loading more work packages than are displayed in the inbox as pagination
       # will only show the top 50 and lowest 10 work packages.
       # But doing only a single query (+ includes) to the database has its benefits, and currently this seems quicker.
-      @work_packages_by_backlog_id = WorkPackage.in_backlog_for(project: @project)
-                                       .merge(filtered_backlog_work_packages)
+      bucket_ids = backlog_filters.bucket_ids_without_inbox
+      show_inbox = backlog_filters.show_inbox?
+
+      @work_packages_by_backlog_id = backlog_query_builder
+                                       .build_backlog_work_packages(bucket_ids:, show_inbox:)
+                                       .merge(WorkPackage.in_backlog_for(project: @project))
                                        .includes(:type, :status, :assigned_to, :priority, :parent)
                                        .group_by(&:backlog_bucket_id)
     end
 
     private
-
-    def filtered_sprint_work_packages
-      return WorkPackage.none if @sprints.empty?
-
-      backlog_query_builder
-        .build(extra_filters: [[:sprint_id, "=", @sprints.map { |s| s.id.to_s }]])
-        .results
-        .work_packages
-    end
-
-    # Since the Query class does not support "OR" conditions, separate queries are generated for the
-    # inbox and the bucket ids. The resulting arel queries are joined with an `.or` query.
-    def filtered_backlog_work_packages
-      backlog_conditions
-        .map { |extra_filters| backlog_query_builder.build(extra_filters:).results.work_packages }
-        .reduce { |relation, other| relation.or(other) }
-    end
-
-    def backlog_conditions
-      selected_bucket_ids = backlog_filters.bucket_ids_without_inbox
-
-      # No bucket_ids param at all means no explicit bucket selection was made. in_backlog_for
-      # (merged in by the caller) already scopes to buckets + inbox, so no extra restriction is needed.
-      return [[]] if selected_bucket_ids.nil?
-
-      conditions = []
-      conditions << [[:backlog_bucket_id, "=", selected_bucket_ids.map(&:to_s)]] if selected_bucket_ids.present?
-      conditions << [[:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE]]] if backlog_filters.show_inbox?
-      conditions
-    end
 
     def backlog_query_builder
       @backlog_query_builder ||= Backlogs::BacklogQueryBuilder.new(project: @project, user: current_user, params:)

--- a/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
+++ b/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
@@ -44,8 +44,7 @@ module Backlogs::Concerns
       # @project, which would still block starting a sprint it owns.
       @active_sprints = Sprint.active.where(project_id: @sprints.map(&:project_id).uniq)
 
-      @work_packages_by_sprint_id = WorkPackage
-                                      .where(sprint: @sprints, project: @project)
+      @work_packages_by_sprint_id = filtered_sprint_work_packages
                                       .includes(:type, :status, :assigned_to, :priority, :parent)
                                       .order_by_position
                                       .group_by(&:sprint_id)
@@ -58,10 +57,46 @@ module Backlogs::Concerns
       # This has the drawback of loading more work packages than are displayed in the inbox as pagination
       # will only show the top 50 and lowest 10 work packages.
       # But doing only a single query (+ includes) to the database has its benefits, and currently this seems quicker.
-      @work_packages_by_backlog_id = WorkPackage
-                                       .in_backlog_for(project: @project)
+      @work_packages_by_backlog_id = WorkPackage.in_backlog_for(project: @project)
+                                       .merge(filtered_backlog_work_packages)
                                        .includes(:type, :status, :assigned_to, :priority, :parent)
                                        .group_by(&:backlog_bucket_id)
+    end
+
+    private
+
+    def filtered_sprint_work_packages
+      return WorkPackage.none if @sprints.empty?
+
+      backlog_query_builder
+        .build(extra_filters: [[:sprint_id, "=", @sprints.map { |s| s.id.to_s }]])
+        .results
+        .work_packages
+    end
+
+    # Since the Query class does not support "OR" conditions, separate queries are generated for the
+    # inbox and the bucket ids. The resulting arel queries are joined with an `.or` query.
+    def filtered_backlog_work_packages
+      selected_bucket_ids = backlog_filters.bucket_ids_without_inbox
+
+      conditions = []
+
+      if selected_bucket_ids.nil?
+        # No bucket_ids param at all means no explicit bucket selection was made, so all buckets are shown.
+        conditions << [[:backlog_bucket_id, "*", []]]
+      elsif selected_bucket_ids.present?
+        conditions << [[:backlog_bucket_id, "=", selected_bucket_ids.map(&:to_s)]]
+      end
+
+      conditions << [[:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE]]] if backlog_filters.show_inbox?
+
+      conditions
+        .map { |extra_filters| backlog_query_builder.build(extra_filters:).results.work_packages }
+        .reduce { |relation, other| relation.or(other) }
+    end
+
+    def backlog_query_builder
+      @backlog_query_builder ||= Backlogs::BacklogQueryBuilder.new(project: @project, user: current_user, params:)
     end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
+++ b/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
@@ -43,9 +43,8 @@ module Backlogs::Concerns
       # another active sprint that isn't shared with (and is thus invisible to)
       # @project, which would still block starting a sprint it owns.
       @active_sprints = Sprint.active.where(project_id: @sprints.map(&:project_id).uniq)
-
       @work_packages_by_sprint_id = backlog_query_builder
-                                      .build_sprint_work_packages(sprint_ids: @sprints.map { |s| s.id.to_s })
+                                      .build_sprint_work_packages(sprint_ids: @sprints.pluck(:id))
                                       .includes(:type, :status, :assigned_to, :priority, :parent)
                                       .order_by_position
                                       .group_by(&:sprint_id)
@@ -58,7 +57,7 @@ module Backlogs::Concerns
       # This has the drawback of loading more work packages than are displayed in the inbox as pagination
       # will only show the top 50 and lowest 10 work packages.
       # But doing only a single query (+ includes) to the database has its benefits, and currently this seems quicker.
-      bucket_ids = backlog_filters.bucket_ids_without_inbox
+      bucket_ids = @backlog_buckets.pluck(:id)
       show_inbox = backlog_filters.show_inbox?
 
       @work_packages_by_backlog_id = backlog_query_builder

--- a/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
+++ b/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
@@ -77,22 +77,22 @@ module Backlogs::Concerns
     # Since the Query class does not support "OR" conditions, separate queries are generated for the
     # inbox and the bucket ids. The resulting arel queries are joined with an `.or` query.
     def filtered_backlog_work_packages
-      selected_bucket_ids = backlog_filters.bucket_ids_without_inbox
-
-      conditions = []
-
-      if selected_bucket_ids.nil?
-        # No bucket_ids param at all means no explicit bucket selection was made, so all buckets are shown.
-        conditions << [[:backlog_bucket_id, "*", []]]
-      elsif selected_bucket_ids.present?
-        conditions << [[:backlog_bucket_id, "=", selected_bucket_ids.map(&:to_s)]]
-      end
-
-      conditions << [[:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE]]] if backlog_filters.show_inbox?
-
-      conditions
+      backlog_conditions
         .map { |extra_filters| backlog_query_builder.build(extra_filters:).results.work_packages }
         .reduce { |relation, other| relation.or(other) }
+    end
+
+    def backlog_conditions
+      selected_bucket_ids = backlog_filters.bucket_ids_without_inbox
+
+      # No bucket_ids param at all means no explicit bucket selection was made. in_backlog_for
+      # (merged in by the caller) already scopes to buckets + inbox, so no extra restriction is needed.
+      return [[]] if selected_bucket_ids.nil?
+
+      conditions = []
+      conditions << [[:backlog_bucket_id, "=", selected_bucket_ids.map(&:to_s)]] if selected_bucket_ids.present?
+      conditions << [[:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE]]] if backlog_filters.show_inbox?
+      conditions
     end
 
     def backlog_query_builder

--- a/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
+++ b/modules/backlogs/app/controllers/backlogs/concerns/container_loading.rb
@@ -63,7 +63,6 @@ module Backlogs::Concerns
 
       @work_packages_by_backlog_id = backlog_query_builder
                                        .build_backlog_work_packages(bucket_ids:, show_inbox:)
-                                       .merge(WorkPackage.in_backlog_for(project: @project))
                                        .includes(:type, :status, :assigned_to, :priority, :parent)
                                        .group_by(&:backlog_bucket_id)
     end

--- a/modules/backlogs/app/controllers/backlogs/filters_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/filters_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,49 +26,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Users
-  class IndexSubHeaderComponent < ApplicationComponent
-    include ApplicationHelper
-
-    def initialize(query:)
-      super
-      @query = query
-    end
-
-    def filter_input_value
-      @query.find_active_filter(:any_name_attribute)&.values&.first
-    end
-
-    def sub_header_data_attributes
-      {
-        controller: "filter--filters-form",
-        "filter--filters-form-turbo-stream-request-value": true,
-        "filter--filters-form-clear-button-id-value": clear_button_id,
-        "filter--filters-form-display-filters-value": filters_expanded?
-      }
-    end
-
-    def filter_input_data_attributes
-      {
-        "filter-name": "any_name_attribute",
-        "filter-type": "string",
-        "filter-operator": "~",
-        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
-      }
-    end
-
-    def clear_button_id
-      "user-filters-form-clear-button"
-    end
-
-    def collapsed_search?
-      filter_input_value.blank?
-    end
-
-    def filters_expanded?
-      params[:filters].present?
+module Backlogs
+  class FiltersController < BaseController
+    def show
+      backlog_query = Backlogs::BacklogQueryBuilder.new(project: @project, user: current_user, params:).build
+      render Backlogs::BacklogFiltersComponent.new(query: backlog_query), layout: false
     end
   end
 end

--- a/modules/backlogs/app/helpers/backlogs/common_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/common_helper.rb
@@ -75,8 +75,7 @@ module Backlogs
     def filtered_buckets_for(project)
       return all_buckets_for(project) if backlog_filters.bucket_ids.nil?
 
-      bucket_ids = backlog_filters.bucket_ids.reject { |id| id == "inbox" }
-      all_buckets_for(project).where(id: bucket_ids)
+      all_buckets_for(project).where(id: backlog_filters.bucket_ids_without_inbox)
     end
 
     def backlogs_move_url_template(project)

--- a/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
+++ b/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
@@ -77,7 +77,14 @@ module Backlogs
     def generic_filters
       return [] if @params[:filters].blank?
 
-      Queries::ParamsParser.parse(@params).fetch(:filters, [])
+      Queries::ParamsParser.parse(@params).fetch(:filters, []).map do |filter|
+        filter.merge(
+          attribute: API::Utilities::QueryFiltersNameConverter.to_ar_name(
+            filter[:attribute],
+            refer_to_ids: true
+          )
+        )
+      end
     rescue JSON::ParserError
       []
     end

--- a/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
+++ b/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
@@ -49,6 +49,20 @@ module Backlogs
       query
     end
 
+    def build_sprint_work_packages(sprint_ids:)
+      build(extra_filters: [[:sprint_id, "=", sprint_ids]])
+       .results
+       .work_packages
+    end
+
+    # Since the Query class does not support "OR" conditions, separate queries are generated for the
+    # inbox and the bucket ids. The resulting arel queries are joined with an `.or` query.
+    def build_backlog_work_packages(bucket_ids:, show_inbox:)
+      backlog_conditions(bucket_ids:, show_inbox:)
+        .map { |extra_filters| build(extra_filters:).results.work_packages }
+        .reduce { |relation, other| relation.or(other) }
+    end
+
     private
 
     def generic_filters
@@ -57,6 +71,17 @@ module Backlogs
       Queries::ParamsParser.parse(@params).fetch(:filters, [])
     rescue JSON::ParserError
       []
+    end
+
+    def backlog_conditions(bucket_ids:, show_inbox:)
+      # No bucket_ids param at all means no explicit bucket selection was made. in_backlog_for
+      # (merged in by the caller) already scopes to buckets + inbox, so no extra restriction is needed.
+      return [[]] if bucket_ids.nil?
+
+      conditions = []
+      conditions << [[:backlog_bucket_id, "=", bucket_ids.map(&:to_s)]] if bucket_ids.present?
+      conditions << [[:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE]]] if show_inbox
+      conditions
     end
   end
 end

--- a/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
+++ b/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
@@ -54,14 +54,18 @@ module Backlogs
     end
 
     def build_sprint_work_packages(sprint_ids:)
+      return WorkPackage.none if sprint_ids.empty?
+
       build(extra_filters: [[:sprint_id, "=", sprint_ids]])
-       .results
-       .work_packages
+        .results
+        .work_packages
     end
 
     # Since the Query class does not support "OR" conditions, separate queries are generated for the
     # inbox and the bucket ids. The resulting arel queries are joined with an `.or` query.
     def build_backlog_work_packages(bucket_ids:, show_inbox:)
+      return WorkPackage.none if bucket_ids.empty? && !show_inbox
+
       backlog_conditions(bucket_ids:, show_inbox:)
         .map { |extra_filters| build(extra_filters:).results.work_packages }
         .reduce { |relation, other| relation.or(other) }
@@ -79,10 +83,6 @@ module Backlogs
     end
 
     def backlog_conditions(bucket_ids:, show_inbox:)
-      # No bucket_ids param at all means no explicit bucket selection was made. in_backlog_for
-      # (merged in by the caller) already scopes to buckets + inbox, so no extra restriction is needed.
-      return [[]] if bucket_ids.nil?
-
       conditions = []
       conditions << [[:backlog_bucket_id, "=", bucket_ids.map(&:to_s)]] if bucket_ids.present?
       conditions << [[:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE]]] if show_inbox

--- a/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
+++ b/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,49 +26,37 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Users
-  class IndexSubHeaderComponent < ApplicationComponent
-    include ApplicationHelper
-
-    def initialize(query:)
-      super
-      @query = query
+module Backlogs
+  # Builds a transient, project-scoped work-package Query for the Backlogs show page.
+  class BacklogQueryBuilder
+    def initialize(project:, user:, params:)
+      @project = project
+      @user = user
+      @params = params
     end
 
-    def filter_input_value
-      @query.find_active_filter(:any_name_attribute)&.values&.first
+    def build(extra_filters: [])
+      query = Query.new(project: @project, user: @user, include_subprojects: false)
+
+      generic_filters.each { |filter| query.add_filter(filter[:attribute], filter[:operator], filter[:values]) }
+      extra_filters.each { |field, operator, values| query.add_filter(field, operator, values) }
+
+      query.sort_criteria = [%w[position asc], %w[id asc]]
+
+      query.valid_subset!
+      query
     end
 
-    def sub_header_data_attributes
-      {
-        controller: "filter--filters-form",
-        "filter--filters-form-turbo-stream-request-value": true,
-        "filter--filters-form-clear-button-id-value": clear_button_id,
-        "filter--filters-form-display-filters-value": filters_expanded?
-      }
-    end
+    private
 
-    def filter_input_data_attributes
-      {
-        "filter-name": "any_name_attribute",
-        "filter-type": "string",
-        "filter-operator": "~",
-        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
-      }
-    end
+    def generic_filters
+      return [] if @params[:filters].blank?
 
-    def clear_button_id
-      "user-filters-form-clear-button"
-    end
-
-    def collapsed_search?
-      filter_input_value.blank?
-    end
-
-    def filters_expanded?
-      params[:filters].present?
+      Queries::ParamsParser.parse(@params).fetch(:filters, [])
+    rescue JSON::ParserError
+      []
     end
   end
 end

--- a/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
+++ b/modules/backlogs/app/models/backlogs/backlog_query_builder.rb
@@ -41,6 +41,10 @@ module Backlogs
       query = Query.new(project: @project, user: @user, include_subprojects: false)
 
       generic_filters.each { |filter| query.add_filter(filter[:attribute], filter[:operator], filter[:values]) }
+
+      # Limit the scope of the query to the current project.
+      query.add_filter("project_id", "=", [@project.id.to_s])
+
       extra_filters.each { |field, operator, values| query.add_filter(field, operator, values) }
 
       query.sort_criteria = [%w[position asc], %w[id asc]]
@@ -61,6 +65,7 @@ module Backlogs
       backlog_conditions(bucket_ids:, show_inbox:)
         .map { |extra_filters| build(extra_filters:).results.work_packages }
         .reduce { |relation, other| relation.or(other) }
+        .merge(WorkPackage.in_backlog_for(project: @project))
     end
 
     private

--- a/modules/backlogs/app/views/backlogs/backlog/show.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/show.html.erb
@@ -55,8 +55,7 @@ See COPYRIGHT and LICENSE files for more details.
                         sortable_lists_move_url_template_value: backlogs_move_url_template(@project),
                         sortable_lists_sortable_lists__list_outlet: "#backlogs_container [data-controller~='sortable-lists--list']",
                         sortable_lists_sortable_lists__item_outlet: "#backlogs_container [data-controller~='sortable-lists--item']",
-                        sortable_lists_sortable_lists__scrollable_outlet: "#backlogs_container [data-controller~='sortable-lists--scrollable']",
-                        turbo_action: "advance"
+                        sortable_lists_sortable_lists__scrollable_outlet: "#backlogs_container [data-controller~='sortable-lists--scrollable']"
                       } %>
 <% end %>
 

--- a/modules/backlogs/app/views/backlogs/backlog/show.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/show.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% content_for :content_header do %>
   <%=
-    render Primer::OpenProject::PageHeader.new(mb: 0) do |header|
+    render Primer::OpenProject::PageHeader.new do |header|
       header.with_title { t(:label_backlog_and_sprints) }
       header.with_breadcrumbs(
         [{ href: project_overview_path(@project), text: @project.name },
@@ -40,6 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
       )
     end
   %>
+  <%= render(Backlogs::IndexSubheaderComponent.new(query: @backlog_query, project: @project)) %>
 <% end %>
 
 <% content_for :content_body do %>
@@ -54,7 +55,8 @@ See COPYRIGHT and LICENSE files for more details.
                         sortable_lists_move_url_template_value: backlogs_move_url_template(@project),
                         sortable_lists_sortable_lists__list_outlet: "#backlogs_container [data-controller~='sortable-lists--list']",
                         sortable_lists_sortable_lists__item_outlet: "#backlogs_container [data-controller~='sortable-lists--item']",
-                        sortable_lists_sortable_lists__scrollable_outlet: "#backlogs_container [data-controller~='sortable-lists--scrollable']"
+                        sortable_lists_sortable_lists__scrollable_outlet: "#backlogs_container [data-controller~='sortable-lists--scrollable']",
+                        turbo_action: "advance"
                       } %>
 <% end %>
 

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -180,6 +180,9 @@ en:
         other: "Show %{count} more items"
       title: "Inbox"
 
+    index_subheader_component:
+      label_search_by_subject: "Search by subject"
+
     label_burndown_chart: "Burndown chart"
     label_is_done_status: "Status %{status_name} means done"
     label_sprint_board: "Sprint board"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -184,7 +184,7 @@ en:
       title: "Inbox"
 
     index_subheader_component:
-      label_search_by_subject: "Search by subject"
+      label_search_by_subject: "Search work packages by subject"
 
     label_burndown_chart: "Burndown chart"
     label_is_done_status: "Status %{status_name} means done"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -132,6 +132,9 @@ en:
         other: "Sprints"
         zero: "All sprints"
       select_panel_title: "Select items"
+
+    blankslate_filtered_title: "No work packages match the filter criteria."
+
     bucket_component:
       action_menu:
         add_existing_work_package: "Add existing work package"

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
 
     namespace :backlogs do
       resource :backlog, controller: :backlog, only: :show
+      resource :filters, controller: :filters, only: %i[show]
       get "backlog/details/:work_package_id(/:tab)",
           to: "backlog#details",
           as: :backlog_details,

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -54,6 +54,7 @@ module OpenProject::Backlogs
       project_module :backlogs, dependencies: :work_package_tracking do
         permission :view_sprints,
                    { "backlogs/backlog": %i[show details],
+                     "backlogs/filters": :show,
                      "backlogs/work_packages": %i[index show menu],
                      "backlogs/inbox": :menu,
                      "backlogs/burndown_chart": :show,

--- a/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
@@ -44,7 +44,7 @@ module OpenProject::Backlogs::Patches::PermittedParamsPatch
     end
 
     def backlog_filters
-      params.permit(:all, bucket_ids: [], sprint_ids: [])
+      params.permit(:all, :filters, bucket_ids: [], sprint_ids: [])
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/backlog_filter_button_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filter_button_component_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,49 +26,40 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Users
-  class IndexSubHeaderComponent < ApplicationComponent
-    include ApplicationHelper
+require "rails_helper"
 
-    def initialize(query:)
-      super
-      @query = query
+RSpec.describe Backlogs::BacklogFilterButtonComponent, type: :component do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:sprint) { create(:sprint, project:) }
+
+  current_user { user }
+
+  describe "#filters_count" do
+    it "excludes the sprint/bucket/inbox/project filters managed by the dedicated picker" do
+      query = Query.new(project:, user:)
+      query.add_filter(:sprint_id, "=", [sprint.id.to_s])
+      query.add_filter(:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE])
+
+      expect(described_class.new(query:).filters_count).to eq(0)
     end
 
-    def filter_input_value
-      @query.find_active_filter(:any_name_attribute)&.values&.first
+    it "counts generic attribute filters added via the panel" do
+      query = Query.new(project:, user:)
+      query.add_filter(:status_id, "o", [""])
+      query.add_filter(:sprint_id, "=", [sprint.id.to_s])
+
+      expect(described_class.new(query:).filters_count).to eq(1)
     end
 
-    def sub_header_data_attributes
-      {
-        controller: "filter--filters-form",
-        "filter--filters-form-turbo-stream-request-value": true,
-        "filter--filters-form-clear-button-id-value": clear_button_id,
-        "filter--filters-form-display-filters-value": filters_expanded?
-      }
-    end
+    it "counts the subject quick-search filter, unlike the picker-controlled ones" do
+      query = Query.new(project:, user:)
+      query.add_filter(:subject, "~", ["foo"])
+      query.add_filter(:sprint_id, "=", [sprint.id.to_s])
 
-    def filter_input_data_attributes
-      {
-        "filter-name": "any_name_attribute",
-        "filter-type": "string",
-        "filter-operator": "~",
-        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
-      }
-    end
-
-    def clear_button_id
-      "user-filters-form-clear-button"
-    end
-
-    def collapsed_search?
-      filter_input_value.blank?
-    end
-
-    def filters_expanded?
-      params[:filters].present?
+      expect(described_class.new(query:).filters_count).to eq(1)
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/backlog_filters_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filters_component_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::BacklogFiltersComponent, type: :component do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:sprint) { create(:sprint, project:) }
+  shared_let(:backlog_bucket) { create(:backlog_bucket, project:) }
+  # StatusFilter#available? checks Status.all.any? -- without at least one
+  # status in the DB it's excluded from available_advanced_filters entirely.
+  shared_let(:status) { create(:status) }
+
+  current_user { user }
+
+  let(:query) do
+    Query.new(project:, user:).tap do |q|
+      q.add_filter(:sprint_id, "=", [sprint.id.to_s])
+      q.add_filter(:backlog_bucket_id, "=", [backlog_bucket.id.to_s])
+      q.add_filter(:backlog_inbox, "=", [OpenProject::Database::DB_VALUE_TRUE])
+      q.add_filter(:status_id, "o", [""])
+    end
+  end
+
+  subject(:component) { described_class.new(query:) }
+
+  # The component's form rendering relies on the current page via
+  # primer_form_with(url: {}, ...). Setting up the current route explcitly,
+  # because vc_test_controller doesn't have one by default.
+  before do
+    vc_test_controller.request.path_parameters = {
+      controller: "backlogs/filters", action: "show", project_id: project.id.to_s
+    }
+  end
+
+  describe "#allowed_filters" do
+    it "still includes generic work package attribute filters" do
+      names = component.allowed_filters.map(&:name)
+
+      expect(names).to include(:status_id)
+    end
+  end
+
+  describe "#turbo_requests?" do
+    it "is true, so the panel live-updates without an Apply/Close footer" do
+      expect(component.turbo_requests?).to be true
+    end
+  end
+
+  it "renders the generic filters, but not the ones controlled by the dedicated picker" do
+    render_inline(component)
+
+    expect(page).to have_css("[data-filter-name='status_id']")
+    expect(page).to have_no_css("[data-filter-name='sprint_id']")
+    expect(page).to have_no_css("[data-filter-name='backlog_bucket_id']")
+    expect(page).to have_no_css("[data-filter-name='backlog_inbox']")
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/backlog_filters_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_filters_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Backlogs::BacklogFiltersComponent, type: :component do
   subject(:component) { described_class.new(query:) }
 
   # The component's form rendering relies on the current page via
-  # primer_form_with(url: {}, ...). Setting up the current route explcitly,
+  # primer_form_with(url: {}, ...). Setting up the current route explicitly,
   # because vc_test_controller doesn't have one by default.
   before do
     vc_test_controller.request.path_parameters = {

--- a/modules/backlogs/spec/components/backlogs/index_subheader_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/index_subheader_component_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::IndexSubheaderComponent, type: :component do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+
+  current_user { user }
+
+  let(:query) { Query.new(project:, user:) }
+
+  subject(:component) { described_class.new(query:, project:) }
+
+  before do
+    vc_test_controller.request.path_parameters = {
+      controller: "backlogs/filters", action: "show", project_id: project.id.to_s
+    }
+  end
+
+  describe "#filter_input_value" do
+    it "is nil when no subject filter is active" do
+      expect(component.filter_input_value).to be_nil
+    end
+
+    it "returns the active subject filter's value" do
+      query.add_filter(:subject, "~", ["foo"])
+
+      expect(component.filter_input_value).to eq("foo")
+    end
+  end
+
+  describe "#filters_expanded?" do
+    it "is false without any active filter" do
+      render_inline(component)
+
+      expect(component.filters_expanded?).to be false
+    end
+
+    it "is false when only filters controlled by dedicated pickers are active" do
+      query.add_filter(:subject, "~", ["foo"])
+      render_inline(component)
+
+      expect(component.filters_expanded?).to be false
+    end
+
+    it "is true when an advanced filter is active" do
+      query.add_filter(:status_id, "o", [""])
+      render_inline(component)
+
+      expect(component.filters_expanded?).to be true
+    end
+  end
+
+  it "renders the permanent subject quick search field" do
+    render_inline(component)
+
+    expect(page).to have_css("[data-filter-name='subject']")
+  end
+end

--- a/modules/backlogs/spec/controllers/backlogs/backlog_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/backlog_controller_spec.rb
@@ -45,8 +45,14 @@ RSpec.describe Backlogs::BacklogController do
   current_user { user }
 
   describe "GET #show" do
+    let(:params) { {} }
+
+    subject do
+      get :show, params: { project_id: project.id }.merge(params), format: :html
+    end
+
     it "loads the backlog page and preserves the backlog menu item", :aggregate_failures do
-      get :show, params: { project_id: project.id }, format: :html
+      subject
 
       expect(response).to be_successful
       expect(response).to render_template("backlogs/backlog/show")
@@ -57,9 +63,10 @@ RSpec.describe Backlogs::BacklogController do
     end
 
     context "for turbo frame request with frame id backlogs_container" do
+      before { request.headers["Turbo-Frame"] = "backlogs_container" }
+
       it "renders the backlog_list partial without layout", :aggregate_failures do
-        request.headers["Turbo-Frame"] = "backlogs_container"
-        get :show, params: { project_id: project.id }, format: :html
+        subject
 
         expect(response).to be_successful
         expect(response).to render_template("backlogs/backlog/_backlog_list")
@@ -70,6 +77,82 @@ RSpec.describe Backlogs::BacklogController do
         expect(assigns(:work_packages_by_sprint_id)).to eq({ sprint.id => [sprint_work_package] })
         expect(assigns(:work_packages_by_backlog_id)).to eq({ nil => [inbox_work_package],
                                                               backlog_bucket.id => [bucket_work_package] })
+      end
+
+      context "when filtering" do
+        context "with a work package attribute via params[:filters]" do
+          shared_let(:other_status) { create(:status, name: "status 2") }
+          shared_let(:other_sprint_work_package) { create(:work_package, project:, status: other_status, sprint:) }
+          shared_let(:other_bucket_work_package) { create(:work_package, project:, status: other_status, backlog_bucket:) }
+
+          let(:params) { { filters: "status_id = \"#{status.id}\"" } }
+
+          it "narrows both the sprint and backlog listings", :aggregate_failures do
+            subject
+
+            expect(assigns(:work_packages_by_sprint_id)).to eq({ sprint.id => [sprint_work_package] })
+            expect(assigns(:work_packages_by_backlog_id)).to eq({ nil => [inbox_work_package],
+                                                                  backlog_bucket.id => [bucket_work_package] })
+          end
+        end
+
+        context "when filtering by the permanent subject search field via params[:filters]" do
+          shared_let(:matching_sprint_wp) { create(:work_package, project:, status:, sprint:, subject: "needle in a haystack") }
+          shared_let(:matching_bucket_wp) do
+            create(:work_package, project:, status:, backlog_bucket:, subject: "needle in a haystack")
+          end
+          shared_let(:non_matching_sprint_wp) { create(:work_package, project:, status:, sprint:, subject: "unrelated") }
+          shared_let(:non_matching_bucket_wp) { create(:work_package, project:, status:, backlog_bucket:, subject: "unrelated") }
+
+          let(:params) { { filters: 'subject ~ "needle"' } }
+
+          it "narrows the sprint and backlog listings to matching subjects", :aggregate_failures do
+            subject
+
+            expect(assigns(:work_packages_by_sprint_id)[sprint.id]).to contain_exactly(matching_sprint_wp)
+            expect(assigns(:work_packages_by_backlog_id)[backlog_bucket.id]).to contain_exactly(matching_bucket_wp)
+          end
+        end
+
+        context "with a malformed filters param" do
+          let(:params) { { filters: "invalid" } }
+
+          it "ignores it instead of erroring", :aggregate_failures do
+            subject
+
+            expect(response).to be_successful
+            expect(assigns(:work_packages_by_sprint_id)).to eq({ sprint.id => [sprint_work_package] })
+          end
+        end
+
+        context "when selecting a specific sprint via sprint_ids" do
+          shared_let(:other_sprint) { create(:sprint, project:) }
+          shared_let(:other_sprint_work_package) { create(:work_package, project:, status:, sprint: other_sprint) }
+
+          let(:params) { { sprint_ids: [sprint.id] } }
+
+          it "only loads the selected sprint's work packages", :aggregate_failures do
+            subject
+
+            expect(assigns(:sprints)).to contain_exactly(sprint)
+            expect(assigns(:work_packages_by_sprint_id)).to eq({ sprint.id => [sprint_work_package] })
+          end
+        end
+
+        context "when selecting both a specific bucket and inbox via bucket_ids" do
+          shared_let(:other_bucket) { create(:backlog_bucket, project:) }
+          shared_let(:other_bucket_work_package) { create(:work_package, project:, status:, backlog_bucket: other_bucket) }
+
+          let(:params) { { bucket_ids: [backlog_bucket.id.to_s, "inbox"] } }
+
+          it "returns the union of the selected bucket's and the inbox's work packages", :aggregate_failures do
+            subject
+
+            expect(assigns(:backlog_buckets)).to contain_exactly(backlog_bucket)
+            expect(assigns(:work_packages_by_backlog_id)).to eq({ nil => [inbox_work_package],
+                                                                  backlog_bucket.id => [bucket_work_package] })
+          end
+        end
       end
 
       context "when a shared sprint's owning project has another active sprint invisible to this project" do
@@ -85,7 +168,6 @@ RSpec.describe Backlogs::BacklogController do
         end
 
         it "includes the invisible active sprint among @active_sprints", :aggregate_failures do
-          request.headers["Turbo-Frame"] = "backlogs_container"
           get :show, params: { project_id: receiving_project.id }, format: :html
 
           expect(assigns(:sprints)).to contain_exactly(shared_sprint)

--- a/modules/backlogs/spec/controllers/backlogs/backlog_filters_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/backlog_filters_spec.rb
@@ -57,6 +57,38 @@ RSpec.describe Backlogs::BacklogFilters, type: :model do
     end
   end
 
+  describe "#bucket_ids_without_inbox" do
+    context "when bucket_ids are absent" do
+      let(:params) { {} }
+
+      it { expect(filters.bucket_ids_without_inbox).to be_nil }
+    end
+
+    context "when bucket_ids only contain real bucket ids" do
+      let(:params) { { bucket_ids: %w[1 2] } }
+
+      it "returns them unchanged" do
+        expect(filters.bucket_ids_without_inbox).to eq([1, 2])
+      end
+    end
+
+    context "when bucket_ids only contain inbox" do
+      let(:params) { { bucket_ids: ["inbox"] } }
+
+      it "returns an empty array" do
+        expect(filters.bucket_ids_without_inbox).to eq([])
+      end
+    end
+
+    context "when bucket_ids contain both real bucket ids and inbox" do
+      let(:params) { { bucket_ids: ["1", "inbox", "2"] } }
+
+      it "strips out inbox and keeps the real bucket ids" do
+        expect(filters.bucket_ids_without_inbox).to eq([1, 2])
+      end
+    end
+  end
+
   describe "#sprint_ids" do
     context "when sprint_ids are absent" do
       let(:params) { {} }
@@ -99,6 +131,28 @@ RSpec.describe Backlogs::BacklogFilters, type: :model do
     end
   end
 
+  describe "#filters_string" do
+    context "when filters are absent" do
+      let(:params) { {} }
+
+      it { expect(filters.filters_string).to be_nil }
+    end
+
+    context "when filters is a params-format string" do
+      let(:params) { { filters: 'status_id = "1"' } }
+
+      it "keeps the raw string" do
+        expect(filters.filters_string).to eq('status_id = "1"')
+      end
+    end
+
+    context "when filters is blank" do
+      let(:params) { { filters: "" } }
+
+      it { expect(filters.filters_string).to be_nil }
+    end
+  end
+
   describe "#to_h" do
     context "with no params" do
       let(:params) { {} }
@@ -129,6 +183,14 @@ RSpec.describe Backlogs::BacklogFilters, type: :model do
 
       it "includes everything" do
         expect(filters.to_h).to eq({ all: true, bucket_ids: [1], sprint_ids: [2] })
+      end
+    end
+
+    context "with filters" do
+      let(:params) { { filters: 'status_id = "1"' } }
+
+      it "includes the raw filters string" do
+        expect(filters.to_h).to eq({ filters: 'status_id = "1"' })
       end
     end
   end

--- a/modules/backlogs/spec/controllers/backlogs/filters_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/filters_controller_spec.rb
@@ -28,46 +28,50 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Backlogs
-  class BacklogController < BaseController
-    include ::WorkPackages::WithSplitView
-    include Backlogs::Concerns::ContainerLoading
+require "rails_helper"
 
-    current_menu_item %i[show details] do
-      :backlog
+RSpec.describe Backlogs::FiltersController do
+  shared_let(:project) { create(:project) }
+
+  let(:all_permissions) { %i[view_sprints view_work_packages show_board_views] }
+  let(:permissions) { all_permissions }
+  let(:user) { create(:user, member_with_permissions: { project => permissions }) }
+
+  current_user { user }
+
+  describe "GET #show" do
+    let(:params) { {} }
+
+    subject do
+      get :show, params: { project_id: project.id }.merge(params), format: :html
     end
 
-    before_action :build_backlog_query, only: %i[show details]
+    it "renders the filters panel without layout", :aggregate_failures do
+      subject
 
-    def show
-      case turbo_frame_request_id
-      when "backlogs_container"
-        load_container_data
+      expect(response).to be_successful
+      expect(response).to render_template(layout: false)
+    end
 
-        render partial: "backlogs/backlog/backlog_list", layout: false
-      else
-        render "backlogs/backlog/show"
+    context "with a filter active" do
+      let(:status) { create(:status) }
+      let(:params) { { filters: "status_id = \"#{status.id}\"" } }
+
+      it "renders a generic attribute filter" do
+        subject
+        expect(response.body).to include("status_id")
       end
     end
 
-    def details
-      if turbo_frame_request?
-        render "work_packages/split_view", layout: false
-      else
-        load_container_data
+    context "without the view_sprints permission" do
+      let(:permissions) { all_permissions - [:view_sprints] }
 
-        render "backlogs/backlog/show"
+      it "responds with forbidden", :aggregate_failures do
+        subject
+
+        expect(response).not_to be_successful
+        expect(response).to have_http_status :forbidden
       end
-    end
-
-    private
-
-    def build_backlog_query
-      @backlog_query = Backlogs::BacklogQueryBuilder.new(project: @project, user: current_user, params:).build
-    end
-
-    def split_view_base_route
-      project_backlogs_backlog_path(@project, request.query_parameters)
     end
   end
 end

--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe "Edit", :js do
   it "lists all open sprints" do
     planning_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
 
-    planning_page.expect_work_package_in_sprint(work_package, first_sprint)
-    planning_page.expect_work_package_not_in_sprint(work_package, second_sprint)
+    planning_page.expect_sprint_items(first_sprint, items: work_package)
+    planning_page.expect_no_sprint_items(second_sprint, items: work_package)
   end
 
   context "with the 'create_sprints' permissions" do
@@ -270,7 +270,7 @@ RSpec.describe "Edit", :js do
   context "when moving work packages from sprints" do
     describe "moving to a different sprint" do
       it "moves a work package to a different sprint" do
-        planning_page.expect_work_package_in_sprint(work_package, first_sprint)
+        planning_page.expect_sprint_items(first_sprint, items: work_package)
 
         planning_page.click_in_work_package_menu(work_package, "Move to sprint")
 
@@ -282,8 +282,8 @@ RSpec.describe "Edit", :js do
           click_on "Move"
         end
 
-        planning_page.expect_work_package_not_in_sprint(work_package, first_sprint)
-        planning_page.expect_work_package_in_sprint(work_package, second_sprint)
+        planning_page.expect_no_sprint_items(first_sprint, items: work_package)
+        planning_page.expect_sprint_items(second_sprint, items: work_package)
       end
     end
   end

--- a/modules/backlogs/spec/features/backlogs/filter_panel_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filter_panel_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Backlog filter panel", :js do
 
     it "shows inbox by default" do
       backlogs_page.expect_inbox
-      backlogs_page.expect_inbox_item(inbox_wp)
+      backlogs_page.expect_inbox_items(items: inbox_wp)
     end
 
     it "lists inbox at the bottom of the bucket filter panel" do
@@ -123,7 +123,7 @@ RSpec.describe "Backlog filter panel", :js do
     it "shows inbox when bucket filter includes inbox" do
       backlogs_page.apply_bucket_filter(bucket_a, include_inbox: true)
       backlogs_page.expect_inbox
-      backlogs_page.expect_inbox_item(inbox_wp)
+      backlogs_page.expect_inbox_items(items: inbox_wp)
       backlogs_page.expect_backlog_bucket(bucket_a)
       backlogs_page.expect_no_backlog_bucket(bucket_b)
     end
@@ -239,7 +239,7 @@ RSpec.describe "Backlog filter panel", :js do
       it "preserves the filter after moving work packages via the action menu" do
         backlogs_page.click_in_work_package_menu(sprint_a_wp, "Move to backlog inbox")
         expect_selected_filters_preserved
-        backlogs_page.expect_inbox_item(sprint_a_wp)
+        backlogs_page.expect_inbox_items(items: sprint_a_wp)
 
         backlogs_page.click_in_work_package_menu(sprint_a_wp, "Move to backlog bucket")
         within_modal "Move to backlog bucket" do
@@ -248,7 +248,7 @@ RSpec.describe "Backlog filter panel", :js do
         end
         wait_for_network_idle
         expect_selected_filters_preserved
-        backlogs_page.expect_work_package_in_backlog_bucket(sprint_a_wp, bucket_a)
+        backlogs_page.expect_bucket_items(bucket_a, items: sprint_a_wp)
 
         backlogs_page.click_in_work_package_menu(bucket_a_wp, "Move to sprint")
         within_modal "Move to sprint" do
@@ -257,7 +257,7 @@ RSpec.describe "Backlog filter panel", :js do
         end
         wait_for_network_idle
         expect_selected_filters_preserved
-        backlogs_page.expect_work_package_in_sprint(bucket_a_wp, sprint_a)
+        backlogs_page.expect_sprint_items(sprint_a, items: bucket_a_wp)
       end
     end
   end

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     create(:work_package, project:, backlog_bucket:, status:, subject:)
   end
 
-  def create_inbox_wp(subject:, status: status_a)=create_bucket_wp(subject:, status:, backlog_bucket: nil)
-  def create_sprint_wp(subject:, status: status_a)=create(:work_package, project:, sprint:, status:, subject:)
+  def create_inbox_wp(subject:, status: status_a) = create_bucket_wp(subject:, status:, backlog_bucket: nil)
+  def create_sprint_wp(subject:, status: status_a) = create(:work_package, project:, sprint:, status:, subject:)
 
   shared_let(:matching_bucket_wp) { create_bucket_wp(subject: "Keep the Needle in a haystack") }
   shared_let(:excluded_bucket_wp) { create_bucket_wp(subject: "Unrelated subject") }

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Backlog quick search and advanced filters", :js do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+
+  shared_let(:user) { create(:admin) }
+
+  shared_let(:status_a) { create(:status, name: "Status A", is_default: true) }
+  shared_let(:status_b) { create(:status, name: "Status B") }
+  shared_let(:bucket) { create(:backlog_bucket, project:) }
+
+  shared_let(:matching_wp) do
+    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Needle in a haystack")
+  end
+  shared_let(:other_wp) do
+    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Unrelated subject")
+  end
+  shared_let(:status_b_wp) do
+    create(:work_package, project:, backlog_bucket: bucket, status: status_b, subject: "Third item")
+  end
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user { user }
+
+  before { backlogs_page.visit! }
+
+  it "narrows the listings as the subject quick search is typed" do
+    backlogs_page.expect_work_package_in_backlog_bucket(matching_wp, bucket)
+    backlogs_page.expect_work_package_in_backlog_bucket(other_wp, bucket)
+    backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
+
+    fill_in "Search by subject", with: "Needle"
+    wait_for_network_idle
+
+    backlogs_page.expect_work_package_in_backlog_bucket(matching_wp, bucket)
+    backlogs_page.expect_work_package_not_in_backlog_bucket(other_wp, bucket)
+    backlogs_page.expect_work_package_not_in_backlog_bucket(status_b_wp, bucket)
+  end
+
+  it "narrows the listings when an advanced filter is applied" do
+    backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
+
+    find_test_selector("filter-component-toggle").click
+    select "Status", from: "Add filter"
+    select "is (OR)", from: "Status"
+
+    status_value = FormFields::Primerized::AutocompleteField.new(
+      :status_id_value,
+      selector: "[data-filter-name='status_id'][data-filter-autocomplete='true']"
+    )
+    status_value.select_option(status_b.name)
+    wait_for_network_idle
+
+    backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
+    backlogs_page.expect_work_package_not_in_backlog_bucket(matching_wp, bucket)
+    backlogs_page.expect_work_package_not_in_backlog_bucket(other_wp, bucket)
+  end
+end

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -53,15 +53,15 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
   def create_sprint_wp(subject:, status: status_a)=create(:work_package, project:, sprint:, status:, subject:)
 
   shared_let(:matching_bucket_wp) { create_bucket_wp(subject: "Keep the Needle in a haystack") }
-  shared_let(:other_bucket_wp) { create_bucket_wp(subject: "Unrelated subject") }
+  shared_let(:excluded_bucket_wp) { create_bucket_wp(subject: "Unrelated subject") }
   shared_let(:status_b_bucket_wp) { create_bucket_wp(subject: "Keep me but wrong status", status: status_b) }
   shared_let(:keep_last_bucket_wp) { create_bucket_wp(subject: "Keep last") }
   shared_let(:matching_sprint_wp) { create_sprint_wp(subject: "Keep the Needle in a haystack") }
-  shared_let(:other_sprint_wp) { create_sprint_wp(subject: "Unrelated subject") }
+  shared_let(:excluded_sprint_wp) { create_sprint_wp(subject: "Unrelated subject") }
   shared_let(:status_b_sprint_wp) { create_sprint_wp(subject: "Keep me but wrong status", status: status_b) }
 
   shared_let(:matching_inbox_wp) { create_inbox_wp(subject: "Keep the Needle in a haystack") }
-  shared_let(:other_inbox_wp) { create_inbox_wp(subject: "Unrelated subject") }
+  shared_let(:excluded_inbox_wp) { create_inbox_wp(subject: "Unrelated subject") }
   shared_let(:status_b_inbox_wp) { create_inbox_wp(subject: "Keep me but wrong status", status: status_b) }
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
@@ -72,28 +72,28 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
 
   it "narrows the listings as the subject quick search is typed" do
     backlogs_page.expect_bucket_items(
-      bucket, items: [matching_bucket_wp, other_bucket_wp, status_b_bucket_wp, keep_last_bucket_wp]
+      bucket, items: [matching_bucket_wp, excluded_bucket_wp, status_b_bucket_wp, keep_last_bucket_wp]
     )
     backlogs_page.expect_backlog_bucket_work_package_count(bucket, 4)
 
-    backlogs_page.expect_sprint_items(sprint, items: [matching_sprint_wp, other_sprint_wp, status_b_sprint_wp])
+    backlogs_page.expect_sprint_items(sprint, items: [matching_sprint_wp, excluded_sprint_wp, status_b_sprint_wp])
     backlogs_page.expect_sprint_work_package_count(sprint, 3)
 
-    backlogs_page.expect_inbox_items(items: [matching_inbox_wp, other_inbox_wp, status_b_inbox_wp])
+    backlogs_page.expect_inbox_items(items: [matching_inbox_wp, excluded_inbox_wp, status_b_inbox_wp])
     backlogs_page.expect_inbox_work_package_count(3)
 
     backlogs_page.apply_subject_filter("Needle")
 
     backlogs_page.expect_bucket_items(bucket, items: matching_bucket_wp)
-    backlogs_page.expect_no_bucket_items(bucket, items: [other_bucket_wp, status_b_bucket_wp, keep_last_bucket_wp])
+    backlogs_page.expect_no_bucket_items(bucket, items: [excluded_bucket_wp, status_b_bucket_wp, keep_last_bucket_wp])
     backlogs_page.expect_backlog_bucket_work_package_count(bucket, 1)
 
     backlogs_page.expect_sprint_items(sprint, items: matching_sprint_wp)
-    backlogs_page.expect_no_sprint_items(sprint, items: [other_sprint_wp, status_b_sprint_wp])
+    backlogs_page.expect_no_sprint_items(sprint, items: [excluded_sprint_wp, status_b_sprint_wp])
     backlogs_page.expect_sprint_work_package_count(sprint, 1)
 
     backlogs_page.expect_inbox_items(items: matching_inbox_wp)
-    backlogs_page.expect_no_inbox_items(items: [other_inbox_wp, status_b_inbox_wp])
+    backlogs_page.expect_no_inbox_items(items: [excluded_inbox_wp, status_b_inbox_wp])
     backlogs_page.expect_inbox_work_package_count(1)
   end
 
@@ -105,15 +105,15 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     backlogs_page.apply_status_filter(status_b)
 
     backlogs_page.expect_bucket_items(bucket, items: status_b_bucket_wp)
-    backlogs_page.expect_no_bucket_items(bucket, items: [matching_bucket_wp, other_bucket_wp, keep_last_bucket_wp])
+    backlogs_page.expect_no_bucket_items(bucket, items: [matching_bucket_wp, excluded_bucket_wp, keep_last_bucket_wp])
     backlogs_page.expect_backlog_bucket_work_package_count(bucket, 1)
 
     backlogs_page.expect_sprint_items(sprint, items: status_b_sprint_wp)
-    backlogs_page.expect_no_sprint_items(sprint, items: [matching_sprint_wp, other_sprint_wp])
+    backlogs_page.expect_no_sprint_items(sprint, items: [matching_sprint_wp, excluded_sprint_wp])
     backlogs_page.expect_sprint_work_package_count(sprint, 1)
 
     backlogs_page.expect_inbox_items(items: status_b_inbox_wp)
-    backlogs_page.expect_no_inbox_items(items: [matching_inbox_wp, other_inbox_wp])
+    backlogs_page.expect_no_inbox_items(items: [matching_inbox_wp, excluded_inbox_wp])
     backlogs_page.expect_inbox_work_package_count(1)
   end
 
@@ -137,9 +137,9 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
 
     def expect_filters_preserved
       expect(page).to have_field("Search by subject", with: "Keep")
-      backlogs_page.expect_no_bucket_items(bucket, items: [other_bucket_wp, status_b_bucket_wp])
-      backlogs_page.expect_no_sprint_items(sprint, items: [other_sprint_wp, status_b_sprint_wp])
-      backlogs_page.expect_no_inbox_items(items: [other_inbox_wp, status_b_inbox_wp])
+      backlogs_page.expect_no_bucket_items(bucket, items: [excluded_bucket_wp, status_b_bucket_wp])
+      backlogs_page.expect_no_sprint_items(sprint, items: [excluded_sprint_wp, status_b_sprint_wp])
+      backlogs_page.expect_no_inbox_items(items: [excluded_inbox_wp, status_b_inbox_wp])
     end
 
     it "preserves the filters after a cross-bucket drag and drop", :selenium do
@@ -172,25 +172,37 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     end
 
     it "persists the drop position among the visible siblings", :selenium do
-      backlogs_page.expect_no_bucket_items(bucket, items: other_bucket_wp)
+      backlogs_page.expect_no_bucket_items(bucket, items: excluded_bucket_wp)
+      backlogs_page.expect_bucket_items_in_order(
+        bucket,
+        work_packages: [matching_bucket_wp, keep_last_bucket_wp, draggable_wp]
+      )
 
       backlogs_page.drag_work_package(matching_bucket_wp, after: keep_last_bucket_wp)
 
-      backlogs_page.apply_subject_filter("")
+      backlogs_page.clear_subject_filter
 
-      backlogs_page.expect_bucket_items(bucket, items: other_bucket_wp)
-      backlogs_page.expect_bucket_items_in_order(bucket, work_packages: [keep_last_bucket_wp, matching_bucket_wp])
+      backlogs_page.expect_bucket_items_in_order(
+        bucket,
+        work_packages: [excluded_bucket_wp, keep_last_bucket_wp, matching_bucket_wp, draggable_wp]
+      )
     end
 
     it "persists the move-up position among the visible siblings" do
-      backlogs_page.expect_no_bucket_items(bucket, items: other_bucket_wp)
+      backlogs_page.expect_no_bucket_items(bucket, items: excluded_bucket_wp)
+      backlogs_page.expect_bucket_items_in_order(
+        bucket,
+        work_packages: [matching_bucket_wp, keep_last_bucket_wp, draggable_wp]
+      )
 
       backlogs_page.click_in_work_package_move_submenu(keep_last_bucket_wp, "Move up")
 
-      backlogs_page.apply_subject_filter("")
+      backlogs_page.clear_subject_filter
 
-      backlogs_page.expect_bucket_items(bucket, items: other_bucket_wp)
-      backlogs_page.expect_bucket_items_in_order(bucket, work_packages: [keep_last_bucket_wp, matching_bucket_wp])
+      backlogs_page.expect_bucket_items_in_order(
+        bucket,
+        work_packages: [keep_last_bucket_wp, matching_bucket_wp, excluded_bucket_wp, draggable_wp]
+      )
     end
 
     it "inserts the dragged work package at the top of the bucket's real list", :selenium do
@@ -198,7 +210,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
 
       backlogs_page.drag_work_package_to_backlog_bucket(draggable_wp, empty_target_bucket)
 
-      backlogs_page.apply_subject_filter("")
+      backlogs_page.clear_subject_filter
 
       backlogs_page.expect_bucket_items_in_order(
         empty_target_bucket, work_packages: [draggable_wp, existing_wp]

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     end
 
     it "inserts the dragged work package at the top of the bucket's real list", :selenium do
-      backlogs_page.expect_backlog_bucket_blankslate(empty_target_bucket)
+      backlogs_page.expect_backlog_bucket_blankslate(empty_target_bucket, filtered: true)
 
       backlogs_page.drag_work_package_to_backlog_bucket(draggable_wp, empty_target_bucket)
 

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -45,13 +45,16 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
   shared_let(:bucket) { create(:backlog_bucket, project:) }
 
   shared_let(:matching_wp) do
-    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Needle in a haystack")
+    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Keep the Needle in a haystack")
   end
   shared_let(:other_wp) do
     create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Unrelated subject")
   end
   shared_let(:status_b_wp) do
-    create(:work_package, project:, backlog_bucket: bucket, status: status_b, subject: "Third item")
+    create(:work_package, project:, backlog_bucket: bucket, status: status_b, subject: "Keep me but wrong status")
+  end
+  shared_let(:keep_last_wp) do
+    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Keep last")
   end
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
@@ -64,31 +67,24 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     backlogs_page.expect_work_package_in_backlog_bucket(matching_wp, bucket)
     backlogs_page.expect_work_package_in_backlog_bucket(other_wp, bucket)
     backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
+    backlogs_page.expect_work_package_in_backlog_bucket(keep_last_wp, bucket)
 
-    fill_in "Search by subject", with: "Needle"
-    wait_for_network_idle
+    backlogs_page.apply_subject_filter("Needle")
 
     backlogs_page.expect_work_package_in_backlog_bucket(matching_wp, bucket)
     backlogs_page.expect_work_package_not_in_backlog_bucket(other_wp, bucket)
     backlogs_page.expect_work_package_not_in_backlog_bucket(status_b_wp, bucket)
+    backlogs_page.expect_work_package_not_in_backlog_bucket(keep_last_wp, bucket)
   end
 
   it "narrows the listings when an advanced filter is applied" do
     backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
 
-    find_test_selector("filter-component-toggle").click
-    select "Status", from: "Add filter"
-    select "is (OR)", from: "Status"
-
-    status_value = FormFields::Primerized::AutocompleteField.new(
-      :status_id_value,
-      selector: "[data-filter-name='status_id'][data-filter-autocomplete='true']"
-    )
-    status_value.select_option(status_b.name)
-    wait_for_network_idle
+    backlogs_page.apply_status_filter(status_b)
 
     backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
     backlogs_page.expect_work_package_not_in_backlog_bucket(matching_wp, bucket)
     backlogs_page.expect_work_package_not_in_backlog_bucket(other_wp, bucket)
+    backlogs_page.expect_work_package_not_in_backlog_bucket(keep_last_wp, bucket)
   end
 end

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -43,19 +43,26 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
   shared_let(:status_a) { create(:status, name: "Status A", is_default: true) }
   shared_let(:status_b) { create(:status, name: "Status B") }
   shared_let(:bucket) { create(:backlog_bucket, project:) }
+  shared_let(:sprint) { create(:sprint, project:) }
 
-  shared_let(:matching_wp) do
-    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Keep the Needle in a haystack")
+  def create_bucket_wp(subject:, status: status_a, backlog_bucket: bucket)
+    create(:work_package, project:, backlog_bucket:, status:, subject:)
   end
-  shared_let(:other_wp) do
-    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Unrelated subject")
-  end
-  shared_let(:status_b_wp) do
-    create(:work_package, project:, backlog_bucket: bucket, status: status_b, subject: "Keep me but wrong status")
-  end
-  shared_let(:keep_last_wp) do
-    create(:work_package, project:, backlog_bucket: bucket, status: status_a, subject: "Keep last")
-  end
+
+  def create_inbox_wp(subject:, status: status_a)=create_bucket_wp(subject:, status:, backlog_bucket: nil)
+  def create_sprint_wp(subject:, status: status_a)=create(:work_package, project:, sprint:, status:, subject:)
+
+  shared_let(:matching_bucket_wp) { create_bucket_wp(subject: "Keep the Needle in a haystack") }
+  shared_let(:other_bucket_wp) { create_bucket_wp(subject: "Unrelated subject") }
+  shared_let(:status_b_bucket_wp) { create_bucket_wp(subject: "Keep me but wrong status", status: status_b) }
+  shared_let(:keep_last_bucket_wp) { create_bucket_wp(subject: "Keep last") }
+  shared_let(:matching_sprint_wp) { create_sprint_wp(subject: "Keep the Needle in a haystack") }
+  shared_let(:other_sprint_wp) { create_sprint_wp(subject: "Unrelated subject") }
+  shared_let(:status_b_sprint_wp) { create_sprint_wp(subject: "Keep me but wrong status", status: status_b) }
+
+  shared_let(:matching_inbox_wp) { create_inbox_wp(subject: "Keep the Needle in a haystack") }
+  shared_let(:other_inbox_wp) { create_inbox_wp(subject: "Unrelated subject") }
+  shared_let(:status_b_inbox_wp) { create_inbox_wp(subject: "Keep me but wrong status", status: status_b) }
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
 
@@ -64,27 +71,138 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
   before { backlogs_page.visit! }
 
   it "narrows the listings as the subject quick search is typed" do
-    backlogs_page.expect_work_package_in_backlog_bucket(matching_wp, bucket)
-    backlogs_page.expect_work_package_in_backlog_bucket(other_wp, bucket)
-    backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
-    backlogs_page.expect_work_package_in_backlog_bucket(keep_last_wp, bucket)
+    backlogs_page.expect_bucket_items(
+      bucket, items: [matching_bucket_wp, other_bucket_wp, status_b_bucket_wp, keep_last_bucket_wp]
+    )
+    backlogs_page.expect_backlog_bucket_work_package_count(bucket, 4)
+
+    backlogs_page.expect_sprint_items(sprint, items: [matching_sprint_wp, other_sprint_wp, status_b_sprint_wp])
+    backlogs_page.expect_sprint_work_package_count(sprint, 3)
+
+    backlogs_page.expect_inbox_items(items: [matching_inbox_wp, other_inbox_wp, status_b_inbox_wp])
+    backlogs_page.expect_inbox_work_package_count(3)
 
     backlogs_page.apply_subject_filter("Needle")
 
-    backlogs_page.expect_work_package_in_backlog_bucket(matching_wp, bucket)
-    backlogs_page.expect_work_package_not_in_backlog_bucket(other_wp, bucket)
-    backlogs_page.expect_work_package_not_in_backlog_bucket(status_b_wp, bucket)
-    backlogs_page.expect_work_package_not_in_backlog_bucket(keep_last_wp, bucket)
+    backlogs_page.expect_bucket_items(bucket, items: matching_bucket_wp)
+    backlogs_page.expect_no_bucket_items(bucket, items: [other_bucket_wp, status_b_bucket_wp, keep_last_bucket_wp])
+    backlogs_page.expect_backlog_bucket_work_package_count(bucket, 1)
+
+    backlogs_page.expect_sprint_items(sprint, items: matching_sprint_wp)
+    backlogs_page.expect_no_sprint_items(sprint, items: [other_sprint_wp, status_b_sprint_wp])
+    backlogs_page.expect_sprint_work_package_count(sprint, 1)
+
+    backlogs_page.expect_inbox_items(items: matching_inbox_wp)
+    backlogs_page.expect_no_inbox_items(items: [other_inbox_wp, status_b_inbox_wp])
+    backlogs_page.expect_inbox_work_package_count(1)
   end
 
   it "narrows the listings when an advanced filter is applied" do
-    backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
+    backlogs_page.expect_bucket_items(bucket, items: status_b_bucket_wp)
+    backlogs_page.expect_sprint_items(sprint, items: status_b_sprint_wp)
+    backlogs_page.expect_inbox_items(items: status_b_inbox_wp)
 
     backlogs_page.apply_status_filter(status_b)
 
-    backlogs_page.expect_work_package_in_backlog_bucket(status_b_wp, bucket)
-    backlogs_page.expect_work_package_not_in_backlog_bucket(matching_wp, bucket)
-    backlogs_page.expect_work_package_not_in_backlog_bucket(other_wp, bucket)
-    backlogs_page.expect_work_package_not_in_backlog_bucket(keep_last_wp, bucket)
+    backlogs_page.expect_bucket_items(bucket, items: status_b_bucket_wp)
+    backlogs_page.expect_no_bucket_items(bucket, items: [matching_bucket_wp, other_bucket_wp, keep_last_bucket_wp])
+    backlogs_page.expect_backlog_bucket_work_package_count(bucket, 1)
+
+    backlogs_page.expect_sprint_items(sprint, items: status_b_sprint_wp)
+    backlogs_page.expect_no_sprint_items(sprint, items: [matching_sprint_wp, other_sprint_wp])
+    backlogs_page.expect_sprint_work_package_count(sprint, 1)
+
+    backlogs_page.expect_inbox_items(items: status_b_inbox_wp)
+    backlogs_page.expect_no_inbox_items(items: [matching_inbox_wp, other_inbox_wp])
+    backlogs_page.expect_inbox_work_package_count(1)
+  end
+
+  context "when executing various actions on the page with filters applied" do
+    shared_let(:other_bucket) { create(:backlog_bucket, project:) }
+    shared_let(:sprint_kept_wp) do
+      create(:work_package, project:, sprint:, status: status_a, subject: "Keep me sprint A")
+    end
+    shared_let(:sprint_kept_wp2) do
+      create(:work_package, project:, sprint:, status: status_a, subject: "Keep me sprint B")
+    end
+    shared_let(:empty_target_bucket) { create(:backlog_bucket, project:) }
+    shared_let(:existing_wp) { create_bucket_wp(subject: "Filtered out", backlog_bucket: empty_target_bucket) }
+    shared_let(:draggable_wp) { create_bucket_wp(subject: "Keep draggable") }
+
+    before do
+      backlogs_page.apply_subject_filter("Keep")
+      backlogs_page.apply_status_filter(status_a)
+      backlogs_page.close_filters
+    end
+
+    def expect_filters_preserved
+      expect(page).to have_field("Search by subject", with: "Keep")
+      backlogs_page.expect_no_bucket_items(bucket, items: [other_bucket_wp, status_b_bucket_wp])
+      backlogs_page.expect_no_sprint_items(sprint, items: [other_sprint_wp, status_b_sprint_wp])
+      backlogs_page.expect_no_inbox_items(items: [other_inbox_wp, status_b_inbox_wp])
+    end
+
+    it "preserves the filters after a cross-bucket drag and drop", :selenium do
+      backlogs_page.drag_work_package_to_backlog_bucket(matching_bucket_wp, other_bucket)
+
+      expect_filters_preserved
+      backlogs_page.expect_bucket_items(other_bucket, items: matching_bucket_wp)
+      backlogs_page.expect_bucket_items(bucket, items: keep_last_bucket_wp)
+    end
+
+    it "preserves the filters after opening and closing the work package details" do
+      details_view = backlogs_page.open_work_package_details(matching_bucket_wp)
+      details_view.close
+
+      expect(page).to have_current_path project_backlogs_backlog_path(project), ignore_query: true
+      expect_filters_preserved
+      backlogs_page.expect_bucket_items(bucket, items: matching_bucket_wp)
+    end
+
+    it "preserves the filters after moving work packages up or down" do
+      backlogs_page.click_in_work_package_move_submenu(keep_last_bucket_wp, "Move up")
+
+      expect_filters_preserved
+      backlogs_page.expect_bucket_items_in_order(bucket, work_packages: [keep_last_bucket_wp, matching_bucket_wp])
+
+      backlogs_page.click_in_sprint_story_move_menu(sprint_kept_wp2, "Move up")
+
+      expect_filters_preserved
+      backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [sprint_kept_wp2, sprint_kept_wp])
+    end
+
+    it "persists the drop position among the visible siblings", :selenium do
+      backlogs_page.expect_no_bucket_items(bucket, items: other_bucket_wp)
+
+      backlogs_page.drag_work_package(matching_bucket_wp, after: keep_last_bucket_wp)
+
+      backlogs_page.apply_subject_filter("")
+
+      backlogs_page.expect_bucket_items(bucket, items: other_bucket_wp)
+      backlogs_page.expect_bucket_items_in_order(bucket, work_packages: [keep_last_bucket_wp, matching_bucket_wp])
+    end
+
+    it "persists the move-up position among the visible siblings" do
+      backlogs_page.expect_no_bucket_items(bucket, items: other_bucket_wp)
+
+      backlogs_page.click_in_work_package_move_submenu(keep_last_bucket_wp, "Move up")
+
+      backlogs_page.apply_subject_filter("")
+
+      backlogs_page.expect_bucket_items(bucket, items: other_bucket_wp)
+      backlogs_page.expect_bucket_items_in_order(bucket, work_packages: [keep_last_bucket_wp, matching_bucket_wp])
+    end
+
+    it "inserts the dragged work package at the top of the bucket's real list", :selenium do
+      backlogs_page.expect_backlog_bucket_blankslate(empty_target_bucket)
+
+      backlogs_page.drag_work_package_to_backlog_bucket(draggable_wp, empty_target_bucket)
+
+      backlogs_page.apply_subject_filter("")
+
+      backlogs_page.expect_bucket_items_in_order(
+        empty_target_bucket, work_packages: [draggable_wp, existing_wp]
+      )
+    end
   end
 end

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -163,19 +163,19 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
       backlogs_page.click_in_work_package_move_submenu(keep_last_bucket_wp, "Move up")
 
       expect_filters_preserved
-      backlogs_page.expect_bucket_items_in_order(bucket, work_packages: [keep_last_bucket_wp, matching_bucket_wp])
+      backlogs_page.expect_bucket_items_in_order(bucket, items: [keep_last_bucket_wp, matching_bucket_wp])
 
       backlogs_page.click_in_sprint_story_move_menu(sprint_kept_wp2, "Move up")
 
       expect_filters_preserved
-      backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [sprint_kept_wp2, sprint_kept_wp])
+      backlogs_page.expect_sprint_items_in_order(sprint, items: [sprint_kept_wp2, sprint_kept_wp])
     end
 
     it "persists the drop position among the visible siblings", :selenium do
       backlogs_page.expect_no_bucket_items(bucket, items: excluded_bucket_wp)
       backlogs_page.expect_bucket_items_in_order(
         bucket,
-        work_packages: [matching_bucket_wp, keep_last_bucket_wp, draggable_wp]
+        items: [matching_bucket_wp, keep_last_bucket_wp, draggable_wp]
       )
 
       backlogs_page.drag_work_package(matching_bucket_wp, after: keep_last_bucket_wp)
@@ -184,7 +184,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
 
       backlogs_page.expect_bucket_items_in_order(
         bucket,
-        work_packages: [excluded_bucket_wp, keep_last_bucket_wp, matching_bucket_wp, draggable_wp]
+        items: [excluded_bucket_wp, keep_last_bucket_wp, matching_bucket_wp, draggable_wp]
       )
     end
 
@@ -192,7 +192,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
       backlogs_page.expect_no_bucket_items(bucket, items: excluded_bucket_wp)
       backlogs_page.expect_bucket_items_in_order(
         bucket,
-        work_packages: [matching_bucket_wp, keep_last_bucket_wp, draggable_wp]
+        items: [matching_bucket_wp, keep_last_bucket_wp, draggable_wp]
       )
 
       backlogs_page.click_in_work_package_move_submenu(keep_last_bucket_wp, "Move up")
@@ -201,7 +201,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
 
       backlogs_page.expect_bucket_items_in_order(
         bucket,
-        work_packages: [keep_last_bucket_wp, matching_bucket_wp, excluded_bucket_wp, draggable_wp]
+        items: [keep_last_bucket_wp, matching_bucket_wp, excluded_bucket_wp, draggable_wp]
       )
     end
 
@@ -213,7 +213,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
       backlogs_page.clear_subject_filter
 
       backlogs_page.expect_bucket_items_in_order(
-        empty_target_bucket, work_packages: [draggable_wp, existing_wp]
+        empty_target_bucket, items: [draggable_wp, existing_wp]
       )
     end
   end

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     end
 
     def expect_filters_preserved
-      expect(page).to have_field("Search by subject", with: "Keep")
+      expect(page).to have_field("Search work packages by subject", with: "Keep")
       backlogs_page.expect_no_bucket_items(bucket, items: [excluded_bucket_wp, status_b_bucket_wp])
       backlogs_page.expect_no_sprint_items(sprint, items: [excluded_sprint_wp, status_b_sprint_wp])
       backlogs_page.expect_no_inbox_items(items: [excluded_inbox_wp, status_b_inbox_wp])

--- a/modules/backlogs/spec/features/backlogs/settings_effect_on_backlog_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/settings_effect_on_backlog_spec.rb
@@ -158,15 +158,12 @@ RSpec.describe "Backlogs settings effect on backlog and sprints", :js do
     backlog_page.expect_and_dismiss_flash type: :success, message: "The sprint was completed."
 
     # Done-like status marks this as finished and therefore not moved to backlog.
-    backlog_page.expect_no_inbox_item(sprint_done_work_package)
-
     # Excluded types are moved to backlog but still hidden from inbox by settings.
     # TODO: add assertion for flash message once it's in
-    backlog_page.expect_no_inbox_item(sprint_excluded_type_work_package)
+    backlog_page.expect_no_inbox_items(items: [sprint_done_work_package, sprint_excluded_type_work_package])
 
     # Regular unfinished work packages are moved to and shown in the inbox.
-    backlog_page.expect_inbox_item(sprint_visible_work_package)
-    backlog_page.expect_inbox_item(inbox_visible_work_package)
+    backlog_page.expect_inbox_items(items: [sprint_visible_work_package, inbox_visible_work_package])
   end
 
   private
@@ -189,14 +186,13 @@ RSpec.describe "Backlogs settings effect on backlog and sprints", :js do
   end
 
   def expect_inbox_filtering
-    backlog_page.expect_no_inbox_item(inbox_hidden_by_done_status)
-    backlog_page.expect_no_inbox_item(inbox_hidden_by_excluded_type)
-    backlog_page.expect_inbox_item(inbox_visible_work_package)
+    backlog_page.expect_no_inbox_items(items: [inbox_hidden_by_done_status, inbox_hidden_by_excluded_type])
+    backlog_page.expect_inbox_items(items: inbox_visible_work_package)
   end
 
   def expect_sprint_items_unaffected
-    backlog_page.expect_work_package_in_sprint(sprint_done_work_package, active_sprint)
-    backlog_page.expect_work_package_in_sprint(sprint_excluded_type_work_package, active_sprint)
-    backlog_page.expect_work_package_in_sprint(sprint_visible_work_package, active_sprint)
+    backlog_page.expect_sprint_items(
+      active_sprint, items: [sprint_done_work_package, sprint_excluded_type_work_package, sprint_visible_work_package]
+    )
   end
 end

--- a/modules/backlogs/spec/features/backlogs/start_finish_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/start_finish_spec.rb
@@ -211,12 +211,12 @@ RSpec.describe "Start and finish sprints", :js do
 
         planning_page.expect_sprint_names_in_order(sprint_from_other_project.name, second_sprint.name)
 
-        planning_page.expect_work_packages_in_sprint_in_order(second_sprint,
+        planning_page.expect_sprint_items_in_order(second_sprint,
                                                               work_packages: [unfinished_work_package1,
                                                                               unfinished_work_package2,
                                                                               wp_in_next_sprint])
 
-        planning_page.expect_work_packages_in_inbox_in_order(work_packages: [backlog_work_package])
+        planning_page.expect_inbox_items_in_order(work_packages: [backlog_work_package])
       end
 
       it "allows moving unfinished work packages to the top of the backlog" do
@@ -229,7 +229,7 @@ RSpec.describe "Start and finish sprints", :js do
 
         planning_page.expect_sprint_names_in_order(sprint_from_other_project.name, second_sprint.name)
 
-        planning_page.expect_work_packages_in_inbox_in_order(work_packages: [unfinished_work_package1,
+        planning_page.expect_inbox_items_in_order(work_packages: [unfinished_work_package1,
                                                                              unfinished_work_package2,
                                                                              backlog_work_package])
       end
@@ -244,7 +244,7 @@ RSpec.describe "Start and finish sprints", :js do
 
         planning_page.expect_sprint_names_in_order(sprint_from_other_project.name, second_sprint.name)
 
-        planning_page.expect_work_packages_in_inbox_in_order(work_packages: [backlog_work_package,
+        planning_page.expect_inbox_items_in_order(work_packages: [backlog_work_package,
                                                                              unfinished_work_package1,
                                                                              unfinished_work_package2])
       end

--- a/modules/backlogs/spec/features/backlogs/start_finish_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/start_finish_spec.rb
@@ -212,11 +212,11 @@ RSpec.describe "Start and finish sprints", :js do
         planning_page.expect_sprint_names_in_order(sprint_from_other_project.name, second_sprint.name)
 
         planning_page.expect_sprint_items_in_order(second_sprint,
-                                                              work_packages: [unfinished_work_package1,
-                                                                              unfinished_work_package2,
-                                                                              wp_in_next_sprint])
+                                                   items: [unfinished_work_package1,
+                                                           unfinished_work_package2,
+                                                           wp_in_next_sprint])
 
-        planning_page.expect_inbox_items_in_order(work_packages: [backlog_work_package])
+        planning_page.expect_inbox_items_in_order(items: [backlog_work_package])
       end
 
       it "allows moving unfinished work packages to the top of the backlog" do
@@ -229,9 +229,9 @@ RSpec.describe "Start and finish sprints", :js do
 
         planning_page.expect_sprint_names_in_order(sprint_from_other_project.name, second_sprint.name)
 
-        planning_page.expect_inbox_items_in_order(work_packages: [unfinished_work_package1,
-                                                                             unfinished_work_package2,
-                                                                             backlog_work_package])
+        planning_page.expect_inbox_items_in_order(items: [unfinished_work_package1,
+                                                          unfinished_work_package2,
+                                                          backlog_work_package])
       end
 
       it "allows moving unfinished work packages to the bottom of the backlog" do
@@ -244,9 +244,9 @@ RSpec.describe "Start and finish sprints", :js do
 
         planning_page.expect_sprint_names_in_order(sprint_from_other_project.name, second_sprint.name)
 
-        planning_page.expect_inbox_items_in_order(work_packages: [backlog_work_package,
-                                                                             unfinished_work_package1,
-                                                                             unfinished_work_package2])
+        planning_page.expect_inbox_items_in_order(items: [backlog_work_package,
+                                                          unfinished_work_package1,
+                                                          unfinished_work_package2])
       end
     end
   end

--- a/modules/backlogs/spec/features/buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/buckets/delete_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Backlog bucket deletion", :js do
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_backlog_bucket(bucket)
 
-    backlogs_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1, inbox_wp2, bucket_wp1, bucket_wp2])
+    backlogs_page.expect_inbox_items_in_order(work_packages: [inbox_wp1, inbox_wp2, bucket_wp1, bucket_wp2])
 
     expect(BacklogBucket.where(id: bucket.id)).to be_empty
     expect(bucket_wp1.reload.backlog_bucket_id).to be_nil

--- a/modules/backlogs/spec/features/buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/buckets/delete_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Backlog bucket deletion", :js do
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_backlog_bucket(bucket)
 
-    backlogs_page.expect_inbox_items_in_order(work_packages: [inbox_wp1, inbox_wp2, bucket_wp1, bucket_wp2])
+    backlogs_page.expect_inbox_items_in_order(items: [inbox_wp1, inbox_wp2, bucket_wp1, bucket_wp2])
 
     expect(BacklogBucket.where(id: bucket.id)).to be_empty
     expect(bucket_wp1.reload.backlog_bucket_id).to be_nil

--- a/modules/backlogs/spec/features/buckets/display_spec.rb
+++ b/modules/backlogs/spec/features/buckets/display_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe "Backlog bucket display", :js do
     backlogs_page.visit!
 
     backlogs_page.expect_backlog_bucket_work_package_count(bucket_alpha, 2)
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(bucket_alpha,
+    backlogs_page.expect_bucket_items_in_order(bucket_alpha,
                                                                   work_packages: [wp_alpha1, wp_alpha2])
     backlogs_page.expect_backlog_bucket_work_package_count(bucket_beta, 1)
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(bucket_beta,
+    backlogs_page.expect_bucket_items_in_order(bucket_beta,
                                                                   work_packages: [wp_beta1])
   end
 

--- a/modules/backlogs/spec/features/buckets/display_spec.rb
+++ b/modules/backlogs/spec/features/buckets/display_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe "Backlog bucket display", :js do
 
     backlogs_page.expect_backlog_bucket_work_package_count(bucket_alpha, 2)
     backlogs_page.expect_bucket_items_in_order(bucket_alpha,
-                                                                  work_packages: [wp_alpha1, wp_alpha2])
+                                               items: [wp_alpha1, wp_alpha2])
     backlogs_page.expect_backlog_bucket_work_package_count(bucket_beta, 1)
     backlogs_page.expect_bucket_items_in_order(bucket_beta,
-                                                                  work_packages: [wp_beta1])
+                                               items: [wp_beta1])
   end
 
   it "shows the '+ Backlog bucket' button" do

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
 
     it "displays all items in position order and hides the blankslate" do
       planning_page.expect_inbox_items(items: [inbox_wp1, inbox_wp2, inbox_wp3])
-      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp1, inbox_wp2, inbox_wp3])
+      planning_page.expect_inbox_items_in_order(items: [inbox_wp1, inbox_wp2, inbox_wp3])
       planning_page.expect_no_inbox_blankslate
     end
 
@@ -241,19 +241,19 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       wait_for_network_idle
 
       planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move down")
-      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp1, inbox_wp3])
+      planning_page.expect_inbox_items_in_order(items: [inbox_wp2, inbox_wp1, inbox_wp3])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move down")
-      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp3, inbox_wp1])
+      planning_page.expect_inbox_items_in_order(items: [inbox_wp2, inbox_wp3, inbox_wp1])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp2, "Move to bottom")
-      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp3, inbox_wp1, inbox_wp2])
+      planning_page.expect_inbox_items_in_order(items: [inbox_wp3, inbox_wp1, inbox_wp2])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp2, "Move to top")
-      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp3, inbox_wp1])
+      planning_page.expect_inbox_items_in_order(items: [inbox_wp2, inbox_wp3, inbox_wp1])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move up")
-      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp1, inbox_wp3])
+      planning_page.expect_inbox_items_in_order(items: [inbox_wp2, inbox_wp1, inbox_wp3])
     end
 
     describe "moving backlog items to a sprint via the 'Move to sprint' menu item" do
@@ -275,7 +275,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
 
         planning_page.expect_no_inbox_items(items: inbox_wp1)
         planning_page.expect_sprint_items(sprint, items: inbox_wp1)
-        planning_page.expect_sprint_items_in_order(sprint, work_packages: [sprint_wp, inbox_wp1])
+        planning_page.expect_sprint_items_in_order(sprint, items: [sprint_wp, inbox_wp1])
       end
 
       context "when the target sprint is completed (race condition #73750)" do
@@ -376,19 +376,19 @@ RSpec.describe "Inbox column in sprint planning view", :js do
         end
 
         planning_page.click_in_work_package_move_submenu(top_item, "Move down")
-        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
+        planning_page.expect_sprint_items_in_order(sprint, items: [middle_item, top_item, bottom_item])
 
         planning_page.click_in_work_package_move_submenu(top_item, "Move down")
-        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
+        planning_page.expect_sprint_items_in_order(sprint, items: [middle_item, bottom_item, top_item])
 
         planning_page.click_in_work_package_move_submenu(middle_item, "Move to bottom")
-        planning_page.expect_sprint_items_in_order(sprint, work_packages: [bottom_item, top_item, middle_item])
+        planning_page.expect_sprint_items_in_order(sprint, items: [bottom_item, top_item, middle_item])
 
         planning_page.click_in_work_package_move_submenu(middle_item, "Move to top")
-        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
+        planning_page.expect_sprint_items_in_order(sprint, items: [middle_item, bottom_item, top_item])
 
         planning_page.click_in_work_package_move_submenu(top_item, "Move up")
-        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
+        planning_page.expect_sprint_items_in_order(sprint, items: [middle_item, top_item, bottom_item])
       end
     end
 

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -215,10 +215,8 @@ RSpec.describe "Inbox column in sprint planning view", :js do
     before { planning_page.visit! }
 
     it "displays all items in position order and hides the blankslate" do
-      planning_page.expect_inbox_item(inbox_wp1)
-      planning_page.expect_inbox_item(inbox_wp2)
-      planning_page.expect_inbox_item(inbox_wp3)
-      planning_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1, inbox_wp2, inbox_wp3])
+      planning_page.expect_inbox_items(items: [inbox_wp1, inbox_wp2, inbox_wp3])
+      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp1, inbox_wp2, inbox_wp3])
       planning_page.expect_no_inbox_blankslate
     end
 
@@ -243,19 +241,19 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       wait_for_network_idle
 
       planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move down")
-      planning_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2, inbox_wp1, inbox_wp3])
+      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp1, inbox_wp3])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move down")
-      planning_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2, inbox_wp3, inbox_wp1])
+      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp3, inbox_wp1])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp2, "Move to bottom")
-      planning_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp3, inbox_wp1, inbox_wp2])
+      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp3, inbox_wp1, inbox_wp2])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp2, "Move to top")
-      planning_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2, inbox_wp3, inbox_wp1])
+      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp3, inbox_wp1])
 
       planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move up")
-      planning_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2, inbox_wp1, inbox_wp3])
+      planning_page.expect_inbox_items_in_order(work_packages: [inbox_wp2, inbox_wp1, inbox_wp3])
     end
 
     describe "moving backlog items to a sprint via the 'Move to sprint' menu item" do
@@ -275,9 +273,9 @@ RSpec.describe "Inbox column in sprint planning view", :js do
           click_button "Move"
         end
 
-        planning_page.expect_no_inbox_item(inbox_wp1)
-        planning_page.expect_work_package_in_sprint(inbox_wp1, sprint)
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp, inbox_wp1])
+        planning_page.expect_no_inbox_items(items: inbox_wp1)
+        planning_page.expect_sprint_items(sprint, items: inbox_wp1)
+        planning_page.expect_sprint_items_in_order(sprint, work_packages: [sprint_wp, inbox_wp1])
       end
 
       context "when the target sprint is completed (race condition #73750)" do
@@ -300,8 +298,8 @@ RSpec.describe "Inbox column in sprint planning view", :js do
             )
 
           # Item was *not* moved:
-          planning_page.expect_inbox_item(inbox_wp1)
-          planning_page.expect_work_package_not_in_sprint(inbox_wp1, sprint)
+          planning_page.expect_inbox_items(items: inbox_wp1)
+          planning_page.expect_no_sprint_items(sprint, items: inbox_wp1)
         end
       end
     end
@@ -309,18 +307,16 @@ RSpec.describe "Inbox column in sprint planning view", :js do
     describe "moving backlog items to a sprint via drag-and-drop", :selenium do
       it "moves multiple items into the sprint one by one" do
         planning_page.drag_work_package_to_sprint(inbox_wp1, sprint)
-        planning_page.expect_no_inbox_item(inbox_wp1)
+        planning_page.expect_no_inbox_items(items: inbox_wp1)
 
         planning_page.drag_work_package_to_sprint(inbox_wp2, sprint)
-        planning_page.expect_no_inbox_item(inbox_wp2)
+        planning_page.expect_no_inbox_items(items: inbox_wp2)
 
         planning_page.drag_work_package_to_sprint(inbox_wp3, sprint)
-        planning_page.expect_no_inbox_item(inbox_wp3)
+        planning_page.expect_no_inbox_items(items: inbox_wp3)
 
         planning_page.expect_inbox_blankslate
-        planning_page.expect_work_package_in_sprint(inbox_wp1, sprint)
-        planning_page.expect_work_package_in_sprint(inbox_wp2, sprint)
-        planning_page.expect_work_package_in_sprint(inbox_wp3, sprint)
+        planning_page.expect_sprint_items(sprint, items: [inbox_wp1, inbox_wp2, inbox_wp3])
       end
 
       context "with real authentication and a private project",
@@ -345,7 +341,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
 
         it "moves a backlog item to the sprint without an error (Regression#73416)" do
           planning_page.drag_work_package_to_sprint(inbox_wp1, sprint)
-          planning_page.expect_no_inbox_item(inbox_wp1)
+          planning_page.expect_no_inbox_items(items: inbox_wp1)
         end
       end
     end
@@ -380,19 +376,19 @@ RSpec.describe "Inbox column in sprint planning view", :js do
         end
 
         planning_page.click_in_work_package_move_submenu(top_item, "Move down")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
+        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
 
         planning_page.click_in_work_package_move_submenu(top_item, "Move down")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
+        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
 
         planning_page.click_in_work_package_move_submenu(middle_item, "Move to bottom")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [bottom_item, top_item, middle_item])
+        planning_page.expect_sprint_items_in_order(sprint, work_packages: [bottom_item, top_item, middle_item])
 
         planning_page.click_in_work_package_move_submenu(middle_item, "Move to top")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
+        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
 
         planning_page.click_in_work_package_move_submenu(top_item, "Move up")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
+        planning_page.expect_sprint_items_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
       end
     end
 
@@ -409,10 +405,8 @@ RSpec.describe "Inbox column in sprint planning view", :js do
         planning_page.drag_work_package_to_backlog_inbox(sprint_wp2)
         wait_for_network_idle
 
-        planning_page.expect_work_package_not_in_sprint(sprint_wp1, sprint)
-        planning_page.expect_work_package_not_in_sprint(sprint_wp2, sprint)
-        planning_page.expect_inbox_item(sprint_wp1)
-        planning_page.expect_inbox_item(sprint_wp2)
+        planning_page.expect_no_sprint_items(sprint, items: [sprint_wp1, sprint_wp2])
+        planning_page.expect_inbox_items(items: [sprint_wp1, sprint_wp2])
       end
 
       context "when the sprint item is configured to be excluded from backlogs" do
@@ -433,8 +427,8 @@ RSpec.describe "Inbox column in sprint planning view", :js do
             "its type or status is excluded from the backlog."
 
           planning_page.expect_and_dismiss_flash(message:, type: :default)
-          planning_page.expect_work_package_not_in_sprint(sprint_wp1, sprint)
-          planning_page.expect_no_inbox_item(sprint_wp1)
+          planning_page.expect_no_sprint_items(sprint, items: sprint_wp1)
+          planning_page.expect_no_inbox_items(items: sprint_wp1)
         end
       end
     end

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -511,6 +511,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
         select sprint.name, from: "list_id"
         click_button "Move"
       end
+      planning_page.expect_no_inbox_items(items: inbox_items.last)
       planning_page.expect_no_inbox_show_more
 
       # Open a sprint story details view, edit the subject, and close

--- a/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
-      backlogs_page.expect_no_inbox_item(work_package)
+      backlogs_page.expect_bucket_items(bucket_a, items: work_package)
+      backlogs_page.expect_no_inbox_items(items: work_package)
 
       backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
       within_modal "Add existing work package" do
@@ -87,8 +87,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_work_package_in_sprint(work_package, sprint_a)
-      backlogs_page.expect_no_inbox_item(work_package)
+      backlogs_page.expect_sprint_items(sprint_a, items: work_package)
+      backlogs_page.expect_no_inbox_items(items: work_package)
 
       backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
       within_modal "Add existing work package" do
@@ -110,8 +110,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_inbox_item(work_package)
-      backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
+      backlogs_page.expect_inbox_items(items: work_package)
+      backlogs_page.expect_no_bucket_items(bucket_a, items: work_package)
 
       backlogs_page.click_in_inbox_menu("Add existing work package")
       within_modal "Add existing work package" do
@@ -129,8 +129,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_b)
-      backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
+      backlogs_page.expect_bucket_items(bucket_b, items: work_package)
+      backlogs_page.expect_no_bucket_items(bucket_a, items: work_package)
 
       backlogs_page.click_in_bucket_menu(bucket_b, "Add existing work package")
       within_modal "Add existing work package" do
@@ -148,8 +148,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_work_package_in_sprint(work_package, sprint_a)
-      backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
+      backlogs_page.expect_sprint_items(sprint_a, items: work_package)
+      backlogs_page.expect_no_bucket_items(bucket_a, items: work_package)
 
       backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
       within_modal "Add existing work package" do
@@ -171,8 +171,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_inbox_item(work_package)
-      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
+      backlogs_page.expect_inbox_items(items: work_package)
+      backlogs_page.expect_no_sprint_items(sprint_a, items: work_package)
 
       backlogs_page.click_in_inbox_menu("Add existing work package")
       within_modal "Add existing work package" do
@@ -190,8 +190,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
-      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
+      backlogs_page.expect_bucket_items(bucket_a, items: work_package)
+      backlogs_page.expect_no_sprint_items(sprint_a, items: work_package)
 
       backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
       within_modal "Add existing work package" do
@@ -209,8 +209,8 @@ RSpec.describe "Add existing work package", :js do
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
-      backlogs_page.expect_work_package_in_sprint(work_package, sprint_b)
-      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
+      backlogs_page.expect_sprint_items(sprint_b, items: work_package)
+      backlogs_page.expect_no_sprint_items(sprint_a, items: work_package)
 
       backlogs_page.click_in_sprint_menu(sprint_b, "Add existing work package")
       within_modal "Add existing work package" do

--- a/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Create work package", :js do
         .to have_no_text "Another story"
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_wp1,
                                                                  sprint1_wp2,
                                                                  created_work_package])
@@ -143,7 +143,7 @@ RSpec.describe "Create work package", :js do
       created_work_package = WorkPackage.last
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint2,
+        .expect_sprint_items_in_order(sprint2,
                                                  work_packages: [created_work_package])
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe "Create work package", :js do
       created_work_package = WorkPackage.last
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_other_project_wp1,
                                                                  created_work_package])
     end
@@ -182,7 +182,7 @@ RSpec.describe "Create work package", :js do
 
       expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
 
-      backlogs_page.expect_work_package_in_backlog_bucket(WorkPackage.last, bucket)
+      backlogs_page.expect_bucket_items(bucket, items: WorkPackage.last)
     end
   end
 
@@ -197,7 +197,7 @@ RSpec.describe "Create work package", :js do
 
       expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
 
-      backlogs_page.expect_inbox_item(WorkPackage.last)
+      backlogs_page.expect_inbox_items(items: WorkPackage.last)
     end
   end
 

--- a/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe "Create work package", :js do
 
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_wp1,
-                                                                 sprint1_wp2,
-                                                                 created_work_package])
+                                      items: [sprint1_wp1,
+                                              sprint1_wp2,
+                                              created_work_package])
 
       # created with the selected type (HighlightedTypeComponent renders type name in uppercase)
       backlogs_page.within_work_package(created_work_package) do
@@ -143,8 +143,7 @@ RSpec.describe "Create work package", :js do
       created_work_package = WorkPackage.last
 
       backlogs_page
-        .expect_sprint_items_in_order(sprint2,
-                                                 work_packages: [created_work_package])
+        .expect_sprint_items_in_order(sprint2, items: [created_work_package])
     end
   end
 
@@ -166,8 +165,8 @@ RSpec.describe "Create work package", :js do
 
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_other_project_wp1,
-                                                                 created_work_package])
+                                      items: [sprint1_other_project_wp1,
+                                              created_work_package])
     end
   end
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
   it "reorders work packages within a bucket" do
     backlogs_page.visit!
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
 
     backlogs_page.drag_work_package(alpha_wp1, before: alpha_wp3)
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
     )
   end
@@ -76,7 +76,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
     backlogs_page.drag_work_package(alpha_wp3, before: alpha_wp1)
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp3, alpha_wp1, alpha_wp2]
     )
   end
@@ -84,14 +84,14 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
   it "does not move the first work package to the end when it is picked up and released" do
     backlogs_page.visit!
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
 
     backlogs_page.pick_up_and_release_work_package(alpha_wp1)
 
     backlogs_page.expect_no_backlogs_move_request
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
   end
@@ -99,14 +99,14 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
   it "does not move a middle work package to the top when it is picked up and released" do
     backlogs_page.visit!
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
 
     backlogs_page.pick_up_and_release_work_package(alpha_wp2)
 
     backlogs_page.expect_no_backlogs_move_request
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
   end
@@ -116,13 +116,13 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
       backlogs_page.visit!
 
       backlogs_page.click_in_inbox_move_menu(alpha_wp2, "Move down")
-      backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      backlogs_page.expect_bucket_items_in_order(
         bucket_alpha, work_packages: [alpha_wp1, alpha_wp3, alpha_wp2]
       )
 
       backlogs_page.drag_work_package(alpha_wp2, before: alpha_wp1)
 
-      backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      backlogs_page.expect_bucket_items_in_order(
         bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
       )
     end
@@ -142,7 +142,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     # move request itself.
     backlogs_page.expect_filter_count(:backlog_bucket, 1)
     backlogs_page.expect_no_backlog_bucket(bucket_beta)
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
     )
   end
@@ -152,10 +152,10 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
     backlogs_page.drag_work_package_to_backlog_bucket(alpha_wp1, bucket_beta)
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp2, alpha_wp3]
     )
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_beta, work_packages: [alpha_wp1]
     )
 
@@ -167,7 +167,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.apply_bucket_filter(bucket_alpha, include_inbox: true)
     backlogs_page.drag_work_package_to_backlog_inbox(alpha_wp1)
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_alpha, work_packages: [alpha_wp2, alpha_wp3]
     )
 
@@ -180,7 +180,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
     backlogs_page.drag_work_package_to_backlog_bucket(inbox_wp1, bucket_beta)
 
-    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+    backlogs_page.expect_bucket_items_in_order(
       bucket_beta, work_packages: [inbox_wp1]
     )
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
   it "moves a work package from a bucket into the Inbox" do
     backlogs_page.visit!
-
+    backlogs_page.apply_bucket_filter(bucket_alpha, include_inbox: true)
     backlogs_page.drag_work_package_to_backlog_inbox(alpha_wp1)
 
     backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
@@ -176,6 +176,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
   it "moves a work package from the Inbox into a bucket" do
     backlogs_page.visit!
+    backlogs_page.apply_bucket_filter(bucket_beta, include_inbox: true)
 
     backlogs_page.drag_work_package_to_backlog_bucket(inbox_wp1, bucket_beta)
 
@@ -197,6 +198,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
   it "shows the blankslate after dragging the last work package out of a bucket" do
     backlogs_page.visit!
+    backlogs_page.apply_bucket_filter(bucket_gamma, include_inbox: true)
     backlogs_page.expect_no_backlog_bucket_blankslate(bucket_gamma)
 
     backlogs_page.drag_work_package_to_backlog_inbox(gamma_wp1)

--- a/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.visit!
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
 
     backlogs_page.drag_work_package(alpha_wp1, before: alpha_wp3)
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
+      bucket_alpha, items: [alpha_wp2, alpha_wp1, alpha_wp3]
     )
   end
 
@@ -77,7 +77,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.drag_work_package(alpha_wp3, before: alpha_wp1)
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp3, alpha_wp1, alpha_wp2]
+      bucket_alpha, items: [alpha_wp3, alpha_wp1, alpha_wp2]
     )
   end
 
@@ -85,14 +85,14 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.visit!
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
 
     backlogs_page.pick_up_and_release_work_package(alpha_wp1)
 
     backlogs_page.expect_no_backlogs_move_request
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
   end
 
@@ -100,14 +100,14 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.visit!
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
 
     backlogs_page.pick_up_and_release_work_package(alpha_wp2)
 
     backlogs_page.expect_no_backlogs_move_request
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp1, alpha_wp2, alpha_wp3]
     )
   end
 
@@ -117,13 +117,13 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
 
       backlogs_page.click_in_inbox_move_menu(alpha_wp2, "Move down")
       backlogs_page.expect_bucket_items_in_order(
-        bucket_alpha, work_packages: [alpha_wp1, alpha_wp3, alpha_wp2]
+        bucket_alpha, items: [alpha_wp1, alpha_wp3, alpha_wp2]
       )
 
       backlogs_page.drag_work_package(alpha_wp2, before: alpha_wp1)
 
       backlogs_page.expect_bucket_items_in_order(
-        bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
+        bucket_alpha, items: [alpha_wp2, alpha_wp1, alpha_wp3]
       )
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.expect_filter_count(:backlog_bucket, 1)
     backlogs_page.expect_no_backlog_bucket(bucket_beta)
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
+      bucket_alpha, items: [alpha_wp2, alpha_wp1, alpha_wp3]
     )
   end
 
@@ -153,10 +153,10 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.drag_work_package_to_backlog_bucket(alpha_wp1, bucket_beta)
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp2, alpha_wp3]
     )
     backlogs_page.expect_bucket_items_in_order(
-      bucket_beta, work_packages: [alpha_wp1]
+      bucket_beta, items: [alpha_wp1]
     )
 
     expect(alpha_wp1.reload.backlog_bucket_id).to eq(bucket_beta.id)
@@ -168,7 +168,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.drag_work_package_to_backlog_inbox(alpha_wp1)
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_alpha, work_packages: [alpha_wp2, alpha_wp3]
+      bucket_alpha, items: [alpha_wp2, alpha_wp3]
     )
 
     expect(alpha_wp1.reload.backlog_bucket_id).to be_nil
@@ -181,7 +181,7 @@ RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
     backlogs_page.drag_work_package_to_backlog_bucket(inbox_wp1, bucket_beta)
 
     backlogs_page.expect_bucket_items_in_order(
-      bucket_beta, work_packages: [inbox_wp1]
+      bucket_beta, items: [inbox_wp1]
     )
 
     expect(inbox_wp1.reload.backlog_bucket_id).to eq(bucket_beta.id)

--- a/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Dragging work packages in the inbox",
     backlogs_page.visit!
 
     backlogs_page
-      .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1,
+      .expect_inbox_items_in_order(work_packages: [inbox_wp1,
                                                               inbox_wp2,
                                                               inbox_wp3,
                                                               inbox_wp4,
@@ -77,7 +77,7 @@ RSpec.describe "Dragging work packages in the inbox",
       .drag_work_package(inbox_wp1, before: inbox_wp4)
 
     backlogs_page
-      .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2,
+      .expect_inbox_items_in_order(work_packages: [inbox_wp2,
                                                               inbox_wp3,
                                                               inbox_wp1,
                                                               inbox_wp4,
@@ -86,7 +86,7 @@ RSpec.describe "Dragging work packages in the inbox",
       .drag_work_package(inbox_wp1, before: inbox_wp3)
 
     backlogs_page
-      .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2,
+      .expect_inbox_items_in_order(work_packages: [inbox_wp2,
                                                               inbox_wp1,
                                                               inbox_wp3,
                                                               inbox_wp4,
@@ -107,14 +107,14 @@ RSpec.describe "Dragging work packages in the inbox",
       backlogs_page.visit!
 
       backlogs_page
-        .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1,
+        .expect_inbox_items_in_order(work_packages: [inbox_wp1,
                                                                 inbox_wp4,
                                                                 inbox_wp5])
       backlogs_page
         .drag_work_package(inbox_wp1, before: inbox_wp5)
 
       backlogs_page
-        .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp4,
+        .expect_inbox_items_in_order(work_packages: [inbox_wp4,
                                                                 inbox_wp1,
                                                                 inbox_wp5])
     end
@@ -125,7 +125,7 @@ RSpec.describe "Dragging work packages in the inbox",
       backlogs_page.visit!
 
       backlogs_page.click_in_inbox_move_menu(inbox_wp2, "Move down")
-      backlogs_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1,
+      backlogs_page.expect_inbox_items_in_order(work_packages: [inbox_wp1,
                                                                            inbox_wp3,
                                                                            inbox_wp2,
                                                                            inbox_wp4,
@@ -133,7 +133,7 @@ RSpec.describe "Dragging work packages in the inbox",
 
       backlogs_page.drag_work_package(inbox_wp2, before: inbox_wp5)
 
-      backlogs_page.expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1,
+      backlogs_page.expect_inbox_items_in_order(work_packages: [inbox_wp1,
                                                                            inbox_wp3,
                                                                            inbox_wp4,
                                                                            inbox_wp2,

--- a/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
@@ -68,29 +68,29 @@ RSpec.describe "Dragging work packages in the inbox",
     backlogs_page.visit!
 
     backlogs_page
-      .expect_inbox_items_in_order(work_packages: [inbox_wp1,
-                                                              inbox_wp2,
-                                                              inbox_wp3,
-                                                              inbox_wp4,
-                                                              inbox_wp5])
+      .expect_inbox_items_in_order(items: [inbox_wp1,
+                                           inbox_wp2,
+                                           inbox_wp3,
+                                           inbox_wp4,
+                                           inbox_wp5])
     backlogs_page
       .drag_work_package(inbox_wp1, before: inbox_wp4)
 
     backlogs_page
-      .expect_inbox_items_in_order(work_packages: [inbox_wp2,
-                                                              inbox_wp3,
-                                                              inbox_wp1,
-                                                              inbox_wp4,
-                                                              inbox_wp5])
+      .expect_inbox_items_in_order(items: [inbox_wp2,
+                                           inbox_wp3,
+                                           inbox_wp1,
+                                           inbox_wp4,
+                                           inbox_wp5])
     backlogs_page
       .drag_work_package(inbox_wp1, before: inbox_wp3)
 
     backlogs_page
-      .expect_inbox_items_in_order(work_packages: [inbox_wp2,
-                                                              inbox_wp1,
-                                                              inbox_wp3,
-                                                              inbox_wp4,
-                                                              inbox_wp5])
+      .expect_inbox_items_in_order(items: [inbox_wp2,
+                                           inbox_wp1,
+                                           inbox_wp3,
+                                           inbox_wp4,
+                                           inbox_wp5])
   end
 
   context "when having closed work packages at the top" do
@@ -107,16 +107,16 @@ RSpec.describe "Dragging work packages in the inbox",
       backlogs_page.visit!
 
       backlogs_page
-        .expect_inbox_items_in_order(work_packages: [inbox_wp1,
-                                                                inbox_wp4,
-                                                                inbox_wp5])
+        .expect_inbox_items_in_order(items: [inbox_wp1,
+                                             inbox_wp4,
+                                             inbox_wp5])
       backlogs_page
         .drag_work_package(inbox_wp1, before: inbox_wp5)
 
       backlogs_page
-        .expect_inbox_items_in_order(work_packages: [inbox_wp4,
-                                                                inbox_wp1,
-                                                                inbox_wp5])
+        .expect_inbox_items_in_order(items: [inbox_wp4,
+                                             inbox_wp1,
+                                             inbox_wp5])
     end
   end
 
@@ -125,19 +125,19 @@ RSpec.describe "Dragging work packages in the inbox",
       backlogs_page.visit!
 
       backlogs_page.click_in_inbox_move_menu(inbox_wp2, "Move down")
-      backlogs_page.expect_inbox_items_in_order(work_packages: [inbox_wp1,
-                                                                           inbox_wp3,
-                                                                           inbox_wp2,
-                                                                           inbox_wp4,
-                                                                           inbox_wp5])
+      backlogs_page.expect_inbox_items_in_order(items: [inbox_wp1,
+                                                        inbox_wp3,
+                                                        inbox_wp2,
+                                                        inbox_wp4,
+                                                        inbox_wp5])
 
       backlogs_page.drag_work_package(inbox_wp2, before: inbox_wp5)
 
-      backlogs_page.expect_inbox_items_in_order(work_packages: [inbox_wp1,
-                                                                           inbox_wp3,
-                                                                           inbox_wp4,
-                                                                           inbox_wp2,
-                                                                           inbox_wp5])
+      backlogs_page.expect_inbox_items_in_order(items: [inbox_wp1,
+                                                        inbox_wp3,
+                                                        inbox_wp4,
+                                                        inbox_wp2,
+                                                        inbox_wp5])
     end
   end
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_sprint_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_sprint_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Dragging work packages in and between sprints",
   context "in a non shared sprint" do
     it "displays work packages in correct order and allows dragging them around" do
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_wp1,
                                                                  sprint1_wp2,
                                                                  sprint1_wp3,
@@ -95,7 +95,7 @@ RSpec.describe "Dragging work packages in and between sprints",
         .drag_work_package(sprint1_wp1, before: sprint1_wp4)
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_wp2,
                                                                  sprint1_wp3,
                                                                  sprint1_wp1,
@@ -104,7 +104,7 @@ RSpec.describe "Dragging work packages in and between sprints",
         .drag_work_package(sprint1_wp1, before: sprint1_wp3)
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_wp2,
                                                                  sprint1_wp1,
                                                                  sprint1_wp3,
@@ -114,19 +114,19 @@ RSpec.describe "Dragging work packages in and between sprints",
         .drag_work_package(sprint1_wp1, into: sprint2)
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_wp2,
                                                                  sprint1_wp3,
                                                                  sprint1_wp4])
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint2,
+        .expect_sprint_items_in_order(sprint2,
                                                  work_packages: [sprint1_wp1])
     end
 
     context "when the sprint item was morphed by a Turbo update" do
       it "allows dragging the morphed item" do
         backlogs_page.click_in_sprint_story_move_menu(sprint1_wp2, "Move down")
-        backlogs_page.expect_work_packages_in_sprint_in_order(sprint1,
+        backlogs_page.expect_sprint_items_in_order(sprint1,
                                                               work_packages: [sprint1_wp1,
                                                                               sprint1_wp3,
                                                                               sprint1_wp2,
@@ -134,7 +134,7 @@ RSpec.describe "Dragging work packages in and between sprints",
 
         backlogs_page.drag_work_package(sprint1_wp2, before: sprint1_wp1)
 
-        backlogs_page.expect_work_packages_in_sprint_in_order(sprint1,
+        backlogs_page.expect_sprint_items_in_order(sprint1,
                                                               work_packages: [sprint1_wp2,
                                                                               sprint1_wp1,
                                                                               sprint1_wp3,
@@ -144,7 +144,7 @@ RSpec.describe "Dragging work packages in and between sprints",
 
     it "keeps drop indicators active after moving a bucket item into the sprint" do
       backlogs_page.drag_work_package(bucket_wp2, before: sprint1_wp4)
-      backlogs_page.expect_work_packages_in_sprint_in_order(
+      backlogs_page.expect_sprint_items_in_order(
         sprint1,
         work_packages: [sprint1_wp1, sprint1_wp2, sprint1_wp3, bucket_wp2, sprint1_wp4]
       )
@@ -167,22 +167,22 @@ RSpec.describe "Dragging work packages in and between sprints",
       # placed relative to it. Previously it was dropped from the drop targets, so
       # the second card fell to the list end instead of landing above the first.
       backlogs_page.drag_work_package(bucket_wp1, into: sprint2)
-      backlogs_page.expect_work_packages_in_sprint_in_order(sprint2, work_packages: [bucket_wp1])
+      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp1])
 
       backlogs_page.drag_work_package(bucket_wp2, before: bucket_wp1)
 
-      backlogs_page.expect_work_packages_in_sprint_in_order(sprint2, work_packages: [bucket_wp2, bucket_wp1])
+      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp2, bucket_wp1])
     end
 
     it "accepts a drop below a card that was itself dropped into the sprint" do
       # Same regression as above, but landing on the lower edge of the
       # re-rendered card, so the second card is placed after it.
       backlogs_page.drag_work_package(bucket_wp1, into: sprint2)
-      backlogs_page.expect_work_packages_in_sprint_in_order(sprint2, work_packages: [bucket_wp1])
+      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp1])
 
       backlogs_page.drag_work_package(bucket_wp2, after: bucket_wp1)
 
-      backlogs_page.expect_work_packages_in_sprint_in_order(sprint2, work_packages: [bucket_wp1, bucket_wp2])
+      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp1, bucket_wp2])
     end
   end
 
@@ -207,7 +207,7 @@ RSpec.describe "Dragging work packages in and between sprints",
 
     it "displays work packages in correct order and allows dragging them around in a shared sprint" do
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_other_project_wp1,
                                                                  sprint1_other_project_wp2,
                                                                  sprint1_other_project_wp3])
@@ -215,7 +215,7 @@ RSpec.describe "Dragging work packages in and between sprints",
         .drag_work_package(sprint1_other_project_wp1, before: sprint1_other_project_wp3)
 
       backlogs_page
-        .expect_work_packages_in_sprint_in_order(sprint1,
+        .expect_sprint_items_in_order(sprint1,
                                                  work_packages: [sprint1_other_project_wp2,
                                                                  sprint1_other_project_wp1,
                                                                  sprint1_other_project_wp3])

--- a/modules/backlogs/spec/features/work_packages/drag_in_sprint_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_sprint_spec.rb
@@ -87,58 +87,57 @@ RSpec.describe "Dragging work packages in and between sprints",
     it "displays work packages in correct order and allows dragging them around" do
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_wp1,
-                                                                 sprint1_wp2,
-                                                                 sprint1_wp3,
-                                                                 sprint1_wp4])
+                                      items: [sprint1_wp1,
+                                              sprint1_wp2,
+                                              sprint1_wp3,
+                                              sprint1_wp4])
       backlogs_page
         .drag_work_package(sprint1_wp1, before: sprint1_wp4)
 
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_wp2,
-                                                                 sprint1_wp3,
-                                                                 sprint1_wp1,
-                                                                 sprint1_wp4])
+                                      items: [sprint1_wp2,
+                                              sprint1_wp3,
+                                              sprint1_wp1,
+                                              sprint1_wp4])
       backlogs_page
         .drag_work_package(sprint1_wp1, before: sprint1_wp3)
 
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_wp2,
-                                                                 sprint1_wp1,
-                                                                 sprint1_wp3,
-                                                                 sprint1_wp4])
+                                      items: [sprint1_wp2,
+                                              sprint1_wp1,
+                                              sprint1_wp3,
+                                              sprint1_wp4])
 
       backlogs_page
         .drag_work_package(sprint1_wp1, into: sprint2)
 
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_wp2,
-                                                                 sprint1_wp3,
-                                                                 sprint1_wp4])
+                                      items: [sprint1_wp2,
+                                              sprint1_wp3,
+                                              sprint1_wp4])
       backlogs_page
-        .expect_sprint_items_in_order(sprint2,
-                                                 work_packages: [sprint1_wp1])
+        .expect_sprint_items_in_order(sprint2, items: [sprint1_wp1])
     end
 
     context "when the sprint item was morphed by a Turbo update" do
       it "allows dragging the morphed item" do
         backlogs_page.click_in_sprint_story_move_menu(sprint1_wp2, "Move down")
         backlogs_page.expect_sprint_items_in_order(sprint1,
-                                                              work_packages: [sprint1_wp1,
-                                                                              sprint1_wp3,
-                                                                              sprint1_wp2,
-                                                                              sprint1_wp4])
+                                                   items: [sprint1_wp1,
+                                                           sprint1_wp3,
+                                                           sprint1_wp2,
+                                                           sprint1_wp4])
 
         backlogs_page.drag_work_package(sprint1_wp2, before: sprint1_wp1)
 
         backlogs_page.expect_sprint_items_in_order(sprint1,
-                                                              work_packages: [sprint1_wp2,
-                                                                              sprint1_wp1,
-                                                                              sprint1_wp3,
-                                                                              sprint1_wp4])
+                                                   items: [sprint1_wp2,
+                                                           sprint1_wp1,
+                                                           sprint1_wp3,
+                                                           sprint1_wp4])
       end
     end
 
@@ -146,7 +145,7 @@ RSpec.describe "Dragging work packages in and between sprints",
       backlogs_page.drag_work_package(bucket_wp2, before: sprint1_wp4)
       backlogs_page.expect_sprint_items_in_order(
         sprint1,
-        work_packages: [sprint1_wp1, sprint1_wp2, sprint1_wp3, bucket_wp2, sprint1_wp4]
+        items: [sprint1_wp1, sprint1_wp2, sprint1_wp3, bucket_wp2, sprint1_wp4]
       )
 
       backlogs_page.drag_work_package(sprint1_wp1, before: sprint1_wp3)
@@ -167,22 +166,22 @@ RSpec.describe "Dragging work packages in and between sprints",
       # placed relative to it. Previously it was dropped from the drop targets, so
       # the second card fell to the list end instead of landing above the first.
       backlogs_page.drag_work_package(bucket_wp1, into: sprint2)
-      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp1])
+      backlogs_page.expect_sprint_items_in_order(sprint2, items: [bucket_wp1])
 
       backlogs_page.drag_work_package(bucket_wp2, before: bucket_wp1)
 
-      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp2, bucket_wp1])
+      backlogs_page.expect_sprint_items_in_order(sprint2, items: [bucket_wp2, bucket_wp1])
     end
 
     it "accepts a drop below a card that was itself dropped into the sprint" do
       # Same regression as above, but landing on the lower edge of the
       # re-rendered card, so the second card is placed after it.
       backlogs_page.drag_work_package(bucket_wp1, into: sprint2)
-      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp1])
+      backlogs_page.expect_sprint_items_in_order(sprint2, items: [bucket_wp1])
 
       backlogs_page.drag_work_package(bucket_wp2, after: bucket_wp1)
 
-      backlogs_page.expect_sprint_items_in_order(sprint2, work_packages: [bucket_wp1, bucket_wp2])
+      backlogs_page.expect_sprint_items_in_order(sprint2, items: [bucket_wp1, bucket_wp2])
     end
   end
 
@@ -208,17 +207,17 @@ RSpec.describe "Dragging work packages in and between sprints",
     it "displays work packages in correct order and allows dragging them around in a shared sprint" do
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_other_project_wp1,
-                                                                 sprint1_other_project_wp2,
-                                                                 sprint1_other_project_wp3])
+                                      items: [sprint1_other_project_wp1,
+                                              sprint1_other_project_wp2,
+                                              sprint1_other_project_wp3])
       backlogs_page
         .drag_work_package(sprint1_other_project_wp1, before: sprint1_other_project_wp3)
 
       backlogs_page
         .expect_sprint_items_in_order(sprint1,
-                                                 work_packages: [sprint1_other_project_wp2,
-                                                                 sprint1_other_project_wp1,
-                                                                 sprint1_other_project_wp3])
+                                      items: [sprint1_other_project_wp2,
+                                              sprint1_other_project_wp1,
+                                              sprint1_other_project_wp3])
     end
   end
 end

--- a/modules/backlogs/spec/features/work_packages/edit_in_split_view_after_move_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/edit_in_split_view_after_move_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe "Editing a work package in the split view after moving it",
 
       move_work_package(target_sprint)
 
-      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint)
-      backlogs_page.expect_work_package_in_sprint(work_package, target_sprint)
+      backlogs_page.expect_no_sprint_items(sprint, items: work_package)
+      backlogs_page.expect_sprint_items(target_sprint, items: work_package)
       split_view.expect_attributes sprint: target_sprint
 
       split_view.edit_field(:subject).update("Updated after move")

--- a/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe "Move to backlog", :js do
 
         planning_page.click_in_work_package_menu(work_package, "Move to backlog inbox")
 
-        planning_page.expect_work_package_not_in_sprint(work_package, sprint)
-        planning_page.expect_inbox_item(work_package)
+        planning_page.expect_no_sprint_items(sprint, items: work_package)
+        planning_page.expect_inbox_items(items: work_package)
         planning_page.expect_no_sprints_total_counter
       end
     end
@@ -76,8 +76,8 @@ RSpec.describe "Move to backlog", :js do
         planning_page.visit!
         planning_page.click_in_work_package_menu(work_package, "Move to backlog inbox")
 
-        planning_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
-        planning_page.expect_inbox_item(work_package)
+        planning_page.expect_no_bucket_items(bucket_a, items: work_package)
+        planning_page.expect_inbox_items(items: work_package)
       end
     end
   end
@@ -97,8 +97,8 @@ RSpec.describe "Move to backlog", :js do
 
         wait_for_network_idle
 
-        planning_page.expect_work_package_not_in_sprint(work_package, sprint)
-        planning_page.expect_work_package_in_backlog_bucket(work_package, bucket_b)
+        planning_page.expect_no_sprint_items(sprint, items: work_package)
+        planning_page.expect_bucket_items(bucket_b, items: work_package)
       end
     end
 
@@ -116,8 +116,8 @@ RSpec.describe "Move to backlog", :js do
 
         wait_for_network_idle
 
-        planning_page.expect_no_inbox_item(work_package)
-        planning_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
+        planning_page.expect_no_inbox_items(items: work_package)
+        planning_page.expect_bucket_items(bucket_a, items: work_package)
       end
     end
 
@@ -137,8 +137,8 @@ RSpec.describe "Move to backlog", :js do
 
         wait_for_network_idle
 
-        planning_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
-        planning_page.expect_work_package_in_backlog_bucket(work_package, bucket_b)
+        planning_page.expect_no_bucket_items(bucket_a, items: work_package)
+        planning_page.expect_bucket_items(bucket_b, items: work_package)
       end
     end
   end
@@ -152,7 +152,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog excluding the current sprint, and moves to another sprint" do
         planning_page.visit!
-        planning_page.expect_work_package_in_sprint(work_package, sprint)
+        planning_page.expect_sprint_items(sprint, items: work_package)
 
         planning_page.click_in_work_package_menu(work_package, "Move to sprint", wait: false)
 
@@ -166,8 +166,8 @@ RSpec.describe "Move to backlog", :js do
 
         wait_for_network_idle
 
-        planning_page.expect_work_package_not_in_sprint(work_package, sprint)
-        planning_page.expect_work_package_in_sprint(work_package, second_sprint)
+        planning_page.expect_no_sprint_items(sprint, items: work_package)
+        planning_page.expect_sprint_items(second_sprint, items: work_package)
       end
     end
 
@@ -187,8 +187,8 @@ RSpec.describe "Move to backlog", :js do
 
         wait_for_network_idle
 
-        planning_page.expect_no_inbox_item(work_package)
-        planning_page.expect_work_package_in_sprint(work_package, sprint)
+        planning_page.expect_no_inbox_items(items: work_package)
+        planning_page.expect_sprint_items(sprint, items: work_package)
         planning_page.expect_sprints_total_count(1)
       end
     end
@@ -209,8 +209,8 @@ RSpec.describe "Move to backlog", :js do
 
         wait_for_network_idle
 
-        planning_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
-        planning_page.expect_work_package_in_sprint(work_package, sprint)
+        planning_page.expect_no_bucket_items(bucket_a, items: work_package)
+        planning_page.expect_sprint_items(sprint, items: work_package)
         planning_page.expect_sprints_total_count(1)
       end
     end

--- a/modules/backlogs/spec/features/work_packages/move_via_menu_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_via_menu_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Move a backlog card via its menu",
   it "moves the card up optimistically and persists" do
     backlogs_page
       .expect_sprint_items_in_order(sprint,
-                                               work_packages: [sprint_wp1, sprint_wp2, sprint_wp3, sprint_wp4])
+                                    items: [sprint_wp1, sprint_wp2, sprint_wp3, sprint_wp4])
 
     # Arm the reload probe before triggering the move: a full frame reload
     # (the old behaviour) would still leave the list in the expected order
@@ -89,7 +89,7 @@ RSpec.describe "Move a backlog card via its menu",
 
     backlogs_page
       .expect_sprint_items_in_order(sprint,
-                                               work_packages: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
+                                    items: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
 
     backlogs_page.expect_backlogs_container_not_reloaded
 
@@ -102,6 +102,6 @@ RSpec.describe "Move a backlog card via its menu",
     backlogs_page.visit!
     backlogs_page
       .expect_sprint_items_in_order(sprint,
-                                               work_packages: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
+                                    items: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
   end
 end

--- a/modules/backlogs/spec/features/work_packages/move_via_menu_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_via_menu_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Move a backlog card via its menu",
 
   it "moves the card up optimistically and persists" do
     backlogs_page
-      .expect_work_packages_in_sprint_in_order(sprint,
+      .expect_sprint_items_in_order(sprint,
                                                work_packages: [sprint_wp1, sprint_wp2, sprint_wp3, sprint_wp4])
 
     # Arm the reload probe before triggering the move: a full frame reload
@@ -88,7 +88,7 @@ RSpec.describe "Move a backlog card via its menu",
       .click_in_sprint_story_move_menu(sprint_wp2, "Move up", wait: false)
 
     backlogs_page
-      .expect_work_packages_in_sprint_in_order(sprint,
+      .expect_sprint_items_in_order(sprint,
                                                work_packages: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
 
     backlogs_page.expect_backlogs_container_not_reloaded
@@ -101,7 +101,7 @@ RSpec.describe "Move a backlog card via its menu",
     # reflected in the client's optimistic DOM state.
     backlogs_page.visit!
     backlogs_page
-      .expect_work_packages_in_sprint_in_order(sprint,
+      .expect_sprint_items_in_order(sprint,
                                                work_packages: [sprint_wp2, sprint_wp1, sprint_wp3, sprint_wp4])
   end
 end

--- a/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "A read-only work package card in Backlogs",
   end
 
   it "can be reordered within its own list, and stays a drop target", :aggregate_failures do
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [movable_wp, rejected_wp])
 
     backlogs_page.expect_work_package_confined(rejected_wp)
 
@@ -81,21 +81,21 @@ RSpec.describe "A read-only work package card in Backlogs",
     # position is not one of its attributes — so the card keeps its drag
     # inside its own list.
     backlogs_page.drag_work_package(rejected_wp, before: movable_wp)
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [rejected_wp, movable_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [rejected_wp, movable_wp])
 
     # Dropping a movable neighbour against it proves the read-only card is
     # also still a drop target: confining its drag must not carve a dead zone
     # out of the list.
     backlogs_page.drag_work_package(movable_wp, before: rejected_wp)
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [movable_wp, rejected_wp])
   end
 
   it "refuses to leave its sprint by drag", :aggregate_failures do
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [movable_wp, rejected_wp])
 
     backlogs_page.drag_work_package_without_move(rejected_wp, into: other_sprint)
 
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [movable_wp, rejected_wp])
     expect(rejected_wp.reload.sprint_id).to eq(sprint.id)
   end
 
@@ -115,11 +115,11 @@ RSpec.describe "A read-only work package card in Backlogs",
   # positional move and the server accepts it, proving the two agree on what a
   # read-only work package may do.
   it "moves within its list through the positional menu actions" do
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [movable_wp, rejected_wp])
 
     backlogs_page.click_in_work_package_move_submenu(rejected_wp, I18n.t(:label_sort_highest))
 
-    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [rejected_wp, movable_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, items: [rejected_wp, movable_wp])
   end
 
   it "keeps the movement actions on a movable card in the same sprint" do

--- a/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "A read-only work package card in Backlogs",
   end
 
   it "can be reordered within its own list, and stays a drop target", :aggregate_failures do
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
 
     backlogs_page.expect_work_package_confined(rejected_wp)
 
@@ -81,21 +81,21 @@ RSpec.describe "A read-only work package card in Backlogs",
     # position is not one of its attributes — so the card keeps its drag
     # inside its own list.
     backlogs_page.drag_work_package(rejected_wp, before: movable_wp)
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [rejected_wp, movable_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [rejected_wp, movable_wp])
 
     # Dropping a movable neighbour against it proves the read-only card is
     # also still a drop target: confining its drag must not carve a dead zone
     # out of the list.
     backlogs_page.drag_work_package(movable_wp, before: rejected_wp)
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
   end
 
   it "refuses to leave its sprint by drag", :aggregate_failures do
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
 
     backlogs_page.drag_work_package_without_move(rejected_wp, into: other_sprint)
 
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
     expect(rejected_wp.reload.sprint_id).to eq(sprint.id)
   end
 
@@ -115,11 +115,11 @@ RSpec.describe "A read-only work package card in Backlogs",
   # positional move and the server accepts it, proving the two agree on what a
   # read-only work package may do.
   it "moves within its list through the positional menu actions" do
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [movable_wp, rejected_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [movable_wp, rejected_wp])
 
     backlogs_page.click_in_work_package_move_submenu(rejected_wp, I18n.t(:label_sort_highest))
 
-    backlogs_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [rejected_wp, movable_wp])
+    backlogs_page.expect_sprint_items_in_order(sprint, work_packages: [rejected_wp, movable_wp])
   end
 
   it "keeps the movement actions on a movable card in the same sprint" do

--- a/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
+++ b/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Backlogs::CommonHelper do
         expect(helper.backlog_filters.bucket_ids).to be_nil
       end
     end
+
+    context "with a filters param" do
+      let(:params) { { filters: 'status_id = "1"' } }
+
+      it "includes it in to_h" do
+        expect(helper.backlog_filters.to_h).to eq({ filters: 'status_id = "1"' })
+      end
+    end
   end
 
   describe "#backlog_filter_params" do
@@ -101,6 +109,16 @@ RSpec.describe Backlogs::CommonHelper do
 
     it "returns the same hash as backlog_filters.to_h" do
       expect(helper.backlog_filter_params).to eq(helper.backlog_filters.to_h)
+    end
+
+    context "with a filters param" do
+      let(:params) { { bucket_ids: %w[1 2], filters: 'status_id = "1"' } }
+
+      it "carries the filters param through alongside bucket_ids/sprint_ids/all" do
+        expect(helper.backlog_filter_params).to eq(
+          { bucket_ids: [1, 2], filters: 'status_id = "1"' }
+        )
+      end
     end
   end
 

--- a/modules/backlogs/spec/models/backlogs/backlog_query_builder_spec.rb
+++ b/modules/backlogs/spec/models/backlogs/backlog_query_builder_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe Backlogs::BacklogQueryBuilder do
     end
   end
 
+  context "with an API style filter name" do
+    shared_let(:status) { create(:status) }
+    let(:params) { { filters: "status = \"#{status.id}\"" } }
+
+    it "applies the parsed filter to the query", :aggregate_failures do
+      filter = query.find_active_filter(:status_id)
+
+      expect(filter).to be_present
+      expect(filter.operator).to eq("=")
+      expect(filter.values).to eq([status.id.to_s])
+    end
+  end
+
   context "with a subject search filter" do
     let(:params) { { filters: 'subject ~ "foo"' } }
 

--- a/modules/backlogs/spec/models/backlogs/backlog_query_builder_spec.rb
+++ b/modules/backlogs/spec/models/backlogs/backlog_query_builder_spec.rb
@@ -38,16 +38,15 @@ RSpec.describe Backlogs::BacklogQueryBuilder do
 
   subject(:query) { described_class.new(project:, user:, params:).build(extra_filters:) }
 
+  let(:params) { {} }
   let(:extra_filters) { [] }
 
   context "with no filters param" do
-    let(:params) { {} }
-
     it "builds a valid, project-scoped query without generic filters", :aggregate_failures do
       expect(query).to be_valid
       expect(query.project).to eq(project)
       expect(query.include_subprojects?).to be false
-      expect(query.filters).to be_empty
+      expect(query.filters.map(&:name)).to contain_exactly(:project_id)
     end
   end
 
@@ -79,13 +78,11 @@ RSpec.describe Backlogs::BacklogQueryBuilder do
     let(:params) { { filters: "not json" } }
 
     it "ignores it and builds a query without generic filters" do
-      expect(query.filters).to be_empty
+      expect(query.filters.map(&:name)).to contain_exactly(:project_id)
     end
   end
 
   context "with default sorting" do
-    let(:params) { {} }
-
     it "sorts by position (with id as a tiebreak)" do
       expect(query.sort_criteria).to eq([%w[position asc], %w[id asc]])
     end
@@ -100,6 +97,112 @@ RSpec.describe Backlogs::BacklogQueryBuilder do
       filter = query.find_active_filter(:sprint_id)
 
       expect(filter.values).to eq([sprint.id.to_s])
+    end
+  end
+
+  describe "#build_sprint_work_packages" do
+    subject(:work_packages) do
+      described_class.new(project:, user:, params:).build_sprint_work_packages(sprint_ids:)
+    end
+
+    shared_let(:other_project) { create(:project) }
+    shared_let(:sprint) { create(:sprint, project:) }
+    shared_let(:other_sprint) { create(:sprint, project:) }
+    shared_let(:own_work_package) { create(:work_package, project:, sprint:) }
+    shared_let(:other_sprint_work_package) { create(:work_package, project:, sprint: other_sprint) }
+
+    context "with no explicit sprint selection" do
+      let(:sprint_ids) { [] }
+
+      it "returns no work packages" do
+        expect(work_packages).to be_empty
+      end
+    end
+
+    context "with a single sprint selected" do
+      let(:sprint_ids) { [sprint.id.to_s] }
+
+      it "returns only that sprint's work packages" do
+        expect(work_packages).to contain_exactly(own_work_package)
+      end
+    end
+
+    context "with multiple sprints selected" do
+      let(:sprint_ids) { [sprint.id.to_s, other_sprint.id.to_s] }
+
+      it "returns work packages from all of the given sprints" do
+        expect(work_packages).to contain_exactly(own_work_package, other_sprint_work_package)
+      end
+    end
+
+    context "when another project's work package shares the same sprint and filters try to widen scope" do
+      shared_let(:other_project_work_package) { create(:work_package, project: other_project, sprint:) }
+      let(:sprint_ids) { [sprint.id.to_s] }
+      let(:params) { { filters: "project_id = \"#{other_project.id}\"" } }
+
+      it "never returns the other project's work package, regardless of the requested project filter" do
+        expect(work_packages).not_to include(other_project_work_package)
+      end
+    end
+  end
+
+  describe "#build_backlog_work_packages" do
+    subject(:work_packages) do
+      described_class.new(project:, user:, params:).build_backlog_work_packages(bucket_ids:, show_inbox:)
+    end
+
+    shared_let(:other_project) { create(:project) }
+    shared_let(:bucket) { create(:backlog_bucket, project:) }
+    shared_let(:bucket_work_package) { create(:work_package, project:, backlog_bucket: bucket) }
+    shared_let(:inbox_work_package) { create(:work_package, project:) }
+
+    context "with no bucket selected and the inbox shown" do
+      let(:bucket_ids) { [] }
+      let(:show_inbox) { true }
+
+      it "returns only the inbox work packages" do
+        expect(work_packages).to contain_exactly(inbox_work_package)
+      end
+    end
+
+    context "with no bucket selected and the inbox is not shown" do
+      let(:bucket_ids) { [] }
+      let(:show_inbox) { false }
+
+      it "returns no work packages" do
+        expect(work_packages).to be_empty
+      end
+    end
+
+    context "with a bucket selected and the inbox hidden" do
+      let(:bucket_ids) { [bucket.id.to_s] }
+      let(:show_inbox) { false }
+
+      it "returns only the selected bucket's work packages" do
+        expect(work_packages).to contain_exactly(bucket_work_package)
+      end
+    end
+
+    context "with a bucket selected and the inbox shown" do
+      let(:bucket_ids) { [bucket.id.to_s] }
+      let(:show_inbox) { true }
+
+      it "returns both bucket and inbox work packages" do
+        expect(work_packages).to contain_exactly(bucket_work_package, inbox_work_package)
+      end
+    end
+
+    context "when another project's work package could match and filters try to widen scope" do
+      shared_let(:other_bucket) { create(:backlog_bucket, project: other_project) }
+      shared_let(:other_work_package) { create(:work_package, project: other_project, backlog_bucket: other_bucket) }
+
+      let(:bucket_ids) { [] }
+      let(:show_inbox) { true }
+      let(:params) { { filters: "project_id = \"#{other_project.id}\"" } }
+
+      it "never returns the other project's work package, regardless of the requested project filter" do
+        expect(work_packages).not_to include(other_work_package)
+      end
     end
   end
 end

--- a/modules/backlogs/spec/models/backlogs/backlog_query_builder_spec.rb
+++ b/modules/backlogs/spec/models/backlogs/backlog_query_builder_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::BacklogQueryBuilder do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+
+  before { login_as(user) }
+
+  subject(:query) { described_class.new(project:, user:, params:).build(extra_filters:) }
+
+  let(:extra_filters) { [] }
+
+  context "with no filters param" do
+    let(:params) { {} }
+
+    it "builds a valid, project-scoped query without generic filters", :aggregate_failures do
+      expect(query).to be_valid
+      expect(query.project).to eq(project)
+      expect(query.include_subprojects?).to be false
+      expect(query.filters).to be_empty
+    end
+  end
+
+  context "with a params-format filters param" do
+    shared_let(:status) { create(:status) }
+    let(:params) { { filters: "status_id = \"#{status.id}\"" } }
+
+    it "applies the parsed filter to the query", :aggregate_failures do
+      filter = query.find_active_filter(:status_id)
+
+      expect(filter).to be_present
+      expect(filter.operator).to eq("=")
+      expect(filter.values).to eq([status.id.to_s])
+    end
+  end
+
+  context "with a subject search filter" do
+    let(:params) { { filters: 'subject ~ "foo"' } }
+
+    it "survives valid_subset! and remains active", :aggregate_failures do
+      filter = query.find_active_filter(:subject)
+
+      expect(filter).to be_present
+      expect(filter.values).to eq(["foo"])
+    end
+  end
+
+  context "with a malformed filters param" do
+    let(:params) { { filters: "not json" } }
+
+    it "ignores it and builds a query without generic filters" do
+      expect(query.filters).to be_empty
+    end
+  end
+
+  context "with default sorting" do
+    let(:params) { {} }
+
+    it "sorts by position (with id as a tiebreak)" do
+      expect(query.sort_criteria).to eq([%w[position asc], %w[id asc]])
+    end
+  end
+
+  context "with extra_filters" do
+    shared_let(:sprint) { create(:sprint, project:) }
+    let(:params) { {} }
+    let(:extra_filters) { [[:sprint_id, "=", [sprint.id.to_s]]] }
+
+    it "applies them onto the query" do
+      filter = query.find_active_filter(:sprint_id)
+
+      expect(filter.values).to eq([sprint.id.to_s])
+    end
+  end
+end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -1068,10 +1068,8 @@ module Pages
     def selenium_drag_backlogs_item(source:, target:, edge: nil)
       install_backlogs_dnd_probe(source:, target:, edge:)
 
-      scroll_backlogs_source_into_view(source)
-
-      target_x, target_y = selenium_target_point(target.native.rect, edge:)
-      perform_native_drag(source:, target_x:, target_y:)
+      offset_x, offset_y = selenium_target_offset(target.native.rect, edge:)
+      perform_native_drag(source:, target:, offset_x:, offset_y:)
 
       # Assert Pragmatic DnD tore down its own honey-pot overlay before we force
       # a cleanup, so a regression that leaves the overlay stuck is caught here
@@ -1080,18 +1078,18 @@ module Pages
       clear_pragmatic_dnd_honey_pot
     end
 
-    def selenium_target_point(rect, edge:)
+    def selenium_target_offset(rect, edge:)
       offset = [6, rect.height / 4].min
 
       [
-        rect.x + (rect.width / 2),
+        0,
         case edge
         when :top
-          rect.y + offset
+          offset - (rect.height / 2)
         when :bottom
-          rect.y + rect.height - offset
+          (rect.height / 2) - offset
         else
-          rect.y + (rect.height / 2)
+          0
         end
       ].map(&:round)
     end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -692,7 +692,7 @@ module Pages
     end
 
     def apply_subject_filter(text)
-      fill_in "Search by subject", with: text
+      fill_in "Search work packages by subject", with: text
       wait_for_network_idle
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -171,21 +171,21 @@ module Pages
       wait_for_backlogs_network_idle
     end
 
-    def expect_inbox_items_in_order(work_packages: [])
+    def expect_inbox_items_in_order(items: [])
       within_backlog_inbox do
-        expect_work_packages_in_order work_packages:
+        expect_work_packages_in_order work_packages: items
       end
     end
 
-    def expect_bucket_items_in_order(bucket, work_packages: [])
+    def expect_bucket_items_in_order(bucket, items: [])
       within_backlog_bucket(bucket) do
-        expect_work_packages_in_order work_packages:
+        expect_work_packages_in_order work_packages: items
       end
     end
 
-    def expect_sprint_items_in_order(sprint, work_packages: [])
+    def expect_sprint_items_in_order(sprint, items: [])
       within_sprint(sprint) do
-        expect_work_packages_in_order work_packages:
+        expect_work_packages_in_order work_packages: items
       end
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -32,6 +32,8 @@ require "support/pages/page"
 
 module Pages
   class Backlog < Page
+    include ::Components::Common::Filters
+
     attr_reader :project
 
     def initialize(project)
@@ -690,6 +692,17 @@ module Pages
         click_on(I18n.t(:label_inbox), role: "option") if include_inbox
         click_on "Apply"
       end
+      wait_for_network_idle
+    end
+
+    def apply_subject_filter(text)
+      fill_in "Search by subject", with: text
+      wait_for_network_idle
+    end
+
+    def apply_status_filter(status, operator: "is (OR)")
+      open_filters
+      set_filter("status_id", "Status", operator, [status.name])
       wait_for_network_idle
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -696,6 +696,11 @@ module Pages
       wait_for_network_idle
     end
 
+    def clear_subject_filter
+      find_by_id("backlog-filters-form-clear-button").click
+      wait_for_network_idle
+    end
+
     def apply_status_filter(status, operator: "is (OR)")
       open_filters
       set_filter("status_id", "Status", operator, [status.name])

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -66,9 +66,11 @@ module Pages
       end
     end
 
-    def expect_backlog_bucket_blankslate(bucket)
+    def expect_backlog_bucket_blankslate(bucket, filtered: false)
+      text = filtered ? I18n.t("backlogs.blankslate_filtered_title") : "Backlog bucket is empty"
+
       within_backlog_bucket(bucket) do
-        expect(page).to have_selector(:heading, level: 4, text: "Backlog bucket is empty")
+        expect(page).to have_selector(:heading, level: 4, text:)
       end
     end
 
@@ -144,7 +146,7 @@ module Pages
       within_backlog_inbox do
         expect(page).to have_css(
           ".Counter",
-          accessible_name: I18n.t(:label_x_work_packages, count:)
+          accessible_name: I18n.t(:label_x_items, count:)
         )
       end
     end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -132,15 +132,20 @@ module Pages
       end
     end
 
-    def expect_inbox_item(work_package)
-      within_backlog_inbox do
-        expect(page).to have_css(work_package_selector(work_package))
-      end
+    def expect_inbox_items(items:)
+      within_backlog_inbox { expect_work_package_items(items:) }
     end
 
-    def expect_no_inbox_item(work_package)
+    def expect_no_inbox_items(items:)
+      within_backlog_inbox { expect_work_package_items(items:, present: false) }
+    end
+
+    def expect_inbox_work_package_count(count)
       within_backlog_inbox do
-        expect(page).to have_no_css(work_package_selector(work_package))
+        expect(page).to have_css(
+          ".Counter",
+          accessible_name: I18n.t(:label_x_work_packages, count:)
+        )
       end
     end
 
@@ -164,20 +169,19 @@ module Pages
       wait_for_backlogs_network_idle
     end
 
-    def expect_work_packages_in_inbox_in_order(work_packages: [])
+    def expect_inbox_items_in_order(work_packages: [])
       within_backlog_inbox do
         expect_work_packages_in_order work_packages:
       end
     end
 
-    def expect_work_packages_in_backlog_bucket_in_order(bucket, work_packages: [])
+    def expect_bucket_items_in_order(bucket, work_packages: [])
       within_backlog_bucket(bucket) do
         expect_work_packages_in_order work_packages:
       end
     end
 
-    def expect_work_packages_in_sprint_in_order(sprint,
-                                                work_packages: [])
+    def expect_sprint_items_in_order(sprint, work_packages: [])
       within_sprint(sprint) do
         expect_work_packages_in_order work_packages:
       end
@@ -245,11 +249,8 @@ module Pages
       end
     end
 
-    def expect_work_package_in_sprint(work_package, sprint)
-      within_sprint(sprint) do
-        expect(page)
-          .to have_selector(work_package_selector(work_package).to_s)
-      end
+    def expect_sprint_items(sprint, items:)
+      within_sprint(sprint) { expect_work_package_items(items:) }
     end
 
     def expect_work_package_text_in_sprint(work_package, sprint, text)
@@ -259,21 +260,16 @@ module Pages
       end
     end
 
-    def expect_work_package_not_in_sprint(work_package, sprint)
-      within_sprint(sprint) do
-        expect(page)
-          .to have_no_selector(work_package_selector(work_package).to_s)
-      end
+    def expect_no_sprint_items(sprint, items:)
+      within_sprint(sprint) { expect_work_package_items(items:, present: false) }
     end
 
     def expect_bucket_names_in_order(*bucket_names)
       expect(bucket_names_in_order).to eq(bucket_names)
     end
 
-    def expect_work_package_in_backlog_bucket(work_package, bucket)
-      within_backlog_bucket(bucket) do
-        expect(page).to have_css(work_package_selector(work_package))
-      end
+    def expect_bucket_items(bucket, items:)
+      within_backlog_bucket(bucket) { expect_work_package_items(items:) }
     end
 
     def expect_backlog_bucket_work_package_count(bucket, count)
@@ -285,10 +281,8 @@ module Pages
       end
     end
 
-    def expect_work_package_not_in_backlog_bucket(work_package, bucket)
-      within_backlog_bucket(bucket) do
-        expect(page).to have_no_css(work_package_selector(work_package))
-      end
+    def expect_no_bucket_items(bucket, items:)
+      within_backlog_bucket(bucket) { expect_work_package_items(items:, present: false) }
     end
 
     def within_sprint_menu(sprint, &)
@@ -993,6 +987,16 @@ module Pages
 
     def work_package_selector(work_package)
       test_selector("work-package-#{work_package.id}")
+    end
+
+    def expect_work_package_items(items:, present: true)
+      Array(items).each do |wp|
+        if present
+          expect(page).to have_css(work_package_selector(wp))
+        else
+          expect(page).to have_no_css(work_package_selector(wp))
+        end
+      end
     end
 
     # `.op-work-package-card` is the class the card component itself owns;

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -186,17 +186,8 @@ module Pages
     # visibility of every method declared after it in this class.
     private def drag_onto_list(source, list_name)
       # rubocop:enable Style/AccessModifierDeclarations
-      # Scroll to source first: perform_native_drag's internal scroll must not
-      # move the page after the target rect below is read.
-      scroll_to_element(source)
-
       target = page.find("#{list_selector(list_name)} [data-test-selector='op-wp-card-view']")
-      rect = target.native.rect
-      perform_native_drag(
-        source:,
-        target_x: rect.x + (rect.width / 2),
-        target_y: rect.y + (rect.height / 2)
-      )
+      perform_native_drag(source:, target:)
       wait_for_lists_reload
 
       # Wait a little more because the cards sorting order can still be changing

--- a/modules/documents/app/components/documents/sub_header_component.rb
+++ b/modules/documents/app/components/documents/sub_header_component.rb
@@ -44,7 +44,7 @@ module Documents
     def sub_header_data_attributes
       {
         controller: "filter--filters-form",
-        "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-turbo-stream-request-value": true,
         "filter--filters-form-url-path-name-value": search_project_documents_path(project),
         "filter--filters-form-output-format-value": "json",
         "filter--filters-form-clear-button-id-value": clear_button_id,

--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -5,7 +5,7 @@
         data: {
           controller: "filter--filters-form",
           "filter--filters-form-output-format-value": "json",
-          "filter--filters-form-perform-turbo-requests-value": true,
+          "filter--filters-form-turbo-stream-request-value": true,
           "filter--filters-form-display-filters-value": filters_expanded?
         }
       )

--- a/modules/wikis/app/components/wikis/wiki_pages/sub_header_component.rb
+++ b/modules/wikis/app/components/wikis/wiki_pages/sub_header_component.rb
@@ -44,7 +44,7 @@ module Wikis
       def sub_header_data_attributes
         {
           controller: "filter--filters-form",
-          "filter--filters-form-perform-turbo-requests-value": true,
+          "filter--filters-form-turbo-stream-request-value": true,
           "filter--filters-form-url-path-name-value": wiki_pages_path,
           "filter--filters-form-output-format-value": "json",
           "filter--filters-form-clear-button-id-value": clear_button_id,

--- a/spec/features/admin/custom_fields/projects/reorder_spec.rb
+++ b/spec/features/admin/custom_fields/projects/reorder_spec.rb
@@ -258,10 +258,8 @@ RSpec.describe "Reordering project attribute sections and fields", :js, :seleniu
   end
 
   def drag_via_handle(handle:, target_element:, edge: nil)
-    scroll_to_element(handle)
-
-    target_x, target_y = selenium_target_point(target_element.native.rect, edge:)
-    perform_native_drag(source: handle, target_x:, target_y:)
+    offset_x, offset_y = selenium_target_offset(target_element.native.rect, edge:)
+    perform_native_drag(source: handle, target: target_element, offset_x:, offset_y:)
 
     # Assert Pragmatic DnD tore down its own honey-pot overlay before we force
     # a cleanup, so a regression that leaves the overlay stuck is caught here
@@ -270,18 +268,18 @@ RSpec.describe "Reordering project attribute sections and fields", :js, :seleniu
     clear_pragmatic_dnd_honey_pot
   end
 
-  def selenium_target_point(rect, edge:)
+  def selenium_target_offset(rect, edge:)
     offset = [6, rect.height / 4].min
 
     [
-      rect.x + (rect.width / 2),
+      0,
       case edge
       when :top
-        rect.y + offset
+        offset - (rect.height / 2)
       when :bottom
-        rect.y + rect.height - offset
+        (rect.height / 2) - offset
       else
-        rect.y + (rect.height / 2)
+        0
       end
     ].map(&:round)
   end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -96,6 +96,23 @@ RSpec.describe Query,
       expect(classes).not_to include(Queries::WorkPackages::Filter::ManualSortFilter)
     end
 
+    it "excludes the relation-type filters and the generic relatable filter" do
+      classes = query.available_advanced_filters.map(&:class)
+
+      expect(classes).not_to include(Queries::WorkPackages::Filter::BlocksFilter,
+                                     Queries::WorkPackages::Filter::BlockedFilter,
+                                     Queries::WorkPackages::Filter::PrecedesFilter,
+                                     Queries::WorkPackages::Filter::FollowsFilter,
+                                     Queries::WorkPackages::Filter::DuplicatesFilter,
+                                     Queries::WorkPackages::Filter::DuplicatedFilter,
+                                     Queries::WorkPackages::Filter::PartofFilter,
+                                     Queries::WorkPackages::Filter::IncludesFilter,
+                                     Queries::WorkPackages::Filter::RequiresFilter,
+                                     Queries::WorkPackages::Filter::RequiredFilter,
+                                     Queries::WorkPackages::Filter::RelatesFilter,
+                                     Queries::WorkPackages::Filter::RelatableFilter)
+    end
+
     it "still exposes regular work-package filters" do
       classes = query.available_advanced_filters.map(&:class)
 

--- a/spec/requests/work_package_types/projects_tab_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "Work package type projects tab", :skip_csrf, type: :rails_reques
       get edit_type_projects_path(type_id: type.id)
 
       expect(page).to have_css("[data-controller~='filter--filters-form']" \
-                               "[data-filter--filters-form-perform-turbo-requests-value='true']")
+                               "[data-filter--filters-form-turbo-stream-request-value='true']")
     end
   end
 

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -218,6 +218,15 @@ module Components
         end
       end
 
+      def close_filters
+        return unless filters_expanded?
+
+        retry_block do
+          toggle_filters_section
+          expect(page).to have_no_css(".op-filters-form.-expanded")
+        end
+      end
+
       def filters_toggle
         page.find('[data-test-selector="filter-component-toggle"]')
       end

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -224,11 +224,10 @@ module Pages
       # These helpers have always meant "insert before the element currently at
       # index `to`" (Dragula's insertBefore semantics), so aim at the target's
       # top quarter — closest-edge resolution then inserts above it either way.
-      target_rect = target.native.rect
       perform_native_drag(
         source: source.find(handler),
-        target_x: target_rect.x + (target_rect.width / 2),
-        target_y: target_rect.y + (target_rect.height / 4)
+        target:,
+        offset_y: -(target.native.rect.height / 4)
       )
 
       sleep 1

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -69,7 +69,7 @@ end
 # chains, so multi-`perform` sequences never deliver the drop. Coordinates are
 # viewport-absolute; callers pick the exact drop point (edge targeting).
 def perform_native_drag(source:, target_x:, target_y:)
-  scroll_to_element(source)
+  scroll_to_element(source, block: :nearest)
 
   rect = source.native.rect
   source_x = (rect.x + (rect.width / 2)).to_i

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -66,14 +66,15 @@ end
 
 # Single-sequence primitive for native HTML5 drags (Pragmatic drag and drop):
 # once the native drag loop starts, Chrome swallows input from later action
-# chains, so multi-`perform` sequences never deliver the drop. Coordinates are
-# viewport-absolute; callers pick the exact drop point (edge targeting).
-def perform_native_drag(source:, target_x:, target_y:)
+# chains, so multi-`perform` sequences never deliver the drop. Offsets are
+# relative to the target element's center (callers pick the exact drop point
+# for edge targeting), so callers don't need to keep the target scrolled into
+# view before computing them.
+def perform_native_drag(source:, target:, offset_x: 0, offset_y: 0)
+  # Ensure both elements are on the page, note this works only if the screen
+  # size can fit both.
   scroll_to_element(source, block: :nearest)
-
-  rect = source.native.rect
-  source_x = (rect.x + (rect.width / 2)).to_i
-  source_y = (rect.y + (rect.height / 2)).to_i
+  scroll_to_element(target, block: :nearest)
 
   page
     .driver
@@ -82,7 +83,7 @@ def perform_native_drag(source:, target_x:, target_y:)
     .move_to(source.native)
     .click_and_hold(source.native)
     .pause(duration: 0.1)
-    .move_by(target_x.to_i - source_x, target_y.to_i - source_y)
+    .move_to(target.native, offset_x, offset_y)
     .pause(duration: 0.1)
     .release
     .perform


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-219

# What are you trying to accomplish?
Add work package filters to the backlogs page.

# What approach did you choose and why?
Use the existing FilterComponent and adapt it to display work package filters. The filter implementation submits a turbo frame request which updates the `#backlogs_container` turbo frame. Since the filter panel is outside of the turbo frame, the filter counts are updated via the `filters-form.controller` stimulus controller.

- [X] Handle the filter button count update via stimulus in the filters-form.controller.
- [X] Use a turbo frame navigation request in the `#backlogs_container` frame instead of relying on a turbo stream update.
- [X] Exclude work package relation filters as they are not UI exposed.
- [X] Use a `Query` object to apply the server side filtering for both sprints and backlog work packages. 
- [X] Fix backlog spacing on mobile with single column list

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
