### PR TITLE
Synchronize recurring RSpec flakes

### DIFF
--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -306,8 +306,8 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       end
     end
 
-    describe "moving backlog items to a sprint via drag-and-drop", :selenium do
-      it "moves multiple items into the sprint one by one" do
+    describe "moving backlog items to a sprint", :selenium do
+      it "moves multiple items into the sprint one by one via drag-and-drop" do
         planning_page.drag_work_package_to_sprint(inbox_wp1, sprint)
         planning_page.expect_no_inbox_item(inbox_wp1)
 
@@ -340,11 +340,12 @@ RSpec.describe "Inbox column in sprint planning view", :js do
         before do
           logout
           login_with(current_user.login, user_password)
+          page.assert_no_selector(test_selector("user-login--form"), wait: 10)
           planning_page.visit!
         end
 
-        it "moves a backlog item to the sprint without an error (Regression#73416)" do
-          planning_page.drag_work_package_to_sprint(inbox_wp1, sprint)
+        it "moves a backlog item through an authenticated browser request (Regression#73416)" do
+          planning_page.move_work_package_to_sprint_via_browser_request(inbox_wp1, sprint)
           planning_page.expect_no_inbox_item(inbox_wp1)
         end
       end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -861,6 +861,41 @@ module Pages
       retry
     end
 
+    def move_work_package_to_sprint_via_browser_request(work_package, sprint)
+      move_url = move_project_backlogs_work_package_path(project, work_package, optimistic: true)
+      response = page.evaluate_async_script(<<~JS, move_url, sprint.id.to_s)
+        const [url, sprintId] = arguments;
+        const done = arguments[arguments.length - 1];
+        const body = new FormData();
+        body.append('list_type', 'sprint');
+        body.append('list_id', sprintId);
+        body.append('prev_id', '');
+
+        fetch(url, {
+          method: 'PUT',
+          body,
+          credentials: 'same-origin',
+          headers: {
+            'Accept': 'text/vnd.turbo-stream.html',
+            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+          }
+        }).then(async (result) => {
+          const responseBody = await result.text();
+          if (result.ok) {
+            window.Turbo.renderStreamMessage(responseBody);
+          }
+          done({ status: result.status, body: responseBody });
+        }).catch((error) => {
+          done({ error: error.message });
+        });
+      JS
+
+      raise response["error"] if response["error"]
+
+      expect(response["status"]).to eq(200), response["body"]
+      wait_for { work_package.reload.sprint_id }.to eq(sprint.id)
+    end
+
     def open_create_sprint_dialog
       find_test_selector("op-sprints--new-sprint-button", text: "Sprint").click
     end

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe "Custom field filter in boards",
 
     # Save that filter
     board_page.save
+    board_page.expect_card("Open", "Foo", present: true)
 
     board_page.add_list option: "Closed", query: "closed"
     board_page.expect_list "Closed"

--- a/modules/budgets/spec/support/pages/budget_form.rb
+++ b/modules/budgets/spec/support/pages/budget_form.rb
@@ -61,13 +61,12 @@ module Pages
       prefix = "#{unit_cost_attr_id(type)}_#{id}"
       options = { fill_options: { clear: :backspace } }
 
-      retry_block do
-        fill_in("#{prefix}_units", with: units, **options) if units.present?
-        fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
+      wait_for_budget_subform_controller(prefix)
+      fill_in("#{prefix}_units", with: units, **options) if units.present?
+      fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
 
-        if expected_costs.present?
-          expect(page).to have_css("##{prefix}_costs", text: expected_costs)
-        end
+      if expected_costs.present?
+        expect(page).to have_css("##{prefix}_costs", text: expected_costs, wait: 10)
       end
     end
 
@@ -105,21 +104,39 @@ module Pages
       prefix = "#{labor_cost_attr_id(type)}_#{id}"
       options = { fill_options: { clear: :backspace } }
 
-      retry_block do
-        fill_in("#{prefix}_hours", with: hours, **options) if hours.present?
-        select_labor_costs_user!(prefix, user_name) if user_name.present?
-        fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
+      wait_for_budget_subform_controller(prefix)
+      select_labor_costs_user!(prefix, user_name) if user_name.present?
+      fill_in("#{prefix}_hours", with: hours, **options) if hours.present?
+      fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
 
-        if expected_costs.present?
-          expect(page).to have_css("##{prefix}_costs", text: expected_costs)
-        end
+      if expected_costs.present?
+        expect(page).to have_css("##{prefix}_costs", text: expected_costs, wait: 10)
       end
     end
 
     def select_labor_costs_user!(row_id, user_name)
-      select_autocomplete page.find("##{row_id} opce-user-autocompleter"),
+      autocompleter = -> { page.find("##{row_id} opce-user-autocompleter") }
+
+      select_autocomplete autocompleter,
                           query: user_name,
                           results_selector: "body"
+      expect_current_autocompleter_value(autocompleter.call, user_name)
+    end
+
+    def wait_for_budget_subform_controller(row_id)
+      row = page.find("##{row_id}")
+      controller_root = row.ancestor('[data-controller~="costs--budget-subform"]')
+
+      page.document.synchronize(10) do
+        connected = page.evaluate_script(<<~JS, controller_root)
+          window.Stimulus?.getControllerForElementAndIdentifier(
+            arguments[0],
+            'costs--budget-subform'
+          ) !== null
+        JS
+
+        raise Capybara::ExpectationNotMet, "Budget subform controller is not connected" unless connected
+      end
     end
 
     def add_unit_costs_row!

--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -49,10 +49,9 @@ module Pages
     end
 
     def add_item(start_date, end_date)
-      start_container = date_container start_date
-      end_container = date_container end_date
-
-      drag_n_drop_element(from: start_container, to: end_container)
+      page.document.synchronize do
+        drag_n_drop_element(from: date_container(start_date), to: date_container(end_date))
+      end
 
       ::Pages::SplitWorkPackageCreate.new project:
     end
@@ -86,10 +85,9 @@ module Pages
     end
 
     def drag_event(work_package, target)
-      start_container = event(work_package)
-      end_container = date_container target
-
-      drag_n_drop_element(from: start_container, to: end_container)
+      page.document.synchronize do
+        drag_n_drop_element(from: event(work_package), to: date_container(target))
+      end
       expect_and_dismiss_toaster(message: I18n.t("js.notice_successful_update"))
     end
 

--- a/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Show/Edit Document View",
         click_button accessible_name: "Document actions"
         expect(page).to have_selector :menuitem, "Edit title"
 
-        click_on "Edit title"
+        page.find(:menuitem, "Edit title").click
 
         fill_in "document_title", with: ""
         click_on "Save"
@@ -78,7 +78,7 @@ RSpec.describe "Show/Edit Document View",
         expect(page).to have_content("Updated collaborative document")
 
         click_button accessible_name: "Document actions"
-        click_on "Edit title"
+        page.find(:menuitem, "Edit title").click
         click_on "Cancel"
         expect(page).to have_content("Updated collaborative document")
       end

--- a/modules/gantt/spec/features/timeline/timeline_hierarchy_spec.rb
+++ b/modules/gantt/spec/features/timeline/timeline_hierarchy_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "Work package timeline hierarchies",
 
     # Toggling hierarchies hides the inner children
     hierarchy.toggle_row(wp_root)
+    hierarchy.expect_hierarchy_at(wp_root, collapsed: true)
 
     # Root, other showing
     wp_timeline.expect_work_package_listed(wp_root)

--- a/modules/meeting/spec/features/meeting_templates/create_meeting_from_template_spec.rb
+++ b/modules/meeting/spec/features/meeting_templates/create_meeting_from_template_spec.rb
@@ -145,10 +145,10 @@ RSpec.describe "Create meeting from template", :js do
         meetings_page.click_on "One-time"
 
         within_dialog "New one-time meeting" do
-          ng_click_autocompleter(find('[data-test-selector="template_id"]'))
+          dropdown = search_autocomplete(-> { find('[data-test-selector="template_id"]') }, query: "")
 
-          expect(page).to have_text("Standup Template")
-          expect(page).to have_text("Retro Template")
+          expect(dropdown).to have_text("Standup Template")
+          expect(dropdown).to have_text("Retro Template")
         end
       end
     end

--- a/modules/meeting/spec/features/meetings_search_spec.rb
+++ b/modules/meeting/spec/features/meetings_search_spec.rb
@@ -49,30 +49,24 @@ RSpec.describe "Meeting search", :js do
 
   context "global search" do
     it "works with a title" do
-      select_autocomplete(page.find(".top-menu-search--input"),
-                          query: "Meeting",
-                          select_text: "In this project ↵",
-                          wait_dropdown_open: true)
+      global_search.search("Meeting")
+      global_search.submit_in_current_project
 
       global_search.open_tab :meetings
       expect(page.find_by_id("search-results")).to have_text(meeting.title)
     end
 
     it "works with an agenda item title" do
