### PR TITLE
Explicitly set current_schedule_start

### DIFF
--- a/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
@@ -40,8 +40,20 @@ module RecurringMeetings
           model.interval = 1
         end
 
-        model.current_schedule_start = model.next_occurrence(from_time: Time.current) || model.start_time
+        determine_current_schedule_start
       end
+    end
+
+    # current_schedule_start will become the DTSTART of the ICS series event.
+    #
+    # If DTSTART is changed and the UID does not change, some clients MAY delete all earlier occurrences.
+    # We have to make sure we never write it unless
+    #  - we are really changing the schedule (schedule_changed?)
+    #  - we are first creating the series
+    def determine_current_schedule_start
+      return unless model.new_record? || model.schedule_changed?
+
+      model.current_schedule_start = model.next_occurrence(from_time: Time.current) || model.start_time
     end
 
     def set_default_attributes(_params)

--- a/modules/meeting/spec/services/recurring_meetings/set_attributes_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/set_attributes_service_spec.rb
@@ -108,6 +108,51 @@ RSpec.describe RecurringMeetings::SetAttributesService, type: :model do
     end
   end
 
+  context "when updating a persisted series" do
+    let(:current_user) { create(:user) }
+    let(:model_instance) do
+      create(:recurring_meeting,
+             author: current_user,
+             start_time: Time.utc(2026, 1, 7, 10, 0, 0),
+             frequency: "weekly",
+             interval: 1,
+             end_after: "never",
+             end_date: nil,
+             time_zone: "UTC")
+    end
+    let(:instance) do
+      described_class.new(user: current_user, model: model_instance, contract_class: RecurringMeetings::UpdateContract)
+    end
+
+    around do |example|
+      travel_to(Time.utc(2026, 6, 15, 9, 0, 0)) { example.run }
+    end
+
+    context "with a schedule change" do
+      let(:params) { { start_time_hour: "14:00" } }
+
+      it "moves the anchor to the next occurrence of the new schedule" do
+        subject
+
+        expect(model_instance.current_schedule_start).to eq("2026-06-17 14:00:00 UTC")
+      end
+    end
+
+    context "without a schedule change" do
+      let(:params) { { title: "A new title" } }
+
+      it "leaves the anchor untouched" do
+        expect { subject }.not_to change(model_instance, :current_schedule_start)
+      end
+
+      it "still applies the other attributes" do
+        subject
+
+        expect(model_instance.title).to eq "A new title"
+      end
+    end
+  end
+
   context "when calling without params to set default attributes" do
     let(:params) { {} }
 


### PR DESCRIPTION
We currently always set `current_schedule_start` to the first occurrence as a side effect of the SetAttributesService. This should not have practical effects unless changing, but I found it hard to reason with.

Instead, make it clear what it is and add a guarding clause so that it's clear IF we update it, it will mark a new "era" of the series.