### PR TITLE
[COMMS-965] Seed observed_in_versions form attribute in bug types

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -50,7 +50,8 @@ module Type::AttributeGroups
         percentage_done: :estimates_and_progress,
         spent_time: :estimates_and_progress,
         priority: :details,
-        observed_in_versions: :versions
+        # `:excluded` is not a "real" group. It's meant to exclude built in fields from the form
+        observed_in_versions: :excluded
       }
     end
 

--- a/app/seeders/basic_data/type_configuration_seeder.rb
+++ b/app/seeders/basic_data/type_configuration_seeder.rb
@@ -36,8 +36,8 @@ module BasicData
     def seed_data!
       seed_data.each("type_configuration") do |type_configuration_data|
         variant = seed_data.find_reference(type_configuration_data["type"]).default_variant
-        groups = query_groups(type_configuration_data)
-        groups += variant.default_attribute_groups if merge_form_configuration?(type_configuration_data)
+        groups = form_groups(type_configuration_data)
+        groups = merge_with_default_groups(groups, variant) if merge_form_configuration?(type_configuration_data)
         variant.update(attribute_groups: groups)
       end
     end
@@ -51,7 +51,7 @@ module BasicData
       references = []
       seed_data.each("type_configuration") do |type_configuration_data|
         Array(type_configuration_data["form_configuration"]).each do |form_config_attr|
-          references << form_config_attr["query"]
+          references << form_config_attr["query"] if form_config_attr["query"]
         end
       end
       references
@@ -61,17 +61,33 @@ module BasicData
 
     # Whether the form configuration defined in the seed data should be merged with the
     # variant's default form configuration as defined in the Ruby code. Defaults to false,
-    # in which case only the query groups from the seed data make up the form configuration.
+    # in which case only the groups from the seed data make up the form configuration.
     def merge_form_configuration?(type_configuration_data)
       ActiveModel::Type::Boolean.new.cast(type_configuration_data["merge_form_configuration"])
     end
 
-    def query_groups(type_configuration_data)
+    def form_groups(type_configuration_data)
       type_configuration_data["form_configuration"].map do |form_config_attr|
-        query = seed_data.find_reference(form_config_attr["query"])
-        query_association = "query_#{query.id}"
-        [form_config_attr["group_name"], [query_association.to_sym]]
+        if form_config_attr["query"]
+          query = seed_data.find_reference(form_config_attr["query"])
+          query_association = "query_#{query.id}"
+          [form_config_attr["group_name"], [query_association.to_sym]]
+        else
+          [form_config_attr["group_name"], Array(form_config_attr["attributes"]).map(&:to_s)]
+        end
       end
+    end
+
+    def merge_with_default_groups(groups, variant)
+      default_groups = variant.default_attribute_groups
+      default_keys = default_groups.map(&:first)
+
+      merged_defaults = default_groups.map do |key, members|
+        seeded = groups.find { |seeded_key, *| seeded_key == key }
+        seeded ? [key, members + seeded[1]] : [key, members]
+      end
+
+      groups.reject { |key, *| default_keys.include?(key) } + merged_defaults
     end
   end
 end

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -1185,6 +1185,12 @@ type_configuration:
     form_configuration:
       - t_group_name: "Tasks"
         query: :default_type_user_story__children_query
+  - type: :default_type_bug
+    merge_form_configuration: true
+    form_configuration:
+      - group_name: :details
+        attributes:
+          - observed_in_versions
 
 workflows:
   - type: :default_type_task

--- a/spec/seeders/basic_data/type_configuration_seeder_spec.rb
+++ b/spec/seeders/basic_data/type_configuration_seeder_spec.rb
@@ -128,4 +128,74 @@ RSpec.describe BasicData::TypeConfigurationSeeder do
       end
     end
   end
+
+  context "with a form_configuration entry listing plain attributes" do
+    context "with an explicit group_name" do
+      let(:data_hash) do
+        YAML.load <<~SEEDING_DATA_YAML
+          type_configuration:
+          - type: :default_type_summary_task
+            form_configuration:
+              - group_name: "Versions"
+                attributes:
+                  - observed_in_versions
+        SEEDING_DATA_YAML
+      end
+
+      it "adds an attribute group with the given title and attributes" do
+        seeder.seed!
+        attribute_groups_now = phase_variant.reload.attribute_groups
+
+        expect(attribute_groups_now)
+          .to include(an_instance_of(Type::AttributeGroup)
+            .and(having_attributes(key: "Versions", attributes: ["observed_in_versions"])))
+      end
+
+      context "with merge_form_configuration enabled" do
+        let(:data_hash) do
+          YAML.load <<~SEEDING_DATA_YAML
+            type_configuration:
+            - type: :default_type_summary_task
+              merge_form_configuration: true
+              form_configuration:
+                - group_name: "Versions"
+                  attributes:
+                    - observed_in_versions
+          SEEDING_DATA_YAML
+        end
+
+        it "keeps the seeded attribute group alongside the type's default form configuration" do
+          default_group_keys = phase_variant.default_attribute_groups.map(&:first)
+          seeder.seed!
+          attribute_groups_now = phase_variant.reload.attribute_groups
+
+          expect(attribute_groups_now.map(&:key)).to include("Versions", *default_group_keys)
+        end
+      end
+    end
+
+    context "with a group_name matching one of the type's default groups" do
+      let(:data_hash) do
+        YAML.load <<~SEEDING_DATA_YAML
+          type_configuration:
+          - type: :default_type_summary_task
+            merge_form_configuration: true
+            form_configuration:
+              - group_name: :details
+                attributes:
+                  - observed_in_versions
+        SEEDING_DATA_YAML
+      end
+
+      it "merges the seeded attributes into that default group instead of creating a separate one" do
+        default_details_members = phase_variant.default_attribute_groups.find { |key, _| key == :details }.last
+        seeder.seed!
+        attribute_groups_now = phase_variant.reload.attribute_groups
+
+        details_groups = attribute_groups_now.select { |group| group.key == :details }
+        expect(details_groups.size).to eq(1)
+        expect(details_groups.first.attributes).to eq(default_details_members + ["observed_in_versions"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-965/activity

# What are you trying to accomplish?
Adjust the default seeder so that Observed In Versions field is automatically available in Bug types on newly setup projects.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