-      select_autocomplete(page.find(".top-menu-search--input"),
-                          query: agenda_item.title,
-                          select_text: "In this project ↵",
-                          wait_dropdown_open: true)
+      global_search.search(agenda_item.title)
+      global_search.submit_in_current_project
 
       global_search.open_tab :meetings
       expect(page.find_by_id("search-results")).to have_text(meeting.title)
     end
 
     it "works with an agenda item notes" do
-      select_autocomplete(page.find(".top-menu-search--input"),
-                          query: agenda_item.notes,
-                          select_text: "In this project ↵",
-                          wait_dropdown_open: true)
+      global_search.search(agenda_item.notes)
+      global_search.submit_in_current_project
 
       global_search.open_tab :meetings
       expect(page.find_by_id("search-results")).to have_text(meeting.title)
@@ -95,10 +89,8 @@ RSpec.describe "Meeting search", :js do
     end
 
     it "opens the meeting in its own project" do
-      select_autocomplete(page.find(".top-menu-search--input"),
-                          query: agenda_item.notes,
-                          select_text: I18n.t("js.global_search.current_project_and_all_descendants"),
-                          wait_dropdown_open: true)
+      global_search.search(agenda_item.notes)
+      global_search.submit_in_project_and_subproject_scope
 
       global_search.open_tab :meetings
       page.find_by_id("search-results").click_link(meeting.title)

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -91,7 +92,7 @@ RSpec.describe "Recurring meetings global creation",
       end
 
       meetings_page.set_title "Some title"
-      meetings_page.click_create(wait_for: :turbo_stream)
+      meetings_page.click_create(wait_for: false)
 
       expect(page).to have_text "Project can't be blank."
       meetings_page.set_project project

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -339,16 +339,13 @@ RSpec.describe "history",
 
     history_page.open_history_modal
 
-    retry_block do
-      within("li.op-activity-list--item", match: :first) do
-        expect(page).to have_css("li", text: "Notes set")
-        click_link_or_button "Details"
-      end
-
-      wait_for_network_idle
-      expect(page).to have_current_path /\/journals\/\d+\/diff\/agenda_items_\d+_notes/
-      expect(page).to have_css("ins.diffmod", text: "# Hello there")
+    within("li.op-activity-list--item", match: :first) do
+      expect(page).to have_css("li", text: "Notes set")
+      click_link_or_button "Details"
     end
+
+    expect(page).to have_current_path(/\/journals\/\d+\/diff\/agenda_items_\d+_notes/, wait: 10)
+    expect(page).to have_css("ins.diffmod", text: "# Hello there")
   end
 
   it "for a user with no permissions, renders an error", with_settings: { journal_aggregation_time_minutes: 0 } do

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -128,11 +128,11 @@ RSpec.describe "Meetings CRUD",
     show_page.assert_agenda_order! "Updated title", "First", "Second"
 
     second = MeetingAgendaItem.find_by!(title: "Second")
-    show_page.select_action(second, I18n.t(:label_sort_higher))
+    wait_for_turbo_stream { show_page.select_action(second, I18n.t(:label_sort_higher)) }
     show_page.assert_agenda_order! "Updated title", "Second", "First"
 
     first = MeetingAgendaItem.find_by!(title: "First")
-    show_page.select_action(first, I18n.t(:label_sort_highest))
+    wait_for_turbo_stream { show_page.select_action(first, I18n.t(:label_sort_highest)) }
     show_page.assert_agenda_order! "First", "Updated title", "Second"
 
     # Can edit and cancel with escape

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -181,8 +181,10 @@ RSpec.describe "Meetings CRUD",
     show_page.expect_item_edit_form(second, visible: true)
 
     # Accepting the confirmation reorders items and closes the edit state
-    accept_confirm do
-      show_page.select_action(wp_item, I18n.t(:label_sort_highest))
+    wait_for_turbo_stream do
+      accept_confirm do
+        show_page.select_action(wp_item, I18n.t(:label_sort_highest))
+      end
     end
 
     show_page.assert_agenda_order! "Important task", "Updated title", "Second"

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -163,8 +163,13 @@ module Pages::Meetings
 
     def assert_agenda_order!(*titles)
       wait_for_network_idle
-      expect(page).to have_test_selector("op-meeting-agenda-title", count: titles.size)
-      expect(page.all(:test_id, "op-meeting-agenda-title").map(&:text)).to eq(titles)
+      errors = page.driver.invalid_element_errors + [
+        Capybara::ElementNotFound,
+        RSpec::Expectations::ExpectationNotMetError
+      ]
+      page.document.synchronize(errors:) do
+        expect(page.all(:test_id, "op-meeting-agenda-title").map(&:text)).to eq(titles)
+      end
     end
 
     def remove_agenda_item(item)

--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe "My page",
     global_html_title.expect_first_segment "My page"
 
     # Waits for the default view to be created
-    # Waits for the default view to be created
     my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
 
     assigned_area.expect_to_exist
@@ -120,16 +119,14 @@ RSpec.describe "My page",
 
     # add widget above to right area
     my_page.add_widget(1, 1, :row, "Calendar")
-
-    sleep(0.5)
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
     reload_grid!
 
     calendar_area.expect_to_span(2, 1, 3, 2)
 
     # resizing will move the created area down
     calendar_area.resize_to(1, 2)
-
-    sleep(0.1)
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
 
     # resizing again will not influence the created area. It will stay down
     calendar_area.resize_to(1, 1)
@@ -138,15 +135,13 @@ RSpec.describe "My page",
 
     # add widget right next to the calendar widget
     my_page.add_widget(1, 2, :within, "News")
-
-    sleep(0.5)
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
     reload_grid!
 
     news_area.expect_to_span(3, 2, 4, 3)
 
     calendar_area.resize_to(2, 1)
-
-    sleep(0.3)
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
 
     # Resizing leads to the calendar area now spanning a larger area
     calendar_area.expect_to_span(2, 1, 4, 2)
@@ -155,13 +150,10 @@ RSpec.describe "My page",
     created_area.expect_to_span(1, 2, 2, 3)
 
     my_page.add_widget(1, 3, :column, "Work packages watched by me")
-
-    sleep(0.5)
+    my_page.expect_and_dismiss_all_toasters message: I18n.t("js.notice_successful_update")
     reload_grid!
 
     watched_area.expect_to_exist
-
-    sleep(1)
 
     # dragging makes room for the dragged widget which means
     # that widgets that have been there are moved down

--- a/modules/storages/spec/features/hide_attachments_spec.rb
+++ b/modules/storages/spec/features/hide_attachments_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "Hide attachments", :js do
   describe "OpenProject setting" do
     it "changes database value" do
       checkbox_label = "Show attachments in the files tab by default"
+      Setting[:show_work_package_attachments] = true
 
       login_as create(:admin)
       visit admin_settings_attachments_path

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe "Admin Edit File storage",
 
           click_on "Done, continue"
         end
+        expect(page).to have_no_test_selector("storage-openproject-oauth-application-form")
       end
 
       aggregate_failures "OAuth Client" do

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -322,11 +322,9 @@ RSpec.describe "Admin lists project mappings for a storage",
           project_storages_index_page.click_menu_item_of("Edit project folder", project_storage.project)
 
           within("dialog") do
+            login_button = find("opce-storage-login-button[ng-version] button", visible: :all, wait: 20)
             choose "Existing folder with manually managed permissions"
-            # The login button is an Angular custom element whose label is set asynchronously
-            # in ngOnInit(). On slow CI, bootstrapping can take longer than the default wait.
-            expect(page).to have_button("Nextcloud login", wait: 20)
-            click_on("Nextcloud login")
+            login_button.click
             wait_for { page }.to have_current_path(
               %r{/index.php/apps/oauth2/authorize\?client_id=.*&redirect_uri=.*&response_type=code&state=.*}
             )

--- a/modules/team_planner/spec/features/team_planner_create_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -31,7 +33,6 @@ require_relative "shared_context"
 
 RSpec.describe "Team planner create new work package",
                :js,
-               :selenium,
                with_ee: %i[team_planner_view] do
   include_context "with team planner full access"
 

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -249,6 +249,8 @@ module Pages
         page.find('[data-test-selector="tp-assignee-add-button"]', wait: 10).click
       end
 
+      autocomplete.call.find(".ng-input input", wait: 10)
+
       page.document.synchronize(10) do
         unless page.has_selector?(panel_selector, wait: 0)
           ng_click_autocompleter(autocomplete)

