### PR TITLE
Reduce repeated work package creation browser setup

### DIFF
--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -70,12 +70,6 @@ RSpec.describe "new work package", :js do
     project_field.set_value project_name
 
     wait_for_network_idle
-
-    # Select self as assignee
-    assignee_field.openSelectField
-    assignee_field.set_value user.name
-
-    wait_for_network_idle
   end
 
   before do
@@ -223,13 +217,6 @@ RSpec.describe "new work package", :js do
       let(:create_method) { method(:create_work_package) }
     end
 
-    it "allows to go to the full page through the toaster (Regression #37555)" do
-      create_work_package(type_task)
-      save_work_package!
-
-      wp_page.expect_toast message: "Successful creation."
-    end
-
     it "reloads the table and selects the new work package" do
       expect(page).to have_no_css(".wp--row")
 
@@ -348,6 +335,10 @@ RSpec.describe "new work package", :js do
       create_work_package_globally(type_task, project.name)
       expect(page).to have_selector(safeguard_selector, wait: 10)
 
+      assignee_field.openSelectField
+      assignee_field.set_value user.name
+      wait_for_network_idle
+
       wp_page.subject_field.set("new work package")
       save_work_package!
       wp_page.dismiss_toaster!
@@ -410,18 +401,12 @@ RSpec.describe "new work package", :js do
     end
   end
 
-  context "as a user with no permissions" do
-    let(:role) { create(:project_role, permissions: %i(view_work_packages)) }
+  context "as a user with no permission to add work packages" do
+    let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
     let(:user) { create(:user, member_with_roles: { project => role }) }
     let(:wp_page) { Pages::Page.new }
 
-    it "shows a 403 error on creation paths" do
-      visit new_work_package_path
-      wp_page.expect_flash(type: :error, message: I18n.t(:notice_not_authorized))
-
-      visit new_project_work_packages_path(project)
-      wp_page.expect_flash(type: :error, message: I18n.t(:notice_not_authorized))
-
+    it "shows the API authorization error on split creation paths" do
       visit new_split_work_packages_path
       wp_page.expect_toast(type: :error, message: I18n.t("api_v3.errors.code_403"))
 
@@ -452,27 +437,6 @@ RSpec.describe "new work package", :js do
       subject_field.expect_read_only
       subject_field.display_element.click
       subject_field.expect_inactive!
-    end
-  end
-
-  context "an anonymous user is prompted to login" do
-    let(:user) { create(:anonymous) }
-    let(:wp_page) { Pages::Page.new }
-
-    let(:paths) do
-      [
-        new_work_package_path,
-        new_split_work_packages_path,
-        new_project_work_packages_path(project),
-        new_split_project_work_packages_path(project)
-      ]
-    end
-
-    it "shows a 403 error on creation paths" do
-      paths.each do |path|
-        visit path
-        expect(wp_page.current_url).to match /#{signin_path}\?back_url=/
-      end
     end
   end
 

--- a/spec/requests/work_packages/creation_authorization_spec.rb
+++ b/spec/requests/work_packages/creation_authorization_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Work package creation authorization", type: :rails_request do
+  let(:project) { create(:project) }
+  let(:creation_paths) do
+    [
+      new_work_package_path,
+      new_split_work_packages_path,
+      new_project_work_packages_path(project),
+      new_split_project_work_packages_path(project)
+    ]
+  end
+  let(:full_page_creation_paths) do
+    [
+      new_work_package_path,
+      new_project_work_packages_path(project)
+    ]
+  end
+
+  context "when signed in without permission to add work packages" do
+    let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
+    let(:user) { create(:user, member_with_roles: { project => role }) }
+
+    before { login_as(user) }
+
+    it "forbids the full-page creation routes" do
+      full_page_creation_paths.each do |path|
+        get path
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  context "when anonymous" do
+    it "redirects every creation route to sign in" do
+      creation_paths.each do |path|
+        get path
+
+        expect(response).to have_http_status(:found)
+        expect(response.location).to start_with("http://test.host#{signin_path}?back_url=")
+
+        follow_redirect!
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t(:label_login))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current hosted runtime report puts the new-work-package feature file at 116.6 aggregate seconds. Its global-create helper selected an assignee in every example even though only one regression verifies assignment, and authorization-only scenarios paid for repeated browser navigations.

This PR:

- selects the assignee only in the assignment regression
- removes a success-toast example that duplicated the shared creation workflow and no longer exercised the full-page behavior named in its title
- moves full-page authorization and all anonymous redirect routes to request specs, including rendering the destination login page
- retains browser coverage for global and project split-view API errors
- fixes the hosted default-description race by waiting for the Angular changeset event and form refreshes, removing the remaining fixed sleep

Matched uninstrumented result with retries disabled:

- control: 20 browser examples, 143.5s RSpec / 168.16s wall
- candidate: 18 browser + 2 request examples, 129.2s / 153.90s wall
- saving: 10.0% RSpec / 8.5% wall, same total example count

Validation:

- exact candidate passes at seed 18934 with retries disabled
- request replacements pass at seed 64003
- both formerly failing Selenium default-description examples pass at hosted retry seed 21768 and seed 64003
- matched SimpleCov plus 281 unchanged dedicated controls: zero lost feature-relevant application lines and zero lost branches
- diff-aware RuboCop and git diff --check: clean
