### PR TITLE
[JIM-147] SPIKE Extend Primer::Beta::Button to support loading state

### DIFF
--- a/app/components/op_primer/spinner_button_component.rb
+++ b/app/components/op_primer/spinner_button_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  class SpinnerButtonComponent < Primer::Beta::Button
+    def initialize(**system_arguments)
+      super
+
+      with_leading_visual_svg(**SpinnerIconComponent.svg_arguments) do
+        SpinnerIconComponent::PATHS
+      end
+    end
+  end
+end

--- a/app/components/op_primer/spinner_icon_component.html.erb
+++ b/app/components/op_primer/spinner_icon_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(Primer::BaseComponent.new(**@system_arguments)) { PATHS } %>

--- a/app/components/op_primer/spinner_icon_component.rb
+++ b/app/components/op_primer/spinner_icon_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  class SpinnerIconComponent < ApplicationComponent
+    include Primer::ClassNameHelper
+
+    # taken from Primer::Beta::Spinner which sadly does not expose the paths for use in other components
+    # https://github.com/opf/primer_view_components/blob/main/app/components/primer/beta/spinner.html.erb
+    PATHS = <<~SVG.html_safe
+      <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke"></circle>
+      <path d="M15 8a7.002 7.002 0 00-7-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke"></path>
+    SVG
+
+    # Attributes for embedding PATHS directly into an svg tag rendered by
+    # another component, e.g. `Primer::Beta::Button#with_leading_visual_svg`.
+    def self.svg_arguments
+      {
+        viewBox: "0 0 16 16",
+        fill: "none",
+        "aria-hidden": true,
+        classes: "anim-rotate"
+      }
+    end
+
+    def initialize(size: 16, **system_arguments)
+      super()
+
+      @system_arguments = self.class.svg_arguments.merge(system_arguments)
+      @system_arguments[:tag] = :svg
+      @system_arguments[:height] = "#{size}px"
+      @system_arguments[:width] = "#{size}px"
+      @system_arguments[:classes] = class_names(self.class.svg_arguments[:classes], system_arguments[:classes])
+    end
+  end
+end

--- a/lookbook/previews/op_primer/spinner_button_component_preview.rb
+++ b/lookbook/previews/op_primer/spinner_button_component_preview.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module OpPrimer
+  # @logical_path OpenProject/Primer
+  # @display min_height 100px
+  class SpinnerButtonComponentPreview < Lookbook::Preview
+    def default
+      render(OpPrimer::SpinnerButtonComponent.new(scheme: :default)) { "Importing" }
+    end
+
+    def primary
+      render(OpPrimer::SpinnerButtonComponent.new(scheme: :primary)) { "Saving" }
+    end
+
+    def disabled
+      render(OpPrimer::SpinnerButtonComponent.new(scheme: :default, disabled: true)) { "Importing" }
+    end
+  end
+end

--- a/lookbook/previews/op_primer/spinner_icon_component_preview.rb
+++ b/lookbook/previews/op_primer/spinner_icon_component_preview.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module OpPrimer
+  # @logical_path OpenProject/Primer
+  # @display min_height 100px
+  class SpinnerIconComponentPreview < Lookbook::Preview
+    def default
+      render(OpPrimer::SpinnerIconComponent.new)
+    end
+
+    def large
+      render(OpPrimer::SpinnerIconComponent.new(size: 32))
+    end
+
+    # `Primer::Beta::Button`'s `svg` leading visual type builds its own outer
+    # `<svg>` tag, so it can't render `SpinnerIconComponent` directly. Pass
+    # `SpinnerIconComponent.svg_arguments` as the tag's attributes and
+    # `SpinnerIconComponent::PATHS` as the block content instead.
+    def with_button
+      render(Primer::Beta::Button.new(scheme: :default)) do |button|
+        button.with_leading_visual_svg(**OpPrimer::SpinnerIconComponent.svg_arguments) do
+          OpPrimer::SpinnerIconComponent::PATHS
+        end
+        "Importing"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-147

# What are you trying to achieve?

The primer spinner in a button is only available for React components, so we need to come up with our own implementation.

# What approach did you choose and why?

There are several ways of doing this. 
We could also add a :op-spinner icon to our icons collection and just use 
`button.with_leading_visual_icon(icon: :op-spinner, animation: :rotate)`

This spike also introduces a spinner_icon_component which is propbably not needed.

# Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
