### PR TITLE
Move project list rendering coverage to components

### DIFF
--- a/spec/components/projects/row_component_spec.rb
+++ b/spec/components/projects/row_component_spec.rb
@@ -38,9 +38,12 @@ RSpec.describe Projects::RowComponent, type: :component do
   end
 
   let(:project) { build_stubbed(:project, name: "My Project No. 1", identifier: "myproject_no_1") }
+  let(:columns) { [Queries::Projects::Selects::Default.new(:name)] }
   let(:table) do
-    instance_double(Projects::TableComponent, columns: [Queries::Projects::Selects::Default.new(:name)],
-                                              favorited_project_ids: [])
+    instance_double(Projects::TableComponent,
+                    columns:,
+                    favorited_project_ids: [],
+                    project_phase_by_definition: nil)
   end
 
   let(:user) { build_stubbed(:user) }
@@ -72,6 +75,84 @@ RSpec.describe Projects::RowComponent, type: :component do
     context "when the user is logged in" do
       it "renders an async Primer ActionMenu shell" do
         expect(rendered_component).to have_element "action-menu"
+      end
+    end
+  end
+
+  describe "project phase columns" do
+    let(:project) { create(:project) }
+    let(:definition) { create(:project_phase_definition) }
+    let(:phase) do
+      create(:project_phase,
+             project:,
+             definition:,
+             start_date: Date.new(2024, 12, 1),
+             finish_date: Date.new(2024, 12, 13))
+    end
+    let(:columns) { [Queries::Projects::Selects::ProjectPhase.new(:"project_phase_#{definition.id}")] }
+
+    before do
+      allow(table).to receive(:project_phase_by_definition).with(definition, project).and_return(phase)
+    end
+
+    context "with permission to view project phases" do
+      let(:user) { create(:user, member_with_permissions: { project => %i[view_project_phases] }) }
+
+      it "renders the phase dates" do
+        expect(rendered_component).to have_css(
+          ".project_phase_#{definition.id}",
+          text: /12\/01\/2024.*12\/13\/2024/m
+        )
+      end
+
+      context "without an active phase for the project" do
+        let(:phase) { nil }
+
+        it "leaves the phase cell empty" do
+          expect(rendered_component).to have_css(".project_phase_#{definition.id}", text: "")
+          expect(rendered_component).to have_no_text("12/01/2024")
+        end
+      end
+    end
+
+    context "without permission to view project phases" do
+      let(:user) { create(:user) }
+
+      it "leaves the phase cell empty" do
+        expect(rendered_component).to have_css(".project_phase_#{definition.id}", text: "")
+        expect(rendered_component).to have_no_text("12/01/2024")
+      end
+    end
+  end
+
+  describe "custom comment columns" do
+    let(:project) { create(:project) }
+    let(:custom_field) do
+      create(:string_project_custom_field, :has_comment, projects: [project])
+    end
+    let(:columns) { [Queries::Projects::Selects::CustomComment.new(:"cfc_#{custom_field.id}")] }
+
+    before do
+      create(:custom_comment, customized: project, custom_field:, text: "Visible project comment")
+    end
+
+    context "with permission to view project attributes" do
+      let(:user) { create(:user, member_with_permissions: { project => %i[view_project_attributes] }) }
+
+      it "renders the custom comment" do
+        expect(rendered_component).to have_css(
+          ".cfc_#{custom_field.id}",
+          text: "Visible project comment"
+        )
+      end
+    end
+
+    context "without permission to view project attributes" do
+      let(:user) { create(:user) }
+
+      it "leaves the custom comment cell empty" do
+        expect(rendered_component).to have_css(".cfc_#{custom_field.id}", text: "")
+        expect(rendered_component).to have_no_text("Visible project comment")
       end
     end
   end

--- a/spec/features/projects/lists/columns_spec.rb
+++ b/spec/features/projects/lists/columns_spec.rb
@@ -301,39 +301,6 @@ RSpec.describe "Projects lists columns", :js, with_settings: { login_required?: 
                                      project_phase.name,
                                      inactive_project_phase.name)
       end
