### PR TITLE
Reduce duplicated Gantt date browser coverage

### DIFF
--- a/frontend/src/app/core/setup/init-locale.spec.ts
+++ b/frontend/src/app/core/setup/init-locale.spec.ts
@@ -1,0 +1,70 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import moment from 'moment';
+import {
+  afterEach, describe, expect, it,
+} from 'vitest';
+import './init-moment-locales';
+import { initializeLocale } from './init-locale';
+
+describe('initializeLocale', () => {
+  afterEach(() => {
+    document.querySelector('meta[name="openproject_initializer"]')?.remove();
+    moment.locale('en');
+  });
+
+  function setInitializer(locale:string) {
+    const meta = document.createElement('meta');
+    meta.name = 'openproject_initializer';
+    meta.dataset.locale = locale;
+    meta.dataset.defaultlocale = 'en';
+    meta.dataset.instancelocale = locale;
+    document.head.appendChild(meta);
+  }
+
+  it('uses the German week numbering rules', async () => {
+    setInitializer('de');
+
+    await initializeLocale();
+
+    expect(moment('2020-12-31').format('ww')).toBe('53');
+    expect(moment('2021-01-01').format('ww')).toBe('53');
+    expect(moment('2021-01-04').format('ww')).toBe('01');
+  });
+
+  it('uses the English week numbering rules', async () => {
+    setInitializer('en');
+
+    await initializeLocale();
+
+    expect(moment('2020-12-31').format('ww')).toBe('01');
+    expect(moment('2021-01-01').format('ww')).toBe('01');
+    expect(moment('2021-01-04').format('ww')).toBe('02');
+  });
+});

--- a/modules/gantt/spec/features/timeline/timeline_dates_spec.rb
+++ b/modules/gantt/spec/features/timeline/timeline_dates_spec.rb
@@ -98,30 +98,6 @@ RSpec.describe "Work package timeline date formatting",
       wp_timeline.expect_timeline!
     end
 
-    context "with german locale user" do
-      let(:current_user) { create(:admin, language: "de") }
-
-      it "shows german ISO dates" do
-        # expect moment to return week 53 for start date
-        expect_date_week work_package.start_date.iso8601, "53"
-        expect_date_week work_package.due_date.iso8601, "53"
-        # Monday, 4th of january is the first week
-        expect_date_week "2021-01-04", "01"
-      end
-    end
-
-    context "with english locale user" do
-      let(:current_user) { create(:admin, language: "en") }
-
-      it "shows english ISO dates" do
-        # expect moment to return week 01 for start date
-        expect_date_week work_package.start_date.iso8601, "01"
-        expect_date_week work_package.due_date.iso8601, "01"
-        # Monday, 4th of january is the second week
-        expect_date_week "2021-01-04", "02"
-      end
-    end
-
     context "with weekdays defined" do
       let(:current_user) { create(:admin, language: "en") }
 
@@ -267,32 +243,6 @@ RSpec.describe "Work package timeline date formatting",
 
       describe "set the start, due date while preserving duration over the weekend" do
         subject { row.click_bar }
-
-        it_behaves_like "sets dates, duration and displays bar" do
-          let(:target_wp) { work_package_with_non_working_days }
-          let(:expected_bar_duration) { work_package_with_non_working_days.duration + 2 }
-          let(:expected_start_date) { Date.parse("2021-01-05") }
-          let(:expected_due_date) { Date.parse("2021-01-11") }
-          let(:expected_duration) { 4 }
-          let(:expected_label) { work_package_with_non_working_days.subject }
-        end
-      end
-
-      describe "sets the start, due dates while preserving duration on a drag and drop create" do
-        subject { row.drag_and_drop(offset_days: -1, days: 5) }
-
-        it_behaves_like "sets dates, duration and displays bar" do
-          let(:target_wp) { work_package_with_non_working_days }
-          let(:expected_bar_duration) { work_package_with_non_working_days.duration }
-          let(:expected_start_date) { Date.parse("2021-01-04") }
-          let(:expected_due_date) { Date.parse("2021-01-08") }
-          let(:expected_duration) { 4 }
-          let(:expected_label) { work_package_with_non_working_days.subject }
-        end
-      end
-
-      describe "sets the start, due dates while preserving duration on a drag and drop create over the weekend" do
-        subject { row.drag_and_drop(days: 7) }
 
         it_behaves_like "sets dates, duration and displays bar" do
           let(:target_wp) { work_package_with_non_working_days }

--- a/spec/helpers/accessibility_helper_spec.rb
+++ b/spec/helpers/accessibility_helper_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe AccessibilityHelper do
+  describe "#menu_item_locale" do
+    before do
+      I18n.backend.store_translations(:en,
+                                      label_same_caption: "Same caption",
+                                      label_different_caption: "English caption",
+                                      label_string_caption: "String caption")
+      I18n.backend.store_translations(:de,
+                                      label_same_caption: "Same caption",
+                                      label_different_caption: "Deutsche Beschriftung",
+                                      label_string_caption: "String caption")
+    end
+
+    def menu_item(name, caption: nil)
+      Redmine::MenuManager::MenuItem.new(name, "/test", caption:)
+    end
+
+    it "uses no explicit locale for English" do
+      I18n.with_locale(:en) do
+        expect(helper.menu_item_locale(menu_item(:same_caption, caption: :label_same_caption))).to be_nil
+      end
+    end
+
+    it "marks a shared symbolic caption as English" do
+      I18n.with_locale(:de) do
+        expect(helper.menu_item_locale(menu_item(:same_caption, caption: :label_same_caption))).to eq(:en)
+      end
+    end
+
+    it "uses the current locale for a translated symbolic caption" do
+      I18n.with_locale(:de) do
+        expect(helper.menu_item_locale(menu_item(:different_caption, caption: :label_different_caption))).to be_nil
+      end
+    end
+
+    it "derives the translation key for a string caption" do
+      I18n.with_locale(:de) do
+        expect(helper.menu_item_locale(menu_item(:string_caption, caption: "Caption"))).to eq(:en)
+      end
+    end
+
+    it "marks a missing translation as English" do
+      I18n.with_locale(:de) do
+        expect(helper.menu_item_locale(menu_item(:missing_caption, caption: :label_missing_caption))).to eq(:en)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Gantt timeline date file spent full Selenium browser lifecycles checking Moment's locale week numbering and repeated two date outcomes across click and drag interactions.

This stacked batch moves the German and English Moment week-number contracts into a focused Chromium unit spec. It removes two drag scenarios whose persisted date results duplicate retained click scenarios; the browser file still covers click and drag creation, weekday and weekend handling, changing duration, rejected weekend endpoints, `ignore_non_working_days`, non-working-day rendering, hover geometry, the today marker, and configured US/CA timeline headers. A direct `AccessibilityHelper#menu_item_locale` spec now owns the Rails branches that the removed German navigation reached only incidentally.

At seed `26690` with retries disabled, the complete Selenium file improves from **151.3s RSpec / 175.43s wall** for 13 examples to **127.1s / 151.18s** for 9 examples: **16.0% less RSpec time and 13.8% less wall time**. The two frontend replacement examples execute in 66ms after test startup, and the five Ruby helper examples execute in 0.13s after boot.

The matched Ruby coverage pair unions the same helper controls into both reports. Each side covers **69,934 application lines and 1,938 branches**, with zero covered lines or branches lost. Three branch maps differ only for dynamically instrumented branches that remain uncovered on both sides. The 9-example feature file and all seven replacement contracts pass with retries disabled.

This PR is stacked on #25064 and should be reviewed commit-by-commit.
