### PR TITLE
[BNE-137] Create work package via text selection in a document

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.3.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
         "tsx": "^4.22.5"
       },
       "devDependencies": {
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@primer/octicons-react": {
-      "version": "19.28.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.28.0.tgz",
-      "integrity": "sha512-Xe3ZS/NtxRK/QXMlqh6Xn49nM4153VXgPQcwyIx6r2McZKkrAhP7xPe7yLhfx3X34rnxj6yimCnX7kswV30Vqw==",
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
-      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.2.tgz",
+      "integrity": "sha512-RX+R0VLg13IbvRuJSxnqykUFS9vQZTl8wYpWPCIUDWVrSGjsQywB5Y+pjzrkboxGAuYfJZVH1InFTdgBdxq6ug==",
       "funding": [
         {
           "type": "individual",
@@ -4168,14 +4168,14 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.3",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
-      "integrity": "sha512-wtkbqjIGECasx/cKkB016YVGIveO8/ezQJ+agTWNTUxqTfPjycAtag5xpdjW5poq22vkdHGU9lYfsluIPpiR/Q==",
+      "version": "0.3.0",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
+      "integrity": "sha512-ikgQ1iXUe4+TB5hpMJD7B1esPuyPlYPafZ5pwtxEYu1ziYOuxhFWvBm2zSIpsKXRFEkaDO0DBh4tU+vcDfEXog==",
       "dependencies": {
-        "@primer/octicons-react": "^19.20.0",
-        "i18next": "^26.3.5",
-        "react-i18next": "^17.0.11",
-        "styled-components": "^6.4.3",
+        "@primer/octicons-react": "^19.33.0",
+        "i18next": "^26.4.0",
+        "react-i18next": "^17.0.12",
+        "styled-components": "^6.5.3",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -4599,12 +4599,12 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
-      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.13.tgz",
+      "integrity": "sha512-Cc1PscmblIHA1kljTqDwrcVMI21ydgmUzw0UAeQBe7pAOgfuRLfzXze4EUBQoeDiICzFIXXhHFoZxuetNg5D0Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
@@ -4855,9 +4855,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.0.tgz",
-      "integrity": "sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.3.tgz",
+      "integrity": "sha512-vAX79sfpmUerP9fsTTxoTrBDE0RuO4ahjInyWYoohNgqrdg63Ms4q6FJ/o2Fyity82NU3cujOT8Ewl9TThBdwg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.3.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
     "tsx": "^4.22.5"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -111,7 +111,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^22.0.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
         "openapi-explorer": "^2.4.801",
         "pako": "^2.2.0",
         "qr-creator": "^1.0.0",
@@ -2199,9 +2199,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5593,9 +5594,9 @@
       }
     },
     "node_modules/@primer/octicons-react": {
-      "version": "19.21.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.21.0.tgz",
-      "integrity": "sha512-KMWYYEIDKNIY0N3fMmNGPWJGHgoJF5NHkJllpOM3upDXuLtAe26Riogp1cfYdhp+sVjGZMt32DxcUhTX7ZhLOQ==",
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11023,9 +11024,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
-      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.2.tgz",
+      "integrity": "sha512-RX+R0VLg13IbvRuJSxnqykUFS9vQZTl8wYpWPCIUDWVrSGjsQywB5Y+pjzrkboxGAuYfJZVH1InFTdgBdxq6ug==",
       "funding": [
         {
           "type": "individual",
@@ -13063,14 +13064,14 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.3",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
-      "integrity": "sha512-wtkbqjIGECasx/cKkB016YVGIveO8/ezQJ+agTWNTUxqTfPjycAtag5xpdjW5poq22vkdHGU9lYfsluIPpiR/Q==",
+      "version": "0.3.0",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
+      "integrity": "sha512-ikgQ1iXUe4+TB5hpMJD7B1esPuyPlYPafZ5pwtxEYu1ziYOuxhFWvBm2zSIpsKXRFEkaDO0DBh4tU+vcDfEXog==",
       "dependencies": {
-        "@primer/octicons-react": "^19.20.0",
-        "i18next": "^26.3.5",
-        "react-i18next": "^17.0.11",
-        "styled-components": "^6.4.3",
+        "@primer/octicons-react": "^19.33.0",
+        "i18next": "^26.4.0",
+        "react-i18next": "^17.0.12",
+        "styled-components": "^6.5.3",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -14128,12 +14129,12 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
-      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.13.tgz",
+      "integrity": "sha512-Cc1PscmblIHA1kljTqDwrcVMI21ydgmUzw0UAeQBe7pAOgfuRLfzXze4EUBQoeDiICzFIXXhHFoZxuetNg5D0Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
@@ -15298,9 +15299,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.0.tgz",
-      "integrity": "sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.3.tgz",
+      "integrity": "sha512-vAX79sfpmUerP9fsTTxoTrBDE0RuO4ahjInyWYoohNgqrdg63Ms4q6FJ/o2Fyity82NU3cujOT8Ewl9TThBdwg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^22.0.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
     "openapi-explorer": "^2.4.801",
     "pako": "^2.2.0",
     "qr-creator": "^1.0.0",

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -39,6 +39,7 @@ import {
   openProjectWorkPackageBlockSpec,
   openProjectWorkPackageInlineSpec,
   getOpenProjectSlashMenuItems,
+  OpenProjectFormattingToolbar,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -142,10 +143,12 @@ export function OpBlockNoteEditor({
       <BlockNoteView
         editor={editor}
         slashMenu={false}
+        formattingToolbar={false}
         theme={theme}
         editable={!readOnly}
         className={'block-note-editor-container'}
       >
+        <OpenProjectFormattingToolbar />
         <SuggestionMenuController
           triggerCharacter="/"
           getItems={async (query:string) => Promise.resolve(filterSuggestionItems(getCustomSlashMenuItems(editor), query))}

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -32,6 +32,7 @@ require "rails_helper"
 
 RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { real_time_text_collaboration_enabled: true } do
   include_context "with hocuspocus"
+  include FormFields::Primerized::BlockNoteEditorBrowserActions
 
   let(:admin) { create(:admin) }
   let(:document) { create(:document, :collaborative) }
@@ -146,7 +147,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
 
         expect(editor.element).to have_no_text("Link existing work package") # search dialog is closed
         expect(editor.element).to have_no_text("Loading")
-        expect(editor.element.text).to match(/LIFE GOALS\s##{work_package.display_id}\sOpen\spet a tiger/)
+        expect(editor.element.text).to match(/LIFE GOALS\s*##{work_package.display_id}\s*Open\s*pet a tiger/)
 
         # Capybara's have_link seems not to work in a shadow dom, so it's tested via the property
         expect(editor.element.find_link(text: "pet a tiger").native.property("href")).to end_with("/wp/#{work_package.id}")
@@ -281,7 +282,8 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         within editor.create_work_package_form do
           expect(page).to have_field("Project", with: project.name)
 
-          select type.name, from: "Type"
+          find_field("Type").click
+          find("[role='option']", text: type.name).click
           fill_in "Subject", with: "Write the release notes"
           fill_in "Release note", with: "16.0"
 
@@ -296,6 +298,43 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
         expect(work_package.type).to eq(type)
         expect(work_package.subject).to eq("Write the release notes")
         expect(work_package.custom_value_for(release_note).value).to eq("16.0")
+      end
+    end
+
+    context "when creating a work package from a text selection" do
+      let(:type) { create(:type_task) }
+      let(:project) { create(:project, name: "Documented project", types: [type]) }
+      let(:document) { create(:document, :collaborative, project:, description: "") }
+      let!(:default_status) { create(:status, is_default: true) }
+      let!(:default_priority) { create(:priority, is_default: true) }
+
+      it "names the work package after the selected text and links it in its place" do
+        expect(WorkPackage.where(subject: "Write the release notes")).not_to exist
+
+        visit document_path(document)
+        expect(page).to have_test_selector("blocknote-document-description")
+
+        editor.fill_in("Write the release notes")
+        select_to_line_start
+        editor.click_formatting_toolbar_button("Create work package")
+
+        within editor.create_work_package_form do
+          expect(page).to have_field("Subject", with: "Write the release notes")
+
+          find_field("Type").click
+          find("[role='option']", text: type.name).click
+
+          click_on "Create"
+        end
+
+        expect(page).to have_no_css("[data-testid='create-wp-modal']")
+
+        work_package = WorkPackage.find_by(subject: "Write the release notes")
+        expect(work_package).to be_present
+        expect(work_package.project).to eq(project)
+
+        expect(editor.element.find_link(text: "Write the release notes").native.property("href"))
+          .to end_with("/wp/#{work_package.id}")
       end
     end
   end

--- a/spec/support/form_fields/primerized/block_note_editor_browser_actions.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_browser_actions.rb
@@ -35,6 +35,10 @@ module FormFields
         JS
       end
 
+      def select_to_line_start
+        page.driver.browser.action.key_down(:shift).send_keys(:home).key_up(:shift).perform
+      end
+
       # Forward Delete via the W3C actions API; pair with a selection helper.
       def send_forward_delete
         page.driver.browser.action.send_keys(:delete).perform

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -24,6 +24,10 @@ module FormFields
         send_keys(:enter)
       end
 
+      def click_formatting_toolbar_button(label)
+        shadow_root.find("button[aria-label='#{label}']").click
+      end
+
       def create_work_package_form
         page.find("[data-testid='create-wp-modal']")
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-137
# What are you trying to accomplish?
Documents get a "Create work package" button in the toolbar that appears on a text selection. The selected text becomes the work package's subject, and the created work package takes the text's place as a link - so a plan that has been approved can be turned into work packages line by line, without leaving the document.

The behaviour itself lives in op-blocknote-extensions; all that is needed here is to hand BlockNote's formatting toolbar over to the one the library assembles, instead of the default one.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
