### PR TITLE
Introduce separate ical_sequence counter for recurring meetings

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -189,11 +189,10 @@ class RecurringMeetingsController < ApplicationController
     )
   end
 
-  def destroy_scheduled # rubocop:disable Metrics/AbcSize
-    if @meeting_to_cancel.persisted?
-      meeting.update_column(:state, Meeting.states[:cancelled])
-      flash[:notice] = I18n.t(:notice_successful_cancel)
-    elsif @meeting_to_cancel.save
+  def destroy_scheduled
+    if cancel_occurrence
+      # The cancelled occurrence becomes an EXDATE on the series event.
+      @recurring_meeting.bump_ical_sequence!
       flash[:notice] = I18n.t(:notice_successful_cancel)
     else
       flash[:error] = I18n.t(:error_failed_to_delete_entry)
@@ -231,6 +230,12 @@ class RecurringMeetingsController < ApplicationController
   end
 
   private
+
+  def cancel_occurrence
+    return meeting.update_column(:state, Meeting.states[:cancelled]) if @meeting_to_cancel.persisted?
+
+    @meeting_to_cancel.save
+  end
 
   def redirect_to_project
     return if @project

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -240,6 +240,12 @@ class Meeting < ApplicationRecord
     template? && recurring_meeting_id.nil?
   end
 
+  # The series event in the ICS renders the template: its location, its duration and its attendees.
+  # A change to any of them is a new revision of that event.
+  def bump_series_ical_sequence!
+    recurring_meeting.bump_ical_sequence! if series_template?
+  end
+
   # One-time meeting time zone
   # is always in the user's time zone
   def time_zone

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -297,6 +297,13 @@ class RecurringMeeting < ApplicationRecord
       .intersect?(SCHEDULE_ATTRIBUTES)
   end
 
+  # Bump the SEQUENCE value of the ICS series event.
+  # Previously, this value would simply match the template's lock_version, but that increases far more often.
+  # By using an explicit database-backed value, we can control when we want to bump it.
+  def bump_ical_sequence!
+    increment!(:ical_sequence)
+  end
+
   def scheduled_occurrences(limit:, from_time: Time.current)
     schedule.next_occurrences(limit, from_time)
   end

--- a/modules/meeting/app/services/meeting_participants/create_service.rb
+++ b/modules/meeting/app/services/meeting_participants/create_service.rb
@@ -39,6 +39,7 @@ module MeetingParticipants
     def after_perform(call)
       meeting = call.result.meeting
       meeting.touch_and_save_journals
+      meeting.bump_series_ical_sequence!
 
       if @notify
         since_invited_ids = meeting.participants.where(invited: true).where.not(id: call.result.id).pluck(:user_id)

--- a/modules/meeting/app/services/meeting_participants/delete_service.rb
+++ b/modules/meeting/app/services/meeting_participants/delete_service.rb
@@ -40,6 +40,7 @@ module MeetingParticipants
     def after_perform(call)
       meeting = model.meeting
       meeting.touch_and_save_journals
+      meeting.bump_series_ical_sequence!
 
       if @notify
         since_invited_ids = meeting.participants.where(invited: true).pluck(:user_id)

--- a/modules/meeting/app/services/meetings/delete_service.rb
+++ b/modules/meeting/app/services/meetings/delete_service.rb
@@ -34,6 +34,8 @@ module Meetings
 
     def after_validate(call)
       Meetings::NotificationDebounceJob.cancel_pending(model)
+      # The occurrence becomes an EXDATE on the series event, so we have to increase the SEQUENCE counter
+      model.recurring_meeting.bump_ical_sequence! if cancel_occurrence?(model)
       send_cancellation_mail(model) if model.notify?
 
       call
@@ -42,12 +44,16 @@ module Meetings
     # For occurrences of a recurring series, keep the record and set state to
     # cancelled instead of destroying it, so the slot remains visible in the series.
     def destroy(meeting)
-      if meeting.recurring? && meeting.recurrence_start_time.present?
+      if cancel_occurrence?(meeting)
         meeting.update_column(:state, Meeting.states[:cancelled])
         true
       else
         meeting.destroy # rubocop:disable Rails/SaveBang
       end
