### PR TITLE
Synchronize remaining browser retry races

### DIFF
--- a/modules/auth_saml/spec/features/administration/saml_crud_spec.rb
+++ b/modules/auth_saml/spec/features/administration/saml_crud_spec.rb
@@ -110,8 +110,14 @@ RSpec.describe "SAML administration CRUD",
 
       click_link_or_button "Delete"
 
-      check "I understand that this deletion cannot be reversed."
-      click_on "Delete permanently"
+      within_dialog "Delete SAML provider" do
+        confirmation = find_field("I understand that this deletion cannot be reversed.")
+        confirmation.click
+
+        expect(confirmation).to be_checked
+        expect(page).to have_button("Delete permanently", disabled: false)
+        click_on "Delete permanently"
+      end
 
       expect(page).to have_text "No SAML providers configured yet."
       expect { provider.reload }.to raise_error ActiveRecord::RecordNotFound

--- a/modules/meeting/spec/features/meeting_templates/create_meeting_from_template_spec.rb
+++ b/modules/meeting/spec/features/meeting_templates/create_meeting_from_template_spec.rb
@@ -398,11 +398,11 @@ RSpec.describe "Create meeting from template", :js do
       project_a_meetings_page.click_on "One-time"
 
       within_dialog "New one-time meeting" do
-        ng_click_autocompleter(find('[data-test-selector="template_id"]'))
+        dropdown = search_autocomplete(-> { find('[data-test-selector="template_id"]') }, query: "")
 
-        expect(page).to have_text("Template A1")
-        expect(page).to have_text("Template A2")
-        expect(page).to have_text("Project B: Template A1")
+        expect(dropdown).to have_text("Template A1")
+        expect(dropdown).to have_text("Template A2")
+        expect(dropdown).to have_text("Project B: Template A1")
       end
     end
 
@@ -411,9 +411,9 @@ RSpec.describe "Create meeting from template", :js do
       project_a_meetings_page.click_on "One-time"
 
       within_dialog "New one-time meeting" do
-        ng_click_autocompleter(find('[data-test-selector="template_id"]'))
+        dropdown = search_autocomplete(-> { find('[data-test-selector="template_id"]') }, query: "")
 
-        options = all(".ng-option", count: 3).map(&:text)
+        options = dropdown.all(".ng-option", count: 3).map(&:text)
         expect(options).to eq(["Template A1", "Template A2", "Project B: Template A1"])
       end
     end

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -171,9 +171,10 @@ RSpec.describe "Jira import select projects modal", :js do
 
     it "tracks the selection counter and shows the submit button once all requests drain" do
       check "Project Alpha"
-      within("[data-admin--jira-projects-target='submitButton']") do
-        expect(page).to have_text("1")
-      end
+      expect(page).to have_css(
+        "[data-admin--jira-projects-target='submitButton']",
+        text: /\b1\b/
+      )
 
       check "Project Beta"
       check "Gamma Project"
@@ -181,9 +182,10 @@ RSpec.describe "Jira import select projects modal", :js do
       expect(page).to have_css("[data-admin--jira-projects-target='spinnerButton'][hidden]", visible: :all)
 
       uncheck "Project Beta"
-      within("[data-admin--jira-projects-target='submitButton']") do
-        expect(page).to have_text("2")
-      end
+      expect(page).to have_css(
+        "[data-admin--jira-projects-target='submitButton']",
+        text: /\b2\b/
+      )
     end
   end
 

--- a/spec/features/admin/settings/work_packages_identifier_spec.rb
+++ b/spec/features/admin/settings/work_packages_identifier_spec.rb
@@ -111,11 +111,13 @@ RSpec.describe "Work packages identifier admin settings", :js do
       it "enables the confirm button only after checking the checkbox" do
         click_on "Convert identifiers"
 
-        within "[role=alertdialog]" do
+        within_dialog "Change work package identifiers" do
           expect(page).to have_button("Change identifiers", disabled: true)
 
-          check "I understand that this will permanently change all work package IDs"
+          confirmation = find_field("I understand that this will permanently change all work package IDs")
+          confirmation.click
 
+          expect(confirmation).to be_checked
           expect(page).to have_button("Change identifiers", disabled: false)
         end
       end

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
   end
 
   it "keeps the archived filter when searching by name (regression #SPPM-292)" do
+    Components::Submenu.new.expect_item("Archived portfolios")
     click_on "Archived portfolios"
     portfolios_page.expect_title("Archived portfolios")
 

--- a/spec/features/users/my/access_tokens_spec.rb
+++ b/spec/features/users/my/access_tokens_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "my access tokens", :js do
 
         # create API token
         fill_in "token_api[token_name]", with: "Testing Token"
-        find_test_selector("create-api-token-button").click
+        wait_for_turbo_stream { find_test_selector("create-api-token-button").click }
 
         within("dialog#api-created-dialog") do
           expect(page).to have_content "The API token has been generated"


### PR DESCRIPTION
The latest 24-CPU hosted feature run completed in 9m44 but needed seven second attempts. Five failures were deterministic synchronization gaps in otherwise valid feature coverage: interactions proceeded before an async dialog, Turbo replacement, fetched autocomplete result, or submenu item was ready.

This PR replaces those timing assumptions with readiness tied to the UI operation itself:

- scope destructive confirmations to their open dialog and verify the checkbox state before using the enabled action
- wait for the API-token Turbo stream before asserting its result dialog
- refind the Jira counter after Turbo replaces it
- wait for fetched meeting-template options and assert within the returned dropdown
- wait for the archived portfolio menu item to be visible before selecting it

Validation:

- affected cohort: 7 examples, 0 failures at hosted seed 64286, retries disabled
- affected cohort: 7 examples, 0 failures at seed 64003, retries disabled
- diff-aware RuboCop: clean
- git diff --check: clean
