### PR TITLE
Fix inline macro wrapping

### DIFF
--- a/app/components/op_primer/inline_macro_component.html.erb
+++ b/app/components/op_primer/inline_macro_component.html.erb
@@ -28,8 +28,6 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= render(Primer::BaseComponent.new(tag: :span, **@system_arguments)) do %>
-  <%= render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :center)) do %>
-    <%= leading_visual_icon %>
-    <%= content %>
-  <% end %>
+  <%= leading_visual_icon %>
+  <%= content -%>
 <% end %>

--- a/app/components/op_primer/inline_macro_component.rb
+++ b/app/components/op_primer/inline_macro_component.rb
@@ -31,7 +31,7 @@
 module OpPrimer
   class InlineMacroComponent < Primer::Component
     renders_one :leading_visual_icon, ->(icon:, color: :muted) do
-      Primer::Beta::Octicon.new(icon:, color:, size: :xsmall, mr: 2)
+      Primer::Beta::Octicon.new(icon:, color:, size: :xsmall, mr: 1, vertical_align: :middle, classes: "op-inline-macro--icon")
     end
 
     def initialize(**system_arguments)

--- a/app/components/op_primer/inline_macro_component.sass
+++ b/app/components/op_primer/inline_macro_component.sass
@@ -1,2 +1,7 @@
 .op-inline-macro
   @include macro--text-style
+
+  .op-inline-macro--icon
+    // Fixing vertical alignment compared to text next to it
+    // maybe replace with "vertical-align: center" or "central" once they are widely supported
+    margin-bottom: 2px

--- a/lookbook/previews/op_primer/inline_macro_component_preview/with_surrounding_text.html.erb
+++ b/lookbook/previews/op_primer/inline_macro_component_preview/with_surrounding_text.html.erb
@@ -1,4 +1,5 @@
 <p>
-  A component commonly used inline is the <%= render(OpPrimer::InlineMacroComponent.new) { |c| c.with_leading_visual_icon(icon: :book); "InlineMacroComponent" } %>. It
-  can appear in the middle of other text.
+  A component commonly used inline is the <%= render(OpPrimer::InlineMacroComponent.new) { |c| c.with_leading_visual_icon(icon: :book); "InlineMacroComponent" } %>.
+  It can appear in the middle of other text.
+  When <%= render(OpPrimer::InlineMacroComponent.new) { |c| c.with_leading_visual_icon(icon: :book); "it contains a longer sentence it can also" } %> wrap multiple lines without issue.
 </p>


### PR DESCRIPTION
The flex layouting caused issues once the macro needed to flow across multiple lines of text. In extreme cases (very long macro on very short lines) this caused the text to be pushed out of the visible background box.

# Ticket
https://community.openproject.org/wp/XWI-162