### PR TITLE
[TITAN-24] Typeerror in storages automaticallymanagedstoragesyncjob p…

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/base.rb
@@ -79,6 +79,16 @@ module Storages
             end
           end
 
+          # Parses a response body as JSON. Nextcloud does not always answer in the requested format: OCS responses
+          # rendered outside of the integration app (e.g. when it is disabled) fall back to XML, and reverse proxies
+          # may answer with an HTML page. Those bodies make HTTPX raise, which would escape the adapter contract.
+          # @return [Dry::Result]
+          def parse_json(response, error)
+            Success(response.json(symbolize_keys: true))
+          rescue HTTPX::Error, MultiJSON::ParseError
+            Failure(error.with(code: :invalid_response, payload: response))
+          end
+
           # Validates the OCS Meta Statuscode for fatal errors (i.e. unexpected server-side errors). Client-side errors,
           # such as a 404 File Not Found do not cause an error.
           # @return [Dry::Result]

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/capabilities_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/capabilities_query.rb
@@ -54,8 +54,7 @@ module Storages
 
               case response
               in { status: 200..299 }
-                json = response.json(symbolize_keys: true)
-                parse_capabilities(json)
+                parse_json(response, error).bind { parse_capabilities(it) }
               in { status: 404 }
                 Failure(error.with(code: :not_found))
               else

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/file_info_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/file_info_query.rb
@@ -55,7 +55,7 @@ module Storages
 
               case response
               in { status: 200..299 }
-                fail_on_ocs_error(response.json(symbolize_keys: true), error)
+                parse_json(response, error).bind { fail_on_ocs_error(it, error) }
               in { status: 404 }
                 Failure(error.with(code: :not_found))
               in { status: 401 }

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_info_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_info_query.rb
@@ -57,7 +57,7 @@ module Storages
 
               case response
               in { status: 200..299 }
-                fail_on_ocs_error(response.json(symbolize_keys: true), error)
+                parse_json(response, error).bind { fail_on_ocs_error(it, error) }
               in { status: 404 }
                 Failure(error.with(code: :not_found))
               in { status: 401 }

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/upload_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/upload_link_query.rb
@@ -66,7 +66,7 @@ module Storages
               case response
               in { status: 200..299 }
                 info "Upload link generated successfully."
-                Success(response.json(symbolize_keys: true))
+                parse_json(response, error)
               in { status: 404 }
                 info "The parent folder was not found."
                 Failure(error.with(code: :not_found))

--- a/modules/storages/app/validator/nextcloud_compatible_host_validator.rb
+++ b/modules/storages/app/validator/nextcloud_compatible_host_validator.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 class NextcloudCompatibleHostValidator < ActiveModel::EachValidator
-  MINIMAL_NEXTCLOUD_VERSION = 22
+  MINIMAL_NEXTCLOUD_VERSION = 32
   AUTHORIZATION_HEADER = "Bearer TESTBEARERTOKEN"
 
   HTTPX_TIMEOUT_SETTINGS = { timeout: { connect_timeout: 5, read_timeout: 3 } }.freeze
@@ -78,16 +78,22 @@ class NextcloudCompatibleHostValidator < ActiveModel::EachValidator
     error_type = check_capabilities_response(response)
 
     if error_type
-      contract.errors.add(attribute, error_type)
+      contract.errors.add(attribute, error_type, **error_options(error_type, response))
       Rails.logger.info(message(value, response, error_type))
     end
+  end
+
+  def error_options(error_type, response)
+    return {} unless error_type == :minimal_nextcloud_version_not_met
+
+    { minimal_version: MINIMAL_NEXTCLOUD_VERSION, detected_version: read_version(response) }
   end
 
   def check_capabilities_response(response)
     return :cannot_be_connected_to if response.error.present?
     return :cannot_be_connected_to unless response.status.in? 200..299
     return :not_nextcloud_server unless read_version(response)
-    return :minimal_nextcloud_version_unmet unless major_version_sufficient?(response)
+    return :minimal_nextcloud_version_not_met unless major_version_sufficient?(response)
 
     nil
   end
@@ -128,8 +134,6 @@ class NextcloudCompatibleHostValidator < ActiveModel::EachValidator
       message << ": #{response.class}: #{response}"
     when :not_nextcloud_server
       message << ": either was not valid json, or value at 'ocs/data/version/major' was not defined"
-    when :minimal_nextcloud_version_unmet
-      message << ": version detected is #{read_version(response).inspect}, minimum is #{MINIMAL_NEXTCLOUD_VERSION}"
     end
 
     message

