### PR TITLE
[OP-19824] Give users the choice to not include descendants when deleting work packages  

### DIFF
--- a/app/components/concerns/work_packages/delete_dialogs/descendants.rb
+++ b/app/components/concerns/work_packages/delete_dialogs/descendants.rb
@@ -49,6 +49,29 @@ module WorkPackages
         User.current
       end
 
+      # The dialogs always show the full cascade, the user's actual choice is applied later by
+      # WorkPackages::DeleteService.
+      def include_descendants?
+        true
+      end
+
+      def render_descendants_choice
+        render(Primer::Alpha::RadioButtonGroup.new(
+                 name: "delete_descendants",
+                 label: t_dialog("descendants_choice.heading"),
+                 visually_hide_label: true,
+                 mb: 3
+               )) do |group|
+          group.radio_button(value: "false",
+                             label: t_dialog("descendants_choice.self_only_label"),
+                             caption: t_dialog("descendants_choice.self_only_caption"))
+          group.radio_button(value: "true",
+                             checked: true,
+                             label: t_dialog("descendants_choice.with_descendants_label"),
+                             caption: t_dialog("descendants_choice.with_descendants_caption"))
+        end
+      end
+
       def variant
         @variant ||=
           if !has_descendants? then :none

--- a/app/components/work_packages/bulk_delete_descendants_dialog_component.html.erb
+++ b/app/components/work_packages/bulk_delete_descendants_dialog_component.html.erb
@@ -1,0 +1,100 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  render(
+    Primer::OpenProject::DangerDialog.new(
+      id:,
+      title:,
+      form_arguments: {
+        action: form_action,
+        method: :delete,
+        data: { turbo: false }
+      },
+      size: :medium_portrait
+    )
+  ) do |dialog|
+%>
+  <% dialog.with_confirmation_message do |message|
+       message.with_heading(tag: :h2) { heading }
+       message.with_description_content(description)
+     end %>
+
+  <% dialog.with_additional_details(display: :block) do %>
+    <% if multiple_projects? %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, icon: :info)) do %>
+        <%= helpers.t("work_packages.bulk_delete_dialog.cross_project_warning_html", projects: project_links) %>
+      <% end %>
+    <% end %>
+    <% if variant == :hidden %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+        <%= I18n.t("work_packages.bulk_delete_dialog.#{hidden_warning_key}", count: undeletable_count) %>
+      <% end %>
+    <% end %>
+    <% if variant == :undeletable %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+        <%# helpers.t, not I18n.t: only the Rails helper honours the _html suffix %>
+        <%= helpers.t(
+              "work_packages.bulk_delete_dialog.#{undeletable_warning_key}",
+              count: undeletable_count,
+              projects: undeletable_project_links
+            ) %>
+      <% end %>
+    <% end %>
+    <%= render(OpPrimer::InsetBoxComponent.new) do %>
+      <% work_packages.each do |wp| %>
+        <%= render WorkPackages::InfoLineComponent.new(
+              work_package: wp,
+              show_subject: true,
+              show_status: false,
+              show_project: multiple_projects?
+            ) %>
+        <% if descendants_for(wp).any? %>
+          <%= render(Primer::Box.new(pl: 2, my: 1)) do %>
+            <%= render(Primer::Beta::Text.new(mt: 1, font_size: :small, font_weight: :bold, display: :block, mb: 1)) do %>
+              <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
+            <% end %>
+            <% descendants_for(wp).each do |descendant| %>
+              <%= render WorkPackages::InfoLineComponent.new(
+                    work_package: descendant,
+                    show_subject: true,
+                    show_status: false,
+                    show_project: descendant.project != wp.project
+                  ) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% dialog.with_confirmation_check_box_content(confirmation_checkbox_text) %>
+<% end %>

--- a/app/components/work_packages/bulk_delete_descendants_dialog_component.rb
+++ b/app/components/work_packages/bulk_delete_descendants_dialog_component.rb
@@ -29,17 +29,17 @@
 #++
 
 module WorkPackages
-  class DeleteDialogComponent < ApplicationComponent
+  class BulkDeleteDescendantsDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
     include WorkPackages::DeleteDialogs::Descendants
 
-    DIALOG_ID = "wp-delete-dialog"
+    DIALOG_ID = "wp-delete-descendants-dialog"
 
-    attr_reader :work_package
+    attr_reader :work_packages
 
-    def initialize(work_package:, back_url: nil)
+    def initialize(work_packages:, back_url: nil)
       super
-      @work_package = work_package
+      @work_packages = work_packages
       @back_url = back_url
     end
 
@@ -47,34 +47,60 @@ module WorkPackages
 
     def id = DIALOG_ID
 
-    def i18n_scope = "work_packages.delete_dialog"
+    def i18n_scope = "work_packages.bulk_delete_dialog"
 
-    def deletion_roots = [work_package]
+    def deletion_roots = work_packages.to_a
 
     def title
-      t_dialog(has_descendants? ? "descendants_choice.heading" : "title")
+      t_dialog("title", count: total_count)
     end
 
     def heading
-      t_dialog(has_descendants? ? "descendants_choice.heading" : "heading")
+      t_dialog("heading", count: total_count)
     end
 
     def description
-      return t_dialog("descendants_choice.question") if has_descendants?
+      key =
+        case variant
+        when :all then "description_with_descendants"
+        when :hidden then nothing_deleted? ? "description" : "description_with_visible_descendants"
+        when :undeletable then nothing_deleted? ? "description" : "description_with_all_descendants"
+        else "description"
+        end
 
-      t_dialog("description", name: work_package.to_s)
+      t_dialog(key)
     end
 
     def confirmation_checkbox_text
-      t_dialog("confirm_deletion")
+      t_dialog(deleted_descendants.any? ? "confirm_descendants_deletion" : "confirm_deletion")
+    end
+
+    def total_count
+      @total_count ||= work_package_ids.size + deleted_descendants.size
+    end
+
+    def multiple_projects?
+      projects.size > 1
+    end
+
+    def project_links
+      link_to_projects(projects)
+    end
+
+    def descendants_for(work_package)
+      deleted_descendants_under(work_package)
     end
 
     def form_action
-      helpers.work_packages_bulk_path(ids: [work_package.id], delete_descendants: false, back_url: @back_url)
+      helpers.work_packages_bulk_path(ids: work_package_ids, delete_descendants: true, back_url: @back_url)
     end
 
-    def confirm_delete_path
-      helpers.confirm_delete_work_packages_bulk_path(ids: [work_package.id], back_url: @back_url)
+    def projects
+      @projects ||= (work_packages.to_a + deleted_descendants).filter_map(&:project).uniq
+    end
+
+    def work_package_ids
+      @work_package_ids ||= work_packages.map(&:id)
     end
   end
 end

--- a/app/components/work_packages/bulk_delete_dialog_component.html.erb
+++ b/app/components/work_packages/bulk_delete_dialog_component.html.erb
@@ -29,72 +29,55 @@
   ++#
 %>
 
-<%=
-  render(
-    Primer::OpenProject::DangerDialog.new(
-      id:,
-      title:,
-      form_arguments: {
-        action: form_action,
-        method: :delete,
-        data: { turbo: false }
-      },
-      size: :medium_portrait
-    )
-  ) do |dialog|
-%>
-  <% dialog.with_confirmation_message do |message|
-       message.with_heading(tag: :h2) { heading }
-       message.with_description_content(description)
-     end %>
-
-  <% dialog.with_additional_details(display: :block) do %>
-    <% if multiple_projects? %>
-      <%= render(Primer::Alpha::Banner.new(mb: 2, icon: :info)) do %>
-        <%= helpers.t("work_packages.bulk_delete_dialog.cross_project_warning_html", projects: project_links) %>
-      <% end %>
-    <% end %>
-    <% if variant == :hidden %>
-      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-        <%= I18n.t("work_packages.bulk_delete_dialog.#{hidden_warning_key}", count: undeletable_count) %>
-      <% end %>
-    <% end %>
-    <% if variant == :undeletable %>
-      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-        <%# helpers.t, not I18n.t: only the Rails helper honours the _html suffix %>
-        <%= helpers.t(
-              "work_packages.bulk_delete_dialog.#{undeletable_warning_key}",
-              count: undeletable_count,
-              projects: undeletable_project_links
-            ) %>
-      <% end %>
-    <% end %>
-    <%= render(OpPrimer::InsetBoxComponent.new) do %>
-      <% work_packages.each do |wp| %>
-        <%= render WorkPackages::InfoLineComponent.new(
-              work_package: wp,
-              show_subject: true,
-              show_status: false,
-              show_project: multiple_projects?
-            ) %>
-        <% if descendants_for(wp).any? %>
-          <%= render(Primer::Box.new(pl: 2, my: 1)) do %>
-            <%= render(Primer::Beta::Text.new(mt: 1, font_size: :small, font_weight: :bold, display: :block, mb: 1)) do %>
-              <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
-            <% end %>
-            <% descendants_for(wp).each do |descendant| %>
-              <%= render WorkPackages::InfoLineComponent.new(
-                    work_package: descendant,
-                    show_subject: true,
-                    show_status: false,
-                    show_project: descendant.project != wp.project
-                  ) %>
-            <% end %>
+<% if has_descendants? %>
+  <%= render(Primer::Alpha::Dialog.new(id:, title:, size: :medium_portrait)) do |dialog| %>
+    <% dialog.with_header(variant: :large) %>
+    <%= primer_form_with(url: confirm_delete_path, method: :post) do %>
+      <%= render(Primer::Alpha::Dialog::Body.new) do %>
+        <%= render(Primer::Beta::Text.new(tag: :p, mb: 3)) { description } %>
+        <% if multiple_projects? %>
+          <%= render(Primer::Alpha::Banner.new(mb: 3, icon: :info)) do %>
+            <%= helpers.t("work_packages.bulk_delete_dialog.cross_project_warning_html", projects: link_to_projects(projects)) %>
           <% end %>
         <% end %>
