### PR TITLE
[COMMS-977] Adjust Baseline to support observed-in versions

### DIFF
--- a/app/models/journable/with_historic_attributes.rb
+++ b/app/models/journable/with_historic_attributes.rb
@@ -263,6 +263,7 @@ class Journable::WithHistoricAttributes < SimpleDelegator
     )
 
     merge_target_versions_changes!(changes, historic_journable)
+    merge_observed_in_versions_changes!(changes, historic_journable)
 
     changes
   end
@@ -275,8 +276,8 @@ class Journable::WithHistoricAttributes < SimpleDelegator
   end
 
   def target_versions_changes(historic_journable)
-    old_ids = sorted_target_version_ids(historic_journable)
-    new_ids = sorted_target_version_ids(__getobj__)
+    old_ids = sorted_version_ids(historic_journable, :target_versions)
+    new_ids = sorted_version_ids(__getobj__, :target_versions)
 
     {}.tap do |changes|
       changes["version_id"] = [old_ids.first, new_ids.first] if old_ids.first != new_ids.first
@@ -284,8 +285,23 @@ class Journable::WithHistoricAttributes < SimpleDelegator
     end
   end
 
-  def sorted_target_version_ids(work_package)
-    work_package.target_versions.map(&:id).sort
+  def merge_observed_in_versions_changes!(changes, historic_journable)
+    return unless __getobj__.respond_to?(:observed_in_versions)
+
+    changes.merge!(observed_in_versions_changes(historic_journable))
+  end
+
+  def observed_in_versions_changes(historic_journable)
+    old_ids = sorted_version_ids(historic_journable, :observed_in_versions)
+    new_ids = sorted_version_ids(__getobj__, :observed_in_versions)
+
+    {}.tap do |changes|
+      changes["observed_in_versions"] = [old_ids, new_ids].map { joined_version_ids(it) } if old_ids != new_ids
+    end
+  end
+
+  def sorted_version_ids(work_package, association)
+    work_package.public_send(association).map(&:id).sort
   end
 
   def joined_version_ids(ids)

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -67,7 +67,8 @@ class Journable::WithHistoricAttributes
       end
 
       load_custom_value_associations(journalized, journal_ids)
-      load_target_versions_associations(journalized, journal_ids)
+      load_versions_associations(journalized, journal_ids, kind: "target", association: :target_versions)
+      load_versions_associations(journalized, journal_ids, kind: "observed_in", association: :observed_in_versions)
 
       journalized
     end
@@ -83,14 +84,14 @@ class Journable::WithHistoricAttributes
       end
     end
 
-    def load_target_versions_associations(journalized, journal_ids)
-      return unless journalized_class.method_defined?(:target_versions)
+    def load_versions_associations(journalized, journal_ids, kind:, association:)
+      return unless journalized_class.method_defined?(association)
 
-      version_journals_by_journal_id = load_version_journals_by_journal_id(journal_ids)
+      version_journals_by_journal_id = load_version_journals_by_journal_id(journal_ids, kind:)
 
       journalized.each do |work_package|
         version_journals = Array(version_journals_by_journal_id[work_package.journal_id])
-        set_target_versions_association_from_journal!(work_package:, version_journals:)
+        set_versions_association_from_journal!(work_package:, version_journals:, association:)
       end
     end
 
@@ -136,9 +137,9 @@ class Journable::WithHistoricAttributes
         .group_by(&:journal_id)
     end
 
-    def load_version_journals_by_journal_id(journal_ids)
+    def load_version_journals_by_journal_id(journal_ids, kind:)
       Journal::WorkPackageVersionJournal
-        .where(journal_id: journal_ids, kind: "target")
+        .where(journal_id: journal_ids, kind:)
         .includes(:version)
         .group_by(&:journal_id)
     end
@@ -155,11 +156,11 @@ class Journable::WithHistoricAttributes
       work_package.association(:custom_values).target = historic_custom_values
     end
 
-    def set_target_versions_association_from_journal!(work_package:, version_journals:)
+    def set_versions_association_from_journal!(work_package:, version_journals:, association:)
       historic_versions = version_journals.filter_map(&:version).sort_by(&:id)
 
-      work_package.association(:target_versions).loaded!
-      work_package.association(:target_versions).target = historic_versions
+      work_package.association(association).loaded!
+      work_package.association(association).target = historic_versions
     end
 
     attr_accessor :journables

--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -52,6 +52,7 @@ module API
           type
           version
           target_versions
+          observed_in_versions
           parent
         ].freeze
 
@@ -102,7 +103,7 @@ module API
         # contains the lower camel-cased names.
         def rendered_properties_for_links
           @rendered_properties_for_links ||= rendered_properties.map do |property|
-            if property.starts_with?("custom_field_") || property == "target_versions"
+            if property.starts_with?("custom_field_") || %w[target_versions observed_in_versions].include?(property)
               API::Utilities::PropertyNameConverter.from_ar_name(property)
             else
               property

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
   let(:priority) { build_stubbed(:priority) }
   let(:version) { build_stubbed(:version) }
   let(:target_versions) { [version] }
