### PR TITLE
Reduce project creation browser coverage

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe ProjectsController do
   end
 
   describe "#new" do
+    render_views
+
     shared_examples_for "successful requests" do
       context "without a parent" do
         let(:parent) { nil }
@@ -76,11 +78,17 @@ RSpec.describe ProjectsController do
 
     shared_examples_for "successful request" do
       it "renders 'new'", :aggregate_failures do
+        cancel_path = parent ? project_overview_path(parent.id) : projects_path
+
         expect(response).to be_successful
         expect(assigns(:new_project)).to be_a_new(Project)
         expect(assigns(:parent)).to eq parent
         expect(assigns(:template)).to eq template
         expect(response).to render_template "new"
+        expect(response.body).to have_link(I18n.t(:button_cancel), href: cancel_path)
+        expect(response.body).to have_css(
+          "[data-test-selector='new_project_form_close_icon'][href='#{cancel_path}']"
+        )
       end
     end
 
@@ -109,6 +117,22 @@ RSpec.describe ProjectsController do
         let(:parent) { create(:project) }
 
         it_behaves_like "successful request"
+      end
+
+      context "with an admin-only project custom field" do
+        let(:parent) { nil }
+
+        it "does not render the field" do
+          create(:string_project_custom_field,
+                 name: "Text for Admins only",
+                 is_required: true,
+                 is_for_all: true,
+                 admin_only: true)
+
+          get :new, params: { workspace_type: }
+
+          expect(response.body).to have_no_text("Text for Admins only")
+        end
       end
     end
 

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -72,55 +72,6 @@ RSpec.describe "Projects", "creation", :js do
     expect(page).to have_content "Foo bar"
   end
 
-  it "redirects to the parent project page when users cancels while creating subproject" do
-    # Go to parent project page
-    visit project_overview_path(project.id)
-
-    # Start creating a subproject from parent context
-    page.find_test_selector("quick-add-menu-button").click
-    page.find_test_selector("quick-add-menu-item", text: "Project", wait: 5).click
-
-    expect(page).to have_heading "New project"
-
-    click_on "Cancel"
-
-    expect(page).to have_current_path project_overview_path(project.id)
-  end
-
-  it "redirects to projects#index when users cancels" do
-    visit new_project_path
-
-    expect(page).to have_heading "New project"
-
-    click_on "Cancel"
-    expect(page).to have_current_path projects_path
-  end
-
-  it "redirects to the parent project page when users press the close icon while creating subproject" do
-    # Go to parent project page
-    visit project_overview_path(project.id)
-
-    # Start creating a subproject from parent context
-    page.find_test_selector("quick-add-menu-button").click
-    page.find_test_selector("quick-add-menu-item", text: "Project", wait: 5).click
-
-    expect(page).to have_heading "New project"
-
-    # Click the close (X) icon in the header
-    find_test_selector("new_project_form_close_icon").click
-
-    expect(page).to have_current_path project_overview_path(project.id)
-  end
-
-  it "redirects to projects#index when users click on close icon" do
-    visit new_project_path
-
-    expect(page).to have_heading "New project"
-
-    find_test_selector("new_project_form_close_icon").click
-    expect(page).to have_current_path projects_path
-  end
-
   it "does not create a project with an already existing identifier" do
     projects_page.create_new_workspace :project, open_menu: true
 
@@ -500,9 +451,8 @@ RSpec.describe "Projects", "creation", :js do
         context "with a non-admin user" do
           current_user { create(:user, global_permissions: %i[add_project]) }
 
-          it "does not show invisible fields in the form and thus not activates the invisible field" do
-            pending "Admin-only project attributes currently prevent users from creating projects (OP#64479)"
-
+          it "does not show invisible fields in the form and thus not activates the invisible field",
+             skip: "Admin-only project attributes currently prevent users from creating projects (OP#64479)" do
             expect(page).to have_no_content "Text for Admins only"
 
             click_on "Complete"


### PR DESCRIPTION
The project creation feature spec spent browser time checking four static link destinations and executing 24 seconds of setup for a known-broken pending example. This made the file a recurring slow-suite contributor without adding proportional browser coverage.

This PR moves the cancel and close-link assertions into the rendered `ProjectsController#new` matrix, covering parent/no-parent and template/no-template responses. It also skips the OP#64479 example before browser setup and preserves its passing behavior in a rendered controller example proving that non-admins cannot see an admin-only required project custom field.

Local native benchmark on the same host and seed:

- Control: 23 examples, 1 pending, 127.99s RSpec time.
- Candidate: 19 examples, 1 pending, 93.19s RSpec time.
- Reduction: 34.80s, or 27.2% of the feature file.
- Added controller coverage: 10 examples, all passing; the new visibility example takes about 1 second in isolation.

Focused SimpleCov comparison found that all project-creation behavior remains covered. The removed browser navigation incidentally executed 60 lines and 18 branches in login/logout, error logging, and projects-index rendering; those destination paths are already exercised by the projects-list feature specs, including the five-example admin table context used as the existing-owner coverage check.

Validation:

- Candidate feature and rendered-controller cohort: 29 examples, 0 failures, 1 metadata skip.
- Admin-only field controller example: passing.
- Controller RuboCop: clean.
- Feature file has only its pre-existing `have_content` style offenses.
