### PR TITLE
Reduce repeated project custom field update flows

### DIFF
--- a/spec/controllers/inplace_edit_fields_controller_spec.rb
+++ b/spec/controllers/inplace_edit_fields_controller_spec.rb
@@ -181,6 +181,34 @@ RSpec.describe InplaceEditFieldsController do
       end
     end
 
+    context "when updating a custom field with calculated dependents" do
+      let(:handler) { double(call: true) }
+      let(:custom_field) { create(:integer_project_custom_field, projects: [model]) }
+      let(:attribute) { custom_field.attribute_name.to_sym }
+
+      before do
+        create(
+          :calculated_value_project_custom_field,
+          :skip_validations,
+          formula: "{{cf_#{custom_field.id}}} * 2",
+          projects: [model]
+        )
+        allow(ProjectCustomField).to receive(:visible).and_return(ProjectCustomField.all)
+      end
+
+      it "refreshes dependent fields when stable-key arguments are omitted" do
+        patch :update, params: {
+          model: model_param,
+          id: model.id,
+          attribute:,
+          project: { custom_field_values: { custom_field.id.to_s => "42" } }
+        }, format: :turbo_stream
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("data-inplace-edit-stable-key")
+      end
+    end
+
     context "when no update handler is registered" do
       let(:handler) { nil }
 

--- a/spec/features/projects/project_custom_fields/overview_page/update_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/update_spec.rb
@@ -118,25 +118,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
             expect(page).to have_content "No"
           end
         end
-
-        it "does not change the value if untouched" do
-          custom_field.update!(has_comment: true)
-          overview_page.visit_page
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_content "Yes"
-          end
-
-          open_dialog do |dialog|
-            # don't touch the input
-          end
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_content "Yes"
-          end
-        end
-
-        include_examples "saves custom comment"
       end
 
       shared_examples "saves a custom field input" do
@@ -269,22 +250,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
           end
         end
 
-        it "does not change the value if untouched" do
-          overview_page.visit_page
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_content expected_initial_value
-          end
-
-          open_dialog do |dialog|
-            # don't touch the input
-          end
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_content expected_initial_value
-          end
-        end
-
         it "removes the value properly" do
           overview_page.visit_page
 
@@ -300,8 +265,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
             expect(page).to have_no_text(expected_initial_value)
           end
         end
-
-        include_examples "saves custom comment"
       end
 
       describe "with boolean CF" do
@@ -355,12 +318,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:expected_updated_value) { "Dolor sit" }
 
         it_behaves_like "a rich text custom field input"
-      end
-
-      describe "with calculated CF with comment enabled" do
-        let(:custom_field) { calculated_from_int_project_custom_field }
-
-        include_examples "saves custom comment"
       end
     end
 
@@ -445,8 +402,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
             expect(page).to have_no_text first_option
           end
         end
-
-        include_examples "saves custom comment"
       end
 
       describe "with list CF" do
@@ -550,26 +505,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
       end
 
       shared_examples "an autocomplete multi select field" do
-        it "saves single selected values properly" do
-          custom_field.custom_values.delete_all
-
-          overview_page.visit_page
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_no_text first_option
-          end
-
-          open_field do
-            field.select_option(first_option)
-          end
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_text first_option
-          end
-        end
-
-        include_examples "saves multiple selected values"
-
         it "removes deselected values properly" do
           overview_page.visit_page
 
@@ -584,25 +519,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_no_text first_option
-            expect(page).to have_text second_option
-          end
-        end
-
-        it "does not remove values when not touching the init values" do
-          overview_page.visit_page
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_text first_option
-            expect(page).to have_text second_option
-          end
-
-          open_field do
-            field.expect_selected(first_option, second_option) # wait for proper initialization
-            # don't touch the values
-          end
-
-          overview_page.within_custom_field_container(custom_field) do
-            expect(page).to have_text first_option
             expect(page).to have_text second_option
           end
         end
@@ -653,8 +569,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
             expect(page).to have_text second_option
           end
         end
-
-        include_examples "saves custom comment"
       end
 
       describe "with multi select list CF" do


### PR DESCRIPTION
The project custom-field update feature repeats the same comment, untouched-value, and multi-select persistence paths across field formats. Those extra browser lifecycles add CPU and tail weight while per-format rendering is already owned by component specs.

This PR keeps one browser owner for comments and untouched persistence, retains every distinct scalar/editor/autocomplete interaction and remote principal/version source, and combines the static multi-select's separate one/two-value submissions into its stronger sequential add flow. A focused controller example directly owns calculated-dependent refreshes when stable-key arguments are absent.

At seed 26690 with retries disabled, the feature file falls from 39 to 29 examples:

- RSpec: 136.9s → 115.18s (15.9% faster)
- Wall: 160.99s → 139.12s (13.6% faster)

Validation:

- Reduced feature file: 29 examples, zero failures
- Reduced feature + full controller specs at seed 48909: 43 examples, zero failures
- Matched SimpleCov union with component, controller, and calculated-value model controls: zero lost application lines and zero lost branches
- RuboCop on the new controller contract and layout check on the reduced feature file


Hosted validation on the canonical 24-CPU / 96-GiB `m8azn.6xlarge` runner: [run 33577310296](https://github.com/opf/openproject/actions/runs/33577310296) passed all 51,335 unit and 3,694 feature examples with no exact-ID fallback. The cumulative stacked feature stage finished in **9m53s** and the whole job in about **14m30s**. Seven feature examples used a second RSpec attempt and one reached a third; that retry tax remains included in the measurement.
