### PR TITLE
[JIM-170] Custom fields of type list and hierarchy are duplicated by Jira Migrator

### DIFF
--- a/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
+++ b/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
@@ -316,8 +316,7 @@ module Import
         return best_value_bearing_candidate(candidates, run_custom_field_ids) if value_bearing_format?
 
         candidates.find { |cf| cf.name.casecmp?(@import_name) } ||
-          candidates.find { |cf| cf.name.casecmp?(stable_base_name) } ||
-          candidates.first
+          candidates.find { |cf| cf.name.casecmp?(stable_base_name) }
       end
 
       def value_bearing_format?

--- a/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
+++ b/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
@@ -402,8 +402,6 @@ module Import
         values = custom_field.custom_options.pluck(:value) + missing_labels.to_a
         service_call = CustomFields::UpdateService.new(user:, model: custom_field).call(possible_values: values)
         raise service_call.message if service_call.failure?
-
-        custom_field.reload
       end
 
       def extend_hierarchy_values!(custom_field, missing_labels)

--- a/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
+++ b/app/workers/import/jira_import_projects_job/jira_import_custom_field_builder.rb
@@ -133,6 +133,11 @@ module Import
         "user" => "user"
       }.freeze
 
+      # Picks how a same-name candidate is matched when Jira Field Contexts have split one
+      # Jira field into several OP custom fields: `:subset` (needed values already covered),
+      # `:exact` (identical option set) or `:extend` (best overlap, missing values appended).
+      VALUE_MATCH_MODE = :subset
+
       def self.supported?(jira_field)
         schema = jira_field.payload["schema"] || {}
         JIRA_SUPPORTED_FIELDS.any? do |entry|
@@ -153,9 +158,10 @@ module Import
         @import_name = default_cf_name
       end
 
-      def find_existing_custom_field
-        existing_cf = custom_field_by_name(@import_name) if %w[hierarchy list].exclude?(format)
-        return existing_cf if existing_cf&.field_format == format
+      def find_existing_custom_field(run_custom_field_ids: [])
+        @pending_value_extension = nil
+        match = best_matching_candidate(compatible_candidates, run_custom_field_ids)
+        return match if match
 
         @import_name = unique_custom_field_name
         nil
@@ -193,15 +199,25 @@ module Import
         populate_hierarchy_items(custom_field) if format == "hierarchy"
       end
 
+      def apply_pending_value_extension(custom_field, user:)
+        return if @pending_value_extension.blank?
+
+        extend_custom_field_values!(custom_field, @pending_value_extension, user:)
+      end
+
       def format
         @format ||= @option_value ? "bool" : jira_to_op_field_format(jira_field)
       end
 
       private
 
-      def default_cf_name
+      def stable_base_name
         base_name = jira_field.payload["name"]
-        base_name = "#{base_name} - #{@option_value}" if @option_value
+        @option_value ? "#{base_name} - #{@option_value}" : base_name
+      end
+
+      def default_cf_name
+        base_name = stable_base_name
         project_keys = context_group_projects
         return base_name if project_keys.empty? || !@needs_disambiguation
 
@@ -274,6 +290,146 @@ module Import
           full_path = parent_path ? "#{parent_path} / #{label}" : label
           [full_path] + flatten_cascading_allowed_values(Array(av["children"]), parent_path: full_path)
         end.uniq
