### PR TITLE
Move update_template to before sending out emails

### DIFF
--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -46,6 +46,12 @@ module RecurringMeetings
 
       recurring_meeting = call.result
 
+      # Make sure we update the template before sending out any emails
+      # to make sure it's attributes (such as a location change) are correctly used
+      update_template(call)
+
+      return call unless call.success?
+
       if should_reschedule?(recurring_meeting)
         reschedule_future_occurrences(recurring_meeting)
         reschedule_init_job(recurring_meeting)
@@ -55,7 +61,7 @@ module RecurringMeetings
       cleanup_cancelled_schedules(recurring_meeting)
       update_future_occurrence_titles(recurring_meeting)
 
-      update_template(call)
+      call
     end
 
     def update_template(call)

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -287,6 +287,17 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
         expect(german_mail.html_part.body).not_to include("Alter Zeitplan")
         expect(german_mail.html_part.body).not_to include("Neuer Zeitplan")
       end
+
+      it "attaches an ICS that referes to the new location" do
+        expect(service_result).to be_success
+        perform_enqueued_jobs
+
+        english_mail = ActionMailer::Base.deliveries.find { |m| m.to.include?(english_recipient.mail) }
+        calendar = english_mail.all_parts.find { |part| part.mime_type == "text/calendar" }
+
+        expect(calendar.body.decoded).to include("LOCATION:New location")
+        expect(calendar.body.decoded).not_to include("LOCATION:Old location")
+      end
     end
   end
 


### PR DESCRIPTION
If we only change the location of a series, that update is not saved until _after_ we send out the emails to users, resulting in embeeding outdated information in the ICS.