### PR TITLE
Remove redundant invite modal retry

### DIFF
--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -206,9 +206,7 @@ RSpec.describe "Invite user modal", :js do
 
       before do
         wp_page.visit!
-        retry_block do
-          assignee_field.activate!
-        end
+        assignee_field.activate!
         find(".ng-dropdown-footer button", text: "Invite", wait: 10).click
       end
 


### PR DESCRIPTION
The invite-user modal setup wrapped `EditField#activate!` in a second manual retry loop. The field helper already waits and retries activation, so the outer loop hid readiness failures and added retry tax under CI contention.

This removes the redundant retry and relies on the shared field activation contract. All 19 invite-modal examples pass with `RSPEC_RETRY_RETRY_COUNT=0` at seeds 64003 and 18934 (2m33.5s and 2m34.6s locally).

This PR is stacked on #25078.
