### PR TITLE
[JIM-204] Make sure jira import stages run in order.

### DIFF
--- a/app/models/import/jira_import_state_machine.rb
+++ b/app/models/import/jira_import_state_machine.rb
@@ -107,9 +107,7 @@ module Import
           .first
 
       if last_importing_transition.nil?
-        batch = GoodJob::Batch.enqueue(on_success: Import::JiraStagedImportJob,
-                                       on_finish: Import::JiraStagedImportJob::FinishCallbackJob,
-                                       on_discard: Import::JiraStagedImportJob::DiscardCallbackJob,
+        batch = GoodJob::Batch.enqueue(on_finish: Import::JiraStagedImportJob,
                                        jira_import_id: jira_import.id,
                                        stage: nil)
       else

--- a/app/workers/import/jira_staged_import_job.rb
+++ b/app/workers/import/jira_staged_import_job.rb
@@ -30,35 +30,11 @@
 
 module Import
   class JiraStagedImportJob < ApplicationJob
-    class FinishCallbackJob < ApplicationJob
-      def perform(batch, context)
-        jira_import = Import::JiraImport.find(batch.properties[:jira_import_id])
-
-        case context[:event]
-        when :finish
-          if jira_import.in_state?(:import_aborting)
-            jira_import.transition_to!(:import_error)
-          end
-        end
-      end
-    end
-
-    class DiscardCallbackJob < ApplicationJob
-      def perform(batch, context)
-        jira_import = Import::JiraImport.find(batch.properties[:jira_import_id])
-        case context[:event]
-        when :discard
-          jira_import.transition_to!(:import_error) unless jira_import.in_state?(:import_aborting, :import_error)
-        end
-      end
-    end
-
     # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
-    def perform(batch, context)
+    def perform(batch, _context)
       jira_import = Import::JiraImport.find(batch.properties[:jira_import_id])
 
-      case context[:event]
-      when :success
+      if batch.succeeded?
         if batch.properties[:stage].nil?
           batch.enqueue(stage: 1) do
             Import::JiraFetchIssueTypesJob.set(good_job_labels: ["stage_1"]).perform_later(jira_import.id)
@@ -99,7 +75,7 @@ module Import
             Import::JiraProject.where(jira_import_id: jira_import.id,
                                       origin_id: jira_import.project_ids).find_each do |jira_project|
               Import::JiraCreateProjectWorkPackagesJob.set(good_job_labels: ["stage_7"])
-                                                      .perform_later(jira_import.id, jira_project.id)
+                .perform_later(jira_import.id, jira_project.id)
             end
           end
         elsif batch.properties[:stage] == 7
@@ -107,12 +83,14 @@ module Import
             Import::JiraProject.where(jira_import_id: jira_import.id,
                                       origin_id: jira_import.project_ids).find_each do |jira_project|
               Import::JiraCreateProjectWorkPackageAttachmentsJob.set(good_job_labels: ["stage_8"])
-                                                                .perform_later(jira_import.id, jira_project.id)
+                .perform_later(jira_import.id, jira_project.id)
             end
           end
         elsif batch.properties[:stage] == 8
           jira_import.transition_to!(:imported)
         end
+      elsif batch.discarded?
+        jira_import.transition_to!(:import_error)
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity

--- a/app/workers/import/jira_staged_import_job.rb
+++ b/app/workers/import/jira_staged_import_job.rb
@@ -35,6 +35,12 @@ module Import
       jira_import = Import::JiraImport.find(batch.properties[:jira_import_id])
 
       if batch.succeeded?
+        # happens when jobs are not progressable and can't react to impot_aborting by discarding themselves.
+        if jira_import.in_state?(:import_aborting)
+          jira_import.transition_to!(:import_error)
+          return
+        end
+
         if batch.properties[:stage].nil?
           batch.enqueue(stage: 1) do
             Import::JiraFetchIssueTypesJob.set(good_job_labels: ["stage_1"]).perform_later(jira_import.id)

--- a/spec/workers/import/jira_staged_import_job_spec.rb
+++ b/spec/workers/import/jira_staged_import_job_spec.rb
@@ -30,62 +30,262 @@
 
 require "spec_helper"
 
-RSpec.describe Import::JiraStagedImportJob do
+RSpec.describe Import::JiraStagedImportJob, with_good_job_batches: [Import::JiraStagedImportJob] do
   let(:jira) { create(:jira) }
   let(:author) { create(:user) }
-  let(:jira_import) { create(:jira_import, jira:, author:) }
+  let(:jira_import) { create(:jira_import, jira:, author:, projects: selected_projects) }
+  let(:selected_projects) { [{ "id" => "10012", "key" => "DPPP", "name" => "Demo project" }] }
 
-  let(:batch) { instance_double(GoodJob::Batch, properties: { jira_import_id: jira_import.id, stage: }) }
+  let(:stage) { nil }
+  let(:discarded) { false }
 
-  def run_stage
-    described_class.perform_now(batch, { event: :success })
+  let(:batch) do
+    batch_record = GoodJob::BatchRecord.create!(
+      serialized_properties: { jira_import_id: jira_import.id, stage: },
+      on_finish: "Import::JiraStagedImportJob",
+      finished_at: Time.current,
+      discarded_at: discarded ? Time.current : nil
+    )
+    GoodJob::Batch.new(_record: batch_record)
   end
 
-  before { allow(batch).to receive(:enqueue).and_yield }
+  subject(:run_callback) { described_class.perform_now(batch, {}) }
 
-  describe "the stage building the import-wide prerequisites" do
-    let(:stage) { 4 }
+  def transition_to_importing
+    allow(Import::JiraInstanceMetaDataJob)
+      .to receive(:perform_later)
+      .and_return(instance_double(Import::JiraInstanceMetaDataJob, job_id: "instance-meta-job-id"))
+    allow(Import::JiraProjectsMetaDataJob)
+      .to receive(:perform_later)
+      .and_return(instance_double(Import::JiraProjectsMetaDataJob, job_id: "projects-meta-job-id"))
 
-    # The custom fields have to exist before the per-project jobs fan out: each of those rebuilds
-    # the registry, and creating the fields once up front keeps the per-project runs to a lookup.
-    it "enqueues the project role and the custom fields job" do
-      run_stage
+    jira_import.transition_to!(:instance_meta_fetching)
+    jira_import.transition_to!(:instance_meta_done)
+    jira_import.transition_to!(:configuring)
+    jira_import.transition_to!(:projects_meta_fetching)
+    jira_import.transition_to!(:projects_meta_done)
+    jira_import.transition_to!(:importing)
+  end
 
-      expect(batch).to have_received(:enqueue).with(stage: 5)
-      expect(Import::JiraCreateProjectRoleJob).to have_been_enqueued.with(jira_import.id)
-      expect(Import::JiraCreateCustomFieldsJob).to have_been_enqueued.with(jira_import.id)
+  before { transition_to_importing }
+
+  context "when batch succeeded" do
+    let(:discarded) { false }
+
+    describe "stage nil (initial stage)" do
+      let(:stage) { nil }
+
+      it "enqueues fetch jobs for issue types, priorities, statuses, and projects" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchIssueTypesJob").count).to eq(1)
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchPrioritiesJob").count).to eq(1)
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchStatusesJob").count).to eq(1)
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchProjectsJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_1" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchIssueTypesJob").last.labels).to include("stage_1")
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchPrioritiesJob").last.labels).to include("stage_1")
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchStatusesJob").last.labels).to include("stage_1")
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchProjectsJob").last.labels).to include("stage_1")
+      end
+    end
+
+    describe "stage 1" do
+      let(:stage) { 1 }
+      let!(:jira_project) do
+        create(:jira_project, jira_import:, origin_id: "10012",
+                              payload: { "id" => "10012", "key" => "DPPP", "name" => "Demo project" })
+      end
+
+      it "enqueues one fetch issues job per selected project" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchProjectIssuesJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_2" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchProjectIssuesJob").last.labels).to include("stage_2")
+      end
+
+      context "with multiple selected projects" do
+        let(:selected_projects) do
+          [
+            { "id" => "10012", "key" => "DPPP", "name" => "Demo project" },
+            { "id" => "10013", "key" => "TEST", "name" => "Test project" }
+          ]
+        end
+        let!(:jira_project2) do
+          create(:jira_project, jira_import:, origin_id: "10013",
+                                payload: { "id" => "10013", "key" => "TEST", "name" => "Test project" })
+        end
+
+        it "enqueues a fetch job for each selected project" do
+          run_callback
+
+          expect(GoodJob::Job.where(job_class: "Import::JiraFetchProjectIssuesJob").count).to eq(2)
+        end
+      end
+
+      context "when a project exists but is not selected for import" do
+        let!(:unselected_project) do
+          create(:jira_project, jira_import:, origin_id: "99999",
+                                payload: { "id" => "99999", "key" => "SKIP", "name" => "Skipped project" })
+        end
+
+        it "does not enqueue a fetch job for the unselected project" do
+          run_callback
+
+          expect(GoodJob::Job.where(job_class: "Import::JiraFetchProjectIssuesJob").count).to eq(1)
+        end
+      end
+    end
+
+    describe "stage 2" do
+      let(:stage) { 2 }
+
+      it "enqueues fetch users and custom fields jobs" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchUsersJob").count).to eq(1)
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchCustomFieldJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_3" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchUsersJob").last.labels).to include("stage_3")
+        expect(GoodJob::Job.where(job_class: "Import::JiraFetchCustomFieldJob").last.labels).to include("stage_3")
+      end
+    end
+
+    describe "stage 3" do
+      let(:stage) { 3 }
+
+      it "enqueues the create users job" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateUsersJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_4" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateUsersJob").last.labels).to include("stage_4")
+      end
+    end
+
+    describe "stage 4" do
+      let(:stage) { 4 }
+
+      it "enqueues the project role and custom fields creation jobs" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectRoleJob").count).to eq(1)
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateCustomFieldsJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_5" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectRoleJob").last.labels).to include("stage_5")
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateCustomFieldsJob").last.labels).to include("stage_5")
+      end
+    end
+
+    describe "stage 5" do
+      let(:stage) { 5 }
+      let!(:jira_project) do
+        create(:jira_project, jira_import:, origin_id: "10012",
+                              payload: { "id" => "10012", "key" => "DPPP", "name" => "Demo project" })
+      end
+
+      it "enqueues one create project job per selected project" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_6" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectJob").last.labels).to include("stage_6")
+      end
+    end
+
+    describe "stage 6" do
+      let(:stage) { 6 }
+      let!(:jira_project) do
+        create(:jira_project, jira_import:, origin_id: "10012",
+                              payload: { "id" => "10012", "key" => "DPPP", "name" => "Demo project" })
+      end
+
+      it "enqueues one create work packages job per selected project" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectWorkPackagesJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_7" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectWorkPackagesJob").last.labels).to include("stage_7")
+      end
+    end
+
+    describe "stage 7" do
+      let(:stage) { 7 }
+      let!(:jira_project) do
+        create(:jira_project, jira_import:, origin_id: "10012",
+                              payload: { "id" => "10012", "key" => "DPPP", "name" => "Demo project" })
+      end
+
+      it "enqueues one create attachments job per selected project" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectWorkPackageAttachmentsJob").count).to eq(1)
+      end
+
+      it "labels enqueued jobs with stage_8" do
+        run_callback
+
+        expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectWorkPackageAttachmentsJob").last.labels)
+          .to include("stage_8")
+      end
+    end
+
+    describe "stage 8 (final stage)" do
+      let(:stage) { 8 }
+
+      it "does not enqueue any more jobs" do
+        expect { run_callback }.not_to change(GoodJob::Job, :count)
+      end
+
+      it "transitions the import to the imported state" do
+        run_callback
+
+        expect(jira_import.reload.current_state).to eq("imported")
+      end
     end
   end
 
