### PR TITLE
Remove retry races from browser feature helpers

### DIFF
--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -163,11 +163,8 @@ module Pages::Meetings
 
     def assert_agenda_order!(*titles)
       wait_for_network_idle
-
-      retry_block do
-        found = page.all(:test_id, "op-meeting-agenda-title").map(&:text)
-        raise "Expected order of agenda items #{titles.inspect}, but found #{found.inspect}" if titles != found
-      end
+      expect(page).to have_test_selector("op-meeting-agenda-title", count: titles.size)
+      expect(page.all(:test_id, "op-meeting-agenda-title").map(&:text)).to eq(titles)
     end
 
     def remove_agenda_item(item)

--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "My page",
 
     # Waits for the default view to be created
     # Waits for the default view to be created
-    my_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
 
     assigned_area.expect_to_exist
     created_area.expect_to_exist
@@ -167,7 +167,7 @@ RSpec.describe "My page",
     # that widgets that have been there are moved down
     created_area.drag_to(1, 3)
 
-    my_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
 
     reload_grid!
 
@@ -182,7 +182,7 @@ RSpec.describe "My page",
     # as no more widgets start in the second column, that column is removed
     news_area.drag_to(1, 3)
 
-    my_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
 
     reload_grid!
 

--- a/spec/features/admin/custom_fields/work_packages/multi_value_list_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/multi_value_list_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Multi-value custom fields creation", :js, :selenium do
 
     click_on "Save"
 
-    index_cf_page.expect_and_dismiss_flash(message: "Successful update.")
+    index_cf_page.expect_and_dismiss_all_flashes(message: "Successful update.")
 
     # Edit again
     expect(page).to have_field("custom_field_custom_options_attributes_0_value", with: "B")

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -344,9 +344,7 @@ RSpec.describe "Working Days", :js do
         expect(page).to have_css("tr", text: nwd.date.strftime("%B %-d, %Y"))
       end
 
-      delete_button = page.first(".op-non-working-days-list--delete-icon .icon-delete", visible: :all)
-      delete_button.hover
-      delete_button.click
+      page.first(".op-non-working-days-list--delete-icon", visible: :all).trigger("click")
 
       click_on "Apply changes"
 
@@ -366,9 +364,7 @@ RSpec.describe "Working Days", :js do
               .and_return(errors)
       # rubocop:enable RSpec/AnyInstance
 
-      delete_button = page.first(".op-non-working-days-list--delete-icon .icon-delete", visible: :all)
-      delete_button.hover
-      delete_button.click
+      page.first(".op-non-working-days-list--delete-icon", visible: :all).trigger("click")
 
       click_on "Apply changes"
 

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "as an accessible inplace editor" do
   it "triggers edit mode on RETURN key" do
     scroll_to_element(field.display_element)
 
-    field.display_element.native.send_keys(:return)
+    field.display_element.send_keys(:return)
     expect(field).to be_editing
     field.cancel_by_escape
   end

--- a/spec/features/work_packages/generate_pdf_spec.rb
+++ b/spec/features/work_packages/generate_pdf_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe "work package generate PDF dialog", :js do
 
     it "downloads with options" do
       check("Hyphenation")
+      expect(page).to have_checked_field("Hyphenation")
       select "Deutsch", from: "hyphenation_language"
       fill_in "footer_text", with: "Custom Footer Text"
       generate!

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -118,14 +118,10 @@ module Components
       end
 
       def switch_to(target)
-        # Switching too fast may result in the click handler not yet firing
-        # so wait a bit initially
         SeleniumHubWaiter.wait unless using_cuprite?
 
-        retry_block do
-          find("#{selector} .op-tab-row--link", text: target.upcase, wait: 2).click
-          selected_tab(target)
-        end
+        find("#{selector} .op-tab-row--link", text: target.upcase, wait: 10).click
+        selected_tab(target)
       end
 
       def selector

--- a/spec/support/flash/expectations.rb
+++ b/spec/support/flash/expectations.rb
@@ -18,6 +18,21 @@ module Flash
       expect_no_flash(type:, message:, exact_message:, wait: 5)
     end
 
+    def expect_and_dismiss_all_flashes(message: nil, exact_message: nil, type: :success, wait: 20)
+      expect_flash(type:, message:, exact_message:, wait:)
+      expected_css = expected_flash_css(type)
+
+      while page.has_css?(expected_css, wait: 1, **{ text: message, exact_text: exact_message }.compact)
+        page.document.synchronize do
+          page.first(expected_css, **{ text: message, exact_text: exact_message }.compact)
+            .find(".Banner-close button") # rubocop:disable Capybara/SpecificActions
+            .click
+        end
+      end
+
+      expect_no_flash(type:, message:, exact_message:, wait: 2)
+    end
+
     def dismiss_flash!
       page.find(".Banner-close button").click # rubocop:disable Capybara/SpecificActions
     end


### PR DESCRIPTION
## Why

The latest canonical hosted gate passed in 9m46 but still paid for five whole-example retries and two shared manual retry loops. The failures exposed replaceable notification elements, incomplete rendered collections, a zero-size icon hit target, a PDF checkbox click that had not taken effect before submit, and a Selenium call that bypassed Capybara stale-element recovery.

## What changed

- Trigger non-working-day deletion through the component anchor's click event instead of hovering and clicking its zero-size icon.
- Send RETURN through the Capybara element so stale Selenium nodes are re-found.
- Dismiss all matching My Page toasts and add a replacement-safe helper for repeated Primer flashes.
- Assert the PDF hyphenation checkbox is checked before downloading.
- Wait up to the normal UI boundary for configuration tabs instead of manually retrying the whole interaction.
- Wait for the complete agenda-title collection before asserting its order instead of manually retrying.

No fixed sleeps or new RSpec retries are added.

## Validation

With `RSPEC_RETRY_RETRY_COUNT=0`:

- the six exact hosted whole-example retry/manual-retry owners pass at seeds `15188` and `64003`;
- the Selenium RETURN-key accessibility contract passes at both seeds;
- the two initially reproduced notification/non-working-day issues pass after re-finding/triggering fixes;
- `git diff --check` passes;
- RuboCop reports no offenses on changed lines. The repository's `bin/dirty-rubocop --uncommitted` exits 2 without reporting offenses under the current local RuboCop 1.89/Ruby 4.0 environment, so the same eight files were checked directly and only pre-existing offenses outside this diff remain.

Stacked on #25070.


## Hosted validation

Run [33586661693](https://github.com/opf/openproject/actions/runs/33586661693) passed the cumulative stack on the pinned 24-CPU / 96-GiB runner. The warm minified build took 13.197s, units passed 51,339 examples in 2m24.4s, and features passed 3,666 examples in **9m44s** with no exact-ID fallback. All seven retry/manual-retry patterns targeted by this PR disappeared. Seven different whole examples and two different shared retry blocks now define the next determinism queue.
