### PR TITLE
[COMMS-969] Sorting and grouping for observed in versions

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -35,6 +35,27 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
 
   class_attribute :property_selects
 
+  def self.versions_sortable(kind)
+    [
+      <<~SQL.squish,
+        (SELECT STRING_AGG(LOWER(v.name), ' ' ORDER BY LOWER(v.name), wpv.version_id)
+           FROM work_package_versions wpv
+           INNER JOIN versions v ON v.id = wpv.version_id
+          WHERE wpv.work_package_id = work_packages.id AND wpv.kind = '#{kind}')
+      SQL
+      versions_groupable(kind)
+    ]
+  end
+
+  def self.versions_groupable(kind)
+    <<~SQL.squish
+      (SELECT STRING_AGG(wpv.version_id::text, '.' ORDER BY LOWER(v.name), wpv.version_id)
+         FROM work_package_versions wpv
+         INNER JOIN versions v ON v.id = wpv.version_id
+        WHERE wpv.work_package_id = work_packages.id AND wpv.kind = '#{kind}')
+    SQL
+  end
+
   self.property_selects = {
     id: {
       sortable: ->(_query = nil) {
@@ -124,31 +145,12 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
     },
     target_versions: {
       if: -> { Setting::WorkPackageMultipleVersions.active? },
-      sortable: [
-        <<~SQL.squish,
-          (SELECT STRING_AGG(LOWER(v.name), ' ' ORDER BY LOWER(v.name), wpv.version_id)
-             FROM work_package_versions wpv
-             INNER JOIN versions v ON v.id = wpv.version_id
-            WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target')
-        SQL
-        <<~SQL.squish
-          (SELECT STRING_AGG(wpv.version_id::text, '.' ORDER BY LOWER(v.name), wpv.version_id)
-             FROM work_package_versions wpv
-             INNER JOIN versions v ON v.id = wpv.version_id
-            WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target')
-        SQL
-      ],
-      groupable:
-        <<~SQL.squish
-          (SELECT STRING_AGG(wpv.version_id::text, '.' ORDER BY LOWER(v.name), wpv.version_id)
-             FROM work_package_versions wpv
-             INNER JOIN versions v ON v.id = wpv.version_id
-            WHERE wpv.work_package_id = work_packages.id AND wpv.kind = 'target')
-        SQL
+      sortable: versions_sortable("target"),
+      groupable: versions_groupable("target")
     },
     observed_in_versions: {
-      sortable: false,
-      groupable: false
+      sortable: versions_sortable("observed_in"),
+      groupable: versions_groupable("observed_in")
     },
     start_date: {
       sortable: "#{WorkPackage.table_name}.start_date"

--- a/spec/models/queries/work_packages/selects/property_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/property_select_spec.rb
@@ -92,5 +92,25 @@ RSpec.describe Queries::WorkPackages::Selects::PropertySelect do
         end
       end
     end
+
+    describe "observed_in_versions column" do
+      it "is displayable, sortable and groupable" do
+        column = described_class.instances.find { it.name == :observed_in_versions }
+
+        expect(column).to be_displayable
+        expect(column).to be_sortable
+        expect(column).to be_groupable
+        expect(column.caption).to eq WorkPackage.human_attribute_name(:observed_in_versions)
+      end
+
+      it "sorts and groups via the work_package_versions join rows, scoped to the observed_in kind" do
+        column = described_class.instances.find { it.name == :observed_in_versions }
+
+        expect(Array(column.sortable)).to all include("work_package_versions")
+        expect(Array(column.sortable)).to all include("kind = 'observed_in'")
+        expect(column.groupable).to include("work_package_versions")
+        expect(column.groupable).to include("kind = 'observed_in'")
+      end
+    end
   end
 end

--- a/spec/models/query/results_observed_in_versions_integration_spec.rb
+++ b/spec/models/query/results_observed_in_versions_integration_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe Query::Results, "Grouping and sorting for observed in versions" do
+  let(:query_results) do
+    described_class.new query
+  end
+  let(:project) { create(:project) }
+  let(:user) do
+    create(:user,
+           firstname: "user",
+           lastname: "1",
+           member_with_permissions: { project => [:view_work_packages] })
+  end
+
+  let(:alpha_version) do
+    create(:version, name: "1. Alpha", project:)
+  end
+
+  let(:beta_version) do
+    create(:version, name: "2. Beta", project:)
+  end
+
+  let!(:alpha_wp) do
+    create_wp_with_observed_in_versions("Alpha wp", [alpha_version])
+  end
+  let!(:both_versions_wp) do
+    create_wp_with_observed_in_versions("Both versions wp", [beta_version, alpha_version])
+  end
+  let!(:beta_wp) do
+    create_wp_with_observed_in_versions("Beta wp", [beta_version])
+  end
+  let!(:no_version_wp) do
+    create(:work_package, subject: "No version wp", project:)
+  end
+
+  let(:group_by) { nil }
+  let(:sort_criteria) { [["observed_in_versions", "asc"]] }
+
+  let(:query) do
+    build(:query,
+          user:,
+          group_by:,
+          show_hierarchies: false,
+          project:).tap do |q|
+      q.filters.clear
+      q.sort_criteria = sort_criteria
+    end
+  end
+
+  # Sorted by the aggregated version names ("1. alpha" < "1. alpha 2. beta" < "2. beta" < NULL)
+  let(:work_packages_asc) { [alpha_wp, both_versions_wp, beta_wp, no_version_wp] }
+  let(:work_packages_desc) { work_packages_asc.reverse }
+
+  def create_wp_with_observed_in_versions(subject, versions, **attributes)
+    create(:work_package, subject:, project:, **attributes).tap do |wp|
+      versions.each do |version|
+        create(:work_package_version, work_package: wp, version:, kind: :observed_in)
+      end
+    end
+  end
+
+  before do
+    login_as(user)
+  end
+
+  describe "sorting ASC by observed in versions" do
+    let(:sort_criteria) { [["observed_in_versions", "asc"]] }
+
+    it "sorts by the aggregated version names with absent versions last" do
+      expect(query_results.work_packages.pluck(:id))
+        .to eq work_packages_asc.map(&:id)
+    end
+  end
+
+  describe "sorting DESC by observed in versions" do
+    let(:sort_criteria) { [["observed_in_versions", "desc"]] }
+
+    it "sorts by the aggregated version names with absent versions first" do
+      expect(query_results.work_packages.pluck(:id))
+        .to eq work_packages_desc.map(&:id)
+    end
+  end
+
+  describe "grouping by observed in versions" do
+    let(:group_by) { "observed_in_versions" }
+
+    it "groups by the set of assigned versions" do
+      # The set of versions is the group key, so {alpha, beta} is a group of
+      # its own, distinct from {alpha} and {beta}. Work packages without any
+      # observed in version are grouped under the empty set.
+      expect(query_results.work_package_count_by_group)
+        .to eql([alpha_version] => 1,
+                [alpha_version, beta_version] => 1,
+                [beta_version] => 1,
+                [] => 1)
+
+      # Group keys are sorted like the work packages themselves
+      expect(query_results.work_package_count_by_group.keys)
+        .to eql [[alpha_version], [alpha_version, beta_version], [beta_version], []]
+
+      # Groups are contiguous in the row order
+      expect(query_results.work_packages.pluck(:id))
+        .to eq work_packages_asc.map(&:id)
+    end
+
+    context "with sums displayed" do
+      let(:query) do
+        build(:query,
+              user:,
+              group_by:,
+              show_hierarchies: false,
+              project:).tap do |q|
+          q.filters.clear
+          q.sort_criteria = sort_criteria
+          q.display_sums = true
+        end
+      end
+
+      let!(:alpha_wp) do
+        create_wp_with_observed_in_versions("Alpha wp", [alpha_version], estimated_hours: 2)
+      end
+      let!(:both_versions_wp) do
+        create_wp_with_observed_in_versions("Both versions wp", [beta_version, alpha_version], estimated_hours: 3)
+      end
+
+      it "sums per version set" do
+        sums = query_results.all_group_sums.transform_values do |by_column|
+          by_column.transform_keys(&:name)[:estimated_hours]
+        end
+
+        expect(sums)
+          .to eq([alpha_version] => 2.0,
+                 [alpha_version, beta_version] => 3.0,
+                 [beta_version] => nil,
+                 [] => nil)
+      end
+    end
+  end
+
+  context "with equally named versions in different projects" do
+    let(:other_project) { create(:project) }
+    let(:user) do
+      create(:user,
+             firstname: "user",
+             lastname: "1",
+             member_with_permissions: {
+               project => [:view_work_packages],
+               other_project => [:view_work_packages]
+             })
+    end
+
+    let(:same_name_version) do
+      create(:version, name: alpha_version.name, project: other_project)
+    end
+
+    let!(:same_name_wp) do
+      create(:work_package, subject: "Same name other project wp", project: other_project).tap do |wp|
+        create(:work_package_version, work_package: wp, version: same_name_version, kind: :observed_in)
+      end
+    end
+
+    let(:query) do
+      build(:query,
+            user:,
+            group_by: "observed_in_versions",
+            show_hierarchies: false,
+            project: nil).tap do |q|
+        q.filters.clear
+        q.sort_criteria = sort_criteria
+      end
+    end
+
+    it "keeps the equally named version sets in separate groups" do
+      expect(query_results.work_package_count_by_group)
+        .to eql([alpha_version] => 1,
+                [same_name_version] => 1,
+                [alpha_version, beta_version] => 1,
+                [beta_version] => 1,
+                [] => 1)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-969/activity

# What are you trying to accomplish?
Allow grouping and sorting for observed in versions

## Screenshots
<img width="2546" height="1724" alt="image" src="https://github.com/user-attachments/assets/44edb68b-4bd6-48e5-8e0d-ef5e2e34d9e0" />

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
