### PR TITLE
Bug/COMMS-997: Include version changes in the "Only changes" activity filter

### DIFF
--- a/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
+++ b/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
@@ -35,6 +35,7 @@
 #   * Attachment changes (compares attachable_journals with predecessor)
 #   * Custom field changes (compares customizable_journals with predecessor)
 #   * File link changes (compares storages_file_links_journals with predecessor)
+#   * Target/observed-in version changes (compares work_package_version_journals with predecessor)
 #   * Cause metadata (system-triggered changes)
 #   * Attribute/data changes (compares work_package_journals columns with immediate predecessor)
 #
@@ -86,6 +87,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
         OR EXISTS (#{attachment_changes_condition_sql})
         OR EXISTS (#{custom_field_changes_condition_sql})
         OR EXISTS (#{file_link_changes_condition_sql})
+        OR EXISTS (#{version_changes_condition_sql})
       SQL
     end
 
@@ -124,6 +126,14 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
         table: Journal::StorableJournal.table_name,
         join_columns: ["file_link_id"],
         value_columns: %w[link_name storage_name]
+      )
+    end
+
+    def version_changes_condition_sql
+      association_changes_condition_sql(
+        table: Journal::WorkPackageVersionJournal.table_name,
+        join_columns: %w[version_id kind],
+        value_columns: []
       )
     end
 

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -825,6 +825,121 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
           expect(records.map(&:id)).not_to include(journal_with_file_link_snapshot.id)
         end
       end
+
+      context "with target version changes" do
+        let!(:journal_with_target_version_added) do
+          version = create(:version, project:)
+          work_package.target_version_ids_replacements = [version.id]
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_target_version_snapshot) do
+          work_package.add_journal(notes: "Unrelated change")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_target_version_removed) do
+          work_package.target_version_ids_replacements = []
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journal where target version was added" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_target_version_added.id)
+
+          changes = journal_with_target_version_added.reload.get_changes
+          expect(changes).to have_key("target_versions")
+        end
+
+        it "excludes journal with only target version snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_target_version_snapshot.reload.work_package_version_journals.count).to eq(1)
+          changes = journal_with_target_version_snapshot.reload.get_changes
+          expect(changes).to eq({}) # no changes
+
+          expect(records.map(&:id)).not_to include(journal_with_target_version_snapshot.id)
+        end
+
+        it "includes journal where target version was removed" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_target_version_removed.id)
+
+          changes = journal_with_target_version_removed.reload.get_changes
+          expect(changes).to have_key("target_versions")
+        end
+      end
+
+      context "with observed in version changes" do
+        let!(:journal_with_observed_in_version_added) do
+          version = create(:version, project:)
+          work_package.observed_in_version_ids_replacements = [version.id]
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_observed_in_version_snapshot) do
+          work_package.add_journal(notes: "Unrelated change")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_observed_in_version_removed) do
+          work_package.observed_in_version_ids_replacements = []
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journal where observed in version was added" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_observed_in_version_added.id)
+
+          changes = journal_with_observed_in_version_added.reload.get_changes
+          expect(changes).to have_key("observed_in_versions")
+        end
+
+        it "excludes journal with only observed in version snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_observed_in_version_snapshot.reload.work_package_version_journals.count).to eq(1)
+          changes = journal_with_observed_in_version_snapshot.reload.get_changes
+          expect(changes).to eq({}) # no changes
+
+          expect(records.map(&:id)).not_to include(journal_with_observed_in_version_snapshot.id)
+        end
+
+        it "includes journal where observed in version was removed" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_observed_in_version_removed.id)
+
+          changes = journal_with_observed_in_version_removed.reload.get_changes
+          expect(changes).to have_key("observed_in_versions")
+        end
+      end
+
+      context "when moving a version from target to observed in" do
+        let!(:journal_with_version_moved_across_kinds) do
+          version = create(:version, project:)
+          work_package.target_version_ids_replacements = [version.id]
+          work_package.save!
+
+          work_package.target_version_ids_replacements = []
+          work_package.observed_in_version_ids_replacements = [version.id]
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes the journal even though the moved version's id alone matches the predecessor" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_version_moved_across_kinds.id)
+
+          changes = journal_with_version_moved_across_kinds.reload.get_changes
+          expect(changes.keys).to include("target_versions", "observed_in_versions")
+        end
+      end
     end
 
     context "with :hide_meetings filter" do

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -940,6 +940,85 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
           expect(changes.keys).to include("target_versions", "observed_in_versions")
         end
       end
+
+      context "with multi-value version changes" do
+        let!(:version1) { create(:version, project:) }
+        let!(:version2) { create(:version, project:) }
+        let!(:version3) { create(:version, project:) }
+
+        let!(:journal_with_two_target_versions) do
+          work_package.target_version_ids_replacements = [version1.id, version2.id]
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_two_target_versions_snapshot) do
+          work_package.add_journal(notes: "Just a comment")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "excludes journal with only a multi-value target version snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_two_target_versions_snapshot.reload.work_package_version_journals.count).to eq(2)
+          expect(journal_with_two_target_versions_snapshot.get_changes).to eq({})
+
+          expect(records.map(&:id)).not_to include(journal_with_two_target_versions_snapshot.id)
+        end
+
+        shared_examples "a journal with version changes" do |key|
+          it "is included with #{key} among its changes" do
+            _pagy, records = paginator.call
+
+            expect(records.map(&:id)).to include(journal.id)
+            expect(journal.reload.get_changes).to have_key(key)
+          end
+        end
+
+        context "when adding a target version to an existing selection" do
+          let!(:journal) do
+            work_package.reload.target_version_ids_replacements = [version1.id, version2.id, version3.id]
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it_behaves_like "a journal with version changes", "target_versions"
+        end
+
+        context "when removing one of several target versions" do
+          let!(:journal) do
+            work_package.reload.target_version_ids_replacements = [version1.id]
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it_behaves_like "a journal with version changes", "target_versions"
+        end
+
+        context "when swapping one of several target versions" do
+          let!(:journal) do
+            work_package.reload.target_version_ids_replacements = [version2.id, version3.id]
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it_behaves_like "a journal with version changes", "target_versions"
+        end
+
+        context "when removing one of several observed in versions" do
+          let!(:journal) do
+            work_package.reload.observed_in_version_ids_replacements = [version1.id, version2.id]
+            work_package.save!
+
+            work_package.observed_in_version_ids_replacements = [version2.id]
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it_behaves_like "a journal with version changes", "observed_in_versions"
+        end
+      end
     end
 
     context "with :hide_meetings filter" do


### PR DESCRIPTION
https://community.openproject.org/wp/COMMS-997

Include version changes in the "Only changes" activity filter

> Before: the journals that only set a target version or an observed-in version are missing under "Show changes only".

<img width="2560" height="1800" alt="before-only-changes-filter" src="https://github.com/user-attachments/assets/8e53440f-c9ca-41dc-927d-bcce3581e5f5" />

> After: both journals are listed.

<img width="2560" height="1800" alt="after-only-changes-filter" src="https://github.com/user-attachments/assets/c38653ae-8e82-4447-a6ff-e76474c30525" />