--- a/modules/storages/app/workers/storages/automatically_managed_storage_sync_job.rb
+++ b/modules/storages/app/workers/storages/automatically_managed_storage_sync_job.rb
@@ -59,8 +59,19 @@ module Storages
 
       sync_result = ManagedFolderSyncService.call(storage)
 
-      sync_result.on_failure { raise Errors::IntegrationJobError, sync_result.errors.full_messages.join(", ") }
+      sync_result.on_failure { raise Errors::IntegrationJobError, health_reason(sync_result.errors) }
       sync_result.on_success { OpenProject::Notifications.send(OpenProject::Events::STORAGE_TURNED_HEALTHY, storage:) }
+    end
+
+    private
+
+    # Health reasons are stored as "<identifier>|<description>".
+    # @see Storages::Storage#health_reason_identifier
+    def health_reason(errors)
+      types = errors.map(&:type).uniq
+      identifier = types.one? ? types.first : :sync_failed
+
+      "#{identifier}|#{errors.map(&:message).uniq.join(', ')}"
     end
   end
 end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -66,7 +66,7 @@ en:
             host:
               authorization_header_missing: is not fully set up. The Nextcloud instance does not receive the "Authorization" header, which is necessary for a Bearer token based authorization of API requests. Please double check your HTTP server configuration.
               cannot_be_connected_to: could not be reached. Please ensure the host is reachable and the OpenProject integration app is installed.
-              minimal_nextcloud_version_unmet: does not meet minimal version requirements (must be Nextcloud 23 or higher)
+              minimal_nextcloud_version_not_met: does not meet minimal version requirements (must be Nextcloud %{minimal_version} or higher, but %{detected_version} was detected)
               not_nextcloud_server: is not a Nextcloud server
               op_application_not_installed: appears to not have the app "OpenProject integration" installed. Please install it first and then try again.
             password:
@@ -135,6 +135,7 @@ en:
         error: An unexpected error occurred. Please check OpenProject logs for more information or contact an administrator
         folder_id_collision: Multiple project storages try to manage the project folder %{folder}. Its synchronization was skipped.
         forbidden: OpenProject could not access the requested resource. Please check your permissions configuration on the Storage Provider.
+        invalid_response: OpenProject could not process the response received from the Storage Provider. Please check OpenProject logs for more information or contact an administrator.
         unauthorized: OpenProject could not authenticate with the Storage Provider. Please ensure that you have access to it.
       models:
         copy_project_folders_service:

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
@@ -131,6 +131,13 @@ module Storages
 
               it_behaves_like "storage adapter: error response", :error
             end
+
+            context "with a non JSON response body", vcr: "nextcloud/file_info_query_xml_response" do
+              let(:file_id) { "56" }
+              let(:error_source) { described_class }
+
+              it_behaves_like "storage adapter: error response", :invalid_response
+            end
           end
         end
       end

--- a/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
@@ -162,7 +162,7 @@ RSpec.shared_examples_for "nextcloud storage contract", :storage_server_helpers,
         let(:capabilities_response_body) { nil } # use default
         let(:capabilities_response_code) { nil } # use default
         let(:capabilities_response_headers) { nil } # use default
-        let(:capabilities_response_major_version) { 22 }
+        let(:capabilities_response_major_version) { NextcloudCompatibleHostValidator::MINIMAL_NEXTCLOUD_VERSION }
         let(:check_config_response_body) { nil } # use default
         let(:check_config_response_code) { nil } # use default
         let(:check_config_response_headers) { nil } # use default
@@ -251,10 +251,18 @@ RSpec.shared_examples_for "nextcloud storage contract", :storage_server_helpers,
           include_examples "contract is invalid", host: :not_nextcloud_server
         end
 
-        context "when Nextcloud version is below the required minimal version which is 22" do
-          let(:capabilities_response_major_version) { 21 }
+        context "when Nextcloud version is below the required minimal version" do
+          let(:capabilities_response_major_version) { NextcloudCompatibleHostValidator::MINIMAL_NEXTCLOUD_VERSION - 1 }
 
