### PR TITLE
[COMMS-969] Allow filtering on observed in versions

### DIFF
--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -59,6 +59,7 @@ module Queries::WorkPackages
     filter Filter::UpdatedAtFilter
     filter Filter::VersionFilter
     filter Filter::TargetVersionsFilter
+    filter Filter::ObservedInVersionsFilter
     filter Filter::WatcherFilter
     filter Filter::DatesIntervalFilter
     filter Filter::ParentFilter

--- a/app/models/queries/work_packages/filter/filter_on_versions_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_on_versions_mixin.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::WorkPackages::Filter::FilterOnTargetVersionsMixin
+module Queries::WorkPackages::Filter::FilterOnVersionsMixin
   STATUS_BY_OPERATOR = { "o" => "open", "c" => "closed", "l" => "locked" }.freeze
 
   def allowed_values
@@ -57,7 +57,7 @@ module Queries::WorkPackages::Filter::FilterOnTargetVersionsMixin
   end
 
   def where
-    target_versions_where
+    versions_where
   end
 
   def value_objects
@@ -90,40 +90,40 @@ module Queries::WorkPackages::Filter::FilterOnTargetVersionsMixin
     end
   end
 
-  def target_versions_where
+  def versions_where
     case operator
     when "!" # is not
-      "NOT (#{target_version_matching_values})"
+      "NOT (#{version_matching_values})"
     when "!*" # empty
-      "NOT (#{any_target_version_associated})"
+      "NOT (#{any_version_associated})"
     when "*" # not empty
-      any_target_version_associated
+      any_version_associated
     when "o", "c", "l" # version status
-      target_version_with_status(STATUS_BY_OPERATOR[operator])
+      version_with_status(STATUS_BY_OPERATOR[operator])
     else # "=" is (or)
-      target_version_matching_values
+      version_matching_values
     end
   end
 
-  def any_target_version_associated
-    "EXISTS (#{target_associations.select(1).to_sql})"
+  def any_version_associated
+    "EXISTS (#{version_associations.select(1).to_sql})"
   end
 
-  def target_version_matching_values
-    "EXISTS (#{target_associations.where(version_id: values).select(1).to_sql})"
+  def version_matching_values
+    "EXISTS (#{version_associations.where(version_id: values).select(1).to_sql})"
   end
 
-  def target_version_with_status(status)
-    sub = target_associations
+  def version_with_status(status)
+    sub = version_associations
             .joins(:version)
             .where(Version.table_name => { status: })
             .select(1)
     "EXISTS (#{sub.to_sql})"
   end
 
-  def target_associations
+  def version_associations
     WorkPackageVersion
-      .where(kind: "target")
+      .where(kind: version_kind)
       .where("#{WorkPackageVersion.table_name}.work_package_id = #{WorkPackage.table_name}.id")
   end
 end

--- a/app/models/queries/work_packages/filter/observed_in_versions_filter.rb
+++ b/app/models/queries/work_packages/filter/observed_in_versions_filter.rb
@@ -28,18 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Queries::WorkPackages::Filter::TargetVersionsFilter <
+class Queries::WorkPackages::Filter::ObservedInVersionsFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
   include ::Queries::WorkPackages::Filter::FilterOnVersionsMixin
 
-  def self.key = :target_version_id
-  def human_name = WorkPackage.human_attribute_name("target_versions")
-
-  def available?
-    Setting::WorkPackageMultipleVersions.active?
-  end
+  def self.key = :observed_in_version_id
+  def human_name = WorkPackage.human_attribute_name("observed_in_versions")
 
   private
 
-  def version_kind = "target"
+  def version_kind = "observed_in"
 end

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -32,7 +32,7 @@ class Queries::WorkPackages::Filter::VersionFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
   # Filters on `target_versions` as it is replacing
   # the legacy `work_packages.version_id` column.
-  include ::Queries::WorkPackages::Filter::FilterOnTargetVersionsMixin
+  include ::Queries::WorkPackages::Filter::FilterOnVersionsMixin
 
   def human_name
     WorkPackage.human_attribute_name("version")
@@ -47,4 +47,8 @@ class Queries::WorkPackages::Filter::VersionFilter <
   def available?
     !Setting::WorkPackageMultipleVersions.active?
   end
+
+  private
+
+  def version_kind = "target"
 end

