### PR TITLE
Try to fix some flaky specs

### DIFF
--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -139,8 +139,10 @@ module Pages
     # Expect the given titled card in the list name to be present (expect=true) or not (expect=false)
     def expect_card(list_name, card_title, present: true)
       within_list(list_name) do
-        # Wait for the card loading to finish
-        expect(page).to have_no_selector(".loading-indicator--background")
+        # Wait for the card loading to finish. A list can start another reload
+        # right after a card was added or moved, so this needs more than the
+        # default wait time.
+        expect(page).to have_no_selector(".loading-indicator--background", wait: 10)
         expect(page).to have_conditional_selector(present,
                                                   '[data-test-selector="op-wp-single-card--content-subject"]',
                                                   text: card_title,

--- a/spec/features/projects/creation_wizard/project_creation_wizard_spec.rb
+++ b/spec/features/projects/creation_wizard/project_creation_wizard_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "Project creation wizard",
                         query: user_assignee.name
     fill_in "Team Size", with: "5"
 
-    click_button "Complete"
+    wait_for_turbo { click_button "Complete" }
     expect(page).to have_text("Project attributes saved and artefact work package created successfully.")
 
     project.reload
@@ -394,7 +394,7 @@ RSpec.describe "Project creation wizard",
                           query: user_assignee.name
       fill_in "Team Size", with: "3"
 
-      click_button "Complete"
+      wait_for_turbo { click_button "Complete" }
 
       expect(page).to have_text("Project attributes saved and artefact work package created successfully.")
 
@@ -481,8 +481,7 @@ RSpec.describe "Project creation wizard",
       select_autocomplete page.find("[data-custom-field-id='#{user_custom_field.id}']"),
                           results_selector: "body",
                           query: user_assignee.name
-      click_button "Complete"
-      wait_for_network_idle
+      wait_for_turbo { click_button "Complete" }
 
       # Comment should be saved
       expect(project.reload.send(string_custom_field.comment_attribute_name)).to eq "foo"

--- a/spec/features/work_packages/table/queries/parent_field_ranking_spec.rb
+++ b/spec/features/work_packages/table/queries/parent_field_ranking_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe "Work package Parent field ranks exact matches first", :js, :sele
     dropdown = field.autocomplete("#PARENTFIELD-5", select: false)
 
     within(dropdown) do
+      # Both matches must be rendered before the options are read, otherwise the
+      # snapshot can be taken while the dropdown still shows the previous results.
+      expect(page).to have_css(".ng-option", text: exact_match.subject)
+      expect(page).to have_css(".ng-option", text: prefix_match.subject)
+
       # The first option is always a "-" (clear/no-parent) entry, unrelated to ranking.
       # This autocompleter's options only render the work package's subject, not its id.
       candidate_texts = all(".ng-option").map(&:text).reject { |text| text == "-" }

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -58,6 +58,11 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "new", over
 
     options.logging_prefs = { browser: "ALL" }
 
+    # axe-core audits and Capybara's own hint gathering run as scripts over the
+    # full DOM. On large pages (permissions matrix, Gantt header) the 30s W3C
+    # default is not enough on a loaded CI machine.
+    options.timeouts = { script: 60_000 }
+
     yield(options) if block_given?
 
     client = Selenium::WebDriver::Remote::Http::Default.new

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -242,18 +242,21 @@ module Components
       # row's data-filter-type as a symbol (:date, :datetime_past, ...).
       #
       # Re-finding is required because adding/operating on a filter re-renders
-      # the row, leaving a captured reference stale (ObsoleteNode). The raising
-      # find waits for the row; the marker check is then instant, mirroring the
-      # synchronous data-filter-type read. The marker check stays wait: 0 on
-      # purpose: rows are pre-rendered, so the marker is present whenever the row
-      # is, and a default wait would only stall the non-autocomplete branches for
-      # the full Capybara timeout before falling through.
+      # the row, leaving a captured reference stale (ObsoleteNode). The row can
+      # also go stale between the find and the reads, so the whole
+      # classification runs in a synchronize block that retries on that error.
+      # The marker check stays wait: 0 on purpose: rows are pre-rendered, so the
+      # marker is present whenever the row is, and a default wait would only
+      # stall the non-autocomplete branches for the full Capybara timeout before
+      # falling through.
       def filter_kind(name)
-        row = page.find(filter_selector(name))
+        page.document.synchronize do
+          row = page.find(filter_selector(name))
 
-        return :autocomplete if row.has_css?('[data-filter-autocomplete="true"]', wait: 0)
+          next :autocomplete if row.has_css?('[data-filter-autocomplete="true"]', wait: 0)
 
-        row[:"data-filter-type"]&.to_sym
+          row[:"data-filter-type"]&.to_sym
+        end
       end
 
       def boolean_filter?(_filter)


### PR DESCRIPTION
Trying to fix some of the reported flaky specs

```


    rspec ./modules/boards/spec/features/action_boards/version_board_spec.rb[1:1:2]
    rspec ./modules/gantt/spec/features/timeline/timeline_dates_spec.rb[1:2:1]
    rspec ./spec/features/projects/creation_wizard/project_creation_wizard_spec.rb[1:8:2]
    rspec ./spec/features/projects/lists/filters_spec.rb[1:6:1]
    rspec ./spec/features/roles/report_spec.rb[1:1]
    rspec ./spec/features/roles/report_spec.rb[1:2]
    rspec ./spec/features/work_packages/table/queries/parent_field_ranking_spec.rb[1:1]