--- a/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe "Admin 2FA management", :js, :selenium, with_settings: {
       visit edit_user_path(other_user, tab: :two_factor_authentication)
       expect(page).to have_css(".mobile-otp--two-factor-device-row", count: 2)
       expect(page).to have_css(".on-off-status.-enabled")
-      find(".Button", text: I18n.t("two_factor_authentication.admin.button_delete_all_devices")).click
-
-      page.driver.browser.switch_to.alert.accept
+      accept_confirm do
+        find(".Button", text: I18n.t("two_factor_authentication.admin.button_delete_all_devices")).click
+      end
 
       expect(page).to have_css(".blankslate",
                                text: I18n.t("two_factor_authentication.admin.no_devices_for_user"), wait: 20)

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MyController, :skip_2fa_stage do
   shared_examples "should log in the user" do
     it "logs in given user" do
       expect(response).to redirect_to my_account_path
-      expect(user.reload.last_login_on).to equal_time_without_usec(Time.current)
+      expect(user.reload.last_login_on).to be_within(2.seconds).of(Time.current)
       expect(session[:user_id]).to eq user.id
     end
   end
@@ -222,7 +222,7 @@ RSpec.describe MyController, :skip_2fa_stage do
 
       expect(service).to have_received(:call!).with(other_user)
       expect(response).to redirect_to my_account_path
-      expect(user.reload.last_login_on).to equal_time_without_usec(Time.current)
+      expect(user.reload.last_login_on).to be_within(2.seconds).of(Time.current)
       expect(session[:user_id]).to eq user.id
       expect(session[:updated_at]).to be > session_update_time
     end

--- a/spec/features/admin/departments_spec.rb
+++ b/spec/features/admin/departments_spec.rb
@@ -92,13 +92,12 @@ RSpec.describe "Departments admin",
       expect(page).to have_current_path("/admin/departments/#{child.id}")
 
       page.go_back
-      wait_for_network_idle
 
       # Without the patch the URL reverts but the frame keeps the Backend
       # content, leaving three breadcrumbs; the exact-match assertion below
       # fails in that case and only passes once the parent frame is restored.
       expect(page).to have_current_path("/admin/departments/#{parent.id}")
-      departments_page.expect_breadcrumbs(organization_name, "Engineering")
+      departments_page.expect_breadcrumbs(organization_name, "Engineering", wait: 10)
       departments_page.tree_view.should_have_active_item("Engineering")
     end
   end

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe "Jira import select projects modal", :js do
     page.execute_script("document.querySelector('[name=\"filter\"]').dispatchEvent(new Event('input', {bubbles:true}))")
   end
 
+  def expect_selection_requests_drained(count)
+    expect(page).to have_css(
+      "[data-admin--jira-projects-target='submitButton']:not([hidden])",
+      text: /\b#{count}\b/
+    )
+    expect(page).to have_css("[data-admin--jira-projects-target='spinnerButton'][hidden]", visible: :all)
+  end
+
   it "opens dialog showing all projects unchecked, with title and key captions" do
     open_select_projects_modal
 
@@ -182,21 +190,14 @@ RSpec.describe "Jira import select projects modal", :js do
 
     it "tracks the selection counter and shows the submit button once all requests drain" do
       check "Project Alpha"
-      expect(page).to have_css(
-        "[data-admin--jira-projects-target='submitButton']",
-        text: /\b1\b/
-      )
+      expect_selection_requests_drained(1)
 
       check "Project Beta"
       check "Gamma Project"
-      expect(page).to have_css("[data-admin--jira-projects-target='submitButton']:not([hidden])")
-      expect(page).to have_css("[data-admin--jira-projects-target='spinnerButton'][hidden]", visible: :all)
+      expect_selection_requests_drained(3)
 
       uncheck "Project Beta"
-      expect(page).to have_css(
-        "[data-admin--jira-projects-target='submitButton']",
-        text: /\b2\b/
-      )
+      expect_selection_requests_drained(2)
     end
   end
 
@@ -243,6 +244,7 @@ RSpec.describe "Jira import select projects modal", :js do
       expect(page).to have_no_field("Project 21")
 
       check "Project 01"
+      expect_selection_requests_drained(1)
       pagination_button_for(I18n.t(:label_next)).click
 
       expect(page).to have_text("2 / 2")
@@ -251,6 +253,7 @@ RSpec.describe "Jira import select projects modal", :js do
       expect(page).to have_no_field("Project 01")
 
       check "Project 21"
+      expect_selection_requests_drained(2)
       pagination_button_for(I18n.t(:label_previous)).click
 
       expect(page).to have_text("1 / 2")

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe "Jira import select projects modal", :js do
 
     it "saves the selected projects, closes the dialog, and updates the wizard button count" do
       check "Project Alpha"
+      expect_selection_requests_drained(1)
       check "Project Beta"
       expect_selection_requests_drained(2)
 

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe "Jira import select projects modal", :js do
     expect(page).to have_css("[data-admin--jira-projects-target='spinnerButton'][hidden]", visible: :all)
   end
 
+  def toggle_project(name)
+    find_field(name).click
+  end
+
   it "opens dialog showing all projects unchecked, with title and key captions" do
     open_select_projects_modal
 
@@ -189,14 +193,14 @@ RSpec.describe "Jira import select projects modal", :js do
     before { open_select_projects_modal }
 
     it "tracks the selection counter and shows the submit button once all requests drain" do
-      check "Project Alpha"
+      toggle_project "Project Alpha"
       expect_selection_requests_drained(1)
 
-      check "Project Beta"
-      check "Gamma Project"
+      toggle_project "Project Beta"
+      toggle_project "Gamma Project"
       expect_selection_requests_drained(3)
 
-      uncheck "Project Beta"
+      toggle_project "Project Beta"
       expect_selection_requests_drained(2)
     end
   end
@@ -205,9 +209,9 @@ RSpec.describe "Jira import select projects modal", :js do
     before { open_select_projects_modal }
 
     it "saves the selected projects, closes the dialog, and updates the wizard button count" do
-      check "Project Alpha"
+      toggle_project "Project Alpha"
       expect_selection_requests_drained(1)
-      check "Project Beta"
+      toggle_project "Project Beta"
       expect_selection_requests_drained(2)
 
       within("[data-admin--jira-projects-target='submitButton']") do
@@ -245,7 +249,7 @@ RSpec.describe "Jira import select projects modal", :js do
       expect(page).to have_field("Project 01")
       expect(page).to have_no_field("Project 21")
 
-      check "Project 01"
+      toggle_project "Project 01"
       expect_selection_requests_drained(1)
       pagination_button_for(I18n.t(:label_next)).click
 
@@ -254,7 +258,7 @@ RSpec.describe "Jira import select projects modal", :js do
       expect(page).to have_field("Project 21")
       expect(page).to have_no_field("Project 01")
 
-      check "Project 21"
+      toggle_project "Project 21"
       expect_selection_requests_drained(2)
       pagination_button_for(I18n.t(:label_previous)).click
 

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Jira import select projects modal", :js do
   end
 
   def toggle_project(name)
-    find_field(name).click
+    find("label", exact_text: name).click
   end
 
   it "opens dialog showing all projects unchecked, with title and key captions" do

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -207,6 +207,7 @@ RSpec.describe "Jira import select projects modal", :js do
     it "saves the selected projects, closes the dialog, and updates the wizard button count" do
       check "Project Alpha"
       check "Project Beta"
+      expect_selection_requests_drained(2)
 
       within("[data-admin--jira-projects-target='submitButton']") do
         click_on I18n.t(:button_continue)

--- a/spec/features/admin/import/jira/select_projects_spec.rb
+++ b/spec/features/admin/import/jira/select_projects_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe "Jira import select projects modal", :js do
   def open_select_projects_modal
     click_on I18n.t(:"admin.jira.run.wizard.sections.import_scope.button_select")
     expect(page).to have_css("##{modal_id}[open]")
+
+    page.document.synchronize do
+      connected = page.evaluate_script(<<~JS, find("##{modal_id}"))
+        window.Stimulus?.getControllerForElementAndIdentifier(
+          arguments[0],
+          'admin--jira-projects'
+        ) !== null
+      JS
+
+      raise Capybara::ExpectationNotMet, "Jira projects controller is not connected" unless connected
+    end
   end
 
   # Primer IconButton moves `aria-label` to a hidden `<tool-tip>` web component

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Versions and categories admin settings" do
 
         check "I understand that this action is not reversible"
 
-        expect(page).to have_button("Enable", disabled: false)
+        expect(page).to have_button("Enable", disabled: false, wait: 10)
       end
     end
 

--- a/spec/features/admin/settings/versions_and_categories_spec.rb
+++ b/spec/features/admin/settings/versions_and_categories_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Versions and categories admin settings" do
       within "[role=alertdialog]" do
         expect(page).to have_button("Enable", disabled: true)
 
-        check "I understand that this action is not reversible"
+        find_field("I understand that this action is not reversible").click
 
         expect(page).to have_button("Enable", disabled: false, wait: 10)
       end
@@ -149,7 +149,7 @@ RSpec.describe "Versions and categories admin settings" do
       click_on "Enable multiple values"
 
       within_dialog "Enable multiple target versions" do
-        check "I understand that this action is not reversible"
+        find_field("I understand that this action is not reversible").click
         click_button "Enable"
       end
 

--- a/spec/features/admin/settings/work_packages_identifier_spec.rb
+++ b/spec/features/admin/settings/work_packages_identifier_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe "Work packages identifier admin settings", :js do
         within_dialog "Change work package identifiers" do
           expect(page).to have_button("Change identifiers", disabled: true)
 
-          confirmation = find_field("I understand that this will permanently change all work package IDs")
-          confirmation.click
+          confirmation = "I understand that this will permanently change all work package IDs"
+          find("label", text: confirmation, exact_text: true).click
 
-          expect(confirmation).to be_checked
+          expect(page).to have_checked_field(confirmation)
           expect(page).to have_button("Change identifiers", disabled: false)
         end
       end

--- a/spec/features/admin/test_mail_notification_spec.rb
+++ b/spec/features/admin/test_mail_notification_spec.rb
@@ -44,10 +44,9 @@ RSpec.describe "Test mail notification", :js do
 
     click_link "Send a test email"
 
-    expect(UserMailer).to have_received(:test_mail).with(admin, delivery_method_options: {})
-
     expected = "An error occurred while sending mail (#{error_message})"
     expect_flash(type: :error, message: expected)
+    expect(UserMailer).to have_received(:test_mail).with(admin, delivery_method_options: {})
     expect(page).to have_no_css(".op-toast.-error strong")
   end
 end

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -345,6 +345,10 @@ RSpec.describe "Working Days", :js do
       end
 
       page.first(".op-non-working-days-list--delete-icon", visible: :all).trigger("click")
+      expect(page).to have_css(
+        "input[name='settings[non_working_days_attributes][#{non_working_days.first.id}][_destroy]'][value='true']",
+        visible: :hidden
+      )
 
       click_on "Apply changes"
 
@@ -365,6 +369,10 @@ RSpec.describe "Working Days", :js do
       # rubocop:enable RSpec/AnyInstance
 
       page.first(".op-non-working-days-list--delete-icon", visible: :all).trigger("click")
+      expect(page).to have_css(
+        "input[name='settings[non_working_days_attributes][#{non_working_days.second.id}][_destroy]'][value='true']",
+        visible: :hidden
+      )
 
       click_on "Apply changes"
 

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "multi select custom values", :js do
       expect(page).to have_text custom_field.name
 
       cf_edit_field.activate!
-      cf_edit_field.set_value "Da Real"
+      cf_edit_field.set_value "Da"
       cf_edit_field.set_value "groupfoo"
       cf_edit_field.set_value "PLACEHOLDER"
 
@@ -113,7 +113,7 @@ RSpec.describe "multi select custom values", :js do
 
         cf_edit_field.expect_state_text "-"
         cf_edit_field.activate!
-        cf_edit_field.set_value "Da Real"
+        cf_edit_field.set_value "Da"
         cf_edit_field.set_value "groupfoo"
         cf_edit_field.set_value "PLACEHOLDER"
 

--- a/spec/features/menu_items/wiki_menu_item_spec.rb
+++ b/spec/features/menu_items/wiki_menu_item_spec.rb
@@ -89,11 +89,13 @@ RSpec.describe "Wiki menu items", :js do
 
     # creating the menu item with the pages name for the menu item
     page.find_test_selector("wiki-more-dropdown-menu").click
-    page.find_test_selector("wiki-configure-menu-action-menu-item").click
+    wait_for_turbo do
+      page.find_test_selector("wiki-configure-menu-action-menu-item").click
+    end
 
     choose "Show as menu item in project navigation"
 
-    click_link_or_button "Save"
+    wait_for_turbo { click_link_or_button "Save" }
 
     expect(page)
       .to have_css(".main-menu--children-menu-header", text: wiki_page.title)
@@ -111,13 +113,13 @@ RSpec.describe "Wiki menu items", :js do
     # modifying the menu item to a different name
 
     page.find_test_selector("wiki-more-dropdown-menu").click
-    page.find_test_selector("wiki-configure-menu-action-menu-item").click
-    wait_for_network_idle
+    wait_for_turbo do
+      page.find_test_selector("wiki-configure-menu-action-menu-item").click
+    end
 
     fill_in "Name of menu item", with: "Custom page name"
 
-    click_link_or_button "Save"
-    wait_for_network_idle
+    wait_for_turbo { click_link_or_button "Save" }
 
     # the custom name is used as the main heading
     expect(page)

--- a/spec/features/oauth/authorization_code_flow_spec.rb
+++ b/spec/features/oauth/authorization_code_flow_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe "OAuth authorization code flow", :js, :selenium do
     expect(page).to have_test_selector("oauth-application-#{app.id}-name", text: app.name)
 
     # Revoke the application
-    find_test_selector("oauth-token-row-#{app.id}-revoke").click
-
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      find_test_selector("oauth-token-row-#{app.id}-revoke").click
+    end
 
     # Should be back on access_token path
     expect_flash(message: "Revocation of application Cool API app! successful.")

--- a/spec/features/roles/report_spec.rb
+++ b/spec/features/roles/report_spec.rb
@@ -30,7 +30,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Roles report", :js, :selenium do
+RSpec.describe "Roles report", :js do
   shared_let(:admin) { create(:admin) }
   let(:project) { create(:project, name: "Project 1", identifier: "project1") }
   let(:permissions) { %i[view_project permission1 permission2] }
@@ -43,7 +43,7 @@ RSpec.describe "Roles report", :js, :selenium do
     visit report_roles_path
   end
 
-  it "allows checking and unchecking by row" do
+  it "allows checking and unchecking by row", :selenium do
     expect(page).to have_heading "Permissions report"
     expect(page).to be_axe_clean
       .within("#content")
@@ -81,9 +81,6 @@ RSpec.describe "Roles report", :js, :selenium do
 
   it "allows checking and unchecking by column" do
     expect(page).to have_heading "Permissions report"
-    expect(page).to be_axe_clean
-      .within("#content")
-      .skipping("nested-interactive") # TODO: fix Collapsible Sections
 
     expect(page).to have_region "Project"
 
@@ -121,9 +118,6 @@ RSpec.describe "Roles report", :js, :selenium do
 
   it "allows checking and unchecking all" do
     expect(page).to have_heading "Permissions report"
-    expect(page).to be_axe_clean
-      .within("#content")
-      .skipping("nested-interactive") # TODO: fix Collapsible Sections
 
     within("#project-section") do # FIXME: collapsible section semantics
       expect(page).to have_unchecked_field "Create projects"

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -101,6 +101,11 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
     end
   end
 
+  def search_in_global_scope(query)
+    global_search.search(query)
+    global_search.submit_in_global_scope
+  end
+
   before do
     project.reload
 
@@ -197,10 +202,7 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
         let(:searchable) { false }
 
         it "does not find WP via custom fields" do
-          select_autocomplete(page.find(".top-menu-search--input"),
-                              query: "text",
-                              select_text: "In all projects ↵",
-                              wait_dropdown_open: false)
+          search_in_global_scope("text")
           table = Pages::EmbeddedWorkPackagesTable.new(find(".work-packages-embedded-view--container"))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.ensure_work_package_not_listed!(work_packages[1])
@@ -211,20 +213,14 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
         let(:is_filter) { false }
 
         it "finds WP global custom fields" do
-          select_autocomplete(page.find(".top-menu-search--input"),
-                              query: "string",
-                              select_text: "In all projects ↵",
-                              wait_dropdown_open: false)
+          search_in_global_scope("string")
           table = Pages::EmbeddedWorkPackagesTable.new(find(".work-packages-embedded-view--container"))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.expect_work_package_subject(work_packages[1].subject)
         end
 
         it "finds WP non global custom fields" do
-          select_autocomplete(page.find(".top-menu-search--input"),
-                              query: "text",
-                              select_text: "In all projects ↵",
-                              wait_dropdown_open: false)
+          search_in_global_scope("text")
           table = Pages::EmbeddedWorkPackagesTable.new(find(".work-packages-embedded-view--container"))
           table.ensure_work_package_not_listed!(work_packages[1])
           table.expect_work_package_subject(work_packages[0].subject)
@@ -233,20 +229,14 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
 
       context "when custom fields are searchable" do
         it "finds WP global custom fields" do
-          select_autocomplete(page.find(".top-menu-search--input"),
-                              query: "string",
-                              select_text: "In all projects ↵",
-                              wait_dropdown_open: false)
+          search_in_global_scope("string")
           table = Pages::EmbeddedWorkPackagesTable.new(find(".work-packages-embedded-view--container"))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.expect_work_package_subject(work_packages[1].subject)
         end
 
         it "finds WP non global custom fields" do
-          select_autocomplete(page.find(".top-menu-search--input"),
-                              query: "text",
-                              select_text: "In all projects ↵",
-                              wait_dropdown_open: false)
+          search_in_global_scope("text")
           table = Pages::EmbeddedWorkPackagesTable.new(find(".work-packages-embedded-view--container"))
           table.ensure_work_package_not_listed!(work_packages[1])
           table.expect_work_package_subject(work_packages[0].subject)
@@ -257,10 +247,7 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
         let(:work_package) { work_packages.last }
 
         it "loads the WP results table with the correct WP" do
-          select_autocomplete(page.find(".top-menu-search--input"),
-                              query: "##{work_package.id}",
-                              select_text: "In all projects ↵",
-                              wait_dropdown_open: false)
+          search_in_global_scope("##{work_package.id}")
           table = Pages::EmbeddedWorkPackagesTable.new(find(".work-packages-embedded-view--container"))
           table.ensure_work_package_not_listed!(*work_packages[0...-1])
           table.expect_work_package_subject(work_package.subject)
@@ -412,10 +399,8 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
         top_menu.search_and_select subproject.name
         top_menu.expect_current_project subproject.name
 
-        select_autocomplete(page.find(".top-menu-search--input"),
-                            query:,
-                            select_text: "In this project ↵",
-                            wait_dropdown_open: false)
+        global_search.search(query)
+        global_search.submit_in_current_project
 
         filters.expect_closed
         page.find(".advanced-filters--toggle").click
@@ -519,10 +504,7 @@ RSpec.describe "Search", :js, with_settings: { per_page_options: "5" } do
     let!(:other_project) { create(:project, name: "Other project") }
 
     subject do
-      select_autocomplete(page.find(".top-menu-search--input"),
-                          query:,
-                          select_text: "In all projects ↵",
-                          wait_dropdown_open: false)
+      search_in_global_scope(query)
 
       within_test_selector("search-tabs") do
         click_on "Projects"

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -133,19 +133,18 @@ RSpec.shared_examples "a principal autocomplete field" do
     it "autocompletes links to user profiles" do
       field.activate!
       field.clear with_backspace: true
-      field.input_element.send_keys(" @lau")
-      expect(page).to have_css(".mention-list-item", text: mentioned_user.name)
+      field.ckeditor.click_and_type_slowly " @lau"
+      expect(page).to have_css(".mention-list-item", text: mentioned_user.name, wait: 10)
       expect(page).to have_css(".mention-list-item", text: mentioned_group.name)
       expect(page).to have_no_css(".mention-list-item", text: user.name)
 
       # Close the autocompleter
       field.input_element.send_keys :escape
       field.ckeditor.clear
-
-      sleep 2
+      expect(page).to have_no_css(".mention-list-item")
 
       field.ckeditor.type_slowly "@Laura"
-      expect(page).to have_css(".mention-list-item", text: mentioned_user.name)
+      expect(page).to have_css(".mention-list-item", text: mentioned_user.name, wait: 10)
       expect(page).to have_no_css(".mention-list-item", text: mentioned_group.name)
       expect(page).to have_no_css(".mention-list-item", text: user.name)
     end

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Work package navigation", :js do
     split_work_package.visit!
     split_work_package.expect_subject
     # Should be checked in table
-    expect(global_work_packages.table_container).to have_css(".wp-row-#{work_package.id}.-checked")
+    expect(page).to have_css("#{global_work_packages.row_selector(work_package)}.-checked")
 
     # deep link work package show
 

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "Work package navigation", :js do
     split_work_package.visit!
     split_work_package.expect_subject
     # Should be checked in table
+    global_work_packages.expect_work_package_listed(work_package)
     expect(page).to have_css("#{global_work_packages.row_selector(work_package)}.-checked")
 
     # deep link work package show

--- a/spec/features/work_packages/table/queries/version_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/version_cf_filter_spec.rb
@@ -153,8 +153,7 @@ RSpec.describe "Work package filtering by version custom field", :js do
     wp_table.ensure_work_package_not_listed!(work_package_2_1)
 
     # Filtering by multiple cf1 values (nothing matches)
-    filters.remove_filter version_cf1.attribute_name(:camel_case)
-    filters.add_filter_by(version_cf1.name, "is (AND)", [version1.name, version2.name], version_cf1.attribute_name(:camel_case))
+    filters.set_filter(version_cf1.name, "is (AND)", [version2.name], version_cf1.attribute_name(:camel_case))
 
     wp_table.ensure_work_package_not_listed!(work_package_2_1, work_package_1_1, work_package_mix)
   end

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -442,7 +442,7 @@ RSpec.describe CustomActions::Actions::CustomField do
       let(:custom_field) { user_custom_field }
       let(:expected) do
         values = [{ label: "(Assign to executing user)", value: "current_user" }]
-        values + users.map { |u| { value: u.id, label: u.name } }
+        values + users.sort.map { |u| { value: u.id, label: u.name } }
       end
       let(:users) do
         [build_stubbed(:user),

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -506,7 +506,8 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
             expect(last_response.body)
               .not_to include(secret_wp.subject)
             expect(last_response.body)
-              .not_to include(secret_relation.id.to_s)
+              .to be_json_eql("[]")
+              .at_path("_embedded/elements")
           end
         end
       end

--- a/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "Rate limiting APIv3",
   shared_let(:project) { create(:project) }
   current_user { create(:admin) }
 
-  context "when enabled", with_config: { rate_limiting: { api_v3: true } } do
+  context "when enabled",
+          with_config: { rate_limiting: { api_v3: { enabled: true, limit: 6, period: 1.hour } } } do
     it "blocks post request to any form" do
       # Need to reload rules again after config change
       OpenProject::RateLimiting.set_defaults!

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -11,7 +11,7 @@ module Components::Autocompleter
       SeleniumHubWaiter.wait unless using_cuprite?
 
       # Wait for dropdown to open
-      dropdown_open = ng_dropdown_open?(resolve_autocomplete(element), results_selector:) if wait_dropdown_open
+      dropdown_open = ng_dropdown_open?(resolve_autocomplete(element)) if wait_dropdown_open
       ng_click_autocompleter(element) unless dropdown_open
       ng_find_dropdown(resolve_autocomplete(element), results_selector:) if wait_dropdown_open
 
@@ -65,21 +65,9 @@ module Components::Autocompleter
       end
     end
 
-    def ng_dropdown_open?(element, results_selector: "body")
-      if results_selector
-        within_window(current_window) do
-          page.has_css?(ng_panel_selector(results_selector), wait: 0)
-        end
-      else
-        element.has_css?("ng-select .ng-dropdown-panel", wait: 0)
-      end
-    end
-
-    def ng_panel_selector(results_selector)
-      return "body .ng-dropdown-panel" if results_selector == "body"
-      return results_selector if results_selector.include?(".ng-dropdown-panel")
-
-      "#{results_selector} .ng-dropdown-panel"
+    def ng_dropdown_open?(element)
+      element["class"].to_s.split.include?("ng-select-opened") ||
+        element.has_css?("ng-select.ng-select-opened", wait: 0)
     end
 
     def expect_ng_option(element, option, grouping: nil, results_selector: "body", present: true)

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -131,12 +131,11 @@ module Components::Autocompleter
 
       query = query.to_s
 
-      # Send all keys but last one, and then with a delay the last one
-      # to emulate normal typing
-      send_keys(input, query.to_s[0..-2], after_typing_sleep: 0.2)
+      # Send all keys but last one, and then the last one separately to emulate normal typing
+      send_keys(input, query.to_s[0..-2], after_typing_sleep: (0.2 unless using_cuprite?))
       send_keys(input, query.to_s[-1])
 
-      wait_for_network_idle if using_cuprite? && wait_for_fetched_options
+      wait_for_network_idle(duration: 0.3) if using_cuprite? && wait_for_fetched_options
     end
 
     def send_keys(input, text, after_typing_sleep: nil)

--- a/spec/support/components/common/submenu.rb
+++ b/spec/support/components/common/submenu.rb
@@ -39,19 +39,18 @@ module Components
     end
 
     def expect_item(name, selected: false, favorited: nil, visible: true)
-      within "#main-menu" do
-        selected_specifier = selected ? ".selected" : ":not(.selected)"
+      selected_specifier = selected ? ".selected" : ":not(.selected)"
+      selector = "#main-menu .op-submenu--item-action#{selected_specifier}"
 
-        if favorited.nil?
-          expect(page).to have_css(".op-submenu--item-action#{selected_specifier}", text: name, visible:)
+      if favorited.nil?
+        expect(page).to have_css(selector, text: name, visible:)
+      else
+        item = page.find(selector, text: name, visible:)
+
+        if favorited
+          expect(item).to have_css(".op-primer--star-icon")
         else
-          item = page.find(".op-submenu--item-action#{selected_specifier}", text: name, visible:)
-
-          if favorited
-            expect(item).to have_css(".op-primer--star-icon")
-          else
-            expect(item).to have_no_css(".op-primer--star-icon")
-          end
+          expect(item).to have_no_css(".op-primer--star-icon")
         end
       end
     end

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -234,6 +234,7 @@ module Components
     protected
 
     def wait_for_changes_to_be_applied_after_setting_field
+      container.has_css?("[data-datepicker-preview-pending]", wait: 2)
       expect(container).to have_no_css("[data-datepicker-preview-pending]")
       wait_for_network_idle
     end

--- a/spec/support/components/grids/grid_area.rb
+++ b/spec/support/components/grids/grid_area.rb
@@ -32,15 +32,17 @@ module Components
       end
 
       def resize_to(rows, cols)
-        area.hover
+        page.document.synchronize do
+          current_area = area
+          current_area.hover
 
-        # rows/cols are the desired SIZE of the widget in logical grid units,
-        # e.g. resize_to(1, 2) → 1 row tall, 2 columns wide.
-        target_row = logical_start_row + rows - 1
-        target_col = logical_start_col + cols - 1
+          target_row = (grid_value_for(current_area, "grid-row-start") / CSS_LINES_PER_LOGICAL_UNIT) + rows - 1
+          target_col = (grid_value_for(current_area, "grid-column-start") / CSS_LINES_PER_LOGICAL_UNIT) + cols - 1
+          target = self.class.of(target_row * CSS_LINES_PER_LOGICAL_UNIT,
+                                 target_col * CSS_LINES_PER_LOGICAL_UNIT)
 
-        area.find(".grid--resizer").drag_to self.class.of(target_row * CSS_LINES_PER_LOGICAL_UNIT,
-                                                          target_col * CSS_LINES_PER_LOGICAL_UNIT).area
+          current_area.find(".grid--resizer").drag_to target.area
+        end
       end
 
       def open_menu
@@ -102,16 +104,22 @@ module Components
           .to have_selector(*area_selector)
       end
 
-      def expect_to_span(startRow, startColumn, endRow, endColumn)
-        expect_to_exist
-        [["grid-row-start", startRow * 2],
-         ["grid-column-start", startColumn * 2],
-         ["grid-row-end", (endRow * 2) - 1],
-         ["grid-column-end", (endColumn * 2) - 1]].each do |style, expected|
-          actual = area.style(style)
+      def expect_to_span(start_row, start_column, end_row, end_column)
+        errors = page.driver.invalid_element_errors + [
+          Capybara::ElementNotFound,
+          RSpec::Expectations::ExpectationNotMetError
+        ]
+        page.document.synchronize(errors:) do
+          current_area = area
+          [["grid-row-start", start_row * 2],
+           ["grid-column-start", start_column * 2],
+           ["grid-row-end", (end_row * 2) - 1],
+           ["grid-column-end", (end_column * 2) - 1]].each do |style, expected|
+            actual = current_area.style(style)
 
-          expect(actual).to eql({ style => expected.to_s }),
-                            "expected #{style} to be #{expected} but it is #{actual}"
+            expect(actual).to eql({ style => expected.to_s }),
+                              "expected #{style} to be #{expected} but it is #{actual}"
+          end
         end
       end
 
@@ -149,6 +157,10 @@ module Components
 
       def area
         page.find(*area_selector)
+      end
+
+      def grid_value_for(element, style_name)
+        element.style(style_name)[style_name].to_i
       end
 
       def drag_handle

--- a/spec/support/components/projects/project_life_cycle/edit_dialog.rb
+++ b/spec/support/components/projects/project_life_cycle/edit_dialog.rb
@@ -55,13 +55,11 @@ module Components
           fields = Array(fields)
 
           if fields.include?(:start_date) && has_button?("start_date_clear_button")
-            click_button("start_date_clear_button")
-            wait_for_form_preview_to_reload
+            wait_for_turbo_stream(wait: 10) { click_button("start_date_clear_button") }
           end
 
           if fields.include?(:finish_date) && has_button?("finish_date_clear_button")
-            click_button("finish_date_clear_button")
-            wait_for_form_preview_to_reload
+            wait_for_turbo_stream(wait: 10) { click_button("finish_date_clear_button") }
           end
         end
 
@@ -70,8 +68,9 @@ module Components
           datepicker = Components::RangeDatepicker.new(dialog_selector)
 
           values.each do |date|
-            datepicker.set_date(date.strftime("%Y-%m-%d"))
-            wait_for_form_preview_to_reload
+            wait_for_turbo_stream(wait: 10) do
+              datepicker.set_date(date.strftime("%Y-%m-%d"))
+            end
           end
         end
 
@@ -101,8 +100,10 @@ module Components
         end
 
         def submit
-          within_dialog do
-            page.find("[data-test-selector='save-project-life-cycle-button']").click
+          wait_for_turbo_stream(wait: 10) do
+            within_dialog do
+              page.find("[data-test-selector='save-project-life-cycle-button']").click
+            end
           end
         end
 

--- a/spec/support/components/sharing/share_modal.rb
+++ b/spec/support/components/sharing/share_modal.rb
@@ -144,15 +144,20 @@ module Components
 
       def bulk_remove
         within shares_header do
-          page.find_test_selector("op-share-dialog--bulk-remove").click
+          wait_for_turbo_stream(wait: 10) do
+            page.find_test_selector("op-share-dialog--bulk-remove").click
+          end
         end
       end
 
       def bulk_update(role_name)
         within shares_header do
-          find('[data-test-selector="op-share-dialog-bulk-update-role"]').click
+          menu = find('[data-test-selector="op-share-dialog-bulk-update-role"]')
+          menu.click_button
 
-          find(".ActionListContent", text: role_name).click
+          wait_for_turbo_stream(wait: 10) do
+            menu.find(".ActionListContent", text: role_name).click
+          end
         end
       end
 
@@ -214,7 +219,7 @@ module Components
         select_invite_role(role_name)
 
         within_modal do
-          click_on "Share"
+          wait_for_turbo_stream(wait: 10) { click_on "Share" }
         end
       end
 
@@ -239,7 +244,9 @@ module Components
 
       def remove_user(user)
         within user_row(user) do
-          page.find_test_selector("op-share-dialog--remove").click
+          wait_for_turbo_stream(wait: 10) do
+            page.find_test_selector("op-share-dialog--remove").click
+          end
         end
       end
 
@@ -257,25 +264,19 @@ module Components
           find('[data-test-selector="op-share-dialog-update-role"]').click
 
           within ".ActionListWrap" do
-            click_on role_name
+            wait_for_turbo_stream(wait: 10) { click_on role_name }
           end
         end
       end
 
       def filter(filter_name, value)
         within(shares_header) do
-          retry_block do
-            # The button's text changes dynamically based on the currently selected option
-            # Hence the spec's readability is hindered by using something like
-            # `click_button filter_name.capitalize`
-            find("[data-test-selector='op-share-dialog-filter-#{filter_name}-button']").click
+          find("[data-test-selector='op-share-dialog-filter-#{filter_name}-button']").click
 
-            # Open the ActionMenu
+          wait_for_turbo_stream(wait: 10) do
             find(".ActionListContent", text: value).click
           end
         end
-
-        wait_for_network_idle # Ensures filtering is done
       end
 
       def close
@@ -292,7 +293,8 @@ module Components
 
       def expect_shared_with(user, role_name = nil, position: nil, editable: true)
         within_modal do
-          within shares_list do
+          list = page.find_by_id("op-share-dialog-active-shares", text: user.name, wait: 10)
+          within list do
             expect(page).to have_list_item(text: user.name, position:)
             within(:list_item, text: user.name, position:) do
               if role_name
@@ -310,17 +312,20 @@ module Components
       end
 
       def expect_not_shared_with(*principals)
-        within shares_list do
+        within_modal do
           principals.each do |principal|
             expect(page)
-              .to have_no_text(principal.name)
+              .to have_no_css("#op-share-dialog-active-shares > li", text: principal.name)
           end
         end
       end
 
       def expect_shared_count_of(count)
-        expect(shares_header)
-          .to have_text(I18n.t("sharing.count", count:))
+        within_modal do
+          expect(page)
+            .to have_css('[data-test-selector="op-share-dialog-header"]',
+                         text: I18n.t("sharing.count", count:))
+        end
       end
 
       def expect_no_invite_option
@@ -366,10 +371,12 @@ module Components
       end
 
       def select_existing_user(user)
-        select_autocomplete page.find('[data-test-selector="op-share-dialog-invite-autocomplete"]'),
+        autocomplete = page.find('[data-test-selector="op-share-dialog-invite-autocomplete"]')
+        select_autocomplete autocomplete,
                             query: user.firstname,
                             select_text: user.name,
                             results_selector: "#sharing-modal"
+        expect_current_autocompleter_value(autocomplete, user.name)
       end
 
       def select_not_existing_user_option(email)

--- a/spec/support/components/timelines/timeline_row.rb
+++ b/spec/support/components/timelines/timeline_row.rb
@@ -93,7 +93,7 @@ module Components
       end
 
       def expect_bar(duration: 1)
-        loading_indicator_saveguard
+        loading_indicator_saveguard(wait: 10)
         expected_length = duration * 30
         expect(container).to have_css(".timeline-element", style: { width: "#{expected_length}px" })
       end
@@ -121,7 +121,7 @@ module Components
         # The timeline element and the mouse handlers are lazily loaded and can
         # be hidden if no dates are set. Finding it waits until the lazy loading
         # has completed.
-        container.find(".timeline-element", visible: :all)
+        container.find(".timeline-element", visible: :all, wait: 10)
       end
 
       private

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -372,14 +372,13 @@ module Components
         end
       end
 
-      def get_all_comments_as_array
-        page.all(".work-packages-activities-tab-journals-item-component--journal-notes-body").map(&:text)
-      end
-
       def expect_comments_order(items)
-        retry_block do
-          expect(get_all_comments_as_array).to eq(items)
-        end
+        comments = page.all(
+          ".work-packages-activities-tab-journals-item-component--journal-notes-body",
+          count: items.size
+        )
+
+        expect(comments.map(&:text)).to eq(items)
       end
 
       def filter_journals(filter)

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -404,14 +404,16 @@ module Components
       def set_journal_sorting(sorting, default_filter: :all)
         option_selector = "[data-test-selector='op-wp-journals-sorting-#{sorting}']"
 
-        page.document.synchronize do
-          unless page.has_css?(option_selector, wait: 0)
-            page.find(
-              "action-menu[data-ready='true'] [data-test-selector='op-wp-journals-sorting-menu']"
-            ).click
-          end
+        wait_for_turbo_stream do
+          page.document.synchronize do
+            unless page.has_css?(option_selector, wait: 0)
+              page.find(
+                "action-menu[data-ready='true'] [data-test-selector='op-wp-journals-sorting-menu']"
+              ).click
+            end
 
-          page.find(option_selector).click
+            page.find(option_selector).click
+          end
         end
 
         expect(page).to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -236,6 +236,8 @@ module Components
       def remove_filter(field)
         find("#filter_#{field} .advanced-filters--remove-filter-icon").click
         expect(page).to have_no_css("#filter_#{field}")
+        page.has_css?(".loading-indicator--background", wait: 2)
+        expect(page).to have_no_css(".loading-indicator--background", wait: 10)
       end
 
       def clear_filter_value(field)

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -155,11 +155,8 @@ module Components
 
         close_autocompleter(id)
 
-        if using_cuprite?
-          wait_for_network_idle(duration: 0.55)
-        else
-          sleep 0.5
-        end
+        page.has_css?(".loading-indicator--background", wait: 2)
+        expect(page).to have_no_css(".loading-indicator--background", wait: 10)
       end
 
       def expect_missing_filter(name)

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -127,19 +127,17 @@ module Components
       end
 
       def add_filter(name)
-        select_autocomplete page.find(".advanced-filters--add-filter-value"),
+        select_autocomplete -> { page.find(".advanced-filters--add-filter-value") },
                             query: name,
                             results_selector: ".ng-dropdown-panel-items"
       end
 
       def add_filter_by(name, operator, value, selector = nil)
+        id = selector || name.downcase
         add_filter(name)
+        expect(page).to have_css("#filter_#{id}")
 
         set_filter(name, operator, value, selector)
-
-        # Wait for the debounce of the filter input to apply filters
-        # See frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts:69
-        sleep 0.5
       end
 
       def set_operator(name, operator, selector = nil)
@@ -156,6 +154,12 @@ module Components
         set_value(id, value, operator) unless value.nil?
 
         close_autocompleter(id)
+
+        if using_cuprite?
+          wait_for_network_idle(duration: 0.55)
+        else
+          sleep 0.5
+        end
       end
 
       def expect_missing_filter(name)
@@ -270,24 +274,21 @@ module Components
       end
 
       def set_value(id, value, operator)
-        retry_block do
-          # wait for filter to be present
-          filter_element = page.find("#filter_#{id}")
-          if filter_element.has_selector?("[data-test-selector='op-basic-range-date-picker']", wait: false)
-            insert_date_range(filter_element, value)
-          elsif operator == "between"
-            insert_two_single_dates(id, value)
-          elsif filter_element.has_selector?(".ng-select-container", wait: false)
-            insert_autocomplete_item(id, value)
-          else
-            insert_plain_value(id, value)
-          end
+        filter_element = page.find("#filter_#{id}")
+        if filter_element.has_selector?("[data-test-selector='op-basic-range-date-picker']", wait: false)
+          insert_date_range(filter_element, value)
+        elsif operator == "between"
+          insert_two_single_dates(id, value)
+        elsif filter_element.has_selector?(".ng-select-container", wait: false)
+          insert_autocomplete_item(id, value)
+        else
+          insert_plain_value(id, value)
         end
       end
 
       def insert_autocomplete_item(id, value)
         Array(value).each do |val|
-          select_autocomplete page.find("#filter_#{id} ng-select"),
+          select_autocomplete -> { page.find("#filter_#{id} ng-select") },
                               query: val,
                               results_selector: ".ng-dropdown-panel-items"
         end

--- a/spec/support/components/work_packages/progress_popover.rb
+++ b/spec/support/components/work_packages/progress_popover.rb
@@ -61,9 +61,10 @@ module Components
 
       attr_reader :create_form
 
-      def initialize(container: page, create_form: false)
+      def initialize(container: page, create_form: false, field_selector_prefix: nil)
         @container_or_lambda_to_get_container = container
         @create_form = create_form
+        @field_selector_prefix = field_selector_prefix
       end
 
       def container
@@ -181,7 +182,10 @@ module Components
 
       def field(field_name)
         field_name = js_field_name(field_name)
-        ProgressEditField.new(container, field_name, create_form:)
+        selector = if @field_selector_prefix
+                     "#{@field_selector_prefix} .inline-edit--container.#{field_name.to_s.camelize(:lower)}"
+                   end
+        ProgressEditField.new(container, field_name, create_form:, selector:)
       end
 
       def js_field_name(field_name)

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -97,7 +97,7 @@ module Components
       end
 
       def expect_open
-        raise "Expected modal to be open" unless open?
+        expect(page).to have_css(".wp-table--configuration-modal")
       end
 
       def open?

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -66,10 +66,18 @@ module Components
 
     def clear
       textarea = container.find(".op-ckeditor-source-element", visible: :all)
-      page.execute_script(
-        'arguments[0].dispatchEvent(new Event("op:ckeditor:clear"))',
-        textarea.native
-      )
+      last_updated_before = last_updated_for(textarea)
+
+      page.execute_script('arguments[0].dispatchEvent(new Event("op:ckeditor:clear"))', textarea.native)
+
+      page.document.synchronize do
+        last_updated_after = last_updated_for(textarea)
+        cleared = editor_element.text.blank?
+
+        unless last_updated_after > last_updated_before && cleared
+          raise Capybara::ElementNotFound, "CKEditor did not process the clear event"
+        end
+      end
     end
 
     def trigger_autosave

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -146,6 +146,7 @@ end
 Ferrum::Contexts.prepend(Module.new do
   def reset
     super
+  ensure
     @default_context = nil
   end
 

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -160,6 +160,14 @@ Ferrum::Contexts.prepend(Module.new do
   end
 end)
 
+Capybara::Cuprite::Browser.prepend(Module.new do
+  def reset
+    super
+  rescue Ferrum::TimeoutError, Ferrum::DeadBrowserError
+    restart
+  end
+end)
+
 register_better_cuprite "en"
 
 RSpec.configure do |config|

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -211,9 +211,13 @@ class EditField
     raise ArgumentError.new("Is not an autocompleter field") unless autocompleter_field?
 
     if select
-      select_autocomplete field_container, query:, select_text:, results_selector: "body"
+      select_autocomplete -> { field_container },
+                          query:,
+                          select_text:,
+                          results_selector: "body",
+                          wait_dropdown_open: false
     else
-      search_autocomplete field_container, query:, results_selector: "body"
+      search_autocomplete -> { field_container }, query:, results_selector: "body", wait_dropdown_open: false
     end
   end
 

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -151,8 +151,8 @@ class EditField
   alias :editing? :active?
 
   def expect_active!
-    expect(field_container)
-      .to have_selector(field_type, wait: 10),
+    expect(context)
+      .to have_css("#{@selector} #{field_type}", wait: 10),
           "Expected field input type '#{field_type}' for attribute '#{property_name}'."
 
     # Also ensure the element is not disabled
@@ -161,8 +161,8 @@ class EditField
   end
 
   def expect_inactive!
-    expect(field_container).to have_selector(display_selector, wait: 10)
-    expect(field_container).to have_no_selector(field_type)
+    expect(context).to have_css("#{@selector} #{display_selector}", wait: 10)
+    expect(context).to have_no_selector("#{@selector} #{field_type}")
   end
 
   def expect_enabled!

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -113,7 +113,7 @@ class EditField
     retry_block(args: { tries: 2 }) do
       unless active?
         SeleniumHubWaiter.wait unless using_cuprite?
-        scroll_to_and_click(display_trigger_element, block: :nearest)
+        scroll_to_and_click(block: :nearest) { display_trigger_element }
         SeleniumHubWaiter.wait unless using_cuprite?
       end
 

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -60,11 +60,8 @@ class EditField
   end
 
   def display_trigger_element
-    if display_element.has_selector?(".inline-edit--display-trigger", wait: 0)
-      display_element.find(".inline-edit--display-trigger")
-    else
-      display_element
-    end
+    display = display_element
+    display.first(".inline-edit--display-trigger", minimum: 0, wait: 0) || display
   end
 
   def input_element

--- a/spec/support/pages/admin/departments.rb
+++ b/spec/support/pages/admin/departments.rb
@@ -82,8 +82,8 @@ module Pages
         end
       end
 
-      def expect_breadcrumbs(*names)
-        page.document.synchronize do
+      def expect_breadcrumbs(*names, wait: Capybara.default_max_wait_time)
+        page.document.synchronize(wait) do
           actual = page.find(detail_component_selector).all("li.breadcrumb-item", wait: 0).map(&:text)
           raise Capybara::ExpectationNotMet, "expected #{names.inspect}, got #{actual.inspect}" unless actual == names
         end

--- a/spec/support/pages/admin/settings/project_phase_definitions.rb
+++ b/spec/support/pages/admin/settings/project_phase_definitions.rb
@@ -43,7 +43,7 @@ module Pages
         end
 
         def expect_listed(names)
-          page.document.synchronize do
+          page.document.synchronize(10) do
             found = page.all("[data-test-selector=project-phase-definition-name]").collect(&:text)
 
             raise Capybara::ExpectationNotMet, "Expected #{names}, got #{found}" unless found == names

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -42,13 +42,9 @@ module Pages
 
     def click_share_button
       within toolbar do
-        # The request to the capabilities endpoint determines
-        # whether the "Share" button is rendered or not.
-        # Instead of waiting for an idle network (which may
-        # include waiting for other network requests unrelated to
-        # sharing), waiting for the button to be present makes
-        # the spec a tad faster.
-        click_button("Share", wait: 10)
+        find_button("Share", wait: 10)
+        wait_for_network_idle(timeout: 10)
+        click_button("Share")
       end
     end
 

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -66,12 +66,10 @@ module Pages
     #
     # @param work_packages [Array<WorkPackage>] The work package objects.
     def expect_work_package_listed(*work_packages)
-      within(table_container) do
-        work_packages.each do |wp|
-          expect(page).to have_css(".wp-row-#{wp.id} td.subject",
-                                   text: wp.subject,
-                                   wait: 20)
-        end
+      work_packages.each do |wp|
+        expect(page).to have_css("#content .work-packages-split-view--tabletimeline-side .wp-row-#{wp.id} td.subject",
+                                 text: wp.subject,
+                                 wait: 20)
       end
     end
 

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -66,10 +66,12 @@ module Pages
     #
     # @param work_packages [Array<WorkPackage>] The work package objects.
     def expect_work_package_listed(*work_packages)
-      work_packages.each do |wp|
-        expect(page).to have_css("#content .work-packages-split-view--tabletimeline-side .wp-row-#{wp.id} td.subject",
-                                 text: wp.subject,
-                                 wait: 20)
+      within(table_container) do
+        work_packages.each do |wp|
+          expect(page).to have_css(".wp-row-#{wp.id} td.subject",
+                                   text: wp.subject,
+                                   wait: 20)
+        end
       end
     end
 

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -376,7 +376,7 @@ module Pages
     end
 
     def progress_popover(work_package)
-      Components::WorkPackages::ProgressPopover.new(container: -> { work_package_container(work_package) })
+      Components::WorkPackages::ProgressPopover.new(container: page, field_selector_prefix: row_selector(work_package))
     end
 
     def expect_no_column_add_option(column_name)
@@ -391,16 +391,18 @@ module Pages
     end
 
     def work_package_field(work_package, key)
-      container = work_package_container(work_package)
+      row = work_package.nil? ? ".wp-inline-create-row" : row_selector(work_package)
+      selector = "#{row} .inline-edit--container.#{key.to_s.camelize(:lower)}"
+
       case key.to_sym
       when :date, :startDate, :dueDate, :combinedDate
-        DateEditField.new container, key, is_milestone: work_package.milestone?, is_table: true
+        DateEditField.new page, key, selector:, is_milestone: work_package.milestone?, is_table: true
       when :estimatedTime, :remainingTime
-        ProgressEditField.new container, key
+        ProgressEditField.new page, key, selector:
       when :project
-        InlineProjectEditField.new container, key
+        InlineProjectEditField.new page, key, selector:
       else
-        EditField.new container, key
+        EditField.new page, key, selector:
       end
     end
 

--- a/spec/support/shared/loading_indicator_saveguard.rb
+++ b/spec/support/shared/loading_indicator_saveguard.rb
@@ -35,13 +35,10 @@
 # completion of said request.
 #
 
-def loading_indicator_saveguard
-  expect(page).to have_no_css(".op-loading-indicator")
+def loading_indicator_saveguard(wait: Capybara.default_max_wait_time)
+  expect(page).to have_no_css(".op-loading-indicator", wait:)
 rescue Selenium::WebDriver::Error::StaleElementReferenceError
-  # The loading indicator disappeared mid-check (stale element reference while Capybara
-  # was building its failure message), which is exactly what we were waiting for.
-  # Retry — the element is gone so the next check will pass.
-  retry
+  nil
 end
 
 # ng-select uses a loading indicator with css class .ng-spinner-loader when

--- a/spec/support/toasts/expectations.rb
+++ b/spec/support/toasts/expectations.rb
@@ -20,20 +20,22 @@ module Toasts
       expect_toast(type:, message:, wait:)
 
       while page.has_css?(".op-toast.-#{type}", wait: 1)
-        page.first(".op-toast.-#{type} .op-toast--close", wait: 1).click
+        page.document.synchronize do
+          page.first(".op-toast.-#{type} .op-toast--close", wait: 0)&.click
+        end
       end
 
       expect_no_toaster(type:, message:, wait: 2)
     end
 
     def dismiss_toaster!
-      sleep 0.1
-      page.find(".op-toast--close").click
+      page.document.synchronize { page.find(".op-toast--close").click }
     end
 
     def dismiss_specific_toaster!(message:, type: :success)
-      sleep 0.1
-      page.find(".op-toast.-#{type}", text: message).find(".op-toast--close").click
+      page.document.synchronize do
+        page.find(".op-toast.-#{type}", text: message).find(".op-toast--close").click
+      end
     end
 
     # Clears a toaster if there is one waiting 1 second max, but do not fail if there is none

--- a/spec/support/workflows/edit_helpers.rb
+++ b/spec/support/workflows/edit_helpers.rb
@@ -70,7 +70,7 @@ module Workflows
         click_link "Status"
       end
       within_dialog "Statuses" do
-        find(".ng-value", text: status.name).find(".ng-value-icon").click
+        find(".ng-value", text: status.name).find(".ng-value-icon").trigger("click")
         expect(page).to have_no_css(".ng-value-label", text: status.name)
         click_button "Apply"
       end


### PR DESCRIPTION
Hosted feature runs still spend time retrying browser races. Those retries repeat expensive setup and browser work, extend the long tail, and hide synchronization defects from developers running one example locally.

This PR replaces fixed sleeps, replay loops, stale DOM scopes, and immediate assertions with waits for the resulting Turbo navigation or stream, component connection, serialized request queue, table loading cycle, modal state, or confirmation. It converts ordinary Selenium interactions to Cuprite where Selenium-specific coverage is unnecessary and restarts a dead Cuprite worker browser so one cleanup failure cannot poison every later file.

The latest batch addresses every retry signature from hosted run `33649558506`:

- removing a work-package filter waits for the debounced table refresh to start and finish, preventing that refresh from overwriting a newly added filter;
- ng-select checks whether the target control is open instead of mistaking an unrelated global dropdown for it;
- wiki configure/save actions wait for their exact Turbo navigation, avoiding obsolete menu nodes during page replacement;
- department browser-back coverage waits for the exact restored breadcrumb sequence with a contention-safe timeout;
- datepicker updates observe the frontend's preview-pending marker before waiting for the debounced preview to finish; and
- the earlier embedded-table scope and visible Primer-label fixes remain covered by the preceding commits.

Local validation with `RSPEC_RETRY_RETRY_COUNT=0`:

- the six-file cohort that previously reproduced the failures passes: 21 examples, 0 failures in 2m25;
- the work-package user custom-field and assignee query regressions each pass five independent process runs;
- the wiki and board custom-field examples each pass five independent process runs;
- department history restoration passes 5/5, including the seed that disproved an earlier frame-event approach;
- the 42-second scheduling-mode example passes three independent process runs;
- 52 embedded-table and form-query examples pass after restoring polymorphic table scope;
- the earlier affected cohorts include 322 work-package examples across 44 files, 88 remaining-signature examples, and repeated Jira, Calendar, stale-row, and version-filter runs; and
- `git diff --check` passes; targeted RuboCop passes, excluding two pre-existing offenses outside changed lines.

Hosted evidence on the pinned 24-CPU/96-GiB runner:

- run `33641611157` passed 51,364 units in 2m22 and all 3,645 features in 9m43; it exposed two stale work-package-table signatures fixed in a later batch;
- stacked run `33641716858` completed in 15m00 and exposed the Jira, Primer checkbox, autocomplete, and timestamp signatures fixed here;
- run `33646293232` exposed a selector regression in embedded work-package tables; restoring polymorphic table scope fixed all 52 affected local examples;
- run `33649558506` completed in 15m23, but its 10m16 feature pass still needed internal retries plus one serial fallback; its six signatures are the target of the current batch;
- current head: `66045606a8e` (hosted inventory gate pending).

This is a reliability batch rather than a claimed material speedup. Avoiding full-example retries should reduce variance and developer wait time; the larger runtime work remains browser-family extraction and reducing the eager frontend bootstrap.