+        <%= render_descendants_choice %>
+      <% end %>
+      <%= render(Primer::Alpha::Dialog::Footer.new) do %>
+        <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": id })) { t(:button_cancel) } %>
+        <%= render(Primer::Beta::Button.new(scheme: :danger, type: :submit)) { t(:button_delete) } %>
       <% end %>
     <% end %>
   <% end %>
-
-  <% dialog.with_confirmation_check_box_content(confirmation_checkbox_text) %>
+<% else %>
+  <%= render(
+        Primer::OpenProject::DangerDialog.new(
+          id:,
+          title:,
+          form_arguments: { action: form_action, method: :delete, data: { turbo: false } },
+          size: :medium_portrait
+        )
+      ) do |dialog| %>
+    <% dialog.with_confirmation_message do |message|
+         message.with_heading(tag: :h2) { heading }
+         message.with_description_content(description)
+       end %>
+    <% dialog.with_additional_details(display: :block) do %>
+      <% if multiple_projects? %>
+        <%= render(Primer::Alpha::Banner.new(mb: 2, icon: :info)) do %>
+          <%= helpers.t("work_packages.bulk_delete_dialog.cross_project_warning_html", projects: link_to_projects(projects)) %>
+        <% end %>
+      <% end %>
+      <%= render(OpPrimer::InsetBoxComponent.new) do %>
+        <% work_packages.each do |wp| %>
+          <%= render WorkPackages::InfoLineComponent.new(
+                work_package: wp,
+                show_subject: true,
+                show_status: false,
+                show_project: multiple_projects?
+              ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+    <% dialog.with_confirmation_check_box_content(confirmation_checkbox_text) %>
+  <% end %>
 <% end %>

--- a/app/components/work_packages/bulk_delete_dialog_component.rb
+++ b/app/components/work_packages/bulk_delete_dialog_component.rb
@@ -43,59 +43,52 @@ module WorkPackages
 
     private
 
-    def id = "wp-delete-dialog"
+    def id = DeleteDialogComponent::DIALOG_ID
 
     def i18n_scope = "work_packages.bulk_delete_dialog"
 
     def deletion_roots = work_packages.to_a
 
     def title
+      return t_dialog("descendants_choice.heading") if has_descendants?
+
       t_dialog("title", count: total_count)
     end
 
     def heading
+      return t_dialog("descendants_choice.heading") if has_descendants?
+
       t_dialog("heading", count: total_count)
     end
 
     def description
-      key =
-        case variant
-        when :all then "description_with_descendants"
-        when :hidden then nothing_deleted? ? "description" : "description_with_visible_descendants"
-        when :undeletable then nothing_deleted? ? "description" : "description_with_all_descendants"
-        else "description"
-        end
+      return t_dialog("descendants_choice.question") if has_descendants?
 
-      t_dialog(key)
+      t_dialog("description")
     end
 
-    # Only the deleted descendants are listed, so only those can be confirmed.
     def confirmation_checkbox_text
-      t_dialog(deleted_descendants.any? ? "confirm_descendants_deletion" : "confirm_deletion")
+      t_dialog("confirm_deletion")
     end
 
     def total_count
       @total_count ||= work_package_ids.size + deleted_descendants.size
     end
 
+    def form_action
+      helpers.work_packages_bulk_path(ids: work_package_ids, delete_descendants: false, back_url: @back_url)
+    end
+
+    def confirm_delete_path
+      helpers.confirm_delete_work_packages_bulk_path(ids: work_package_ids, back_url: @back_url)
+    end
+
     def multiple_projects?
       projects.size > 1
     end
 
-    def project_links
-      link_to_projects(projects)
-    end
-
-    def descendants_for(work_package)
-      deleted_descendants_under(work_package)
-    end
-
-    def form_action
-      helpers.work_packages_bulk_path(ids: work_package_ids, back_url: @back_url)
-    end
-
     def projects
-      @projects ||= (work_packages.to_a + deleted_descendants).filter_map(&:project).uniq
+      @projects ||= work_packages.filter_map(&:project).uniq
     end
 
     def work_package_ids

--- a/app/components/work_packages/delete_descendants_dialog_component.html.erb
+++ b/app/components/work_packages/delete_descendants_dialog_component.html.erb
@@ -1,0 +1,92 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  render(
+    Primer::OpenProject::DangerDialog.new(
+      id:,
+      title:,
+      form_arguments: {
+        action: form_action,
+        method: :delete,
+        data: { turbo: false }
+      },
+      size: :medium_portrait
+    )
+  ) do |dialog|
+%>
+  <% dialog.with_confirmation_message do |message|
+       message.with_heading(tag: :h2) { heading }
+       message.with_description_content(description)
+     end %>
+
+  <% dialog.with_additional_details(display: :block) do %>
+    <% if cross_project_descendants? %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+        <%= helpers.t("work_packages.delete_dialog.cross_project_warning_html", projects: all_project_links) %>
+      <% end %>
+    <% end %>
+    <% if variant == :hidden %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+        <%= I18n.t("work_packages.delete_dialog.#{hidden_warning_key}", count: undeletable_count) %>
+      <% end %>
+    <% end %>
+    <% if variant == :undeletable %>
+      <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
+        <%# helpers.t, not I18n.t: only the Rails helper honours the _html suffix %>
+        <%= helpers.t(
+              "work_packages.delete_dialog.#{undeletable_warning_key}",
+              count: undeletable_count,
+              projects: undeletable_project_links
+            ) %>
+      <% end %>
+    <% end %>
+    <% if deleted_descendants.any? %>
+      <%= render(OpPrimer::InsetBoxComponent.new) do %>
+        <%= render(Primer::Beta::Text.new(font_size: :small, font_weight: :bold, display: :block, mb: 2)) do %>
+          <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
+        <% end %>
+        <% deleted_descendants.each do |descendant| %>
+          <%= render WorkPackages::InfoLineComponent.new(
+                pl: 2,
+                my: 1,
+                work_package: descendant,
+                show_subject: true,
+                show_status: false,
+                show_project: descendant.project != work_package.project
+              ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% dialog.with_confirmation_check_box_content(confirmation_checkbox_text) %>
+<% end %>

--- a/app/components/work_packages/delete_descendants_dialog_component.rb
+++ b/app/components/work_packages/delete_descendants_dialog_component.rb
@@ -29,11 +29,11 @@
 #++
 
 module WorkPackages
-  class DeleteDialogComponent < ApplicationComponent
+  class DeleteDescendantsDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
     include WorkPackages::DeleteDialogs::Descendants
 
-    DIALOG_ID = "wp-delete-dialog"
+    DIALOG_ID = "wp-delete-descendants-dialog"
 
     attr_reader :work_package
 
@@ -52,29 +52,37 @@ module WorkPackages
     def deletion_roots = [work_package]
 
     def title
-      t_dialog(has_descendants? ? "descendants_choice.heading" : "title")
+      t_dialog("title")
     end
 
     def heading
-      t_dialog(has_descendants? ? "descendants_choice.heading" : "heading")
+      t_dialog("heading")
     end
 
     def description
-      return t_dialog("descendants_choice.question") if has_descendants?
-
       t_dialog("description", name: work_package.to_s)
     end
 
     def confirmation_checkbox_text
-      t_dialog("confirm_deletion")
+      t_dialog(deleted_descendants.any? ? "confirm_descendants_deletion" : "confirm_deletion")
+    end
+
+    def cross_project_descendants?
+      deleted_descendants.any? { |d| d.project != work_package.project }
+    end
+
+    def all_project_links
+      projects = deleted_descendants
+        .filter_map(&:project)
+        .uniq
+        .reject { |p| p == work_package.project }
+        .unshift(work_package.project)
+
+      link_to_projects(projects)
     end
 
     def form_action
-      helpers.work_packages_bulk_path(ids: [work_package.id], delete_descendants: false, back_url: @back_url)
-    end
-
-    def confirm_delete_path
-      helpers.confirm_delete_work_packages_bulk_path(ids: [work_package.id], back_url: @back_url)
+      helpers.work_packages_bulk_path(ids: [work_package.id], delete_descendants: true, back_url: @back_url)
     end
   end
 end

--- a/app/components/work_packages/delete_dialog_component.html.erb
+++ b/app/components/work_packages/delete_dialog_component.html.erb
@@ -29,66 +29,33 @@
   ++#
 %>
 
-<%=
-  render(
-    Primer::OpenProject::DangerDialog.new(
-      id:,
-      title:,
-      form_arguments: {
-        action: form_action,
-        method: :delete,
-        data: { turbo: false }
-      },
-      size: :medium_portrait
-    )
-  ) do |dialog|
-%>
-  <% dialog.with_confirmation_message do |message|
-       message.with_heading(tag: :h2) { heading }
-       message.with_description_content(description)
-     end %>
-
-  <% if has_descendants? %>
-    <% dialog.with_additional_details(display: :block) do %>
-      <% if cross_project_descendants? %>
-        <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-          <%= helpers.t("work_packages.delete_dialog.cross_project_warning_html", projects: all_project_links) %>
-        <% end %>
+<% if has_descendants? %>
+  <%= render(Primer::Alpha::Dialog.new(id:, title:, size: :medium_portrait)) do |dialog| %>
+    <% dialog.with_header(variant: :large) %>
+    <%= primer_form_with(url: confirm_delete_path, method: :post) do %>
+      <%= render(Primer::Alpha::Dialog::Body.new) do %>
+        <%= render(Primer::Beta::Text.new(tag: :p, mb: 3)) { description } %>
+        <%= render_descendants_choice %>
       <% end %>
-      <% if variant == :hidden %>
-        <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-          <%= I18n.t("work_packages.delete_dialog.#{hidden_warning_key}", count: undeletable_count) %>
-        <% end %>
-      <% end %>
-      <% if variant == :undeletable %>
-        <%= render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do %>
-          <%# helpers.t, not I18n.t: only the Rails helper honours the _html suffix %>
-          <%= helpers.t(
-                "work_packages.delete_dialog.#{undeletable_warning_key}",
-                count: undeletable_count,
-                projects: undeletable_project_links
-              ) %>
-        <% end %>
-      <% end %>
-      <% if deleted_descendants.any? %>
-        <%= render(OpPrimer::InsetBoxComponent.new) do %>
-          <%= render(Primer::Beta::Text.new(font_size: :small, font_weight: :bold, display: :block, mb: 2)) do %>
-            <%= I18n.t("work_packages.bulk_delete_dialog.children_label") %>
-          <% end %>
-          <% deleted_descendants.each do |descendant| %>
-            <%= render WorkPackages::InfoLineComponent.new(
-                  pl: 2,
-                  my: 1,
-                  work_package: descendant,
-                  show_subject: true,
-                  show_status: false,
-                  show_project: descendant.project != work_package.project
-                ) %>
-          <% end %>
-        <% end %>
+      <%= render(Primer::Alpha::Dialog::Footer.new) do %>
+        <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": id })) { t(:button_cancel) } %>
+        <%= render(Primer::Beta::Button.new(scheme: :danger, type: :submit)) { t(:button_delete) } %>
       <% end %>
     <% end %>
   <% end %>
-
-  <% dialog.with_confirmation_check_box_content(confirmation_checkbox_text) %>
+<% else %>
+  <%= render(
+        Primer::OpenProject::DangerDialog.new(
+          id:,
+          title:,
+          form_arguments: { action: form_action, method: :delete, data: { turbo: false } },
+          size: :medium_portrait
+        )
+      ) do |dialog| %>
+    <% dialog.with_confirmation_message do |message|
+         message.with_heading(tag: :h2) { heading }
+         message.with_description_content(description)
+       end %>
+    <% dialog.with_confirmation_check_box_content(confirmation_checkbox_text) %>
+  <% end %>
 <% end %>

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -52,6 +52,15 @@ class WorkPackages::BulkController < ApplicationController
     respond_with_dialog component
   end
 
+  def confirm_delete
+    return perform_deletion unless delete_descendants?
+
+    close_dialog_via_turbo_stream(WorkPackages::DeleteDialogComponent::DIALOG_ID)
+    dialog_via_turbo_stream(component: delete_descendants_dialog_component)
+
+    respond_with_turbo_streams
+  end
+
   def edit
     setup_edit
   end
@@ -83,9 +92,18 @@ class WorkPackages::BulkController < ApplicationController
     end
   end
 
-  def destroy # rubocop:disable Metrics/AbcSize
+  def destroy
+    perform_deletion
+  end
+
+  private
+
+  def perform_deletion # rubocop:disable Metrics/AbcSize
     unless WorkPackage.cleanup_associated_before_destructing_if_required(@work_packages, current_user, params[:to_do])
-      return redirect_to(action: :reassign, ids: @work_packages.map(&:id), back_url: params[:back_url])
+      return redirect_to(action: :reassign,
+                         ids: @work_packages.map(&:id),
+                         delete_descendants: delete_descendants?,
+                         back_url: params[:back_url])
     end
 
     calls = destroy_work_packages(@work_packages)
@@ -108,7 +126,13 @@ class WorkPackages::BulkController < ApplicationController
     end
   end
 
-  private
+  def delete_descendants_dialog_component
+    if @work_packages.one?
+      WorkPackages::DeleteDescendantsDialogComponent.new(work_package: @work_packages.first, back_url: params[:back_url])
+    else
+      WorkPackages::BulkDeleteDescendantsDialogComponent.new(work_packages: @work_packages, back_url: params[:back_url])
+    end
+  end
 
   def setup_edit
     @available_statuses = @projects.map { |p| Workflow.available_statuses(p) }.inject(&:&)
@@ -138,12 +162,17 @@ class WorkPackages::BulkController < ApplicationController
       WorkPackages::DeleteService
         .new(user: current_user,
              model: work_package.reload)
-        .call
+        .call(delete_descendants: delete_descendants?)
     rescue ::ActiveRecord::RecordNotFound
       # raised by #reload if work package no longer exists
       # nothing to do, work package was already deleted (eg. by a parent)
       nil
     end
+  end
+
+  # Absent means cascade, consistent with WorkPackages::DeleteService's default.
+  def delete_descendants?
+    ActiveModel::Type::Boolean.new.cast(params.fetch(:delete_descendants, true))
   end
 
   # A call also carries the descendants it deleted, next to work packages it only

--- a/app/services/work_packages/delete_service.rb
+++ b/app/services/work_packages/delete_service.rb
@@ -38,6 +38,9 @@ class WorkPackages::DeleteService < BaseServices::Delete
 
   def deletion_user = user
 
+  # Cascade deletions by default when no parameter is explicitly passed.
+  def include_descendants? = params.fetch(:delete_descendants, true)
+
   def deletable?(descendant)
     validate(descendant, user, options: contract_options).first
   end

--- a/app/services/work_packages/shared/deletion_planning.rb
+++ b/app/services/work_packages/shared/deletion_planning.rb
@@ -64,10 +64,11 @@ module WorkPackages
 
       private
 
-      # Unlinking a survivor is a side effect of the deletion, so this deliberately does not
-      # consider the "manage_subtasks" permission.
+      # include_descendants? is supplied by the includer. When false, every descendant is detached instead of deleted.
+      # Unlinking a survivor is a side effect of the deletion, so this deliberately does not consider the
+      # "manage_subtasks" permission.
       def deleted_with_roots?(descendant)
-        visible_descendant_ids.include?(descendant.id) && deletable?(descendant)
+        include_descendants? && visible_descendant_ids.include?(descendant.id) && deletable?(descendant)
       end
 
       def deletable?(descendant)

--- a/app/views/work_packages/bulk/reassign.html.erb
+++ b/app/views/work_packages/bulk/reassign.html.erb
@@ -54,9 +54,11 @@ See COPYRIGHT and LICENSE files for more details.
     raw_back_url = (params[:back_url] || request.env["HTTP_REFERER"]).presence
     cancel_url = RedirectPolicy.new(raw_back_url, hostname: request.host, default: work_packages_path).redirect_url
     back_url = back_url_is_wp_show? ? nil : raw_back_url&.then { |url| CGI.escape(CGI.unescape(url.to_s)) }
+    delete_descendants = params[:delete_descendants]
 
     render_inline_form(f) do |form|
       form.hidden(name: "back_url", value: back_url, scope_name_to_model: false) if back_url
+      form.hidden(name: "delete_descendants", value: delete_descendants, scope_name_to_model: false)
 
       work_packages.each do |wp|
         form.hidden(name: "ids[]", value: wp.id, scope_name_to_model: false)

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -466,7 +466,7 @@ Rails.application.reloader.to_prepare do
       wpt.permission :delete_work_packages,
                      {
                        work_packages: :destroy,
-                       "work_packages/bulk": %i[delete_dialog destroy reassign]
+                       "work_packages/bulk": %i[delete_dialog confirm_delete destroy reassign]
                      },
                      permissible_on: :project,
                      require: :member,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7095,6 +7095,13 @@ en:
       confirm_deletion: "I confirm that the selected work packages and all associated data will be deleted."
       confirm_descendants_deletion: "I confirm that all descendants listed above will also be deleted."
       cross_project_warning_html: "These work packages span multiple projects: %{projects}"
+      descendants_choice:
+        heading: "Delete all descendants too?"
+        question: "You are trying to delete work packages that have descendants. Do you want to delete them as well?"
+        self_only_label: "Delete just the selected work packages"
+        self_only_caption: "Descendants will not be deleted but hierarchical relations will be removed."
+        with_descendants_label: "Delete the selected work packages and their descendants"
+        with_descendants_caption: "The entire hierarchy will be deleted."
       description: "Are you sure you want to delete the selected work packages and all associated data?"
       description_with_all_descendants: "Are you sure you want to delete the selected work packages and all of their descendants?"
       description_with_descendants: "Are you sure you want to delete the selected work packages and all the following descendants?"
@@ -7174,6 +7181,13 @@ en:
       confirm_deletion: "I confirm that the work package and all associated data will be deleted."
       confirm_descendants_deletion: "I confirm that all descendants listed above will also be deleted."
       cross_project_warning_html: "Work packages from the following projects will be deleted: %{projects}"
+      descendants_choice:
+        heading: "Delete all descendants too?"
+        question: "This work package has descendants. Do you want to delete them as well?"
+        self_only_label: "Delete just this work package"
+        self_only_caption: "Descendants will not be deleted but hierarchical relations will be removed."
+        with_descendants_label: "Delete this work package and descendants"
+        with_descendants_caption: "The entire hierarchy will be deleted."
       description: 'Are you sure you want to delete "%{name}"?'
       heading: "Permanently delete this work package?"
       hidden_descendants_only_warning:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7099,9 +7099,9 @@ en:
         heading: "Delete all descendants too?"
         question: "You are trying to delete work packages that have descendants. Do you want to delete them as well?"
         self_only_label: "Delete just the selected work packages"
-        self_only_caption: "Descendants will not be deleted but hierarchical relations will be removed."
+        self_only_caption: "This will not delete descendants but will remove hierarchical relations."
         with_descendants_label: "Delete the selected work packages and their descendants"
-        with_descendants_caption: "The entire hierarchy will be deleted."
+        with_descendants_caption: "This will delete all child work packages visible to you. You will have a chance to review the full list in the next step."
       description: "Are you sure you want to delete the selected work packages and all associated data?"
       description_with_all_descendants: "Are you sure you want to delete the selected work packages and all of their descendants?"
       description_with_descendants: "Are you sure you want to delete the selected work packages and all the following descendants?"
@@ -7185,9 +7185,9 @@ en:
         heading: "Delete all descendants too?"
         question: "This work package has descendants. Do you want to delete them as well?"
         self_only_label: "Delete just this work package"
-        self_only_caption: "Descendants will not be deleted but hierarchical relations will be removed."
+        self_only_caption: "This will not delete descendants but will remove hierarchical relations."
         with_descendants_label: "Delete this work package and descendants"
-        with_descendants_caption: "The entire hierarchy will be deleted."
+        with_descendants_caption: "This will delete all child work packages visible to you. You will have a chance to review the full list in the next step."
       description: 'Are you sure you want to delete "%{name}"?'
       heading: "Permanently delete this work package?"
       hidden_descendants_only_warning:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1043,6 +1043,7 @@ Rails.application.routes.draw do
       collection do
         match :reassign, via: %i[get delete]
         get :delete_dialog
+        post :confirm_delete
       end
     end
   end

--- a/spec/components/work_packages/bulk_delete_descendants_dialog_component_spec.rb
+++ b/spec/components/work_packages/bulk_delete_descendants_dialog_component_spec.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+# Second step of the bulk delete flow: shown after the user chose to delete descendants.
+# It owns the deletion preview (and the descendant-inclusive counts/projects) that
+# BulkDeleteDialogComponent used to render, so these examples were migrated from
+# bulk_delete_dialog_component_spec unchanged.
+RSpec.describe WorkPackages::BulkDeleteDescendantsDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { create(:admin) }
+
+  let(:main_project) { create(:project, name: "Main Project") }
+  let(:sub_project) { create(:project, name: "Sub Project", parent: main_project) }
+  let(:sub_sub_project) { create(:project, name: "Sub Sub Project", parent: sub_project) }
+
+  let(:wp_main) { create(:work_package, project: main_project) }
+  let(:work_packages) { [wp_main] }
+
+  subject(:component) { described_class.new(work_packages:) }
+
+  before do
+    User.current = user
+  end
+
+  describe "#projects" do
+    context "when work packages have descendants in sub-projects" do
+      let(:child_wp) { create(:work_package, project: sub_project, parent: wp_main) }
+      let(:grandchild_wp) { create(:work_package, project: sub_sub_project, parent: child_wp) }
+
+      before do
+        grandchild_wp # ensure all records are created
+      end
+
+      it "includes projects from descendants" do
+        projects = component.send(:projects)
+
+        expect(projects).to include(main_project, sub_project, sub_sub_project)
+      end
+
+      it "reports multiple projects" do
+        expect(component.send(:multiple_projects?)).to be true
+      end
+
+      it "links every project name" do
+        render_inline(component)
+
+        [main_project, sub_project, sub_sub_project].each do |project|
+          expect(page).to have_link project.name, href: project_path(project)
+        end
+      end
+    end
+  end
+
+  describe "descendants the user may not delete" do
+    shared_let(:permitted_project) { create(:project, name: "Permitted Project") }
+    shared_let(:view_only_project) { create(:project, name: "View Only Project") }
+    shared_let(:invisible_project) { create(:project, name: "Invisible Project") }
+
+    let(:permitted_permissions) { %i[view_work_packages delete_work_packages] }
+    let(:permitted_user) do
+      create(:user,
+             member_with_permissions: {
+               permitted_project => permitted_permissions,
+               view_only_project => %i[view_work_packages]
+             })
+    end
+
+    shared_let(:parent_wp) { create(:work_package, project: permitted_project, subject: "Parent to delete") }
+
+    subject do
+      render_inline(described_class.new(work_packages: [parent_wp]))
+      page
+    end
+
+    before do
+      login_as(permitted_user)
+    end
+
+    def t(key, **)
+      I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
+    end
+
+    context "with a child in an invisible project" do
+      shared_let(:invisible_child) do
+        create(:work_package, project: invisible_project, parent: parent_wp, subject: "Secret child")
+      end
+
+      it "does not disclose the invisible work package or its project" do
+        expect(subject).to have_no_text "Secret child"
+        expect(subject).to have_no_text "Invisible Project"
+      end
+
+      it "asks about the selection alone, since nothing else gets deleted" do
+        expect(subject).to have_text t("description")
+        expect(subject).to have_text t("hidden_descendants_only_warning", count: 1)
+        expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
+      end
+
+      it "does not claim the deletion spans multiple projects" do
+        expect(subject).to have_no_text "span multiple projects"
+      end
+
+      it "does not claim descendants will be deleted" do
+        expect(subject).to have_no_text t("children_label")
+        expect(subject).to have_text t("confirm_deletion")
+      end
+    end
+
+    context "with a visible child the user may not delete" do
+      shared_let(:view_only_child) do
+        create(:work_package, project: view_only_project, parent: parent_wp, subject: "View only child")
+      end
+
+      it "does not offer to delete it" do
+        expect(subject).to have_no_text t("children_label")
+      end
+
+      it "warns that it is preserved and links its project" do
+        expect(subject).to have_text t("description")
+        expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                       count: 1,
+                                       projects: view_only_project.name)
+        expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
+      end
+
+      it "counts only the selection" do
+        expect(subject).to have_text t("heading", count: 1)
+      end
+    end
+
+    context "with a grandchild in an invisible project" do
+      shared_let(:visible_child) do
+        create(:work_package, project: permitted_project, parent: parent_wp, subject: "Visible child")
+      end
+      shared_let(:invisible_grandchild) do
+        create(:work_package, project: invisible_project, parent: visible_child, subject: "Secret grandchild")
+      end
+
+      it "lists only the descendant it deletes" do
+        expect(subject).to have_text "Visible child"
+        expect(subject).to have_no_text "Secret grandchild"
+        expect(subject).to have_no_text "Invisible Project"
+      end
+
+      it "warns about the grandchild it cannot see" do
+        expect(subject).to have_text t("hidden_descendants_warning", count: 1)
+      end
+    end
+
+    context "with one child hidden and another visible but undeletable" do
+      shared_let(:view_only_child) do
+        create(:work_package, project: view_only_project, parent: parent_wp, subject: "View only child")
+      end
+      shared_let(:invisible_child) do
+        create(:work_package, project: invisible_project, parent: parent_wp, subject: "Secret child")
+      end
+
+      it "uses the permission wording and folds the hidden one into the count" do
+        expect(subject).to have_text t("undeletable_descendants_warning", count: 2)
+        expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
+      end
+
+      it "names no project, since the count covers one it cannot show" do
+        expect(subject).to have_no_text "Invisible Project"
+        expect(subject).to have_no_link view_only_project.name
+      end
+    end
+  end
+
+  describe "#total_count" do
+    context "when a selected work package is itself a descendant of another selection" do
+      let(:child_wp) { create(:work_package, project: main_project, parent: wp_main) }
+      let(:grandchild_wp) { create(:work_package, project: main_project, parent: child_wp) }
+      let(:work_packages) { [wp_main, child_wp] }
+
+      before do
+        grandchild_wp
+      end
+
+      it "counts every affected work package once" do
+        expect(component.send(:total_count)).to eq(3)
+      end
+    end
+
+    context "with a descendant the user may not delete" do
+      let(:restricted_project) { create(:project, name: "Restricted Project") }
+      let(:restricted_user) do
+        create(:user,
+               member_with_permissions: {
+                 main_project => %i[view_work_packages delete_work_packages]
+               })
+      end
+      let(:selected_wp) { create(:work_package, project: main_project) }
+      let(:deleted_child) { create(:work_package, project: main_project, parent: selected_wp) }
+      let(:unlinked_child) { create(:work_package, project: restricted_project, parent: selected_wp) }
+
+      let(:work_packages) { [selected_wp] }
+
+      before do
+        deleted_child
+        unlinked_child
+        login_as(restricted_user)
+      end
+
+      it "counts only the selection and the descendants it deletes" do
+        expect(component.send(:total_count)).to eq(2)
+      end
+
+      it "reports the one that is only unlinked separately" do
+        expect(component.send(:undeletable_count)).to eq(1)
+      end
+
+      it "puts the listed count in the heading" do
+        render_inline(component)
+
+        expect(page).to have_text I18n.t("work_packages.bulk_delete_dialog.heading", count: 2)
+      end
+    end
+  end
+
+  describe "#description" do
+    context "when work packages have descendants" do
+      let(:child_wp) { create(:work_package, project: main_project, parent: wp_main) }
+
+      before do
+        child_wp # ensure record is created
+      end
+
+      it "returns the description mentioning children" do
+        expect(component.send(:description)).to eq(
+          I18n.t("work_packages.bulk_delete_dialog.description_with_descendants")
+        )
+      end
+    end
+  end
+end

--- a/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
 
   let(:main_project) { create(:project, name: "Main Project") }
   let(:sub_project) { create(:project, name: "Sub Project", parent: main_project) }
-  let(:sub_sub_project) { create(:project, name: "Sub Sub Project", parent: sub_project) }
 
   let(:wp_main) { create(:work_package, project: main_project) }
   let(:work_packages) { [wp_main] }
@@ -54,200 +53,6 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
         expect(component.send(:projects)).to eq([main_project])
       end
     end
-
-    context "when work packages have descendants in sub-projects" do
-      let(:child_wp) { create(:work_package, project: sub_project, parent: wp_main) }
-      let(:grandchild_wp) { create(:work_package, project: sub_sub_project, parent: child_wp) }
-
-      before do
-        grandchild_wp # ensure all records are created
-      end
-
-      it "includes projects from descendants" do
-        projects = component.send(:projects)
-
-        expect(projects).to include(main_project, sub_project, sub_sub_project)
-      end
-
-      it "reports multiple projects" do
-        expect(component.send(:multiple_projects?)).to be true
-      end
-
-      it "links every project name" do
-        render_inline(component)
-
-        [main_project, sub_project, sub_sub_project].each do |project|
-          expect(page).to have_link project.name, href: project_path(project)
-        end
-      end
-    end
-  end
-
-  describe "descendants the user may not delete" do
-    shared_let(:permitted_project) { create(:project, name: "Permitted Project") }
-    shared_let(:view_only_project) { create(:project, name: "View Only Project") }
-    shared_let(:invisible_project) { create(:project, name: "Invisible Project") }
-
-    let(:permitted_permissions) { %i[view_work_packages delete_work_packages] }
-    let(:permitted_user) do
-      create(:user,
-             member_with_permissions: {
-               permitted_project => permitted_permissions,
-               view_only_project => %i[view_work_packages]
-             })
-    end
-
-    shared_let(:parent_wp) { create(:work_package, project: permitted_project, subject: "Parent to delete") }
-
-    subject do
-      render_inline(described_class.new(work_packages: [parent_wp]))
-      page
-    end
-
-    before do
-      login_as(permitted_user)
-    end
-
-    def t(key, **)
-      I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
-    end
-
-    context "with a child in an invisible project" do
-      shared_let(:invisible_child) do
-        create(:work_package, project: invisible_project, parent: parent_wp, subject: "Secret child")
-      end
-
-      it "does not disclose the invisible work package or its project" do
-        expect(subject).to have_no_text "Secret child"
-        expect(subject).to have_no_text "Invisible Project"
-      end
-
-      it "asks about the selection alone, since nothing else gets deleted" do
-        expect(subject).to have_text t("description")
-        expect(subject).to have_text t("hidden_descendants_only_warning", count: 1)
-        expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
-      end
-
-      it "does not claim the deletion spans multiple projects" do
-        expect(subject).to have_no_text "span multiple projects"
-      end
-
-      it "does not claim descendants will be deleted" do
-        expect(subject).to have_no_text t("children_label")
-        expect(subject).to have_text t("confirm_deletion")
-      end
-    end
-
-    context "with a visible child the user may not delete" do
-      shared_let(:view_only_child) do
-        create(:work_package, project: view_only_project, parent: parent_wp, subject: "View only child")
-      end
-
-      it "does not offer to delete it" do
-        expect(subject).to have_no_text t("children_label")
-      end
-
-      it "warns that it is preserved and links its project" do
-        expect(subject).to have_text t("description")
-        expect(subject).to have_text t("undeletable_descendants_warning_html",
-                                       count: 1,
-                                       projects: view_only_project.name)
-        expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
-      end
-
-      it "counts only the selection" do
-        expect(subject).to have_text t("heading", count: 1)
-      end
-    end
-
-    context "with a grandchild in an invisible project" do
-      shared_let(:visible_child) do
-        create(:work_package, project: permitted_project, parent: parent_wp, subject: "Visible child")
-      end
-      shared_let(:invisible_grandchild) do
-        create(:work_package, project: invisible_project, parent: visible_child, subject: "Secret grandchild")
-      end
-
-      it "lists only the descendant it deletes" do
-        expect(subject).to have_text "Visible child"
-        expect(subject).to have_no_text "Secret grandchild"
-        expect(subject).to have_no_text "Invisible Project"
-      end
-
-      it "warns about the grandchild it cannot see" do
-        expect(subject).to have_text t("hidden_descendants_warning", count: 1)
-      end
-    end
-
-    context "with one child hidden and another visible but undeletable" do
-      shared_let(:view_only_child) do
-        create(:work_package, project: view_only_project, parent: parent_wp, subject: "View only child")
-      end
-      shared_let(:invisible_child) do
-        create(:work_package, project: invisible_project, parent: parent_wp, subject: "Secret child")
-      end
-
-      it "uses the permission wording and folds the hidden one into the count" do
-        expect(subject).to have_text t("undeletable_descendants_warning", count: 2)
-        expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
-      end
-
-      it "names no project, since the count covers one it cannot show" do
-        expect(subject).to have_no_text "Invisible Project"
-        expect(subject).to have_no_link view_only_project.name
-      end
-    end
-  end
-
-  describe "#total_count" do
-    context "when a selected work package is itself a descendant of another selection" do
-      let(:child_wp) { create(:work_package, project: main_project, parent: wp_main) }
-      let(:grandchild_wp) { create(:work_package, project: main_project, parent: child_wp) }
-      let(:work_packages) { [wp_main, child_wp] }
-
-      before do
-        grandchild_wp
-      end
-
-      it "counts every affected work package once" do
-        expect(component.send(:total_count)).to eq(3)
-      end
-    end
-
-    context "with a descendant the user may not delete" do
-      let(:restricted_project) { create(:project, name: "Restricted Project") }
-      let(:restricted_user) do
-        create(:user,
-               member_with_permissions: {
-                 main_project => %i[view_work_packages delete_work_packages]
-               })
-      end
-      let(:selected_wp) { create(:work_package, project: main_project) }
-      let(:deleted_child) { create(:work_package, project: main_project, parent: selected_wp) }
-      let(:unlinked_child) { create(:work_package, project: restricted_project, parent: selected_wp) }
-
-      let(:work_packages) { [selected_wp] }
-
-      before do
-        deleted_child
-        unlinked_child
-        login_as(restricted_user)
-      end
-
-      it "counts only the selection and the descendants it deletes" do
-        expect(component.send(:total_count)).to eq(2)
-      end
-
-      it "reports the one that is only unlinked separately" do
-        expect(component.send(:undeletable_count)).to eq(1)
-      end
-
-      it "puts the listed count in the heading" do
-        render_inline(component)
-
-        expect(page).to have_text I18n.t("work_packages.bulk_delete_dialog.heading", count: 2)
-      end
-    end
   end
 
   describe "#description" do
@@ -262,14 +67,61 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
     context "when work packages have descendants" do
       let(:child_wp) { create(:work_package, project: main_project, parent: wp_main) }
 
-      before do
-        child_wp # ensure record is created
+      before { child_wp }
+
+      it "asks whether to also delete the descendants" do
+        expect(component.send(:description)).to eq(
+          I18n.t("work_packages.bulk_delete_dialog.descendants_choice.question")
+        )
+      end
+    end
+  end
+
+  describe "the descendants choice" do
+    subject do
+      render_inline(component)
+      page
+    end
+
+    def t(key, **)
+      I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
+    end
+
+    context "with descendants" do
+      let(:child_wp) { create(:work_package, project: main_project, parent: wp_main, subject: "Child wp") }
+
+      before { child_wp }
+
+      it "asks whether to delete the descendants too" do
+        expect(subject).to have_text t("descendants_choice.question")
       end
 
-      it "returns the description mentioning children" do
-        expect(component.send(:description)).to eq(
-          I18n.t("work_packages.bulk_delete_dialog.description_with_descendants")
-        )
+      it "offers both choices, defaulting to deleting the descendants" do
+        expect(subject).to have_text t("descendants_choice.self_only_label")
+        expect(subject).to have_checked_field(t("descendants_choice.with_descendants_label"), visible: :all)
+      end
+
+      it "does not preview the descendants or ask to confirm them yet" do
+        expect(subject).to have_no_text "Child wp"
+        expect(subject).to have_no_text t("confirm_deletion")
+      end
+    end
+
+    context "when the selected work packages span multiple projects" do
+      let(:descendant_project) { create(:project, name: "Descendant Project") }
+      let(:wp_other) { create(:work_package, project: sub_project) }
+      let(:work_packages) { [wp_main, wp_other] }
+
+      before do
+        create(:work_package, parent: wp_main, project: descendant_project, subject: "Deep child")
+      end
+
+      it "warns that the roots span multiple projects, linking each root's project but not the descendants'" do
+        expect(subject).to have_text t("cross_project_warning_html",
+                                       projects: "#{main_project.name}, #{sub_project.name}")
+        expect(subject).to have_link main_project.name, href: project_path(main_project)
+        expect(subject).to have_link sub_project.name, href: project_path(sub_project)
+        expect(subject).to have_no_link "Descendant Project"
       end
     end
   end

--- a/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
 
   subject(:component) { described_class.new(work_packages:) }
 
+  def t(key, **)
+    I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
+  end
+
   before do
     User.current = user
   end
@@ -83,10 +87,6 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
       page
     end
 
-    def t(key, **)
-      I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
-    end
-
     context "with descendants" do
       let(:child_wp) { create(:work_package, project: main_project, parent: wp_main, subject: "Child wp") }
 
@@ -123,6 +123,29 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
         expect(subject).to have_link sub_project.name, href: project_path(sub_project)
         expect(subject).to have_no_link "Descendant Project"
       end
+    end
+  end
+
+  describe "the no-descendants dialog" do
+    let(:wp_one) { create(:work_package, project: main_project, subject: "First to delete") }
+    let(:wp_two) { create(:work_package, project: sub_project, subject: "Second to delete") }
+    let(:work_packages) { [wp_one, wp_two] }
+
+    subject do
+      render_inline(component)
+      page
+    end
+
+    it "lists each selected work package and asks to confirm the deletion" do
+      expect(subject).to have_text "First to delete"
+      expect(subject).to have_text "Second to delete"
+      expect(subject).to have_text t("confirm_deletion")
+    end
+
+    it "warns when the selection spans multiple projects" do
+      expect(subject).to have_text t("cross_project_warning_html",
+                                     projects: "#{main_project.name}, #{sub_project.name}")
+      expect(subject).to have_link main_project.name, href: project_path(main_project)
     end
   end
 end

--- a/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/bulk_delete_dialog_component_spec.rb
@@ -41,11 +41,9 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
   let(:wp_main) { create(:work_package, project: main_project) }
   let(:work_packages) { [wp_main] }
 
-  subject(:component) { described_class.new(work_packages:) }
+  let(:translation_scope) { "work_packages.bulk_delete_dialog" }
 
-  def t(key, **)
-    I18n.t("work_packages.bulk_delete_dialog.#{key}", **)
-  end
+  subject(:component) { described_class.new(work_packages:) }
 
   before do
     User.current = user
@@ -63,7 +61,7 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
     context "when work packages have no descendants" do
       it "returns the description without children mention" do
         expect(component.send(:description)).to eq(
-          I18n.t("work_packages.bulk_delete_dialog.description")
+          I18n.t("description", scope: translation_scope)
         )
       end
     end
@@ -75,7 +73,7 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
 
       it "asks whether to also delete the descendants" do
         expect(component.send(:description)).to eq(
-          I18n.t("work_packages.bulk_delete_dialog.descendants_choice.question")
+          I18n.t("descendants_choice.question", scope: translation_scope)
         )
       end
     end
@@ -93,17 +91,19 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
       before { child_wp }
 
       it "asks whether to delete the descendants too" do
-        expect(subject).to have_text t("descendants_choice.question")
+        expect(subject).to have_text I18n.t("descendants_choice.question", scope: translation_scope)
       end
 
       it "offers both choices, defaulting to deleting the descendants" do
-        expect(subject).to have_text t("descendants_choice.self_only_label")
-        expect(subject).to have_checked_field(t("descendants_choice.with_descendants_label"), visible: :all)
+        expect(subject).to have_text I18n.t("descendants_choice.self_only_label", scope: translation_scope)
+        expect(subject).to have_checked_field(
+          I18n.t("descendants_choice.with_descendants_label", scope: translation_scope), visible: :all
+        )
       end
 
       it "does not preview the descendants or ask to confirm them yet" do
         expect(subject).to have_no_text "Child wp"
-        expect(subject).to have_no_text t("confirm_deletion")
+        expect(subject).to have_no_text I18n.t("confirm_deletion", scope: translation_scope)
       end
     end
 
@@ -117,8 +117,8 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
       end
 
       it "warns that the roots span multiple projects, linking each root's project but not the descendants'" do
-        expect(subject).to have_text t("cross_project_warning_html",
-                                       projects: "#{main_project.name}, #{sub_project.name}")
+        expect(subject).to have_text I18n.t("cross_project_warning_html", scope: translation_scope,
+                                                                          projects: "#{main_project.name}, #{sub_project.name}")
         expect(subject).to have_link main_project.name, href: project_path(main_project)
         expect(subject).to have_link sub_project.name, href: project_path(sub_project)
         expect(subject).to have_no_link "Descendant Project"
@@ -139,12 +139,12 @@ RSpec.describe WorkPackages::BulkDeleteDialogComponent, type: :component do
     it "lists each selected work package and asks to confirm the deletion" do
       expect(subject).to have_text "First to delete"
       expect(subject).to have_text "Second to delete"
-      expect(subject).to have_text t("confirm_deletion")
+      expect(subject).to have_text I18n.t("confirm_deletion", scope: translation_scope)
     end
 
     it "warns when the selection spans multiple projects" do
-      expect(subject).to have_text t("cross_project_warning_html",
-                                     projects: "#{main_project.name}, #{sub_project.name}")
+      expect(subject).to have_text I18n.t("cross_project_warning_html", scope: translation_scope,
+                                                                        projects: "#{main_project.name}, #{sub_project.name}")
       expect(subject).to have_link main_project.name, href: project_path(main_project)
     end
   end

--- a/spec/components/work_packages/delete_descendants_dialog_component_spec.rb
+++ b/spec/components/work_packages/delete_descendants_dialog_component_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::DeleteDescendantsDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:home_project) { create(:project, name: "Home project") }
+  shared_let(:deletable_project) { create(:project, name: "Deletable project") }
+  shared_let(:view_only_project) { create(:project, name: "View only project") }
+  shared_let(:invisible_project) { create(:project, name: "Invisible project") }
+
+  let(:home_permissions) { %i[view_work_packages delete_work_packages] }
+  let(:user) do
+    create(:user,
+           member_with_permissions: {
+             home_project => home_permissions,
+             deletable_project => %i[view_work_packages delete_work_packages],
+             view_only_project => %i[view_work_packages]
+           })
+  end
+
+  shared_let(:work_package) { create(:work_package, project: home_project, subject: "Parent to delete") }
+
+  subject do
+    render_inline(described_class.new(work_package:))
+    page
+  end
+
+  before do
+    login_as(user)
+  end
+
+  def t(key, **)
+    I18n.t("work_packages.delete_dialog.#{key}", **)
+  end
+
+  def deletable_child
+    create(:work_package, project: deletable_project, parent: work_package, subject: "Deletable child")
+  end
+
+  def view_only_child
+    create(:work_package, project: view_only_project, parent: work_package, subject: "View only child")
+  end
+
+  def invisible_child
+    create(:work_package, project: invisible_project, parent: work_package, subject: "Secret child")
+  end
+
+  context "with every descendant deletable" do
+    before { deletable_child }
+
+    it "asks about the listed descendants and lists them" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text I18n.t("work_packages.bulk_delete_dialog.children_label")
+      expect(subject).to have_text "Deletable child"
+      expect(subject).to have_text t("confirm_descendants_deletion")
+    end
+
+    it "names the projects it deletes from and links each one" do
+      expect(subject).to have_text t("cross_project_warning_html",
+                                     projects: "#{home_project.name}, #{deletable_project.name}")
+      expect(subject).to have_link home_project.name, href: project_path(home_project)
+      expect(subject).to have_link deletable_project.name, href: project_path(deletable_project)
+    end
+
+    it "warns about nothing surviving" do
+      expect(subject).to have_no_text "will not be deleted"
+      expect(subject).to have_no_text "cannot be deleted"
+    end
+  end
+
+  context "with a deletable descendant and one the user cannot see" do
+    before do
+      deletable_child
+      invisible_child
+    end
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+    end
+
+    it "leads with what gets deleted, then the hidden one" do
+      expect(subject).to have_text t("hidden_descendants_warning", count: 1)
+    end
+
+    it "discloses neither the hidden work package nor its project" do
+      expect(subject).to have_no_text "Secret child"
+      expect(subject).to have_no_text "Invisible project"
+    end
+  end
+
+  context "with nothing deletable and the only descendant hidden" do
+    before { invisible_child }
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text t("confirm_deletion")
+    end
+
+    it "drops the clause about what gets deleted" do
+      expect(subject).to have_text t("hidden_descendants_only_warning", count: 1)
+      expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
+    end
+  end
+
+  context "with a deletable descendant and one the user cannot delete" do
+    before do
+      deletable_child
+      view_only_child
+    end
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+    end
+
+    it "counts only the preserved one" do
+      expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                     count: 1,
+                                     projects: view_only_project.name)
+    end
+
+    it "links the project it cannot delete in" do
+      expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
+    end
+
+    it "lists only the descendant it deletes" do
+      expect(subject).to have_text "Deletable child"
+      expect(subject).to have_no_text "View only child"
+    end
+  end
+
+  context "with one visible descendant the user cannot delete" do
+    before { view_only_child }
+
+    it "asks about the work package alone" do
+      expect(subject).to have_text t("description", name: work_package.to_s)
+      expect(subject).to have_text t("confirm_deletion")
+    end
+
+    it "drops the clause about what gets deleted and still links the project" do
+      expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                     count: 1,
+                                     projects: view_only_project.name)
+      expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
+    end
+
+    it "does not offer to delete it" do
+      expect(subject).to have_no_text I18n.t("work_packages.bulk_delete_dialog.children_label")
+    end
+  end
+
+  context "with one preserved descendant visible and another hidden" do
+    before do
+      deletable_child
+      view_only_child
+      invisible_child
+    end
+
+    it "uses the permission wording and folds the hidden one into the count" do
+      expect(subject).to have_text t("undeletable_descendants_warning", count: 2)
+    end
+
+    it "names no project, since the count covers one it cannot show" do
+      expect(subject).to have_no_text "Invisible project"
+      expect(subject).to have_no_link view_only_project.name
+    end
+  end
+
+  context "with a deletable work package below an undeletable one" do
+    before do
+      child = view_only_child
+      create(:work_package, project: deletable_project, parent: child, subject: "Deletable grandchild")
+    end
+
+    it "counts only the survivor and never mentions its subtree" do
+      expect(subject).to have_text t("undeletable_descendants_warning_html",
+                                     count: 1,
+                                     projects: view_only_project.name)
+      expect(subject).to have_no_text "Deletable grandchild"
+    end
+  end
+end