+      end
+
+      # Matches `Example`, `Example (2)`, `Example (DYX)` and `Example (DYX, ABC)
+      def candidate_custom_fields
+        base_name = stable_base_name
+        escaped = ActiveRecord::Base.sanitize_sql_like(base_name)
+        WorkPackageCustomField
+          .where("LOWER(name) = LOWER(?)", base_name)
+          .or(WorkPackageCustomField.where("name ILIKE ?", "#{escaped} (%"))
+          .order(:id)
+      end
+
+      def compatible_candidates
+        candidate_custom_fields.select { |cf| cf.field_format == format && compatible_multi_value?(cf) }
+      end
+
+      def compatible_multi_value?(custom_field)
+        return true unless %w[list user].include?(format)
+
+        custom_field.multi_value? == jira_field_multi_value?
+      end
+
+      def best_matching_candidate(candidates, run_custom_field_ids)
+        return best_value_bearing_candidate(candidates, run_custom_field_ids) if value_bearing_format?
+
+        candidates.find { |cf| cf.name.casecmp?(@import_name) } ||
+          candidates.find { |cf| cf.name.casecmp?(stable_base_name) } ||
+          candidates.first
+      end
+
+      def value_bearing_format?
+        %w[list hierarchy].include?(format)
+      end
+
+      def best_value_bearing_candidate(candidates, run_custom_field_ids)
+        needed = needed_value_labels.to_set
+        return nil if needed.empty?
+
+        same_run, other_runs = candidates.partition { |cf| run_custom_field_ids.include?(cf.id) }
+        exact_match(same_run, needed) || match_by_mode(other_runs, needed)
+      end
+
+      def match_by_mode(candidates, needed)
+        case VALUE_MATCH_MODE
+        when :exact then exact_match(candidates, needed)
+        when :extend then extend_best_overlapping_candidate(candidates, needed)
+        else candidates.find { |cf| needed.subset?(existing_value_labels(cf).to_set) }
+        end
+      end
+
+      def exact_match(candidates, needed)
+        candidates.find { |cf| existing_value_labels(cf).to_set == needed }
+      end
+
+      def needed_value_labels
+        format == "hierarchy" ? flatten_cascading_allowed_values(context_group_allowed_values) : list_field_option_values
+      end
+
+      def existing_value_labels(custom_field)
+        labels = format == "hierarchy" ? hierarchy_labels(custom_field) : custom_field.custom_options.pluck(:value)
+        labels.map { |label| option_label(label) }.compact_blank
+      end
+
+      def hierarchy_labels(custom_field)
+        root = custom_field.hierarchy_root
+        return [] if root.nil?
+
+        CustomFields::Hierarchy::HierarchicalItemService
+          .new
+          .get_descendants(item: root, include_self: false)
+          .fmap { |items| items.map(&:ancestry_path) }
+          .value_or([])
+      end
+
+      def extend_best_overlapping_candidate(candidates, needed)
+        scored = candidates.filter_map { |cf| score_extension_candidate(cf, needed) }
+        return nil if scored.empty?
+
+        candidate, existing = scored.min_by { |cf, values| [-(needed & values).size, cf.id] }
+        @pending_value_extension = needed - existing
+        candidate
+      end
+
+      def score_extension_candidate(custom_field, needed)
+        existing = existing_value_labels(custom_field).to_set
+        return unless needed.intersect?(existing)
+
+        [custom_field, existing] if needed.subset?(existing) || import_owned?(custom_field)
+      end
+
+      def import_owned?(custom_field)
+        Import::JiraOpenProjectReference.exists?(
+          op_entity_id: custom_field.id,
+          op_entity_class: custom_field.class.to_s,
+          jira_id: @jira_import.jira_id
+        )
+      end
+
+      def extend_custom_field_values!(custom_field, missing_labels, user:)
+        return if missing_labels.empty?
+
+        if format == "hierarchy"
+          extend_hierarchy_values!(custom_field, missing_labels)
+        else
+          extend_list_values!(custom_field, missing_labels, user:)
+        end
+      end
+
+      def extend_list_values!(custom_field, missing_labels, user:)
+        values = custom_field.custom_options.pluck(:value) + missing_labels.to_a
+        service_call = CustomFields::UpdateService.new(user:, model: custom_field).call(possible_values: values)
+        raise service_call.message if service_call.failure?
+
+        custom_field.reload
+      end
+
+      def extend_hierarchy_values!(custom_field, missing_labels)
+        custom_field.reload
+        root = custom_field.hierarchy_root
+        return unless root
+
+        service = CustomFields::Hierarchy::HierarchicalItemService.new
+        contract = CustomFields::Hierarchy::InsertListItemContract
+        context_group_allowed_values.each do |option|
+          insert_missing_hierarchy_option(service, contract, root, option, missing_labels)
+        end
+      end
+
+      def insert_missing_hierarchy_option(service, contract, parent, option, missing_labels, parent_path: nil)
+        label = option_label(option["value"])
+        return if label.blank?
+
+        full_path = parent_path ? "#{parent_path} / #{label}" : label
+        item = parent.children.find_by(label:)
+        item = insert_hierarchy_item(service, contract, parent, label) if item.nil? && missing_labels.include?(full_path)
+        return unless item
+
+        Array(option["children"]).each do |child_option|
+          insert_missing_hierarchy_option(service, contract, item, child_option, missing_labels, parent_path: full_path)
+        end
       end
 
       def custom_field_by_name(name)
