### PR TITLE
Add time_zone to attributes affecting schedule

### DIFF
--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -283,7 +283,7 @@ class RecurringMeeting < ApplicationRecord
 
   # Attributes that affect the recurrence schedule itself (not template-only fields like location).
   SCHEDULE_ATTRIBUTES = %w[frequency monthly_day monthly_ordinal monthly_weekday start_date start_time
-                           start_time_hour iterations interval end_after end_date].freeze
+                           start_time_hour time_zone iterations interval end_after end_date].freeze
 
   def reschedule_required?(previous: false)
     (previous ? previous_changes : changes)

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -446,6 +446,38 @@ RSpec.describe RecurringMeeting,
     end
   end
 
+  describe "#schedule_changed? and #reschedule_required?" do
+    let(:series) { create(:recurring_meeting, time_zone: "UTC") }
+
+    it "reports a time zone change as a schedule change" do
+      series.time_zone = "Europe/Berlin"
+
+      expect(series).to be_schedule_changed
+      expect(series).to be_reschedule_required
+    end
+
+    it "reports a frequency change as a schedule change" do
+      series.frequency = "daily"
+
+      expect(series).to be_schedule_changed
+      expect(series).to be_reschedule_required
+    end
+
+    it "does not report a title change as either" do
+      series.title = "A new title"
+
+      expect(series).not_to be_schedule_changed
+      expect(series).not_to be_reschedule_required
+    end
+
+    it "reports a location change as a reschedule but not as a schedule change" do
+      series.location = "A new location"
+
+      expect(series).not_to be_schedule_changed
+      expect(series).to be_reschedule_required
+    end
+  end
+
   describe "#uid" do
     it "assigns a uid on create" do
       series = build(:recurring_meeting)

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -235,6 +235,31 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
       end
     end
 
+    context "when updating only the time zone" do
+      let(:params) do
+        { time_zone: "Europe/Berlin" }
+      end
+
+      let(:recipient) do
+        create(:user, member_with_permissions: { project => %i(view_meetings) })
+      end
+
+      before do
+        series.template.participants.delete_all
+        series.template.participants << MeetingParticipant.new(user: recipient, invited: true)
+      end
+
+      it "sends out updated mails carrying the new time zone" do
+        expect(service_result).to be_success
+        perform_enqueued_jobs
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+        calendar = ActionMailer::Base.deliveries.first.all_parts.find { |part| part.mime_type == "text/calendar" }
+        expect(calendar.body.decoded).to include("TZID:Europe/Berlin")
+      end
+    end
+
     context "when updating only the location with recipients with different locales" do
       let(:german_author) do
         create(:user,


### PR DESCRIPTION
We did not consider "time_zone" part of the schedule changes. This could result in API changes causing wrong updates to the schedule, but only if the time_zone itself would change. 

The UI does not allow changing the time_zone of a series currently.