### PR TITLE
[AUTOWORK-157] Allow setting on a type to allow or disallow project-specific variants

### DIFF
--- a/app/components/projects/settings/work_packages/types/list_component.html.erb
+++ b/app/components/projects/settings/work_packages/types/list_component.html.erb
@@ -82,16 +82,24 @@ See COPYRIGHT and LICENSE files for more details.
 
       <% if manageable? %>
         <% list.with_footer do %>
-          <%= render(
-                Primer::Beta::Link.new(
-                  href: add_variant_path(project_type.type),
-                  muted: true,
-                  display: :inline_flex,
-                  align_items: :center
-                )
-              ) do %>
-            <%= render(Primer::Beta::Octicon.new(icon: :plus, mr: 1)) %>
-            <%= t("projects.settings.types.add_variant") %>
+          <% if project_variants_allowed?(project_type.type) %>
+            <%= render(
+                  Primer::Beta::Link.new(
+                    href: add_variant_path(project_type.type),
+                    muted: true,
+                    display: :inline_flex,
+                    align_items: :center
+                  )
+                ) do %>
+              <%= render(Primer::Beta::Octicon.new(icon: :plus, mr: 1)) %>
+              <%= t("projects.settings.types.add_variant") %>
+            <% end %>
+          <% else %>
+            <%= render(Primer::Beta::Button.new(**disabled_add_variant_arguments(project_type.type))) do |button| %>
+              <% button.with_leading_visual_icon(icon: :plus) %>
+              <% button.with_tooltip(text: variants_not_allowed_caption, type: :description, direction: :n) %>
+              <%= t("projects.settings.types.add_variant") %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/projects/settings/work_packages/types/list_component.rb
+++ b/app/components/projects/settings/work_packages/types/list_component.rb
@@ -117,6 +117,22 @@ module Projects
             User.current.allowed_in_project?(:manage_project_variants, project)
           end
 
+          def project_variants_allowed?(type) = type.allow_project_variants?
+
+          def variants_not_allowed_caption = t("projects.settings.types.variants_not_allowed")
+
+          # Inactive rather than disabled: a disabled button takes neither hover nor focus, and the
+          # reason would go with it.
+          def disabled_add_variant_arguments(type)
+            {
+              id: "add-project-variant-#{type.id}",
+              scheme: :invisible,
+              inactive: true,
+              pl: 0,
+              aria: { disabled: true }
+            }
+          end
+
           # Named explicitly: this page is not one of the variant screens, so no request carries
           # the project for it.
           def add_variant_path(type)
@@ -169,8 +185,17 @@ module Projects
           end
 
           def add_variant_action(menu, type)
+            return disabled_add_variant_action(menu) unless project_variants_allowed?(type)
+
             menu.with_item(label: t("projects.settings.types.add_variant"), href: add_variant_path(type)) do |item|
               item.with_leading_visual_icon(icon: :plus)
+            end
+          end
+
+          def disabled_add_variant_action(menu)
+            menu.with_item(label: t("projects.settings.types.add_variant"), disabled: true) do |item|
+              item.with_leading_visual_icon(icon: :plus)
+              item.with_tooltip(text: variants_not_allowed_caption)
             end
           end
 

--- a/app/contracts/work_package_types/create_contract.rb
+++ b/app/contracts/work_package_types/create_contract.rb
@@ -30,11 +30,12 @@
 
 module WorkPackageTypes
   class CreateContract < BaseContract
+    attribute :allow_project_variants
     attribute :color_id
     attribute :is_in_roadmap
     attribute :is_milestone
     attribute :name
 
-    validates :is_milestone, :is_in_roadmap, inclusion: { in: [true, false] }
+    validates :is_milestone, :is_in_roadmap, :allow_project_variants, inclusion: { in: [true, false] }
   end
 end

--- a/app/contracts/work_package_types/create_variant_contract.rb
+++ b/app/contracts/work_package_types/create_variant_contract.rb
@@ -51,9 +51,12 @@ module WorkPackageTypes
 
     private
 
