### PR TITLE
Reduce duplicate meeting index browser coverage

### DIFF
--- a/modules/meeting/spec/components/meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/row_component_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Meetings::RowComponent, type: :component do
 
         it "shows default menu items" do
           expect(subject).to have_link "Download iCalendar event"
+          expect(subject).to have_no_link "Duplicate meeting"
+          expect(subject).to have_no_link "Delete meeting"
         end
       end
 

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -348,27 +348,6 @@ RSpec.describe "Meetings", "Index", :js do
 
         meetings_page.expect_no_create_new_button
       end
-
-      it "shows a download ical event action button for each meeting" do
-        invite_to_meeting(meeting)
-        meetings_page.visit!
-
-        meetings_page.expect_ical_action(meeting)
-      end
-
-      it "doesn't show a copy meeting action button for each meeting" do
-        invite_to_meeting(meeting)
-        meetings_page.visit!
-
-        meetings_page.expect_no_copy_action(meeting)
-      end
-
-      it "doesn't show a delete meeting action button for each meeting" do
-        invite_to_meeting(meeting)
-        meetings_page.visit!
-
-        meetings_page.expect_no_delete_action(meeting)
-      end
     end
 
     context "and the user is allowed to create meetings" do
@@ -384,24 +363,6 @@ RSpec.describe "Meetings", "Index", :js do
         meetings_page.visit!
 
         meetings_page.expect_create_new_types
-      end
-
-      it "shows a copy meeting action button for each meeting" do
-        invite_to_meeting(meeting)
-        meetings_page.visit!
-
-        meetings_page.expect_copy_action(meeting)
-      end
-    end
-
-    context "and the user is allowed to delete meetings" do
-      let(:permissions) { %i(view_meetings delete_meetings) }
-
-      it "shows a delete meeting action button for each meeting" do
-        invite_to_meeting(meeting)
-        meetings_page.visit!
-
-        meetings_page.expect_delete_action(meeting)
       end
     end
 
@@ -461,26 +422,21 @@ RSpec.describe "Meetings", "Index", :js do
       expect(page).to have_no_button I18n.t(:label_project), exact: true
     end
 
-    include_examples "sidebar filtering", context: :project
+    it "applies a project-scoped time filter" do
+      setup_meeting_involvement
+      meetings_page.visit!
+      meetings_page.set_sidebar_filter "All meetings"
+      meetings_page.set_quick_filter upcoming: false
+
+      meetings_page.expect_meetings_listed_in_table(yesterdays_meeting, meeting, ongoing_meeting)
+      meetings_page.expect_meetings_not_listed(tomorrows_meeting, other_project_meeting)
+    end
 
     specify "with 1 meeting listed" do
       invite_to_meeting(meeting)
       meetings_page.visit!
 
       meetings_page.expect_meetings_listed(meeting)
-    end
-
-    it "renders a link to each meeting's location if present and a valid URL" do
-      invite_to_meeting(meeting)
-      invite_to_meeting(meeting_with_no_location)
-      invite_to_meeting(meeting_with_malicious_location)
-      invite_to_meeting(tomorrows_meeting)
-
-      meetings_page.visit!
-      meetings_page.expect_link_to_meeting_location(meeting)
-      meetings_page.expect_plaintext_meeting_location(tomorrows_meeting)
-      meetings_page.expect_plaintext_meeting_location(meeting_with_malicious_location)
-      meetings_page.expect_no_meeting_location(meeting_with_no_location)
     end
   end
 


### PR DESCRIPTION
The meetings index repeats row-action permission checks, the complete sidebar-filter matrix, and location rendering in both global and project browser contexts. Those repeated browser lifecycles add stable CPU cost without exercising a distinct integration boundary.

This stacked follow-up:

- removes five browser examples whose iCalendar, duplicate, and delete action states are already owned by `Meetings::RowComponent`;
- adds explicit negative duplicate/delete assertions to the component's one-time meeting case;
- replaces seven repeated project-context sidebar-filter examples with one project-scoped Turbo time-filter workflow;
- removes the duplicate project-context location rendering example while retaining the exhaustive global browser case.

The feature file falls from 35 to 23 browser examples. Charging all eight row-component examples to the candidate, the combined 31-example selection passes without retries in 74.04s and 74.60s RSpec time at two seeds, versus 116.86s for the original feature file: **36.6% less focused RSpec time**.

Matched SimpleCov line/branch reports compare the original feature file with the final feature-plus-component selection. They report **zero lost application lines and zero lost branches**. This does not claim JavaScript coverage; retained browser workflows still cover the menu interaction, create-type dialog, global filtering matrix, project-scoped Turbo filtering, permissions, project filtering, navigation, and breadcrumb behavior.

This PR is intentionally based on `auto/rspec-speedup-integration` / #25061 so the test-level reduction can be reviewed independently from the first campaign batch.
