### PR TITLE
Reduce duplicated BIM navigation coverage

### DIFF
--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "BIM navigation spec", :js, with_config: { edition: "bim" } do
   let(:full_view) { Pages::FullWorkPackage.new(work_package) }
   let(:model_tree) { Components::XeokitModelTree.new }
   let(:destroy_modal) { Components::WorkPackages::DestroyModal.new }
+  let(:model_page) { Pages::IfcModels::ShowDefault.new project }
 
   before do
     login_as user
@@ -61,22 +62,15 @@ RSpec.describe "BIM navigation spec", :js, with_config: { edition: "bim" } do
     before do
       model_page.visit!
       model_page.finished_loading
+      model_page.model_viewer_visible true
+      model_page.model_viewer_shows_a_toolbar true
+      model_page.page_shows_a_toolbar true
+      model_tree.sidebar_shows_viewer_menu true
+      page.find_test_selector("op-wp-card-view")
+      card_view.expect_work_package_listed work_package
     end
 
     context "deep link on the page" do
-      before do
-        model_page.visit!
-        model_page.finished_loading
-
-        # Should be at split view
-        model_page.model_viewer_visible true
-        model_page.model_viewer_shows_a_toolbar true
-        model_page.page_shows_a_toolbar true
-        model_tree.sidebar_shows_viewer_menu true
-        expect(page).to have_test_selector("op-wp-card-view")
-        card_view.expect_work_package_listed work_package
-      end
-
       it "can switch between the different view modes" do
         # Opening details view with info icon
         card_view.click_info_icon(work_package)
@@ -157,15 +151,5 @@ RSpec.describe "BIM navigation spec", :js, with_config: { edition: "bim" } do
     end
   end
 
-  context "on default page" do
-    let(:model_page) { Pages::IfcModels::ShowDefault.new project }
-
-    it_behaves_like "can switch from split to viewer to list-only"
-  end
-
-  context "on show page" do
-    let(:model_page) { Pages::IfcModels::Show.new project, model.id }
-
-    it_behaves_like "can switch from split to viewer to list-only"
-  end
+  it_behaves_like "can switch from split to viewer to list-only"
 end


### PR DESCRIPTION
The BIM navigation feature spec runs the same three browser workflows against both the default model route and an explicit model route. Dedicated feature specs already own the default-route redirect and explicit model-page behavior, so this duplicated browser matrix adds cost without distinct coverage.

This change keeps the navigation workflow on the default model route and retains the existing viewer, toolbar, tree, card-list, view-mode, details, and deletion assertions. The integration base now owns the related determinism repair that re-finds the destroy dialog after its confirmation checkbox rerenders; this PR itself only changes BIM route ownership.

At seed 26690 with retries disabled, the file falls from 6 examples in 110.97s RSpec / 134.81s wall to 3 examples in 51.98s / 76.08s. That is 53.2% less RSpec time and 43.6% less wall time.

The matched coverage selection includes the default-route and explicit-model owner specs plus focused model and API controls. Both reports cover 71,059 application lines and 2,196 branches, with zero covered line or branch loss. The candidate passes retry-free, including the deletion flow with the integration-base dialog repair.