-    # Only creation is governed: turning the setting off later leaves the variants a project
-    # already owns in place, which is why this rule is not in AuthorizesVariantAuthoring.
+    # Only a project authoring something new is governed, which is why this rule is not in
+    # AuthorizesVariantAuthoring: turning the setting off leaves the variants a project already
+    # owns in place, and a variant standing in for configuration the project had before variants
+    # existed is one of those.
     def validate_type_allows_project_variants
+      return if options[:pre_existing_configuration]
       return if model.project.nil?
       return if model.type&.allow_project_variants?
 

--- a/app/controllers/work_package_types/creation_wizard_controller.rb
+++ b/app/controllers/work_package_types/creation_wizard_controller.rb
@@ -46,9 +46,11 @@ module WorkPackageTypes
 
     def show; end
 
-    def new
+    def new # rubocop:disable Metrics/AbcSize
       if params[:type_id]
         @type = ::Type.find(params.expect(:type_id))
+        return render_404 if variant_scope_project && !@type.allow_project_variants?
+
         @variant = @type.variants.new(project: variant_scope_project)
       else
         return render_404 if variant_scope_project # a type itself is created in administration
@@ -224,7 +226,7 @@ module WorkPackageTypes
     end
 
     def details_params
-      params.expect(type: %i[name color_id is_milestone is_in_roadmap])
+      params.expect(type: %i[name color_id is_milestone is_in_roadmap allow_project_variants])
     end
 
     def variant_details_params

--- a/app/controllers/work_package_types/details_tab_controller.rb
+++ b/app/controllers/work_package_types/details_tab_controller.rb
@@ -69,7 +69,7 @@ module WorkPackageTypes
     end
 
     def permitted_details_params
-      params.expect(type: %i[name color_id is_milestone is_in_roadmap])
+      params.expect(type: %i[name color_id is_milestone is_in_roadmap allow_project_variants])
     end
 
     def permitted_variant_params

--- a/app/forms/work_package_types/details_form.rb
+++ b/app/forms/work_package_types/details_form.rb
@@ -59,11 +59,21 @@ module WorkPackageTypes
                              label: label(:is_in_roadmap),
                              disabled: inherited?,
                              caption: inherited_caption)
+
+      if offers_project_variants?
+        details_form.check_box(name: :allow_project_variants,
+                               label: label(:allow_project_variants),
+                               caption: I18n.t("types.edit.details.allow_project_variants_caption"))
+      end
     end
 
     private
 
     def inherited? = model.is_a?(TypeVariant)
+
+    def offers_project_variants?
+      !inherited? && OpenProject::FeatureDecisions.type_variants_active?
+    end
 
     def name_attribute = inherited? ? :variant_name : :name
 

--- a/app/services/work_package_types/build_variant_from_project_service.rb
+++ b/app/services/work_package_types/build_variant_from_project_service.rb
@@ -79,7 +79,7 @@ module WorkPackageTypes
 
     def create_variant(project)
       CreateVariantService
-        .new(user:, type: source.type)
+        .new(user:, type: source.type, contract_options: { pre_existing_configuration: true })
         .call(variant_name: variant_name(project), project:)
     end
 

--- a/app/services/work_package_types/duplicate_service.rb
+++ b/app/services/work_package_types/duplicate_service.rb
@@ -70,7 +70,8 @@ module WorkPackageTypes
           name: duplicated_name,
           color_id: source.color_id,
           is_milestone: source.is_milestone,
-          is_in_roadmap: source.is_in_roadmap
+          is_in_roadmap: source.is_in_roadmap,
+          allow_project_variants: source.allow_project_variants
         )
     end
 

--- a/app/services/work_package_types/set_attributes_service.rb
+++ b/app/services/work_package_types/set_attributes_service.rb
@@ -47,7 +47,7 @@ module WorkPackageTypes
     end
 
     def validate_and_result
-      success, errors = validate(model, user, options: {})
+      success, errors = validate(model, user, options: contract_options || {})
 
       if @param_validations.empty?
         ServiceResult.new(success:, errors:, result: model)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,7 @@ en:
       token/named:
         token_name: "Token name"
       type:
+        allow_project_variants: "Allow project-specific variants"
         color: "Color"
         is_in_roadmap: "Displayed in roadmap by default"
         is_milestone: "Is milestone"
@@ -854,6 +855,7 @@ en:
             base:
               borrowed_by_variants: "Cannot be deleted while its configuration is reused by %{names}."
               is_default_variant: "The default configuration of a type cannot be deleted."
