### PR TITLE
Reduce work package meetings browser coverage

### DIFF
--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -638,20 +638,8 @@ RSpec.describe "Open the Meetings tab",
 
         context "when testing section selection behaviour" do
           shared_let(:meeting_without_sections) { create(:meeting, project:, start_time: 1.hour.from_now) }
-          shared_let(:meeting_with_sections) do
-            create(:meeting, project:, start_time: 2.hours.from_now).tap do |meeting|
-              create(:meeting_section, meeting:, title: "Section 1")
-              create(:meeting_section, meeting:, title: "Section 2")
-            end
-          end
           shared_let(:recurring_meeting) do
             create(:recurring_meeting, project:)
-          end
-          shared_let(:empty_recurring_meeting_occurrence) do
-            create(:recurring_meeting_occurrence,
-                   project:,
-                   recurring_meeting:,
-                   start_time: 3.hours.from_now)
           end
           shared_let(:recurring_meeting_occurrence) do
             create(:recurring_meeting_occurrence,
@@ -663,77 +651,20 @@ RSpec.describe "Open the Meetings tab",
             end
           end
 
-          it "automatically selects the backlog for one-time meetings without sections" do
-            check_section_auto_selection(meeting_without_sections, "Agenda backlog")
-          end
-
-          it "automatically selects the backlog for one-time meetings with sections" do
-            check_section_auto_selection(meeting_with_sections, "Agenda backlog")
-          end
-
-          it "automatically selects the last section for recurring meeting occurrences that is not the series backlog" do
-            last_section = recurring_meeting_occurrence.sections.last.title
-            check_section_auto_selection(recurring_meeting_occurrence, last_section)
-          end
-
-          it "always has the series backlog as a manually selectable option" do
-            work_package_page.visit!
-            switch_to_meetings_tab
-
-            meetings_tab.open_add_to_meeting_dialog
-
-            fill_in("meeting_agenda_item_meeting_id", with: recurring_meeting_occurrence.title)
-            page.find(".ng-option-marked", text: recurring_meeting_occurrence.title)
-            page.find(".ng-option-marked").click
-
-            wait_for_network_idle
-
-            section_field = find_field("meeting_agenda_item_meeting_section_id")
-            section_field.click
-
-            expect(page).to have_css(".ng-option", text: "Series backlog")
-          end
-
-          it "shows the automatically created untitled section when no sections exist for recurring meeting occurrences" do
-            meeting = empty_recurring_meeting_occurrence
-
-            check_section_auto_selection(meeting, "Untitled section")
-          end
-
           it "updates section selection when switching between meetings" do
             work_package_page.visit!
             switch_to_meetings_tab
 
             meetings_tab.open_add_to_meeting_dialog
 
-            retry_block do
-              fill_in("meeting_agenda_item_meeting_id", with: recurring_meeting_occurrence.title)
-              page.find(".ng-option-marked", text: recurring_meeting_occurrence.title)
-              page.find(".ng-option-marked").click
+            meetings_tab.select_meeting(recurring_meeting_occurrence)
 
-              wait_for_network_idle
+            last_section = recurring_meeting_occurrence.sections.last
+            expect(page).to have_text(last_section.title)
 
-              last_section = recurring_meeting_occurrence.sections.last
-              expect(page).to have_text(last_section.title)
+            meetings_tab.select_meeting(meeting_without_sections)
 
-              fill_in("meeting_agenda_item_meeting_id", with: meeting_without_sections.title)
-              page.find(".ng-option-marked", text: meeting_without_sections.title)
-              page.find(".ng-option-marked").click
-
-              wait_for_network_idle
-
-              expect(page).to have_text("Agenda backlog")
-            end
-          end
-
-          it "shows section autocompleter as disabled when no meeting is selected" do
-            work_package_page.visit!
-            switch_to_meetings_tab
-
-            meetings_tab.open_add_to_meeting_dialog
-
-            page.find_field("meeting_agenda_item_meeting_section_id", disabled: true, visible: false)
-            expect(page).to have_text("Meeting selection is required first")
+            expect(page).to have_text("Agenda backlog")
           end
         end
       end
@@ -743,7 +674,12 @@ RSpec.describe "Open the Meetings tab",
   describe "work package split view" do
     let(:work_package_page) { Pages::SplitWorkPackage.new(work_package) }
 
-    it_behaves_like "meetings tab integration"
+    it "renders the meetings tab" do
+      work_package_page.visit!
+      work_package_page.switch_to_tab(tab: "meetings")
+
+      meetings_tab.expect_tab_content_rendered
+    end
   end
 
   private
@@ -751,23 +687,5 @@ RSpec.describe "Open the Meetings tab",
   def switch_to_meetings_tab
     work_package_page.switch_to_tab(tab: "meetings")
     meetings_tab.expect_tab_content_rendered # wait for the tab to be rendered
-  end
-
-  def check_section_auto_selection(meeting, expected_section)
-    work_package_page.visit!
-    switch_to_meetings_tab
-
-    meetings_tab.open_add_to_meeting_dialog
-
-    fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
-    page.find(".ng-option-marked", text: meeting.title)
-    page.find(".ng-option-marked").click
-
-    wait_for_network_idle
-
-    section_field = find_field("meeting_agenda_item_meeting_section_id")
-    expect(section_field).not_to be_disabled
-
-    expect(page).to have_css(".ng-value-label", text: expected_section)
   end
 end

--- a/modules/meeting/spec/forms/meeting/add_to_section_spec.rb
+++ b/modules/meeting/spec/forms/meeting/add_to_section_spec.rb
@@ -39,8 +39,19 @@ RSpec.describe Meeting::AddToSection, type: :forms do
   let(:params) { {} }
 
   def section_option_names
-    expect(page).to have_css("opce-autocompleter")
-    JSON.parse(page.find("opce-autocompleter")["data-items"]).map { |o| o["name"] }
+    autocompleter_items.map { |item| item["name"] }
+  end
+
+  def selected_section_name
+    JSON.parse(autocompleter["data-model"])&.fetch("name")
+  end
+
+  def autocompleter_items
+    JSON.parse(autocompleter["data-items"])
+  end
+
+  def autocompleter
+    page.find("opce-autocompleter")
   end
 
   # Sections must be created inside `let(:model)` so they exist when the form is evaluated.
@@ -59,6 +70,7 @@ RSpec.describe Meeting::AddToSection, type: :forms do
     it "lists named sections and the backlog, without a placeholder" do
       expect(section_option_names).to include("Section A", "Section B", "Agenda backlog")
       expect(section_option_names).not_to include("Untitled section")
+      expect(selected_section_name).to eq("Agenda backlog")
     end
   end
 
@@ -70,6 +82,7 @@ RSpec.describe Meeting::AddToSection, type: :forms do
 
     it "inserts an untitled placeholder before the backlog" do
       expect(section_option_names).to eq(["Untitled section", "Agenda backlog"])
+      expect(selected_section_name).to eq("Agenda backlog")
     end
   end
 
@@ -80,12 +93,50 @@ RSpec.describe Meeting::AddToSection, type: :forms do
       create(:meeting_agenda_item, meeting: recurring_meeting.template)
     end
     let(:params) do
-      recurring_meeting = model.meeting.recurring_meeting
-      { occurrence: recurring_meeting.meetings.where(template: false).first }
+      { occurrence: model.meeting.recurring_meeting.meetings.find_by!(template: false) }
+    end
+
+    it "inserts an untitled placeholder for the occurrence" do
+      expect(section_option_names).to contain_exactly("Untitled section")
+      expect(selected_section_name).to eq("Untitled section")
+    end
+  end
+
+  context "when a recurring occurrence with no named sections is selected" do
+    let(:model) do
+      recurring_meeting = create(:recurring_meeting, project:, author: user)
+      occurrence = create(:recurring_meeting_occurrence, project:, recurring_meeting:)
+      create(:meeting_agenda_item, meeting: occurrence)
     end
 
     it "inserts an untitled placeholder before the series backlog" do
-      expect(section_option_names).to include("Untitled section")
+      expect(section_option_names).to contain_exactly("Untitled section", "Series backlog")
+      expect(selected_section_name).to eq("Untitled section")
+    end
+  end
+
+  context "when an occurrence with named sections is given" do
+    let(:model) do
+      recurring_meeting = create(:recurring_meeting, project:, author: user)
+      occurrence = create(:recurring_meeting_occurrence, project:, recurring_meeting:)
+      create(:meeting_section, meeting: occurrence, title: "Section A")
+      create(:meeting_section, meeting: occurrence, title: "Section B")
+      create(:meeting_agenda_item, meeting: occurrence)
+    end
+
+    it "lists the occurrence sections and series backlog and selects the last section" do
+      expect(section_option_names).to contain_exactly("Section A", "Section B", "Series backlog")
+      expect(selected_section_name).to eq("Section B")
+    end
+  end
+
+  context "when no meeting is selected" do
+    let(:model) { build(:meeting_agenda_item, meeting: nil) }
+
+    it "disables the section autocompleter and explains the prerequisite" do
+      expect(autocompleter["data-disabled"]).to be_json_eql(true)
+      expect(autocompleter["data-placeholder"])
+        .to be_json_eql(I18n.t("placeholder_section_select_meeting_first").to_json)
     end
   end
 end

--- a/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
+++ b/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
@@ -98,14 +98,18 @@ module Pages
     end
 
     def fill_and_submit_meeting_dialog(meeting, notes, counter)
-      fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
-      wait_for_turbo_stream do
-        page.find(".ng-option-marked", text: meeting.title).click
-      end
+      select_meeting(meeting)
       page.find(".ck-editor__editable").set(notes)
 
       wait_for_turbo_stream { click_on("Save") }
       expect_upcoming_counter_to_be(counter)
+    end
+
+    def select_meeting(meeting)
+      fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
+      wait_for_turbo_stream do
+        page.find(".ng-option-marked", text: meeting.title).click
+      end
     end
 
     private


### PR DESCRIPTION
## Why

The work package meetings feature spec repeated the same integration scenarios in full-page and split-view layouts, and exercised section-option rules through Chrome even though those rules are rendered by `Meeting::AddToSection`. This made one of the feature suite's expensive files slower and left a meeting-switch scenario dependent on a manual retry and a broad network-idle wait.

## What changed

- Keep the complete meetings-tab integration workflow on the full work package page.
- Keep a distinct split-view render check without repeating all shared scenarios.
- Move section options, automatic selection, series backlog, empty-occurrence, and disabled-state coverage into six focused form specs.
- Keep the meeting-switch interaction as a browser example.
- Synchronize meeting selection on its exact Turbo Stream response and remove the manual retry.

## Result

On the same host at seed `27182`, with RSpec retries disabled:

- control: 39 browser examples, 2m17.1 RSpec / 2m41.4 process wall
- candidate: 29 browser + 6 form examples, 1m39.3 RSpec / 2m03.7 process wall
- change: 27.6% less RSpec time / 23.3% less wall time

The candidate completed all 35 examples without failures. A Ruby line-and-branch coverage union of the reduced browser cohort and the six form specs versus the original feature and form cohorts lost 0 application lines and 0 branches. This does not measure JavaScript coverage or assertion semantics.

## Validation

- exact 35-example candidate, retries disabled: 0 failures
- `bin/dirty-rubocop --uncommitted`
- `git diff --check`

Stacked on #25069.