--- a/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
@@ -54,6 +54,8 @@ export function attributeNameForFilter(filterId:string):string {
     case 'version':
     case 'targetVersion':
       return 'targetVersions';
+    case 'observedInVersion':
+      return 'observedInVersions';
     default:
       return filterId;
   }
@@ -209,6 +211,6 @@ export class WorkPackageFilterValues {
   }
 
   private isMultiValueAttribute(attributeName:string):boolean {
-    return attributeName === 'targetVersions';
+    return attributeName === 'targetVersions' || attributeName === 'observedInVersions';
   }
 }

--- a/lib/api/v3/queries/schemas/observed_in_versions_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/observed_in_versions_filter_dependency_representer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/lib/api/v3/queries/schemas/observed_in_versions_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/observed_in_versions_filter_dependency_representer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -28,18 +27,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Queries::WorkPackages::Filter::TargetVersionsFilter <
-  Queries::WorkPackages::Filter::WorkPackageFilter
-  include ::Queries::WorkPackages::Filter::FilterOnVersionsMixin
-
-  def self.key = :target_version_id
-  def human_name = WorkPackage.human_attribute_name("target_versions")
-
-  def available?
-    Setting::WorkPackageMultipleVersions.active?
+module API
+  module V3
+    module Queries
+      module Schemas
+        class ObservedInVersionsFilterDependencyRepresenter <
+          TargetVersionsFilterDependencyRepresenter
+        end
+      end
+    end
   end
-
-  private
-
-  def version_kind = "target"
 end

