### PR TITLE
Reduce project custom field browser matrix

### DIFF
--- a/spec/features/projects/project_custom_fields/overview_page/inputs_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/inputs_spec.rb
@@ -259,50 +259,52 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
     end
 
     describe "with single select fields" do
-      shared_examples "an autocomplete single select field" do |comments: false|
+      shared_examples "an autocomplete single select field" do |comments: false, widget_interactions: true|
         it "shows the correct value if given" do
           field.within_field do
             form_field.expect_selected(expected_initial_value)
           end
         end
 
-        it "shows a blank input if no value or default value is given" do
-          custom_field.custom_values.destroy_all
+        if widget_interactions
+          it "shows a blank input if no value or default value is given" do
+            custom_field.custom_values.destroy_all
 
-          field.within_field do
-            form_field.expect_blank
+            field.within_field do
+              form_field.expect_blank
+            end
           end
-        end
 
-        it "filters the list based on the input" do
-          field.within_field do
-            form_field.search(second_option)
+          it "filters the list based on the input" do
+            field.within_field do
+              form_field.search(second_option)
 
-            form_field.expect_option(second_option)
-            form_field.expect_no_option(first_option)
-            form_field.expect_no_option(third_option)
+              form_field.expect_option(second_option)
+              form_field.expect_no_option(first_option)
+              form_field.expect_no_option(third_option)
+            end
           end
-        end
 
-        it "enables the user to select a single value from a list" do
-          field.within_field do
-            form_field.search(second_option)
-            form_field.select_option(second_option)
+          it "enables the user to select a single value from a list" do
+            field.within_field do
+              form_field.search(second_option)
+              form_field.select_option(second_option)
 
-            form_field.expect_selected(second_option)
+              form_field.expect_selected(second_option)
 
-            form_field.search(third_option)
-            form_field.select_option(third_option)
+              form_field.search(third_option)
+              form_field.select_option(third_option)
 
-            form_field.expect_selected(third_option)
-            form_field.expect_not_selected(second_option)
+              form_field.expect_selected(third_option)
+              form_field.expect_not_selected(second_option)
+            end
           end
-        end
 
-        it "clears the input if clicked on the clear button" do
-          field.within_field do
-            form_field.clear
-            form_field.expect_blank
+          it "clears the input if clicked on the clear button" do
+            field.within_field do
+              form_field.clear
+              form_field.expect_blank
+            end
           end
         end
 
@@ -332,7 +334,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:second_option) { second_version.name }
         let(:third_option) { third_version.name }
 
-        it_behaves_like "an autocomplete single select field"
+        it_behaves_like "an autocomplete single select field", widget_interactions: false
 
         describe "with correct version scoping" do
           context "with a version on a different project" do
@@ -395,7 +397,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:second_option) { another_member_in_project.name }
         let(:third_option) { one_more_member_in_project.name }
 
-        it_behaves_like "an autocomplete single select field", comments: true
+        it_behaves_like "an autocomplete single select field", comments: true, widget_interactions: false
 
         describe "with correct user scoping" do
           let!(:member_in_other_project) do
@@ -461,68 +463,70 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
     end
 
     describe "with multi select fields" do
-      shared_examples "an autocomplete multi select field" do |comments: false|
+      shared_examples "an autocomplete multi select field" do |comments: false, widget_interactions: true|
         it "shows the correct value if given" do
           field.within_field do
             form_field.expect_selected(*expected_initial_value)
           end
         end
 
-        it "shows a blank input if no value or default value is given" do
-          custom_field.custom_values.destroy_all
+        if widget_interactions
+          it "shows a blank input if no value or default value is given" do
+            custom_field.custom_values.destroy_all
 
-          field.within_field do
-            form_field.expect_blank
+            field.within_field do
+              form_field.expect_blank
+            end
           end
-        end
 
-        it "filters the list based on the input" do
-          field.within_field do
-            form_field.search(second_option)
+          it "filters the list based on the input" do
+            field.within_field do
+              form_field.search(second_option)
 
-            form_field.expect_option(second_option)
-            form_field.expect_no_option(first_option)
-            form_field.expect_no_option(third_option)
+              form_field.expect_option(second_option)
+              form_field.expect_no_option(first_option)
+              form_field.expect_no_option(third_option)
+            end
           end
-        end
 