--- a/spec/components/work_packages/delete_dialog_component_spec.rb
+++ b/spec/components/work_packages/delete_dialog_component_spec.rb
@@ -35,16 +35,13 @@ RSpec.describe WorkPackages::DeleteDialogComponent, type: :component do
 
   shared_let(:home_project) { create(:project, name: "Home project") }
   shared_let(:deletable_project) { create(:project, name: "Deletable project") }
-  shared_let(:view_only_project) { create(:project, name: "View only project") }
-  shared_let(:invisible_project) { create(:project, name: "Invisible project") }
 
   let(:home_permissions) { %i[view_work_packages delete_work_packages] }
   let(:user) do
     create(:user,
            member_with_permissions: {
              home_project => home_permissions,
-             deletable_project => %i[view_work_packages delete_work_packages],
-             view_only_project => %i[view_work_packages]
+             deletable_project => %i[view_work_packages delete_work_packages]
            })
   end
 
@@ -67,14 +64,6 @@ RSpec.describe WorkPackages::DeleteDialogComponent, type: :component do
     create(:work_package, project: deletable_project, parent: work_package, subject: "Deletable child")
   end
 
-  def view_only_child
-    create(:work_package, project: view_only_project, parent: work_package, subject: "View only child")
-  end
-
-  def invisible_child
-    create(:work_package, project: invisible_project, parent: work_package, subject: "Secret child")
-  end
-
   context "with no descendants" do
     it "asks about the work package alone and mentions no descendants" do
       expect(subject).to have_text t("description", name: work_package.to_s)