-  describe "the stage creating the projects" do
-    let(:stage) { 5 }
-    let!(:jira_project) do
-      create(:jira_project, jira_import:, origin_id: "10012",
-                            payload: { "id" => "10012", "key" => "DPPP", "name" => "Demo project" })
+  context "when batch has been discarded" do
+    let(:stage) { 3 }
+    let(:discarded) { true }
+
+    it "does not enqueue any jobs" do
+      expect { run_callback }.not_to change(GoodJob::Job, :count)
     end
 
-    before { jira_import.update!(projects: [{ "id" => "10012", "key" => "DPPP", "name" => "Demo project" }]) }
+    it "transitions the import to import_error state" do
+      run_callback
 
-    it "enqueues one project job per selected project" do
-      run_stage
-
-      expect(batch).to have_received(:enqueue).with(stage: 6)
-      expect(Import::JiraCreateProjectJob).to have_been_enqueued.with(jira_import.id, jira_project.id)
-    end
-  end
-
-  describe "the final stage" do
-    let(:stage) { 8 }
-
-    before { allow(batch).to receive(:enqueue) }
-
-    it "marks the import as imported" do
-      allow(jira_import).to receive(:transition_to!)
-      allow(Import::JiraImport).to receive(:find).with(jira_import.id).and_return(jira_import)
-
-      run_stage
-
-      expect(jira_import).to have_received(:transition_to!).with(:imported)
+      expect(jira_import.reload.current_state).to eq("import_error")
     end
   end
 end

