### PR TITLE
[AUTOWORK-254] "Name" attribute of a type variant should indicate it is not public  

### DIFF
--- a/app/forms/work_package_types/details_form.rb
+++ b/app/forms/work_package_types/details_form.rb
@@ -38,7 +38,8 @@ module WorkPackageTypes
         input_width: :large,
         required: true,
         autocomplete: "off",
-        validation_message: validation_message_for(name_attribute)
+        validation_message: validation_message_for(name_attribute),
+        caption: name_caption
       )
 
       details_form.color_select_list(
@@ -85,6 +86,10 @@ module WorkPackageTypes
 
     def validation_message_for(attribute)
       model.errors.messages_for(attribute).to_sentence.presence
+    end
+
+    def name_caption
+      helpers.t("types.edit.details.variant_name_caption_html", type: model.type.name) if inherited?
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6512,6 +6512,7 @@ en:
         inherited_from_type_html: "Inherited from type <b>%{type}</b>."
         tab: "Details"
         type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.
+        variant_name_caption_html: "This is an internal name only visible to administrators. Variants replace the original parent type, so if this variant is used in a project, it will appear as <b>%{type}</b> to all members."
       export_configuration:
         artefact_export:
           attachment:

--- a/spec/features/types/crud_spec.rb
+++ b/spec/features/types/crud_spec.rb
@@ -132,6 +132,18 @@ RSpec.describe "Types", :js do
       expect(page).to have_text I18n.t(:notice_successful_update)
       expect(existing_type.reload.name).to eq("Renamed existing type")
     end
+
+    it "captions the name field for a variant" do
+      variant = create(:type_variant, type: existing_type, variant_name: "Hardware")
+
+      visit edit_type_details_path(type_id: existing_type.id)
+      expect(page).to have_field("Name")
+      expect(page).to have_no_text("This is an internal name only visible to administrators")
+
+      visit edit_type_details_path(type_id: existing_type.id, variant_id: variant.id)
+      expect(page).to have_text("This is an internal name only visible to administrators")
+      expect(page).to have_text("it will appear as #{existing_type.name} to all members")
+    end
   end
 
   context "when a work package of a given type is part of an archived project" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/AUTOWORK-254

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
