### PR TITLE
Refactor TokenPropertyMapper

### DIFF
--- a/app/models/work_package_types/pattern_resolver.rb
+++ b/app/models/work_package_types/pattern_resolver.rb
@@ -50,11 +50,11 @@ module WorkPackageTypes
     private
 
     def get_value(work_package, pattern_token)
-      context = pattern_token.context == :work_package ? work_package : work_package.public_send(pattern_token.context)
-      return ATTRIBUTE_PLACEHOLDER if context.nil?
-
       attribute_token = @tokens.detect { |t| t.key == pattern_token.key }
       return ATTRIBUTE_PLACEHOLDER if attribute_token.nil?
+
+      context = attribute_token.context == :work_package ? work_package : work_package.public_send(attribute_token.context)
+      return ATTRIBUTE_PLACEHOLDER if context.nil?
 
       I18n.with_locale(Setting.default_language) do
         stringify(attribute_token.call(context), nil_replacement(attribute_token))

--- a/app/models/work_package_types/patterns/attribute_token.rb
+++ b/app/models/work_package_types/patterns/attribute_token.rb
@@ -30,7 +30,7 @@
 
 module WorkPackageTypes
   module Patterns
-    AttributeToken = Data.define(:key, :label_fn, :resolve_fn, :formatter) do
+    AttributeToken = Data.define(:key, :context, :label_fn, :resolve_fn, :formatter) do
       def label_with_context
         attribute_context = I18n.t("types.edit.defaults.token.context.#{context}")
         I18n.t("types.edit.defaults.token.label_with_context", attribute_context:, attribute_label: label)
@@ -43,17 +43,6 @@ module WorkPackageTypes
       def call(*)
         value = resolve_fn.call(*)
         formatter.call(value)
-      end
-
-      def context
-        case key.to_s
-        when /^project_/
-          :project
-        when /^parent_/
-          :parent
-        else
-          :work_package
-        end
       end
 
       # --- Equality overrides ---

--- a/app/models/work_package_types/patterns/pattern_token.rb
+++ b/app/models/work_package_types/patterns/pattern_token.rb
@@ -36,17 +36,6 @@ module WorkPackageTypes
       def self.build(pattern)
         new(pattern, pattern.tr("{}", "").to_sym)
       end
-
-      def context
-        case key.to_s
-        when /^project_/
-          :project
-        when /^parent_/
-          :parent
-        else
-          :work_package
-        end
-      end
     end
   end
 end

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -37,88 +37,34 @@ module WorkPackageTypes
       DURATION = ->(v) { DurationConverter.output(v) }
 
       class << self
-        def attribute(key, label_fn, value_fn, formatter = STRING_OR_NIL)
-          AttributeToken.new(key, label_fn, value_fn, formatter)
+        def add_static_attribute(key, label_fn, value_fn, formatter = STRING_OR_NIL)
+          static_tokens << AttributeToken.new(key, label_fn, value_fn, formatter)
+        end
+
+        def static_tokens
+          @static_tokens ||= []
+        end
+
+        def add_custom_fields(scope_fn, prefix = "")
+          custom_field_definitions << [scope_fn, prefix]
+        end
+
+        def custom_field_definitions
+          @custom_field_definitions ||= []
         end
       end
-      # rubocop:disable Layout/LineLength
-      BASE_ATTRIBUTE_TOKENS = [
-        attribute(:id, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id }),
-        attribute(:accountable, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible }),
-        attribute(:assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to }),
-        attribute(:author, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author }),
-        attribute(:category, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category }),
-        attribute(:creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }, DATE),
-        attribute(:estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }, DURATION),
-        attribute(:remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }, DURATION),
-        attribute(:finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }, DATE),
-        attribute(:observed_in_versions, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(wp) { wp.observed_in_versions }, ARRAY),
-        attribute(:parent_id, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id }),
-        attribute(:parent_assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to }),
-        attribute(:parent_author, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author }),
-        attribute(:parent_category, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category }),
-        attribute(:parent_creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }, DATE),
-        attribute(:parent_estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }, DURATION),
-        attribute(:parent_remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }, DURATION),
-        attribute(:parent_finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }, DATE),
-        attribute(:parent_observed_in_versions, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(parent) { parent.observed_in_versions }, ARRAY),
-        attribute(:parent_priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority }),
-        attribute(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
-        attribute(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status }),
-        attribute(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type }),
-        attribute(:parent_version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, ARRAY),
-        attribute(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
-        attribute(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
-        attribute(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
-        attribute(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project }),
-        attribute(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") }),
-        attribute(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id }),
-        attribute(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? }),
-        attribute(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, DATE),
-        attribute(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status }),
-        attribute(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type }),
-        attribute(:version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, ARRAY)
-      ].freeze
-      # rubocop:enable Layout/LineLength
 
       def partitioned_tokens_for_type(variant)