+    end
+
+    def cancel_occurrence?(meeting)
+      meeting.recurring? && meeting.recurrence_start_time.present?
     end
 
     def send_cancellation_mail(meeting)

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -95,7 +95,7 @@ module Meetings
 
         e.created = recurring_meeting.template.created_at.utc
         e.last_modified = [recurring_meeting.template.updated_at, recurring_meeting.updated_at].max.utc
-        e.sequence = recurring_meeting.template.lock_version
+        e.sequence = recurring_meeting.ical_sequence
 
         e.rrule = recurring_meeting.ical_schedule.rrules.first.to_ical # We currently only have one recurrence rule
         e.dtstart = ical_datetime(recurring_meeting.current_schedule_start, timezone: recurring_meeting.time_zone)
@@ -145,7 +145,7 @@ module Meetings
 
         e.created = meeting.created_at.utc
         e.last_modified = meeting.updated_at.utc
-        e.sequence = [meeting.lock_version, recurring_meeting.template.lock_version].max
+        e.sequence = [meeting.lock_version, recurring_meeting.ical_sequence].max
 
         e.recurrence_id = ical_datetime(meeting.recurrence_start_time, timezone: recurring_meeting.time_zone)
         e.dtstart = ical_datetime(meeting.start_time, timezone: recurring_meeting.time_zone)
@@ -361,7 +361,7 @@ module Meetings
 
           e.created = recurring_meeting.template.created_at.utc
           e.last_modified = [recurring_meeting.template.updated_at, recurring_meeting.updated_at].max.utc
-          e.sequence = recurring_meeting.template.lock_version
+          e.sequence = recurring_meeting.ical_sequence
 
           e.dtstart = ical_datetime(start_time, timezone: recurring_meeting.time_zone)
           e.dtend = ical_datetime(start_time + recurring_meeting.template.duration.hours, timezone: recurring_meeting.time_zone)

--- a/modules/meeting/app/services/meetings/update_service.rb
+++ b/modules/meeting/app/services/meetings/update_service.rb
@@ -40,6 +40,7 @@ module Meetings
     def after_perform(call)
       if call.success?
         meeting = call.result
+        meeting.bump_series_ical_sequence!
 
         if send_initial_invitations?(meeting)
           MeetingNotificationService.new(meeting).call(:invited)

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -115,6 +115,7 @@ module RecurringMeetings
       ::RecurringMeetings::ResetToTemplateService
         .new(user:, meeting:, params: { state: :open })
         .call
+        .on_success { recurring_meeting.bump_ical_sequence! }
     end
 
     def copy_from_template(start_time)

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -45,6 +45,7 @@ module RecurringMeetings
       return call unless call.success?
 
       recurring_meeting = call.result
+      recurring_meeting.bump_ical_sequence!
 
       if should_reschedule?(recurring_meeting)
         reschedule_future_occurrences(recurring_meeting)

--- a/modules/meeting/db/migrate/20260902070000_add_ical_sequence_to_recurring_meetings.rb
+++ b/modules/meeting/db/migrate/20260902070000_add_ical_sequence_to_recurring_meetings.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddICalSequenceToRecurringMeetings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recurring_meetings, :ical_sequence, :integer, null: false, default: 0
+
+    up_only do
+      # The current value for sequence is the template's lock_version.
+      # we use this as the seed for the current version to ensure the ICS output remains the same.
+      execute <<~SQL.squish
+        UPDATE recurring_meetings
+        SET ical_sequence = COALESCE(
+          (SELECT meetings.lock_version
+           FROM meetings
+           WHERE meetings.recurring_meeting_id = recurring_meetings.id
+             AND meetings.template
+           LIMIT 1),
+          0
+        )
+      SQL
+    end
+  end
+end

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -115,6 +115,8 @@ RSpec.describe "Recurring meetings CRUD",
   it "can cancel an occurrence from the show page" do
     show_page.visit!
 