@@ -376,13 +532,17 @@ module Import
         label = option_label(option["value"])
         return if label.blank?
 
-        result = service.insert_item(contract_class: contract, parent:, label:)
-        return unless result.success?
+        item = insert_hierarchy_item(service, contract, parent, label)
+        return unless item
 
-        item = result.value!
         Array(option["children"]).each do |child_option|
           insert_hierarchy_option(service, contract, item, child_option)
         end
+      end
+
+      def insert_hierarchy_item(service, contract, parent, label)
+        result = service.insert_item(contract_class: contract, parent:, label:)
+        result.success? ? result.value! : nil
       end
 
       # Fallback for scalar formats (string, float, date, link). Hash values

--- a/app/workers/import/jira_import_projects_job/jira_import_custom_fields.rb
+++ b/app/workers/import/jira_import_projects_job/jira_import_custom_fields.rb
@@ -319,17 +319,29 @@ module Import
         }
       end
 
+      def run_custom_field_ids
+        @run_custom_field_ids ||= Set.new
+      end
+
       def find_or_create_custom_field(jira_field, builder)
-        existing_cf = builder.find_existing_custom_field
-        if existing_cf
-          unless Import::JiraOpenProjectReference.exists?(op_entity_id: existing_cf.id,
-                                                          op_entity_class: existing_cf.class.to_s,
-                                                          jira_id: @jira_id)
-            create_reference!(op_leg: existing_cf, jira_leg: jira_field, jira_import: @jira_import, uses_existing: true)
-          end
-          return existing_cf
+        existing_cf = builder.find_existing_custom_field(run_custom_field_ids:)
+        custom_field = if existing_cf
+                         reuse_custom_field(existing_cf, jira_field, builder)
+                       else
+                         create_custom_field(jira_field, builder)
+                       end
+        run_custom_field_ids << custom_field.id
+        custom_field
+      end
+
+      def reuse_custom_field(custom_field, jira_field, builder)
+        unless Import::JiraOpenProjectReference.exists?(op_entity_id: custom_field.id,
+                                                        op_entity_class: custom_field.class.to_s,
+                                                        jira_id: @jira_id)
+          create_reference!(op_leg: custom_field, jira_leg: jira_field, jira_import: @jira_import, uses_existing: true)
         end
-        create_custom_field(jira_field, builder)
+        builder.apply_pending_value_extension(custom_field, user: @system_user)
+        custom_field
       end
 
       def create_custom_field(jira_field, builder)

--- a/spec/workers/import/jira_import_projects_job/jira_import_custom_field_builder_spec.rb
+++ b/spec/workers/import/jira_import_projects_job/jira_import_custom_field_builder_spec.rb
@@ -1034,11 +1034,21 @@ RSpec.describe Import::JiraImportProjectsJob::JiraImportCustomFieldBuilder do
         expect(date_builder.find_existing_custom_field).to eq(exact)
       end
 
-      it "falls back to the oldest suffixed candidate when no exact name exists" do
-        oldest = create(:date_wp_custom_field, name: "Due (archived)")
+      it "does not reuse a suffixed candidate when no exact name matches" do
+        create(:date_wp_custom_field, name: "Due (archived)")
         create(:date_wp_custom_field, name: "Due (2)")
 
