### PR TITLE
[AUTOWORK-255] UX for project-owned type variants

### DIFF
--- a/app/components/projects/settings/work_packages/types/in_use_marker_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/in_use_marker_component.html.erb
@@ -1,0 +1,39 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(Primer::Beta::Octicon.new(icon: "check-circle-fill", color: :success, ml: 2)) %>
+<%= render(
+      Primer::Beta::Text.new(
+        color: :success,
+        font_size: :small,
+        font_weight: :normal,
+        ml: 1,
+        test_selector: "in-use-marker"
+      )
+    ) { label } %>

--- a/app/components/projects/settings/work_packages/types/in_use_marker_component.rb
+++ b/app/components/projects/settings/work_packages/types/in_use_marker_component.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  module Settings
+    module WorkPackages
+      module Types
+        class InUseMarkerComponent < ApplicationComponent
+          include OpPrimer::ComponentHelpers
+
+          def initialize(label:)
+            super()
+
+            @label = label
+          end
+
+          private
+
+          attr_reader :label
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -71,9 +71,13 @@ See COPYRIGHT and LICENSE files for more details.
                   linked: configurable?(variant)
                 )
               ) do |row| %>
-            <% row.with_label { t("projects.settings.types.only_available_here") } if owned?(variant) %>
-            <% if in_use?(project_type, variant) %>
-              <% row.with_label(scheme: :accent) { t("projects.settings.types.in_use") } %>
+            <% row.with_state do %>
+              <% if owned?(variant) %>
+                <%= render(Primer::Beta::Label.new(ml: 2)) { t("projects.settings.types.only_available_here") } %>
+              <% end %>
+              <% if in_use?(project_type, variant) %>
+                <%= render(Primer::Beta::Label.new(scheme: :accent, ml: 2)) { t("projects.settings.types.in_use") } %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -38,31 +38,32 @@ See COPYRIGHT and LICENSE files for more details.
             data: { test_selector: "project-types-row-#{project_type.variant.id}" }
           )
         ) do |list| %>
-      <% list.with_header(collapsed: true) do |header| %>
+      <%# Open where a variant is in use: the row saying so is inside the group. %>
+      <% list.with_header(
+           count: variants_count(project_type),
+           collapsed: base_type_in_use?(project_type)
+         ) do |header| %>
         <% header.with_title do %>
           <%= render(Primer::Beta::Text.new(tag: :span, pl: 1)) { helpers.icon_for_type(project_type.type) } %>
-          <%= render(Primer::Beta::Text.new(tag: :span, font_weight: :semibold, ml: 2)) { project_type.type.name } %>
-          <% if project_type.variant.default? %>
-            <%= render(Primer::Beta::Label.new(scheme: :accent, ml: 2)) { t("projects.settings.types.in_use") } %>
-          <% else %>
-            <%= render(Primer::Beta::Text.new(tag: :span, color: :muted, font_size: :small, ml: 2)) do %>
-              <%= t("projects.settings.types.variant_prefix") %>
-            <% end %>
-            <%= render(Primer::Beta::Text.new(tag: :span, color: :muted, font_weight: :bold, font_size: :small)) do %>
-              <%= project_type.variant.variant_name %>
-            <% end %>
+          <%= render(Primer::Beta::Text.new(tag: :span, font_weight: :bold, ml: 2)) { project_type.type.name } %>
+          <% if base_type_in_use?(project_type) %>
+            <%= in_use_marker(t("projects.settings.types.base_type_in_use")) %>
           <% end %>
         <% end %>
-        <% header.with_menu do |menu| %>
-          <% switch_action(menu, project_type.type) if switchable?(project_type) %>
-          <% remove_action(menu, project_type.type) %>
+        <% if type_actions?(project_type) %>
+          <% header.with_menu do |menu| %>
+            <% add_variant_action(menu, project_type.type) if manageable? %>
+            <% use_action(menu, base_variant(project_type)) if base_type_usable?(project_type) %>
+            <% menu.with_divider if removal_set_apart?(project_type) %>
+            <% remove_action(menu, project_type.type) if manages_types? %>
+          <% end %>
         <% end %>
       <% end %>
 
       <% selectable_variants(project_type).each do |variant| %>
         <% list.with_item(data: { test_selector: "project-types-variant-#{variant.id}" }) do |item| %>
-          <% if configurable?(variant) %>
-            <% item.with_menu { |menu| variant_actions(menu, variant) } %>
+          <% if actionable?(project_type, variant) %>
+            <% item.with_menu { |menu| variant_actions(menu, project_type, variant) } %>
           <% end %>
           <%# Unlinked unless the reader may open it: the global variants are administration's. %>
           <%= render(
@@ -71,13 +72,9 @@ See COPYRIGHT and LICENSE files for more details.
                   linked: configurable?(variant)
                 )
               ) do |row| %>
-            <% row.with_state do %>
-              <% if owned?(variant) %>
-                <%= render(Primer::Beta::Label.new(ml: 2)) { t("projects.settings.types.only_available_here") } %>
-              <% end %>
-              <% if in_use?(project_type, variant) %>
-                <%= render(Primer::Beta::Label.new(scheme: :accent, ml: 2)) { t("projects.settings.types.in_use") } %>
-              <% end %>
+            <% row.with_caption { variant_caption(variant) } %>
+            <% if in_use?(project_type, variant) %>
+              <% row.with_state { in_use_marker(t("projects.settings.types.variant_in_use")) } %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -92,13 +92,9 @@ module Projects
             count if count.positive?
           end
 
+          # Constant lookup in a compiled template does not walk the enclosing modules.
           def in_use_marker(label)
-            safe_join(
-              [
-                render(Primer::Beta::Octicon.new(icon: "check-circle-fill", color: :success, ml: 2)),
-                render(Primer::Beta::Text.new(color: :success, font_size: :small, font_weight: :normal, ml: 1)) { label }
-              ]
-            )
+            render(InUseMarkerComponent.new(label:))
           end
 
           def variant_caption(variant)

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -53,8 +53,24 @@ module Projects
                                         .sort_by { |project_type| project_type.type.position }
           end
 
-          def switchable?(project_type)
-            selectable_variants(project_type).any?
+          def manages_types?
+            User.current.allowed_in_project?(:manage_types, project)
+          end
+
+          def base_variant(project_type) = project_type.type.default_variant
+
+          def switch_targets(project_type)
+            @switch_targets ||= {}
+            @switch_targets[project_type.id] ||=
+              TypeVariant.switch_targets(user: User.current, project:, source: project_type.variant)
+                         .where.not(id: project_type.variant_id)
+                         .ids
+          end
+
+          # The header offers the type's own configuration, so it offers nothing once the project
+          # runs on it.
+          def base_type_usable?(project_type)
+            usable?(project_type, base_variant(project_type))
           end
 
           def selectable_variants(project_type)
@@ -63,6 +79,34 @@ module Projects
 
           def in_use?(project_type, variant)
             project_type.variant_id == variant.id
+          end
+
+          def base_type_in_use?(project_type)
+            project_type.variant.default?
+          end
+
+          # Left out rather than shown as zero, so the badge never labels a type with nothing to
+          # choose from.
+          def variants_count(project_type)
+            count = selectable_variants(project_type).size
+            count if count.positive?
+          end
+
+          def in_use_marker(label)
+            safe_join(
+              [
+                render(Primer::Beta::Octicon.new(icon: "check-circle-fill", color: :success, ml: 2)),
+                render(Primer::Beta::Text.new(color: :success, font_size: :small, font_weight: :normal, ml: 1)) { label }
+              ]
+            )
+          end
+
+          def variant_caption(variant)
+            if owned?(variant)
+              t("projects.settings.types.project_specific_variant")
+            else
+              t("projects.settings.types.variant_label")
+            end
           end
 
           def owned?(variant)
@@ -91,10 +135,22 @@ module Projects
             type_variant_path(in_project_id: project, type_id: variant.type_id, id: variant.id)
           end
 
-          def variant_actions(menu, variant)
+          def actionable?(project_type, variant)
+            usable?(project_type, variant) || configurable?(variant)
+          end
+
+          def usable?(project_type, variant)
+            switch_targets(project_type).include?(variant.id)
+          end
+
+          def variant_actions(menu, project_type, variant)
+            use_action(menu, variant) if usable?(project_type, variant)
+            return unless configurable?(variant)
+
             menu.with_item(label: t(:button_edit), href: edit_variant_path(variant)) do |entry|
               entry.with_leading_visual_icon(icon: :pencil)
             end
