### PR TITLE
Scope Team Planner work package fixtures

### DIFF
--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe "Team planner",
                view_work_packages edit_work_packages view_team_planner manage_team_planner
              ] })
     end
-    let!(:user_outside_project) { create(:user, firstname: "Not", lastname: "In Project") }
+    let(:user_outside_project) { create(:user, firstname: "Not", lastname: "In Project") }
     let(:type_task) { create(:type_task) }
     let(:type_bug) { create(:type_bug) }
     let(:closed_status) { create(:status, is_closed: true) }
 
-    let!(:other_task) do
+    let(:other_task) do
       create(:work_package,
              project:,
              type: type_task,
@@ -86,7 +86,7 @@ RSpec.describe "Team planner",
              due_date: Time.zone.today.monday + 3.days,
              subject: "A task for the other user")
     end
-    let!(:other_bug) do
+    let(:other_bug) do
       create(:work_package,
              project:,
              type: type_bug,
@@ -95,7 +95,7 @@ RSpec.describe "Team planner",
              due_date: Time.zone.today.monday + 3.days,
              subject: "Another task for the other user")
     end
-    let!(:closed_bug) do
+    let(:closed_bug) do
       create(:work_package,
              project:,
              type: type_bug,
@@ -105,7 +105,7 @@ RSpec.describe "Team planner",
              due_date: Time.zone.today.monday + 3.days,
              subject: "Closed bug")
     end
-    let!(:user_bug) do
+    let(:user_bug) do
       create(:work_package,
              project:,
              type: type_bug,
@@ -114,7 +114,7 @@ RSpec.describe "Team planner",
              due_date: Time.zone.today + 20.days,
              subject: "A task for the logged in user")
     end
-    let!(:user_bug_next_week) do
+    let(:user_bug_next_week) do
       create(:work_package,
              project:,
              type: type_bug,
@@ -123,7 +123,7 @@ RSpec.describe "Team planner",
              due_date: Time.zone.today.monday + 12.days,
              subject: "A task for the logged in user in the next week")
     end
-    let!(:user_bug_last_week) do
+    let(:user_bug_last_week) do
       create(:work_package,
              project:,
              type: type_bug,
@@ -132,7 +132,7 @@ RSpec.describe "Team planner",
              due_date: Time.zone.today.monday - 5.days,
              subject: "A task for the logged in user in the last week")
     end
-    let!(:user_bug_on_weekend) do
+    let(:user_bug_on_weekend) do
       create(:work_package,
              project:,
              type: type_bug,
@@ -142,12 +142,20 @@ RSpec.describe "Team planner",
              subject: "A task for the logged in user on the weekend")
     end
 
-    before do
+    def prepare_project_types
       project.project_types.create!(type: type_bug)
       project.project_types.create!(type: type_task)
     end
 
+    def prepare_work_package_matrix
+      prepare_project_types
+
+      [other_task, other_bug, closed_bug, user_bug, user_bug_next_week, user_bug_last_week, user_bug_on_weekend]
+        .each(&:id)
+    end
+
     it "renders a team planner displaying work packages by assignee and date" do
+      prepare_work_package_matrix
       team_planner.visit!
 
       team_planner.title
@@ -302,6 +310,8 @@ RSpec.describe "Team planner",
       end
 
       it "renders assignees and assignee dropdown correctly" do
+        prepare_project_types
+        other_task.id
         team_planner.visit!
         team_planner.wait_for_loaded
 

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -86,13 +86,9 @@ module Pages
     end
 
     def switch_view_mode(text)
-      retry_block do
-        find('[data-test-selector="op-team-planner--view-select-dropdown"]').click
-
-        within("#op-team-planner--view-select-dropdown") do
-          click_button(text)
-        end
-      end
+      expect(page).to have_no_css("#op-team-planner--view-select-dropdown")
+      find('[data-test-selector="op-team-planner--view-select-dropdown"]').click
+      find("#op-team-planner--view-select-dropdown .menu-item", exact_text: text).click
 
       expect_view_mode(text)
     end


### PR DESCRIPTION
## Why

`team_planner_spec.rb` eagerly created a seven-work-package date/type matrix before every assignee scenario. Only the calendar-rendering scenario needs that matrix; the assignee controls otherwise paid for unrelated factories, API serialization, and calendar payload. Its view-mode helper also retried the complete click sequence instead of waiting for the old menu to close and the new menu to open.

## What changed

- Make the seven dated work packages lazy and create the complete matrix only for the rendering scenario.
- Retain one work package for the pagination/save scenario because query creation requires a complete work-package schema.
- Keep all six browser examples and every assertion unchanged.
- Replace the view-mode manual retry with explicit menu close/open readiness.
- Keep the file on Selenium. A Cuprite screen was rejected after the Angular context-menu option was replaced during the second switch in four retry-free variants.

## Result

Two matched fixed-seed pairs with `RSPEC_RETRY_RETRY_COUNT=0`:

- seed `27182`: 1m20.95s → 1m16.61s RSpec; 1m45.15s → 1m40.78s wall
- seed `64003`: 1m19.32s → 1m17.06s RSpec; 1m43.94s → 1m41.40s wall
- mean: 4.1% less RSpec time and 3.3% less wall time

Both matched SimpleCov runs passed all six examples. Exact application line and branch identities report 0 lost lines, 0 gained lines, 0 lost branches, and 0 gained branches.

The two other feature owners of `switch_view_mode` pass together at seed `64003` with retries disabled.

Stacked on #25071.
