### PR TITLE
Remove six retry-only failure modes

### DIFF
--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -114,7 +114,7 @@ module Pages
       JS
 
       page.execute_script(script, assignee, start_date, end_date)
-      ::Pages::SplitWorkPackageCreate.new project:
+      ::Pages::SplitWorkPackageCreate.new(project:).tap(&:expect_fully_loaded)
     end
 
     def remove_assignee(user)

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -504,9 +504,10 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
               .to be_json_eql("0")
               .at_path("total")
             expect(last_response.body)
-              .not_to include(secret_wp.subject)
+              .to have_json_size(0)
+              .at_path("_embedded/elements")
             expect(last_response.body)
-              .not_to include(secret_relation.id.to_s)
+              .not_to include(secret_wp.subject)
           end
         end
       end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -349,7 +349,8 @@ module Components
 
         select_relation_type "Child"
 
-        within "##{WorkPackageRelationsTab::AddWorkPackageHierarchyFormComponent::DIALOG_ID}" do
+        dialog = page.find("##{WorkPackageRelationsTab::AddWorkPackageHierarchyFormComponent::DIALOG_ID}", wait: 10)
+        within dialog do
           autocomplete_field = page.find_test_selector("work-package-hierarchy-form-id")
           select_autocomplete(autocomplete_field,
                               query: work_package.subject,
@@ -365,7 +366,8 @@ module Components
 
         select_relation_type "Parent"
 
-        within "##{WorkPackageRelationsTab::AddWorkPackageHierarchyFormComponent::DIALOG_ID}" do
+        dialog = page.find("##{WorkPackageRelationsTab::AddWorkPackageHierarchyFormComponent::DIALOG_ID}", wait: 10)
+        within dialog do
           autocomplete_field = page.find_test_selector("work-package-hierarchy-form-id")
           select_autocomplete(autocomplete_field,
                               query: work_package.subject,

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -126,7 +126,7 @@ class DateEditField < EditField
   end
 
   def expect_inactive!
-    expect(context).to have_selector(display_selector, wait: 10)
+    expect(context).to have_selector("#{selector} #{display_selector}", wait: 10)
     expect(page).to have_no_css("#{modal_selector} #{input_selector}")
   end
 

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -126,7 +126,7 @@ class DateEditField < EditField
   end
 
   def expect_inactive!
-    expect(context).to have_selector("#{selector} #{display_selector}", wait: 10)
+    expect(context).to have_css("#{selector} #{display_selector}", wait: 10)
     expect(page).to have_no_css("#{modal_selector} #{input_selector}")
   end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -341,9 +341,15 @@ module Pages
       def activate_menu_of(project)
         within_row(project) do |row|
           row.hover
-          menu = find("[data-test-selector='project-list-row--action-menu']")
-          menu_button = find("[data-test-selector='project-list-row--action-menu'] button")
+          menu_selector = "[data-test-selector='project-list-row--action-menu']"
+          expect(row).to have_css(menu_selector, visible: :visible)
+
+          menu = row.find(menu_selector)
+          menu_button = menu.find("button[popovertarget]")
+          overlay_selector = "##{menu_button['popovertarget']}:popover-open"
+
           menu_button.click
+          page.find(overlay_selector, visible: :all)
           wait_for_network_idle
           expect(page).to have_css("[data-test-selector='project-list-row--action-menu-item']")
           yield menu

--- a/spec/workers/work_packages/exports/export_job_integration_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_integration_spec.rb
@@ -66,9 +66,7 @@ RSpec.describe WorkPackages::ExportJob, "Integration" do
     JobStatus::Status.find_by(job_id: job.job_id)
   end
 
-  before do
-    allow(Time.zone).to receive(:now).and_return(test_time)
-  end
+  around { |example| travel_to(test_time, &example) }
 
   describe "with special characters in the project title" do
     let(:project) { create(:project, name: "Foo Bla. Report No. 4/2021 with/for Case 42") }


### PR DESCRIPTION
Two recent hosted runs exposed another set of retry-only failures. Four feature cases proceeded before their concrete UI boundary, while two unit cases had assertions that depended on incidental values.

This PR:

- waits for a visible project-row action menu and its native popover before selecting an item
- scopes date-field inactivity to the target field rather than any display field on the page
- waits up to the existing long UI boundary for hierarchy dialogs to render
- requires the Team Planner split-create form to be fully loaded before returning it
- asserts an empty relation collection structurally instead of checking whether a numeric relation ID appears anywhere in JSON, where it can collide with `pageSize`
- uses `travel_to` for export filename tests so `Time.current` cannot cross a minute boundary outside a partial mock

Validation:

- affected cohort: 11 examples, 0 failures at hosted seed 47728, retries disabled
- affected cohort: 11 examples, 0 failures at seed 64003, retries disabled
- diff-aware RuboCop: clean
- git diff --check: clean
