### PR TITLE
Avoid duplicate master VEVENT

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -323,8 +323,22 @@ module Meetings
 
     def instantiated_occurrences_for_export(recurring_meeting)
       # We should not emit previous-schedule instances as individual VEVENTs as some implementations (such as OpenXchange)
-      # reject the whole series if an event is < master DTSTART.
-      upcoming_schedule_occurrences(recurring_meeting)
+      # may reject the whole series if an event is < master DTSTART.
+      upcoming_schedule_occurrences(recurring_meeting).reject do |meeting|
+        first_series_occurrence?(meeting, recurring_meeting)
+      end
+    end
+
+    def first_series_occurrence?(meeting, recurring_meeting)
+      same_time?(meeting.recurrence_start_time, recurring_meeting.current_schedule_start) &&
+        !meeting.cancelled? &&
+        same_time?(meeting.start_time, meeting.recurrence_start_time) &&
+        same_time?(meeting.start_time, recurring_meeting.current_schedule_start) &&
+        same_time?(meeting.end_time, recurring_meeting.current_schedule_end)
+    end
+
+    def same_time?(left, right)
+      left.to_time.utc == right.to_time.utc
     end
 
     def upcoming_schedule_occurrences(recurring_meeting)

--- a/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
@@ -149,6 +149,8 @@ RSpec.describe MeetingSeriesMailer do
       let!(:occurrence) do
         create(:recurring_meeting_occurrence,
                recurring_meeting: series,
+               title: series.title,
+               location: series.location,
                start_time: series.start_time,
                recurrence_start_time: series.start_time)
       end
@@ -156,16 +158,12 @@ RSpec.describe MeetingSeriesMailer do
       let(:master_event) { calendar.events.find { |event| event.recurrence_id.blank? } }
       let(:occurrence_event) { calendar.events.find { |event| event.recurrence_id.present? } }
 
-      it "renders the series master and occurrence override" do
-        expect(calendar.events.length).to eq(2)
+      it "renders only the series master when the occurrence matches the series anchor" do
+        expect(calendar.events.length).to eq(1)
 
         expect(master_event.uid).to eq(series.uid)
         expect(master_event.rrule).not_to be_empty
-
-        expect(occurrence_event.uid).to eq(series.uid)
-        expect(occurrence_event.recurrence_id).to eq(occurrence.recurrence_start_time)
-        expect(occurrence_event.description.to_s)
-          .to include("Link to meeting occurrence: http://#{Setting.host_name}/meetings/#{occurrence.id}")
+        expect(occurrence_event).to be_nil
       end
     end
   end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
     it "starts the ical schedule with the original start time" do
       builder.add_series_event(recurring_meeting: recurring_meeting)
 
-      # we have the recurring meeting event + the first instantiated meeting
-      expect(parsed_calendar.events.count).to eq(2)
+      # the anchor occurrence is already covered by the master event
+      expect(parsed_calendar.events.count).to eq(1)
 
       # our recurring event starts at the original start time
       event = parsed_calendar.events.find { |e| e.recurrence_id.nil? }
@@ -106,12 +106,6 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       expect(rrule.frequency).to eq("WEEKLY")
       expect(rrule.interval).to eq(2)
       expect(rrule.count).to eq(26)
-
-      # the first recurring meeting is part of the calendar with the fitting recurrence id
-      first_meeting_event = parsed_calendar.events.find { |e| e.recurrence_id.present? }
-      expect(first_meeting_event.dtstart).to eq first_meeting.start_time
-      expect(first_meeting_event.recurrence_id).to eq first_meeting.start_time
-      expect(first_meeting_event.rrule).to be_empty
     end
   end
 
@@ -141,9 +135,8 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       # updated start time is the next occurrence of the meeting after the time of our change
       new_start_time = recurring_meeting.next_occurrence(from_time: start_time + 2.days)
 
-      # the master event + the upcoming occurrence created by the update service.
-      # the first occurrence is from the previous schedule and is no longer emitted.
-      expect(parsed_calendar.events.count).to eq(2)
+      # only the master event: the upcoming occurrence matches the new series anchor.
+      expect(parsed_calendar.events.count).to eq(1)
 
       # our recurring event starts at the updated start time
       master_event = parsed_calendar.events.find { |e| e.recurrence_id.nil? }
@@ -157,11 +150,6 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
 
       # the previous-schedule occurrence is no longer represented as an RDATE
       expect(Array(master_event.rdate)).to be_empty
-
-      # the second occurence is emitted as an override already using the new starting times
-      second_occurrence_event = parsed_calendar.events.find { |e| e.recurrence_id.present? }
-      expect(second_occurrence_event.dtstart).to eq new_start_time
-      expect(second_occurrence_event.rrule).to be_empty
     end
   end
 
@@ -191,9 +179,8 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       # updated start time is the next occurrence of the meeting after the time of our change
       new_start_time = recurring_meeting.next_occurrence(from_time: start_time + 2.days)
 
-      # the master event + the upcoming occurrence created by the update service.
-      # the first occurrence is from the previous schedule and is no longer emitted.
-      expect(parsed_calendar.events.count).to eq(2)
+      # only the master event: the upcoming occurrence matches the new series anchor.
+      expect(parsed_calendar.events.count).to eq(1)
 
       # our recurring event starts at the updated start time
       master_event = parsed_calendar.events.find { |e| e.recurrence_id.nil? }
@@ -206,11 +193,6 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
 
       # the previous-schedule occurrence is no longer represented as an RDATE
       expect(Array(master_event.rdate)).to be_empty
-
-      # the second occurence is emitted as an override already using the new starting times
-      second_occurrence_event = parsed_calendar.events.find { |e| e.recurrence_id.present? }
-      expect(second_occurrence_event.dtstart).to eq new_start_time
-      expect(second_occurrence_event.rrule).to be_empty
     end
   end
 


### PR DESCRIPTION
In the invitation sent for the type standup upgrade, we can see the master VEVENT and then a RECURRENCE-ID for that first iteration, since we output all open occurrences.

We should not output the master event as a recurrence UNLESS it has been moved.

For the first instance of the current schedule, the master already defines that slot via DTSTART + RRULE. Adding an override event with the same RECURRENCE-ID makes no difference, as all params are the same.

This duplicate likely caused OX to fail as soon we changed current_schedule_start. The master’s DTSTART jumped to the new time (e.g. Aug 31 09:00), InitNextOccurrenceJob instantiated the first occurrence, so we output another event there. But OX still has the old master in and doesn't know what to move it to.