+            menu.with_divider
             menu.with_item(
               label: t(:button_delete),
               scheme: :danger,
@@ -105,18 +161,33 @@ module Projects
             end
           end
 
-          def switch_path(type)
-            new_project_settings_work_packages_type_switch_path(project, type)
+          # The reader has already chosen on the row, so the dialog opens on that variant.
+          def use_action(menu, variant)
+            menu.with_item(
+              label: t("projects.settings.types.use_in_project"),
+              href: switch_path(variant),
+              content_arguments: { data: { controller: "async-dialog" } }
+            ) do |entry|
+              entry.with_leading_visual_icon(icon: "check-circle")
+            end
           end
 
-          def switch_action(menu, type)
-            menu.with_item(
-              label: t("projects.settings.types.switch_type"),
-              href: switch_path(type),
-              content_arguments: { data: { controller: "async-dialog" } }
-            ) do |item|
-              item.with_leading_visual_icon(icon: "list-ordered")
+          def add_variant_action(menu, type)
+            menu.with_item(label: t("projects.settings.types.add_variant"), href: add_variant_path(type)) do |item|
+              item.with_leading_visual_icon(icon: :plus)
             end
+          end
+
+          def type_actions?(project_type)
+            manageable? || base_type_usable?(project_type) || manages_types?
+          end
+
+          def removal_set_apart?(project_type)
+            manages_types? && (manageable? || base_type_usable?(project_type))
+          end
+
+          def switch_path(variant)
+            new_project_settings_work_packages_type_switch_path(project, variant.type, target_id: variant.id)
           end
 
           def remove_path(type)

--- a/app/components/projects/settings/work_packages/types/switch_dialog_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/switch_dialog_component.html.erb
@@ -38,6 +38,6 @@ See COPYRIGHT and LICENSE files for more details.
   <% dialog.with_header(variant: :large) %>
 
   <%= render(
-        Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(project:, source:, url:)
+        Projects::Settings::WorkPackages::Types::SwitchFormComponent.new(project:, source:, url:, selected:)
       ) %>
 <% end %>

--- a/app/components/projects/settings/work_packages/types/switch_dialog_component.rb
+++ b/app/components/projects/settings/work_packages/types/switch_dialog_component.rb
@@ -39,17 +39,18 @@ module Projects
 
           DIALOG_ID = "project-types-switch-dialog"
 
-          def initialize(project:, source:, url:)
+          def initialize(project:, source:, url:, selected: source)
             super()
 
             @project = project
             @source = source
             @url = url
+            @selected = selected
           end
 
           private
 
-          attr_reader :project, :source, :url
+          attr_reader :project, :source, :url, :selected
         end
       end
     end

--- a/app/components/projects/settings/work_packages/types/switch_fields_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/switch_fields_component.html.erb
@@ -28,11 +28,6 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= flex_layout(direction: :column) do |body| %>
-  <% body.with_row(mb: 2) do %>
-    <%= render(Primer::Beta::Text.new(tag: :p)) do %>
-      <%= t("projects.settings.types.switch.description") %>
-    <% end %>
-  <% end %>
   <% body.with_row do %>
     <%= render(
           Projects::Settings::WorkPackages::Types::SwitchForm.new(

--- a/app/components/projects/settings/work_packages/types/switch_form_component.rb
+++ b/app/components/projects/settings/work_packages/types/switch_form_component.rb
@@ -53,7 +53,7 @@ module Projects
           attr_reader :project, :source, :url, :selected, :validation_message
 
           def available_targets
-            source.type.variants.available_in(project).in_display_order
+            TypeVariant.switch_targets(user: User.current, project:, source:).in_display_order
           end
 
           # The route addresses the type, as the switch route does: the variant is what the

--- a/app/components/projects/settings/work_packages/types/switch_form_component.rb
+++ b/app/components/projects/settings/work_packages/types/switch_form_component.rb
@@ -53,7 +53,7 @@ module Projects
           attr_reader :project, :source, :url, :selected, :validation_message
 
           def available_targets
-            source.type.variants.in_display_order
+            source.type.variants.available_in(project).in_display_order
           end
 
           # The route addresses the type, as the switch route does: the variant is what the

--- a/app/components/settings/project_work_packages/header_component.rb
+++ b/app/components/settings/project_work_packages/header_component.rb
@@ -43,7 +43,7 @@ module Settings
       end
 
       def show_types?
-        User.current.allowed_in_project?(:manage_types, @project)
+        User.current.allowed_in_project?(%i[manage_types manage_project_variants], @project)
       end
 
       def show_categories?

--- a/app/components/work_package_types/types/grouped_list_component.html.erb
+++ b/app/components/work_package_types/types/grouped_list_component.html.erb
@@ -38,13 +38,14 @@ See COPYRIGHT and LICENSE files for more details.
                 empty_state_behavior: :none
               )
             ) do |list| %>
-          <% list.with_header(collapsed: collapsed?(root), show_drag_handle: reorderable?(root)) do |header| %>
+          <% list.with_header(
+               collapsed: collapsed?(root),
+               show_drag_handle: reorderable?(root),
+               count: variants_count(root)
+             ) do |header| %>
             <% header.with_title do %>
               <%= render(Primer::Beta::Text.new(tag: :span, pl: 1)) { helpers.icon_for_type(root) } %>
-              <%= render(Primer::Beta::Text.new(tag: :a, href: edit_type_details_path(type_id: root.id), color: :accent, font_weight: :semibold)) { root.name } %>
-              <% if named_variants(root).any? %>
-                <%= render(Primer::Beta::Text.new(tag: :span, font_weight: :semibold, ml: 2)) { variants_count_label(root) } %>
-              <% end %>
+              <%= render(Primer::Beta::Text.new(tag: :a, href: edit_type_details_path(type_id: root.id), color: :accent, font_weight: :bold)) { root.name } %>
             <% end %>
             <% add_default_label(header, root) %>
             <% header.with_menu(menu_id: menu_id(root), src: menu_src(root)) %>
@@ -53,15 +54,25 @@ See COPYRIGHT and LICENSE files for more details.
           <% listed_variants(root).each do |child| %>
             <% list.with_item do |item| %>
               <% item.with_menu(menu_id: variant_menu_id(child), src: variant_menu_src(child)) %>
-              <%= render(
-                    WorkPackageTypes::VariantRowComponent.new(
-                      variant: child,
-                      caption: t("types.index.variant_label")
-                    )
-                  ) do |row| %>
+              <%= render(WorkPackageTypes::VariantRowComponent.new(variant: child)) do |row| %>
+                <% row.with_caption { t("types.index.variant_label") } %>
                 <% if child.enabled_in_new_projects? %>
                   <% row.with_status_label { t("types.index.enabled_in_new_projects") } %>
                 <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+
+          <% if (owned_count = owned_variants_count(root)).positive? %>
+            <% list.with_item do %>
+              <%= render(
+                    Primer::Beta::Link.new(
+                      href: owned_variants_path(root),
+                      underline: false,
+                      test_selector: "type-#{root.id}-project-variants"
+                    )
+                  ) do %>
+                <%= t("types.index.project_variants_count", count: owned_count) %>
               <% end %>
             <% end %>
           <% end %>
@@ -82,23 +93,6 @@ See COPYRIGHT and LICENSE files for more details.
             <% end %>
           <% end %>
 
-          <% if (owned_count = owned_variants_count(root)).positive? %>
-            <% list.with_footer do %>
-              <%= render(
-                    Primer::Beta::Link.new(
-                      href: owned_variants_path(root),
-                      color: :muted,
-                      underline: false,
-                      display: :inline_flex,
-                      align_items: :center,
-                      test_selector: "type-#{root.id}-project-variants"
-                    )
-                  ) do %>
-                <%= render(Primer::Beta::Octicon.new(icon: :project, mr: 1)) %>
-                <%= t("types.index.project_variants_count", count: owned_count) %>
-              <% end %>
-            <% end %>
-          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/work_package_types/types/grouped_list_component.rb
+++ b/app/components/work_package_types/types/grouped_list_component.rb
@@ -53,12 +53,15 @@ module WorkPackageTypes
         root.variants.non_default_variants
       end
 
-      def listed_variants(root)
-        named_variants(root).global.in_display_order
+      # Left out rather than shown as zero, so the badge never labels a type nobody has made a
+      # variant of.
+      def variants_count(root)
+        count = named_variants(root).size
+        count if count.positive?
       end
 
-      def variants_count_label(root)
-        t("types.index.variants_count", count: named_variants(root).size)
+      def listed_variants(root)
+        named_variants(root).global.in_display_order
       end
 
       def owned_variants_count(root)
@@ -69,20 +72,11 @@ module WorkPackageTypes
         type_variants_path(type_id: root.id)
       end
 
-      # A named variant carrying the flag is only visible once the group is expanded, so the
-      # collapsed header names it instead.
+      # Only the type's own configuration: a variant carrying the flag says so on its own row.
       def add_default_label(header, type)
-        if type.default_variant.enabled_in_new_projects?
-          header.with_label { t("types.index.enabled_in_new_projects") }
-        elsif (variant = default_variant_for_new_projects(type))
-          header.with_label(scheme: :secondary) do
-            t("types.index.variant_enabled_in_new_projects", name: variant.variant_name)
-          end
-        end
-      end
+        return unless type.default_variant.enabled_in_new_projects?
 
-      def default_variant_for_new_projects(type)
-        type.variants.detect(&:enabled_in_new_projects?)
+        header.with_label { t("types.index.enabled_in_new_projects") }
       end
 
       def add_variant_path(type)

--- a/app/components/work_package_types/variant_row_component.html.erb
+++ b/app/components/work_package_types/variant_row_component.html.erb
@@ -34,11 +34,11 @@ See COPYRIGHT and LICENSE files for more details.
     <% else %>
       <%= render(Primer::Beta::Text.new(font_weight: :bold)) { variant.variant_name } %>
     <% end %>
-    <% if caption %>
-      <%= render(Primer::Beta::Text.new(color: :muted, ml: 2)) { caption } %>
+    <% if caption? %>
+      <%= caption %>
     <% end %>
-    <% labels.each do |label| %>
-      <%= label %>
+    <% if state? %>
+      <%= state %>
     <% end %>
   <% end %>
 

--- a/app/components/work_package_types/variant_row_component.rb
+++ b/app/components/work_package_types/variant_row_component.rb
@@ -36,29 +36,27 @@ module WorkPackageTypes
   class VariantRowComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    # Labels shown after the name. Each list says something different about a variant, so what
-    # they say is the caller's.
-    renders_many :labels, ->(**system_arguments) { Primer::Beta::Label.new(ml: 2, **system_arguments) }
+    renders_one :caption, ->(**system_arguments) { Primer::Beta::Text.new(color: :muted, ml: 2, **system_arguments) }
+
+    # What a list says about the variant in use here. Takes markup: one list uses an icon.
+    renders_one :state
 
     # A right-aligned label, for supplementary status rather than an affordance. Mirrors the
     # surrounding BorderBoxListComponent header's own.
     renders_one :status_label, ->(**system_arguments) { Primer::Beta::Label.new(**system_arguments) }
 
-    # @param caption [String, nil] muted text after the name, telling rows apart where the
-    #   list mixes variants with other records.
     # @param linked [Boolean] whether the name leads to the variant's configuration. Pass false
     #   where the reader may not open it.
-    def initialize(variant:, caption: nil, linked: true)
+    def initialize(variant:, linked: true)
       super()
 
       @variant = variant
-      @caption = caption
       @linked = linked
     end
 
     private
 
-    attr_reader :variant, :caption, :linked
+    attr_reader :variant, :linked
 
     alias_method :linked?, :linked
 

--- a/app/components/work_package_types/variants_list_component.html.erb
+++ b/app/components/work_package_types/variants_list_component.html.erb
@@ -59,30 +59,47 @@ See COPYRIGHT and LICENSE files for more details.
 
         page.with_row do
           helpers.turbo_frame_tag(FRAME_ID, target: "_top") do
-            render(
-              OpenProject::Common::BorderBoxListComponent.new(
-                container: "type-variants",
-                padding: :condensed,
-                mb: 3,
-                test_selector: "type-variants"
-              )
-            ) do |list|
-              list.with_empty_state(title: I18n.t("types.edit.variants.filter_no_results"), icon: :search)
-
-              variants.each do |variant|
-                list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
-                  item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
-
-                  render(WorkPackageTypes::VariantRowComponent.new(variant:)) do |row|
-                    if variant.project_owned?
-                      row.with_label { t("types.index.owned_by", project: variant.project.name) }
+            if sections.empty?
+              render(
+                OpenProject::Common::BorderBoxListComponent.new(
+                  container: "type-variants",
+                  padding: :condensed,
+                  mb: 3,
+                  test_selector: "type-variants"
+                )
+              ) do |list|
+                list.with_empty_state(title: I18n.t("types.edit.variants.filter_no_results"), icon: :search)
+              end
+            else
+              safe_join(
+                sections.map do |section, section_variants|
+                  render(
+                    OpenProject::Common::BorderBoxListComponent.new(
+                      container: "type-variants-#{section}",
+                      padding: :condensed,
+                      mb: 3,
+                      test_selector: "type-variants-#{section}"
+                    )
+                  ) do |list|
+                    list.with_header(title: I18n.t("types.edit.variants.#{section}.title")) do |header|
+                      header.with_description_content(I18n.t("types.edit.variants.#{section}.description"))
                     end
-                    if variant.enabled_in_new_projects?
-                      row.with_status_label { t("types.index.enabled_in_new_projects") }
+
+                    section_variants.each do |variant|
+                      list.with_item(test_selector: "type-variant-#{variant.id}") do |item|
+                        item.with_menu(menu_id: menu_id(variant), src: menu_src(variant))
+
+                        render(WorkPackageTypes::VariantRowComponent.new(variant:)) do |row|
+                          row.with_caption { created_in(variant.project) } if variant.project_owned?
+                          if variant.enabled_in_new_projects?
+                            row.with_status_label { t("types.index.enabled_in_new_projects") }
+                          end
+                        end
+                      end
                     end
                   end
                 end
-              end
+              )
             end
           end
         end

--- a/app/components/work_package_types/variants_list_component.rb
+++ b/app/components/work_package_types/variants_list_component.rb
@@ -60,6 +60,14 @@ module WorkPackageTypes
 
     def any_variants? = named_variants.exists?
 
+    # An empty section is dropped: a section explains what is in it.
+    def sections
+      @sections ||= variants
+                      .partition { |variant| !variant.project_owned? }
+                      .zip(%i[global_section project_specific_section])
+                      .filter_map { |list, key| [key, list] if list.any? }
+    end
+
     def filter_form_data
       {
         controller: "auto-submit",
@@ -80,5 +88,13 @@ module WorkPackageTypes
     end
 
     def variants_path = type_variants_path(type_id: type.id)
+
+    def created_in(project)
+      link = render(Primer::Beta::Link.new(href: project_settings_work_packages_types_path(project))) do
+        project.name
+      end
+
+      t("types.edit.variants.created_in_html", project: link)
+    end
   end
 end

--- a/app/controllers/projects/settings/work_packages/types/switches_controller.rb
+++ b/app/controllers/projects/settings/work_packages/types/switches_controller.rb
@@ -40,7 +40,7 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
 
   def new
     respond_with_dialog Projects::Settings::WorkPackages::Types::SwitchDialogComponent
-                          .new(project: @project, source: @source, url: switch_path)
+                          .new(project: @project, source: @source, url: switch_path, selected: requested_target)
   end
 
   def create
@@ -70,6 +70,12 @@ class Projects::Settings::WorkPackages::Types::SwitchesController < Projects::Se
         project: @project, source: @source, url: switch_path, selected: target || @source, validation_message: message
       )
     )
+  end
+
+  # A list row asks about the variant it sits on, so the dialog opens on that one. It comes off a
+  # URL: only a variant this project may use counts, as in the list itself.
+  def requested_target
+    @source.type.variants.available_in(@project).find_by(id: params[:target_id]) || @source
   end
 
   def switch_path

