### PR TITLE
Reduce project help-text browser matrix

### DIFF
--- a/spec/features/projects/project_custom_fields/overview_page/attribute_help_texts_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/attribute_help_texts_spec.rb
@@ -36,180 +36,78 @@ RSpec.describe "Edit project custom fields on project overview page", "attribute
   include API::V3::Utilities::PathHelper
 
   let(:overview_page) { Pages::Projects::Show.new(project) }
+  let(:representative_fields) do
+    [date_project_custom_field, text_project_custom_field, list_project_custom_field, multi_list_project_custom_field]
+  end
 
   before do
     login_as member_with_project_attributes_edit_permissions
     overview_page.visit_page
   end
 
-  context "for input fields section" do
-    context "without attribute help texts defined" do
-      it "shows field labels without help text link" do
-        input_fields.each do |custom_field|
-          field = if custom_field == text_project_custom_field
-                    overview_page.open_modal_for_custom_field(custom_field)
-                  else
-                    overview_page.open_inplace_edit_field_for_custom_field(custom_field)
-                  end
-          field.expect_field_label_without_help_text custom_field.name
-          field.close
-        end
-      end
+  def open_field(custom_field)
+    if custom_field == text_project_custom_field
+      overview_page.open_modal_for_custom_field(custom_field)
+    else
+      overview_page.open_inplace_edit_field_for_custom_field(custom_field)
     end
+  end
 
-    context "with attribute help texts defined" do
-      let!(:boolean_help_text) { create(:project_help_text, attribute_name: boolean_project_custom_field.attribute_name) }
-      let!(:date_help_text)    { create(:project_help_text, attribute_name: date_project_custom_field.attribute_name) }
-      let!(:float_help_text)   { create(:project_help_text, attribute_name: float_project_custom_field.attribute_name) }
-      let!(:integer_help_text) { create(:project_help_text, attribute_name: integer_project_custom_field.attribute_name) }
-      let!(:link_help_text)    { create(:project_help_text, attribute_name: link_project_custom_field.attribute_name) }
-      let!(:string_help_text)  { create(:project_help_text, attribute_name: string_project_custom_field.attribute_name) }
-      let!(:text_help_text)    { create(:project_help_text, attribute_name: text_project_custom_field.attribute_name) }
-
-      it "shows field labels with help text link" do
-        input_fields.each do |custom_field|
-          field = if custom_field == text_project_custom_field
-                    overview_page.open_modal_for_custom_field(custom_field)
-                  else
-                    overview_page.open_inplace_edit_field_for_custom_field(custom_field)
-                  end
-          field.expect_field_label_with_help_text custom_field.name
-          field.close
-        end
-      end
-
-      context "without attachments" do
-        it "shows help text modal on clicking help text link" do
-          field = overview_page.open_inplace_edit_field_for_custom_field(date_project_custom_field)
-
-          field.click_help_text_link_for_label "Date field"
-
-          expect(page).to have_modal "Date field"
-          within_modal "Date field" do
-            expect(page).to have_text "Attribute help text"
-            expect(page).to have_no_heading "Attachments"
-
-            click_on "Close"
-          end
-          expect(page).to have_no_modal "Date field"
-        end
-      end
-
-      context "with attachments" do
-        let!(:attachments) { create_list(:attachment, 2, container: integer_help_text) }
-
-        it "shows help text modal, including attachments, on clicking help text link" do
-          field = overview_page.open_inplace_edit_field_for_custom_field(integer_project_custom_field)
-
-          field.click_help_text_link_for_label "Integer field"
-          expect(page).to have_modal "Integer field"
-          within_modal "Integer field" do
-            expect(page).to have_text "Attribute help text"
-
-            expect(page).to have_heading "Attachments"
-            expect(page).to have_list_item count: attachments.count
-            expect(page).to have_list_item text: attachments.first.filename
-            expect(page).to have_list_item text: attachments.second.filename
-
-            attachment_window = window_opened_by do
-              click_on attachments.first.filename
-            end
-            within_window(attachment_window) do
-              expect(page).to have_current_path api_v3_paths.attachment_content(attachments.first.id)
-              expect(page).to have_text "test content"
-            end
-            attachment_window.close
-
-            click_on "Close"
-          end
-          expect(page).to have_no_modal "Integer field"
-        end
+  context "without attribute help texts defined" do
+    it "shows every field label without a help text link" do
+      representative_fields.each do |custom_field|
+        field = open_field(custom_field)
+        field.expect_field_label_without_help_text custom_field.name
+        field.close
       end
     end
   end
 
-  context "for select fields section" do
-    context "without attribute help texts defined" do
-      it "shows field labels without help text link" do
-        select_fields.each do |custom_field|
-          field = overview_page.open_inplace_edit_field_for_custom_field(custom_field)
-          field.expect_field_label_without_help_text custom_field.name
-          field.close
-        end
+  context "with attribute help texts defined" do
+    let!(:help_texts) do
+      representative_fields.map do |custom_field|
+        create(:project_help_text, attribute_name: custom_field.attribute_name)
       end
     end
 
