### PR TITLE
Deal with missing host in resource metadata

### DIFF
--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -169,7 +169,8 @@ module Accounts::CurrentUser
         end
 
         format.any(:xml, :js, :json, :turbo_stream) do
-          head :unauthorized, "WWW-Authenticate" => OpenProject::Authentication::WWWAuthenticate.response_header
+          head :unauthorized,
+               "WWW-Authenticate" => OpenProject::Authentication::WWWAuthenticate.response_header(env: request.env)
         end
 
         format.all { head :not_acceptable }

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -279,7 +279,7 @@ module API
 
     def self.auth_headers
       lambda do
-        header = OpenProject::Authentication::WWWAuthenticate.response_header(scope: authentication_scope)
+        header = OpenProject::Authentication::WWWAuthenticate.response_header(env:, scope: authentication_scope)
 
         { "WWW-Authenticate" => header }
       end

--- a/lib_static/open_project/authentication.rb
+++ b/lib_static/open_project/authentication.rb
@@ -248,8 +248,8 @@ module OpenProject
         Manager.scope_config(scope).realm || default_realm
       end
 
-      def response_header(scope: nil, error: nil, error_description: nil)
-        header = %{Bearer realm="#{scope_realm(scope)}", resource_metadata="#{resource_metadata}"}
+      def response_header(env:, scope: nil, error: nil, error_description: nil)
+        header = %{Bearer realm="#{scope_realm(scope)}", resource_metadata="#{resource_metadata(env)}"}
         header << %{, scope="#{escape_string scope}"} if scope
 
         if error
@@ -264,8 +264,15 @@ module OpenProject
         string.to_s.dump[1..-2]
       end
 
-      def resource_metadata
-        OpenProject::StaticRouting::StaticRouter.new.url_helpers.protected_resource_metadata_url
+      def resource_metadata(env)
+        request = ActionDispatch::Request.new(env)
+        url_helpers = OpenProject::StaticRouting::StaticRouter.new.url_helpers
+
+        url_helpers.protected_resource_metadata_url(
+          host: request.host,
+          protocol: request.protocol,
+          port: request.optional_port
+        )
       end
     end
 

--- a/lib_static/open_project/authentication/failure_app.rb
+++ b/lib_static/open_project/authentication/failure_app.rb
@@ -75,7 +75,7 @@ module OpenProject
       end
 
       def unauthorized_header(env)
-        header = OpenProject::Authentication::WWWAuthenticate.response_header(scope: scope(env))
+        header = OpenProject::Authentication::WWWAuthenticate.response_header(env:, scope: scope(env))
 
         { "WWW-Authenticate" => header }
       end

--- a/lib_static/open_project/authentication/strategies/warden/fail_with_header.rb
+++ b/lib_static/open_project/authentication/strategies/warden/fail_with_header.rb
@@ -36,6 +36,7 @@ module OpenProject
           def fail_with_header!(error:, error_description: nil)
             headers(
               "WWW-Authenticate" => OpenProject::Authentication::WWWAuthenticate.response_header(
+                env:,
                 scope:,
                 error:,
                 error_description:

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -123,6 +123,26 @@ RSpec.describe "API V3 Authentication" do
     end
   end
 
+  describe "without a known application hostname", with_settings: { host_name: nil } do
+    let(:expected_message) { "You need to be authenticated to access this resource." }
+
+    before do
+      allow(ActionMailer::Base).to receive(:default_url_options).and_return({})
+      header "Host", "central.example.com"
+
+      get resource
+    end
+
+    it "uses the request host for the resource metadata" do
+      expect(last_response).to have_http_status :unauthorized
+      expect(last_response.header["WWW-Authenticate"]).to eq(
+        'Bearer realm="OpenProject API", ' \
+        'resource_metadata="http://central.example.com/.well-known/oauth-protected-resource", scope="api_v3"'
+      )
+      expect(JSON.parse(last_response.body)).to eq(error_response_body)
+    end
+  end
+
   describe "oauth" do
     let(:oauth_access_token) { "" }
     let(:expected_message) { "You did not provide the correct credentials." }

--- a/spec/requests/projects/identifier_suggestion_spec.rb
+++ b/spec/requests/projects/identifier_suggestion_spec.rb
@@ -69,6 +69,9 @@ RSpec.describe "GET /projects/identifier_suggestion", type: :rails_request do
       it "requires login" do
         get "/projects/identifier_suggestion", params: { name: "Test" }, as: :json
         expect(response).to have_http_status(:unauthorized).or have_http_status(:redirect)
+        expect(response.headers["WWW-Authenticate"]).to include(
+          'resource_metadata="http://test.host/.well-known/oauth-protected-resource"'
+        )
       end
     end
 


### PR DESCRIPTION
Fixes https://appsignal.com/openproject-gmbh/sites/673c8be183eb67dcd6c4e75d/exceptions/incidents/1746/traces/0e83b62a2277acbad353133a1fb4823d

Disclaimer: I could not reproduce how the request ends up without a hostname, but it may be unset if the tenant switching didn't work. I can only fix the reported issue by omitting the request in this case. This may not be what we want.