-        enabled_tokens = [
-          *BASE_ATTRIBUTE_TOKENS,
-          *tokenize(work_package_cfs_for(variant)),
-          *tokenize(project_cfs, "project_"),
-          *tokenize(all_work_package_cfs, "parent_")
-        ].to_set
-
-        all_tokens.partition { |token| enabled_tokens.include?(token) }
+        enabled_cf_tokens = custom_field_tokens(variant)
+        [self.class.static_tokens + enabled_cf_tokens, custom_field_tokens(nil) - enabled_cf_tokens]
       end
 
       private
 
-      def all_tokens
-        [
-          *BASE_ATTRIBUTE_TOKENS,
-          *tokenize(all_work_package_cfs),
-          *tokenize(project_cfs, "project_"),
-          *tokenize(all_work_package_cfs, "parent_")
-        ]
-      end
-
-      def default_tokens
-        BASE_ATTRIBUTE_TOKENS.each_with_object({ work_package: {}, project: {}, parent: {} }) do |token, obj|
-          case token.key.to_s
-          when /^project_/
-            obj[:project][token.key] = token
-          when /^parent_/
-            obj[:parent][token.key] = token
-          else
-            obj[:work_package][token.key] = token
-          end
+      def custom_field_tokens(variant)
+        self.class.custom_field_definitions.flat_map do |scope_fn, prefix|
+          tokenize(scope_fn.call(variant), prefix)
         end
-      end
-
-      def prefixed_label(context, attribute_label)
-        attribute_context = I18n.t("types.edit.defaults.token.context.#{context}")
-        I18n.t("types.edit.defaults.token.label_with_context", attribute_context:, attribute_label:)
       end
 
       def tokenize(custom_field_scope, prefix = nil)
@@ -142,18 +88,6 @@ module WorkPackageTypes
             formatter
           )
         end
-      end
-
-      def work_package_cfs_for(variant)
-        all_work_package_cfs.merge(variant.custom_fields)
-      end
-
-      def all_work_package_cfs
-        WorkPackageCustomField.where.not(field_format: %w[text link empty]).order(:name)
-      end
-
-      def project_cfs
-        ProjectCustomField.where.not(field_format: %w[text link empty]).where(admin_only: false, multi_value: false).order(:name)
       end
     end
   end

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -37,16 +37,16 @@ module WorkPackageTypes
       DURATION = ->(v) { DurationConverter.output(v) }
 
       class << self
-        def add_static_attribute(key, label_fn, value_fn, formatter = STRING_OR_NIL)
-          static_tokens << AttributeToken.new(key, label_fn, value_fn, formatter)
+        def add_static_attribute(key, context, label_fn, value_fn, formatter = STRING_OR_NIL)
+          static_tokens << AttributeToken.new(key, context, label_fn, value_fn, formatter)
         end
 
         def static_tokens
           @static_tokens ||= []
         end
 
-        def add_custom_fields(scope_fn, prefix = "")
-          custom_field_definitions << [scope_fn, prefix]
+        def add_custom_fields(scope_fn, context, prefix = "")
+          custom_field_definitions << [scope_fn, context, prefix]
         end
 
         def custom_field_definitions
@@ -62,12 +62,12 @@ module WorkPackageTypes
       private
 
       def custom_field_tokens(variant)
-        self.class.custom_field_definitions.flat_map do |scope_fn, prefix|
-          tokenize(scope_fn.call(variant), prefix)
+        self.class.custom_field_definitions.flat_map do |scope_fn, context, prefix|
+          tokenize(scope_fn.call(variant), context, prefix)
         end
       end
 
-      def tokenize(custom_field_scope, prefix = nil)
+      def tokenize(custom_field_scope, context_name, prefix = nil)
         custom_field_scope.pluck(:name, :id, :field_format, :multi_value).map do |name, id, format, multiple|
           formatter = if multiple
                         ARRAY
