### PR TITLE
Replace retry loops with DOM readiness waits

### DIFF
--- a/spec/features/admin/backup_spec.rb
+++ b/spec/features/admin/backup_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe "backup", :js, :selenium do
 
     expect(page).to have_content /#{I18n.t('js.backup.title')}/i
 
-    click_on I18n.t("backup.label_delete_token")
-
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      click_on I18n.t("backup.label_delete_token")
+    end
 
     expect(page).to have_content I18n.t("backup.text_token_deleted")
 

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
     it "executes the custom action (Regression#49588)" do
       login_as(user)
       wp_table.visit_query(query)
+      wp_table.expect_work_package_listed(work_package)
       wp_page = wp_table.open_full_screen_by_link(work_package)
 
       wp_page.ensure_page_loaded

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -27,8 +27,7 @@ module Components::Autocompleter
         end
       end
 
-      # Wait for options to be refreshed after having entered some text.
-      expect(resolve_autocomplete(element)).to have_no_css(".ng-spinner-loader", wait:)
+      wait_for_selenium_autocomplete(element, wait:)
 
       # probably not necessary anymore
       sleep(0.5) unless using_cuprite?
@@ -197,6 +196,12 @@ module Components::Autocompleter
 
     def resolve_autocomplete(element)
       element.respond_to?(:call) ? element.call : element
+    end
+
+    def wait_for_selenium_autocomplete(element, wait:)
+      return if using_cuprite?
+
+      expect(resolve_autocomplete(element)).to have_no_css(".ng-spinner-loader", wait:)
     end
 
     def expect_current_autocompleter_value(element, value)

--- a/spec/support/components/common/submenu.rb
+++ b/spec/support/components/common/submenu.rb
@@ -63,14 +63,18 @@ module Components
     end
 
     def expect_item_with_count(item, count)
-      within page.find_test_selector("op-submenu--item-action", text: item) do
-        expect_count count
+      page.document.synchronize do
+        page
+          .find_test_selector("op-submenu--item-action", text: item)
+          .find("[data-test-selector='op-submenu--item-count']", exact_text: count.to_s)
       end
     end
 
     def expect_item_with_no_count(item)
-      within page.find_test_selector("op-submenu--item-action", text: item) do
-        expect_no_count
+      page.document.synchronize do
+        page
+          .find_test_selector("op-submenu--item-action", text: item)
+          .assert_no_selector("[data-test-selector='op-submenu--item-count']")
       end
     end
 

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -402,16 +402,19 @@ module Components
       end
 
       def set_journal_sorting(sorting, default_filter: :all)
-        retry_block do
-          menu_button = page.find_test_selector("op-wp-journals-sorting-menu")
-          action_menu = menu_button.find(:xpath, "./ancestor::action-menu")
-          wait_for { action_menu["data-ready"] }.to eq("true")
+        option_selector = "[data-test-selector='op-wp-journals-sorting-#{sorting}']"
 
-          menu_button.click
-          sorting_option = page.find_test_selector("op-wp-journals-sorting-#{sorting}")
-          sorting_option.click
-          expect(page).to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")
+        page.document.synchronize do
+          unless page.has_css?(option_selector, wait: 0)
+            page.find(
+              "action-menu[data-ready='true'] [data-test-selector='op-wp-journals-sorting-menu']"
+            ).click
+          end
+
+          page.find(option_selector).click
         end
+
+        expect(page).to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")
       end
 
       def trigger_update_streams_poll

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -102,7 +102,7 @@ class DateEditField < EditField
   def activate!(expect_open: true)
     unless active?(wait: 0)
       SeleniumHubWaiter.wait unless using_cuprite?
-      scroll_to_and_click(display_trigger_element, block: :nearest)
+      scroll_to_and_click(block: :nearest) { display_trigger_element }
       SeleniumHubWaiter.wait unless using_cuprite?
     end
 

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -6,8 +6,7 @@ class EditField
   include RSpec::Matchers
   include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 
-  attr_reader :context,
-              :property_name,
+  attr_reader :property_name,
               :selector
 
   attr_accessor :field_type
@@ -38,6 +37,10 @@ class EditField
 
   def create_form?
     @create_form
+  end
+
+  def context
+    @context.respond_to?(:call) ? @context.call : @context
   end
 
   def visible_on_create_form?
@@ -145,7 +148,7 @@ class EditField
   end
 
   def active?
-    @context.has_selector? "#{@selector} #{input_selector}", wait: 1
+    context.has_selector? "#{@selector} #{input_selector}", wait: 1
   end
 
   alias :editing? :active?
@@ -166,7 +169,7 @@ class EditField
   end
 
   def expect_enabled!
-    expect(@context).to have_no_css "#{@selector} #{input_selector}[disabled]", wait: 10
+    expect(context).to have_no_css "#{@selector} #{input_selector}[disabled]", wait: 10
   end
 
   def expect_invalid

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -242,7 +242,7 @@ module Pages
       when /customField(\d+)$/
         work_package_custom_field(key, $1)
       when :date, :startDate, :dueDate, :combinedDate
-        DateEditField.new container, key, is_milestone: work_package&.milestone?
+        DateEditField.new -> { container }, key, is_milestone: work_package&.milestone?
       when :estimatedTime, :remainingTime, :percentageDone, :statusWithinProgressModal
         ProgressEditField.new container, key, create_form: create_page?
       when :description

--- a/spec/support/shared/scroll_into_view_helpers.rb
+++ b/spec/support/shared/scroll_into_view_helpers.rb
@@ -45,10 +45,11 @@ def scroll_to_element(element, block: :start, inline: :nearest)
   end
 end
 
-def scroll_to_and_click(element, block: :start, inline: :nearest)
-  retry_block do
-    scroll_to_element(element, block:, inline:)
-    element.click
+def scroll_to_and_click(element = nil, block: :start, inline: :nearest)
+  page.document.synchronize do
+    current_element = block_given? ? yield : element
+    scroll_to_element(current_element, block:, inline:)
+    current_element.click
   end
 end
 


### PR DESCRIPTION
The latest cumulative 24-CPU hosted run passed in 9m44 but paid for seven whole-example retries and two shared manual retry loops. Five failures came from interacting through retained nodes or before an asynchronous UI boundary was observable.

This PR replaces those retry paths with DOM readiness:

- re-finds the date editor trigger inside Capybara synchronization after Angular replaces it;
- re-finds notification submenu items while Turbo updates their counters;
- waits for the ready activity sorting action menu and re-finds its option;
- uses Capybara's confirm lifecycle for backup-token deletion;
- waits for the asynchronous query row before opening the custom-action work package.

No sleeps or retry loops are added. The board dropdown retry remains outside this PR because the legacy Angular directive exposes no reliable handler-readiness signal; the local reproduction passed, so hiding it behind another retry would not establish determinism.

Validation:

- The four original failing examples pass together with `RSPEC_RETRY_RETRY_COUNT=0` at seed 64003.
- The notification case passes independently at hosted seed 18934.
- A broader 13-example cohort covering all activity-sort callers, the full notification submenu spec, date editing, backup deletion, and custom-action row loading passed every changed interaction at seed 18934. Its sole failure was the unchanged backup-download example because the native diagnostic host does not have `pg_dump`; the changed backup-delete example passed in both focused runs.
- Ruby syntax, `git diff --check`, and RuboCop on the four helper files pass. Whole-file RuboCop on the two feature specs reports only pre-existing offenses outside the changed lines.

This is stacked on #25072.