@@ -83,137 +72,22 @@ RSpec.describe WorkPackages::DeleteDialogComponent, type: :component do
     end
   end
 
-  context "with every descendant deletable" do
+  context "with descendants" do
     before { deletable_child }
 
-    it "asks about the listed descendants and lists them" do
-      expect(subject).to have_text t("description", name: work_package.to_s)
-      expect(subject).to have_text I18n.t("work_packages.bulk_delete_dialog.children_label")
-      expect(subject).to have_text "Deletable child"
-      expect(subject).to have_text t("confirm_descendants_deletion")
+    it "asks whether to delete the descendants too" do
+      expect(subject).to have_text t("descendants_choice.question")
     end
 
-    it "names the projects it deletes from and links each one" do
-      expect(subject).to have_text t("cross_project_warning_html",
-                                     projects: "#{home_project.name}, #{deletable_project.name}")
-      expect(subject).to have_link home_project.name, href: project_path(home_project)
-      expect(subject).to have_link deletable_project.name, href: project_path(deletable_project)
+    it "offers both choices, defaulting to deleting the descendants" do
+      expect(subject).to have_text t("descendants_choice.self_only_label")
+      expect(subject).to have_checked_field(t("descendants_choice.with_descendants_label"), visible: :all)
     end
 
-    it "warns about nothing surviving" do
-      expect(subject).to have_no_text "will not be deleted"
-      expect(subject).to have_no_text "cannot be deleted"
-    end
-  end
-
-  context "with a deletable descendant and one the user cannot see" do
-    before do
-      deletable_child
-      invisible_child
-    end
-
-    it "asks about the work package alone" do
-      expect(subject).to have_text t("description", name: work_package.to_s)
-    end
-
-    it "leads with what gets deleted, then the hidden one" do
-      expect(subject).to have_text t("hidden_descendants_warning", count: 1)
-    end
-
-    it "discloses neither the hidden work package nor its project" do
-      expect(subject).to have_no_text "Secret child"
-      expect(subject).to have_no_text "Invisible project"
-    end
-  end
-
-  context "with nothing deletable and the only descendant hidden" do
-    before { invisible_child }
-
-    it "asks about the work package alone" do
-      expect(subject).to have_text t("description", name: work_package.to_s)
-      expect(subject).to have_text t("confirm_deletion")
-    end
-
-    it "drops the clause about what gets deleted" do
-      expect(subject).to have_text t("hidden_descendants_only_warning", count: 1)
-      expect(subject).to have_no_text t("hidden_descendants_warning", count: 1)
-    end
-  end
-
-  context "with a deletable descendant and one the user cannot delete" do
-    before do
-      deletable_child
-      view_only_child
-    end
-
-    it "asks about the work package alone" do
-      expect(subject).to have_text t("description", name: work_package.to_s)
-    end
-
-    it "counts only the preserved one" do
-      expect(subject).to have_text t("undeletable_descendants_warning_html",
-                                     count: 1,
-                                     projects: view_only_project.name)
-    end
-
-    it "links the project it cannot delete in" do
-      expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
-    end
-
-    it "lists only the descendant it deletes" do
-      expect(subject).to have_text "Deletable child"
-      expect(subject).to have_no_text "View only child"
-    end
-  end
-
-  context "with one visible descendant the user cannot delete" do
-    before { view_only_child }
-
-    it "asks about the work package alone" do
-      expect(subject).to have_text t("description", name: work_package.to_s)
-      expect(subject).to have_text t("confirm_deletion")
-    end
-
-    it "drops the clause about what gets deleted and still links the project" do
-      expect(subject).to have_text t("undeletable_descendants_warning_html",
-                                     count: 1,
-                                     projects: view_only_project.name)
-      expect(subject).to have_link view_only_project.name, href: project_path(view_only_project)
-    end
-
-    it "does not offer to delete it" do
-      expect(subject).to have_no_text I18n.t("work_packages.bulk_delete_dialog.children_label")
-    end
-  end
-
-  context "with one preserved descendant visible and another hidden" do
-    before do
-      deletable_child
-      view_only_child
-      invisible_child
-    end
-
-    it "uses the permission wording and folds the hidden one into the count" do
-      expect(subject).to have_text t("undeletable_descendants_warning", count: 2)
-    end
-
-    it "names no project, since the count covers one it cannot show" do
-      expect(subject).to have_no_text "Invisible project"
-      expect(subject).to have_no_link view_only_project.name
-    end
-  end
-
-  context "with a deletable work package below an undeletable one" do
-    before do
-      child = view_only_child
-      create(:work_package, project: deletable_project, parent: child, subject: "Deletable grandchild")
-    end
-
-    it "counts only the survivor and never mentions its subtree" do
-      expect(subject).to have_text t("undeletable_descendants_warning_html",
-                                     count: 1,
-                                     projects: view_only_project.name)
-      expect(subject).to have_no_text "Deletable grandchild"
+    it "does not preview the descendants or ask to confirm them yet" do
+      expect(subject).to have_no_text "Deletable child"
+      expect(subject).to have_no_text t("confirm_descendants_deletion")
+      expect(subject).to have_no_text t("confirm_deletion")
     end
   end
 end

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -820,7 +820,9 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
         send_destroy_request
         expect(WorkPackage.find_by(id: work_package1.id)).to be_present
         expect(WorkPackage.find_by(id: work_package2.id)).to be_present