@@ -78,6 +78,7 @@ module WorkPackageTypes
                       end
           AttributeToken.new(
             :"#{prefix}custom_field_#{id}",
+            context_name,
             -> { name },
             ->(context) do
               key = :"custom_field_#{id}"

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -36,7 +36,29 @@ module WorkPackageTypes
       DATE = ->(v) { v&.strftime(Setting.date_format || "%Y-%m-%d") }
       DURATION = ->(v) { DurationConverter.output(v) }
 
+      class StaticAttributeDSL
+        def initialize(context:, label_model:)
+          @context = context
+          @label_model = label_model
+        end
+
+        def add(key, value_fn, formatter = STRING_OR_NIL, label: key)
+          label_fn = label
+          unless label_fn.respond_to?(:call)
+            raise ArgumentError, "label must be passed as function when no label_model is provided" if @label_model.nil?
+
+            label_fn = -> { @label_model.human_attribute_name(label) }
+          end
+
+          TokenPropertyMapper.add_static_attribute(key, @context, label_fn, value_fn, formatter)
+        end
+      end
+
       class << self
+        def configure_static_attributes(context:, label_model: nil, &)
+          StaticAttributeDSL.new(context:, label_model:).instance_exec(&)
+        end
+
         def add_static_attribute(key, context, label_fn, value_fn, formatter = STRING_OR_NIL)
           static_tokens << AttributeToken.new(key, context, label_fn, value_fn, formatter)
         end

--- a/config/initializers/work_package_subject_patterns.rb
+++ b/config/initializers/work_package_subject_patterns.rb
@@ -29,46 +29,54 @@
 #++
 
 Rails.application.config.to_prepare do
-  # rubocop:disable Layout/LineLength
   mapper = WorkPackageTypes::Patterns::TokenPropertyMapper
-  mapper.add_static_attribute(:id, :work_package, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id })
-  mapper.add_static_attribute(:accountable, :work_package, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible })
-  mapper.add_static_attribute(:assignee, :work_package, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to })
-  mapper.add_static_attribute(:author, :work_package, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author })
-  mapper.add_static_attribute(:category, :work_package, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category })
-  mapper.add_static_attribute(:creation_date, :work_package, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }, mapper::DATE)
-  mapper.add_static_attribute(:estimated_time, :work_package, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:remaining_time, :work_package, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:finish_date, :work_package, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }, mapper::DATE)
-  mapper.add_static_attribute(:observed_in_versions, :work_package, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(wp) { wp.observed_in_versions }, mapper::ARRAY)
-  mapper.add_static_attribute(:priority, :work_package, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority })
-  mapper.add_static_attribute(:start_date, :work_package, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, mapper::DATE)
-  mapper.add_static_attribute(:status, :work_package, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status })
-  mapper.add_static_attribute(:type, :work_package, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type })
-  mapper.add_static_attribute(:version, :work_package, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, mapper::ARRAY)
+  mapper.configure_static_attributes(context: :work_package, label_model: WorkPackage) do
+    add(:id, ->(wp) { wp.id }, label: :id)
+    add(:accountable, ->(wp) { wp.responsible }, label: :responsible)
+    add(:assignee, ->(wp) { wp.assigned_to }, label: :assigned_to)
+    add(:author, ->(wp) { wp.author }, label: :author)
+    add(:category, ->(wp) { wp.category }, label: :category)
+    add(:creation_date, ->(wp) { wp.created_at }, mapper::DATE, label: :created_at)
+    add(:estimated_time, ->(wp) { wp.estimated_hours }, mapper::DURATION, label: :estimated_hours)
+    add(:remaining_time, ->(wp) { wp.remaining_hours }, mapper::DURATION, label: :remaining_hours)
+    add(:finish_date, ->(wp) { wp.due_date }, mapper::DATE, label: :due_date)
+    add(:observed_in_versions, ->(wp) { wp.observed_in_versions }, mapper::ARRAY, label: :observed_in_versions)
+    add(:priority, ->(wp) { wp.priority }, label: :priority)
+    add(:start_date, ->(wp) { wp.start_date }, mapper::DATE, label: :start_date)
+    add(:status, ->(wp) { wp.status }, label: :status)
+    add(:type, ->(wp) { wp.type }, label: :type)
+    add(:version, ->(wp) { wp.target_versions }, mapper::ARRAY, label: -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }) # rubocop:disable Metrics/LineLength
+  end
 
