### PR TITLE
[COMMS-992] Adjust drag and dropping on the correct 'edge' under grouped lists

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
@@ -187,7 +187,7 @@ export class DragAndDropTransformer {
         const persistedOrder = await this.wpTableOrder.move([...order], wpId, rowIndex);
 
         const el = locateTableRow(wpId);
-        await this.withRowAtTarget(el, newOrder[rowIndex + 1] ?? null, async () => {
+        await this.withRowAtTarget(el, targetId, edge, async () => {
           if (el) {
             await this.actionService.handleDrop(workPackage, el);
           }
@@ -221,17 +221,17 @@ export class DragAndDropTransformer {
    * moments later, so restoring first would visibly snap it back before
    * that rebuild moves it again.
    */
-  private async withRowAtTarget(el:HTMLElement|null, siblingId:string|null, fn:() => Promise<void>):Promise<void> {
+  private async withRowAtTarget(el:HTMLElement|null, targetId:string|null, edge:Edge|null, fn:() => Promise<void>):Promise<void> {
     if (!el) {
       await fn();
       return;
     }
 
     const { parentNode, nextSibling } = el;
-    const sibling = siblingId ? locateTableRow(siblingId) : null;
+    const targetRow = targetId ? locateTableRow(targetId) : null;
 
-    if (sibling) {
-      this.table.tbody.insertBefore(el, sibling);
+    if (targetRow) {
+      this.table.tbody.insertBefore(el, edge === 'top' ? targetRow : targetRow.nextSibling);
     } else {
       this.table.tbody.appendChild(el);
     }

--- a/spec/features/work_packages/sorting/manual_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/manual_sorting_spec.rb
@@ -219,6 +219,31 @@ RSpec.describe "Manual sorting of WP table", :js, :selenium do
         expect(page).to have_css(".group--value", text: "Bug (3)")
       end
 
+      it "keeps the work package in the same group when dropped on the bottom edge of that group's last row" do
+        expect(page).to have_css(".group--value", text: "Task (2)")
+        expect(page).to have_css(".group--value", text: "Bug (2)")
+
+        rows = page.all(".wp-table--row")
+        source_row = rows[0]
+        scroll_to_element(source_row)
+        source_row.hover
+        source = source_row.find(".wp-table--drag-and-drop-handle")
+        # Last row of the *same* (Task) group, not the last row overall.
+        same_group_last_row_rect = rows[1].native.rect
+
+        # cannot use the helper because it aims to the "above" edge
+        perform_native_drag(
+          source:,
+          target_x: same_group_last_row_rect.x + (same_group_last_row_rect.width / 2),
+          target_y: same_group_last_row_rect.y + (same_group_last_row_rect.height * 3 / 4)
+        )
+        loading_indicator_saveguard
+
+        expect(page).to have_css(".group--value", text: "Task (2)")
+        expect(page).to have_css(".group--value", text: "Bug (2)")
+        expect(page).to have_no_css ".op-toast.error"
+      end
+
       it "dragging item with parent does not result in an error (Regression #30832)" do
         expect(page).to have_css(".group--value", text: "Task (2)")
         expect(page).to have_css(".group--value", text: "Bug (2)")

--- a/spec/features/work_packages/sorting/manual_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/manual_sorting_spec.rb
@@ -217,30 +217,19 @@ RSpec.describe "Manual sorting of WP table", :js, :selenium do
 
         expect(page).to have_css(".group--value", text: "Task (1)")
         expect(page).to have_css(".group--value", text: "Bug (3)")
-      end
-
-      it "keeps the work package in the same group when dropped on the bottom edge of that group's last row" do
-        expect(page).to have_css(".group--value", text: "Task (2)")
-        expect(page).to have_css(".group--value", text: "Bug (2)")
 
         rows = page.all(".wp-table--row")
-        source_row = rows[0]
+        source_row = rows[1]
         scroll_to_element(source_row)
         source_row.hover
         source = source_row.find(".wp-table--drag-and-drop-handle")
-        # Last row of the *same* (Task) group, not the last row overall.
-        same_group_last_row_rect = rows[1].native.rect
+        target_row = rows[3]
 
-        # cannot use the helper because it aims to the "above" edge
-        perform_native_drag(
-          source:,
-          target_x: same_group_last_row_rect.x + (same_group_last_row_rect.width / 2),
-          target_y: same_group_last_row_rect.y + (same_group_last_row_rect.height * 3 / 4)
-        )
+        perform_native_drag(source:, target: target_row, offset_y: target_row.native.rect.height / 4)
         loading_indicator_saveguard
 
-        expect(page).to have_css(".group--value", text: "Task (2)")
-        expect(page).to have_css(".group--value", text: "Bug (2)")
+        expect(page).to have_css(".group--value", text: "Task (1)")
+        expect(page).to have_css(".group--value", text: "Bug (3)")
         expect(page).to have_no_css ".op-toast.error"
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/COMMS-992/activity

# What are you trying to accomplish?
It was not possible to drag and drop work packages to the last item of a group. Fixing that.

## Screenshots
**Before**
![before](https://github.com/user-attachments/assets/519c4ac1-210f-4cd9-a2f3-9ed5ab14de6b)

**AFTER**
![after](https://github.com/user-attachments/assets/352ea495-7e64-452a-a29a-2efe2490f3ab)


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