--- a/app/controllers/projects/settings/work_packages_controller.rb
+++ b/app/controllers/projects/settings/work_packages_controller.rb
@@ -32,7 +32,7 @@ class Projects::Settings::WorkPackagesController < Projects::SettingsController
   menu_item :settings_work_packages
 
   def show
-    if User.current.allowed_in_project?(:manage_types, @project)
+    if User.current.allowed_in_project?(%i[manage_types manage_project_variants], @project)
       redirect_to project_settings_work_packages_types_path
     elsif User.current.allowed_in_project?(:manage_categories, @project)
       redirect_to project_settings_work_packages_categories_path

--- a/app/models/type_variant.rb
+++ b/app/models/type_variant.rb
@@ -103,7 +103,7 @@ class TypeVariant < ApplicationRecord
   validate :base_variant_is_never_owned
   validate :owned_variant_is_never_enabled_in_new_projects
 
-  scopes :with_effective_configuration, :with_effective_source
+  scopes :switch_targets, :with_effective_configuration, :with_effective_source
 
   scope :enabled_in_new_projects, -> { where(enabled_in_new_projects: true) }
 

--- a/app/models/type_variants/scopes/switch_targets.rb
+++ b/app/models/type_variants/scopes/switch_targets.rb
@@ -28,37 +28,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
-  module Types
-    class SwitchVariantContract < ::BaseContract
-      validate :validate_user_allowed_to_switch
-      validate :validate_target_selectable
+module TypeVariants::Scopes
+  module SwitchTargets
+    extend ActiveSupport::Concern
 
-      protected
+    class_methods do
+      # The variants of the source's type a user may move a project onto. Deciding which variant a
+      # project runs on goes with authoring its variants, not with choosing which types it uses.
+      # Another project's variant is never among them.
+      def switch_targets(user:, project:, source:)
+        return none unless user.allowed_in_project?(:manage_project_variants, project)
 
-      # Deferred to validate_target_selectable, which names what is wrong with the pair itself.
-      def validate_user_allowed_to_switch
-        return if target.nil? || target.type_id != source.type_id
-        return if ::TypeVariant.switchable?(user:, project: model, source:, target:)
-
-        errors.add :base, :error_unauthorized
+        source.type.variants.available_in(project)
       end
 
-      def validate_target_selectable
-        if target.nil?
-          errors.add(:types, :switch_target_blank)
-        elsif target == source
-          errors.add(:types, :switch_target_identical)
-        elsif source.type_id != target.type_id
-          errors.add(:types, :switch_target_not_in_family)
-        end
+      def switchable?(user:, project:, source:, target:)
+        switch_targets(user:, project:, source:).exists?(id: target.id)
       end
-
-      private
-
-      def source = options[:source]
-
-      def target = options[:target]
     end
   end
 end

--- a/app/views/projects/settings/work_packages/types/index.html.erb
+++ b/app/views/projects/settings/work_packages/types/index.html.erb
@@ -30,16 +30,18 @@ See COPYRIGHT and LICENSE files for more details.
 <%= render(Settings::ProjectWorkPackages::HeaderComponent.new(@project)) %>
 
 <% if OpenProject::FeatureDecisions.type_variants_active? %>
-  <%= render(Primer::OpenProject::SubHeader.new) do |subheader| %>
-    <% subheader.with_action_button(
-         scheme: :primary,
-         leading_icon: :plus,
-         label: t("projects.settings.types.add_type"),
-         tag: :a,
-         href: new_project_settings_work_packages_type_path(@project),
-         data: { controller: "async-dialog" },
-         test_selector: "project-types-add-button"
-       ) { t("activerecord.attributes.work_package.type") } %>
+  <% if User.current.allowed_in_project?(:manage_types, @project) %>
+    <%= render(Primer::OpenProject::SubHeader.new) do |subheader| %>
+      <% subheader.with_action_button(
+           scheme: :primary,
+           leading_icon: :plus,
+           label: t("projects.settings.types.add_type"),
+           tag: :a,
+           href: new_project_settings_work_packages_type_path(@project),
+           data: { controller: "async-dialog" },
+           test_selector: "project-types-add-button"
+         ) { t("activerecord.attributes.work_package.type") } %>
+    <% end %>
   <% end %>
 
   <%= render(Projects::Settings::WorkPackages::Types::ListComponent.new(project: @project)) %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -785,7 +785,7 @@ Redmine::MenuManager.map :project_menu do |menu|
       caption: :label_work_package_plural,
       if: ->(project) {
         User.current.allowed_in_project?(:edit_project, project) ||
-          User.current.allowed_in_project?(:manage_types, project) ||
+          User.current.allowed_in_project?(%i[manage_types manage_project_variants], project) ||
           User.current.allowed_in_project?(:manage_categories, project) ||
           User.current.allowed_in_project?(:select_custom_fields, project)
       }

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -239,9 +239,8 @@ Rails.application.reloader.to_prepare do
 
       map.permission :manage_types,
                      {
-                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update],
-                       "projects/settings/work_packages/types/switches": %i[new create],
-                       "projects/settings/work_packages/types/switches/impacts": %i[create]
+                       "projects/settings/work_packages": %i[show],
+                       "projects/settings/work_packages/types": %i[index new create destroy bulk_update]
                      },
                      permissible_on: :project,
                      require: :member
@@ -250,6 +249,10 @@ Rails.application.reloader.to_prepare do
       # authoring the project's own variants of them, on administration's own controllers.
       map.permission :manage_project_variants,
                      {
+                       "projects/settings/work_packages": %i[show],
+                       "projects/settings/work_packages/types": %i[index],
+                       "projects/settings/work_packages/types/switches": %i[new create],
+                       "projects/settings/work_packages/types/switches/impacts": %i[create],
                        "work_package_types/variants": %i[destroy menu],
                        "work_package_types/creation_wizard": %i[new create show update],
                        "work_package_types/details_tab": %i[edit update],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5394,15 +5394,15 @@ en:
           type_label: "Type"
           type_placeholder: "Select a type"
         add_type: "Add type"
-        add_variant: "Add a variant for this project"
+        add_variant: "Add a project-specific variant"
+        base_type_in_use: "Base type used in this project"
         empty_state:
           description: "Add a type to let people create work packages of that type in this project."
           title: "No types are active in this project"
         form:
           enable_type_in_project: 'Enable type "%{type}"'
-        in_use: "In use"
         no_results_title_text: There are currently no types available.
-        only_available_here: "Only available in this project"
+        project_specific_variant: "Project-specific variant"
         remove_from_project: "Remove from project"
         switch:
           apply: "Apply"
@@ -5425,10 +5425,10 @@ en:
           success: "The project now uses %{type}."
           target_label: "Variant"
           title: "%{type}: Switch variant"
-        switch_type: "Switch variant"
         type_not_found: "The selected type could not be found."
-        # Carries its own punctuation so locales can set their own spacing.
-        variant_prefix: "Variant:"
+        use_in_project: "Use in this project"
+        variant_in_use: "Variant in this project"
+        variant_label: "Variant"
       versions:
         no_results_content_text: Create a new version
         no_results_title_text: There are currently no versions for the project.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6470,7 +6470,7 @@ en:
 
   types:
     creation_wizard:
-      add_variant: "Add variant to %{name}"
+      add_variant: "Add a variant to %{name}"
       create_type: "Create type"
       create_variant: "Create variant"
       fields:
@@ -6708,15 +6708,22 @@ en:
             Each variant can inherit, copy or have its own custom configuration for the default
             template, custom fields, workflows and preferences.
           title: "No variants exist for this type"
+        created_in_html: "Created in %{project}"
         delete:
           description: "The projects using this variant will be switched to the variant you choose below before this variant is deleted."
           title: "Delete %{name}"
         filter: "Filter by text"
         filter_no_results: "No variants match this filter"
+        global_section:
+          description: "These variants are available across all projects."
+          title: "Variants"
+        project_specific_section:
+          description: "These variants are only available within the projects in which they were created."
+          title: "Project-specific variants"
       workflow:
         tab: "Workflows"
     index:
-      add_variant: "Add variant to %{name}"
+      add_variant: "Add a variant to %{name}"
       add_variant_action: "Add variant"
       description: >
         Each configuration area inside types and variants can be independently configured, limited
@@ -6728,19 +6735,13 @@ en:
       make_default_notice: "%{name} is now activated in new projects."
       no_results_content_text: Create a new type
       no_results_title_text: There are currently no types.
-      # Administration sees every project's variants side by side, so an owned one says whose.
-      owned_by: "Owned by %{project}"
       project_variants_count:
-        one: "1 variant owned by a project"
-        other: "%{count} variants owned by projects"
+        one: "1 project-specific variant"
+        other: "%{count} project-specific variants"
       remove_default: "Do not activate in new projects"
       remove_default_notice: "%{name} is no longer activated in new projects."
       type_label: "Type"
-      variant_enabled_in_new_projects: "Variant %{name} active in new projects"
       variant_label: "Variant"
-      variants_count:
-        one: "1 variant"
-        other: "%{count} variants"
     milestone_indicator: "Milestone"
 
   unsupported_browser:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5406,7 +5406,6 @@ en:
         remove_from_project: "Remove from project"
         switch:
           apply: "Apply"
-          description: "Select a different variant of this type to use in this project."
           impact:
             hidden_heading: "Fields that will no longer be shown"
             missing_statuses_description: "The workflow you are switching to has no transition out of these statuses, so nobody will be able to move these work packages on."

--- a/spec/components/projects/settings/work_packages/types/in_use_marker_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/in_use_marker_component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::WorkPackages::Types::InUseMarkerComponent, type: :component do
+  subject(:rendered_component) { render_inline(described_class.new(label: "Variant in this project")) }
+
+  it "says what is in use" do
+    expect(rendered_component).to have_text("Variant in this project")
+  end
+
+  it "checks it off, so the reader finds it without reading" do
+    expect(rendered_component).to have_css(".octicon-check-circle-fill")
+  end
+
+  it "sets the words in the colour that means so" do
+    expect(rendered_component).to have_css(".color-fg-success", text: "Variant in this project")
+  end
+
+  # A statement of fact rather than something to notice: a header's title slot would otherwise lend
+  # it the type name's weight.
+  it "does not emphasise it" do
+    expect(rendered_component).to have_css(".text-normal", text: "Variant in this project")
+  end
+
+  # The lists that show it assert on this rather than on the markup above.
+  it "is addressable by its own test selector" do
+    expect(rendered_component).to have_css("[data-test-selector='in-use-marker']", text: "Variant in this project")
+  end
+end

--- a/spec/components/projects/settings/work_packages/types/in_use_marker_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/in_use_marker_component_spec.rb
@@ -45,13 +45,10 @@ RSpec.describe Projects::Settings::WorkPackages::Types::InUseMarkerComponent, ty
     expect(rendered_component).to have_css(".color-fg-success", text: "Variant in this project")
   end
 
-  # A statement of fact rather than something to notice: a header's title slot would otherwise lend
-  # it the type name's weight.
-  it "does not emphasise it" do
+  it "leaves the words in normal weight" do
     expect(rendered_component).to have_css(".text-normal", text: "Variant in this project")
   end
 
-  # The lists that show it assert on this rather than on the markup above.
   it "is addressable by its own test selector" do
     expect(rendered_component).to have_css("[data-test-selector='in-use-marker']", text: "Variant in this project")
   end

--- a/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
 
   subject(:component) { described_class.new(project:) }
 
+  def group(variant) = page.find("[data-test-selector='project-types-row-#{variant.id}']")
+  def row(variant) = page.find("[data-test-selector='project-types-variant-#{variant.id}']")
+
+  def switch_path(target)
+    new_project_settings_work_packages_type_switch_path(project, bug, target_id: target.id)
+  end
+
+  def header_of(variant) = group(variant).find(".op-border-box-list-header")
+
+  def use_variant(variant)
+    project.project_types.find_by(type: bug).update!(variant:)
+  end
+
   context "when the member may manage them" do
     current_user do
       create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
@@ -66,20 +79,29 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_no_text("Demo only")
     end
 
-    it "marks which of them is the project's own" do
-      expect(page).to have_text("Only available in this project")
+    # The type heads the group, as bold as the variant names below it.
+    it "sets the type's name in the same weight as its variants" do
+      expect(header_of(bug.default_variant)).to have_css(".text-bold", text: "Bug")
     end
 
-    # Which variant the project is using is what a reader is looking for, so that is the label
-    # the accent belongs to. Ownership is a statement of fact about the row it sits on.
-    it "accents the variant in use rather than the one it owns" do
-      expect(page).to have_css(".Label--accent", text: "In use")
-      expect(page).to have_no_css(".Label--accent", text: "Only available in this project")
+    it "captions the variant the project owns as the project's own" do
+      expect(row(ours)).to have_text("Project-specific variant")
+    end
+
+    it "captions a variant every project may use plainly" do
+      expect(row(global)).to have_text("Variant")
+      expect(row(global)).to have_no_text("Project-specific variant")
+    end
+
+    # Which variant is in use is a state, not something to act on, and ownership is a plain
+    # statement about the row it sits on. Neither is a label.
+    it "labels nothing" do
+      expect(page).to have_no_css(".Label")
     end
 
     it "offers to add one" do
       expect(page).to have_link(
-        "Add a variant for this project",
+        "Add a project-specific variant",
         href: new_creation_wizard_types_path(in_project_id: project, type_id: bug.id)
       )
     end
@@ -110,6 +132,16 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       )
     end
 