+              project_variants_not_allowed: "This type does not allow creation of variants inside projects."
               restrict_dependent_destroy:
                 has_many: "Cannot be deleted while projects are still using it."
             defaults_source_id:
@@ -5428,6 +5430,7 @@ en:
         use_in_project: "Use in this project"
         variant_in_use: "Variant in this project"
         variant_label: "Variant"
+        variants_not_allowed: "This type does not allow creation of variants inside projects."
       versions:
         no_results_content_text: Create a new version
         no_results_title_text: There are currently no versions for the project.
@@ -6509,6 +6512,7 @@ en:
             work_package: "Work package"
           label_with_context: "%{attribute_context}: %{attribute_label}"
       details:
+        allow_project_variants_caption: "For project administrators with the permission to manage variants, this type can be extended or modified within a project."
         inherited_from_type_html: "Inherited from type <b>%{type}</b>."
         tab: "Details"
         type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.

--- a/db/migrate/20260903090000_add_allow_project_variants_to_types.rb
+++ b/db/migrate/20260903090000_add_allow_project_variants_to_types.rb
@@ -28,36 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackageTypes
-  # A named variant's own attributes. Everything else about it is configuration, which the
-  # aspect tabs and their services own.
-  class CreateVariantContract < ::ModelContract
-    include AuthorizesVariantAuthoring
-
-    def self.model = TypeVariant
-
-    attribute :variant_name
-
-    # The owner an :error_unauthorized is raised over, so it has to be writable for the rule in
-    # AuthorizesVariantAuthoring to be the one that decides.
-    attribute :project_id
-
-    # Set by CreateVariantService rather than by whoever calls it: a new variant belongs to the
-    # type it was added to and starts out Linked to that type's base configuration.
-    attribute :type_id
-    TypeVariant::ASPECTS.each { |aspect| attribute :"#{aspect}_source_id" }
-
-    validate :validate_type_allows_project_variants
-
-    private
-
-    # Only creation is governed: turning the setting off later leaves the variants a project
-    # already owns in place, which is why this rule is not in AuthorizesVariantAuthoring.
-    def validate_type_allows_project_variants
-      return if model.project.nil?
-      return if model.type&.allow_project_variants?
-
-      errors.add(:base, :project_variants_not_allowed)
-    end
+class AddAllowProjectVariantsToTypes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :types, :allow_project_variants, :boolean, default: true, null: false
   end
 end

--- a/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
+++ b/spec/components/projects/settings/work_packages/types/list_component_owned_variants_spec.rb
@@ -405,4 +405,40 @@ RSpec.describe Projects::Settings::WorkPackages::Types::ListComponent,
       expect(row(ours)).to have_no_css("action-menu")
     end
   end
+
+  context "when the type does not allow project-specific variants" do
+    current_user do
+      create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] })
+    end
+
+    before do
+      bug.update!(allow_project_variants: false)
+      render_inline(component)
+    end
+
+    it "shows the way to add one, without offering it" do
+      expect(page).to have_css("button[aria-disabled='true']", text: "Add a project-specific variant")
+      expect(page).to have_no_link("Add a project-specific variant")
+    end
+
+    it "says why it cannot be used" do
+      expect(page).to have_css(
+        "tool-tip[for='add-project-variant-#{bug.id}']",
+        text: "This type does not allow creation of variants inside projects",
+        visible: :all
+      )
+    end
+
+    it "says it on the entry in the type's menu too" do
+      expect(header_of(bug.default_variant)).to have_css(
+        "tool-tip",
+        text: "This type does not allow creation of variants inside projects",
+        visible: :all
+      )
+    end
+
+    it "keeps the variants the project already owns" do
+      expect(page).to have_text("Internal review")
+    end
+  end
 end

--- a/spec/components/work_package_types/details_component_spec.rb
+++ b/spec/components/work_package_types/details_component_spec.rb
@@ -28,36 +28,35 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackageTypes
-  # A named variant's own attributes. Everything else about it is configuration, which the
-  # aspect tabs and their services own.
-  class CreateVariantContract < ::ModelContract
-    include AuthorizesVariantAuthoring
+require "rails_helper"
 
