### PR TITLE
Move invite custom-field regressions below the browser

### DIFF
--- a/spec/controllers/users/invite_controller_spec.rb
+++ b/spec/controllers/users/invite_controller_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Users::InviteController do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:project) { create(:project) }
+  shared_let(:role) { create(:project_role) }
+
+  before { login_as(admin) }
+
+  def invite(principal_type:, id_or_email:)
+    post :step,
+         params: {
+           step: "principal",
+           user_invitation: {
+             project_id: project.id,
+             principal_type:,
+             id_or_email:,
+             role_id: role.id,
+             message: "Welcome"
+           }
+         },
+         format: :turbo_stream
+  end
+
+  def create_required_user_custom_fields
+    create(:user_custom_field, :list, is_required: true, editable: false, default_option: "A")
+    create(:user_custom_field, :string, is_required: true)
+  end
+
+  def create_required_group_custom_fields
+    create(:group_custom_field, :list, is_required: true, editable: false, default_option: "A")
+    create(:group_custom_field, :string, is_required: true)
+  end
+
+  describe "POST #step for the principal step" do
+    it "adds an existing user with missing required custom fields" do
+      principal = create(:user)
+      create_required_user_custom_fields
+
+      invite(principal_type: "User", id_or_email: principal.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(project.members.find_by(user_id: principal.id)&.roles).to eq([role])
+    end
+
+    it "invites and adds a new user with missing required custom fields" do
+      create_required_user_custom_fields
+
+      invite(principal_type: "User", id_or_email: "new-user@example.com")
+
+      principal = User.find_by!(mail: "new-user@example.com")
+      expect(response).to have_http_status(:ok)
+      expect(principal).to be_invited
+      expect(project.members.find_by(user_id: principal.id)&.roles).to eq([role])
+    end
+
+    it "adds a group with missing required custom fields" do
+      principal = create(:group)
+      create_required_group_custom_fields
+
+      invite(principal_type: "Group", id_or_email: principal.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(project.members.find_by(user_id: principal.id)&.roles).to eq([role])
+    end
+  end
+end

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -228,35 +228,6 @@ RSpec.describe "Invite user modal", :js do
             let(:mail_membership_recipients) { [principal] }
           end
         end
-
-        context "with a required list user CF (regression #58429)" do
-          let(:current_user) { create(:admin) }
-          let(:list_cf) do
-            create(:user_custom_field,
-                   :list,
-                   name: "List",
-                   is_required: true,
-                   editable: false,
-                   default_option: "A")
-          end
-
-          before do
-            list_cf
-          end
-
-          context "when another required CF value is missing" do
-            let(:string_cf) { create(:user_custom_field, :string, name: "Department", is_required: true) }
-
-            before do
-              string_cf
-            end
-
-            it_behaves_like "invites the principal to the project" do
-              let(:added_principal) { principal }
-              let(:mail_membership_recipients) { [principal] }
-            end
-          end
-        end
       end
 
       context "with a user to be invited" do
@@ -270,36 +241,6 @@ RSpec.describe "Invite user modal", :js do
             let(:added_principal) { User.find_by!(mail: principal.mail) }
             let(:mail_invite_recipients) { [added_principal] }
             let(:mail_membership_recipients) { [added_principal] }
-          end
-
-          context "with a required list user CF" do
-            let(:current_user) { create(:admin) }
-            let(:list_cf) do
-              create(:user_custom_field,
-                     :list,
-                     name: "List",
-                     is_required: true,
-                     editable: false,
-                     default_option: "A")
-            end
-
-            before do
-              list_cf
-            end
-
-            context "when the required list CF value is missing" do
-              let(:string_cf) { create(:user_custom_field, :string, name: "Department", is_required: true) }
-
-              before do
-                string_cf
-              end
-
-              it_behaves_like "invites the principal to the project" do
-                let(:added_principal) { User.find_by!(mail: principal.mail) }
-                let(:mail_invite_recipients) { [added_principal] }
-                let(:mail_membership_recipients) { [added_principal] }
-              end
-            end
           end
         end
 
@@ -406,35 +347,6 @@ RSpec.describe "Invite user modal", :js do
           let(:added_principal) { principal }
           # Groups get no invite mail themselves but their members do
           let(:mail_membership_recipients) { [group_user] }
-        end
-
-        context "with a required group custom field" do
-          let(:current_user) { create(:admin) }
-          let(:list_cf) do
-            create(:group_custom_field,
-                   :list,
-                   name: "Department",
-                   is_required: true,
-                   editable: false,
-                   default_option: "A")
-          end
-
-          before do
-            list_cf
-          end
-
-          context "when the required group CF value is missing" do
-            let(:string_cf) { create(:group_custom_field, :string, name: "Team Type", is_required: true) }
-
-            before do
-              string_cf
-            end
-
-            it_behaves_like "invites the principal to the project" do
-              let(:added_principal) { principal }
-              let(:mail_membership_recipients) { [group_user] }
-            end
-          end
         end
       end
     end

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -562,6 +562,18 @@ RSpec.describe CustomField do
     end
   end
 
+  describe "#cache_key" do
+    it "distinguishes single- and multi-value fields" do
+      field = create(:list_wp_custom_field, multi_value: false)
+
+      expect(field.cache_key).to end_with("/sv")
+
+      field.update!(multi_value: true)
+
+      expect(field.cache_key).to end_with("/mv")
+    end
+  end
+
   describe "#allow_non_open_versions?" do
     context "with a wp list cf" do
       let(:field) { build_stubbed(:list_wp_custom_field) }


### PR DESCRIPTION
Three required-custom-field regressions repeat the complete invite modal flow for existing users, new users, and groups. The Angular custom-field component they originally guarded was removed in 2025; today these cases only verify that the controller can create memberships when required custom-field values are absent. Keeping all three in the browser adds roughly 30 seconds to one of the suite's slowest feature files.

This PR keeps the generic browser flow for every principal type and moves the required-custom-field variants to controller specs that post the real principal step without stubbing its services. It also adds a focused model assertion for the single- versus multi-value custom-field cache key, which the removed browser examples reached incidentally without asserting.

Local native benchmark on the same host and seed (`38299`):

- control feature file: 19 examples in 2m32.4s;
- candidate feature file: 16 examples in 2m02.2s;
- reduction: 30.2s, or 19.8% of RSpec time for the file;
- replacement controller coverage: 3 examples in 1.29s.

Coverage validation used SimpleCov line and branch coverage. Comparing the control browser file with the candidate plus the unit specs that already run in the same CI job reports 0 lost covered lines and 0 lost covered branches. The final candidate cohort (feature, controller regressions, and cache-key assertion) passes 20 examples with coverage enabled.

This is stacked on #25093 so the hosted gate includes the current retry fixes.