+    # Set apart the way the type's own menu sets removal apart: a destructive action should not sit
+    # flush against the one above it.
+    it "puts a divider before deleting the one it owns" do
+      items = row(ours).all("action-menu li").map do |item|
+        item[:class].to_s.include?("ActionList-sectionDivider") ? "---" : item.text.strip
+      end
+
+      expect(items.last(2)).to eq(["---", "Delete"])
+    end
+
     it "offers to delete the one it owns" do
       expect(page).to have_css(
         "form[action='#{type_variant_path(in_project_id: project, type_id: bug.id, id: ours.id)}']",
@@ -117,12 +149,64 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       )
     end
 
+    # Authoring the project's own variant and putting it to use are one job: leaving the second
+    # half to whoever administers the instance's types makes the first half pointless.
+    it "offers the variant it owns for use" do
+      expect(row(ours)).to have_link(
+        "Use in this project",
+        href: new_project_settings_work_packages_type_switch_path(project, bug, target_id: ours.id)
+      )
+    end
+
+    # Which of the variants it may use the project runs on is the project's own choice.
+    it "offers a global variant for use as well" do
+      expect(row(global)).to have_link(
+        "Use in this project",
+        href: new_project_settings_work_packages_type_switch_path(project, bug, target_id: global.id)
+      )
+    end
+
+    it "offers no way to take the type out of the project" do
+      expect(page).to have_no_button("Remove from project", visible: :all)
+    end
+
     # A global variant belongs to every project, so no single one may edit or remove it.
+    # The type's own menu gathers everything that can be done to it, while the row at the foot of
+    # the group stays: a reader scanning the variants finds it there without opening a menu.
+    it "offers to add a project-specific variant from the type's menu as well as the last row" do
+      expect(header_of(bug.default_variant)).to have_link(
+        "Add a project-specific variant",
+        href: new_creation_wizard_types_path(in_project_id: project, type_id: bug.id)
+      )
+      expect(group(bug.default_variant)).to have_link("Add a project-specific variant", count: 2)
+    end
+
     it "offers no action on a global variant" do
       expect(page).to have_no_link(
         "Edit",
         href: edit_type_details_path(in_project_id: project, type_id: bug.id, variant_id: global.id)
       )
+    end
+  end
+
+  # The reader opening a group is choosing among the variants this project may use, so that is
+  # what the count counts.
+  describe "the count on a type" do
+    shared_let(:plain) { create(:type, name: "Plain").tap { |type| type.update_column(:position, 2) } }
+
+    current_user { create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+    before do
+      create(:project_type, project:, type: plain)
+      render_inline(component)
+    end
+
+    it "counts the variants the project may use" do
+      expect(group(bug.default_variant)).to have_css(".Counter", text: "2")
+    end
+
+    it "counts nothing where there is nothing to choose from" do
+      expect(group(plain.default_variant)).to have_no_css(".Counter")
     end
   end
 
@@ -148,41 +232,180 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
-  # The header row is the type's own configuration. Which of the two is in use is said the same
-  # way throughout: the row that is in use carries the label, named variant or not.
-  describe "the header when the type's own configuration is in use" do
+  describe "when the project uses the type's own configuration" do
     current_user { create(:user, member_with_permissions: { project => %i[view_project] }) }
 
     before { render_inline(component) }
 
-    it "marks it in use rather than naming it" do
-      expect(page).to have_text("In use")
+    it "states so on the header, which is that configuration's own row" do
+      expect(group(bug.default_variant)).to have_text("Base type used in this project")
     end
 
-    it "names no variant" do
-      expect(page).to have_no_text("Variant:")
+    it "checks it off, so the reader finds it without reading" do
+      expect(group(bug.default_variant)).to have_css(".octicon-check-circle-fill")
     end
 
-    # Nothing is nested under the header for it, so the label there is the only thing saying so.
-    it "puts the label on the header, not on a variant row" do
-      expect(page).to have_css(".Label", text: "In use", count: 1)
+    # A statement of fact rather than something to notice: the header's title slot would
+    # otherwise lend it the type name's weight.
+    it "does not emphasise it" do
+      expect(group(bug.default_variant)).to have_css(".text-normal", text: "Base type used in this project")
+    end
+
+    # Nothing below the header is in use, so the group has nothing the reader must see.
+    it "leaves the group closed" do
+      expect(group(bug.default_variant)).to have_css(".CollapsibleHeader--collapsed")
+    end
+
+    it "says nothing about a variant being in use" do
+      expect(page).to have_no_text("Variant in this project")
     end
   end
 
-  describe "the header when a named variant is in use" do
+  describe "when the project uses a named variant" do
     current_user { create(:user, member_with_permissions: { project => %i[view_project] }) }
 
     before do
-      project.project_types.find_by(type: bug).update!(variant: global)
+      use_variant(global)
       render_inline(component)
     end
 
-    it "names that variant" do
-      expect(page).to have_text(/Variant:\s*Mobile/)
+    it "states so on that variant's row" do
+      expect(row(global)).to have_text("Variant in this project")
     end
 
-    it "leaves the in-use label to that variant's own row" do
-      expect(page).to have_text("In use")
+    it "checks that row off" do
+      expect(row(global)).to have_css(".octicon-check-circle-fill")
+    end
+
+    it "says nothing of the sort on the variants the project is not using" do
+      expect(row(ours)).to have_no_text("Variant in this project")
+    end
+
+    # The row saying so is inside the group, so the group has to be open for it to be read.
+    it "opens the group" do
+      expect(group(global)).to have_no_css(".CollapsibleHeader--collapsed")
+    end
+
+    it "leaves the header naming the type alone" do
+      expect(group(global)).to have_no_text("Base type used in this project")
+    end
+  end
+
+  describe "switching which variant the project uses" do
+    current_user do
+      create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
+    end
+
+    context "when the project uses the type's own configuration" do
+      before { render_inline(component) }
+
+      # The reader has already chosen on the row, so the dialog opens on that variant rather than
+      # asking them to find it again in a select.
+      it "offers a row's variant for use, with the dialog set to it" do
+        expect(page).to have_link(
+          "Use in this project",
+          href: new_project_settings_work_packages_type_switch_path(project, bug, target_id: global.id)
+        )
+      end
+
+      it "offers the project's own variant for use too" do
+        expect(page).to have_link(
+          "Use in this project",
+          href: new_project_settings_work_packages_type_switch_path(project, bug, target_id: ours.id)
+        )
+      end
+    end
+
+    context "when the project already uses one of them" do
+      before do
+        use_variant(global)
+        render_inline(described_class.new(project:))
+      end
+
+      it "offers nothing to the row already in use" do
+        expect(row(global)).to have_no_link("Use in this project")
+      end
+
+      it "still offers the others" do
+        expect(row(ours)).to have_link("Use in this project")
+      end
+    end
+  end
+
+  # The header stands for the type's own configuration, the way each row below it stands for a
+  # variant. Its action therefore puts that configuration to use, named and preselected exactly
+  # as a row's is.
+  describe "the type's own menu" do
+    current_user do
+      create(:user, member_with_permissions: { project => %i[view_project manage_types manage_project_variants] })
+    end
+
+    context "when the project uses a named variant" do
+      before do
+        use_variant(ours)
+        render_inline(described_class.new(project:))
+      end
+
+      it "offers the type's own configuration for use, already chosen" do
+        expect(header_of(ours)).to have_link("Use in this project", href: switch_path(bug.default_variant))
+      end
+
+      it "marks it with the same check the rows carry" do
+        expect(header_of(ours)).to have_css(".octicon-check-circle")
+      end
+    end
+
+    context "when the project already uses the type's own configuration" do
+      before { render_inline(component) }
+
+      it "offers nothing to put to use" do
+        expect(header_of(bug.default_variant)).to have_no_link("Use in this project")
+      end
+
+      # Taking the type out of the project is not of a kind with the rest of the menu.
+      it "still sets taking the type out of the project apart" do
+        expect(header_of(bug.default_variant)).to have_css(".ActionList-sectionDivider")
+      end
+    end
+  end
+
+  # Choosing the types the project uses is not choosing which variant of one it runs on.
+  describe "a member who may only choose the project's types" do
+    current_user { create(:user, member_with_permissions: { project => %i[view_project manage_types] }) }
+
+    before { render_inline(component) }
+
+    it "offers no way to switch from the type's menu" do
+      expect(page).to have_no_link("Use in this project")
+    end
+
+    it "offers no way to switch from a variant's row" do
+      expect(row(global)).to have_no_css("action-menu")
+    end
+
+    it "still offers to take the type out of the project" do
+      expect(page).to have_button("Remove from project", visible: :all)
+    end
+
+    # Nothing precedes it in the menu, so there is nothing to set it apart from.
+    it "renders no divider" do
+      expect(header_of(bug.default_variant)).to have_no_css(".ActionList-sectionDivider")
+    end
+  end
+
+  # Applying one's own variant would be a trap if it could not be undone.
+  describe "an author of the project's variants, once the project uses their variant" do
+    current_user do
+      create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
+    end
+
+    before do
+      use_variant(ours)
+      render_inline(described_class.new(project:))
+    end
+
+    it "offers the type's own configuration for use, so the variant can be taken back off" do
+      expect(page).to have_link("Use in this project", href: switch_path(bug.default_variant))
     end
   end
 
@@ -197,16 +420,25 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
 
     it "offers no way to add one" do
-      expect(page).to have_no_link("Add a variant for this project")
+      expect(page).to have_no_link("Add a project-specific variant")
     end
 
     it "offers no way to configure one" do
       expect(page).to have_no_link("Edit")
     end
 
+    it "offers no way to switch to one" do
+      expect(page).to have_no_link("Use in this project")
+    end
+
     it "leaves even its own variant's name unlinked" do
       expect(page).to have_text("Internal review")
       expect(page).to have_no_link("Internal review")
+    end
+
+    # An empty kebab is a promise of something to do, on every row of every type.
+    it "renders no action menu on a row it can do nothing with" do
+      expect(row(ours)).to have_no_css("action-menu")
     end
   end
 end

--- a/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
@@ -241,14 +241,9 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(group(bug.default_variant)).to have_text("Base type used in this project")
     end
 
-    it "checks it off, so the reader finds it without reading" do
-      expect(group(bug.default_variant)).to have_css(".octicon-check-circle-fill")
-    end
-
-    # A statement of fact rather than something to notice: the header's title slot would
-    # otherwise lend it the type name's weight.
-    it "does not emphasise it" do
-      expect(group(bug.default_variant)).to have_css(".text-normal", text: "Base type used in this project")
+    it "marks it as the one in use" do
+      expect(group(bug.default_variant)).to have_css("[data-test-selector='in-use-marker']",
+                                                     text: "Base type used in this project")
     end
 
     # Nothing below the header is in use, so the group has nothing the reader must see.
@@ -273,8 +268,8 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(row(global)).to have_text("Variant in this project")
     end
 
-    it "checks that row off" do
-      expect(row(global)).to have_css(".octicon-check-circle-fill")
+    it "marks that row as the one in use" do
+      expect(row(global)).to have_css("[data-test-selector='in-use-marker']")
     end
 
     it "says nothing of the sort on the variants the project is not using" do

--- a/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
@@ -74,12 +74,10 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_text("Mobile")
     end
 
-    # The point of the whole feature: one project's variant is invisible to the others.
     it "never lists another project's variant" do
       expect(page).to have_no_text("Demo only")
     end
 
-    # The type heads the group, as bold as the variant names below it.
     it "sets the type's name in the same weight as its variants" do
       expect(header_of(bug.default_variant)).to have_css(".text-bold", text: "Bug")
     end
@@ -93,9 +91,7 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(row(global)).to have_no_text("Project-specific variant")
     end
 
-    # Which variant is in use is a state, not something to act on, and ownership is a plain
-    # statement about the row it sits on. Neither is a label.
-    it "labels nothing" do
+    it "renders no label for ownership or use" do
       expect(page).to have_no_css(".Label")
     end
 
@@ -106,9 +102,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       )
     end
 