-  mapper.add_static_attribute(:parent_id, :parent, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id })
-  mapper.add_static_attribute(:parent_assignee, :parent, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to })
-  mapper.add_static_attribute(:parent_author, :parent, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author })
-  mapper.add_static_attribute(:parent_category, :parent, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category })
-  mapper.add_static_attribute(:parent_creation_date, :parent, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }, mapper::DATE)
-  mapper.add_static_attribute(:parent_estimated_time, :parent, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:parent_remaining_time, :parent, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:parent_finish_date, :parent, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }, mapper::DATE)
-  mapper.add_static_attribute(:parent_observed_in_versions, :parent, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(parent) { parent.observed_in_versions }, mapper::ARRAY)
-  mapper.add_static_attribute(:parent_priority, :parent, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority })
-  mapper.add_static_attribute(:parent_subject, :parent, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject })
-  mapper.add_static_attribute(:parent_status, :parent, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status })
-  mapper.add_static_attribute(:parent_type, :parent, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type })
-  mapper.add_static_attribute(:parent_version, :parent, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, mapper::ARRAY)
+  mapper.configure_static_attributes(context: :parent, label_model: WorkPackage) do
+    add(:parent_id, ->(parent) { parent.id }, label: :id)
+    add(:parent_assignee, ->(parent) { parent.assigned_to }, label: :assigned_to)
+    add(:parent_author, ->(parent) { parent.author }, label: :author)
+    add(:parent_category, ->(parent) { parent.category }, label: :category)
+    add(:parent_creation_date, ->(parent) { parent.created_at }, mapper::DATE, label: :created_at)
+    add(:parent_estimated_time, ->(parent) { parent.estimated_hours }, mapper::DURATION, label: :estimated_hours)
+    add(:parent_remaining_time, ->(parent) { parent.remaining_hours }, mapper::DURATION, label: :remaining_hours)
+    add(:parent_finish_date, ->(parent) { parent.due_date }, mapper::DATE, label: :due_date)
+    add(:parent_observed_in_versions, ->(parent) { parent.observed_in_versions }, mapper::ARRAY, label: :observed_in_versions)
+    add(:parent_priority, ->(parent) { parent.priority }, label: :priority)
+    add(:parent_subject, ->(parent) { parent.subject }, label: :subject)
+    add(:parent_status, ->(parent) { parent.status }, label: :status)
+    add(:parent_type, ->(parent) { parent.type }, label: :type)
+    add(:parent_version, ->(parent) { parent.target_versions }, mapper::ARRAY, label: -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }) # rubocop:disable Metrics/LineLength
+  end
 
-  mapper.add_static_attribute(:project_id, :project, -> { Project.human_attribute_name(:id) }, ->(project) { project.id })
-  mapper.add_static_attribute(:project_active, :project, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? })
-  mapper.add_static_attribute(:project_name, :project, -> { Project.human_attribute_name(:name) }, ->(project) { project })
-  mapper.add_static_attribute(:project_status, :project, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") })
-  mapper.add_static_attribute(:project_parent, :project, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id })
-  mapper.add_static_attribute(:project_public, :project, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? })
-  # rubocop:enable Layout/LineLength
+  mapper.configure_static_attributes(context: :project, label_model: Project) do
+    add(:project_id, ->(project) { project.id }, label: :id)
+    add(:project_active, ->(project) { project.active? }, label: :active)
+    add(:project_name, ->(project) { project }, label: :name)
+    add(
+      :project_status,
+      ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") },
+      label: :status_code
+    )
+    add(:project_parent, ->(project) { project.parent_id }, label: :parent)
+    add(:project_public, ->(project) { project.public? }, label: :public)
+  end
 
   mapper.add_custom_fields(->(variant) {
     all_wp_cfs = WorkPackageCustomField.where.not(field_format: %w[text link empty]).order(:name)

--- a/config/initializers/work_package_subject_patterns.rb
+++ b/config/initializers/work_package_subject_patterns.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+Rails.application.config.to_prepare do
+  # rubocop:disable Layout/LineLength
+  mapper = WorkPackageTypes::Patterns::TokenPropertyMapper
+  mapper.add_static_attribute(:id, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id })
+  mapper.add_static_attribute(:accountable, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible })
+  mapper.add_static_attribute(:assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to })
+  mapper.add_static_attribute(:author, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author })
+  mapper.add_static_attribute(:category, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category })
+  mapper.add_static_attribute(:creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }, mapper::DATE)
+  mapper.add_static_attribute(:estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }, mapper::DATE)
+  mapper.add_static_attribute(:observed_in_versions, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(wp) { wp.observed_in_versions }, mapper::ARRAY)
+  mapper.add_static_attribute(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority })
+  mapper.add_static_attribute(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, mapper::DATE)
+  mapper.add_static_attribute(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status })
+  mapper.add_static_attribute(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type })
+  mapper.add_static_attribute(:version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, mapper::ARRAY)
+
+  mapper.add_static_attribute(:parent_id, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id })
+  mapper.add_static_attribute(:parent_assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to })
+  mapper.add_static_attribute(:parent_author, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author })
+  mapper.add_static_attribute(:parent_category, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category })
+  mapper.add_static_attribute(:parent_creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }, mapper::DATE)
+  mapper.add_static_attribute(:parent_estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:parent_remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:parent_finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }, mapper::DATE)
+  mapper.add_static_attribute(:parent_observed_in_versions, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(parent) { parent.observed_in_versions }, mapper::ARRAY)
+  mapper.add_static_attribute(:parent_priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority })
+  mapper.add_static_attribute(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject })
+  mapper.add_static_attribute(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status })
+  mapper.add_static_attribute(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type })
+  mapper.add_static_attribute(:parent_version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, mapper::ARRAY)
+
+  mapper.add_static_attribute(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id })
+  mapper.add_static_attribute(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? })
+  mapper.add_static_attribute(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project })
+  mapper.add_static_attribute(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") })
+  mapper.add_static_attribute(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id })
+  mapper.add_static_attribute(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? })
+  # rubocop:enable Layout/LineLength
+
+  mapper.add_custom_fields(->(variant) {
+    all_wp_cfs = WorkPackageCustomField.where.not(field_format: %w[text link empty]).order(:name)
+    if variant
+      all_wp_cfs.merge(variant.custom_fields)
+    else
+      all_wp_cfs
+    end
+  })
+
+  mapper.add_custom_fields(->(_) {
+    ProjectCustomField.where.not(field_format: %w[text link empty]).where(admin_only: false, multi_value: false).order(:name)
+  }, "project_")
+
+  mapper.add_custom_fields(->(_) { WorkPackageCustomField.where.not(field_format: %w[text link empty]).order(:name) }, "parent_")
+end