-        expect(response).to redirect_to(reassign_work_packages_bulk_path(ids: [work_package1.id, work_package2.id]))
+        expect(response).to redirect_to(
+          reassign_work_packages_bulk_path(ids: [work_package1.id, work_package2.id], delete_descendants: true)
+        )
       end
     end
 

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -878,4 +878,100 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
       end
     end
   end
+
+  describe "the descendants deletion choice" do
+    let(:parent_wp) { create(:work_package, author: user, type:, status:, project: project1) }
+    let!(:child_wp) do
+      create(:work_package, author: user, type:, status:, project: project1, parent: parent_wp)
+    end
+
+    describe "#delete_dialog" do
+      it "offers two choices when the selection has descendants" do
+        as_logged_in_user(user) do
+          get :delete_dialog, params: { ids: [parent_wp.id] }, format: :turbo_stream
+        end
+
+        expect(response.body).to include("delete_descendants")
+        expect(response.body).to include(I18n.t("work_packages.delete_dialog.descendants_choice.self_only_label"))
+      end
+    end
+
+    describe "#confirm_delete" do
+      it "opens the confirmation dialog without deleting anything when cascading" do
+        as_logged_in_user(user) do
+          post :confirm_delete, params: { ids: [parent_wp.id], delete_descendants: true }, format: :turbo_stream
+        end
+
+        expect(response).to be_successful
+        expect(response.body).to include(WorkPackages::DeleteDescendantsDialogComponent::DIALOG_ID)
+        expect(WorkPackage).to exist(parent_wp.id)
+        expect(child_wp.reload.parent_id).to eq(parent_wp.id)
+      end
+
+      it "deletes only the roots and detaches the descendants when keeping them" do
+        as_logged_in_user(user) do
+          post :confirm_delete, params: { ids: [parent_wp.id], delete_descendants: false }
+        end
+
+        expect(WorkPackage).not_to exist(parent_wp.id)
+        expect(WorkPackage).to exist(child_wp.id)
+        expect(child_wp.reload.parent_id).to be_nil
+      end
+
+      context "when the user may see but not delete the work packages" do
+        shared_let(:view_only_project) { create(:project, types: [type]) }
+        shared_let(:view_only_role) { create(:project_role, permissions: %i[view_work_packages]) }
+        shared_let(:view_only_member) do
+          create(:member, project: view_only_project, principal: user, roles: [view_only_role])
+        end
+        shared_let(:undeletable_wp) { create(:work_package, type:, status:, project: view_only_project) }
+
+        it "denies access" do
+          post :confirm_delete, params: { ids: [undeletable_wp.id], delete_descendants: true }, format: :turbo_stream
+
+          expect(response).to have_http_status(:forbidden)
+          expect(WorkPackage).to exist(undeletable_wp.id)
+        end
+      end
+    end
+
+    describe "#destroy with the keep-descendants choice" do
+      it "detaches a deletable descendant instead of deleting it" do
+        as_logged_in_user(user) do
+          delete :destroy, params: { ids: [parent_wp.id], delete_descendants: false }
+        end
+
+        expect(WorkPackage).not_to exist(parent_wp.id)
+        expect(WorkPackage).to exist(child_wp.id)
+        expect(child_wp.reload.parent_id).to be_nil
+      end
+
+      it "carries the choice through the reassign redirect when cleanup is required" do
+        allow(WorkPackage)
+          .to receive(:cleanup_associated_before_destructing_if_required)
+          .and_return false
+
+        as_logged_in_user(user) do
+          delete :destroy, params: { ids: [parent_wp.id], to_do: "blubs", delete_descendants: false }
+        end
+
+        expect(response).to redirect_to(
+          reassign_work_packages_bulk_path(ids: [parent_wp.id], delete_descendants: false)
+        )
+      end
+    end
+
+    describe "#reassign" do
+      render_views
+
+      it "renders the form and carries the descendants choice through a hidden field" do
+        as_logged_in_user(user) do
+          get :reassign, params: { ids: [parent_wp.id], delete_descendants: "false" }
+        end
+
+        expect(response).to be_successful
+        expect(response.body).to include('name="delete_descendants"')
+      end
+    end
+  end
 end

