### PR TITLE
Report slowest feature files in CI

### DIFF
--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -181,7 +181,9 @@ report_slowest_feature_files() {
 
 	if [ -s "$runtime_log" ]; then
 		echo "20 slowest feature files by aggregate example time:"
-		sort -t: -k2,2nr "$runtime_log" | awk -F: 'NR <= 20 { printf "%8.1fs  %s\n", $2, $1 }'
+		awk -F: '$1 ~ /^(modules\/[^:]+|spec\/[^:]+)_spec\.rb$/ { print }' "$runtime_log" \
+			| sort -t: -k2,2nr \
+			| awk -F: 'NR <= 20 { printf "%8.1fs  %s\n", $2, $1 }'
 	fi
 }
 

--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -171,8 +171,18 @@ run_features() {
 	if ! execute "time bundle exec turbo_tests --verbose -n $JOBS --runtime-log spec/support/runtime-logs/turbo_runtime_features.log {,modules/*/}spec/features/**/*_spec.rb"; then
 		retry_failed_features
 	fi
+	report_slowest_feature_files
 
 	cleanup
+}
+
+report_slowest_feature_files() {
+	local runtime_log="spec/support/runtime-logs/turbo_runtime_features.log"
+
+	if [ -s "$runtime_log" ]; then
+		echo "20 slowest feature files by aggregate example time:"
+		sort -t: -k2,2nr "$runtime_log" | awk -F: 'NR <= 20 { printf "%8.1fs  %s\n", $2, $1 }'
+	fi
 }
 
 retry_failed_features() {
@@ -206,7 +216,7 @@ run_all() {
 	cleanup
 }
 
-export -f cleanup execute execute_quiet run_psql create_db_cluster reset_dbs setup_tests setup_hocuspocus start_hocuspocus backend_stuff frontend_stuff run_units run_features retry_failed_features run_all
+export -f cleanup execute execute_quiet run_psql create_db_cluster reset_dbs setup_tests setup_hocuspocus start_hocuspocus backend_stuff frontend_stuff run_units run_features report_slowest_feature_files retry_failed_features run_all
 
 if [ "$1" == "setup-tests" ]; then
 	shift


### PR DESCRIPTION
CI already records aggregate example time per feature file so `turbo_tests` can balance later runs, but that data is only stored in an opaque cache. After the recent reductions, this leaves the next long-tail target hidden behind stale local rankings.

This prints the 20 slowest feature files after each passing feature run, sorted by aggregate example time. It reads the runtime log already produced by the test command, so it adds no instrumentation and no additional test pass. Failed suites still retain their normal failure behavior.

Validation:
- `bash -n docker/ci/entrypoint.sh`
- formatter checked against the existing runtime-log format
- ShellCheck reports no diagnostics on the added lines
