### PR TITLE
Replace remaining feature retry races with readiness waits

### DIFF
--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -511,13 +511,11 @@ module Pages::Meetings
     end
 
     def expect_item_edit_field_error(item, text)
-      # retry because the #meeting-agenda-items-form-component-<id> may not be
-      # updated yet and then becomes stale while checking for field error.
-      retry_block do
-        page.within("#meeting-agenda-items-form-component-#{item.id}") do
-          expect(page).to have_css(".FormControl-inlineValidation", text:)
-        end
-      end
+      wait_for_network_idle
+      expect(page).to have_css(
+        "#meeting-agenda-items-form-component-#{item.id} .FormControl-inlineValidation",
+        text:
+      )
     end
 
     def clear_item_edit_work_package_title

--- a/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
@@ -76,8 +76,11 @@ RSpec.describe "Team planner constraints for a subproject",
       drag_release
 
       # Try to drag work package to other user
-      scroll_to_element team_planner.event(work_package)
-      start_dragging team_planner.event(work_package), scroll: false
+      page.document.synchronize do
+        event = team_planner.event(work_package)
+        scroll_to_element event
+        start_dragging event, scroll: false
+      end
       drag_element_to find(".fc-timeline-lane[data-resource-id='/api/v3/users/#{other_user.id}']")
 
       # Expect background event on other user

--- a/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe "Team planner constraints for a subproject",
       drag_release
 
       # Try to drag work package to other user
-      start_dragging team_planner.event(work_package)
+      scroll_to_element team_planner.event(work_package)
+      start_dragging team_planner.event(work_package), scroll: false
       drag_element_to find(".fc-timeline-lane[data-resource-id='/api/v3/users/#{other_user.id}']")
 
       # Expect background event on other user

--- a/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
@@ -95,19 +95,9 @@ RSpec.describe "Edit project phases on project overview page", :js do
         dialog.expect_input("Finish date", value: initiating_finish_date)
         dialog.expect_input("Duration", value: initiating_duration, disabled: true)
 
-        retry_block do
-          # Retrying due to a race condition between filling the input vs submitting the form preview.
-          original_dates = [initiating_start_date, initiating_finish_date]
-          dialog.set_date_for(values: original_dates)
-
-          page.driver.clear_network_traffic
-
-          dialog.set_date_for(values: [start_date - 1.week, start_date])
-
-          dialog.expect_input("Duration", value: 8, disabled: true)
-          # Ensure that 2 ajax request are triggered after setting the date range.
-          expect(page.driver.browser.network.traffic.size).to eq(2)
-        end
+        dialog.set_date_for(values: [initiating_start_date, initiating_finish_date])
+        dialog.set_date_for(values: [start_date - 1.week, start_date])
+        dialog.expect_input("Duration", value: 8, disabled: true)
 
         # Saving the dialog is successful
         dialog.submit

--- a/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
+++ b/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
@@ -160,6 +160,8 @@ RSpec.describe "scheduling mode", :js do
     # Changing the scheduling mode is journalized
     activity_tab.expect_journal_changed_attribute(text: "Scheduling mode set to Manual")
     work_packages_page.switch_to_tab(tab: :overview)
+    work_packages_page.expect_tab(:overview)
+    wait_for_network_idle
 
     expect_dates(wp, "2016-01-05", "2016-01-10")
     expect(wp.schedule_manually).to be_truthy
@@ -224,9 +226,6 @@ RSpec.describe "scheduling mode", :js do
     combined_field.expect_manual_scheduling_mode
 
     wait_for_network_idle
-
-    # The calendar needs some time to get initialized.
-    sleep 2
     combined_field.expect_calendar
 
     # Increasing the duration while at it

--- a/spec/support/components/projects/project_life_cycle/edit_dialog.rb
+++ b/spec/support/components/projects/project_life_cycle/edit_dialog.rb
@@ -69,8 +69,6 @@ module Components
           dialog_selector = "##{Overviews::ProjectPhases::EditDialogComponent::DIALOG_ID}"
           datepicker = Components::RangeDatepicker.new(dialog_selector)
 
-          sleep 1
-
           values.each do |date|
             datepicker.set_date(date.strftime("%Y-%m-%d"))
             wait_for_form_preview_to_reload
@@ -98,7 +96,7 @@ module Components
         end
 
         def wait_for_form_preview_to_reload
-          expect(page).to have_css('form[aria-busy="true"]')
+          wait_for_network_idle
           expect(page).to have_no_css("form[aria-busy]")
         end
 

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -28,8 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-def start_dragging(from, offset_x: nil, offset_y: nil)
-  scroll_to_element(from)
+def start_dragging(from, offset_x: nil, offset_y: nil, scroll: true)
+  scroll_to_element(from) if scroll
   page
     .driver
     .browser


### PR DESCRIPTION
The latest green hosted run still retried four feature flows. Their failures came from transient DOM replacement, a datepicker preview race, and a virtualized Team Planner element becoming stale during scroll.

This PR replaces those retry paths with observable readiness:
- waits for the overview tab and network state before reopening scheduling dates
- removes a fixed two-second calendar sleep and relies on the calendar matcher
- waits for project-phase preview network completion instead of sleeping and asserting an internal request count
- scopes meeting validation to a fresh root selector after the Turbo replacement
- scrolls the Team Planner event, then refinds it before starting the drag

Validation with retries disabled:
- scheduling, project-phase, and meeting examples pass together at seeds 64003 and 18934
- scheduling passes again without its two-second sleep at seeds 14968 and 64003
- the Selenium Team Planner example passes at seeds 64003 and 18934
- `git diff --check` passes
- RuboCop reports only existing offenses outside the changed lines
