### PR TITLE
Move work package filter semantics out of browser specs

### DIFF
--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe "filter work packages", :js do
       wp_table.visit!
     end
 
-    it "allows filtering, saving and retrieving the saved filter" do
+    it "filters by a list custom field and excludes the selected value from the autocomplete" do
       # Wait for form to load
       filters.expect_loaded
 
@@ -324,28 +324,6 @@ RSpec.describe "filter work packages", :js do
       filters.open_autocompleter list_cf.attribute_name(:camel_case)
 
       expect(page).to have_no_css(".ng-option", text: list_cf.custom_options.last.value)
-
-      wp_table.save_as("Some query name")
-
-      filters.remove_filter list_cf.attribute_name(:camel_case)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_list_value, work_package_with_anti_list_value
-
-      last_query = Query.last
-
-      wp_table.visit_query(last_query)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_list_value
-      wp_table.ensure_work_package_not_listed! work_package_with_anti_list_value
-
-      filters.open
-
-      filters.expect_filter_by(list_cf.name,
-                               "is not",
-                               list_cf.custom_options.last.value,
-                               "customField#{list_cf.id}")
     end
   end
 
@@ -466,13 +444,12 @@ RSpec.describe "filter work packages", :js do
         skip("Database does not support full text search.") unless OpenProject::Database::allows_tsv?
       end
 
-      it "allows filtering and retrieving and altering the saved filter" do
+      it "wires attachment content and file name filters to the table" do
         wp_table.visit!
         wp_table.expect_work_package_listed wp_with_attachment_a, wp_with_attachment_b
 
         filters.open
 
