### PR TITLE
Use generic work package finders in MCP

### DIFF
--- a/app/services/mcp_tools/create_work_package_comment.rb
+++ b/app/services/mcp_tools/create_work_package_comment.rb
@@ -41,8 +41,8 @@ module McpTools
       required: %i[work_package_id comment],
       properties: {
         work_package_id: {
-          type: :number,
-          description: "The ID of the work package to which a comment shall be added."
+          type: %w[string number],
+          description: "The identifier of the work package to which a comment shall be added."
         },
         comment: {
           type: :string,
@@ -57,7 +57,7 @@ module McpTools
     )
 
     def call(work_package_id:, comment:, internal: false)
-      work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
+      work_package = WorkPackage.visible(current_user).find_by_display_id(work_package_id)
       return Failure("The given work package could not be found.") if work_package.nil?
 
       result = AddWorkPackageNoteService.new(user: current_user, work_package:).call(comment, send_notifications: true, internal:)

--- a/app/services/mcp_tools/create_work_package_relation.rb
+++ b/app/services/mcp_tools/create_work_package_relation.rb
@@ -41,11 +41,11 @@ module McpTools
       required: %i[from_work_package_id to_work_package_id],
       properties: {
         from_work_package_id: {
-          type: :number,
+          type: %w[string number],
           description: "The work package that acts as the origin for the relation."
         },
         to_work_package_id: {
-          type: :number,
+          type: %w[string number],
           description: "The work package that acts as the target for the relation."
         },
         type: {
@@ -81,8 +81,8 @@ module McpTools
     private
 
     def call(from_work_package_id:, to_work_package_id:, type: "relates", description: nil, lag: nil)
-      from = WorkPackage.visible(current_user).find_by(id: from_work_package_id)
-      to = WorkPackage.visible(current_user).find_by(id: to_work_package_id)
+      from = WorkPackage.visible(current_user).find_by_display_id(from_work_package_id)
+      to = WorkPackage.visible(current_user).find_by_display_id(to_work_package_id)
       return Failure("The given work package could not be found.") if from.nil? || to.nil?
 
       result = Relations::CreateService.new(user: current_user).call(

--- a/app/services/mcp_tools/list_work_package_comments.rb
+++ b/app/services/mcp_tools/list_work_package_comments.rb
@@ -42,8 +42,8 @@ module McpTools
       required: %i[work_package_id],
       properties: {
         work_package_id: {
-          type: :number,
-          description: "The ID of the work package whose comments shall be listed."
+          type: %w[string number],
+          description: "The identifier of the work package whose comments shall be listed."
         }
       }
     )
@@ -57,7 +57,7 @@ module McpTools
     end
 
     def base_scope(work_package_id:)
-      work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
+      work_package = WorkPackage.visible(current_user).find_by_display_id(work_package_id)
       return Failure("Can't find given work package.") if work_package.nil?
 
       Success(

--- a/app/services/mcp_tools/list_work_package_relations.rb
+++ b/app/services/mcp_tools/list_work_package_relations.rb
@@ -41,8 +41,8 @@ module McpTools
       required: %i[work_package_id],
       properties: {
         work_package_id: {
-          type: :number,
-          description: "The ID of the work package whose relations shall be listed."
+          type: %w[string number],
+          description: "The identifier of the work package whose relations shall be listed."
         }
       }
     )
@@ -52,7 +52,7 @@ module McpTools
     end
 
     def base_scope(work_package_id:)
-      work_package = WorkPackage.visible(current_user).find_by(id: work_package_id)
+      work_package = WorkPackage.visible(current_user).find_by_display_id(work_package_id)
       return Failure("Can't find given work package.") if work_package.nil?
 
       Success(

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -53,7 +53,7 @@ module McpTools
     # an instantiated Query to be used.
     filter :assigned_to_id
     filter :author_id
-    filter :id
+    filter :id, filter_proc: ->(wps, v) { wps.where_display_id_in(v) }
     filter :project_id
     filter :status_id
     filter :type_id
@@ -76,7 +76,7 @@ module McpTools
                        "Pass null to search for work packages without an assignee."
         },
         author_id: { type: "number", description: "The ID of the user that created this work package." },
-        id: { type: "number", description: "The ID of the work package." },
+        id: { type: %w[string number], description: "The identifier of the work package." },
         project_id: { type: "number", description: "The ID of the project that this work package belongs to." },
         status_id: { type: "number", description: "The ID of the work package's status." },
         subject: {

--- a/app/services/mcp_tools/update_work_package.rb
+++ b/app/services/mcp_tools/update_work_package.rb
@@ -41,8 +41,8 @@ module McpTools
       required: %w[id data],
       properties: {
         id: {
-          type: :number,
-          description: "The ID of the work package that shall be updated."
+          type: %w[string number],
+          description: "The identifier of the work package that shall be updated."
         },
         data: {
           type: %w[object],
@@ -66,7 +66,7 @@ module McpTools
     )
 
     def call(id:, data:)
-      work_package = WorkPackage.visible(current_user).find_by(id:)
+      work_package = WorkPackage.visible(current_user).find_by_display_id(id)
       return Failure("The given work package could not be found.") if work_package.nil?
 
       attributes = parse_work_package(data).on_failure { |result| return Failure(result.message) }.result

--- a/modules/costs/app/services/mcp_tools/search_time_entries.rb
+++ b/modules/costs/app/services/mcp_tools/search_time_entries.rb
@@ -42,7 +42,9 @@ module McpTools
 
     filter :id
     filter :user_id
-    filter :work_package_id, filter_proc: ->(entries, v) { entries.where(entity_type: "WorkPackage", entity_id: v) }
+    filter :work_package_id, filter_proc: ->(entries, v) {
+      entries.where(entity_type: "WorkPackage", entity_id: WorkPackage.where_display_id_in(v))
+    }
     filter :spent_since, filter_proc: ->(entries, v) { entries.where(spent_on: v..) }
     filter :spent_until, filter_proc: ->(entries, v) { entries.where(spent_on: ..v) }
 
@@ -51,7 +53,10 @@ module McpTools
       properties: {
         id: { type: "number", description: "The ID of the time entry." },
         user_id: { type: "number", description: "The ID of the user that the time entry tracks expenditures for." },
-        work_package_id: { type: "number", description: "The ID of the work package that the time entry is created on." },
+        work_package_id: {
+          type: %w[string number],
+          description: "The identifier of the work package that the time entry is created on."
+        },
         spent_since: {
           type: :string,
           format: :date,

--- a/modules/costs/spec/requests/mcp_tools/search_time_entries_spec.rb
+++ b/modules/costs/spec/requests/mcp_tools/search_time_entries_spec.rb
@@ -115,12 +115,31 @@ RSpec.describe McpTools::SearchTimeEntries do
     end
 
     describe "filtering by work_package_id" do
-      let(:call_args) { { work_package_id: time_entries.first.entity_id } }
+      before do
+        time_entries.each_with_index do |entry, i|
+          entry.entity.assign_attributes(identifier: "PROJ-#{100 + i}", sequence_number: 100 + i)
+          entry.entity.save!(context: :identifier_rewrite)
+        end
+      end
 
-      it "finds only time entries with the given entity" do
-        mcp_request
-        expect(result_items.size).to eq(1)
-        expect(result_items.first["id"]).to eq(time_entries.first.id)
+      context "when searching by classic id" do
+        let(:call_args) { { work_package_id: time_entries.first.entity_id } }
+
+        it "finds only time entries with the given entity" do
+          mcp_request
+          expect(result_items.size).to eq(1)
+          expect(result_items.first["id"]).to eq(time_entries.first.id)
+        end
+      end
+
+      context "when searching by semantic id" do
+        let(:call_args) { { work_package_id: "PROJ-100" } }
+
+        it "finds only time entries with the given entity" do
+          mcp_request
+          expect(result_items.size).to eq(1)
+          expect(result_items.first["id"]).to eq(time_entries.first.id)
+        end
       end
     end
 

--- a/spec/requests/mcp/mcp_tools/create_work_package_comment_spec.rb
+++ b/spec/requests/mcp/mcp_tools/create_work_package_comment_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe McpTools::CreateWorkPackageComment do
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
   let(:result_item) { parsed_results.fetch("structuredContent") }
 
-  let(:work_package) { create(:work_package).reload }
+  let(:work_package) { create(:work_package, identifier: "PROJ-101").reload }
 
   let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
   let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
@@ -85,6 +85,21 @@ RSpec.describe McpTools::CreateWorkPackageComment do
       mcp_request
 
       expect(result_item.to_json).to match_json_schema.from_docs("work_package_activities_model")
+    end
+
+    context "when specifying the work package via semantic identifier" do
+      let(:call_args) do
+        {
+          work_package_id: work_package.identifier,
+          comment: "This is a comment I'd like to add."
+        }
+      end
+
+      it "adds a work package comment" do
+        expect { mcp_request }.to change { work_package.reload.journals.count }.by(1)
+
+        expect(work_package.reload.journals.last.notes).to eq("This is a comment I'd like to add.")
+      end
     end
 
     context "when requesting to create an internal comment" do

--- a/spec/requests/mcp/mcp_tools/create_work_package_relation_spec.rb
+++ b/spec/requests/mcp/mcp_tools/create_work_package_relation_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe McpTools::CreateWorkPackageRelation do
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
   let(:result_item) { parsed_results.fetch("structuredContent") }
 
-  let(:work_package_a) { create(:work_package, project: allowed_project) }
-  let(:work_package_b) { create(:work_package, project: allowed_project) }
+  let(:work_package_a) { create(:work_package, project: allowed_project, identifier: "PROJ-42") }
+  let(:work_package_b) { create(:work_package, project: allowed_project, identifier: "PROJ-1337") }
 
   let(:allowed_project) { create(:project) }
   let(:disallowed_project) { create(:project) }
@@ -97,6 +97,30 @@ RSpec.describe McpTools::CreateWorkPackageRelation do
         {
           from_work_package_id: work_package_a.id,
           to_work_package_id: work_package_b.id,
+          type: "follows",
+          lag: 5,
+          description: "A follows B."
+        }
+      end
+
+      it "creates a work package relation" do
+        expect { mcp_request }.to change(Relation, :count).from(0).to(1)
+
+        expect(Relation.first).to have_attributes(
+          from: work_package_a,
+          to: work_package_b,
+          relation_type: "follows",
+          lag: 5,
+          description: "A follows B."
+        )
+      end
+    end
+
+    context "when defining work package via semantic identifier" do
+      let(:call_args) do
+        {
+          from_work_package_id: work_package_a.identifier,
+          to_work_package_id: work_package_b.identifier,
           type: "follows",
           lag: 5,
           description: "A follows B."

--- a/spec/requests/mcp/mcp_tools/list_work_package_comments_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_work_package_comments_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe McpTools::ListWorkPackageComments do
   let(:call_args) { { work_package_id: work_package.id } }
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
 
-  let!(:work_package) { create(:work_package, project: allowed_project, created_at: 5.days.ago, updated_at: 5.days.ago) }
+  let!(:work_package) do
+    create(:work_package, identifier: "PROJ-42", project: allowed_project, created_at: 5.days.ago, updated_at: 5.days.ago)
+  end
   let(:comment) { "I am a comment about the work package." }
 
   let(:allowed_project) { create(:project, enabled_internal_comments: true) }
@@ -118,6 +120,15 @@ RSpec.describe McpTools::ListWorkPackageComments do
       let(:call_args) { {} }
 
       it_behaves_like "MCP tool execution error response"
+    end
+
+    context "when passing a semantic identifier as work_package_id" do
+      let(:call_args) { { work_package_id: work_package.identifier } }
+
+      it "finds all comments of the work package" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(1)
+      end
     end
 
     context "when the comment has emoji reactions" do

--- a/spec/requests/mcp/mcp_tools/list_work_package_relations_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_work_package_relations_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe McpTools::ListWorkPackageRelations do
   let(:call_args) { { work_package_id: work_package.id } }
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
 
-  let!(:work_package) { create(:work_package, project: allowed_project) }
+  let!(:work_package) { create(:work_package, identifier: "PROJ-123", project: allowed_project) }
   let!(:relations) do
     [
       create(:relates_relation, from: work_package),
@@ -98,6 +98,15 @@ RSpec.describe McpTools::ListWorkPackageRelations do
       let(:call_args) { {} }
 
       it_behaves_like "MCP tool execution error response"
+    end
+
+    context "when passing a semantic identifier as work_package_id" do
+      let(:call_args) { { work_package_id: work_package.identifier } }
+
+      it "finds all relations of the work package" do
+        mcp_request
+        expect(parsed_results.dig("structuredContent", "items").size).to eq(relations.size)
+      end
     end
 
     context "when not allowed to see the source work package" do

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe McpTools::SearchWorkPackages do
 
   let!(:work_package_a) do
     create(:work_package,
+           identifier: "PROJ-42",
            project:,
            type:,
            status:,
@@ -74,6 +75,7 @@ RSpec.describe McpTools::SearchWorkPackages do
 
   let!(:work_package_b) do
     create(:work_package,
+           identifier: "PROJ-64",
            project:,
            type:,
            status:,
@@ -145,12 +147,24 @@ RSpec.describe McpTools::SearchWorkPackages do
     end
 
     describe "filtering by id" do
-      let(:call_args) { { id: work_package_a.id } }
+      context "when searching by a classic identifier" do
+        let(:call_args) { { id: work_package_a.id } }
 
-      it "finds the work package" do
-        mcp_request
-        expect(result_items.size).to eq(1)
-        expect(result_items.first["id"]).to eq(work_package_a.id)
+        it "finds the work package" do
+          mcp_request
+          expect(result_items.size).to eq(1)
+          expect(result_items.first["id"]).to eq(work_package_a.id)
+        end
+      end
+
+      context "when searching by a semantic identifier" do
+        let(:call_args) { { id: work_package_a.identifier } }
+
+        it "finds the work package" do
+          mcp_request
+          expect(result_items.size).to eq(1)
+          expect(result_items.first["id"]).to eq(work_package_a.id)
+        end
       end
     end
 

--- a/spec/requests/mcp/mcp_tools/update_work_package_spec.rb
+++ b/spec/requests/mcp/mcp_tools/update_work_package_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe McpTools::UpdateWorkPackage do
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
   let(:result_item) { parsed_results.fetch("structuredContent") }
 
-  let(:work_package) { create(:work_package).reload }
+  let(:work_package) { create(:work_package, identifier: "PROJ-1337").reload }
 
   let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
   let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
@@ -106,6 +106,24 @@ RSpec.describe McpTools::UpdateWorkPackage do
 
       it "does not update the work package" do
         expect { mcp_request }.not_to change { work_package.reload.subject }
+      end
+    end
+
+    context "when finding the work package via its semantic identifier" do
+      let(:call_args) do
+        {
+          id: work_package.identifier,
+          data: {
+            lockVersion: work_package.lock_version,
+            subject: "The new subject"
+          }
+        }
+      end
+
+      it "updates the work package" do
+        expect { mcp_request }.not_to change(WorkPackage, :count)
+
+        expect(work_package.reload.subject).to eq("The new subject")
       end
     end
   end


### PR DESCRIPTION
Making sure that work packages can not only be found by their internal database ID, but also by their semantic identifier.

# Ticket
https://community.openproject.org/wp/AI-131