--- a/config/initializers/work_package_subject_patterns.rb
+++ b/config/initializers/work_package_subject_patterns.rb
@@ -31,43 +31,43 @@
 Rails.application.config.to_prepare do
   # rubocop:disable Layout/LineLength
   mapper = WorkPackageTypes::Patterns::TokenPropertyMapper
-  mapper.add_static_attribute(:id, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id })
-  mapper.add_static_attribute(:accountable, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible })
-  mapper.add_static_attribute(:assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to })
-  mapper.add_static_attribute(:author, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author })
-  mapper.add_static_attribute(:category, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category })
-  mapper.add_static_attribute(:creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }, mapper::DATE)
-  mapper.add_static_attribute(:estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }, mapper::DATE)
-  mapper.add_static_attribute(:observed_in_versions, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(wp) { wp.observed_in_versions }, mapper::ARRAY)
-  mapper.add_static_attribute(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority })
-  mapper.add_static_attribute(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, mapper::DATE)
-  mapper.add_static_attribute(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status })
-  mapper.add_static_attribute(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type })
-  mapper.add_static_attribute(:version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, mapper::ARRAY)
+  mapper.add_static_attribute(:id, :work_package, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id })
+  mapper.add_static_attribute(:accountable, :work_package, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible })
+  mapper.add_static_attribute(:assignee, :work_package, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to })
+  mapper.add_static_attribute(:author, :work_package, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author })
+  mapper.add_static_attribute(:category, :work_package, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category })
+  mapper.add_static_attribute(:creation_date, :work_package, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }, mapper::DATE)
+  mapper.add_static_attribute(:estimated_time, :work_package, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:remaining_time, :work_package, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:finish_date, :work_package, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }, mapper::DATE)
+  mapper.add_static_attribute(:observed_in_versions, :work_package, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(wp) { wp.observed_in_versions }, mapper::ARRAY)
+  mapper.add_static_attribute(:priority, :work_package, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority })
+  mapper.add_static_attribute(:start_date, :work_package, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, mapper::DATE)
+  mapper.add_static_attribute(:status, :work_package, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status })
+  mapper.add_static_attribute(:type, :work_package, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type })
+  mapper.add_static_attribute(:version, :work_package, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.target_versions }, mapper::ARRAY)
 
