### PR TITLE
Move date banner coverage to component specs

### DIFF
--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -99,6 +99,41 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
     it "can switch to automatic scheduling mode" do
       expect(dialog_content).to have_link(I18n.t("work_packages.datepicker_modal.mode.automatic"))
     end
+
+    it "does not show a relation banner without predecessors, successors, a parent, or children" do
+      expect(dialog_content).to have_no_css("[data-test-selector='op-modal-banner-warning']")
+      expect(dialog_content).to have_no_css("[data-test-selector='op-modal-banner-info']")
+    end
+
+    context "with a child" do
+      let(:work_package) { build_stubbed(:work_package, children: [build_stubbed(:work_package)]) }
+
+      it "shows that child dates are ignored" do
+        expect(dialog_content).to have_css(
+          "[data-test-selector='op-modal-banner-warning']",
+          text: "Manually scheduled. Dates not affected by relations. " \
+                "This has child work packages but their start dates are ignored.",
+          normalize_ws: true
+        )
+      end
+    end
+
+    context "with a direct predecessor" do
+      shared_let_work_packages(<<~TABLE)
+        subject      | MTWTFSS | scheduling mode | predecessors
+        predecessor  |         | manual          |
+        work_package |         | automatic       | predecessor
+      TABLE
+
+      it "shows that predecessor dates are ignored" do
+        expect(dialog_content).to have_css(
+          "[data-test-selector='op-modal-banner-warning']",
+          text: "Manually scheduled. Dates not affected by relations. " \
+                'Click on "Show relations" for Gantt overview.',
+          normalize_ws: true
+        )
+      end
+    end
   end
 
   context "when automatically scheduled" do
@@ -119,6 +154,11 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
 
       it "has a disabled save button" do
         expect(dialog_content).to have_button(I18n.t("button_save"), disabled: true)
+      end
+
+      it "does not show a relation banner" do
+        expect(dialog_content).to have_no_css("[data-test-selector='op-modal-banner-warning']")
+        expect(dialog_content).to have_no_css("[data-test-selector='op-modal-banner-info']")
       end
     end
 
@@ -202,6 +242,39 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
 
       it "has a disabled save button" do
         expect(dialog_content).to have_button(I18n.t("button_save"), disabled: true)