-    # The name is the affordance administration's list already uses. The others have no page
-    # this reader may open: the type's own configuration and the global variants are
-    # administration's.
     it "links the name of the variant it owns" do
       expect(page).to have_link(
         "Internal review",
@@ -132,8 +125,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       )
     end
 
-    # Set apart the way the type's own menu sets removal apart: a destructive action should not sit
-    # flush against the one above it.
     it "puts a divider before deleting the one it owns" do
       items = row(ours).all("action-menu li").map do |item|
         item[:class].to_s.include?("ActionList-sectionDivider") ? "---" : item.text.strip
@@ -149,8 +140,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       )
     end
 
-    # Authoring the project's own variant and putting it to use are one job: leaving the second
-    # half to whoever administers the instance's types makes the first half pointless.
     it "offers the variant it owns for use" do
       expect(row(ours)).to have_link(
         "Use in this project",
@@ -158,7 +147,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       )
     end
 
-    # Which of the variants it may use the project runs on is the project's own choice.
     it "offers a global variant for use as well" do
       expect(row(global)).to have_link(
         "Use in this project",
@@ -170,9 +158,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_no_button("Remove from project", visible: :all)
     end
 
-    # A global variant belongs to every project, so no single one may edit or remove it.
-    # The type's own menu gathers everything that can be done to it, while the row at the foot of
-    # the group stays: a reader scanning the variants finds it there without opening a menu.
     it "offers to add a project-specific variant from the type's menu as well as the last row" do
       expect(header_of(bug.default_variant)).to have_link(
         "Add a project-specific variant",
@@ -189,8 +174,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
-  # The reader opening a group is choosing among the variants this project may use, so that is
-  # what the count counts.
   describe "the count on a type" do
     shared_let(:plain) { create(:type, name: "Plain").tap { |type| type.update_column(:position, 2) } }
 
@@ -210,8 +193,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
-  # A type the project uses no named variant of shows an empty group, as it does on the types
-  # index, rather than a blank slate telling the reader nothing they cannot see.
   describe "a type with no variant the project may use" do
     shared_let(:plain) { create(:type, name: "Plain") }
 
@@ -246,7 +227,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
                                                      text: "Base type used in this project")
     end
 
-    # Nothing below the header is in use, so the group has nothing the reader must see.
     it "leaves the group closed" do
       expect(group(bug.default_variant)).to have_css(".CollapsibleHeader--collapsed")
     end
@@ -276,7 +256,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(row(ours)).to have_no_text("Variant in this project")
     end
 
-    # The row saying so is inside the group, so the group has to be open for it to be read.
     it "opens the group" do
       expect(group(global)).to have_no_css(".CollapsibleHeader--collapsed")
     end
@@ -294,8 +273,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     context "when the project uses the type's own configuration" do
       before { render_inline(component) }
 
-      # The reader has already chosen on the row, so the dialog opens on that variant rather than
-      # asking them to find it again in a select.
       it "offers a row's variant for use, with the dialog set to it" do
         expect(page).to have_link(
           "Use in this project",
@@ -327,9 +304,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
     end
   end
 
-  # The header stands for the type's own configuration, the way each row below it stands for a
-  # variant. Its action therefore puts that configuration to use, named and preselected exactly
-  # as a row's is.
   describe "the type's own menu" do
     current_user do
       create(:user, member_with_permissions: { project => %i[view_project manage_types manage_project_variants] })
@@ -357,14 +331,12 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
         expect(header_of(bug.default_variant)).to have_no_link("Use in this project")
       end
 
-      # Taking the type out of the project is not of a kind with the rest of the menu.
       it "still sets taking the type out of the project apart" do
         expect(header_of(bug.default_variant)).to have_css(".ActionList-sectionDivider")
       end
     end
   end
 
-  # Choosing the types the project uses is not choosing which variant of one it runs on.
   describe "a member who may only choose the project's types" do
     current_user { create(:user, member_with_permissions: { project => %i[view_project manage_types] }) }
 
@@ -382,13 +354,11 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_button("Remove from project", visible: :all)
     end
 
-    # Nothing precedes it in the menu, so there is nothing to set it apart from.
     it "renders no divider" do
       expect(header_of(bug.default_variant)).to have_no_css(".ActionList-sectionDivider")
     end
   end
 
-  # Applying one's own variant would be a trap if it could not be undone.
   describe "an author of the project's variants, once the project uses their variant" do
     current_user do
       create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
@@ -431,7 +401,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_no_link("Internal review")
     end
 
-    # An empty kebab is a promise of something to do, on every row of every type.
     it "renders no action menu on a row it can do nothing with" do
       expect(row(ours)).to have_no_css("action-menu")
     end

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
   shared_let(:bug) { create(:type, name: "Bug").tap { |type| type.update_column(:position, 2) } }
   shared_let(:design) { create(:type_variant, type: epic, variant_name: "Design") }
 
+  # Which types the project uses is only offered to a reader who may change it.
+  current_user { create(:user, member_with_permissions: { project => %i[view_project manage_types] }) }
+
   subject(:component) { described_class.new(project:) }
 
   context "when a type is active through its base variant" do
@@ -70,10 +73,12 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_no_text("Epic: Design")
     end
 
-    # normalize_ws because render_inline keeps the newline between the two Text
-    # components that a browser lays out on one line.
-    it "names the active variant after the type it presents as" do
-      expect(page).to have_text("Variant: Design", normalize_ws: true)
+    # The variant's own row says it is the one in use, so the header does not repeat it. The
+    # group is open for that row to be read.
+    it "leaves saying which variant is in use to that variant's row" do
+      expect(page).to have_no_text("Variant: Design")
+      expect(page).to have_css("[data-test-selector='project-types-variant-#{design.id}']",
+                               text: "Variant in this project")
     end
 
     it "points the remove action at the type the variant belongs to" do

--- a/spec/components/projects/settings/work_packages/types/list_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
   shared_let(:bug) { create(:type, name: "Bug").tap { |type| type.update_column(:position, 2) } }
   shared_let(:design) { create(:type_variant, type: epic, variant_name: "Design") }
 
-  # Which types the project uses is only offered to a reader who may change it.
   current_user { create(:user, member_with_permissions: { project => %i[view_project manage_types] }) }
 
   subject(:component) { described_class.new(project:) }
@@ -73,8 +72,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(page).to have_no_text("Epic: Design")
     end
 
-    # The variant's own row says it is the one in use, so the header does not repeat it. The
-    # group is open for that row to be read.
     it "leaves saying which variant is in use to that variant's row" do
       expect(page).to have_no_text("Variant: Design")
       expect(page).to have_css("[data-test-selector='project-types-variant-#{design.id}']",

--- a/spec/components/projects/settings/work_packages/types/switch_form_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/switch_form_component_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::WorkPackages::Types::SwitchFormComponent,
+               type: :component,
+               with_flag: { type_variants: true } do
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:base) { type.default_variant }
+  shared_let(:global) { create(:type_variant, type:, variant_name: "Mobile") }
+  shared_let(:project) { create(:project, types: [type]) }
+  shared_let(:ours) { create(:project_owned_type_variant, type:, project:, variant_name: "Internal") }
+  shared_let(:theirs) do
+    create(:project_owned_type_variant, type:, project: create(:project), variant_name: "Demo only")
+  end
+
+  current_user do
+    create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
+  end
+
+  def render_form(source: base, selected: nil)
+    render_inline(described_class.new(project:, source:, url: "/switch", **{ selected: }.compact))
+  end
+
+  it "offers the variants the project may use, in display order" do
+    render_form
+
+    expect(page).to have_select("Variant", options: [base, global, ours].map(&:composite_name))
+  end
+
+  # Switching to it would be refused, and its name alone tells this project's administrators what
+  # another project called its own variant.
+  it "offers no variant another project owns" do
+    render_form
+
+    expect(page).to have_no_css("option", text: "Demo only")
+  end
+
+  it "opens on the variant it is given" do
+    render_form(selected: ours)
+
+    expect(page).to have_select("Variant", selected: ours.composite_name)
+  end
+
+  it "opens on the variant in force when it is given none" do
+    render_form
+
+    expect(page).to have_select("Variant", selected: base.composite_name)
+  end
+
+  context "when the reader may not switch" do
+    current_user { create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+    it "offers nothing" do
+      render_form
+
+      expect(page).to have_select("Variant", options: [])
+    end
+  end
+end

--- a/spec/components/projects/settings/work_packages/types/switch_form_component_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/switch_form_component_spec.rb
@@ -56,8 +56,6 @@ RSpec.describe Projects::Settings::WorkPackages::Types::SwitchFormComponent,
     expect(page).to have_select("Variant", options: [base, global, ours].map(&:composite_name))
   end
 
-  # Switching to it would be refused, and its name alone tells this project's administrators what
-  # another project called its own variant.
   it "offers no variant another project owns" do
     render_form
 

--- a/spec/components/work_package_types/types/grouped_list_component_spec.rb
+++ b/spec/components/work_package_types/types/grouped_list_component_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
 
   current_user { create(:admin) }
 
-  # An administrator sees every project's variants together, so an owned one has to say whose it
-  # is; otherwise it is indistinguishable from a variant every project may use.
   describe "a variant a project owns" do
     shared_let(:owning_project) { create(:project, name: "Apollo") }
     shared_let(:root_type) { create(:type, name: "Bug") }
@@ -51,13 +49,10 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
       end
     end
 
-    # The index is the list of variants every project may use. A project's own belong to that
-    # project, and are reached from the type's variants tab instead.
     it "does not list it" do
       expect(rendered_component).to have_no_text("Internal")
     end
 
-    # As bold as the variant names below it: the type heads the group, it does not caption it.
     it "sets the type's name in the same weight as its variants" do
       expect(rendered_component).to have_css(".Box-header a.text-bold", text: "Bug")
     end
@@ -71,8 +66,6 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
                                               href: type_variants_path(type_id: root_type.id))
     end
 
-    # A plain link, like the variant names above it: it leads somewhere the reader may go, and it
-    # is not an affordance of the kind the add action below it is.
     it "leads with the count rather than an icon", :aggregate_failures do
       row = "[data-test-selector='type-#{root_type.id}-project-variants']"
 
@@ -81,8 +74,6 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
       expect(rendered_component).to have_no_css("#{row}.color-fg-muted")
     end
 
-    # The count summarises variants this list does not show; the add action creates one that it
-    # will, and closes the group.
     it "counts them in a row above the add action", :aggregate_failures do
       count_link = "a[href='#{type_variants_path(type_id: root_type.id)}']"
       add_link = "a[href='#{new_creation_wizard_types_path(type_id: root_type.id, back_url: types_path)}']"
@@ -100,19 +91,17 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
       expect(rendered_component).to have_no_text("2 project-specific variants")
     end
 
-    # The badge counts every named variant of the type, listed here or not: one on this list plus
-    # the one the project owns.
     it "counts both in a badge on the header" do
       expect(rendered_component).to have_css(".Box-header .Counter", text: "2")
     end
 
-    # Asserted on the markup rather than on what shows: Primer hides a zero counter by itself, so
-    # a visible-only assertion would hold without the count ever being left out.
     context "when the type has no variant at all" do
       shared_let(:root_type) { create(:type, name: "Plain") }
       shared_let(:owned) { nil }
       shared_let(:global) { nil }
 
+      # visible: :all, because Primer hides a zero counter by itself: a visible-only assertion
+      # would hold whether or not the count is left out.
       it "shows no badge" do
         expect(rendered_component).to have_no_css(".Box-header .Counter", visible: :all)
       end
@@ -169,7 +158,6 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
     context "when a named variant carries it" do
       before { variant.update!(enabled_in_new_projects: true) }
 
-      # Said on the variant's own row, and nowhere else.
       it "marks the variant's own row and leaves the header alone", :aggregate_failures do
         expect(rendered_component).to have_css(".Box-row .Label", text: label_text)
         expect(rendered_component).to have_no_css(".Box-header .Label")

--- a/spec/components/work_package_types/types/grouped_list_component_spec.rb
+++ b/spec/components/work_package_types/types/grouped_list_component_spec.rb
@@ -57,43 +57,69 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
       expect(rendered_component).to have_no_text("Internal")
     end
 
+    # As bold as the variant names below it: the type heads the group, it does not caption it.
+    it "sets the type's name in the same weight as its variants" do
+      expect(rendered_component).to have_css(".Box-header a.text-bold", text: "Bug")
+    end
+
     it "still lists the variants every project may use" do
       expect(rendered_component).to have_text("Mobile")
     end
 
     it "counts it, and links the count to the type's variants tab" do
-      expect(rendered_component).to have_link("1 variant owned by a project",
+      expect(rendered_component).to have_link("1 project-specific variant",
                                               href: type_variants_path(type_id: root_type.id))
     end
 
-    it "counts it in the footer rather than in a row", :aggregate_failures do
-      count_link = "a[href='#{type_variants_path(type_id: root_type.id)}']"
+    # A plain link, like the variant names above it: it leads somewhere the reader may go, and it
+    # is not an affordance of the kind the add action below it is.
+    it "leads with the count rather than an icon", :aggregate_failures do
+      row = "[data-test-selector='type-#{root_type.id}-project-variants']"
 
-      expect(rendered_component).to have_css(".Box-footer #{count_link}")
-      expect(rendered_component).to have_no_css(".Box-row #{count_link}")
+      expect(rendered_component).to have_css(row)
+      expect(rendered_component).to have_no_css("#{row} svg")
+      expect(rendered_component).to have_no_css("#{row}.color-fg-muted")
     end
 
-    # The last row of the list, below the variants and above the footer.
-    it "adds a variant from a row, not from the group header", :aggregate_failures do
+    # The count summarises variants this list does not show; the add action creates one that it
+    # will, and closes the group.
+    it "counts them in a row above the add action", :aggregate_failures do
+      count_link = "a[href='#{type_variants_path(type_id: root_type.id)}']"
       add_link = "a[href='#{new_creation_wizard_types_path(type_id: root_type.id, back_url: types_path)}']"
 
-      expect(rendered_component).to have_css(".Box-row #{add_link}")
-      expect(rendered_component).to have_no_css(".Box-header #{add_link}")
-      expect(rendered_component).to have_no_css(".Box-footer #{add_link}")
+      expect(rendered_component).to have_css(".Box-row #{count_link}")
+      expect(rendered_component).to have_no_css(".Box-footer #{count_link}")
+      expect(rendered_component).to have_css(".Box-row:last-of-type #{add_link}")
     end
 
     it "names the type it adds to" do
-      expect(rendered_component).to have_link("Add variant to Bug")
+      expect(rendered_component).to have_link("Add a variant to Bug")
     end
 
     it "counts only the variants projects own" do
-      expect(rendered_component).to have_no_text("2 variants owned by projects")
+      expect(rendered_component).to have_no_text("2 project-specific variants")
     end
 
-    # The header counts every named variant of the type, listed or not, so it is the whole
-    # picture: one listed here plus the one the project owns.
-    it "counts both in the header" do
-      expect(rendered_component).to have_css(".Box-header", text: "2 variants")
+    # The badge counts every named variant of the type, listed here or not: one on this list plus
+    # the one the project owns.
+    it "counts both in a badge on the header" do
+      expect(rendered_component).to have_css(".Box-header .Counter", text: "2")
+    end
+
+    # Asserted on the markup rather than on what shows: Primer hides a zero counter by itself, so
+    # a visible-only assertion would hold without the count ever being left out.
+    context "when the type has no variant at all" do
+      shared_let(:root_type) { create(:type, name: "Plain") }
+      shared_let(:owned) { nil }
+      shared_let(:global) { nil }
+
+      it "shows no badge" do
+        expect(rendered_component).to have_no_css(".Box-header .Counter", visible: :all)
+      end
+    end
+
+    it "no longer spells the count out" do
+      expect(rendered_component).to have_no_text("2 variants")
     end
   end
 
@@ -117,9 +143,6 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
     let(:root_type) { create(:type, name: "Task") }
     let!(:variant) { create(:type_variant, type: root_type, variant_name: "Hardware") }
     let(:label_text) { I18n.t("types.index.enabled_in_new_projects") }
-    let(:variant_label_text) do
-      I18n.t("types.index.variant_enabled_in_new_projects", name: variant.variant_name)
-    end
 
     subject(:rendered_component) do
       with_request_url "/types" do
@@ -129,9 +152,8 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
     end
 
     context "when no variant of the type carries the flag" do
-      it "renders nowhere", :aggregate_failures do
+      it "renders nowhere" do
         expect(rendered_component).to have_no_css(".Label", text: label_text)
-        expect(rendered_component).to have_no_css(".Label", text: variant_label_text)
       end
     end
 
@@ -147,12 +169,10 @@ RSpec.describe WorkPackageTypes::Types::GroupedListComponent, type: :component d
     context "when a named variant carries it" do
       before { variant.update!(enabled_in_new_projects: true) }
 
-      it "names the variant in the group header, which stays visible when collapsed" do
-        expect(rendered_component).to have_css(".Box-header .Label", text: variant_label_text)
-      end
-
-      it "marks the variant's own row too" do
+      # Said on the variant's own row, and nowhere else.
+      it "marks the variant's own row and leaves the header alone", :aggregate_failures do
         expect(rendered_component).to have_css(".Box-row .Label", text: label_text)
+        expect(rendered_component).to have_no_css(".Box-header .Label")
       end
     end
   end

--- a/spec/components/work_package_types/variant_row_component_spec.rb
+++ b/spec/components/work_package_types/variant_row_component_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe WorkPackageTypes::VariantRowComponent, type: :component do
   shared_let(:type) { create(:type, name: "Bug") }
   shared_let(:variant) { create(:type_variant, type:, variant_name: "Hardware") }
 
-  subject(:rendered_component) { render_inline(described_class.new(variant:, caption:)) }
-
-  let(:caption) { nil }
+  subject(:rendered_component) { render_inline(described_class.new(variant:)) }
 
   it "links the variant to its settings page" do
     expect(rendered_component)
@@ -53,26 +51,28 @@ RSpec.describe WorkPackageTypes::VariantRowComponent, type: :component do
     expect(rendered_component).to have_no_text(I18n.t("types.index.variant_label"))
   end
 
+  # A slot rather than a string, because one list says "Created in <project>" with the project
+  # linked, which no string can carry.
+  it "renders the caption its caller gives it" do
+    rendered = render_inline(described_class.new(variant:)) do |row|
+      row.with_caption { I18n.t("types.index.variant_label") }
+    end
+
+    expect(rendered).to have_text(I18n.t("types.index.variant_label"))
+  end
+
   it "says nothing about new projects while the variant is not the one they start with" do
     expect(rendered_component).to have_no_text(I18n.t("types.index.enabled_in_new_projects"))
   end
 
-  context "with a caption" do
-    let(:caption) { I18n.t("types.index.variant_label") }
-
-    it "renders it next to the name" do
-      expect(rendered_component).to have_text(caption)
-    end
-  end
-
-  it "renders the labels its caller gives it" do
+  # What a list says about the variant's state here. Not a label: one list says it with a green
+  # check and coloured words, which a Label cannot carry.
+  it "renders the state its caller gives it" do
     rendered = render_inline(described_class.new(variant:)) do |row|
-      row.with_label { "Only available in this project" }
-      row.with_label(scheme: :accent) { "In use" }
+      row.with_state { "Variant in this project" }
     end
 
-    expect(rendered).to have_css(".Label", text: "Only available in this project")
-    expect(rendered).to have_css(".Label--accent", text: "In use")
+    expect(rendered).to have_text("Variant in this project")
   end
 
   it "says nothing of its own about ownership or new projects" do

--- a/spec/components/work_package_types/variant_row_component_spec.rb
+++ b/spec/components/work_package_types/variant_row_component_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe WorkPackageTypes::VariantRowComponent, type: :component do
     expect(rendered_component).to have_no_text(I18n.t("types.index.variant_label"))
   end
 
-  # A slot rather than a string, because one list says "Created in <project>" with the project
-  # linked, which no string can carry.
   it "renders the caption its caller gives it" do
     rendered = render_inline(described_class.new(variant:)) do |row|
       row.with_caption { I18n.t("types.index.variant_label") }
@@ -65,8 +63,6 @@ RSpec.describe WorkPackageTypes::VariantRowComponent, type: :component do
     expect(rendered_component).to have_no_text(I18n.t("types.index.enabled_in_new_projects"))
   end
 
-  # What a list says about the variant's state here. Not a label: one list says it with a green
-  # check and coloured words, which a Label cannot carry.
   it "renders the state its caller gives it" do
     rendered = render_inline(described_class.new(variant:)) do |row|
       row.with_state { "Variant in this project" }
@@ -79,7 +75,6 @@ RSpec.describe WorkPackageTypes::VariantRowComponent, type: :component do
     expect(rendered_component).to have_no_css(".Label")
   end
 
-  # Right-aligned, for status rather than an affordance.
   it "sets a status label apart from the rest" do
     rendered = render_inline(described_class.new(variant:)) do |row|
       row.with_status_label { "Active in new projects" }

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
     new_creation_wizard_types_path(type_id: type.id, back_url: type_variants_path(type_id: type.id))
   end
 
-  # The types index counts these rather than listing them, so this tab is where an administrator
-  # sees whose they are.
   context "with a variant a project owns" do
     shared_let(:owning_project) { create(:project, name: "Apollo") }
     shared_let(:owned) do
@@ -56,7 +54,6 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
       expect(rendered_component).to have_text("Created in Apollo")
     end
 
-    # The one page where that variant means anything: where it is listed, used and configured.
     it "links that project to its own types settings" do
       expect(rendered_component)
         .to have_link("Apollo", href: project_settings_work_packages_types_path(owning_project))
@@ -88,7 +85,6 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
     end
   end
 
-  # A section explains what is in it, so an empty one explains nothing.
   context "with no project-specific variant" do
     before { create(:type_variant, type:, variant_name: "Everywhere") }
 

--- a/spec/components/work_package_types/variants_list_component_spec.rb
+++ b/spec/components/work_package_types/variants_list_component_spec.rb
@@ -52,8 +52,14 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
       create(:project_owned_type_variant, type:, project: owning_project, variant_name: "Internal")
     end
 
-    it "attributes it to the project owning it" do
-      expect(rendered_component).to have_text("Owned by Apollo")
+    it "says which project it was created in" do
+      expect(rendered_component).to have_text("Created in Apollo")
+    end
+
+    # The one page where that variant means anything: where it is listed, used and configured.
+    it "links that project to its own types settings" do
+      expect(rendered_component)
+        .to have_link("Apollo", href: project_settings_work_packages_types_path(owning_project))
     end
 
     it "links it into the project owning it" do
@@ -61,6 +67,38 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
         .to have_link("Internal",
                       href: edit_type_details_path(in_project_id: owning_project,
                                                    type_id: type.id, variant_id: owned.id))
+    end
+  end
+
+  context "with both kinds of variant" do
+    shared_let(:owning_project) { create(:project, name: "Apollo") }
+
+    before do
+      create(:type_variant, type:, variant_name: "Everywhere")
+      create(:project_owned_type_variant, type:, project: owning_project, variant_name: "Only here")
+    end
+
+    it "heads the variants every project may use with their own section" do
+      expect(rendered_component).to have_text(I18n.t("types.edit.variants.global_section.description"))
+    end
+
+    it "heads the project-specific ones with their own section" do
+      expect(rendered_component)
+        .to have_text(I18n.t("types.edit.variants.project_specific_section.description"))
+    end
+  end
+
+  # A section explains what is in it, so an empty one explains nothing.
+  context "with no project-specific variant" do
+    before { create(:type_variant, type:, variant_name: "Everywhere") }
+
+    it "leaves the project-specific section out" do
+      expect(rendered_component)
+        .to have_no_text(I18n.t("types.edit.variants.project_specific_section.title"))
+    end
+
+    it "still heads the others" do
+      expect(rendered_component).to have_text(I18n.t("types.edit.variants.global_section.title"))
     end
   end
 
@@ -135,7 +173,7 @@ RSpec.describe WorkPackageTypes::VariantsListComponent, type: :component do
   context "without named variants" do
     it "renders a blankslate offering to add one, instead of an empty list" do
       expect(rendered_component).to have_css("[data-test-selector='type-variants-blankslate']")
-      expect(rendered_component).to have_no_css("[data-test-selector='type-variants']")
+      expect(rendered_component).to have_no_css("[data-test-selector^='type-variant-']")
       expect(rendered_component).to have_text(I18n.t("types.edit.variants.blankslate.title"))
       expect(rendered_component)
         .to have_css("[data-test-selector='type-variants-blankslate'] p br")

--- a/spec/features/projects/settings/work_package_types_spec.rb
+++ b/spec/features/projects/settings/work_package_types_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe "Project settings work package types", :js, with_flag: { type_var
   let(:settings_page) { Pages::Projects::Settings::WorkPackageTypes.new(project) }
 
   current_user do
-    create(:user, member_with_permissions: { project => %i[edit_project manage_types view_work_packages] })
+    permissions = %i[edit_project manage_types manage_project_variants view_work_packages]
+
+    create(:user, member_with_permissions: { project => permissions })
   end
 
   before { settings_page.visit! }
@@ -121,12 +123,14 @@ because it's still in use by work packages)
     expect(project.reload.project_types.find_by(type: epic).variant).to eq(epic.default_variant)
   end
 
-  it "opens on the variant in use, with nothing reported yet" do
+  # The type's action puts the type's own configuration to use, so that is what the dialog opens
+  # on. What it costs is reported once the reader changes their mind in the select.
+  it "opens on the type's own configuration, with nothing reported yet" do
     settings_page.open_switch_dialog(design)
 
     within(settings_page.switch_dialog) do
       expect(page).to have_text("Epic: Switch variant")
-      expect(page).to have_select("Variant", selected: "Epic: Design")
+      expect(page).to have_select("Variant", selected: "Epic")
       expect(page).to have_no_text("Fields that")
     end
   end
@@ -135,6 +139,7 @@ because it's still in use by work packages)
   # was made.
   it "refuses to apply the variant the project already uses" do
     settings_page.open_switch_dialog(design)
+    settings_page.choose_switch_target("Epic: Design")
     settings_page.apply_switch
 
     within(settings_page.switch_dialog) do
@@ -144,9 +149,8 @@ because it's still in use by work packages)
     expect(project.reload.project_types.find_by(type: epic).variant).to eq(design)
   end
 
-  # A type with no named variants has nothing to switch to, so offering the action
-  # would open a dialog whose only option is the current one.
-  it "does not offer the switch action on a type without variants" do
+  # The type's action puts its own configuration to use, which this project already does.
+  it "does not offer the type's own configuration when the project already uses it" do
     settings_page.expect_no_switch_action(bug.default_variant)
   end
 

--- a/spec/features/projects/settings/work_package_types_spec.rb
+++ b/spec/features/projects/settings/work_package_types_spec.rb
@@ -123,8 +123,6 @@ because it's still in use by work packages)
     expect(project.reload.project_types.find_by(type: epic).variant).to eq(epic.default_variant)
   end
 
-  # The type's action puts the type's own configuration to use, so that is what the dialog opens
-  # on. What it costs is reported once the reader changes their mind in the select.
   it "opens on the type's own configuration, with nothing reported yet" do
     settings_page.open_switch_dialog(design)
 
@@ -149,7 +147,6 @@ because it's still in use by work packages)
     expect(project.reload.project_types.find_by(type: epic).variant).to eq(design)
   end
 
-  # The type's action puts its own configuration to use, which this project already does.
   it "does not offer the type's own configuration when the project already uses it" do
     settings_page.expect_no_switch_action(bug.default_variant)
   end

--- a/spec/features/types/variants_index_spec.rb
+++ b/spec/features/types/variants_index_spec.rb
@@ -67,15 +67,16 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
     )
   end
 
-  it "counts a type's named variants in its header" do
+  it "counts a type's named variants in a badge on its header" do
     visit types_path
 
     within("[data-draggable-id='#{bug_type.id}'] .Box-header") do
-      expect(page).to have_text(I18n.t("types.index.variants_count", count: 2))
+      expect(page).to have_css(".Counter", text: "2")
     end
 
+    # Nothing to count, so nothing to show.
     within("[data-draggable-id='#{feature_type.id}'] .Box-header") do
-      expect(page).to have_no_text(I18n.t("types.index.variants_count", count: 0))
+      expect(page).to have_no_css(".Counter")
     end
   end
 

--- a/spec/features/types/variants_index_spec.rb
+++ b/spec/features/types/variants_index_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe "Work package variants index", :js, with_flag: { type_variants: t
       expect(page).to have_css(".Counter", text: "2")
     end
 
-    # Nothing to count, so nothing to show.
     within("[data-draggable-id='#{feature_type.id}'] .Box-header") do
       expect(page).to have_no_css(".Counter")
     end

--- a/spec/models/type_variants/scopes/switch_targets_spec.rb
+++ b/spec/models/type_variants/scopes/switch_targets_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Who may move a project from one variant of a type to another: whoever authors the project's own
+# variants. A variant another project owns is nobody else's to use.
+RSpec.describe TypeVariants::Scopes::SwitchTargets do
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:base) { type.default_variant }
+  shared_let(:global) { create(:type_variant, type:, variant_name: "Mobile") }
+  shared_let(:project) { create(:project, types: [type]) }
+  shared_let(:ours) { create(:project_owned_type_variant, type:, project:, variant_name: "Internal") }
+  shared_let(:theirs) do
+    create(:project_owned_type_variant, type:, project: create(:project), variant_name: "Demo only")
+  end
+
+  shared_let(:type_manager) { create(:user, member_with_permissions: { project => %i[manage_types] }) }
+  shared_let(:variant_author) do
+    create(:user, member_with_permissions: { project => %i[manage_project_variants] })
+  end
+  shared_let(:member) { create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+  def targets(user, source:)
+    TypeVariant.switch_targets(user:, project:, source:)
+  end
+
+  # Selecting which types the project uses is a different job from deciding which variant of one
+  # it runs on, and it does not carry it.
+  describe "an administrator of the project's types" do
+    it "may not switch variants" do
+      expect(targets(type_manager, source: base)).to be_empty
+    end
+  end
+
+  describe "an author of the project's own variants" do
+    it "may switch to the variant the project owns" do
+      expect(targets(variant_author, source: base)).to include(ours)
+    end
+
+    # The project's own choice among the configurations it may use, whichever of them it is on.
+    it "may switch to the type's base and to a variant every project shares" do
+      expect(targets(variant_author, source: ours)).to contain_exactly(base, global, ours)
+    end
+
+    it "may not switch to a variant another project owns" do
+      expect(targets(variant_author, source: base)).not_to include(theirs)
+    end
+  end
+
+  it "offers a plain member nothing" do
+    expect(targets(member, source: base)).to be_empty
+  end
+end

--- a/spec/models/type_variants/scopes/switch_targets_spec.rb
+++ b/spec/models/type_variants/scopes/switch_targets_spec.rb
@@ -30,8 +30,6 @@
 
 require "spec_helper"
 
-# Who may move a project from one variant of a type to another: whoever authors the project's own
-# variants. A variant another project owns is nobody else's to use.
 RSpec.describe TypeVariants::Scopes::SwitchTargets do
   shared_let(:type) { create(:type, name: "Bug") }
   shared_let(:base) { type.default_variant }
@@ -52,8 +50,6 @@ RSpec.describe TypeVariants::Scopes::SwitchTargets do
     TypeVariant.switch_targets(user:, project:, source:)
   end
 
-  # Selecting which types the project uses is a different job from deciding which variant of one
-  # it runs on, and it does not carry it.
   describe "an administrator of the project's types" do
     it "may not switch variants" do
       expect(targets(type_manager, source: base)).to be_empty
@@ -65,7 +61,6 @@ RSpec.describe TypeVariants::Scopes::SwitchTargets do
       expect(targets(variant_author, source: base)).to include(ours)
     end
 
-    # The project's own choice among the configurations it may use, whichever of them it is on.
     it "may switch to the type's base and to a variant every project shares" do
       expect(targets(variant_author, source: ours)).to contain_exactly(base, global, ours)
     end

--- a/spec/requests/projects/settings/work_packages/types/switches/dialog_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/switches/dialog_spec.rb
@@ -89,18 +89,4 @@ RSpec.describe "The variant switch dialog",
 
     expect(dialog).to have_select("Variant", selected: epic.default_variant.composite_name)
   end
-
-  it "offers the variants the project may use" do
-    open_dialog
-
-    expect(dialog).to have_select("Variant", options: [epic.default_variant, delivery, ours].map(&:composite_name))
-  end
-
-  # Switching to it would be refused, and its name alone tells this project's administrators
-  # what another project called its own variant.
-  it "offers no variant another project owns" do
-    open_dialog
-
-    expect(dialog).to have_no_css("option", text: "Demo only")
-  end
 end

--- a/spec/requests/projects/settings/work_packages/types/switches/dialog_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/switches/dialog_spec.rb
@@ -53,8 +53,6 @@ RSpec.describe "The variant switch dialog",
   # The dialog arrives inside a turbo-stream template, whose contents Capybara does not enter.
   def dialog = Capybara.string(Nokogiri::HTML5.fragment(response.body).css("template").inner_html)
 
-  # A row's action names the variant it was asked from, so the reader does not have to find it
-  # again in the select.
   it "opens on the variant it was asked about" do
     open_dialog(target_id: delivery.id)
 
@@ -62,8 +60,6 @@ RSpec.describe "The variant switch dialog",
     expect(dialog).to have_select("Variant", selected: delivery.composite_name)
   end
 
-  # The reader chose on the row they came from, so the dialog states the choice rather than asking
-  # for it again; the select is there to change one's mind, not to make the decision.
   it "does not ask the reader to choose a variant" do
     open_dialog(target_id: delivery.id)
 
@@ -82,8 +78,6 @@ RSpec.describe "The variant switch dialog",
     expect(dialog).to have_select("Variant", selected: epic.default_variant.composite_name)
   end
 
-  # The parameter comes off a URL, so it decides nothing on its own: a variant this project may
-  # not use is no more selectable here than it is in the list.
   it "ignores a variant another project owns" do
     open_dialog(target_id: theirs.id)
 

--- a/spec/requests/projects/settings/work_packages/types/switches/dialog_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/switches/dialog_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "The variant switch dialog",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:admin) { create(:admin) }
+
+  shared_let(:epic) { create(:type, name: "Epic") }
+  shared_let(:delivery) { create(:type_variant, type: epic, variant_name: "Delivery") }
+  shared_let(:project) { create(:project, types: [epic]) }
+  shared_let(:ours) { create(:project_owned_type_variant, type: epic, project:, variant_name: "Internal") }
+  shared_let(:theirs) do
+    create(:project_owned_type_variant, type: epic, project: create(:project), variant_name: "Demo only")
+  end
+
+  before { login_as admin }
+
+  def open_dialog(**params)
+    get new_project_settings_work_packages_type_switch_path(project, epic, **params), as: :turbo_stream
+  end
+
+  # The dialog arrives inside a turbo-stream template, whose contents Capybara does not enter.
+  def dialog = Capybara.string(Nokogiri::HTML5.fragment(response.body).css("template").inner_html)
+
+  # A row's action names the variant it was asked from, so the reader does not have to find it
+  # again in the select.
+  it "opens on the variant it was asked about" do
+    open_dialog(target_id: delivery.id)
+
+    expect(response).to have_http_status(:ok)
+    expect(dialog).to have_select("Variant", selected: delivery.composite_name)
+  end
+
+  # The reader chose on the row they came from, so the dialog states the choice rather than asking
+  # for it again; the select is there to change one's mind, not to make the decision.
+  it "does not ask the reader to choose a variant" do
+    open_dialog(target_id: delivery.id)
+
+    expect(dialog).to have_no_text("Select a different variant of this type to use in this project.")
+  end
+
+  it "opens on the project's own variant when that is the one asked about" do
+    open_dialog(target_id: ours.id)
+
+    expect(dialog).to have_select("Variant", selected: ours.composite_name)
+  end
+
+  it "opens on the variant in use when asked about none" do
+    open_dialog
+
+    expect(dialog).to have_select("Variant", selected: epic.default_variant.composite_name)
+  end
+
+  # The parameter comes off a URL, so it decides nothing on its own: a variant this project may
+  # not use is no more selectable here than it is in the list.
+  it "ignores a variant another project owns" do
+    open_dialog(target_id: theirs.id)
+
+    expect(dialog).to have_select("Variant", selected: epic.default_variant.composite_name)
+  end
+
+  it "offers the variants the project may use" do
+    open_dialog
+
+    expect(dialog).to have_select("Variant", options: [epic.default_variant, delivery, ours].map(&:composite_name))
+  end
+
+  # Switching to it would be refused, and its name alone tells this project's administrators
+  # what another project called its own variant.
+  it "offers no variant another project owns" do
+    open_dialog
+
+    expect(dialog).to have_no_css("option", text: "Demo only")
+  end
+end

--- a/spec/requests/projects/settings/work_packages/types/switches/variant_author_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/switches/variant_author_spec.rb
@@ -30,8 +30,6 @@
 
 require "spec_helper"
 
-# A member who may author the project's own variants can reach them, apply one and take it back
-# off again, without also holding the permission to choose which types the project uses.
 RSpec.describe "Switching to a variant a project owns",
                :skip_csrf,
                type: :rails_request,
@@ -71,7 +69,6 @@ RSpec.describe "Switching to a variant a project owns",
       expect(response.body).to include("Internal")
     end
 
-    # Which types the project uses is not theirs to change, so the page offers none of it.
     it "offers no way to add or remove a type" do
       expect(response.body).not_to include("project-types-add-button")
       expect(response.body).not_to include("Remove from project")
@@ -88,9 +85,6 @@ RSpec.describe "Switching to a variant a project owns",
     expect(response).to redirect_to(project_settings_work_packages_types_path(project))
   end
 
-  # Both permissions reach the same page, so both need the same way in: the sidebar's Project
-  # settings entry deep-links to the first settings section the member may open, and this is the
-  # one that leads to the types.
   context "when the member may only choose which types the project uses" do
     before { login_as create(:user, member_with_permissions: { project => %i[view_project manage_types] }) }
 
@@ -134,8 +128,6 @@ RSpec.describe "Switching to a variant a project owns",
     expect(applied_variant).to eq(base)
   end
 
-  # Which variant the project uses is the project's own choice, whether or not the project
-  # authored the variant.
   it "switches the project to a variant every project shares" do
     switch_to(global)
 

--- a/spec/requests/projects/settings/work_packages/types/switches/variant_author_spec.rb
+++ b/spec/requests/projects/settings/work_packages/types/switches/variant_author_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# A member who may author the project's own variants can reach them, apply one and take it back
+# off again, without also holding the permission to choose which types the project uses.
+RSpec.describe "Switching to a variant a project owns",
+               :skip_csrf,
+               type: :rails_request,
+               with_flag: { type_variants: true } do
+  shared_let(:type) { create(:type, name: "Bug") }
+  shared_let(:base) { type.default_variant }
+  shared_let(:global) { create(:type_variant, type:, variant_name: "Mobile") }
+  shared_let(:project) { create(:project, types: [type]) }
+  shared_let(:ours) { create(:project_owned_type_variant, type:, project:, variant_name: "Internal") }
+
+  shared_let(:variant_author) do
+    create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
+  end
+
+  before { login_as variant_author }
+
+  def applied_variant = project.reload.project_types.find_by(type:).variant
+
+  def switch_to(target)
+    post project_settings_work_packages_type_switch_path(project, type),
+         params: { target_id: target.id },
+         as: :turbo_stream
+  end
+
+  def use_variant(variant)
+    project.project_types.find_by(type:).update!(variant:)
+  end
+
+  describe "the project's types page" do
+    before { get project_settings_work_packages_types_path(project) }
+
+    it "opens" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists the variant the project owns" do
+      expect(response.body).to include("Internal")
+    end
+
+    # Which types the project uses is not theirs to change, so the page offers none of it.
+    it "offers no way to add or remove a type" do
+      expect(response.body).not_to include("project-types-add-button")
+      expect(response.body).not_to include("Remove from project")
+    end
+
+    it "offers the variant it owns for use" do
+      expect(response.body).to include("Use in this project")
+    end
+  end
+
+  it "sends them to the types page from the work packages settings" do
+    get project_settings_work_packages_path(project)
+
+    expect(response).to redirect_to(project_settings_work_packages_types_path(project))
+  end
+
+  # Both permissions reach the same page, so both need the same way in: the sidebar's Project
+  # settings entry deep-links to the first settings section the member may open, and this is the
+  # one that leads to the types.
+  context "when the member may only choose which types the project uses" do
+    before { login_as create(:user, member_with_permissions: { project => %i[view_project manage_types] }) }
+
+    it "sends them to the types page from the work packages settings" do
+      get project_settings_work_packages_path(project)
+
+      expect(response).to redirect_to(project_settings_work_packages_types_path(project))
+    end
+
+    it "refuses the switch dialog" do
+      get new_project_settings_work_packages_type_switch_path(project, type), as: :turbo_stream
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "refuses the switch" do
+      switch_to(ours)
+
+      expect(applied_variant).to eq(base)
+    end
+  end
+
+  it "opens the switch dialog" do
+    get new_project_settings_work_packages_type_switch_path(project, type, target_id: ours.id),
+        as: :turbo_stream
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "switches the project to the variant it owns" do
+    switch_to(ours)
+
+    expect(applied_variant).to eq(ours)
+  end
+
+  it "switches the project back off it" do
+    use_variant(ours)
+
+    switch_to(base)
+
+    expect(applied_variant).to eq(base)
+  end
+
+  # Which variant the project uses is the project's own choice, whether or not the project
+  # authored the variant.
+  it "switches the project to a variant every project shares" do
+    switch_to(global)
+
+    expect(applied_variant).to eq(global)
+  end
+
+  it "refuses a switch to a variant another project owns" do
+    theirs = create(:project_owned_type_variant, type:, project: create(:project), variant_name: "Demo only")
+
+    switch_to(theirs)
+
+    expect(applied_variant).to eq(base)
+  end
+
+  context "when the member may not author the project's variants" do
+    before { login_as create(:user, member_with_permissions: { project => %i[view_project] }) }
+
+    it "refuses the types page" do
+      get project_settings_work_packages_types_path(project)
+
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "refuses the switch" do
+      switch_to(ours)
+
+      expect(applied_variant).to eq(base)
+    end
+  end
+end

--- a/spec/services/projects/types/switch_variant_service_spec.rb
+++ b/spec/services/projects/types/switch_variant_service_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Projects::Types::SwitchVariantService, with_flag: { type_variants
     end
   end
 
-  context "when the user is not allowed to manage types" do
+  context "when the user may not author the project's variants" do
     let(:user) { create(:user) }
 
     it "fails without changing anything" do

--- a/spec/services/projects/types/switch_variant_service_spec.rb
+++ b/spec/services/projects/types/switch_variant_service_spec.rb
@@ -104,6 +104,11 @@ RSpec.describe Projects::Types::SwitchVariantService, with_flag: { type_variants
       expect(service_call).to be_failure
       expect(service_call.errors.symbols_for(:types)).to contain_exactly(:switch_target_not_in_family)
     end
+
+    # The pair is malformed, not the user unwelcome: reporting both would name the wrong problem.
+    it "says nothing about the user's permissions" do
+      expect(service_call.errors.symbols_for(:base)).to be_empty
+    end
   end
 
   # Refused rather than raised on: the caller reaches the service with whatever the request

--- a/spec/services/projects/types/switch_variant_service_spec.rb
+++ b/spec/services/projects/types/switch_variant_service_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe Projects::Types::SwitchVariantService, with_flag: { type_variants
       expect(service_call.errors.symbols_for(:types)).to contain_exactly(:switch_target_not_in_family)
     end
 
-    # The pair is malformed, not the user unwelcome: reporting both would name the wrong problem.
     it "says nothing about the user's permissions" do
       expect(service_call.errors.symbols_for(:base)).to be_empty
     end

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -52,7 +52,12 @@ module Pages
           row = find_row(variant)
 
           expect(row).to have_text(variant.name)
-          expect(row).to have_text("Variant: #{variant_name}") if variant_name
+          return if variant_name.nil?
+
+          # A named variant in use says so on its own row, inside the group the type heads.
+          expect(row).to have_css("[data-test-selector='project-types-variant-#{variant.id}']",
+                                  text: "Variant in this project")
+          expect(row).to have_text(variant_name)
         end
 
         def expect_no_type_row(variant)
@@ -60,7 +65,7 @@ module Pages
         end
 
         def remove_type(variant)
-          within(find_row(variant)) { find("action-menu > button").click }
+          open_type_menu(variant)
           click_on "Remove from project"
         end
 
@@ -71,10 +76,15 @@ module Pages
         end
 
         def open_switch_dialog(variant)
-          within(find_row(variant)) { find("action-menu > button").click }
-          click_on "Switch variant"
+          open_type_menu(variant)
+          click_on "Use in this project"
 
           expect(switch_dialog).to have_select("Variant")
+        end
+
+        # The type's own menu, not one of the variant rows below it: both live inside the group.
+        def open_type_menu(variant)
+          within(find_row(variant)) { find(".op-border-box-list-header action-menu > button").click }
         end
 
         def choose_switch_target(target)
@@ -98,9 +108,10 @@ module Pages
         end
 
         def expect_no_switch_action(variant)
-          within(find_row(variant)) { find("action-menu > button").click }
+          open_type_menu(variant)
 
-          expect(page).to have_no_text("Switch variant")
+          # Scoped to the group: another type's menu carries the same item, hidden until opened.
+          expect(find_row(variant)).to have_no_text("Use in this project")
         end
 
         def find_row(variant)

--- a/spec/support/pages/projects/settings/work_package_types.rb
+++ b/spec/support/pages/projects/settings/work_package_types.rb
@@ -54,7 +54,6 @@ module Pages
           expect(row).to have_text(variant.name)
           return if variant_name.nil?
 
-          # A named variant in use says so on its own row, inside the group the type heads.
           expect(row).to have_css("[data-test-selector='project-types-variant-#{variant.id}']",
                                   text: "Variant in this project")
           expect(row).to have_text(variant_name)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AUTOWORK-255

# What are you trying to accomplish?

Implement the designer's UX for project-owned type variants.

**A project's types settings**

- [x] Captioned `Variant` or `Project-specific variant`
- [x] Which one the project uses is stated with a green check and label
- [x] Counter badge of the variants the project may use, hidden at zero
- [x] Group open when the project runs on a variant
- [x] `Use in this project` on every variant the project may use, the type's own row included
- [x] `Add a project-specific variant` in the type's menu, kept as the last row too
- [x] Destructive actions behind a divider
- [x] No menu on a row with nothing to do

**A type's variants tab**

- [x] `Variants` and `Project-specific variants` sections
- [x] Owning project named and linked

**The types index**

- [x] Counter badge, hidden at zero
- [x] `N project-specific variants` as a plain link
- [x] `Add a variant to <Type>`

**Permissions**

- [x] `manage_project_variants` reaches the project's types settings and the switch
- [x] `manage_types` keeps which types the project uses, and no longer switches

## Screenshots

### Global types administration

<img width="1006" height="791" alt="Screenshot of global types administration" src="https://github.com/user-attachments/assets/420e3cf4-7f26-4d3f-b489-ca66c1290697" />

### Global type variants tab

<img width="1006" height="720" alt="Screenshot of the variants tab" src="https://github.com/user-attachments/assets/8e86959f-1590-4a21-8bcb-bc9a284ec3bd" />

### Project administration

<img width="1006" height="870" alt="Screenshot of project administration" src="https://github.com/user-attachments/assets/b3ac4884-64cf-431a-8b97-5cbb64ce84dc" />

# What approach did you choose and why?

- One rule for who may switch, in `TypeVariants::Scopes::SwitchTargets`, read by the contract, the dialog and the list — no screen offers what the request refuses. It also stops the dialog offering variants other projects own.
- Both ways into the dialog preselect their variant, so its standing instruction to choose is gone.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox)

