### PR TITLE
[COMMS-984] Global search should continue to work after a failed request

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -31,7 +31,7 @@
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, ElementRef, EventEmitter, forwardRef, HostBinding, Injector, Input, OnChanges, OnInit, Output, SimpleChanges, TemplateRef, Type, ViewChild, ViewContainerRef, ViewEncapsulation, inject } from '@angular/core';
 import { DropdownPosition, NgSelectComponent } from '@ng-select/ng-select';
 import { BehaviorSubject, merge, NEVER, Observable, of, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import {
@@ -490,19 +490,22 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
       tap(() => this.loading$.next(true)),
       debounceTime(this.debounceTimeForCurrentEnvironment),
       switchMap((queryString:string) => {
+        let source$:Observable<unknown> = NEVER;
+
         if (this.getOptionsFn) {
-          return this.getOptionsFn(queryString);
+          source$ = this.getOptionsFn(queryString);
+        } else if (this.url) {
+          source$ = this.opAutocompleterService.loadFromUrl(this.url, queryString, this.resource, this.filters, this.searchKey);
+        } else if (this.defaultData) {
+          source$ = this.opAutocompleterService.loadData(queryString, this.resource, this.filters, this.searchKey);
         }
 
-        if (this.url) {
-          return this.opAutocompleterService.loadFromUrl(this.url, queryString, this.resource, this.filters, this.searchKey);
-        }
-
-        if (this.defaultData) {
-          return this.opAutocompleterService.loadData(queryString, this.resource, this.filters, this.searchKey);
-        }
-
-        return NEVER;
+        return source$.pipe(
+          catchError((error) => {
+            console.error(error);
+            return of([]);
+          }),
+        );
       }),
       tap({
         next: () => this.loading$.next(false),

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -31,7 +31,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { States } from 'core-app/core/states/states.service';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ChangeDetectionStrategy, Component, NO_ERRORS_SCHEMA } from '@angular/core';
-import { of, map } from 'rxjs';
+import { of, map, throwError } from 'rxjs';
 import { NgSelectModule } from '@ng-select/ng-select';
 
 import { OpAutocompleterComponent } from './op-autocompleter.component';
@@ -198,6 +198,51 @@ describe('autocompleter', () => {
         fixture.detectChanges();
 
         expect(select.itemsList.items.length).toEqual(1);
+      }
+      finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should recover and keep loading results after a lookup fails', () => {
+      vi.useFakeTimers();
+      try {
+        getOptionsFnSpy.mockImplementation((searchTerm:string) => {
+          if (searchTerm === 'bad') {
+            return throwError(() => new Error('backend rejected the query'));
+          }
+
+          return of(workPackagesStub).pipe(map((wps) => wps.filter((wp) => searchTerm !== '' && wp.subject.includes(searchTerm))));
+        });
+
+        fixture.detectChanges();
+        vi.advanceTimersByTime(1000);
+        fixture.detectChanges();
+        const select = fixture.componentInstance.ngSelectInstance;
+
+        select.open();
+        select.focus();
+
+        const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+        const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+
+        inputElement.value = 'bad';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        vi.advanceTimersByTime(0);
+        fixture.detectChanges();
+
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('bad');
+        expect(select.itemsList.items.length).toEqual(0);
+
+        inputElement.value = 'Wor';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        vi.advanceTimersByTime(0);
+        fixture.detectChanges();
+
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
+        expect(select.itemsList.items.length).toEqual(2);
       }
       finally {
         vi.useRealTimers();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-984

# What are you trying to accomplish?
The search stopped working as soon as one request returned an error. That means also all next searches of the user would not lead to results, even if they would have been valid, until the user reloads the page.
Now errors are catched and will show a "No items found" message to give feedback to the user. Errors still show up in the Javascript console.

The behaviour of breaking as soon as there was an error is especially problematic since multiple of our filters return an error when no result was found.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
