### PR TITLE
Fix XWiki specs.

### DIFF
--- a/modules/wikis/spec/services/wikis/adapters/authentication_strategies/bearer_token_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/authentication_strategies/bearer_token_spec.rb
@@ -33,16 +33,13 @@ require_module_spec_helper
 
 RSpec.describe Wikis::Adapters::AuthenticationStrategies::BearerToken, :webmock do
   let(:url) { "https://xwiki.local/rest/" }
-  let(:user) { build_stubbed(:user) }
-  let(:oauth_client) { build_stubbed(:oauth_client) }
-  let(:provider) { instance_double(Wikis::XWikiProvider, oauth_client:) }
-  let(:oauth_client_token) { instance_double(OAuthClientToken, access_token: "test-token", expires_in: nil) }
+  let(:user) { create(:user) }
+  let(:provider) { create(:xwiki_provider, :with_oauth_client) }
+  let!(:oauth_client_token) do
+    create(:oauth_client_token, oauth_client: provider.oauth_client, user:, access_token: "test-token")
+  end
 
   subject(:strategy) { described_class.new(user, provider) }
-
-  before do
-    allow(OAuthClientToken).to receive(:find_by).with(user:, oauth_client:).and_return(oauth_client_token)
-  end
 
   describe "#call" do
     it "yields an http client configured with the bearer token" do
@@ -67,7 +64,7 @@ RSpec.describe Wikis::Adapters::AuthenticationStrategies::BearerToken, :webmock 
       expect(request_stub).to have_been_requested
     end
 
-    context "when no OAuth token exists for the user" do
+    context "when the user has not connected to the provider" do
       let(:oauth_client_token) { nil }
 
       it "returns a missing_token failure without yielding" do

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/user_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/user_spec.rb
@@ -32,20 +32,15 @@ require "spec_helper"
 require_module_spec_helper
 
 RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::User, :webmock do
-  let(:user) { build_stubbed(:user) }
-  let(:oauth_client) { build_stubbed(:oauth_client) }
-  let(:wiki_provider) { build_stubbed(:xwiki_provider, url: "https://xwiki.local/") }
+  let(:user) { create(:user) }
+  let(:wiki_provider) do
+    create(:xwiki_provider, :with_connected_user,
+           url: "https://xwiki.local/", connected_user: user, connected_user_token: "some-token")
+  end
   let(:root_url) { "https://xwiki.local/rest/" }
   let(:auth_strategy) { Wikis::Adapters::Input::AuthStrategy.build(key: :bearer_token, user:, provider: wiki_provider).value! }
 
   subject(:query) { described_class.new(model: wiki_provider) }
-
-  before do
-    allow(wiki_provider).to receive(:oauth_client).and_return(oauth_client)
-    allow(OAuthClientToken).to receive(:find_by)
-      .with(user:, oauth_client:)
-      .and_return(instance_double(OAuthClientToken, access_token: "some-token", expires_in: nil))
-  end
 
   it "is registered" do
     expect(Wikis::Adapters::Registry.resolve("xwiki.queries.user")).to eq(described_class)


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
TokenFetcher now looks up the token via
OAuthClientToken.lock("FOR UPDATE").find_by, so the specs' stub on OAuthClientToken.find_by no longer applies, and the real query found nothing.

Use real records via the xwiki_provider factory instead of stubbing the collaborator's query.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