--- a/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
@@ -49,7 +49,7 @@ RSpec.shared_examples_for "provides a single WP context menu" do
     # Open Delete
     open_context_menu.call
     menu.choose("Delete")
-    destroy_modal.expect_listed(work_package)
+    destroy_modal.expect_open
     destroy_modal.cancel_deletion
 
     # Open create new child

--- a/spec/features/work_packages/table/delete_work_packages_with_descendants_spec.rb
+++ b/spec/features/work_packages/table/delete_work_packages_with_descendants_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Delete work packages that have descendants", :js do
+  let(:user) { create(:admin) }
+  let(:context_menu) { Components::WorkPackages::ContextMenu.new }
+
+  before do
+    login_as(user)
+  end
+
+  describe "deleting a single work package" do
+    let(:project) { create(:project) }
+    let!(:parent) { create(:work_package, project:, subject: "Parent wp") }
+    let!(:child) { create(:work_package, project:, parent:, subject: "Child wp") }
+
+    let(:wp_table) { Pages::WorkPackagesTable.new(project.identifier) }
+    let(:destroy_modal) { Components::WorkPackages::DestroyModal.new }
+
+    before do
+      wp_table.visit!
+      wp_table.expect_work_package_listed(parent, child)
+      context_menu.open_for(parent)
+      context_menu.choose("Delete")
+      destroy_modal.expect_descendants_choice
+    end
+
+    it "cascades to the descendants when the user chooses to" do
+      destroy_modal.confirm_descendants_deletion
+
+      loading_indicator_saveguard
+      wp_table.expect_no_work_package_listed
+      expect(WorkPackage).not_to exist(parent.id)
+      expect(WorkPackage).not_to exist(child.id)
+    end
+
+    it "detaches the descendants when the user keeps them" do
+      destroy_modal.confirm_roots_only_deletion
+
+      loading_indicator_saveguard
+      wp_table.ensure_work_package_not_listed!(parent)
+      wp_table.expect_work_package_listed(child)
+      expect(WorkPackage).not_to exist(parent.id)
+      expect(child.reload.parent_id).to be_nil
+    end
+  end
+
+  describe "bulk deleting across projects" do
+    let!(:project_a) { create(:project, name: "Project Alpha") }
+    let!(:project_b) { create(:project, name: "Project Beta") }
+    let!(:parent_a) { create(:work_package, project: project_a, subject: "Parent Alpha") }
+    let!(:child_a) { create(:work_package, project: project_a, parent: parent_a, subject: "Child Alpha") }
+    let!(:parent_b) { create(:work_package, project: project_b, subject: "Parent Beta") }
+    let!(:child_b) { create(:work_package, project: project_b, parent: parent_b, subject: "Child Beta") }
+
+    let(:query) do
+      create(:query, project: nil, user:, show_hierarchies: false).tap do |q|
+        q.add_filter("id", "=", [parent_a.id.to_s, parent_b.id.to_s])
+        q.save(validate: false)
+      end
+    end
+
+    let(:wp_table) { Pages::WorkPackagesTable.new }
+    let(:destroy_modal) { Components::WorkPackages::DestroyModal.new(bulk_mode: true) }
+
+    it "warns that it spans projects and cascades the whole hierarchy" do
+      wp_table.visit_query(query)
+      wp_table.expect_work_package_listed(parent_a, parent_b)
+
+      find("body").send_keys [:control, "a"]
+      context_menu.open_for(parent_a)
+      context_menu.choose("Bulk delete")
+
+      destroy_modal.expect_descendants_choice
+      destroy_modal.expect_cross_project_warning(project_a, project_b)
+      destroy_modal.confirm_descendants_deletion
+
+      loading_indicator_saveguard
+      wp_table.expect_no_work_package_listed
+      expect(WorkPackage.count).to eq(0)
+    end
+  end
+end

