### PR TITLE
Scope project sidebar feature fixtures

### DIFF
--- a/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_relative "shared_context"
 
 RSpec.describe "Show project custom fields on project overview page", :js do
-  include_context "with seeded projects, members and project custom fields"
+  include_context "with seeded projects, members and project custom fields", seed_all: false
 
   let(:overview_page) { Pages::Projects::Show.new(project) }
 
@@ -41,6 +41,7 @@ RSpec.describe "Show project custom fields on project overview page", :js do
   end
 
   it "does show the project attributes sidebar" do
+    boolean_project_custom_field
     overview_page.visit_page
 
     expect(page).to have_test_selector "project-custom-fields-sidebar"
@@ -48,6 +49,7 @@ RSpec.describe "Show project custom fields on project overview page", :js do
 
   describe "with correct order and scoping" do
     it "shows the project custom field sections in the correct order" do
+      all_fields
       overview_page.visit_page
 
       overview_page.within_project_attributes_sidebar do
@@ -76,6 +78,7 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     it "shows the project custom fields in the correct order within the sections" do
+      all_fields
       overview_page.visit_page
 
       overview_page.within_project_attributes_sidebar do
@@ -140,6 +143,7 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     it "does not show project custom fields not enabled for this project in a sidebar" do
+      boolean_project_custom_field
       create(:string_project_custom_field, projects: [other_project], name: "String field enabled for other project")
 
       overview_page.visit_page
@@ -152,6 +156,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
 
   describe "with correct values" do
     describe "with boolean CF" do
+      before { boolean_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -226,6 +232,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with string CF" do
+      before { string_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -288,6 +296,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with integer CF" do
+      before { integer_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -350,6 +360,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with date CF" do
+      before { date_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -412,6 +424,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with float CF" do
+      before { float_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -474,6 +488,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with text CF" do
+      before { text_project_custom_field }
+
       describe "with value set by user" do
         context "with a value that does not have a line break and spans less than 3 lines" do
           before do
@@ -574,6 +590,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with calculated value CFs", with_ee: %i[calculated_values] do
+      before { calculated_value_fields }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -699,6 +717,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with list CF" do
+      before { list_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -773,6 +793,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with version CF" do
+      before { version_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -822,6 +844,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with user CF" do
+      before { user_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct value for the project custom field if given" do
           overview_page.visit_page
@@ -897,6 +921,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with multi list CF" do
+      before { multi_list_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct values for the project custom field if given" do
           overview_page.visit_page
@@ -958,6 +984,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with multi version CF" do
+      before { multi_version_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct values for the project custom field if given" do
           overview_page.visit_page
@@ -990,6 +1018,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
     end
 
     describe "with multi user CF" do
+      before { multi_user_project_custom_field }
+
       describe "with value set by user" do
         it "shows the correct values for the project custom field if given" do
           overview_page.visit_page

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -179,6 +179,21 @@ RSpec.describe Project, "customizable" do
         end
       end
     end
+
+    describe "#custom_field_changes" do
+      let(:multi_list_custom_field) do
+        create(:list_project_custom_field, multi_value: true, possible_values: ["First", "Second"])
+      end
+
+      it "reports sorted changes for a multi-value field" do
+        project.project_custom_fields << multi_list_custom_field
+        values = multi_list_custom_field.custom_options.reverse.map { it.id.to_s }
+        project.custom_field_values = { multi_list_custom_field.id => values }
+
+        expect(project.custom_field_changes)
+          .to eq(multi_list_custom_field.attribute_name => [[], values.sort])
+      end
+    end
   end
 
   context "when creating with custom field values" do


### PR DESCRIPTION
The project-attributes sidebar feature spec eagerly creates the complete three-section, 15-custom-field, multi-user and multi-version fixture graph before every example. Most scenarios exercise one field, so the setup repeats unrelated database work 53 times.

This change keeps all 53 browser examples and assertions while opting out of broad shared seeding. Each field context creates only the field and associations it exercises; the ordering scenarios still create the complete matrix. A focused project-model example now owns multi-value change tracking that the old broad setup reached incidentally.

At seed 26690 with retries disabled, the file falls from 107.86s RSpec / 131.93s wall to 90.70s / 114.76s. That is 15.9% less RSpec time and 13.0% less wall time. Factory time falls from 21.53s to 8.34s.

Both browser runs pass all 53 examples. With the new model control unioned into both coverage reports, the candidate loses zero covered application lines and zero covered branches.
