### PR TITLE
[DREAM-796] Show subitem widget only when subitems exist

### DIFF
--- a/modules/grids/app/components/grids/widgets/subitems.rb
+++ b/modules/grids/app/components/grids/widgets/subitems.rb
@@ -45,6 +45,10 @@ module Grids
         t(".title")
       end
 
+      def render?
+        !project.project? || project.children.exists?
+      end
+
       def displayed_subitems
         subitems_with_more.first
       end

--- a/modules/grids/app/components/grids/widgets/subitems.rb
+++ b/modules/grids/app/components/grids/widgets/subitems.rb
@@ -46,7 +46,7 @@ module Grids
       end
 
       def render?
-        !project.project? || project.children.visible(current_user).exists?
+        !project.project? || project.children.visible.exists?
       end
 
       def displayed_subitems

--- a/modules/grids/app/components/grids/widgets/subitems.rb
+++ b/modules/grids/app/components/grids/widgets/subitems.rb
@@ -46,7 +46,7 @@ module Grids
       end
 
       def render?
-        !project.project? || project.children.exists?
+        !project.project? || project.children.visible(current_user).exists?
       end
 
       def displayed_subitems

--- a/modules/grids/spec/components/grids/widgets/subitems_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/subitems_spec.rb
@@ -52,18 +52,8 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
     end
   end
 
-  shared_examples "empty-state with action" do
-    it "renders empty blankslate with action button" do
-      expect(rendered_component).to have_test_selector("subitems-widget-empty")
-      expect(rendered_component).to have_text("This widget is currently empty.")
-      expect(rendered_component).to have_test_selector("subitems-widget-add-button")
-    end
-  end
-
   context "with no children" do
     let(:user) { build_stubbed(:user) }
-    let(:empty_selector) { "subitems-widget-empty" }
-    let(:empty_message)  { "This widget is currently empty." }
 
     before do
       mock_permissions_for(user) do |mock|
@@ -71,18 +61,28 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
       end
     end
 
-    it_behaves_like "empty-state with action"
+    context "for a project" do
+      let(:project) { create(:project) }
 
-    context "when user cannot add subprojects but can view" do
-      let(:user) { build_stubbed(:user) }
-
-      before do
-        mock_permissions_for(user) do |mock|
-          mock.allow_in_project(:view_project, project:)
-        end
+      it "does not render the widget" do
+        expect(rendered_component.to_html).to be_empty
       end
+    end
 
-      it_behaves_like "empty-state without action"
+    context "for a portfolio" do
+      let(:project) { create(:portfolio) }
+
+      it "renders the empty widget" do
+        expect(rendered_component).to have_test_selector("subitems-widget-empty")
+      end
+    end
+
+    context "for a program" do
+      let(:project) { create(:program) }
+
+      it "renders the empty widget" do
+        expect(rendered_component).to have_test_selector("subitems-widget-empty")
+      end
     end
   end
 
@@ -96,7 +96,9 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
     end
 
     context "for a regular project" do
-      let(:project) { build_stubbed(:project, workspace_type: :project) }
+      let(:project) { create(:project, workspace_type: :project) }
+
+      before { create(:project, parent: project) }
 
       it "shows the add project menu item" do
         expect(rendered_component).to have_link "Project", href: new_project_path(parent_id: project.id)
@@ -130,6 +132,7 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
 
     context "when user cannot add subprojects" do
       let(:user) { build_stubbed(:user) }
+      let(:project) { build_stubbed(:portfolio) }
 
       before do
         mock_permissions_for(user) do |mock|
@@ -137,7 +140,8 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
         end
       end
 
-      it "does not show any menu items" do
+      it "renders without creation links", :aggregate_failures do
+        expect(rendered_component).to have_test_selector("subitems-widget-empty")
         expect(rendered_component).to have_no_link "Project"
         expect(rendered_component).to have_no_link "Program"
       end

--- a/modules/grids/spec/components/grids/widgets/subitems_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/subitems_spec.rb
@@ -44,14 +44,6 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
 
   subject(:rendered_component) { render_component(project, current_user:, **params) }
 
-  shared_examples "empty-state without action" do
-    it "renders empty blankslate without action button" do
-      expect(rendered_component).to have_test_selector(empty_selector)
-      expect(rendered_component).to have_text(empty_message)
-      expect(rendered_component).to have_no_test_selector("subitems-widget-add-button")
-    end
-  end
-
   context "with no children" do
     let(:user) { build_stubbed(:user) }
 
@@ -97,8 +89,14 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
 
     context "for a regular project" do
       let(:project) { create(:project, workspace_type: :project) }
-
-      before { create(:project, parent: project) }
+      let!(:subproject) { create(:project, parent: project) }
+      let(:user) do
+        create(:user,
+               member_with_permissions: {
+                 project => %i[view_project add_subprojects],
+                 subproject => %i[view_project]
+               })
+      end
 
       it "shows the add project menu item" do
         expect(rendered_component).to have_link "Project", href: new_project_path(parent_id: project.id)
@@ -225,8 +223,6 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
 
     context "when user can view parent but does not have permission to view any subprojects" do
       let(:user) { build_stubbed(:user) }
-      let(:empty_selector) { "subitems-widget-no-permission" }
-      let(:empty_message)  { "This widget is not available." }
 
       before do
         mock_permissions_for(user) do |mock|
@@ -234,15 +230,17 @@ RSpec.describe Grids::Widgets::Subitems, type: :component do
         end
       end
 
-      it_behaves_like "empty-state without action"
+      it "does not render the widget" do
+        expect(rendered_component.to_html).to be_empty
+      end
     end
 
     context "when user doesn't have permission to view project" do
       let(:user) { build_stubbed(:user) }
-      let(:empty_selector) { "subitems-widget-no-permission" }
-      let(:empty_message)  { "This widget is not available." }
 
-      it_behaves_like "empty-state without action"
+      it "does not render the widget" do
+        expect(rendered_component.to_html).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-796

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Hide the Subitems widget on project overviews when the project has
no child projects.

Keep the widget visible for portfolios and programs, and cover the
empty and permission-restricted states.
