### PR TITLE
Code maintenance/COMMS-919: Remove version attribute compatibility translators

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -155,20 +155,7 @@ module Type::AttributeGroups
   end
 
   def custom_attribute_groups
-    groups = self[:attribute_groups].presence
-    return if groups.nil?
-
-    # Only one version attribute is offered at a time, so render whichever one a
-    # saved configuration holds as the one the current feature state exposes.
-    stored, offered = if Setting::WorkPackageMultipleVersions.active?
-                        %w[version target_versions]
-                      else
-                        %w[target_versions version]
-                      end
-
-    groups.map do |key, attributes, *rest|
-      [key, attributes.map { |attribute| attribute == stored ? offered : attribute }.uniq, *rest]
-    end
+    self[:attribute_groups].presence
   end
 
   def default_group_key(key)

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -46,7 +46,8 @@ module Type::Attributes
                 parent_id
                 parent
                 readonly
-                schedule_manually].freeze
+                schedule_manually
+                version].freeze
 
   included do
     # Allow plugins to define constraints
@@ -85,7 +86,6 @@ module Type::Attributes
       OpenProject::Cache.fetch_request_cached("all_work_package_form_attributes",
                                               *wp_cf_cache_parts,
                                               EXCLUDED.length,
-                                              Setting::WorkPackageMultipleVersions.active?,
                                               merge_date) do
         calculate_all_work_package_form_attributes(merge_date)
       end
@@ -139,14 +139,7 @@ module Type::Attributes
       # We always want to include the priority even if its required
       return false if key == "priority"
 
-      excluded_version_attribute?(key) || EXCLUDED.include?(key) || definition[:required]
-    end
-
-    # Only one of the two version attributes is offered at a time, matching the
-    # query columns: target_versions with the multiple versions feature enabled,
-    # the deprecated single version without it.
-    def excluded_version_attribute?(key)
-      key == (Setting::WorkPackageMultipleVersions.active? ? "version" : "target_versions")
+      EXCLUDED.include?(key) || definition[:required]
     end
 
     def merge_date_for_form_attributes(attributes)

--- a/app/models/work_package/pdf_export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/wp/attributes.rb
@@ -290,7 +290,13 @@ module WorkPackage::PDFExport::Wp::Attributes
   end
 
   def column_entry(column_name)
-    { label: WorkPackage.human_attribute_name(column_name), name: column_name }
+    { label: WorkPackage.human_attribute_name(column_label_attribute(column_name)), name: column_name }
+  end
+
+  def column_label_attribute(column_name)
+    return "version" if column_name == "target_versions" && !Setting::WorkPackageMultipleVersions.active?
+
+    column_name
   end
 
   def build_columns_table_cells(attribute_data)

--- a/db/migrate/20260831120000_migrate_version_to_target_versions_in_type_variants.rb
+++ b/db/migrate/20260831120000_migrate_version_to_target_versions_in_type_variants.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require Rails.root.join("db/migrate/migration_utils/utils")
+
+class MigrateVersionToTargetVersionsInTypeVariants < ActiveRecord::Migration[8.1]
+  include Migration::Utils
+
+  class MigratedTypeVariant < ActiveRecord::Base
+    self.table_name = "type_variants"
+    serialize :attribute_groups, type: Array
+  end
+
+  def up
+    migrate_attribute_groups
+    migrate_excluded_elements
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def migrate_attribute_groups
+    in_configurable_batches(MigratedTypeVariant.where.not(attribute_groups: nil)) do |batches|
+      batches.each_record do |variant|
+        groups = variant.attribute_groups
+        migrated = migrate_groups(groups)
+        next if migrated == groups
+
+        variant.update_column(:attribute_groups, migrated)
+      end
+    end
+  end
+
+  def migrate_groups(groups)
+    keep_renamed = groups.none? { |_key, attributes, *| attributes.include?("target_versions") }
+    groups.map do |key, attributes, *rest|
+      migrated = attributes.filter_map do |attribute|
+        next attribute unless attribute == "version"
+        next unless keep_renamed
+
+        keep_renamed = false
+        "target_versions"
+      end.uniq
+      [key, migrated, *rest]
+    end
+  end
+
+  def migrate_excluded_elements
+    execute <<~SQL.squish
+      UPDATE type_variants
+      SET form_configuration_excluded_elements =
+        ARRAY(SELECT DISTINCT unnest(array_replace(form_configuration_excluded_elements, 'version', 'target_versions')))
+      WHERE 'version' = ANY (form_configuration_excluded_elements)
+    SQL
+  end
+end

