### PR TITLE
[JIM-181] Free file descriptors.

### DIFF
--- a/app/services/import/jira_client.rb
+++ b/app/services/import/jira_client.rb
@@ -274,7 +274,10 @@ module Import
     rescue Timeout::Error => e
       raise ConnectionError, I18n.t("admin.jira.client.connection_timeout", message: e.message)
     ensure
-      File.unlink(tempfile) if tempfile
+      if tempfile
+        File.unlink(tempfile)
+        tempfile.close
+      end
     end
 
     private


### PR DESCRIPTION
https://community.openproject.org/wp/JIM-181

`File.unlink` frees the name, but does not free fd. `File#close` frees fd. So, we have to call it manually after tempfile has been used.