--- a/spec/services/work_packages/shared/deletion_planning_spec.rb
+++ b/spec/services/work_packages/shared/deletion_planning_spec.rb
@@ -178,4 +178,37 @@ RSpec.describe WorkPackages::Shared::DeletionPlanning do
       expect(plan.unlinked_descendants).to eq([child])
     end
   end
+
+  describe "when the includer opts out of deleting descendants" do
+    let(:host_class) do
+      Class.new do
+        include WorkPackages::Shared::DeletionPlanning
+
+        attr_reader :deletion_roots, :deletion_user
+
+        def initialize(roots, user)
+          @deletion_roots = Array(roots)
+          @deletion_user = user
+        end
+
+        def include_descendants? = false
+      end
+    end
+
+    let!(:root) { create(:work_package, project: home_project) }
+    let!(:child) { create(:work_package, project: home_project, parent: root) }
+    let!(:grandchild) { create(:work_package, project: home_project, parent: child) }
+    let(:roots) { root }
+
+    it "detaches every descendant rather than deleting any" do
+      expect(plan.deleted_descendants).to be_empty
+      expect(plan.unlinked_descendants).to eq([child])
+    end
+
+    it "stops at the direct children, leaving the deeper subtree attached to the survivor" do
+      expect(plan.deleted_descendants).not_to include(grandchild)
+      expect(plan.unlinked_descendants).not_to include(grandchild)
+      expect(grandchild.reload.parent).to eq(child)
+    end
+  end
 end