-        # content contains with multiple hits
         filters.add_filter_by("Attachment content",
                               "contains",
                               ["text"],
@@ -486,58 +463,6 @@ RSpec.describe "filter work packages", :js do
         filters.remove_filter "attachmentContent"
         loading_indicator_saveguard
 
-        filters.add_filter_by("Attachment content",
-                              "contains",
-                              ["first 1.99"],
-                              "attachmentContent")
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a
-        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
-
-        filters.remove_filter "attachmentContent"
-        loading_indicator_saveguard
-
-        # content does not contain
-        filters.add_filter_by("Attachment content",
-                              "doesn't contain",
-                              ["first"],
-                              "attachmentContent")
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_b, wp_without_attachment
-        wp_table.ensure_work_package_not_listed! wp_with_attachment_a
-
-        filters.remove_filter "attachmentContent"
-        loading_indicator_saveguard
-
-        # ignores special characters
-        filters.add_filter_by("Attachment content",
-                              "contains",
-                              ["! first:* ')"],
-                              "attachmentContent")
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a
-        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
-
-        filters.remove_filter "attachmentContent"
-        loading_indicator_saveguard
-
-        # file name contains
-        filters.add_filter_by("Attachment file name",
-                              "contains",
-                              ["first"],
-                              "attachmentFileName")
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a
-        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
-
-        filters.remove_filter "attachmentFileName"
-        loading_indicator_saveguard
-
-        # file name does not contain
         filters.add_filter_by("Attachment file name",
                               "doesn't contain",
                               ["first"],
@@ -547,16 +472,6 @@ RSpec.describe "filter work packages", :js do
         wp_table.expect_work_package_listed wp_with_attachment_b
         wp_table.ensure_work_package_not_listed! wp_with_attachment_a
       end
-    end
-  end
-
-  context "DB does not offer TSVector support" do
-    before do
-      allow(OpenProject::Database).to receive(:allows_tsv?).and_return(false)
-    end
-
-    it "does not offer attachment filters" do
-      expect(page).to have_no_select "add_filter_select", with_options: ["Attachment content", "Attachment file name"]
     end
   end
 
@@ -611,76 +526,6 @@ RSpec.describe "filter work packages", :js do
       wp_table.ensure_work_package_not_listed! wp_updated_3d_ago, wp_updated_5d_ago
     end
 
-    it "filters on date by updated_at" do
-      wp_table.visit!
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago
-
-      filters.open
-
-      filters.add_filter_by "Updated",
-                            "on",
-                            [Date.current.iso8601],
-                            "updatedAt"
-
-      loading_indicator_saveguard
-
-      wp_table.expect_work_package_listed wp_updated_today
-      wp_table.ensure_work_package_not_listed! wp_updated_3d_ago, wp_updated_5d_ago
-    end
-
-    it "filters between date by updated_at", skip: "flickering spec (#68677)" do
-      wp_table.visit!
-      wait_for_network_idle
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago
-
-      filters.open
-
-      filters.add_filter_by "Updated",
-                            "between",
-                            [4.days.ago.to_date.iso8601, 2.days.ago.to_date.iso8601],
-                            "updatedAt"
-
-      wait_for_network_idle
-      loading_indicator_saveguard
-
-      wp_table.expect_work_package_listed wp_updated_3d_ago
-      wp_table.ensure_work_package_not_listed! wp_updated_today, wp_updated_5d_ago
-
-      wp_table.save_as("Some query name")
-
-      filters.remove_filter "updatedAt"
-
-      wait_for_network_idle
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago
-
-      last_query = Query.where(name: "Some query name").first
-      date_filter = last_query.filters.last
-
-      # The frontend sends the date as a datetime string in utc where both bounds have the local offset deduced
-      # e.g. ["2023-05-31T22:00:00Z", "2023-06-03T21:59:59Z"]
-      Time.use_zone(user.time_zone) do
-        expect(date_filter.values)
-          .to eq [4.days.ago.beginning_of_day.utc.iso8601, 2.days.ago.end_of_day.utc.iso8601]
-      end
-
-      wp_table.visit_query(last_query)
-
-      wait_for_network_idle
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_3d_ago
-      wp_table.ensure_work_package_not_listed! wp_updated_today, wp_updated_5d_ago
-
-      filters.open
-
-      filters.expect_filter_by "Updated on",
-                               "between",
-                               [4.days.ago.to_date.iso8601, 2.days.ago.to_date.iso8601],
-                               "updatedAt"
-    end
-
     it "filters between date by updated_at (lower boundary only)" do
       wp_table.visit!
       loading_indicator_saveguard
@@ -699,19 +544,6 @@ RSpec.describe "filter work packages", :js do
       wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
 
       wp_table.save_as("Some query name")
-
-      filters.remove_filter "updatedAt"
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
-
-      filters.add_filter_by "Updated",
-                            "between",
-                            [6.days.ago.to_date.iso8601],
-                            "updatedAt"
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago
 
       last_query = Query.where(name: "Some query name").first
       date_filter = last_query.filters.last
@@ -753,19 +585,6 @@ RSpec.describe "filter work packages", :js do
 
       wp_table.save_as("Some query name")
 
-      filters.remove_filter "updatedAt"
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago
-
-      filters.add_filter_by "Updated",
-                            "between",
-                            [nil, 6.days.ago.to_date.iso8601],
-                            "updatedAt"
-
-      loading_indicator_saveguard
-      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago, wp_updated_3d_ago, wp_updated_today
-
       last_query = Query.where(name: "Some query name").first
       date_filter = last_query.filters.last
       Time.use_zone(user.time_zone) do
@@ -799,8 +618,6 @@ RSpec.describe "filter work packages", :js do
       filters.open
       filters.add_filter_by "Target versions", "is (OR)", [version2.name, version1.name], "targetVersion"
       loading_indicator_saveguard
-
-      sleep(3)
 
       filters.expect_filter_by "Target versions", "is (OR)", [version1.name], "targetVersion"
       filters.expect_filter_by "Target versions", "is (OR)", [version2.name], "targetVersion"

--- a/spec/models/queries/work_packages/filter/attachment_content_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/attachment_content_filter_spec.rb
@@ -32,34 +32,77 @@ require "spec_helper"
 
 RSpec.describe Queries::WorkPackages::Filter::AttachmentContentFilter do
   if OpenProject::Database.allows_tsv?
-    context "WP with attachment" do
+    context "when filtering work packages" do
       let(:context) { nil }
-      let(:value) { "ipsum" }
-      let(:operator) { "~" }
       let(:instance) do
         described_class.create!(name: :search, context:, operator:, values: [value])
       end
-
-      let(:work_package) { create(:work_package) }
-      let(:text) { "lorem ipsum" }
-      let(:attachment) { create(:attachment, container: work_package) }
+      let(:work_package_a) { create(:work_package) }
+      let(:work_package_b) { create(:work_package) }
+      let!(:work_package_without_attachment) { create(:work_package) }
+      let(:attachment_a) { create(:attachment, container: work_package_a) }
+      let(:attachment_b) { create(:attachment, container: work_package_b) }
       let(:plaintext_file_handler) do
-        Plaintext::Resolver.file_handlers.find { |h| h.accept? attachment.content_type }.tap do |plaintext_file_handler|
+        Plaintext::Resolver.file_handlers.find { |h| h.accept? attachment_a.content_type }.tap do |plaintext_file_handler|
           if plaintext_file_handler.nil?
-            fail "Plaintext::FileHandler not found for content type #{attachment.content_type}"
+            fail "Plaintext::FileHandler not found for content type #{attachment_a.content_type}"
           end
         end
       end
 
       before do
-        allow(plaintext_file_handler).to receive(:text).and_return(text)
+        allow(plaintext_file_handler).to receive(:text).and_return("I am the first text $1.99.")
+        Attachments::ExtractFulltextJob.perform_now(attachment_a.id)
+        allow(plaintext_file_handler).to receive(:text).and_return("I am the second text.")
+        Attachments::ExtractFulltextJob.perform_now(attachment_b.id)
       end
 
-      it "finds WP through attachment content" do
-        perform_enqueued_jobs
+      subject(:results) { WorkPackage.where(instance.where) }
 
-        expect(WorkPackage.joins(instance.joins).where(instance.where))
-          .to contain_exactly(work_package)
+      context "with a matching term" do
+        let(:operator) { "~" }
+        let(:value) { "text" }
+
+        it "finds every matching work package" do
+          expect(results).to contain_exactly(work_package_a, work_package_b)
+        end
+      end
+
+      context "with words and numbers" do
+        let(:operator) { "~" }
+        let(:value) { "first 1.99" }
+
+        it "finds the matching work package" do
+          expect(results).to contain_exactly(work_package_a)
+        end
+      end
+
+      context "with special search characters" do
+        let(:operator) { "~" }
+        let(:value) { "! first:* ')" }
+
+        it "ignores the special characters" do
+          expect(results).to contain_exactly(work_package_a)
+        end
+      end
+
+      context "with a negative match" do
+        let(:operator) { "!~" }
+        let(:value) { "first" }
+
+        it "finds non-matching work packages, including those without attachments" do
+          expect(results).to contain_exactly(work_package_b, work_package_without_attachment)
+        end
+      end
+    end
+
+    context "without full text search support" do
+      before do
+        allow(OpenProject::Database).to receive(:allows_tsv?).and_return(false)
+      end
+
+      it "is unavailable" do
+        expect(described_class.create!(name: :search)).not_to be_available
       end
     end
 

--- a/spec/models/queries/work_packages/filter/attachment_file_name_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/attachment_file_name_filter_spec.rb
@@ -32,6 +32,40 @@ require "spec_helper"
 
 RSpec.describe Queries::WorkPackages::Filter::AttachmentFileNameFilter do
   if OpenProject::Database.allows_tsv?
+    describe "filtering work packages" do
+      let(:instance) do
+        described_class.create!(name: :search, operator:, values: ["first"])
+      end
+      let(:work_package_a) { create(:work_package) }
+      let(:work_package_b) { create(:work_package) }
+      let!(:work_package_without_attachment) { create(:work_package) }
+      let(:attachment_a) { create(:attachment, filename: "attachment-first.pdf", container: work_package_a) }
+      let(:attachment_b) { create(:attachment, filename: "attachment-second.pdf", container: work_package_b) }
+
+      before do
+        Attachments::ExtractFulltextJob.perform_now(attachment_a.id)
+        Attachments::ExtractFulltextJob.perform_now(attachment_b.id)
+      end
+
+      subject(:results) { WorkPackage.where(instance.where) }
+
+      context "with a matching file name" do
+        let(:operator) { "~" }
+
+        it "finds the matching work package" do
+          expect(results).to contain_exactly(work_package_a)
+        end
+      end
+
+      context "with a negative match" do
+        let(:operator) { "!~" }
+
+        it "finds non-matching work packages, including those without attachments" do
+          expect(results).to contain_exactly(work_package_b, work_package_without_attachment)
+        end
+      end
+    end
+
     it_behaves_like "basic query filter" do
       let(:type) { :text }
       let(:name) { "Attachment file name" }

--- a/spec/models/queries/work_packages/filter/updated_at_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/updated_at_filter_spec.rb
@@ -31,6 +31,54 @@
 require "spec_helper"
 
 RSpec.describe Queries::WorkPackages::Filter::UpdatedAtFilter do
+  describe "filtering work packages" do
+    let(:reference_time) { Time.utc(2025, 1, 8, 12) }
+    let!(:updated_today) { create(:work_package, updated_at: reference_time) }
+    let!(:updated_three_days_ago) { create(:work_package, updated_at: reference_time - 3.days) }
+    let!(:updated_five_days_ago) { create(:work_package, updated_at: reference_time - 5.days) }
+    let(:instance) do
+      described_class.create!(name: :updated_at, operator:, values:)
+    end
+
+    subject(:results) { WorkPackage.where(instance.where) }
+
+    context "with an on-date filter" do
+      let(:operator) { "=d" }
+      let(:values) { ["2025-01-08T00:00:00Z"] }
+
+      it "finds work packages updated on that date" do
+        expect(results).to contain_exactly(updated_today)
+      end
+    end
+
+    context "with both boundaries" do
+      let(:operator) { "<>d" }
+      let(:values) { ["2025-01-04T00:00:00Z", "2025-01-06T23:59:59Z"] }
+
+      it "finds work packages within the range" do
+        expect(results).to contain_exactly(updated_three_days_ago)
+      end
+    end
+
+    context "with only the lower boundary" do
+      let(:operator) { "<>d" }
+      let(:values) { ["2025-01-05T00:00:00Z"] }
+
+      it "finds work packages on or after the boundary" do
+        expect(results).to contain_exactly(updated_today, updated_three_days_ago)
+      end
+    end
+
+    context "with only the upper boundary" do
+      let(:operator) { "<>d" }
+      let(:values) { ["", "2025-01-04T23:59:59Z"] }
+
+      it "finds work packages on or before the boundary" do
+        expect(results).to contain_exactly(updated_five_days_ago)
+      end
+    end
+  end
+
   it_behaves_like "basic query filter" do
     let(:type) { :datetime_past }
     let(:class_key) { :updated_at }

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -223,8 +223,10 @@ module Components
 
       def expect_filter_order(name, values, selector = nil)
         id = selector || name.downcase
+        value_selector = "#values-#{id} .ng-value-label"
 
-        expect(page.all("#values-#{id} .ng-value-label").map(&:text)).to eq(values)
+        expect(page).to have_css(value_selector, count: values.size)
+        expect(page.all(value_selector).map(&:text)).to eq(values)
       end
 
       def remove_filter(field)


### PR DESCRIPTION
The work-package query filter feature file took 111 seconds in the latest hosted runtime report and repeated filter semantics, persistence cycles, and attachment operators through the browser. It also contained a fixed three-second sleep and a permanently skipped datetime-range example. This made an already large worker unit slower without adding distinct UI coverage.

This PR keeps browser coverage for each distinct filter control and integration boundary: watcher, status, parent, local/global version grouping, date and datetime inputs, list and string custom fields, attachment content and filename controls, persistence, URL characters, and selected-value order. Attachment and updated-at query semantics move to focused filter/model specs. The selected-value regression now waits for the exact rendered label count instead of sleeping.

At matched settings with RSpec retries disabled, the browser file improves from 2m17.4s to 1m44.6s, a 23.9% reduction; process wall time improves from 2m41.62s to 2m09.45s, a 19.9% reduction. The complete candidate passes 52 examples at two seeds, including a final post-rebase run. Matched SimpleCov line and branch identity comparison, unioned with the same existing filter controls on both sides, reports zero lost or gained application lines and zero lost or gained branches.

This is stacked on #25089 and should be reviewed after that PR.
