### PR TITLE
Indicate error content type completely

### DIFF
--- a/lib/api/mcp.rb
+++ b/lib/api/mcp.rb
@@ -34,7 +34,7 @@ module API
 
     default_format :json
 
-    error_representer ::API::Mcp::ErrorRepresenter, :json
+    error_representer ::API::Mcp::ErrorRepresenter, "application/json; charset=utf-8"
     authentication_scope OpenProject::Authentication::Scope::MCP_SCOPE
 
     helpers do


### PR DESCRIPTION
Not sure why it was previously implemented as `:json`. No other occurence of `error_representer` uses
a short symbol.

# Ticket
https://community.openproject.org/wp/AI-130