-    def self.model = TypeVariant
+RSpec.describe WorkPackageTypes::DetailsComponent, type: :component do
+  shared_let(:bug) { create(:type, name: "Bug") }
 
-    attribute :variant_name
+  current_user { create(:admin) }
 
-    # The owner an :error_unauthorized is raised over, so it has to be writable for the rule in
-    # AuthorizesVariantAuthoring to be the one that decides.
-    attribute :project_id
+  let(:checkbox_label) { "Allow project-specific variants" }
 
-    # Set by CreateVariantService rather than by whoever calls it: a new variant belongs to the
-    # type it was added to and starts out Linked to that type's base configuration.
-    attribute :type_id
-    TypeVariant::ASPECTS.each { |aspect| attribute :"#{aspect}_source_id" }
+  context "with the variants feature enabled", with_flag: { type_variants: true } do
+    it "offers the setting on the type" do
+      render_inline(described_class.new(bug))
 
-    validate :validate_type_allows_project_variants
+      expect(page).to have_field(checkbox_label)
+      expect(page).to have_text("this type can be extended or modified within a project")
+    end
 
-    private
+    it "leaves it out on a variant, which the type decides it for" do
+      render_inline(described_class.new(create(:type_variant, type: bug, variant_name: "Hardware")))
 
-    # Only creation is governed: turning the setting off later leaves the variants a project
-    # already owns in place, which is why this rule is not in AuthorizesVariantAuthoring.
-    def validate_type_allows_project_variants
-      return if model.project.nil?
-      return if model.type&.allow_project_variants?
+      expect(page).to have_no_field(checkbox_label)
+    end
+  end
 
-      errors.add(:base, :project_variants_not_allowed)
+  context "with the variants feature disabled" do
+    it "leaves it out" do
+      render_inline(described_class.new(bug))
+
+      expect(page).to have_no_field(checkbox_label)
     end
   end
 end

--- a/spec/contracts/work_package_types/create_variant_contract_spec.rb
+++ b/spec/contracts/work_package_types/create_variant_contract_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module WorkPackageTypes
+  RSpec.describe CreateVariantContract do
+    shared_let(:bug) { create(:type, name: "Bug") }
+    shared_let(:project) { create(:project) }
+
+    let(:user) { create(:user, member_with_permissions: { project => %i[manage_project_variants] }) }
+    let(:owner) { project }
+    let(:variant) { bug.variants.new(variant_name: "Internal review", project: owner) }
+
+    subject(:contract) { described_class.new(variant, user, options: {}) }
+
+    def base_errors
+      contract.validate
+      contract.errors.symbols_for(:base)
+    end
+
+    context "when the type allows project-specific variants" do
+      it "is valid" do
+        expect(base_errors).to be_empty
+      end
+    end
+
+    context "when the type does not allow project-specific variants" do
+      before { bug.update!(allow_project_variants: false) }
+
+      it "refuses it" do
+        expect(base_errors).to include(:project_variants_not_allowed)
+      end
+
+      context "and the user is an administrator" do
+        let(:user) { create(:admin) }
+
+        it "refuses it as well" do
+          expect(base_errors).to include(:project_variants_not_allowed)
+        end
+      end
+
+      context "and the variant is a global one" do
+        let(:user) { create(:admin) }
+        let(:owner) { nil }
+
+        it "allows it: the setting governs only the variants a project owns" do
+          expect(base_errors).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/contracts/work_package_types/create_variant_contract_spec.rb
+++ b/spec/contracts/work_package_types/create_variant_contract_spec.rb
@@ -39,7 +39,9 @@ module WorkPackageTypes
     let(:owner) { project }
     let(:variant) { bug.variants.new(variant_name: "Internal review", project: owner) }
 
-    subject(:contract) { described_class.new(variant, user, options: {}) }
+    let(:options) { {} }
+
+    subject(:contract) { described_class.new(variant, user, options:) }
 
     def base_errors
       contract.validate
@@ -64,6 +66,14 @@ module WorkPackageTypes
 
         it "refuses it as well" do
           expect(base_errors).to include(:project_variants_not_allowed)