+      end
+    end
+  end
+
+  context "with a direct successor but no predecessor, parent, or children" do
+    shared_let(:work_package) { create(:work_package) }
+    shared_let(:successor) { create(:work_package) }
+    let!(:relation) do
+      create(:relation,
+             from: work_package,
+             to: successor,
+             relation_type: Relation::TYPE_PRECEDES)
+    end
+
+    context "when manually scheduled" do
+      let(:schedule_manually) { true }
+
+      it "shows that successor dates are ignored" do
+        expect(dialog_content).to have_css(
+          "[data-test-selector='op-modal-banner-warning']",
+          text: "Manually scheduled. Dates not affected by relations. " \
+                'Click on "Show relations" for Gantt overview.',
+          normalize_ws: true
+        )
+      end
+    end
+
+    context "when automatically scheduled" do
+      let(:schedule_manually) { false }
+
+      it "does not show a relation banner" do
+        expect(dialog_content).to have_no_css("[data-test-selector='op-modal-banner-warning']")
+        expect(dialog_content).to have_no_css("[data-test-selector='op-modal-banner-info']")
       end
     end
   end

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -335,26 +335,6 @@ RSpec.describe "date inplace editor", :js, with_settings: { date_format: "%Y-%m-
     end
   end
 
-  context "with the work package having no relations whatsoever" do
-    let!(:work_package) { create(:work_package, project:) }
-
-    before do
-      start_date.activate!
-      start_date.expect_active!
-    end
-
-    it "does not show a banner with or without manual scheduling" do
-      expect(page).not_to have_test_selector("op-modal-banner-warning")
-      expect(page).not_to have_test_selector("op-modal-banner-info")
-
-      # When toggling manually scheduled
-      start_date.toggle_scheduling_mode
-
-      expect(page).not_to have_test_selector("op-modal-banner-warning")
-      expect(page).not_to have_test_selector("op-modal-banner-info")
-    end
-  end
-
   context "with the work package being the last in the hierarchy" do
     let!(:parent) { create(:work_package, project:, schedule_manually:, start_date: 1.day.ago, due_date: 5.days.from_now) }
     let!(:work_package) { create(:work_package, project:, schedule_manually:, parent:) }
@@ -407,29 +387,6 @@ RSpec.describe "date inplace editor", :js, with_settings: { date_format: "%Y-%m-
       start_date.expect_active!
     end
 
-    context "when parent is manually scheduled" do
-      let(:schedule_manually) { true }
-
-      it "shows a banner that the relations are ignored" do
-        expect(page).to have_css(test_selector("op-modal-banner-warning").to_s,
-                                 text: "Manually scheduled. Dates not affected by relations.\nThis has child work packages but their start dates are ignored.")
-
-        # When toggling manually scheduled
-        start_date.toggle_scheduling_mode
-
-        # Expect banner to switch
-        expect(page).to have_css(test_selector("op-modal-banner-info").to_s,
-                                 text: "The dates are determined by child work packages.\nClick on \"Show relations\" for Gantt overview.")
-
-        new_window = window_opened_by { click_on "Show relations" }
-        switch_to_window new_window
-
-        wp_table.expect_work_package_listed child
-        wp_table.expect_work_package_listed work_package
-        wp_timeline.expect_timeline!
-      end
-    end
-
     context "when parent is not manually scheduled" do
       let(:schedule_manually) { false }
 
@@ -474,90 +431,6 @@ RSpec.describe "date inplace editor", :js, with_settings: { date_format: "%Y-%m-
     end
   end
 
-  context "with the work package having a precedes relation" do
-    let!(:work_package) { create(:work_package, project:, schedule_manually:, start_date: wp_start_date, due_date: wp_due_date) }
-    let!(:preceding) { create(:work_package, project:, start_date: 10.days.ago, due_date: 5.days.ago) }
-
-    let!(:relationship) do
-      create(:relation,
-             from: preceding,
-             to: work_package,
-             relation_type: Relation::TYPE_PRECEDES)
-    end
-
-    before do
-      start_date.activate!
-      start_date.expect_active!
-    end
-
-    context "when work package is manually scheduled" do
-      let(:schedule_manually) { true }
-      let(:wp_start_date) { nil }
-      let(:wp_due_date) { nil }
-
-      it "shows a banner that the relations are ignored" do
-        expect(page).to have_css(test_selector("op-modal-banner-warning").to_s,
-                                 text: "Manually scheduled. Dates not affected by relations.\nClick on \"Show relations\" for Gantt overview.")
-
-        # When toggling manually scheduled
-        start_date.toggle_scheduling_mode
-
-        # Expect new banner info
-        expect(page).to have_css(test_selector("op-modal-banner-info").to_s,
-                                 text: "The start date is set by a predecessor.\nClick on \"Show relations\" for Gantt overview.")
-
-        new_window = window_opened_by { click_on "Show relations" }
-        switch_to_window new_window
-
-        wp_table.expect_work_package_listed preceding
-        wp_table.expect_work_package_listed work_package
-        wp_timeline.expect_timeline!
-      end
-    end
-  end
-
-  context "with the work package having a follows relation" do
-    let!(:work_package) { create(:work_package, project:, schedule_manually:) }
-    let!(:following) { create(:work_package, project:, start_date: 5.days.from_now, due_date: 10.days.from_now) }
-
-    let!(:relationship) do
-      create(:relation,
-             from: following,
-             to: work_package,
-             relation_type: Relation::TYPE_FOLLOWS)
-    end
-
-    before do
-      start_date.activate!
-      start_date.expect_active!
-    end
-
-    context "when work package is manually scheduled" do
-      let(:schedule_manually) { true }
-
-      it "shows a banner that the relations are ignored" do
-        expect(page).to have_css(test_selector("op-modal-banner-warning").to_s,
-                                 text: "Manually scheduled. Dates not affected by relations.\nClick on \"Show relations\" for Gantt overview.")
-
-        # When toggling manually scheduled
-        start_date.toggle_scheduling_mode
-
-        # There is no banner
-        expect(page).not_to have_test_selector("op-modal-banner-warning")
-        expect(page).not_to have_test_selector("op-modal-banner-info")
-
-        # Toggle back to see the banner again
-        start_date.toggle_scheduling_mode
-
-        new_window = window_opened_by { click_on "Show relations" }
-        switch_to_window new_window
-
-        wp_table.expect_work_package_listed following
-        wp_table.expect_work_package_listed work_package
-        wp_timeline.expect_timeline!
-      end
-    end
-  end
   # rubocop:enable Layout/LineLength
 
   context "with a negative time zone", driver: :chrome_new_york_time_zone do


### PR DESCRIPTION
The date editor feature spec starts a browser for relation-banner combinations that are rendered entirely by `WorkPackages::DatePicker::DialogContentComponent`. Those cases add Chrome work while duplicating the component boundary.

This moves the no-relation, child, predecessor, and successor banner combinations into component specs. The feature spec keeps the live date interactions, validation, mode switching, parent working-days regression, and the distinct Gantt relation-link/navigation contract.

The feature file drops from 19 to 15 browser examples while component coverage grows from 24 to 30 examples. At seed 18934 with RSpec retries disabled, the feature file improves from 1m57.63s to 1m39.21s (15.7%); process wall improves from 2m21.83s to 2m03.57s (12.9%). Matched SimpleCov reports show zero lost application lines and zero lost branches.

Validation:
- 45 candidate feature/component examples pass together at seed 64003
- 30 component examples pass at seed 18934
- RuboCop passes for both changed files
- `git diff --check` passes