-
-      specify "inactive project phase columns have no cell content" do
-        col_names = [project_phase_with_gates,
-                     project_phase,
-                     inactive_project_phase_with_gates,
-                     inactive_project_phase].collect(&:name)
-
-        projects_page.set_columns(*col_names)
-        # Inactive columns are still displayed in the header:
-        projects_page.expect_columns("Name", *col_names)
-
-        projects_page.within_row(development_project) do
-          expect(page).to have_css(".name", text: development_project.name)
-          expect(page).to have_css(".project_phase_#{project_phase_with_gates.definition_id}",
-                                   text: "12/01/2024\n-\n12/13/2024")
-          # project phase assigned to other project, no text here
-          expect(page).to have_css(".project_phase_#{project_phase.definition_id}", text: "")
-          # inactive project phases, no text here
-          expect(page).to have_css(".project_phase_#{inactive_project_phase.definition_id}", text: "")
-          expect(page).to have_css(".project_phase_#{inactive_project_phase_with_gates.definition_id}", text: "")
-        end
-
-        projects_page.within_row(project) do
-          expect(page).to have_css(".name", text: project.name)
-          expect(page).to have_css(".project_phase_#{project_phase.definition_id}",
-                                   text: "12/01/2024\n-\n12/13/2024")
-          # project phase assigned to other project, no text here
-          expect(page).to have_css(".project_phase_#{project_phase_with_gates.definition_id}", text: "")
-          # inactive project phases, no text here
-          expect(page).to have_css(".project_phase_#{inactive_project_phase.definition_id}", text: "")
-          expect(page).to have_css(".project_phase_#{inactive_project_phase_with_gates.definition_id}", text: "")
-        end
-      end
     end
 
     context "with a user" do
