### PR TITLE
[AUTOWORK-251] Rename "Form configuration" to "Form"

### DIFF
--- a/app/controllers/work_package_types/form_configuration_groups_tab_controller.rb
+++ b/app/controllers/work_package_types/form_configuration_groups_tab_controller.rb
@@ -210,9 +210,12 @@ module WorkPackageTypes
       )
     end
 
-    def render_existing_group_update_error(call)
+    def render_existing_group_update_error(call) # rubocop:disable Metrics/AbcSize
       @variant.reload
       group = active_groups_for_form.find { |active_group| active_group[:key].to_s == group_key_param.to_s }
+
+      # A group deleted from another tab leaves no editor to re-render the rejected name into.
+      return render_form_configuration_error(call) if group.nil?
 
       update_main_content_via_turbo_stream(
         editing_group_key: group_key_param,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,11 +371,11 @@ en:
       type/configuration_link:
         source: "Source type"
       type_variant:
-        attribute_groups: "Form configuration"
+        attribute_groups: "Form"
         default_work_package_description: "Default text for description"
         defaults_source: "Defaults source"
         enabled_in_new_projects: "Active in new projects"
-        form_configuration_source: "Form configuration source"
+        form_configuration_source: "Form source"
         patterns: "Patterns"
         pdf_export_source: "PDF export source"
         project_attributes_source: "Project attributes source"
@@ -2829,7 +2829,7 @@ en:
         more_info: "Note: the used logo will be publicly accessible."
         title: "Custom color theme and logo"
       edit_attribute_groups:
-        description: "Customize form configuration with these additional add-ons:"
+        description: "Customize the form with these additional add-ons:"
         features:
           groups: "Add new attribute sections"
           related: "Add a table of related work packages"
@@ -3604,7 +3604,6 @@ en:
   label_float: "Float"
   label_folder: "Folder"
   label_follows: "follows"
-  label_form_configuration: "Form configuration"
   label_formula: "Formula"
   label_forum_new: "New forum"
   label_forum_plural: "Forums"
@@ -4998,7 +4997,7 @@ en:
       caption: Work package details rendered as a PMflex Artefact.
       label: "PMflex Artefact"
     template_attributes:
-      caption: All the attributes present in the current form configuration using the default template.
+      caption: All the attributes present in the current form using the default template.
       label: "Attributes and description"
     template_contract:
       caption: Work package details formatted to the standard German contract form.
@@ -6479,7 +6478,7 @@ en:
       steps:
         defaults: "Defaults"
         details: "Details"
-        form_configuration: "Form configuration"
+        form_configuration: "Form"
         pdf: "PDF generation"
         project_attributes: "Project attributes"
         projects: "Projects"
@@ -6550,7 +6549,7 @@ en:
         blankslate_title: "No groups yet"
         builtin_field: "Built-in field"
         confirm_delete_group: "Are you sure you want to delete this section? This action cannot be automatically reversed."
-        confirm_reset: "Are you sure you want to reset the form configuration?"
+        confirm_reset: "Are you sure you want to reset the form?"
         custom_field: "Custom field"
         delete_group: "Delete section"
         drag_to_activate: "Drag fields from here to activate them"
@@ -6565,20 +6564,20 @@ en:
         group_actions: "Section actions"
         group_name_label: "Section name"
         inactive_attributes_heading: "Inactive attributes"
-        invalid_attribute_groups: "The form configuration payload is invalid."
+        invalid_attribute_groups: "The form payload is invalid."
         invalid_query: "The embedded query configuration is invalid."
         label_group: "Section"
         no_inactive_attributes: "No inactive attributes"
-        not_found: "The requested form configuration item could not be found."
+        not_found: "The requested form item could not be found."
         query_group_label: "Related work packages table"
         remove_attribute: "Remove from section"
         rename_group: "Rename section"
         reset_description: >
           This will reset the attributes to their default group and disable ALL custom fields.
-        reset_title: "Reset form configuration"
+        reset_title: "Reset form"
         reset_to_defaults: "Reset form"
         row_actions: "Row actions"
-        tab: "Form configuration"
+        tab: "Form"
         untitled_group: "Untitled group"
       project_attributes:
         actions:

--- a/spec/controllers/work_package_types/form_configuration_groups_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/form_configuration_groups_tab_controller_spec.rb
@@ -136,6 +136,22 @@ RSpec.describe WorkPackageTypes::FormConfigurationGroupsTabController do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context "when the group was deleted meanwhile" do
+      it "flashes the failure rather than re-rendering the editor of a gone group" do
+        patch :update,
+              params: {
+                type_id: type.id,
+                key: "Gone group",
+                group: { name: "Any name" }
+              },
+              format: :turbo_stream
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_turbo_stream(action: "flash", target: "op-primer-flash-component")
+        expect(response.body).to include("The requested form item could not be found.")
+      end
+    end
   end
 
   describe "POST #create (duplicate name)", with_ee: %i[edit_attribute_groups] do

--- a/spec/controllers/work_package_types/form_configuration_groups_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/form_configuration_groups_tab_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe WorkPackageTypes::FormConfigurationGroupsTabController do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include("Second group")
         expect(response.body).to include("Group names must be unique.")
-        expect(response.body).not_to include("Form configuration")
+        expect(response.body).not_to include("Form Group names must be unique.")
       end
 
       it "preserves the entered name in the input field" do
@@ -154,7 +154,7 @@ RSpec.describe WorkPackageTypes::FormConfigurationGroupsTabController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include('action="update"')
       expect(response.body).to include('target="work-package-types-form-configuration-main-content-component"')
-      expect(response.body).not_to include("Form configuration")
+      expect(response.body).not_to include("Form Group names must be unique.")
     end
 
     it "returns a main content turbo stream response" do

--- a/spec/features/types/creation_wizard_spec.rb
+++ b/spec/features/types/creation_wizard_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Type creation wizard", :js, with_flag: { type_variants: true } d
     click_on I18n.t(:button_continue)
     expect_step_saved(:defaults, linked: false)
 
-    expect(page).to have_heading("Form configuration")
+    expect(page).to have_heading("Form")
     expect(page).to have_text("Manual configuration")
     click_on I18n.t(:button_continue)
     expect_step_saved(:form_configuration, linked: false)

--- a/spec/services/work_package_types/update_service_spec.rb
+++ b/spec/services/work_package_types/update_service_spec.rb
@@ -212,8 +212,14 @@ module WorkPackageTypes
         result = service.call(attribute_groups: "{")
 
         expect(result).to be_failure
-        expect(result.errors[:attribute_groups].to_sentence)
-          .to eq(I18n.t("types.edit.form_configuration.invalid_attribute_groups"))
+        expect(result.errors[:attribute_groups].to_sentence).to eq("The form payload is invalid.")
+      end
+
+      it "returns a failure result for valid JSON that is not a list of groups" do
+        result = service.call(attribute_groups: "{}")
+
+        expect(result).to be_failure
+        expect(result.errors[:attribute_groups].to_sentence).to eq("The form payload is invalid.")
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AUTOWORK-251

# What are you trying to accomplish?

* Administration → Work packages → Types
   - [x] Creation wizard step and heading — **+ Type** (requires `feature_type_variants_active`) → sidebar
   * *Task* edit page
      - [x] Tab name `Form`
      * *Form* tab
         - [x] Enterprise upsell banner — with no EE token active
         - [x] Reset dialog — **Reset form** button + confirmation
         - [x] Stale-section flash — with EE token active, open Form in two tabs, delete a section in one, rename it in the other
            - [x] An opportunistic HTTP 500 fix in a separate commit.
         - [x] Linked-configuration error flash — link variant *Small*'s form to *Big*, then *Big*'s to *Small*
      * _Generate PDF_ tab
         - [x] *Attributes and description* caption
- [x] Malformed payload error — no UI path; `spec/services/work_package_types/update_service_spec.rb`

## Screenshots

### `Form` tab, EE banner, `Reset form` button and confirmation

<img width="1006" height="616" alt="Screenshot of the Type Form tab" src="https://github.com/user-attachments/assets/e8fd9aba-3c9a-41d6-a01f-cf5599c36f61" />

<img width="509" height="323" alt="Screenshot of confirmation dialog" src="https://github.com/user-attachments/assets/8f4c5507-783b-41d6-b192-b8b9039fbd79" />

### Linked configuration flash message

<img width="1006" height="202" alt="Screenshot of flash message" src="https://github.com/user-attachments/assets/7c401853-3b56-451c-95d4-0b21a216abce" />

### PDF export template caption

<img width="1006" height="260" alt="image" src="https://github.com/user-attachments/assets/1d297777-6be9-4188-bbd5-c1191fbcc046" />

### `Form` in wizard

<img width="1006" height="237" alt="Screenshot of the wizard" src="https://github.com/user-attachments/assets/4d598c9c-b182-427d-9f19-1fbdb772e8cb" />

# What approach did you choose and why?

- Wording only: i18n keys, routes, controllers and `TypeVariant::FORM_CONFIGURATION` keep "form_configuration", so existing Crowdin translations survive.
- `docs/` is untouched — left for the documentation team.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox)