-        expect(date_builder.find_existing_custom_field).to eq(oldest)
+        expect(date_builder.find_existing_custom_field).to be_nil
+      end
+
+      it "keeps two Jira fields apart when one is named like the other's dedup suffix" do
+        suffixed = create(:string_wp_custom_field, name: "foo (2)")
+        schema = { "type" => "string", "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:textfield" }
+        builder = described_class.new(jira_field_for(name: "foo", schema:), jira_import:)
+
+        expect(builder.find_existing_custom_field).to be_nil
+        expect(builder.custom_field_settings.first).to eq("foo")
+        expect(suffixed.reload.name).to eq("foo (2)")
       end
     end
 

--- a/spec/workers/import/jira_import_projects_job/jira_import_custom_field_builder_spec.rb
+++ b/spec/workers/import/jira_import_projects_job/jira_import_custom_field_builder_spec.rb
@@ -827,4 +827,264 @@ RSpec.describe Import::JiraImportProjectsJob::JiraImportCustomFieldBuilder do
       expect(minor.children).to be_empty
     end
   end
+
+  describe "#find_existing_custom_field" do
+    let(:jira) { create(:jira) }
+    let(:jira_import) { create(:jira_import, jira:, author: create(:user)) }
+
+    def list_builder(name: "Severity", values: %w[Low High], projects: [], needs_disambiguation: false,
+                     multi_value: false)
+      schema = if multi_value
+                 { "type" => "array", "items" => "option",
+                   "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:multiselect" }
+               else
+                 { "type" => "option", "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select" }
+               end
+      context_group = { "projects" => projects, "issuetypes" => [],
+                        "allowedValues" => values.map { |value| { "value" => value } } }
+      described_class.new(jira_field_for(name:, schema:, context_groups: [context_group]),
+                          context_group:, needs_disambiguation:, jira_import:)
+    end
+
+    def import_owned(custom_field)
+      create(:jira_open_project_reference,
+             jira:,
+             jira_import:,
+             op_entity_id: custom_field.id,
+             op_entity_class: "WorkPackageCustomField",
+             jira_entity_class: "Import::JiraField")
+      custom_field
+    end
+
+    def with_mode(mode)
+      stub_const("#{described_class}::VALUE_MATCH_MODE", mode)
+    end
+
+    context "with a list field" do
+      it "reuses a custom field left behind by an earlier run" do
+        existing = create(:list_wp_custom_field, name: "Severity", possible_values: %w[Low High])
+
+        expect(list_builder.find_existing_custom_field).to eq(existing)
+      end
+
+      it "looks past a dedup-counter suffix on the existing name" do
+        existing = create(:list_wp_custom_field, name: "Severity (2)", possible_values: %w[Low High])
+
+        expect(list_builder.find_existing_custom_field).to eq(existing)
+      end
+
+      it "looks past a project-key disambiguation suffix on either side" do
+        existing = create(:list_wp_custom_field, name: "Severity (DYX)", possible_values: %w[Low High])
+        builder = list_builder(projects: %w[ABC], needs_disambiguation: true)
+
+        expect(builder.find_existing_custom_field).to eq(existing)
+      end
+
+      it "does not reuse the only candidate when its values are incompatible" do
+        create(:list_wp_custom_field, name: "Severity", possible_values: %w[Blocker])
+
+        expect(list_builder.find_existing_custom_field).to be_nil
+      end
+
+      it "creates a free name for itself when it does not reuse a candidate" do
+        create(:list_wp_custom_field, name: "Severity", possible_values: %w[Red Green])
+        builder = list_builder
+
+        expect(builder.find_existing_custom_field).to be_nil
+        expect(builder.custom_field_settings.first).to eq("Severity (2)")
+      end
+
+      it "does not reuse a candidate of another format" do
+        create(:string_wp_custom_field, name: "Severity")
+
+        expect(list_builder.find_existing_custom_field).to be_nil
+      end
+
+      it "does not reuse a candidate whose multi_value differs" do
+        create(:list_wp_custom_field, name: "Severity", possible_values: %w[Low High], multi_value: true)
+
+        expect(list_builder(multi_value: false).find_existing_custom_field).to be_nil
+      end
+
+      it "picks the split that covers the needed values" do
+        create(:list_wp_custom_field, name: "Severity", possible_values: %w[Red Green])
+        matching = create(:list_wp_custom_field, name: "Severity (DYX)", possible_values: %w[Low High Critical])
+
+        expect(list_builder.find_existing_custom_field).to eq(matching)
+      end
+
+      it "never matches when the context declares no values at all" do
+        create(:list_wp_custom_field, name: "Severity", possible_values: %w[Low High])
+
+        expect(list_builder(values: []).find_existing_custom_field).to be_nil
+      end
+
+      it "creates a new field when no candidate shares a value, under every mode" do
+        create(:list_wp_custom_field, name: "Severity", possible_values: %w[Red Green])
+
+        %i[subset exact extend].each do |mode|
+          with_mode(mode)
+          expect(list_builder.find_existing_custom_field).to be_nil
+        end
+      end
+    end
+
+    context "when the needed values are a subset of an existing field's" do
+      let!(:existing) { create(:list_wp_custom_field, name: "Severity", possible_values: %w[Low High Critical]) }
+      let(:builder) { list_builder(values: %w[Low High]) }
+
+      it "reuses it under :subset" do
+        with_mode(:subset)
+
+        expect(builder.find_existing_custom_field).to eq(existing)
+      end
+
+      it "reuses it untouched under :extend" do
+        with_mode(:extend)
+
+        expect(builder.find_existing_custom_field).to eq(existing)
+        builder.apply_pending_value_extension(existing, user: User.system)
+        expect(existing.reload.custom_options.pluck(:value)).to eq(%w[Low High Critical])
+      end
+
+      it "creates a new field under :exact" do
+        with_mode(:exact)
+
+        expect(builder.find_existing_custom_field).to be_nil
+      end
+    end
+
+    context "when the needed values only partially overlap an existing field's" do
+      let!(:existing) { create(:list_wp_custom_field, name: "Severity", possible_values: %w[Low High]) }
+      let(:builder) { list_builder(values: %w[High Critical]) }
+
+      it "creates a new field under :subset" do
+        with_mode(:subset)
+
+        expect(builder.find_existing_custom_field).to be_nil
+      end
+
+      it "creates a new field under :exact" do
+        with_mode(:exact)
+
+        expect(builder.find_existing_custom_field).to be_nil
+      end
+
+      it "leaves a custom field this import does not own alone under :extend" do
+        with_mode(:extend)
+
+        expect(builder.find_existing_custom_field).to be_nil
+      end
+
+      context "with :extend, on a field this import owns" do
+        before do
+          with_mode(:extend)
+          import_owned(existing)
+        end
+
+        it "reuses the best overlapping candidate" do
+          expect(builder.find_existing_custom_field).to eq(existing)
+        end
+
+        it "appends only the missing labels and keeps the existing options" do
+          option_ids = existing.custom_options.pluck(:id)
+          builder.find_existing_custom_field
+          builder.apply_pending_value_extension(existing, user: User.system)
+
+          expect(existing.reload.custom_options.pluck(:value)).to eq(%w[Low High Critical])
+          expect(existing.custom_options.pluck(:id).first(2)).to eq(option_ids)
+        end
+      end
+    end
+
+    context "with two context groups of the same run" do
+      let!(:sibling) { create(:list_wp_custom_field, name: "Severity (DYX)", possible_values: %w[Low High]) }
+
+      it "shares one custom field when their option sets are identical" do
+        builder = list_builder(values: %w[Low High], projects: %w[ABC], needs_disambiguation: true)
+
+        expect(builder.find_existing_custom_field(run_custom_field_ids: [sibling.id])).to eq(sibling)
+      end
+
+      it "keeps the split when the second group only needs a subset" do
+        builder = list_builder(values: %w[Low], projects: %w[ABC], needs_disambiguation: true)
+
+        expect(builder.find_existing_custom_field(run_custom_field_ids: [sibling.id])).to be_nil
+      end
+
+      it "keeps the split under :extend as well" do
+        with_mode(:extend)
+        import_owned(sibling)
+        builder = list_builder(values: %w[Low Critical], projects: %w[ABC], needs_disambiguation: true)
+
+        expect(builder.find_existing_custom_field(run_custom_field_ids: [sibling.id])).to be_nil
+      end
+    end
+
+    context "with a non-value-bearing format" do
+      def date_builder
+        schema = { "type" => "date", "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:datepicker" }
+        described_class.new(jira_field_for(name: "Due", schema:), jira_import:)
+      end
+
+      it "prefers the exact base name over an older suffixed candidate" do
+        create(:date_wp_custom_field, name: "Due (archived)")
+        exact = create(:date_wp_custom_field, name: "Due")
+
+        expect(date_builder.find_existing_custom_field).to eq(exact)
+      end
+
+      it "falls back to the oldest suffixed candidate when no exact name exists" do
+        oldest = create(:date_wp_custom_field, name: "Due (archived)")
+        create(:date_wp_custom_field, name: "Due (2)")
+
+        expect(date_builder.find_existing_custom_field).to eq(oldest)
+      end
+    end
+
+    context "with a hierarchy field", with_ee: [:custom_field_hierarchies] do
+      def hierarchy_builder(allowed_values)
+        schema = { "type" => "option-with-child",
+                   "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect" }
+        context_group = { "projects" => [], "issuetypes" => [], "allowedValues" => allowed_values }
+        described_class.new(jira_field_for(name: "Impact", schema:, context_groups: [context_group]),
+                            context_group:, jira_import:)
+      end
+
+      def hierarchy_cf_with(allowed_values)
+        custom_field = create(:hierarchy_wp_custom_field, name: "Impact")
+        hierarchy_builder(allowed_values).custom_field_post_processing(custom_field)
+        custom_field.reload
+      end
+
+      it "reuses a field that already carries the needed paths" do
+        existing = hierarchy_cf_with([{ "value" => "Critical", "children" => [{ "value" => "Security" }] },
+                                      { "value" => "Minor" }])
+
+        expect(hierarchy_builder([{ "value" => "Minor" }]).find_existing_custom_field).to eq(existing)
+      end
+
+      it "does not reuse a field missing one of the needed paths" do
+        hierarchy_cf_with([{ "value" => "Critical" }])
+
+        expect(hierarchy_builder([{ "value" => "Minor" }]).find_existing_custom_field).to be_nil
+      end
+
+      it "walks into existing branches and adds only the missing nodes under :extend" do
+        with_mode(:extend)
+        existing = import_owned(hierarchy_cf_with([{ "value" => "Critical", "children" => [{ "value" => "Security" }] }]))
+        builder = hierarchy_builder(
+          [{ "value" => "Critical", "children" => [{ "value" => "Security" }, { "value" => "Performance" }] }]
+        )
+
+        expect(builder.find_existing_custom_field).to eq(existing)
+        builder.apply_pending_value_extension(existing, user: User.system)
+
+        root = existing.reload.hierarchy_root
+        expect(root.children.pluck(:label)).to contain_exactly("Critical")
+        expect(root.children.find_by(label: "Critical").children.pluck(:label))
+          .to contain_exactly("Security", "Performance")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-170

# What are you trying to achieve?

Lists and hierarchy custom fields were not reused (at all!) between import runs.

# What approach did you choose and why?

- Candidates are found by the field's **stable base name**, ignoring both the `(2)` dedup counter and the `(DYX, ABC)` project suffix, since neither is stable across runs.
- A candidate must agree on `field_format` and`multi_value` before it is considered.
- Introduce `VALUE_MATCH_MODE`
   There is currently no way for a user to specify the mode, it is for future use only (and out-of-scope for this bugfix)
  - `:subset` (default): Reuse a field that already covers everything this project needs.
      There might be more values in the existing custom field as used in the imported project
  - `:exact`: Reuse only on an identical option set.                                                                                                                                                                                                                                                                                                                                         
  - `:extend`: any non-empty overlap. Picks the candidate sharing the most values and appends the entries it is missing. 

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