--- a/spec/services/work_packages/shared/deletion_planning_spec.rb
+++ b/spec/services/work_packages/shared/deletion_planning_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe WorkPackages::Shared::DeletionPlanning do
         @deletion_roots = Array(roots)
         @deletion_user = user
       end
+
+      def include_descendants? = true
     end
   end
 
@@ -162,6 +164,7 @@ RSpec.describe WorkPackages::Shared::DeletionPlanning do
           @deletion_user = user
         end
 
+        def include_descendants? = true
         def deletable?(_descendant) = false
       end
     end

--- a/spec/support/components/work_packages/destroy_modal.rb
+++ b/spec/support/components/work_packages/destroy_modal.rb
@@ -35,13 +35,12 @@ module Components
       include Capybara::RSpecMatchers
       include RSpec::Matchers
 
-      def initialize(bulk_mode: false)
+      def initialize(bulk_mode: false, dialog_id: "wp-delete-dialog")
         @bulk_mode = bulk_mode
+        @dialog_id = dialog_id
       end
 
-      def dialog_id
-        "wp-delete-dialog"
-      end
+      attr_reader :dialog_id
 
       def dialog_css_selector
         "dialog##{dialog_id}"
@@ -49,6 +48,10 @@ module Components
 
       def within_dialog(&)
         within(dialog_css_selector, &)
+      end
+
+      def expect_open
+        expect(page).to have_css(dialog_css_selector)
       end
 
       def expect_listed(*work_packages)
@@ -72,6 +75,44 @@ module Components
         within_dialog do
           click_button "Cancel"
         end
+      end
+
+      def expect_descendants_choice
+        within_dialog do
+          expect(page).to have_text "Delete all descendants too?"
+        end
+      end
+
+      def expect_cross_project_warning(*projects)
+        within_dialog do
+          projects.each { |project| expect(page).to have_link project.name }
+        end
+      end
+
+      # "Delete this work package and descendants" is preselected, so submitting opens the danger
+      # dialog that previews and confirms the cascade.
+      def confirm_descendants_deletion
+        within_dialog { click_button "Delete" }
+        descendants_dialog.confirm_deletion
+      end
+
+      def confirm_roots_only_deletion
+        within_dialog do
+          choose choice_label("self_only_label"), allow_label_click: true
+          expect(page).to have_checked_field(choice_label("self_only_label"), visible: :all)
+          click_button "Delete"
+        end
+      end
+
+      private
+
+      def descendants_dialog
+        self.class.new(bulk_mode: @bulk_mode, dialog_id: "wp-delete-descendants-dialog")
+      end
+
+      def choice_label(key)
+        scope = @bulk_mode ? "bulk_delete_dialog" : "delete_dialog"
+        I18n.t("work_packages.#{scope}.descendants_choice.#{key}")
       end
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-19824

# What?

- Split the single dialog deletion flow into a two dialog flow:
   - One that directly deletes a WP when descendants aren't to be deleted
   - One that shows the entire tree when descendants are being deleted
- This is done by passing a new param `include_descendants` explicitly to `deletion_planning`. The dialogs always have this as true to be able to show the entire (potentially) affected tree, but the choice dialog (only delete this vs. delete descendants) submits this param to the controller/deletion service as a user decision
- Lots of spec changes from splitting the process up into two parts

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