-        it "allows to select multiple values" do
-          custom_field.custom_values.destroy_all
+          it "allows to select multiple values" do
+            custom_field.custom_values.destroy_all
 
-          field.within_field do
-            form_field.select_option(second_option)
-            form_field.select_option(third_option)
+            field.within_field do
+              form_field.select_option(second_option)
+              form_field.select_option(third_option)
 
-            form_field.expect_selected(second_option)
-            form_field.expect_selected(third_option)
+              form_field.expect_selected(second_option)
+              form_field.expect_selected(third_option)
+            end
           end
-        end
 
-        it "allows to remove selected values" do
-          custom_field.custom_values.destroy_all
+          it "allows to remove selected values" do
+            custom_field.custom_values.destroy_all
 
-          field.within_field do
-            form_field.select_option(second_option)
-            form_field.select_option(third_option)
+            field.within_field do
+              form_field.select_option(second_option)
+              form_field.select_option(third_option)
 
-            form_field.deselect_option(third_option)
+              form_field.deselect_option(third_option)
 
-            form_field.expect_selected(second_option)
-            form_field.expect_not_selected(third_option)
+              form_field.expect_selected(second_option)
+              form_field.expect_not_selected(third_option)
+            end
           end
-        end
 
-        it "allows to remove all selected values at once" do
-          custom_field.custom_values.destroy_all
+          it "allows to remove all selected values at once" do
+            custom_field.custom_values.destroy_all
 
-          field.within_field do
-            form_field.select_option(second_option)
-            form_field.select_option(third_option)
+            field.within_field do
+              form_field.select_option(second_option)
+              form_field.select_option(third_option)
 
-            form_field.clear
+              form_field.clear
 
-            form_field.expect_not_selected(second_option)
-            form_field.expect_not_selected(third_option)
+              form_field.expect_not_selected(second_option)
+              form_field.expect_not_selected(third_option)
+            end
           end
         end
 
@@ -552,7 +556,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:second_option) { second_version.name }
         let(:third_option) { third_version.name }
 
-        it_behaves_like "an autocomplete multi select field"
+        it_behaves_like "an autocomplete multi select field", widget_interactions: false
 
         describe "with correct version scoping" do
           context "with a version on a different project" do
@@ -615,7 +619,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:second_option) { another_member_in_project.name }
         let(:third_option) { one_more_member_in_project.name }
 
-        it_behaves_like "an autocomplete multi select field", comments: true
+        it_behaves_like "an autocomplete multi select field", comments: true, widget_interactions: false
 
         describe "with correct user scoping" do
           let!(:member_in_other_project) do

--- a/spec/forms/custom_fields/inputs/single_version_select_list_spec.rb
+++ b/spec/forms/custom_fields/inputs/single_version_select_list_spec.rb
@@ -43,4 +43,12 @@ RSpec.describe CustomFields::Inputs::SingleVersionSelectList, type: :forms do
       expect(autocompleter["data-model"]).to be_json_eql(%{{"name": "Version 26"}}).excluding("group_by", "selected", "disabled")
     end
   end
+
+  context "with a blank stored value" do
+    before { model.custom_field_values.first.value = nil }
+
+    it "renders no selected version" do
+      expect(rendered_form.find("opce-autocompleter")["data-model"]).to be_json_eql("null")
+    end
+  end
 end


### PR DESCRIPTION
The project custom-field overview spec repeats the same generic autocomplete mechanics for local lists, versions, and users in both single and multi modes. This makes one of the slowest feature files pay for 18 browser lifecycles that do not add a distinct domain rule.

This change keeps the full blank, filtering, selection, deselection, and clear contract on the local single/multi list widgets. Version and user fields still cover their selected values, remote/source behavior, project and status scoping, comments, permissions, groups, placeholders, and the distinct multi-value group/placeholder flows. It also adds a fast form-level blank-value contract for the single-version input.

Validation:

- 49 retained feature examples pass with retries disabled at seed 27182; the control had 67.
- RSpec time: 2m42.4s to 1m53.4s (30.2% faster).
- Process wall: 3m07.2s to 2m17.6s (26.5% faster).
- 12 single/multi version form examples pass in 2.52s after boot.
- Matched SimpleCov line/branch identity comparison plus the replacement form specs loses zero application lines and zero branches.
- RuboCop passes both changed files.

This PR is stacked on #25068 and should be reviewed after it.
