### PR TITLE
Move proven feature specs off Selenium

### DIFF
--- a/modules/webhooks/spec/features/manage_webhooks_spec.rb
+++ b/modules/webhooks/spec/features/manage_webhooks_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Manage webhooks through UI", :js, :selenium do
+RSpec.describe "Manage webhooks through UI", :js do
   before do
     login_as user
   end

--- a/spec/features/external_link_capture_spec.rb
+++ b/spec/features/external_link_capture_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "External link capture", :js, :selenium do
+RSpec.describe "External link capture", :js do
   shared_let(:admin) { create(:admin) }
 
   let(:project) { create(:project, :with_internal_wiki) }

--- a/spec/features/placeholder_users/create_spec.rb
+++ b/spec/features/placeholder_users/create_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "create placeholder users", :selenium do
+RSpec.describe "create placeholder users" do
   let(:new_placeholder_user_page) { Pages::NewPlaceholderUser.new }
 
   shared_examples_for "placeholders creation flow" do

--- a/spec/features/users/user_memberships_spec.rb
+++ b/spec/features/users/user_memberships_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_relative "../principals/shared_memberships_examples"
 
-RSpec.describe "user memberships through user page", :js, :selenium do
+RSpec.describe "user memberships through user page", :js do
   include_context "principal membership management context"
 
   shared_let(:principal) { create(:user, firstname: "Foobar", lastname: "Blabla") }

--- a/spec/features/work_package_show_spec.rb
+++ b/spec/features/work_package_show_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Work package show page", :selenium do
+RSpec.describe "Work package show page" do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let(:grand_parent) do

--- a/spec/features/work_packages/details/context_menu_spec.rb
+++ b/spec/features/work_packages/details/context_menu_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Work package single context menu", :js, :selenium do
+RSpec.describe "Work package single context menu", :js do
   let(:user) { create(:admin) }
   let(:work_package) { create(:work_package) }
 

--- a/spec/features/work_packages/details/details_toolbar_spec.rb
+++ b/spec/features/work_packages/details/details_toolbar_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require "features/work_packages/work_packages_page"
 
-RSpec.describe "Work package details toolbar", :js, :selenium do
+RSpec.describe "Work package details toolbar", :js do
   let(:project) { create(:project_with_types, public: true) }
   let!(:work_package) { create(:work_package, project:) }
   let(:work_packages_page) { WorkPackagesPage.new(project) }

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Work package navigation", :js, :selenium do
+RSpec.describe "Work package navigation", :js do
   let(:user) { create(:admin) }
   let(:project) { create(:project, name: "Some project", enabled_module_names: [:work_package_tracking]) }
   let(:work_package) { build(:work_package, project:) }


### PR DESCRIPTION
The feature suite still starts Selenium for files that do not depend on Selenium-specific APIs. Those browser sessions add startup and navigation cost to the most expensive CI stage.

This PR moves seven JavaScript feature files (32 examples) to the default Cuprite driver and removes the browser entirely from the five-example placeholder-user flow, which does not exercise JavaScript.

Validation:
- forced-Cuprite cohort, retries disabled: 37 examples pass at seeds 64003 and 18934
- normal metadata cohort after the change, retries disabled: 37 examples pass at seeds 64003 and 18934
- both normal runs complete in about 1m24 with eight workers
- `git diff --check` passes
- RuboCop reports one existing current-path matcher offense in the placeholder-user spec; the metadata-only change adds no offense