+  let(:observed_in_versions) { [] }
   let(:parent) do
     build_stubbed(:work_package).tap do |wp|
       allow(wp)
@@ -99,7 +100,8 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       allow(wp)
         .to receive_messages(available_custom_fields:,
                              custom_field_values: [custom_value],
-                             effective_target_versions: target_versions)
+                             effective_target_versions: target_versions,
+                             effective_observed_in_versions: observed_in_versions)
     end
   end
   let(:timestamp) { Timestamp.new(1.day.ago) }
@@ -304,6 +306,41 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
             {
               "href" => api_v3_paths.version(version_b.id),
               "title" => version_b.name
+            }
+          ],
+          "self" => {
+            "href" => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
+            "title" => work_package.subject
+          },
+          "schema" => {
+            "href" => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
+          }
+        }
+      }.to_json
+    end
+
+    it "renders as expected" do
+      expect(subject)
+        .to be_json_eql(expected_json)
+    end
+  end
+
+  context "with only the observed in versions changed" do
+    let(:observed_in_versions) { [version] }
+    let(:attributes_changed_to_baseline) { %w[observed_in_versions] }
+
+    let(:expected_json) do
+      {
+        "_meta" => {
+          "matchesFilters" => true,
+          "exists" => true,
+          "timestamp" => timestamp.to_s
+        },
+        "_links" => {
+          "observedInVersions" => [
+            {
+              "href" => api_v3_paths.version(version.id),
+              "title" => version.name
             }
           ],
           "self" => {
@@ -568,6 +605,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
               "title" => version.name
             }
           ],
+          "observedInVersions" => [],
           "parent" => {
             "displayId" => parent.display_id.to_s,
             "href" => api_v3_paths.work_package(parent.id),

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -726,4 +726,99 @@ RSpec.describe Journable::WithHistoricAttributes,
       end
     end
   end
+
+  describe "observed in versions" do
+    shared_let(:version_a) { create(:version, project:, name: "Version A") }
+    shared_let(:version_b) { create(:version, project:, name: "Version B") }
+
+    let(:work_package) do
+      create(:work_package,
+             subject: "The versioned work package",
+             project:,
+             journals: {
+               created_at => {},
+               1.day.ago => {}
+             })
+    end
+
+    subject { described_class.wrap(work_package, timestamps:) }
+
+    def update_observed_in_versions(*versions)
+      work_package.observed_in_version_ids_replacements = versions.map(&:id)
+      work_package.save!
+    end
+
+    describe "#at_timestamp" do
+      it "returns the observed in versions from the journal snapshot, not the current ones" do
+        # Journal rows are stamped by the database clock, so the baseline snapshot
+        # is seeded directly rather than journalled at a past date.
+        create(:journal_work_package_version_journal,
+               journal: work_package.journals.first,
+               version: version_a,
+               kind: "observed_in")
+        update_observed_in_versions(version_a, version_b)
+
+        expect(subject.at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")).observed_in_versions)
+          .to contain_exactly(version_a)
+        expect(work_package.reload.observed_in_versions)
+          .to contain_exactly(version_a, version_b)
+      end
+
+      it "omits snapshotted observed in versions that were deleted since" do
+        update_observed_in_versions(version_a, version_b)
+        version_b.destroy!
+
+        # 1 hour in the future so the journal written by the update above is
+        # unambiguously in the past, regardless of sub-second timing.
+        expect(subject.at_timestamp(Timestamp.parse(1.hour.from_now.iso8601)).observed_in_versions)
+          .to contain_exactly(version_a)
+      end
+    end
+
+    describe "#changed_at_timestamp" do
+      context "when an observed in version was added" do
+        it "marks the observed in versions as changed" do
+          update_observed_in_versions(version_a, version_b)
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("observed_in_versions")
+        end
+      end
+
+      context "when one of several observed in versions was removed" do
+        it "marks only the observed in versions as changed" do
+          # Journal rows are stamped by the database clock, so a past removal
+          # can't be journalled directly; seed the baseline snapshot instead.
+          create(:journal_work_package_version_journal,
+                 journal: work_package.journals.first,
+                 version: version_b,
+                 kind: "observed_in")
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("observed_in_versions")
+        end
+      end
+
+      context "when all observed in versions were removed" do
+        it "marks the observed in versions as changed" do
+          create(:journal_work_package_version_journal,
+                 journal: work_package.journals.first,
+                 version: version_a,
+                 kind: "observed_in")
+
+          update_observed_in_versions
+
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to contain_exactly("observed_in_versions")
+        end
+      end
+
+      context "when the observed in versions are unchanged" do
+        it "reports no version change" do
+          expect(subject.changed_at_timestamp(Timestamp.parse("2022-01-01T00:00:00Z")))
+            .to be_empty
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/FND/work_packages/COMMS-977/activity

# What are you trying to accomplish?
Make baseline show diff of Observed in Versions

## Screenshots
<img width="1082" height="237" alt="Screenshot 2026-08-31 at 19 15 20" src="https://github.com/user-attachments/assets/e6f93f9a-ffc3-44a9-ba8b-6a2a42017fe9" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