-          include_examples "contract is invalid", host: :minimal_nextcloud_version_unmet
+          include_examples "contract is invalid", host: :minimal_nextcloud_version_not_met
+
+          it "reports the required and the detected version" do
+            contract.validate
+
+            expect(contract.errors.full_messages_for(:host).first)
+              .to include(NextcloudCompatibleHostValidator::MINIMAL_NEXTCLOUD_VERSION.to_s,
+                          capabilities_response_major_version.to_s)
+          end
         end
 
         context 'when Nextcloud instance is missing the "OpenProject integration" app' do

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/file_info_query_xml_response.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/file_info_query_xml_response.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/56
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenProject 17.0.0 HTTPX Client
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Ocs-Apirequest:
+      - 'true'
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Date:
+      - Fri, 21 Aug 2026 12:44:40 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.65 (Debian)
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.3.27
+      X-Request-Id:
+      - 4ExwMYGMGWHnoFDsbJVa
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-User-Id:
+      - OpenProject
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <ocs>
+         <meta>
+          <status>failure</status>
+          <statuscode>998</statuscode>
+          <message>Invalid query, please check the syntax. API specifications are here: http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.
+        </message>
+          <totalitems></totalitems>
+          <itemsperpage></itemsperpage>
+         </meta>
+         <data/>
+        </ocs>
+  recorded_at: Fri, 21 Aug 2026 12:44:40 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/workers/storages/automatically_managed_storage_sync_job_spec.rb
+++ b/modules/storages/spec/workers/storages/automatically_managed_storage_sync_job_spec.rb
@@ -111,6 +111,49 @@ RSpec.describe Storages::AutomaticallyManagedStorageSyncJob, type: :job do
       end
     end
 
+    context "when several sync steps fail with the same error" do
+      let(:errors) do
+        ActiveModel::Errors.new(Storages::NextcloudManagedFolderPermissionsService.new(storage: managed_nextcloud))
+          .tap do |messages|
+            messages.add(:ensure_root_folder_permissions, :invalid_response)
+            messages.add(:set_folder_permission, :invalid_response)
+          end
+      end
+
+      before do
+        mailer_job = class_double(Storages::HealthStatusMailerJob)
+        allow(Storages::HealthStatusMailerJob).to receive(:set).and_return(mailer_job)
+        allow(mailer_job).to receive(:perform_later)
+
+        allow(Storages::ManagedFolderSyncService)
+          .to receive(:call).with(managed_nextcloud).and_return(ServiceResult.failure(errors:))
+      end
+
+      it "reports the error code as health reason identifier and the message only once" do
+        perform_enqueued_jobs { described_class.perform_later(managed_nextcloud) }
+
+        managed_nextcloud.reload
+        expect(managed_nextcloud.health_reason_identifier).to eq("invalid_response")
+        expect(managed_nextcloud.health_reason_description).to eq(I18n.t("services.errors.messages.invalid_response"))
+      end
+
+      context "with errors of different types" do
+        let(:errors) do
+          ActiveModel::Errors.new(Storages::NextcloudManagedFolderPermissionsService.new(storage: managed_nextcloud))
+            .tap do |messages|
+              messages.add(:set_folder_permission, :invalid_response)
+              messages.add(:base, :unauthorized)
+            end
+        end
+
+        it "reports a generic health reason identifier" do
+          perform_enqueued_jobs { described_class.perform_later(managed_nextcloud) }
+
+          expect(managed_nextcloud.reload.health_reason_identifier).to eq("sync_failed")
+        end
+      end
+    end
+
     context "when Storages::Errors::IntegrationJobError is raised" do
       before do
         errors = ActiveModel::Errors.new(Storages::ManagedFolderSyncService.new(managed_nextcloud))

--- a/spec/support/storage_server_helpers.rb
+++ b/spec/support/storage_server_helpers.rb
@@ -34,7 +34,7 @@ module StorageServerHelpers
                                         response_headers: nil,
                                         response_body: nil,
                                         timeout: false,
-                                        response_nextcloud_major_version: 22)
+                                        response_nextcloud_major_version: NextcloudCompatibleHostValidator::MINIMAL_NEXTCLOUD_VERSION)
     response_code ||= 200
     response_headers ||= {
       "Content-Type" => "application/json; charset=utf-8"


### PR DESCRIPTION
# Ticket
[TITAN-24](https://community.openproject.org/projects/TITAN/work_packages/TITAN-24/activity)

# What are you trying to accomplish?
- Fix an issue where NC is returning XML instead of the JSON we are expecting. Example: when NC was configured (31) and then the configuration on the NC side had changed or when OP plugin in NC is turned off. 
- Improve health check error message from the `AutomaticallyManagedStorageSyncJob`
- Bumped minimal NC version to 32 (supported one)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
