### PR TITLE
[COMMS-996] Search is missing an index for work_package_semantic_aliases

### DIFF
--- a/db/migrate/20260903120000_add_index_on_work_package_semantic_aliases_lower_identifier.rb
+++ b/db/migrate/20260903120000_add_index_on_work_package_semantic_aliases_lower_identifier.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddIndexOnWorkPackageSemanticAliasesLowerIdentifier < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL.squish
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS index_wp_semantic_aliases_on_lower_identifier_text_pattern
+      ON work_package_semantic_aliases ((lower(identifier)) text_pattern_ops)
+    SQL
+  end
+
+  def down
+    execute <<~SQL.squish
+      DROP INDEX CONCURRENTLY IF EXISTS index_wp_semantic_aliases_on_lower_identifier_text_pattern
+    SQL
+  end
+end

--- a/spec/models/work_package_semantic_alias_spec.rb
+++ b/spec/models/work_package_semantic_alias_spec.rb
@@ -33,6 +33,10 @@ require "spec_helper"
 RSpec.describe WorkPackageSemanticAlias do
   let(:work_package) { create(:work_package) }
 
+  describe "database indexes" do
+    it { is_expected.to have_db_index("lower((identifier)::text) text_pattern_ops") }
+  end
+
   describe "validations" do
     it "is valid with an identifier and work_package" do
       record = described_class.new(identifier: "PROJ-1", work_package:)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-996

# What are you trying to accomplish?
This adds an index for that table for the typeahead search, which is used e.g. in the global search.
See https://community.openproject.org/projects/COMMS/work_packages/COMMS-996/activity#comment-1729695 for postgres explain output (before / after).

# What approach did you choose and why?
Add the appropriate index that was missing (the existing b-tree index was not used by the typeahead search)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