-    context "with attribute help texts defined" do
-      let!(:list_help_text)    { create(:project_help_text, attribute_name: list_project_custom_field.attribute_name) }
-      let!(:version_help_text) { create(:project_help_text, attribute_name: version_project_custom_field.attribute_name) }
-      let!(:user_help_text)    { create(:project_help_text, attribute_name: user_project_custom_field.attribute_name) }
-
-      it "shows field labels with help text link" do
-        select_fields.each do |custom_field|
-          field = overview_page.open_inplace_edit_field_for_custom_field(custom_field)
-          field.expect_field_label_with_help_text custom_field.name
-          field.close
-        end
+    it "shows every field label with a help text link" do
+      representative_fields.each do |custom_field|
+        field = open_field(custom_field)
+        field.expect_field_label_with_help_text custom_field.name
+        field.close
       end
+    end
 
-      it "shows help text modal on clicking help text link" do
-        field = overview_page.open_inplace_edit_field_for_custom_field(user_project_custom_field)
+    context "with attachments" do
+      let!(:integer_help_text) do
+        create(:project_help_text, attribute_name: integer_project_custom_field.attribute_name)
+      end
+      let!(:attachments) { create_list(:attachment, 2, container: integer_help_text) }
 
-        field.click_help_text_link_for_label "User field"
+      it "opens the help text modal and downloads its attachments" do
+        field = overview_page.open_inplace_edit_field_for_custom_field(integer_project_custom_field)
 
-        expect(page).to have_modal "User field"
-        within_modal "User field" do
+        field.click_help_text_link_for_label "Integer field"
+        expect(page).to have_modal "Integer field"
+        within_modal "Integer field" do
           expect(page).to have_text "Attribute help text"
+          expect(page).to have_heading "Attachments"
+          expect(page).to have_list_item count: attachments.count
+          expect(page).to have_list_item text: attachments.first.filename
+          expect(page).to have_list_item text: attachments.second.filename
+
+          attachment_window = window_opened_by do
+            click_on attachments.first.filename
+          end
+          within_window(attachment_window) do
+            expect(page).to have_current_path api_v3_paths.attachment_content(attachments.first.id)
+            expect(page).to have_text "test content"
+          end
+          attachment_window.close
 
           click_on "Close"
         end
-        expect(page).to have_no_modal "User field"
-      end
-    end
-  end
-
-  context "for multi select fields" do
-    context "without attribute help texts defined" do
-      it "shows field labels without help text link" do
-        multi_select_fields.each do |custom_field|
-          field = overview_page.open_inplace_edit_field_for_custom_field(custom_field)
-          field.expect_field_label_without_help_text custom_field.name
-          field.close
-        end
-      end
-    end
-
-    context "with attribute help texts defined" do
-      let!(:multi_list_help_text) do
-        create(:project_help_text, attribute_name: multi_list_project_custom_field.attribute_name)
-      end
-      let!(:multi_version_help_text) do
-        create(:project_help_text, attribute_name: multi_version_project_custom_field.attribute_name)
-      end
-      let!(:multi_user_help_text) do
-        create(:project_help_text, attribute_name: multi_user_project_custom_field.attribute_name)
-      end
-
-      it "shows field labels with help text link" do
-        multi_select_fields.each do |custom_field|
-          field = overview_page.open_inplace_edit_field_for_custom_field(custom_field)
-          field.expect_field_label_with_help_text custom_field.name
-          field.close
-        end
-      end
-
-      it "shows help text modal on clicking help text link" do
-        field = overview_page.open_inplace_edit_field_for_custom_field(multi_list_project_custom_field)
-
-        field.click_help_text_link_for_label "Multi list field"
-
-        expect(page).to have_modal "Multi list field"
-        within_modal "Multi list field" do
-          expect(page).to have_text "Attribute help text"
-
-          click_on "Close"
-        end
-        expect(page).to have_no_modal "Multi list field"
+        expect(page).to have_no_modal "Integer field"
       end
     end
   end


### PR DESCRIPTION
The project custom-field help-text feature file is the second-slowest valid file in the fresh hosted runtime log at 129.4 aggregate seconds. Its ten browser examples repeatedly exercise shared label and async-dialog plumbing across every custom-field format, although those contracts already have dedicated component and form coverage.

This PR keeps three end-to-end browser contracts:
- help links absent and present across four distinct editor shells: inline scalar, text modal, single select, and multi-select
- the real async help dialog and attachment download

The exhaustive help-link, label, modal content, no-attachment, attachment, permission, and omitted editor-format behavior remains covered by existing component/form/controller/service specs.

Validation with retries disabled:
- control: 10 feature examples, 2m15.9 RSpec / 159.92s wall
- candidate: 3 feature examples, 39.38s / 63.48s at seed 64003
- candidate plus all 69 existing help-text component examples: 72 examples, 42.92s at seed 18934
- reduction: 71.0% RSpec / 60.3% wall for the feature file
- matched SimpleCov plus 274 existing relevant unit controls loses zero help-text, attribute-label, or generic display-field application lines and branches
- RuboCop and `git diff --check` pass
