### PR TITLE
Allow linking work package with semantic link

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/entity_representer_factory.rb
+++ b/modules/costs/lib/api/v3/time_entries/entity_representer_factory.rb
@@ -138,7 +138,9 @@ module API
               represented.public_send("#{name}_id=", result[:id])
               represented.public_send("#{name}_type=", "Meeting")
             when "work_packages"
-              represented.public_send("#{name}_id=", result[:id])
+              id = WorkPackage.find_by_display_id(result[:id])&.id if WorkPackage::SemanticIdentifier.semantic_id?(result[:id])
+              id ||= result[:id]
+              represented.public_send("#{name}_id=", id)
               represented.public_send("#{name}_type=", "WorkPackage")
             else
               # TODO: Handle error if unexpected object

--- a/modules/costs/spec/requests/mcp_tools/create_time_entry_spec.rb
+++ b/modules/costs/spec/requests/mcp_tools/create_time_entry_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe McpTools::CreateTimeEntry do
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
   let(:result_item) { parsed_results.fetch("structuredContent") }
 
-  let(:work_package) { create(:work_package) }
+  let(:work_package) { create(:work_package, identifier: "PROJ-51") }
 
   let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
   let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }
@@ -90,6 +90,29 @@ RSpec.describe McpTools::CreateTimeEntry do
       mcp_request
 
       expect(result_item.to_json).to match_json_schema.from_docs("time_entry_model")
+    end
+
+    context "when specifying the work package URL using the semantic identifier" do
+      let(:call_args) do
+        {
+          data: {
+            hours: "PT2H30M",
+            _links: {
+              entity: { href: "/api/v3/work_packages/#{work_package.identifier}" }
+            }
+          }
+        }
+      end
+
+      it "creates a new time entry" do
+        expect { mcp_request }.to change(TimeEntry, :count).from(0).to(1)
+
+        entry = TimeEntry.first
+        expect(entry.entity).to eq(work_package)
+        expect(entry.user).to eq(user)
+        expect(entry.spent_on).to eq(Time.zone.today)
+        expect(entry.hours).to eq(2.5)
+      end
     end
 
     context "when passing a user" do


### PR DESCRIPTION
Making sure that the APIv3 representation parser will accept work package links like

    /api/v3/work_packages/PROJ-123

Caveat: This fix only affects the parser of time entries and not the APIv3 at large. Maybe this should be pushed higher, where it can also do the same for projects and for WPs in other contexts?

# Ticket
https://community.openproject.org/wp/AI-131

Done in the scope of this MCP-specific work package, though this also affects APIv3.