+    ical_sequence = meeting.ical_sequence
+
     show_page.cancel_occurrence date: "12/31/2024 01:30 PM"
     show_page.within_modal "Cancel meeting occurrence" do
       click_on "Cancel occurrence"
@@ -126,10 +128,14 @@ RSpec.describe "Recurring meetings CRUD",
 
     show_page.expect_no_open_meeting date: "12/31/2024 01:30 PM"
     show_page.expect_cancelled_meeting date: "12/31/2024 01:30 PM"
+
+    expect(meeting.reload.ical_sequence).to eq ical_sequence + 1
   end
 
   it "can cancel a planned occurrence from the show page" do
     show_page.visit!
+
+    ical_sequence = meeting.ical_sequence
 
     show_page.cancel_occurrence date: "01/07/2025 01:30 PM"
     show_page.within_modal "Cancel meeting occurrence" do
@@ -141,6 +147,8 @@ RSpec.describe "Recurring meetings CRUD",
     expect(page).to have_current_path(show_page.path)
 
     show_page.expect_cancelled_meeting date: "01/07/2025 01:30 PM"
+
+    expect(meeting.reload.ical_sequence).to eq ical_sequence + 1
   end
 
   it "sends an email notification when restoring a cancelled planned occurrence" do
@@ -155,8 +163,12 @@ RSpec.describe "Recurring meetings CRUD",
     expect_flash(type: :success, message: "Successful cancellation.")
     show_page.expect_cancelled_meeting date: "01/07/2025 01:30 PM"
 
+    ical_sequence = meeting.reload.ical_sequence
+
     show_page.restore date: "01/07/2025 01:30 PM"
     wait_for_reload
+
+    expect(meeting.reload.ical_sequence).to eq ical_sequence + 1
 
     ActionMailer::Base.deliveries.clear
 

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_participants_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_participants_spec.rb
@@ -55,6 +55,23 @@ RSpec.describe "Series template participant management",
     template_page.visit!
   end
 
+  describe "the ICS revision of the series" do
+    it "advances when a participant is added to the template" do
+      ical_sequence = recurring_meeting.ical_sequence
+
+      template_page.open_participant_form
+      template_page.in_participant_form do
+        template_page.uncheck_apply_to_upcoming
+
+        wait_for_turbo_stream do
+          template_page.select_participant(participant_a)
+        end
+      end
+
+      expect(recurring_meeting.reload.ical_sequence).to eq ical_sequence + 1
+    end
+  end
+
   describe "'apply to upcoming' checkbox state" do
     context "when adding multiple participants with checkbox unchecked" do
       it "keeps the checkbox unchecked after each addition" do

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -454,6 +454,17 @@ RSpec.describe RecurringMeeting,
     end
   end
 