--- a/spec/models/queries/work_packages/filter/observed_in_versions_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/observed_in_versions_filter_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::WorkPackages::Filter::ObservedInVersionsFilter do
+  let(:actual_project) { create(:project) }
+  let(:version) { create(:version, project: actual_project) }
+  let(:other_project_version) { create(:version, project: create(:project)) }
+
+  let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
+  let(:user) { create(:user, member_with_roles: { actual_project => role }) }
+
+  before { login_as(user) }
+
+  it_behaves_like "basic query filter" do
+    let(:project) { actual_project }
+    let(:type) { :list_optional }
+    let(:class_key) { :observed_in_version_id }
+    let(:values) { [version.id.to_s] }
+    let(:name) { WorkPackage.human_attribute_name("observed_in_versions") }
+
+    describe "#valid?" do
+      context "within a project" do
+        context "and the version belongs to the project" do
+          it "is valid" do
+            expect(instance).to be_valid
+          end
+        end
+
+        context "and the version is from another project" do
+          let(:values) { [other_project_version.id.to_s] }
+
+          it "is not valid" do
+            expect(instance).not_to be_valid
+          end
+        end
+      end
+
+      context "without a project" do
+        let(:project) { nil }
+
+        context "and the version is visible to the user" do
+          it "is valid" do
+            expect(instance).to be_valid
+          end
+        end
+
+        context "and the version does not exist" do
+          let(:values) { ["12345"] }
+
+          it "is not valid" do
+            expect(instance).not_to be_valid
+          end
+        end
+      end
+
+      context "with a version status operator and no values" do
+        let(:operator) { "o" }
+        let(:values) { [] }
+
+        it "is valid" do
+          expect(instance).to be_valid
+        end
+      end
+    end
+
+    describe "#allowed_values" do
+      context "within a project" do
+        it "returns the project's shared versions" do
+          expect(instance.allowed_values)
+            .to contain_exactly([version.id.to_s, version.id.to_s])
+        end
+      end
+
+      context "without a project" do
+        let(:project) { nil }
+
+        it "returns only versions visible to the current user" do
+          other_project_version
+
+          expect(instance.allowed_values)
+            .to contain_exactly([version.id.to_s, version.id.to_s])
+        end
+      end
+    end
+
+    describe "#value_objects" do
+      let!(:other_version) { create(:version, project: actual_project) }
+
+      it "returns the Version records matching the filter values" do
+        expect(instance.value_objects).to contain_exactly(version)
+      end
+    end
+
+    describe "#available_operators" do
+      it "includes the version status operators" do
+        expect(instance.available_operators).to include(
+          Queries::Operators::Versions::OpenStatus,
+          Queries::Operators::Versions::ClosedStatus,
+          Queries::Operators::Versions::LockedStatus
+        )
+      end
+    end
+
+    describe "#operator_strategy" do
+      context 'for "o"' do
+        let(:operator) { "o" }
+
+        it "is the open status operator" do
+          expect(instance.operator_strategy).to eq(Queries::Operators::Versions::OpenStatus)
+        end
+      end
+
+      context 'for "c"' do
+        let(:operator) { "c" }
+
+        it "is the closed status operator" do
+          expect(instance.operator_strategy).to eq(Queries::Operators::Versions::ClosedStatus)
+        end
+      end
+
+      context 'for "l"' do
+        let(:operator) { "l" }
+
+        it "is the locked status operator" do
+          expect(instance.operator_strategy).to eq(Queries::Operators::Versions::LockedStatus)
+        end
+      end
+
+      context 'for "="' do
+        it "is the equals operator" do
+          expect(instance.operator_strategy).to eq(Queries::Operators::EqualsOr)
+        end
+      end
+    end
+
+    describe "#where" do
+      let(:open_version) { version }
+      let(:closed_version) { create(:version, project: actual_project, status: "closed") }
+      let(:locked_version) { create(:version, project: actual_project, status: "locked") }
+
+      let!(:wp_observing_open) do
+        create(:work_package, project: actual_project).tap do |wp|
+          create(:work_package_version, work_package: wp, version: open_version, kind: :observed_in)
+        end
+      end
+      let!(:wp_observing_closed) do
+        create(:work_package, project: actual_project).tap do |wp|
+          create(:work_package_version, work_package: wp, version: closed_version, kind: :observed_in)
+        end
+      end
+      let!(:wp_observing_locked) do
+        create(:work_package, project: actual_project).tap do |wp|
+          create(:work_package_version, work_package: wp, version: locked_version, kind: :observed_in)
+        end
+      end
+      let!(:wp_targeting_only) do
+        create(:work_package, project: actual_project).tap do |wp|
+          create(:work_package_version, work_package: wp, version: open_version, kind: :target)
+        end
+      end
+      let!(:wp_without_versions) { create(:work_package, project: actual_project) }
+
+      subject(:result) { WorkPackage.where(instance.where) }
+
+      context 'for "=" with a version' do
+        let(:values) { [open_version.id.to_s] }
+
+        it "returns work packages observed in that version" do
+          expect(result).to contain_exactly(wp_observing_open)
+        end
+      end
+
+      context 'for "!" with a version' do
+        let(:operator) { "!" }
+        let(:values) { [open_version.id.to_s] }
+
+        it "returns work packages not observed in that version, including ones without observed in versions" do
+          expect(result).to contain_exactly(wp_observing_closed, wp_observing_locked, wp_targeting_only, wp_without_versions)
+        end
+      end
+
+      context 'for "*" (any observed in version)' do
+        let(:operator) { "*" }
+        let(:values) { [] }
+
+        it "returns work packages with at least one observed in version" do
+          expect(result).to contain_exactly(wp_observing_open, wp_observing_closed, wp_observing_locked)
+        end
+      end
+
+      context 'for "!*" (no observed in version)' do
+        let(:operator) { "!*" }
+        let(:values) { [] }
+
+        it "returns work packages without any observed in version" do
+          expect(result).to contain_exactly(wp_targeting_only, wp_without_versions)
+        end
+      end
+
+      context 'for "o" (open version)' do
+        let(:operator) { "o" }
+        let(:values) { [] }
+
+        it "returns work packages observed in an open version" do
+          expect(result).to contain_exactly(wp_observing_open)
+        end
+      end
+
+      context 'for "c" (closed version)' do
+        let(:operator) { "c" }
+        let(:values) { [] }
+
+        it "returns work packages observed in a closed version" do
+          expect(result).to contain_exactly(wp_observing_closed)
+        end
+      end
+
+      context 'for "l" (locked version)' do
+        let(:operator) { "l" }
+        let(:values) { [] }
+
+        it "returns work packages observed in a locked version" do
+          expect(result).to contain_exactly(wp_observing_locked)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-969/activity

# What are you trying to accomplish?
Make it possible to filter work packages by observed in versions

## Screenshots
<img width="2333" height="1501" alt="image" src="https://github.com/user-attachments/assets/6ad8cc37-04c0-4822-be94-1b21f38d263a" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