-  mapper.add_static_attribute(:parent_id, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id })
-  mapper.add_static_attribute(:parent_assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to })
-  mapper.add_static_attribute(:parent_author, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author })
-  mapper.add_static_attribute(:parent_category, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category })
-  mapper.add_static_attribute(:parent_creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }, mapper::DATE)
-  mapper.add_static_attribute(:parent_estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:parent_remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }, mapper::DURATION)
-  mapper.add_static_attribute(:parent_finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }, mapper::DATE)
-  mapper.add_static_attribute(:parent_observed_in_versions, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(parent) { parent.observed_in_versions }, mapper::ARRAY)
-  mapper.add_static_attribute(:parent_priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority })
-  mapper.add_static_attribute(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject })
-  mapper.add_static_attribute(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status })
-  mapper.add_static_attribute(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type })
-  mapper.add_static_attribute(:parent_version, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, mapper::ARRAY)
+  mapper.add_static_attribute(:parent_id, :parent, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id })
+  mapper.add_static_attribute(:parent_assignee, :parent, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to })
+  mapper.add_static_attribute(:parent_author, :parent, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author })
+  mapper.add_static_attribute(:parent_category, :parent, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category })
+  mapper.add_static_attribute(:parent_creation_date, :parent, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }, mapper::DATE)
+  mapper.add_static_attribute(:parent_estimated_time, :parent, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:parent_remaining_time, :parent, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }, mapper::DURATION)
+  mapper.add_static_attribute(:parent_finish_date, :parent, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }, mapper::DATE)
+  mapper.add_static_attribute(:parent_observed_in_versions, :parent, -> { WorkPackage.human_attribute_name(:observed_in_versions) }, ->(parent) { parent.observed_in_versions }, mapper::ARRAY)
+  mapper.add_static_attribute(:parent_priority, :parent, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority })
+  mapper.add_static_attribute(:parent_subject, :parent, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject })
+  mapper.add_static_attribute(:parent_status, :parent, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status })
+  mapper.add_static_attribute(:parent_type, :parent, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type })
+  mapper.add_static_attribute(:parent_version, :parent, -> { Setting::WorkPackageMultipleVersions.active? ? WorkPackage.human_attribute_name(:target_versions) : WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.target_versions }, mapper::ARRAY)
 
-  mapper.add_static_attribute(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id })
-  mapper.add_static_attribute(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? })
-  mapper.add_static_attribute(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project })
-  mapper.add_static_attribute(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") })
-  mapper.add_static_attribute(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id })
-  mapper.add_static_attribute(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? })
+  mapper.add_static_attribute(:project_id, :project, -> { Project.human_attribute_name(:id) }, ->(project) { project.id })
+  mapper.add_static_attribute(:project_active, :project, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? })
+  mapper.add_static_attribute(:project_name, :project, -> { Project.human_attribute_name(:name) }, ->(project) { project })
+  mapper.add_static_attribute(:project_status, :project, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") })
+  mapper.add_static_attribute(:project_parent, :project, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id })
+  mapper.add_static_attribute(:project_public, :project, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? })
   # rubocop:enable Layout/LineLength
 
   mapper.add_custom_fields(->(variant) {
@@ -77,11 +77,13 @@ Rails.application.config.to_prepare do
     else
       all_wp_cfs
     end
-  })
+  }, :work_package)
 
   mapper.add_custom_fields(->(_) {
     ProjectCustomField.where.not(field_format: %w[text link empty]).where(admin_only: false, multi_value: false).order(:name)
-  }, "project_")
+  }, :project, "project_")
 
-  mapper.add_custom_fields(->(_) { WorkPackageCustomField.where.not(field_format: %w[text link empty]).order(:name) }, "parent_")
+  mapper.add_custom_fields(
+    ->(_) { WorkPackageCustomField.where.not(field_format: %w[text link empty]).order(:name) }, :parent, "parent_"
+  )
 end

--- a/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
     end
   end
 
-  described_class::BASE_ATTRIBUTE_TOKENS.each do |token|
+  described_class::static_tokens.each do |token|
     it "the attribute token named #{token.key} resolves successfully" do
-      context = case token.key
-                when /^parent_/
+      context = case token.context
+                when :parent
                   work_package_parent
-                when /^project_/
+                when :project
                   project
                 else
                   work_package


### PR DESCRIPTION
Instead of defining all tokens centrally inside the TokenPropertyMapper, it now allows to add token definitions via a class-interface, so that initializers of modules can add their own definitions.

# Ticket
https://community.openproject.org/wp/DB-914