+  describe "#bump_ical_sequence!" do
+    it "advances the counter without touching the lock version of the template" do
+      series = create(:recurring_meeting)
+      lock_version = series.template.lock_version
+
+      expect { series.bump_ical_sequence! }.to change(series, :ical_sequence).by(1)
+      expect(series.reload.ical_sequence).to eq 1
+      expect(series.template.reload.lock_version).to eq lock_version
+    end
+  end
+
   describe "#occurrence_count_until_end_date" do
     it "counts the remaining occurrences up to the end date" do
       series = build(:recurring_meeting,

--- a/modules/meeting/spec/services/meeting_participants/create_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_participants/create_service_spec.rb
@@ -142,6 +142,40 @@ RSpec.describe MeetingParticipants::CreateService do
       end
     end
 
+    context "when the meeting is a series template" do
+      shared_let(:series) { create(:recurring_meeting, project:) }
+
+      let(:user_id) { user_with_meeting_permissions.id }
+
+      subject do
+        described_class.new(user: current_user)
+                       .call(meeting: series.template, user_id:, invited: true, attended: false)
+      end
+
+      it "advances the ICS revision of the series" do
+        expect { expect(subject).to be_success }
+          .to change { series.reload.ical_sequence }.by(1)
+      end
+    end
+
+    context "when the meeting is an occurrence of a series" do
+      shared_let(:occurrence_series) { create(:recurring_meeting, project:) }
+      shared_let(:occurrence) do
+        create(:recurring_meeting_occurrence, recurring_meeting: occurrence_series, start_time: 1.day.from_now)
+      end
+
+      let(:user_id) { user_with_meeting_permissions.id }
+
+      subject do
+        described_class.new(user: current_user).call(meeting: occurrence, user_id:, invited: true, attended: false)
+      end
+
+      it "leaves the ICS revision of the series alone" do
+        expect { expect(subject).to be_success }
+          .not_to change { occurrence_series.reload.ical_sequence }
+      end
+    end
+
     context "when creating with custom attributes" do
       let(:user_id) { user_with_meeting_permissions.id }
       let(:invited) { false }

--- a/modules/meeting/spec/services/meeting_participants/create_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_participants/create_service_spec.rb
@@ -161,7 +161,10 @@ RSpec.describe MeetingParticipants::CreateService do
     context "when the meeting is an occurrence of a series" do
       shared_let(:occurrence_series) { create(:recurring_meeting, project:) }
       shared_let(:occurrence) do
-        create(:recurring_meeting_occurrence, recurring_meeting: occurrence_series, start_time: 1.day.from_now)
+        create(:recurring_meeting_occurrence,
+               recurring_meeting: occurrence_series,
+               project:,
+               start_time: 1.day.from_now)
       end
 
       let(:user_id) { user_with_meeting_permissions.id }

--- a/modules/meeting/spec/services/meeting_participants/delete_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_participants/delete_service_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe MeetingParticipants::DeleteService do
         expect(Meetings::NotificationDebounceJob).to have_received(:debounce).with(meeting, since_invited_ids: anything)
       end
 
+      context "when the meeting is a series template" do
+        shared_let(:series) { create(:recurring_meeting, project:) }
+
+        let(:series_participant) do
+          create(:meeting_participant, :invitee, meeting: series.template, user: participant_user)
+        end
+
+        subject { described_class.new(user: current_user, model: series_participant).call }
+
+        it "advances the ICS revision of the series" do
+          series_participant
+
+          expect { expect(subject).to be_success }
+            .to change { series.reload.ical_sequence }.by(1)
+        end
+      end
+
       context "when notify: false" do
         subject { described_class.new(user: current_user, model: participant, notify: false).call }
 

--- a/modules/meeting/spec/services/meetings/delete_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/delete_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Meetings::DeleteService do
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  shared_let(:current_user) do
+    create(:user, member_with_permissions: { project => %i[view_meetings delete_meetings] })
+  end
+  shared_let(:series) { create(:recurring_meeting, project:) }
+
+  subject { described_class.new(model: meeting, user: current_user).call }
+
+  describe "#call" do
+    context "when the meeting is an occurrence of a series" do
+      let(:meeting) do
+        create(:recurring_meeting_occurrence, recurring_meeting: series, project:, start_time: 1.day.from_now)
+      end
+
+      it "cancels the occurrence instead of destroying it" do
+        meeting
+
+        expect { expect(subject).to be_success }.not_to change(Meeting, :count)
+
+        expect(meeting.reload).to be_cancelled
+      end
+
+      it "advances the ICS revision of the series" do
+        meeting
+
+        expect { expect(subject).to be_success }
+          .to change { series.reload.ical_sequence }.by(1)
+      end
+
+      context "with an invited participant" do
+        let(:recipient) { create(:user, member_with_permissions: { project => %i(view_meetings) }) }
+
+        before do
+          series.update_column(:ical_sequence, 7)
+          create(:meeting_participant, :invitee, meeting:, user: recipient)
+        end
+
+        it "sends the cancellation carrying the new revision, not the one it replaces" do
+          expect(subject).to be_success
+
+          calendar = ActionMailer::Base.deliveries.last.all_parts.find { |part| part.mime_type == "text/calendar" }
+
+          expect(series.reload.ical_sequence).to eq 8
+          expect(calendar.body.decoded).to include("SEQUENCE:8")
+        end
+      end
+    end
+
+    context "when the meeting does not belong to a series" do
+      let(:meeting) { create(:meeting, project:) }
+
+      it "destroys it and leaves the ICS revision of every series alone" do
+        meeting
+
+        expect { expect(subject).to be_success }.to change(Meeting, :count).by(-1)
+
+        expect(series.reload.ical_sequence).to eq 0
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -261,6 +261,24 @@ RSpec.describe Meetings::IcalendarBuilder,
       meeting
     end
 
+    context "when the series has advanced its ICS revision" do
+      subject(:builder) { described_class.new(timezone:) }
+
+      before do
+        recurring_meeting.update_column(:ical_sequence, 7)
+      end
+
+      it "takes the master SEQUENCE from the series, not from the template lock version" do
+        builder.add_series_event(recurring_meeting:)
+
+        parsed_calendar = Icalendar::Calendar.parse(builder.to_ical).first
+        master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+
+        expect(recurring_meeting.template.lock_version).not_to eq 7
+        expect(master.sequence).to eq 7
+      end
+    end
+
     context "when emitting an instantiated occurrence within the current schedule" do
       subject(:builder) { described_class.new(timezone:) }
 

--- a/modules/meeting/spec/services/meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/meetings/update_service_integration_spec.rb
@@ -45,6 +45,30 @@ RSpec.describe Meetings::UpdateService, "integration", type: :model do
   let(:service_result) { instance.call(attributes:, **params) }
   let(:updated_meeting) { service_result.result }
 
+  describe "the ICS revision counter of the series" do
+    shared_let(:series, refind: true) { create(:recurring_meeting, project:, frequency: "daily") }
+
+    let(:params) { { location: "A new location" } }
+
+    context "when the meeting is the series template" do
+      let(:meeting) { series.template }
+
+      it "advances it, because the series event renders the template" do
+        expect { expect(service_result).to be_success }
+          .to change { series.reload.ical_sequence }.by(1)
+      end
+    end
+
+    context "when the meeting is not a template" do
+      let(:meeting) { create(:meeting, project:) }
+
+      it "leaves every series alone" do
+        expect { expect(service_result).to be_success }
+          .not_to change { series.reload.ical_sequence }
+      end
+    end
+  end
+
   context "when meeting is in a series and scheduled to the future" do
     shared_let(:recurring_meeting, refind: true) { create(:recurring_meeting, project:, frequency: "daily") }
     shared_let(:meeting, refind: true) do

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -199,6 +199,42 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
     end
   end
 
+  describe "the ICS revision counter" do
+    let(:recipient) do
+      create(:user, member_with_permissions: { project => %i(view_meetings) })
+    end
+
+    before do
+      series.template.participants.delete_all
+      series.template.participants << MeetingParticipant.new(user: recipient, invited: true)
+    end
+
+    context "when changing only the frequency" do
+      let(:params) do
+        { frequency: "weekly" }
+      end
+
+      it "advances although the template stays untouched" do
+        lock_version = series.template.lock_version
+
+        expect { expect(service_result).to be_success }
+          .to change { series.reload.ical_sequence }.by(1)
+
+        expect(series.template.reload.lock_version).to eq lock_version
+      end
+
+      it "puts the new revision into the attached ICS" do
+        expect(service_result).to be_success
+        perform_enqueued_jobs
+
+        calendar = ActionMailer::Base.deliveries.first.all_parts.find { |part| part.mime_type == "text/calendar" }
+
+        expect(series.reload.ical_sequence).to eq 1
+        expect(calendar.body.decoded).to include("SEQUENCE:1")
+      end
+    end
+  end
+
   describe "rescheduling mails" do
     context "when updating the title" do
       let(:params) do


### PR DESCRIPTION
Previously, the SEQUENCE value would be taken from the template's lock_version, but that increases far more often, and is also meant for a different purpose. So bumping it as a side-effect of an occurrence would cause write errors when someone edited the template.

By using an explicit database-backed value, we can control when we want to bump it without these effects.

https://community.openproject.org/work_packages/MEET-594