+        end
+      end
+
+      context "and the variant stands in for configuration the project already had" do
+        let(:options) { { pre_existing_configuration: true } }
+
+        it "allows it: the project is not authoring anything new" do
+          expect(base_errors).to be_empty
         end
       end
 

--- a/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
+++ b/spec/controllers/work_package_types/creation_wizard_controller_spec.rb
@@ -179,4 +179,26 @@ RSpec.describe WorkPackageTypes::CreationWizardController, with_flag: { type_var
       it { expect(response).to have_http_status(:not_found) }
     end
   end
+
+  context "when adding a variant from inside a project" do
+    shared_let(:type) { create(:type, name: "Critical") }
+    shared_let(:project) { create(:project, types: [type]) }
+
+    let(:user) { create(:user, member_with_permissions: { project => %i[view_project manage_project_variants] }) }
+
+    describe "GET new" do
+      before { get :new, params: { in_project_id: project.id, type_id: type.id } }
+
+      it { expect(response).to have_http_status(:ok) }
+
+      context "when the type does not allow project-specific variants" do
+        before do
+          type.update!(allow_project_variants: false)
+          get :new, params: { in_project_id: project.id, type_id: type.id }
+        end
+
+        it { expect(response).to have_http_status(:not_found) }
+      end
+    end
+  end
 end

--- a/spec/controllers/work_package_types/details_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/details_tab_controller_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe WorkPackageTypes::DetailsTabController do
             "name" => "Galactic Order",
             "color_id" => lightsaber_red.id.to_s,
             "is_milestone" => "0",
-            "is_in_roadmap" => "1"
+            "is_in_roadmap" => "1",
+            "allow_project_variants" => "0"
           }
         }
       end
@@ -85,7 +86,8 @@ RSpec.describe WorkPackageTypes::DetailsTabController do
         expect(type.reload).to have_attributes(name: "Galactic Order",
                                                color_id: lightsaber_red.id,
                                                is_milestone: false,
-                                               is_in_roadmap: true)
+                                               is_in_roadmap: true,
+                                               allow_project_variants: false)
       end
 
       context "if the the params are invalid" do

--- a/spec/services/work_package_types/build_variant_from_project_service_spec.rb
+++ b/spec/services/work_package_types/build_variant_from_project_service_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe WorkPackageTypes::BuildVariantFromProjectService, with_flag: { ty
       expect(service_call.result.project).to eq(project)
     end
 
+    # The narrowing predates the setting, so it is carried over rather than dropped on the floor.
+    it "creates it even when the type disallows project-specific variants" do
+      type.update!(allow_project_variants: false)
+
+      expect { service_call }.to change(TypeVariant, :count).by(1)
+      expect(service_call).to be_success
+    end
+
     it "links every aspect to the type's base variant" do
       variant = service_call.result
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AUTOWORK-157

# What are you trying to accomplish?

- [x] Checkbox _"Allow project-specific variants"_ on the details tab of a type
   - [x] With it on, project administrators holding `manage_project_variants` create variants in their project as before
   - [x] With it off, both ways into the creation wizard are shown disabled
- [x] The restriction is enforced on creation only, and applies to instance administrators too

## Screenshots

### Type details tab

<img width="796" height="528" alt="Screenshot of the details tab" src="https://github.com/user-attachments/assets/5b837d95-289b-4514-be8c-beb023e3c488" />

### The footer button and its tooltip

<img width="807" height="218" alt="Screenshot of the footer button" src="https://github.com/user-attachments/assets/6d2505c8-9d54-4b2a-8c49-17983acee43b" />

### Overflow menu open, showing the disabled entry

<img width="718" height="212" alt="Screenshot of the overflow menu" src="https://github.com/user-attachments/assets/e16be500-1e8c-4ada-b440-fbec0c9b4519" />

# What approach did you choose and why?

- Turning the setting off leaves the variants a project already owns in place, editable and deletable
   - The rule sits in `CreateVariantContract` rather than in the shared `AuthorizesVariantAuthoring`, which also guards update and delete — the setting governs creation only.
- A project's pre-variants form configuration still becomes a variant, whatever the setting says
   - `BuildVariantFromProjectService` exempts itself: that narrowing predates the setting, and dropping it would take away configuration the project already had, which nobody can restore afterwards.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox)