@@ -365,33 +332,6 @@ RSpec.describe "Projects lists columns", :js, with_settings: { login_required?: 
           projects_page.set_columns(project_phase_with_gates.name)
 
           expect(page).to have_text(project_phase_with_gates.name.upcase)
-        end
-
-        specify "not permitted project phase columns have no cell content" do
-          col_names = [project_phase_with_gates,
-                       project_phase,
-                       inactive_project_phase_with_gates,
-                       inactive_project_phase].collect(&:name)
-
-          projects_page.set_columns(*col_names)
-          # Inactive columns are still displayed in the header:
-          projects_page.expect_columns("Name", *col_names)
-
-          projects_page.within_row(development_project) do
-            expect(page).to have_css(".name", text: development_project.name)
-            expect(page).to have_css(".project_phase_#{project_phase_with_gates.definition_id}",
-                                     text: "12/01/2024\n-\n12/13/2024")
-            # project phase assigned to other project, no text here
-            expect(page).to have_css(".project_phase_#{project_phase.definition_id}", text: "")
-            # inactive project phases, no text here
-            expect(page).to have_css(".project_phase_#{inactive_project_phase.definition_id}", text: "")
-            expect(page).to have_css(".project_phase_#{inactive_project_phase_with_gates.definition_id}", text: "")
-          end
-
-          # Not permitted project phase steps never show their date values
-          projects_page.within_row(project) do
-            expect(page).to have_css(".project_phase_#{project_phase.definition_id}", text: "")
-          end
         end
       end
     end
@@ -509,10 +449,6 @@ RSpec.describe "Projects lists columns", :js, with_settings: { login_required?: 
     context "for admin" do
       let(:user) { admin }
 
-      it "doesn't allow custom comment column for fields that do not allow comments" do
-        projects_page.expect_no_config_columns(comment_column_name(custom_field))
-      end
-
       it "displays custom comment columns", :aggregate_failures do
         projects_page.set_columns("Name", comment_column_name(commentable), comment_column_name(admin_commentable))
 
@@ -534,35 +470,6 @@ RSpec.describe "Projects lists columns", :js, with_settings: { login_required?: 
 
           expect(page).to have_css(".cfc_#{admin_commentable.id}", text: "")
           expect(page).to have_no_css(".cfc_#{admin_commentable.id} button.ellipsis-expander")
-        end
-      end
-    end
-
-    context "for non admin user with view permissions" do
-      let(:user) do
-        create(:user, member_with_permissions: { project => %i(view_project_attributes),
-                                                 development_project => %i(view_project_attributes) })
-      end
-
-      it "doesn't allow custom comment column for fields that do not allow comments or that are admin only" do
-        projects_page.expect_no_config_columns(comment_column_name(custom_field), comment_column_name(admin_commentable))
-      end
-
-      it "displays custom comment columns", :aggregate_failures do
-        projects_page.set_columns("Name", comment_column_name(commentable))
-
-        projects_page.within_row(project) do
-          expect(page).to have_css(".name", text: project.name)
-
-          expect(page).to have_css(".cfc_#{commentable.id}", text: "short text" * 20)
-          expect(page).to have_css(".cfc_#{commentable.id} button.ellipsis-expander")
-        end
-
-        projects_page.within_row(development_project) do
-          expect(page).to have_css(".name", text: development_project.name)
-
-          expect(page).to have_css(".cfc_#{commentable.id}", text: "short text b")
-          expect(page).to have_no_css(".cfc_#{commentable.id} button.ellipsis-expander")
         end
       end
     end

--- a/spec/features/work_packages/new/work_package_default_description_spec.rb
+++ b/spec/features/work_packages/new/work_package_default_description_spec.rb
@@ -34,27 +34,33 @@ RSpec.describe "new work package", :js, :selenium do
 
     type_field.openSelectField
     type_field.set_value type_task
+    loading_indicator_saveguard
     expect(page).to have_css(".inline-edit--container.description h1", text: "New Task template")
 
     type_field.openSelectField
     type_field.set_value type_bug
+    loading_indicator_saveguard
     expect(page).to have_css(".inline-edit--container.description h1", text: "New Bug template")
 
-    description_field.set_value "Something different than the default."
+    wait_for_browser_event("work-package-updated") do
+      description_field.set_value "Something different than the default."
+    end
     description_field.expect_value "Something different than the default."
 
     type_field.openSelectField
     type_field.set_value type_task
+    loading_indicator_saveguard
     expect(page).to have_css(".inline-edit--container.description", text: "Something different than the default.")
 
     type_field.openSelectField
     type_field.set_value type_bug
+    loading_indicator_saveguard
     expect(page).to have_css(".inline-edit--container.description", text: "Something different than the default.")
 
     if set_project
       project_field.openSelectField
       project_field.set_value project
-      sleep 1
+      loading_indicator_saveguard
     end
 
     scroll_to_and_click find_by_id("work-packages--edit-actions-save")

--- a/spec/models/queries/projects/selects/custom_comment_spec.rb
+++ b/spec/models/queries/projects/selects/custom_comment_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe Queries::Projects::Selects::CustomComment do
+  shared_let(:project) { create(:project) }
+  shared_let(:commentable) { create(:string_project_custom_field, :has_comment, projects: [project]) }
+  shared_let(:admin_commentable) do
+    create(:string_project_custom_field, :admin_only, :has_comment, projects: [project])
+  end
+  shared_let(:without_comments) { create(:string_project_custom_field, projects: [project]) }
+
+  subject(:available_attributes) { described_class.all_available.map(&:attribute) }
+
+  before do
+    RequestStore.clear!
+  end
+
+  context "for an admin" do
+    current_user { create(:admin) }
+
+    it "includes commentable regular and admin-only fields" do
+      expect(available_attributes)
+        .to contain_exactly(:"cfc_#{commentable.id}", :"cfc_#{admin_commentable.id}")
+    end
+  end
+
+  context "for a non-admin" do
+    current_user { create(:user, member_with_permissions: { project => %i[view_project_attributes] }) }
+
+    it "excludes fields without comments and admin-only fields" do
+      expect(available_attributes).to contain_exactly(:"cfc_#{commentable.id}")
+    end
+  end
+end


### PR DESCRIPTION
The project-list columns feature file spent browser time rechecking server-rendered phase and custom-comment cells across permission contexts. Those behaviors are produced by `Projects::RowComponent` and query select availability, while the same file already has browser coverage for configuring columns and expanding long comments.

This moves the phase-cell permission/absence contracts and custom-comment permission contract into the row component spec. A focused custom-comment select spec owns regular, non-commentable, and admin-only availability. The browser file retains column selection, all header-menu interactions, life-cycle configuration permissions, calculated values, custom-comment expansion, and the no-project-permission boundary.

With retries disabled at seed 64003, the matched browser file falls from 20 examples in 2m26.7s to 15 examples in 1m35.4s, a 35.0% reduction. The candidate plus replacement specs also passes at seed 18934 (25 examples in 1m38.1s). Matched SimpleCov reports cover the same 68,427 application lines and 1,547 branches, with zero covered line or branch identities lost.

This PR is stacked on #25085.