--- a/spec/workers/import/jira_staged_import_job_spec.rb
+++ b/spec/workers/import/jira_staged_import_job_spec.rb
@@ -72,6 +72,36 @@ RSpec.describe Import::JiraStagedImportJob, with_good_job_batches: [Import::Jira
   context "when batch succeeded" do
     let(:discarded) { false }
 
+    context "when the import is being aborted" do
+      before { jira_import.transition_to!(:import_aborting) }
+
+      describe "a stage that finished before the abort reached its jobs" do
+        let(:stage) { 4 }
+
+        it "does not enqueue the next stage" do
+          run_callback
+
+          expect(GoodJob::Job.where(job_class: "Import::JiraCreateProjectRoleJob").count).to eq(0)
+          expect(GoodJob::Job.where(job_class: "Import::JiraCreateCustomFieldsJob").count).to eq(0)
+        end
+
+        it "transitions the import to import_error" do
+          run_callback
+
+          expect(jira_import.reload.current_state).to eq("import_error")
+        end
+      end
+
+      describe "the final stage" do
+        let(:stage) { 8 }
+
+        it "transitions the import to import_error instead of raising" do
+          expect { run_callback }.not_to raise_error
+          expect(jira_import.reload.current_state).to eq("import_error")
+        end
+      end
+    end
+
     describe "stage nil (initial stage)" do
       let(:stage) { nil }
 


### PR DESCRIPTION
https://community.openproject.org/wp/JIM-204

Use only on_finish callback for both advancing stages and transition jira_import to the import state.
Using both on_finish and on_success created a race condition and sometimes jira_import stage was advanced when previous stage jobs had not been finished yet.
New implementation should not have this issue. And it should be simpler to understand hopefully.