--- a/db/migrate/20260831120000_migrate_version_to_target_versions_in_type_variants.rb
+++ b/db/migrate/20260831120000_migrate_version_to_target_versions_in_type_variants.rb
@@ -41,11 +41,10 @@ class MigrateVersionToTargetVersionsInTypeVariants < ActiveRecord::Migration[8.1
   def up
     migrate_attribute_groups
     migrate_excluded_elements
+    migrate_attribute_help_texts
   end
 
-  def down
-    raise ActiveRecord::IrreversibleMigration
-  end
+  def down; end
 
   private
 
@@ -62,13 +61,13 @@ class MigrateVersionToTargetVersionsInTypeVariants < ActiveRecord::Migration[8.1
   end
 
   def migrate_groups(groups)
-    keep_renamed = groups.none? { |_key, attributes, *| attributes.include?("target_versions") }
+    rename_next_occurrence = groups.none? { |_key, attributes, *| attributes.include?("target_versions") }
     groups.map do |key, attributes, *rest|
       migrated = attributes.filter_map do |attribute|
         next attribute unless attribute == "version"
-        next unless keep_renamed
+        next unless rename_next_occurrence
 
-        keep_renamed = false
+        rename_next_occurrence = false
         "target_versions"
       end.uniq
       [key, migrated, *rest]
@@ -81,6 +80,17 @@ class MigrateVersionToTargetVersionsInTypeVariants < ActiveRecord::Migration[8.1
       SET form_configuration_excluded_elements =
         ARRAY(SELECT DISTINCT unnest(array_replace(form_configuration_excluded_elements, 'version', 'target_versions')))
       WHERE 'version' = ANY (form_configuration_excluded_elements)
+    SQL
+  end
+
+  def migrate_attribute_help_texts
+    execute <<~SQL.squish
+      UPDATE attribute_help_texts
+      SET attribute_name = 'target_versions'
+      WHERE id = (SELECT min(id) FROM attribute_help_texts
+                  WHERE type = 'AttributeHelpText::WorkPackage' AND attribute_name = 'version')
+        AND NOT EXISTS (SELECT 1 FROM attribute_help_texts t
+                        WHERE t.type = 'AttributeHelpText::WorkPackage' AND t.attribute_name = 'target_versions')
     SQL
   end
 end

--- a/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
+++ b/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
@@ -237,26 +237,23 @@ module WorkPackageTypes
           end
         end
 
-        context "when the multiple versions feature is inactive",
-                with_settings: { work_package_multiple_versions: false } do
-          it "accepts the deprecated version" do
-            model.attribute_groups = [["foo", ["version"]]]
+        it "accepts target_versions" do
+          model.attribute_groups = [["foo", ["target_versions"]]]
 
-            expect(contract).to be_valid
-          end
-
-          it "rejects target_versions as an unknown attribute" do
-            model.attribute_groups = [["foo", ["target_versions"]]]
-
-            expect(contract).not_to be_valid
-            expect(contract.errors.details[:attribute_groups]).to include(
-              error: "Invalid work package attribute used: target_versions"
-            )
-          end
+          expect(contract).to be_valid
         end
 
-        context "when the multiple versions feature is active",
-                with_settings: { work_package_multiple_versions: true } do
+        it "rejects the deprecated version as an unknown attribute" do
+          model.attribute_groups = [["foo", ["version"]]]
+
+          expect(contract).not_to be_valid
+          expect(contract.errors.details[:attribute_groups]).to include(
+            error: "Invalid work package attribute used: version"
+          )
+        end
+
+        context "when the multiple versions feature is inactive",
+                with_settings: { work_package_multiple_versions: false } do
           it "accepts target_versions" do
             model.attribute_groups = [["foo", ["target_versions"]]]
 

--- a/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
+++ b/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
@@ -254,12 +254,6 @@ module WorkPackageTypes
 
         context "when the multiple versions feature is inactive",
                 with_settings: { work_package_multiple_versions: false } do
-          it "accepts target_versions" do
-            model.attribute_groups = [["foo", ["target_versions"]]]
-
-            expect(contract).to be_valid
-          end
-
           it "rejects the deprecated version as an unknown attribute" do
             model.attribute_groups = [["foo", ["version"]]]
 

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -30,8 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "form configuration", :js, :selenium,
-               with_settings: { work_package_multiple_versions: false } do
+RSpec.describe "form configuration", :js, :selenium do
   shared_let(:admin) { create(:admin) }
   let(:type) { create(:type) }
   let(:variant) { type.default_variant }
@@ -148,15 +147,15 @@ RSpec.describe "form configuration", :js, :selenium,
                           { key: :category, translation: "Category" },
                           { key: :date, translation: "Date" },
                           { key: :priority, translation: "Priority" },
-                          { key: :version, translation: "Version" }
+                          { key: :target_versions, translation: "Target versions" }
 
         #
         # Modify configuration
         #
 
-        # Disable version
-        form.drag_and_drop(form.find_attribute_handle(:version), form.inactive_group)
-        form.expect_inactive(:version)
+        # Disable target_versions
+        form.drag_and_drop(form.find_attribute_handle(:target_versions), form.inactive_group)
+        form.expect_inactive(:target_versions)
 
         # Rename section
         form.rename_group("Details", "Whatever")
@@ -201,7 +200,7 @@ RSpec.describe "form configuration", :js, :selenium,
                           "New Group",
                           { key: :category, translation: "Category" }
 
-        form.expect_inactive(:version)
+        form.expect_inactive(:target_versions)
 
         # Test the actual type backend
         variant.reload
@@ -214,7 +213,7 @@ RSpec.describe "form configuration", :js, :selenium,
         wp_page.visit!
         wp_page.ensure_page_loaded
 
-        # Version should be hidden
+        # Target versions should be hidden
         wp_page.expect_hidden_field(:targetVersions)
 
         wp_page.expect_group("New Group") do
@@ -252,25 +251,22 @@ RSpec.describe "form configuration", :js, :selenium,
         loading_indicator_saveguard
       end
 
-      context "with multiple versions enabled",
-              with_settings: { work_package_multiple_versions: true } do
-        it "offers target versions in place of the deprecated version" do
-          form.expect_group "details",
-                            "Details",
-                            { key: :category, translation: "Category" },
-                            { key: :date, translation: "Date" },
-                            { key: :priority, translation: "Priority" },
-                            { key: :target_versions, translation: "Target versions" }
+      it "offers target versions in the default configuration" do
+        form.expect_group "details",
+                          "Details",
+                          { key: :category, translation: "Category" },
+                          { key: :date, translation: "Date" },
+                          { key: :priority, translation: "Priority" },
+                          { key: :target_versions, translation: "Target versions" }
 
-          # The drag moves the row before the request that persists it, so the stream has to be
-          # waited for or the read below races it.
-          wait_for_turbo_stream do
-            form.drag_and_drop(form.find_attribute_handle(:target_versions), form.inactive_group)
-          end
-          form.expect_inactive(:target_versions)
-
-          expect(persisted_attribute_order(:details)).not_to include("target_versions")
+        # The drag moves the row before the request that persists it, so the stream has to be
+        # waited for or the read below races it.
+        wait_for_turbo_stream do
+          form.drag_and_drop(form.find_attribute_handle(:target_versions), form.inactive_group)
         end
+        form.expect_inactive(:target_versions)
+
+        expect(persisted_attribute_order(:details)).not_to include("target_versions")
       end
 
       context "with field format labels" do

--- a/spec/migrations/migrate_version_to_target_versions_in_type_variants_spec.rb
+++ b/spec/migrations/migrate_version_to_target_versions_in_type_variants_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe MigrateVersionToTargetVersionsInTypeVariants, type: :model do
     ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
 
     expect(excluded_elements_variant.reload.read_attribute(:form_configuration_excluded_elements))
-      .to eq(%w[target_versions priority])
+      .to match_array(%w[target_versions priority])
   end
 
   it "dedupes form_configuration_excluded_elements when a row already excludes both keys" do
@@ -144,5 +144,72 @@ RSpec.describe MigrateVersionToTargetVersionsInTypeVariants, type: :model do
 
     expect(excluded_elements_both_variant.reload.read_attribute(:form_configuration_excluded_elements))
       .to match_array(%w[target_versions priority])
+  end
+
+  it "renames the sole version attribute help text to target_versions" do
+    help_text = create(:work_package_help_text, attribute_name: "status")
+    help_text.update_column(:attribute_name, "version")
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(help_text.reload.attribute_name).to eq("target_versions")
+  end
+
+  it "leaves a version row untouched when a target_versions row already exists" do
+    survivor = create(:work_package_help_text, attribute_name: "target_versions")
+    duplicate = create(:work_package_help_text, attribute_name: "status")
+    duplicate.update_column(:attribute_name, "version")
+    duplicate_attachment = create(:attachment, container: duplicate)
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(survivor.reload.attribute_name).to eq("target_versions")
+    expect(duplicate.reload.attribute_name).to eq("version")
+    expect(Attachment.exists?(duplicate_attachment.id)).to be true
+  end
+
+  it "renames only the lowest-id version row when several exist and no target_versions row exists" do
+    lower_id_help_text = create(:work_package_help_text, attribute_name: "status")
+    lower_id_help_text.update_column(:attribute_name, "version")
+    lower_id_attachment = create(:attachment, container: lower_id_help_text)
+    higher_id_help_text = create(:work_package_help_text, attribute_name: "priority")
+    higher_id_help_text.update_column(:attribute_name, "version")
+    higher_id_attachment = create(:attachment, container: higher_id_help_text)
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(lower_id_help_text.reload.attribute_name).to eq("target_versions")
+    expect(higher_id_help_text.reload.attribute_name).to eq("version")
+    expect(Attachment.exists?(lower_id_attachment.id)).to be true
+    expect(Attachment.exists?(higher_id_attachment.id)).to be true
+  end
+
+  it "leaves a non-WorkPackage attribute help text named version untouched" do
+    project_help_text = create(:project_help_text, attribute_name: "members")
+    project_help_text.update_column(:attribute_name, "version")
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(project_help_text.reload.attribute_name).to eq("version")
+  end
+
+  it "leaves a work package attribute help text with another attribute name untouched" do
+    status_help_text = create(:work_package_help_text, attribute_name: "status")
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(status_help_text.reload.attribute_name).to eq("status")
+  end
+
+  it "leaves migrated data unchanged when rolled back" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+    attribute_groups_after_up = duplicate_after_rename_variant.reload.read_attribute(:attribute_groups)
+    excluded_elements_after_up = excluded_elements_variant.reload.read_attribute(:form_configuration_excluded_elements)
+
+    expect { ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) } }.not_to raise_error
+
+    expect(duplicate_after_rename_variant.reload.read_attribute(:attribute_groups)).to eq(attribute_groups_after_up)
+    expect(excluded_elements_variant.reload.read_attribute(:form_configuration_excluded_elements))
+      .to eq(excluded_elements_after_up)
   end
 end

--- a/spec/migrations/migrate_version_to_target_versions_in_type_variants_spec.rb
+++ b/spec/migrations/migrate_version_to_target_versions_in_type_variants_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20260831120000_migrate_version_to_target_versions_in_type_variants")
+
+RSpec.describe MigrateVersionToTargetVersionsInTypeVariants, type: :model do
+  shared_let(:mixed_group_and_key_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:attribute_groups, [
+                              ["details", %w[category version]],
+                              ["version", %w[subject], "Version"],
+                              ["Related", [:query_1]] # rubocop:disable Naming/VariableNumber
+                            ])
+    end
+  end
+
+  shared_let(:duplicate_after_rename_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:attribute_groups, [["details", %w[version target_versions]]])
+    end
+  end
+
+  shared_let(:cross_group_with_original_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:attribute_groups, [["a", %w[version]], ["b", %w[target_versions]]])
+    end
+  end
+
+  shared_let(:cross_group_without_original_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:attribute_groups, [["a", %w[version]], ["b", %w[version subject]]])
+    end
+  end
+
+  shared_let(:untouched_variant) do
+    create(:type).default_variant.tap { |variant| variant.update_column(:attribute_groups, nil) }
+  end
+
+  shared_let(:no_version_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:attribute_groups, [["a", %w[category subject]]])
+    end
+  end
+
+  shared_let(:excluded_elements_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:form_configuration_excluded_elements, %w[version priority])
+    end
+  end
+
+  shared_let(:excluded_elements_both_variant) do
+    create(:type).default_variant.tap do |variant|
+      variant.update_column(:form_configuration_excluded_elements, %w[version target_versions priority])
+    end
+  end
+
+  it "renames the version attribute to target_versions, leaving group keys and query members alone" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(mixed_group_and_key_variant.reload.read_attribute(:attribute_groups)).to eq(
+      [
+        ["details", %w[category target_versions]],
+        ["version", %w[subject], "Version"],
+        ["Related", [:query_1]] # rubocop:disable Naming/VariableNumber
+      ]
+    )
+  end
+
+  it "dedupes an attribute list that already contains both version and target_versions" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(duplicate_after_rename_variant.reload.read_attribute(:attribute_groups)).to eq(
+      [["details", %w[target_versions]]]
+    )
+  end
+
+  it "leaves a NULL attribute_groups column untouched" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(untouched_variant.reload.attribute_groups_before_type_cast).to be_nil
+  end
+
+  it "drops the renamed attribute from every group but the first when another group already has target_versions" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(cross_group_with_original_variant.reload.read_attribute(:attribute_groups)).to eq(
+      [["a", []], ["b", %w[target_versions]]]
+    )
+  end
+
+  it "renames only the first version occurrence across groups when no group has an original target_versions" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(cross_group_without_original_variant.reload.read_attribute(:attribute_groups)).to eq(
+      [["a", %w[target_versions]], ["b", %w[subject]]]
+    )
+  end
+
+  it "leaves a row without a version attribute byte-identical" do
+    raw_attribute_groups = no_version_variant.attribute_groups_before_type_cast
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(no_version_variant.reload.attribute_groups_before_type_cast).to eq(raw_attribute_groups)
+  end
+
+  it "renames version to target_versions in form_configuration_excluded_elements" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(excluded_elements_variant.reload.read_attribute(:form_configuration_excluded_elements))
+      .to eq(%w[target_versions priority])
+  end
+
+  it "dedupes form_configuration_excluded_elements when a row already excludes both keys" do
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(excluded_elements_both_variant.reload.read_attribute(:form_configuration_excluded_elements))
+      .to match_array(%w[target_versions priority])
+  end
+end

--- a/spec/models/type/attributes_spec.rb
+++ b/spec/models/type/attributes_spec.rb
@@ -36,17 +36,14 @@ RSpec.describe Type::Attributes do
   describe ".all_work_package_form_attributes" do
     subject(:attributes) { TypeVariant.all_work_package_form_attributes }
 
-    context "when the multiple versions feature is inactive",
-            with_settings: { work_package_multiple_versions: false } do
-      it "offers the deprecated version and hides target_versions" do
-        expect(attributes).to have_key("version")
-        expect(attributes).not_to have_key("target_versions")
-      end
+    it "offers target_versions and hides the deprecated version" do
+      expect(attributes).to have_key("target_versions")
+      expect(attributes).not_to have_key("version")
     end
 
-    context "when the multiple versions feature is active",
-            with_settings: { work_package_multiple_versions: true } do
-      it "offers target_versions and hides the deprecated version" do
+    context "when the multiple versions feature is inactive",
+            with_settings: { work_package_multiple_versions: false } do
+      it "still offers target_versions and hides the deprecated version" do
         expect(attributes).to have_key("target_versions")
         expect(attributes).not_to have_key("version")
       end
@@ -54,20 +51,9 @@ RSpec.describe Type::Attributes do
   end
 
   describe ".translated_work_package_form_attributes" do
-    context "when the multiple versions feature is inactive",
-            with_settings: { work_package_multiple_versions: false } do
-      it "labels the deprecated version field" do
-        expect(TypeVariant.translated_work_package_form_attributes["version"])
-          .to eq(I18n.t("activerecord.attributes.work_package.version"))
-      end
-    end
-
-    context "when the multiple versions feature is active",
-            with_settings: { work_package_multiple_versions: true } do
-      it "labels the target versions field" do
-        expect(TypeVariant.translated_work_package_form_attributes["target_versions"])
-          .to eq(I18n.t("activerecord.attributes.work_package.target_versions"))
-      end
+    it "labels the target versions field" do
+      expect(TypeVariant.translated_work_package_form_attributes["target_versions"])
+        .to eq(I18n.t("activerecord.attributes.work_package.target_versions"))
     end
   end
 end

--- a/spec/models/type_variant/type_variant_attribute_groups_spec.rb
+++ b/spec/models/type_variant/type_variant_attribute_groups_spec.rb
@@ -158,54 +158,30 @@ RSpec.describe TypeVariant do
   end
 
   describe "target versions in the form configuration" do
-    context "when the multiple versions feature is inactive",
-            with_settings: { work_package_multiple_versions: false } do
-      it "offers the deprecated version in the default configuration" do
-        members = variant.default_attribute_groups.to_h
+    it "offers target_versions in the default configuration" do
+      members = variant.default_attribute_groups.to_h
 
-        expect(members[:details]).to include("version")
-        expect(members[:details]).not_to include("target_versions")
-      end
-
-      it "renders a persisted target_versions key as the deprecated version" do
-        variant[:attribute_groups] = [["details", %w[category target_versions]]]
-        variant.unset_attribute_groups_objects
-
-        details = variant.attribute_groups.detect { |group| group.key == "details" }
-
-        expect(details.attributes).to include("version")
-        expect(details.attributes).not_to include("target_versions")
-      end
+      expect(members[:details]).to include("target_versions")
+      expect(members[:details]).not_to include("version")
     end
 
-    context "when the multiple versions feature is active",
-            with_settings: { work_package_multiple_versions: true } do
-      it "offers target_versions in the default configuration" do
-        members = variant.default_attribute_groups.to_h
+    it "leaves a persisted target_versions key untouched" do
+      variant[:attribute_groups] = [["details", %w[category target_versions]]]
+      variant.unset_attribute_groups_objects
 
-        expect(members[:details]).to include("target_versions")
-        expect(members[:details]).not_to include("version")
-      end
+      details = variant.attribute_groups.detect { |group| group.key == "details" }
 
-      it "renders a persisted legacy version key as target_versions" do
-        variant[:attribute_groups] = [["details", %w[category version]]]
-        variant.unset_attribute_groups_objects
+      expect(details.attributes).to eq(%w[category target_versions])
+    end
 
-        details = variant.attribute_groups.detect { |group| group.key == "details" }
+    it "leaves a persisted literal version key untranslated but drops it from members" do
+      variant[:attribute_groups] = [["details", %w[category version]]]
+      variant.unset_attribute_groups_objects
 
-        expect(details.attributes).to include("target_versions")
-        expect(details.attributes).not_to include("version")
-      end
+      details = variant.attribute_groups.detect { |group| group.key == "details" }
 
-      it "keeps the display name of a renamed group while normalizing it" do
-        variant[:attribute_groups] = [["details", %w[category version], "Custom Details"]]
-        variant.unset_attribute_groups_objects
-
-        details = variant.attribute_groups.detect { |group| group.key == "details" }
-
-        expect(details.attributes).to include("target_versions")
-        expect(details.display_name).to eq("Custom Details")
-      end
+      expect(details.attributes).to eq(%w[category version])
+      expect(details.members).not_to include("version")
     end
 
     it "leaves query group members untouched" do

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       "Priority", "Normal",
       *(work_package.sprint.present? ? ["Sprint", work_package.sprint] : ["Sprint"]),
       *(work_package.backlog_bucket.present? ? ["Backlog bucket", work_package.backlog_bucket] : ["Backlog bucket"]),
-      WorkPackage.human_attribute_name(:target_versions), work_package.target_versions.first,
+      WorkPackage.human_attribute_name(:version), work_package.target_versions.first,
       "Category", work_package.category,
       "Project phase",
       "Date", "05/30/2024 - 03/13/2025",

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       "Priority", "Normal",
       *(work_package.sprint.present? ? ["Sprint", work_package.sprint] : ["Sprint"]),
       *(work_package.backlog_bucket.present? ? ["Backlog bucket", work_package.backlog_bucket] : ["Backlog bucket"]),
-      "Version", work_package.target_versions.first,
+      WorkPackage.human_attribute_name(:target_versions), work_package.target_versions.first,
       "Category", work_package.category,
       "Project phase",
       "Date", "05/30/2024 - 03/13/2025",


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-919

Follows: #24364

Replaces the flag-gated read-time resolution of stored `version` / `target_versions` keys in the type form configuration with a data migration.
