### PR TITLE
[AUTOWORK-266] Primerize Status administration

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -19,6 +19,7 @@
 @import "projects/wizard/page_component"
 @import "shares/invite_user_form_component"
 @import "shares/modal_body_component"
+@import "statuses/index_component"
 @import "step_wizard/footer_component"
 @import "step_wizard/page_layout_component"
 @import "users/hover_card_component"

--- a/app/components/op_primer/quick_filter/param_select_panel_component.html.erb
+++ b/app/components/op_primer/quick_filter/param_select_panel_component.html.erb
@@ -1,0 +1,60 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  render(
+    Primer::Alpha::SelectPanel.new(
+      select_variant: :multiple,
+      fetch_strategy: :local,
+      title: title,
+      data: data_attributes,
+      test_selector: test_selector
+    )
+  ) do |panel|
+    panel.with_show_button(scheme: :secondary) do |button|
+      button.with_trailing_visual_icon(icon: :"triangle-down")
+      button_label
+    end
+
+    records.each do |record|
+      panel.with_item(label: record.name, active: selected.include?(record), item_id: record.id)
+    end
+
+    panel.with_footer(show_divider: true) do
+      render(
+        Primer::Beta::Button.new(
+          scheme: :primary,
+          data: { action: "click->quick-filter--param-select-panel#apply" }
+        )
+      ) { t(:button_apply) }
+    end
+  end
+%>

--- a/app/components/op_primer/quick_filter/param_select_panel_component.rb
+++ b/app/components/op_primer/quick_filter/param_select_panel_component.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  module QuickFilter
+    # A multi-select quick filter whose selection lives in a plain array query
+    # parameter, for pages that filter without a Queries object.
+    class ParamSelectPanelComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+
+      def initialize(title:, param:, records:, selected:, all_label:, many_label_key:, test_selector: nil)
+        super()
+
+        @title = title
+        @param = param
+        @records = records
+        @selected = selected
+        @all_label = all_label
+        @many_label_key = many_label_key
+        @test_selector = test_selector
+      end
+
+      private
+
+      attr_reader :title, :param, :records, :selected, :all_label, :many_label_key, :test_selector
+
+      def button_label
+        case selected.size
+        when 0 then all_label
+        when 1 then selected.first.name
+        else t(many_label_key, count: selected.size)
+        end
+      end
+
+      def data_attributes
+        {
+          controller: "quick-filter--param-select-panel",
+          "quick-filter--param-select-panel-param-value": param
+        }
+      end
+    end
+  end
+end

--- a/app/components/statuses/index_component.html.erb
+++ b/app/components/statuses/index_component.html.erb
@@ -1,0 +1,103 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    flex_layout do |flex|
+      flex.with_row do
+        render(Primer::OpenProject::SubHeader.new) do |subheader|
+          subheader.with_action_button(
+            scheme: :primary,
+            leading_icon: :plus,
+            label: t(:label_work_package_status_new),
+            tag: :a,
+            href: new_status_path,
+            test_selector: "add-status-button"
+          ) do
+            t(:label_status)
+          end
+        end
+      end
+
+      flex.with_row do
+        render(border_box_container) do |box|
+          box.with_header(font_weight: :bold) do
+            grid_layout("op-statuses-list--header", tag: :div, align_items: :center, classes: header_modifier_class) do |grid|
+              grid.with_area(:name, tag: :div) do
+                render(Primer::Beta::Text.new(font_weight: :semibold)) { Status.human_attribute_name(:name) }
+              end
+
+              if show_done_ratio?
+                grid.with_area(:"done-ratio", tag: :div, hide: :sm) do
+                  render(Primer::Beta::Text.new(font_weight: :semibold)) do
+                    WorkPackage.human_attribute_name(:done_ratio)
+                  end
+                end
+              end
+
+              grid.with_area(:"is-default", tag: :div, hide: :sm) do
+                render(Primer::Beta::Text.new(font_weight: :semibold)) { t("statuses.index.headers.is_default") }
+              end
+
+              grid.with_area(:"is-closed", tag: :div, hide: :sm) do
+                render(Primer::Beta::Text.new(font_weight: :semibold)) { t("statuses.index.headers.is_closed") }
+              end
+
+              grid.with_area(:"is-readonly", tag: :div, hide: :sm) do
+                render(Primer::Beta::Text.new(font_weight: :semibold)) { t("statuses.index.headers.is_readonly") }
+              end
+            end
+          end
+
+          if statuses.empty?
+            box.with_row do
+              render(Primer::Beta::Blankslate.new(spacious: true)) do |blank_slate|
+                blank_slate.with_visual_icon(icon: :alert)
+                blank_slate.with_heading(tag: :h3) { empty_state_title }
+                blank_slate.with_description { empty_state_description }
+              end
+            end
+          else
+            statuses.each do |status|
+              box.with_row(test_selector: "status-row-#{status.id}") do
+                render(Statuses::ItemComponent.new(status:, max_position:, page_args:))
+              end
+            end
+          end
+        end
+      end
+
+      flex.with_row(mt: 3) do
+        helpers.pagination_links_full(statuses)
+      end
+    end
+  end
+%>

--- a/app/components/statuses/index_component.html.erb
+++ b/app/components/statuses/index_component.html.erb
@@ -34,6 +34,38 @@
     flex_layout(data: wrapper_data_attributes) do |flex|
       flex.with_row do
         render(Primer::OpenProject::SubHeader.new) do |subheader|
+          subheader.with_filter_component do
+            render(Primer::OpenProject::FlexLayout.new(align_items: :center)) do |flex|
+              flex.with_column do
+                render(
+                  OpPrimer::QuickFilter::ParamSelectPanelComponent.new(
+                    title: t("statuses.index.filter.by_type"),
+                    param: "type_ids",
+                    records: types,
+                    selected: selected_types,
+                    all_label: t("statuses.index.filter.all_types"),
+                    many_label_key: "statuses.index.filter.types",
+                    test_selector: "type-quick-filter"
+                  )
+                )
+              end
+
+              flex.with_column(ml: 2) do
+                render(
+                  OpPrimer::QuickFilter::ParamSelectPanelComponent.new(
+                    title: t("statuses.index.filter.by_role"),
+                    param: "role_ids",
+                    records: roles,
+                    selected: selected_roles,
+                    all_label: t("statuses.index.filter.all_roles"),
+                    many_label_key: "statuses.index.filter.roles",
+                    test_selector: "role-quick-filter"
+                  )
+                )
+              end
+            end
+          end
+
           subheader.with_action_button(
             scheme: :primary,
             leading_icon: :plus,
@@ -82,13 +114,13 @@
               render(Primer::Beta::Blankslate.new(spacious: true)) do |blank_slate|
                 blank_slate.with_visual_icon(icon: :alert)
                 blank_slate.with_heading(tag: :h3) { empty_state_title }
-                blank_slate.with_description { empty_state_description }
+                blank_slate.with_description { empty_state_description } if empty_state_description
               end
             end
           else
             statuses.each do |status|
               box.with_row(test_selector: "status-row-#{status.id}", data: draggable_item_config(status)) do
-                render(Statuses::ItemComponent.new(status:, max_position:, page_args:))
+                render(Statuses::ItemComponent.new(status:, max_position:, reorderable: reorderable?, page_args:))
               end
             end
           end
@@ -96,7 +128,7 @@
       end
 
       flex.with_row(mt: 3) do
-        helpers.pagination_links_full(statuses)
+        helpers.pagination_links_full(statuses, allowed_params: %w[type_ids role_ids])
       end
     end
   end

--- a/app/components/statuses/index_component.html.erb
+++ b/app/components/statuses/index_component.html.erb
@@ -31,7 +31,7 @@
 
 <%=
   component_wrapper do
-    flex_layout do |flex|
+    flex_layout(data: wrapper_data_attributes) do |flex|
       flex.with_row do
         render(Primer::OpenProject::SubHeader.new) do |subheader|
           subheader.with_action_button(
@@ -48,7 +48,7 @@
       end
 
       flex.with_row do
-        render(border_box_container) do |box|
+        render(border_box_container(data: drop_target_config)) do |box|
           box.with_header(font_weight: :bold) do
             grid_layout("op-statuses-list--header", tag: :div, align_items: :center, classes: header_modifier_class) do |grid|
               grid.with_area(:name, tag: :div) do
@@ -87,7 +87,7 @@
             end
           else
             statuses.each do |status|
-              box.with_row(test_selector: "status-row-#{status.id}") do
+              box.with_row(test_selector: "status-row-#{status.id}", data: draggable_item_config(status)) do
                 render(Statuses::ItemComponent.new(status:, max_position:, page_args:))
               end
             end

--- a/app/components/statuses/index_component.rb
+++ b/app/components/statuses/index_component.rb
@@ -59,5 +59,25 @@ module Statuses
     def empty_state_description
       t("statuses.index.no_results_content_text")
     end
+
+    def wrapper_data_attributes
+      { controller: "generic-drag-and-drop" }
+    end
+
+    def drop_target_config
+      {
+        generic_drag_and_drop_target: "container",
+        "target-container-accessor": ":scope > ul",
+        "target-allowed-drag-type": "status"
+      }
+    end
+
+    def draggable_item_config(status)
+      {
+        "draggable-id": status.id,
+        "draggable-type": "status",
+        "drop-url": move_status_path(status, **page_args.to_h)
+      }
+    end
   end
 end

--- a/app/components/statuses/index_component.rb
+++ b/app/components/statuses/index_component.rb
@@ -35,6 +35,8 @@ module Statuses
     include OpTurbo::Streamable
 
     options :statuses
+    options :type_ids
+    options :role_ids
     options :page_args
 
     private
@@ -43,6 +45,18 @@ module Statuses
     def max_position
       Status.maximum(:position)
     end
+
+    def types
+      @types ||= ::Type.order(:position)
+    end
+
+    def roles
+      @roles ||= Workflow.eligible_roles.order(Arel.sql("builtin, position"))
+    end
+
+    def selected_types = types.select { |type| type_ids.include?(type.id) }
+
+    def selected_roles = roles.select { |role| role_ids.include?(role.id) }
 
     def show_done_ratio?
       WorkPackage.status_based_mode?
@@ -53,18 +67,32 @@ module Statuses
     end
 
     def empty_state_title
-      t("statuses.index.no_results_title_text")
+      if reorderable?
+        t("statuses.index.no_results_title_text")
+      else
+        t("statuses.index.no_filter_results_title_text")
+      end
     end
 
     def empty_state_description
-      t("statuses.index.no_results_content_text")
+      t("statuses.index.no_results_content_text") if reorderable?
+    end
+
+    # Positions are global while a filtered list shows a subset, so a drop would
+    # resolve against neighbours the list does not display.
+    def reorderable?
+      type_ids.blank? && role_ids.blank?
     end
 
     def wrapper_data_attributes
+      return {} unless reorderable?
+
       { controller: "generic-drag-and-drop" }
     end
 
     def drop_target_config
+      return {} unless reorderable?
+
       {
         generic_drag_and_drop_target: "container",
         "target-container-accessor": ":scope > ul",
@@ -73,6 +101,8 @@ module Statuses
     end
 
     def draggable_item_config(status)
+      return {} unless reorderable?
+
       {
         "draggable-id": status.id,
         "draggable-type": "status",

--- a/app/components/statuses/index_component.rb
+++ b/app/components/statuses/index_component.rb
@@ -29,43 +29,35 @@
 #++
 
 module Statuses
-  class TableComponent < ::TableComponent
-    def initial_sort
-      %i[id asc]
+  class IndexComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+
+    options :statuses
+    options :page_args
+
+    private
+
+    # The list may show one page of statuses while positions run across all of them.
+    def max_position
+      Status.maximum(:position)
     end
 
-    def sortable?
-      false
+    def show_done_ratio?
+      WorkPackage.status_based_mode?
     end
 
-    def columns
-      headers.map(&:first)
+    def header_modifier_class
+      "op-statuses-list--header_without-done-ratio" unless show_done_ratio?
     end
 
-    def inline_create_link
-      link_to new_status_path,
-              aria: { label: t(:label_work_package_status_new) },
-              class: "wp-inline-create--add-link",
-              title: t(:label_work_package_status_new) do
-        helpers.op_icon("icon icon-add")
-      end
+    def empty_state_title
+      t("statuses.index.no_results_title_text")
     end
 
-    def empty_row_message
-      I18n.t :no_results_title_text
-    end
-
-    def headers
-      [
-        [:name, { caption: Status.human_attribute_name(:name) }],
-        [:color, { caption: Status.human_attribute_name(:color) }],
-        [:done_ratio, { caption: WorkPackage.human_attribute_name(:done_ratio) }],
-        [:default?, { caption: I18n.t("statuses.index.headers.is_default") }],
-        [:closed?, { caption: I18n.t("statuses.index.headers.is_closed") }],
-        [:readonly?, { caption: I18n.t("statuses.index.headers.is_readonly") }],
-        [:excluded_from_totals?, { caption: I18n.t("statuses.index.headers.excluded_from_totals") }],
-        [:sort, { caption: I18n.t(:label_sort) }]
-      ]
+    def empty_state_description
+      t("statuses.index.no_results_content_text")
     end
   end
 end

--- a/app/components/statuses/index_component.sass
+++ b/app/components/statuses/index_component.sass
@@ -1,0 +1,27 @@
+.op-statuses-list--header,
+.op-statuses-list--item
+  display: grid
+  // Header and rows are separate grids, so every track must resolve to the same
+  // width in both: no content-sized tracks, and the same columns on each side.
+  grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
+  grid-template-areas: "name done-ratio is-default is-closed is-readonly actions"
+  column-gap: 8px
+
+  &_without-done-ratio
+    grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 40px
+    grid-template-areas: "name is-default is-closed is-readonly actions"
+
+  &--done-ratio,
+  &--is-default,
+  &--is-closed,
+  &--is-readonly
+    text-align: center
+
+  &--actions
+    justify-self: end
+
+@media screen and (max-width: $breakpoint-sm)
+  .op-statuses-list--header,
+  .op-statuses-list--item
+    grid-template-columns: minmax(0, 1fr) 40px
+    grid-template-areas: "name actions"

--- a/app/components/statuses/index_component.sass
+++ b/app/components/statuses/index_component.sass
@@ -3,13 +3,13 @@
   display: grid
   // Header and rows are separate grids, so every track must resolve to the same
   // width in both: no content-sized tracks, and the same columns on each side.
-  grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
-  grid-template-areas: "name done-ratio is-default is-closed is-readonly actions"
+  grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
+  grid-template-areas: "drag-handle name done-ratio is-default is-closed is-readonly actions"
   column-gap: 8px
 
   &_without-done-ratio
-    grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 40px
-    grid-template-areas: "name is-default is-closed is-readonly actions"
+    grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 40px
+    grid-template-areas: "drag-handle name is-default is-closed is-readonly actions"
 
   &--done-ratio,
   &--is-default,
@@ -23,5 +23,5 @@
 @media screen and (max-width: $breakpoint-sm)
   .op-statuses-list--header,
   .op-statuses-list--item
-    grid-template-columns: minmax(0, 1fr) 40px
-    grid-template-areas: "name actions"
+    grid-template-columns: 20px minmax(0, 1fr) 40px
+    grid-template-areas: "drag-handle name actions"

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -33,7 +33,7 @@
   component_wrapper do
     grid_layout("op-statuses-list--item", tag: :div, align_items: :center, classes: grid_modifier_class) do |grid|
       grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
-        render(Primer::OpenProject::DragHandle.new)
+        render(Primer::OpenProject::DragHandle.new) if reorderable
       end
 
       grid.with_area(:name, tag: :div, classes: "ellipsis") do

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -32,6 +32,10 @@
 <%=
   component_wrapper do
     grid_layout("op-statuses-list--item", tag: :div, align_items: :center, classes: grid_modifier_class) do |grid|
+      grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
+        render(Primer::OpenProject::DragHandle.new)
+      end
+
       grid.with_area(:name, tag: :div, classes: "ellipsis") do
         flex_layout(align_items: :center) do |flex|
           flex.with_column(mr: 2) do

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -1,0 +1,80 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    grid_layout("op-statuses-list--item", tag: :div, align_items: :center, classes: grid_modifier_class) do |grid|
+      grid.with_area(:name, tag: :div, classes: "ellipsis") do
+        flex_layout(align_items: :center) do |flex|
+          flex.with_column(mr: 2) do
+            helpers.icon_for_color(status.color)
+          end
+
+          flex.with_column(classes: "ellipsis") do
+            render(Primer::Beta::Link.new(href: edit_status_path(status), underline: false)) do
+              render(Primer::Beta::Text.new(font_weight: :bold)) { status.name }
+            end
+          end
+        end
+      end
+
+      if show_done_ratio?
+        grid.with_area(:"done-ratio", tag: :div, hide: :sm) do
+          render(Primer::Beta::Text.new(color: :subtle, test_selector: "done-ratio")) { done_ratio }
+        end
+      end
+
+      grid.with_area(:"is-default", tag: :div, hide: :sm) do
+        checkmark(status.is_default?, label: t("statuses.index.headers.is_default"))
+      end
+
+      grid.with_area(:"is-closed", tag: :div, hide: :sm) do
+        checkmark(status.is_closed?, label: t("statuses.index.headers.is_closed"))
+      end
+
+      grid.with_area(:"is-readonly", tag: :div, hide: :sm) do
+        checkmark(status.is_readonly?, label: t("statuses.index.headers.is_readonly"))
+      end
+
+      grid.with_area(:actions, tag: :div, classes: "hide-when-print") do
+        render(Primer::Alpha::ActionMenu.new(test_selector: "status-action-menu")) do |menu|
+          menu.with_show_button(
+            icon: "kebab-horizontal",
+            scheme: :invisible,
+            "aria-label": t("statuses.index.status_actions")
+          )
+
+          build_status_menu(menu)
+        end
+      end
+    end
+  end
+%>

--- a/app/components/statuses/item_component.rb
+++ b/app/components/statuses/item_component.rb
@@ -36,6 +36,7 @@ module Statuses
 
     options :status
     options :max_position
+    options :reorderable
     options :page_args
 
     private
@@ -73,6 +74,8 @@ module Statuses
     def build_status_menu(menu)
       with_item_group(menu) { edit_status(menu) }
       with_item_group(menu) do
+        next unless reorderable
+
         unless first_item?
           move_status(menu, :highest, I18n.t(:label_sort_highest), "move-to-top")
           move_status(menu, :higher, I18n.t(:label_sort_higher), "chevron-up")

--- a/app/components/statuses/item_component.rb
+++ b/app/components/statuses/item_component.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Statuses
+  class ItemComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+
+    options :status
+    options :max_position
+    options :page_args
+
+    private
+
+    def wrapper_uniq_by
+      status.id
+    end
+
+    def first_item?
+      status.position == 1
+    end
+
+    def last_item?
+      status.position == max_position
+    end
+
+    def show_done_ratio?
+      WorkPackage.status_based_mode?
+    end
+
+    def grid_modifier_class
+      "op-statuses-list--item_without-done-ratio" unless show_done_ratio?
+    end
+
+    def done_ratio
+      helpers.number_to_percentage(status.default_done_ratio, precision: 0)
+    end
+
+    def checkmark(flagged, label:)
+      return unless flagged
+
+      render(Primer::Beta::Octicon.new(icon: :check, "aria-label": label))
+    end
+
+    def build_status_menu(menu)
+      with_item_group(menu) { edit_status(menu) }
+      with_item_group(menu) do
+        unless first_item?
+          move_status(menu, :highest, I18n.t(:label_sort_highest), "move-to-top")
+          move_status(menu, :higher, I18n.t(:label_sort_higher), "chevron-up")
+        end
+        unless last_item?
+          move_status(menu, :lower, I18n.t(:label_sort_lower), "chevron-down")
+          move_status(menu, :lowest, I18n.t(:label_sort_lowest), "move-to-bottom")
+        end
+      end
+      with_item_group(menu) { delete_status(menu) }
+    end
+
+    def edit_status(menu)
+      menu.with_item(label: I18n.t(:button_edit),
+                     tag: :a,
+                     href: edit_status_path(status)) do |item|
+        item.with_leading_visual_icon(icon: :pencil)
+      end
+    end
+
+    def move_status(menu, move_to, label, icon)
+      menu.with_item(label:,
+                     tag: :button,
+                     href: move_status_path(status, **page_args.to_h),
+                     form_arguments: { method: :put, inputs: [{ name: "move_to", value: move_to.to_s }] }) do |item|
+        item.with_leading_visual_icon(icon:)
+      end
+    end
+
+    def delete_status(menu)
+      menu.with_item(label: I18n.t(:button_delete),
+                     tag: :button,
+                     scheme: :danger,
+                     href: status_path(status),
+                     content_arguments: { data: { turbo_confirm: I18n.t(:text_are_you_sure) } },
+                     form_arguments: { method: :delete }) do |item|
+        item.with_leading_visual_icon(icon: :trash)
+      end
+    end
+  end
+end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -38,6 +38,8 @@ class StatusesController < ApplicationController
 
   def index
     @statuses = paginated_statuses
+    @type_ids = filter_type_ids
+    @role_ids = filter_role_ids
     @page_args = page_args
   end
 
@@ -101,15 +103,29 @@ class StatusesController < ApplicationController
   protected
 
   def index_component
-    Statuses::IndexComponent.new(statuses: paginated_statuses, page_args:)
+    Statuses::IndexComponent.new(statuses: paginated_statuses,
+                                 type_ids: filter_type_ids,
+                                 role_ids: filter_role_ids,
+                                 page_args:)
   end
 
   def paginated_statuses
-    Status.page(page_param).per_page(per_page_param)
+    Status
+      .in_workflow(type_ids: filter_type_ids, role_ids: filter_role_ids)
+      .page(page_param)
+      .per_page(per_page_param)
   end
 
   def page_args
     { page: page_param, per_page: per_page_param }
+  end
+
+  def filter_type_ids
+    Array(params[:type_ids]).map(&:to_i)
+  end
+
+  def filter_role_ids
+    Array(params[:role_ids]).map(&:to_i)
   end
 
   def move_params

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -119,7 +119,9 @@ class StatusesController < ApplicationController
     if move_to.in?(%w[highest higher lower lowest])
       { move_to: }
     elsif position
-      { position: }
+      # The dropped position is an index within the rendered page, while
+      # acts_as_list positions run across the whole list.
+      { position: position + ((page_param - 1) * per_page_param) }
     else
       {}
     end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -30,15 +30,15 @@
 
 class StatusesController < ApplicationController
   include PaginationHelper
+  include OpTurbo::ComponentStream
 
   layout "admin"
 
   before_action :require_admin
 
   def index
-    @statuses = Status.page(page_param).per_page(per_page_param)
-
-    render action: "index", layout: false if request.xhr?
+    @statuses = paginated_statuses
+    @page_args = page_args
   end
 
   def new
@@ -84,7 +84,46 @@ class StatusesController < ApplicationController
     redirect_to action: "index", status: :see_other
   end
 
+  def move
+    status = Status.find(params.expect(:id))
+
+    if status.update(move_params)
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
+    else
+      render_error_flash_message_via_turbo_stream(message: I18n.t("statuses.index.could_not_be_moved"))
+    end
+
+    replace_via_turbo_stream(component: index_component)
+
+    respond_with_turbo_streams
+  end
+
   protected
+
+  def index_component
+    Statuses::IndexComponent.new(statuses: paginated_statuses, page_args:)
+  end
+
+  def paginated_statuses
+    Status.page(page_param).per_page(per_page_param)
+  end
+
+  def page_args
+    { page: page_param, per_page: per_page_param }
+  end
+
+  def move_params
+    move_to = params[:move_to]
+    position = Integer(params[:position], exception: false)
+
+    if move_to.in?(%w[highest higher lower lowest])
+      { move_to: }
+    elsif position
+      { position: }
+    else
+      {}
+    end
+  end
 
   def recompute_progress_values
     attributes_triggering_recomputing = ["excluded_from_totals"]

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -51,6 +51,20 @@ class Status < ApplicationRecord
 
   scope :visible, ->(user = User.current) { user.allowed_in_any_project?(:view_work_packages) ? all : none }
 
+  # Statuses have no type or role of their own: they relate to both only through the
+  # workflow transitions naming them. Type and role therefore narrow a single set of
+  # transitions rather than filtering independently, so that selecting Task and Member
+  # matches only statuses of the Task/Member workflow.
+  scope :in_workflow, ->(type_ids:, role_ids:) do
+    next all if type_ids.blank? && role_ids.blank?
+
+    transitions = Workflow.all
+    transitions = transitions.where(type_variant: TypeVariant.where(type_id: type_ids)) if type_ids.present?
+    transitions = transitions.where(role_id: role_ids) if role_ids.present?
+
+    where(id: transitions.select(:old_status_id)).or(where(id: transitions.select(:new_status_id)))
+  end
+
   def unmark_old_default_value
     Status.where.not(id:).update_all(is_default: false)
   end

--- a/app/views/statuses/edit.html.erb
+++ b/app/views/statuses/edit.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       { href: statuses_path, text: t(:label_status) },
+       { href: statuses_path, text: t(:label_status_plural) },
        @status.name_was]
     )
   end

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -27,15 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), t(:label_work_package_plural), I18n.t(:label_status) -%>
+<% html_title t(:label_administration), t(:label_work_package_plural), I18n.t(:label_status_plural) -%>
 
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { I18n.t(:label_status) }
+    header.with_title { I18n.t(:label_status_plural) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       I18n.t(:label_status)]
+       I18n.t(:label_status_plural)]
     )
   end
 %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -39,18 +39,4 @@ See COPYRIGHT and LICENSE files for more details.
     )
   end
 %>
-<%=
-  render(Primer::OpenProject::SubHeader.new) do |subheader|
-    subheader.with_action_button(
-      scheme: :primary,
-      leading_icon: :plus,
-      label: t(:label_work_package_status_new),
-      tag: :a,
-      href: new_status_path
-    ) do
-      t(:label_status)
-    end
-  end
-%>
-
-<%= render ::Statuses::TableComponent.new(rows: @statuses) %>
+<%= render ::Statuses::IndexComponent.new(statuses: @statuses, page_args: @page_args) %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -39,4 +39,4 @@ See COPYRIGHT and LICENSE files for more details.
     )
   end
 %>
-<%= render ::Statuses::IndexComponent.new(statuses: @statuses, page_args: @page_args) %>
+<%= render ::Statuses::IndexComponent.new(statuses: @statuses, type_ids: @type_ids, role_ids: @role_ids, page_args: @page_args) %>

--- a/app/views/statuses/new.html.erb
+++ b/app/views/statuses/new.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       { href: statuses_path, text: t(:label_status) },
+       { href: statuses_path, text: t(:label_status_plural) },
        t(:label_work_package_status_new)]
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6239,13 +6239,14 @@ en:
         <br>
         <strong>Note</strong>: Inherited values (e.g., from children or relations) will still apply.
     index:
+      could_not_be_moved: "Status could not be moved."
       headers:
-        excluded_from_totals: "Excluded from totals"
         is_closed: "Closed"
         is_default: "Default"
         is_readonly: "Read-only"
       no_results_content_text: Add a new status
       no_results_title_text: There are currently no work package statuses.
+      status_actions: "Status actions"
 
   # Used in array.to_sentence.
   support:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6240,10 +6240,18 @@ en:
         <strong>Note</strong>: Inherited values (e.g., from children or relations) will still apply.
     index:
       could_not_be_moved: "Status could not be moved."
+      filter:
+        all_roles: "All roles"
+        all_types: "All types"
+        by_role: "Filter by role"
+        by_type: "Filter by type"
+        roles: "%{count} roles"
+        types: "%{count} types"
       headers:
         is_closed: "Closed"
         is_default: "Default"
         is_readonly: "Read-only"
+      no_filter_results_title_text: "No status matches the current filter."
       no_results_content_text: Add a new status
       no_results_title_text: There are currently no work package statuses.
       status_actions: "Status actions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -306,7 +306,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :statuses, except: :show
+  resources :statuses, except: :show do
+    member do
+      put :move
+    end
+  end
 
   get "custom_style/:digest/logo/:filename" => "custom_styles#logo_download",
       as: "custom_style_logo",

--- a/frontend/src/stimulus/controllers/dynamic/quick-filter/param-select-panel.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/quick-filter/param-select-panel.controller.ts
@@ -1,0 +1,62 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Controller } from '@hotwired/stimulus';
+import { visit } from '@hotwired/turbo';
+import type { SelectPanelElement } from '@primer/view-components/app/components/primer/alpha/select_panel_element';
+
+/**
+ * Drives a multi-select quick filter that lives in a plain array query parameter
+ * rather than in the serialized filters of a Queries object.
+ */
+export default class ParamSelectPanelController extends Controller {
+  static values = { param: String };
+
+  declare paramValue:string;
+
+  apply(event:Event) {
+    // Stop the panel from updating its own label, since the page navigates anyway
+    event.stopPropagation();
+
+    const panel = this.element as HTMLElement as SelectPanelElement;
+    const selectedIds = panel.items
+      .filter((item) => panel.isItemChecked(item))
+      .map((item) => item.getAttribute('data-item-id'))
+      .filter((id):id is string => id !== null);
+
+    visit(this.urlWith(selectedIds));
+  }
+
+  private urlWith(ids:string[]):string {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(`${this.paramValue}[]`);
+    ids.forEach((id) => url.searchParams.append(`${this.paramValue}[]`, id));
+
+    return url.toString();
+  }
+}

--- a/lookbook/docs/components/quick-filters.md.erb
+++ b/lookbook/docs/components/quick-filters.md.erb
@@ -1,10 +1,11 @@
 Quick filters are lightweight controls that let users toggle a single filter without opening the full filter panel. Each click or selection navigates to a new URL with updated `filters` and `sortBy` params,
 preserving any other active filters.
 
-There are currently three variants:
+There are currently four variants:
 * SegmentedControlComponent
 * BooleanComponent
 * SelectPanelComponent
+* ParamSelectPanelComponent
 
 ## SegmentedControlComponent
 
@@ -57,6 +58,25 @@ Note: Clicking on buttons in the above preview will break it and redirect to the
 
 Pass `src` to lazily load the panel items from an endpoint instead of providing them inline.
 The filter must implement `#value_objects`, and `src` cannot be combined with inline items or `select_variant: :single`.
+
+## ParamSelectPanelComponent
+
+A multi-select panel for pages that filter without a `Queries` object. Instead of serializing into `filters`,
+the selection lives in a plain array query parameter named by `param`, and the "Apply" button navigates to the
+current URL with that parameter rewritten. Items come from `records`, which need only `id` and `name`.
+
+The show button names the selection: `all_label` when nothing is picked, the record's name when one is, and
+`many_label_key` interpolated with `count` beyond that — so that key must accept `%{count}`.
+
+<%= embed OpPrimer::QuickFilterPreview, :param_select_panel, panels: %i[source] %>
+
+### With a selection
+
+<%= embed OpPrimer::QuickFilterPreview, :param_select_panel_with_selection, panels: %i[source] %>
+
+Note: a `SubHeader` requires an "All filters" button once it holds more than one `with_quick_filter`. Pages using
+this component have no advanced filter panel to open, so they place their panels in a single `with_filter_component`
+slot instead.
 
 ## Keeping in sync with "All filters"
 

--- a/lookbook/previews/op_primer/quick_filter_preview.rb
+++ b/lookbook/previews/op_primer/quick_filter_preview.rb
@@ -60,7 +60,20 @@ module OpPrimer
       render_with_template(locals: { query: })
     end
 
+    def param_select_panel
+      render_with_template(locals: { records: preview_types, selected: [] })
+    end
+
+    def param_select_panel_with_selection
+      records = preview_types
+      render_with_template(locals: { records:, selected: records.first(2) })
+    end
+
     private
+
+    def preview_types
+      ::Type.order(:position).limit(5).to_a
+    end
 
     def meeting_query
       Queries::Meetings::MeetingQuery.new(user: User.current)

--- a/lookbook/previews/op_primer/quick_filter_preview/param_select_panel.html.erb
+++ b/lookbook/previews/op_primer/quick_filter_preview/param_select_panel.html.erb
@@ -1,0 +1,10 @@
+<%= render(
+      OpPrimer::QuickFilter::ParamSelectPanelComponent.new(
+        title: "Filter by type",
+        param: "type_ids",
+        records: records,
+        selected: selected,
+        all_label: "All types",
+        many_label_key: "label_x_items_selected"
+      )
+    ) %>

--- a/lookbook/previews/op_primer/quick_filter_preview/param_select_panel_with_selection.html.erb
+++ b/lookbook/previews/op_primer/quick_filter_preview/param_select_panel_with_selection.html.erb
@@ -1,0 +1,10 @@
+<%= render(
+      OpPrimer::QuickFilter::ParamSelectPanelComponent.new(
+        title: "Filter by type",
+        param: "type_ids",
+        records: records,
+        selected: selected,
+        all_label: "All types",
+        many_label_key: "label_x_items_selected"
+      )
+    ) %>

--- a/spec/components/op_primer/quick_filter/param_select_panel_component_spec.rb
+++ b/spec/components/op_primer/quick_filter/param_select_panel_component_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OpPrimer::QuickFilter::ParamSelectPanelComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/statuses") do
+      render_inline(
+        described_class.new(
+          title: "Filter by type",
+          param: "type_ids",
+          records: types,
+          selected:,
+          all_label: "All types",
+          many_label_key: "statuses.index.filter.types"
+        )
+      )
+    end
+  end
+
+  let(:task) { create(:type, name: "Task") }
+  let(:bug) { create(:type, name: "Bug") }
+  let(:types) { [task, bug] }
+  let(:selected) { [] }
+
+  it "drives the select panel element itself, which holds the item checked state" do
+    expect(rendered_component).to have_css(
+      "select-panel[data-controller='quick-filter--param-select-panel']" \
+      "[data-quick-filter--param-select-panel-param-value='type_ids']"
+    )
+  end
+
+  describe "button label" do
+    it "reads as unfiltered when nothing is selected" do
+      expect(rendered_component).to have_button(text: "All types")
+    end
+
+    context "with one record selected" do
+      let(:selected) { [task] }
+
+      it "names it" do
+        expect(rendered_component).to have_button(text: "Task")
+      end
+    end
+
+    context "with several records selected" do
+      let(:selected) { [task, bug] }
+
+      it "counts them" do
+        expect(rendered_component).to have_button(text: "2 types")
+      end
+    end
+  end
+end

--- a/spec/components/statuses/index_component_spec.rb
+++ b/spec/components/statuses/index_component_spec.rb
@@ -33,10 +33,12 @@ require "rails_helper"
 RSpec.describe Statuses::IndexComponent, type: :component do
   subject(:rendered_component) do
     with_request_url("/statuses") do
-      render_inline(described_class.new(statuses:, page_args:))
+      render_inline(described_class.new(statuses:, type_ids:, role_ids:, page_args:))
     end
   end
 
+  let(:type_ids) { [] }
+  let(:role_ids) { [] }
   let(:page_args) { { page: 1, per_page: 20 } }
   let(:statuses) { relation.page(page_args[:page]).per_page(page_args[:per_page]) }
 
@@ -123,6 +125,37 @@ RSpec.describe Statuses::IndexComponent, type: :component do
 
       expect(rendered_component).to have_css("#{row} button", text: "Move down")
       expect(rendered_component).to have_css("#{row} button", text: "Move to bottom")
+    end
+  end
+
+  describe "the role filter", with_ee: %i[work_package_sharing] do
+    let!(:project_role) { create(:project_role, name: "Manager") }
+    let!(:work_package_editor) { create(:edit_work_package_role) }
+    let(:relation) { Status.none }
+
+    it "offers every role a workflow can be defined for" do
+      expect(rendered_component).to have_css("[data-item-id='#{project_role.id}']")
+      expect(rendered_component).to have_css("[data-item-id='#{work_package_editor.id}']")
+    end
+  end
+
+  context "when filtered" do
+    let!(:new_status) { create(:status, name: "New") }
+    let(:relation) { Status.where(id: new_status.id) }
+    let(:type_ids) { [create(:type).id] }
+
+    it "offers no reordering, since positions are global and the list is a subset" do
+      expect(rendered_component).to have_no_css("[data-generic-drag-and-drop-target='container']")
+      expect(rendered_component).to have_no_css(".Box-row[data-draggable-type='status']")
+    end
+
+    context "when the filter matches nothing" do
+      let(:relation) { Status.none }
+
+      it "says the filter came up empty rather than that no status exists" do
+        expect(rendered_component).to have_text("No status matches the current filter.")
+        expect(rendered_component).to have_no_text("There are currently no work package statuses.")
+      end
     end
   end
 

--- a/spec/components/statuses/index_component_spec.rb
+++ b/spec/components/statuses/index_component_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Statuses::IndexComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/statuses") do
+      render_inline(described_class.new(statuses:, page_args:))
+    end
+  end
+
+  let(:page_args) { { page: 1, per_page: 20 } }
+  let(:statuses) { relation.page(page_args[:page]).per_page(page_args[:per_page]) }
+
+  context "with statuses" do
+    let!(:new_status) { create(:status, name: "New", is_default: true, default_done_ratio: 0) }
+    let!(:closed_status) { create(:status, name: "Closed", is_closed: true, default_done_ratio: 100) }
+    let(:relation) { Status.where(id: [new_status.id, closed_status.id]) }
+
+    it_behaves_like "rendering Box", row_count: 2
+
+    it "captions every column", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-header", text: Status.human_attribute_name(:name))
+      expect(rendered_component).to have_no_css(".Box-header", text: Status.human_attribute_name(:color))
+      expect(rendered_component).to have_css(".Box-header", text: "Default")
+      expect(rendered_component).to have_css(".Box-header", text: "Closed")
+      expect(rendered_component).to have_css(".Box-header", text: "Read-only")
+    end
+
+    context "in status-based progress mode", with_settings: { work_package_done_ratio: "status" } do
+      it "captions the % Complete column" do
+        expect(rendered_component)
+          .to have_css(".Box-header", text: WorkPackage.human_attribute_name(:done_ratio))
+      end
+
+      it "lays header and rows out on the same columns", :aggregate_failures do
+        expect(rendered_component).to have_no_css(".op-statuses-list--header_without-done-ratio")
+        expect(rendered_component).to have_no_css(".op-statuses-list--item_without-done-ratio")
+      end
+    end
+
+    context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
+      it "drops the % Complete caption along with the column" do
+        expect(rendered_component)
+          .to have_no_css(".Box-header", text: WorkPackage.human_attribute_name(:done_ratio))
+      end
+
+      # Header and rows are separate grids: they only stay aligned while both
+      # drop the same column.
+      it "narrows header and rows together", :aggregate_failures do
+        expect(rendered_component).to have_css(".op-statuses-list--header_without-done-ratio")
+        expect(rendered_component).to have_css(".op-statuses-list--item_without-done-ratio")
+      end
+    end
+
+    it "renders a row per status", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-row", text: "New")
+      expect(rendered_component).to have_css(".Box-row", text: "Closed")
+    end
+
+    it "links each status to its edit page" do
+      expect(rendered_component).to have_link("New", href: "/statuses/#{new_status.id}/edit")
+    end
+  end
+
+  describe "reordering across pages" do
+    let!(:first) { create(:status, name: "First") }
+    let!(:second) { create(:status, name: "Second") }
+    let!(:third) { create(:status, name: "Third") }
+    let(:relation) { Status.all }
+    let(:page_args) { { page: 1, per_page: 2 } }
+
+    it "keeps the downward moves on the last row of a page, which is not the last of the list" do
+      row = "[data-test-selector='status-row-#{second.id}']"
+
+      expect(rendered_component).to have_css("#{row} button", text: "Move down")
+      expect(rendered_component).to have_css("#{row} button", text: "Move to bottom")
+    end
+  end
+
+  context "without statuses" do
+    let(:relation) { Status.where(id: nil) }
+
+    it "says no status exists yet" do
+      expect(rendered_component).to have_text("There are currently no work package statuses.")
+    end
+  end
+end

--- a/spec/components/statuses/index_component_spec.rb
+++ b/spec/components/statuses/index_component_spec.rb
@@ -89,6 +89,26 @@ RSpec.describe Statuses::IndexComponent, type: :component do
     it "links each status to its edit page" do
       expect(rendered_component).to have_link("New", href: "/statuses/#{new_status.id}/edit")
     end
+
+    it "renders a drag-and-drop enabled container" do
+      expect(rendered_component)
+        .to have_css(".Box[data-generic-drag-and-drop-target='container']") do |box|
+          expect(box["data-target-container-accessor"]).to eq(":scope > ul")
+          expect(box["data-target-allowed-drag-type"]).to eq("status")
+        end
+    end
+
+    it "renders each status as a draggable row pointing at its drop URL", :aggregate_failures do
+      [new_status, closed_status].each do |status|
+        selector = ".Box-row[data-draggable-type='status'][data-draggable-id='#{status.id}']"
+
+        expect(rendered_component).to have_css(selector) do |row|
+          # The page travels with the drop so the server can resolve the dropped
+          # index against the whole list.
+          expect(row["data-drop-url"]).to eq("/statuses/#{status.id}/move?page=1&per_page=20")
+        end
+      end
+    end
   end
 
   describe "reordering across pages" do

--- a/spec/components/statuses/item_component_spec.rb
+++ b/spec/components/statuses/item_component_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe Statuses::ItemComponent, type: :component do
   subject(:rendered_component) do
     with_request_url("/statuses") do
       render_inline(
-        described_class.new(status:, max_position: status.position + 1, page_args:)
+        described_class.new(status:, max_position: status.position + 1, reorderable:, page_args:)
       )
     end
   end
 
   let(:status) { create(:status, name: "In progress", default_done_ratio: 40) }
+  let(:reorderable) { true }
   let(:page_args) { { page: 1, per_page: 20 } }
 
   it "renders the status name as a link to its edit page" do
@@ -104,6 +105,24 @@ RSpec.describe Statuses::ItemComponent, type: :component do
     context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
       it "omits % Complete, which has no effect in that mode" do
         expect(rendered_component).to have_no_test_selector("done-ratio")
+      end
+    end
+  end
+
+  describe "reordering" do
+    it "offers a drag handle and move actions" do
+      expect(rendered_component).to have_css(".DragHandle")
+      expect(rendered_component).to have_button("Move to bottom")
+    end
+
+    context "when reordering is not offered" do
+      let(:reorderable) { false }
+
+      it "drops the drag handle and the move actions, keeping edit and delete" do
+        expect(rendered_component).to have_no_css(".DragHandle")
+        expect(rendered_component).to have_no_button("Move to bottom")
+        expect(rendered_component).to have_link("Edit")
+        expect(rendered_component).to have_button("Delete")
       end
     end
   end

--- a/spec/components/statuses/item_component_spec.rb
+++ b/spec/components/statuses/item_component_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Statuses::ItemComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/statuses") do
+      render_inline(
+        described_class.new(status:, max_position: status.position + 1, page_args:)
+      )
+    end
+  end
+
+  let(:status) { create(:status, name: "In progress", default_done_ratio: 40) }
+  let(:page_args) { { page: 1, per_page: 20 } }
+
+  it "renders the status name as a link to its edit page" do
+    expect(rendered_component).to have_link("In progress", href: "/statuses/#{status.id}/edit")
+  end
+
+  it "shows the colour beside the name rather than in a column of its own" do
+    status.update!(color: create(:color, name: "Blue", hexcode: "#1F83D6"))
+
+    expect(rendered_component).to have_css(".op-statuses-list--item--name .color--preview")
+  end
+
+  describe "flag columns" do
+    context "when the status is the default one" do
+      let(:status) { create(:status, name: "New", is_default: true) }
+
+      it "checks the default column" do
+        expect(rendered_component).to have_css("[aria-label='Default']")
+      end
+    end
+
+    context "when the status is closed" do
+      let(:status) { create(:status, name: "Closed", is_closed: true) }
+
+      it "checks the closed column" do
+        expect(rendered_component).to have_css("[aria-label='Closed']")
+      end
+    end
+
+    context "when the status is read-only", with_ee: %i[readonly_work_packages] do
+      let(:status) { create(:status, name: "Rejected", is_readonly: true) }
+
+      it "checks the read-only column" do
+        expect(rendered_component).to have_css("[aria-label='Read-only']")
+      end
+    end
+
+    context "when the status is read-only without an enterprise token", with_ee: false do
+      let(:status) { create(:status, name: "Rejected", is_readonly: true) }
+
+      it "leaves the read-only column unchecked, since the flag has no effect" do
+        expect(rendered_component).to have_no_css("[aria-label='Read-only']")
+      end
+    end
+
+    context "when the status carries no flag" do
+      it "leaves every flag column unchecked", :aggregate_failures do
+        expect(rendered_component).to have_no_css("[aria-label='Default']")
+        expect(rendered_component).to have_no_css("[aria-label='Closed']")
+        expect(rendered_component).to have_no_css("[aria-label='Read-only']")
+      end
+    end
+  end
+
+  describe "% Complete" do
+    context "in status-based progress mode", with_settings: { work_package_done_ratio: "status" } do
+      it "shows the default % Complete of the status" do
+        expect(rendered_component).to have_test_selector("done-ratio", text: "40%")
+      end
+    end
+
+    context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
+      it "omits % Complete, which has no effect in that mode" do
+        expect(rendered_component).to have_no_test_selector("done-ratio")
+      end
+    end
+  end
+end

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -40,6 +40,66 @@ RSpec.describe "Statuses admin page", :js do
     login_as(admin)
   end
 
+  describe "index page" do
+    # Reordering persists across examples, so each one starts from a known order.
+    before do
+      [status_new, status_in_progress, status_done].each_with_index do |status, index|
+        status.update_column(:position, index + 1)
+      end
+    end
+
+    let(:statuses_page) { Pages::Admin::Statuses.new }
+
+    it "reorders statuses through the action menu" do
+      statuses_page.visit!
+
+      statuses_page.expect_listed("New", "In Progress", "Done")
+
+      statuses_page.click_status_action(status_new, action: "Move to bottom")
+
+      expect(page).to have_text("Successful update.")
+      statuses_page.expect_listed("In Progress", "Done", "New")
+
+      statuses_page.click_status_action(status_done, action: "Move up")
+
+      statuses_page.expect_listed("Done", "In Progress", "New")
+    end
+
+    it "offers no upward move on the first status, and no downward move on the last" do
+      statuses_page.visit!
+
+      statuses_page.within_status(status_new) do
+        click_on accessible_name: "Status actions"
+        expect(page).to have_no_button("Move to top")
+        expect(page).to have_button("Move to bottom")
+      end
+    end
+
+    describe "pagination", with_settings: { per_page_options: "2, 100" } do
+      it "pages the list, and shows it whole at a larger page size" do
+        statuses_page.visit!
+
+        statuses_page.expect_listed("New", "In Progress")
+
+        statuses_page.set_page_size(100)
+
+        statuses_page.expect_listed("New", "In Progress", "Done")
+      end
+
+      it "keeps the reader on their page after a move" do
+        statuses_page.visit!
+        statuses_page.go_to_page(2)
+
+        statuses_page.expect_listed("Done")
+
+        statuses_page.click_status_action(status_done, action: "Move up")
+
+        statuses_page.expect_listed("In Progress")
+        expect(Status.order(:position).pluck(:name)).to eq(["New", "Done", "In Progress"])
+      end
+    end
+  end
+
   describe "create page" do
     context "with enterprise edition", with_ee: %i[readonly_work_packages] do
       it "has 'is read-only' checkbox unchecked and disabled only when 'is default' is checked (mutually exclusive)" do

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe "Statuses admin page", :js do
 
     let(:statuses_page) { Pages::Admin::Statuses.new }
 
+    it "names the page for the collection it lists" do
+      statuses_page.visit!
+
+      statuses_page.expect_header_to_display("Statuses")
+    end
+
     it "reorders statuses through the action menu" do
       statuses_page.visit!
 

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -75,8 +75,20 @@ RSpec.describe "Statuses admin page", :js do
       end
     end
 
+    it "reorders statuses by dragging them" do
+      statuses_page.visit!
+
+      statuses_page.drag_status(from_index: 0, to_index: 2)
+      wait_for_network_idle
+
+      statuses_page.expect_listed("In Progress", "Done", "New")
+
+      statuses_page.reload!
+      statuses_page.expect_listed("In Progress", "Done", "New")
+    end
+
     describe "pagination", with_settings: { per_page_options: "2, 100" } do
-      it "pages the list, and shows it whole at a larger page size" do
+      it "pages the list, and a larger page size widens what drag and drop can reach" do
         statuses_page.visit!
 
         statuses_page.expect_listed("New", "In Progress")
@@ -84,6 +96,11 @@ RSpec.describe "Statuses admin page", :js do
         statuses_page.set_page_size(100)
 
         statuses_page.expect_listed("New", "In Progress", "Done")
+
+        statuses_page.drag_status(from_index: 0, to_index: 2)
+        wait_for_network_idle
+
+        statuses_page.expect_listed("In Progress", "Done", "New")
       end
 
       it "keeps the reader on their page after a move" do

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -87,6 +87,37 @@ RSpec.describe "Statuses admin page", :js do
       statuses_page.expect_listed("In Progress", "Done", "New")
     end
 
+    describe "quick filters" do
+      shared_let(:task) { create(:type, name: "Task") }
+      shared_let(:manager) { create(:project_role, name: "Manager") }
+      shared_let(:member) { create(:project_role, name: "Member") }
+      shared_let(:task_manager_transition) do
+        create(:workflow, type: task, role: manager, old_status: status_new, new_status: status_in_progress)
+      end
+
+      it "narrows the list to the statuses of the selected type and role" do
+        statuses_page.visit!
+        statuses_page.expect_listed("New", "In Progress", "Done")
+
+        statuses_page.filter_by_type(task)
+
+        statuses_page.expect_listed("New", "In Progress")
+
+        statuses_page.filter_by_role(member)
+
+        statuses_page.expect_listed
+      end
+
+      it "offers no reordering while filtered, since positions are global" do
+        statuses_page.visit!
+        expect(page).to have_css(".DragHandle")
+
+        statuses_page.filter_by_type(task)
+
+        statuses_page.expect_no_reordering
+      end
+    end
+
     describe "pagination", with_settings: { per_page_options: "2, 100" } do
       it "pages the list, and a larger page size widens what drag and drop can reach" do
         statuses_page.visit!

--- a/spec/features/statuses/statuses_administration_spec.rb
+++ b/spec/features/statuses/statuses_administration_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe "Statuses administration" do
     context "without any statuses" do
       it 'displays the "no results" text' do
         visit statuses_path
-        expect(page).to have_content(I18n.t("no_results_title_text"))
+        expect(page).to have_text("There are currently no work package statuses.")
+        expect(page).to have_text("Add a new status")
       end
     end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -140,4 +140,55 @@ RSpec.describe Status do
               .to(false)
     end
   end
+
+  describe ".in_workflow" do
+    shared_let(:task) { create(:type, name: "Task") }
+    shared_let(:bug) { create(:type, name: "Bug") }
+    shared_let(:manager) { create(:project_role, name: "Manager") }
+    shared_let(:member) { create(:project_role, name: "Member") }
+
+    shared_let(:new_status) { create(:status, name: "New") }
+    shared_let(:in_progress) { create(:status, name: "In progress") }
+    shared_let(:rejected) { create(:status, name: "Rejected") }
+    shared_let(:unused) { create(:status, name: "Unused") }
+
+    shared_let(:task_manager_transition) do
+      create(:workflow, type: task, role: manager, old_status: new_status, new_status: in_progress)
+    end
+    shared_let(:bug_member_transition) do
+      create(:workflow, type: bug, role: member, old_status: rejected, new_status: new_status)
+    end
+
+    it "returns statuses on either side of a transition" do
+      expect(described_class.in_workflow(type_ids: [task.id], role_ids: [manager.id]))
+        .to contain_exactly(new_status, in_progress)
+    end
+
+    it "returns every status when no type and no role is given" do
+      expect(described_class.in_workflow(type_ids: [], role_ids: []))
+        .to contain_exactly(new_status, in_progress, rejected, unused)
+    end
+
+    it "filters on the type alone when no role is given" do
+      expect(described_class.in_workflow(type_ids: [bug.id], role_ids: []))
+        .to contain_exactly(rejected, new_status)
+    end
+
+    it "filters on the role alone when no type is given" do
+      expect(described_class.in_workflow(type_ids: [], role_ids: [manager.id]))
+        .to contain_exactly(new_status, in_progress)
+    end
+
+    it "unions the selected types and roles" do
+      expect(described_class.in_workflow(type_ids: [task.id, bug.id], role_ids: [manager.id, member.id]))
+        .to contain_exactly(new_status, in_progress, rejected)
+    end
+
+    it "matches a type and a role only when the same workflow pairs them" do
+      # Task/Manager and Bug/Member exist; Task/Member does not, so nothing matches it
+      # even though both sides are used elsewhere.
+      expect(described_class.in_workflow(type_ids: [task.id], role_ids: [member.id]))
+        .to be_empty
+    end
+  end
 end

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -79,6 +79,29 @@ RSpec.describe "Statuses", :skip_csrf, type: :rails_request do
         expect(response.body).to include(*statuses.map(&:name))
       end
     end
+
+    context "with a type and role filter" do
+      shared_let(:task) { create(:type, name: "Task") }
+      shared_let(:manager) { create(:project_role, name: "Manager") }
+      shared_let(:listed) { create(:status, name: "Listed status") }
+      shared_let(:unlisted) { create(:status, name: "Unlisted status") }
+      shared_let(:transition) do
+        create(:workflow, type: task, role: manager, old_status: listed, new_status: listed)
+      end
+
+      it "lists only the statuses of the matching workflow" do
+        get statuses_path(type_ids: [task.id], role_ids: [manager.id])
+
+        expect(response.body).to include("Listed status")
+        expect(response.body).not_to include("Unlisted status")
+      end
+
+      it "lists every status when the selection is empty" do
+        get statuses_path(type_ids: [], role_ids: [])
+
+        expect(response.body).to include("Listed status", "Unlisted status")
+      end
+    end
   end
 
   describe "PUT /statuses/:id/move" do

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -99,5 +99,24 @@ RSpec.describe "Statuses", :skip_csrf, type: :rails_request do
       expect(response).to have_http_status(:ok)
       expect(Status.order(:position).pluck(:name)).to eq(%w[Third First Second])
     end
+
+    context "when the list is paginated", with_settings: { per_page_options: "2, 100" } do
+      before { Status.delete_all }
+
+      let!(:a) { create(:status, name: "A") }
+      let!(:b) { create(:status, name: "B") }
+      let!(:c) { create(:status, name: "C") }
+      let!(:d) { create(:status, name: "D") }
+      let!(:e) { create(:status, name: "E") }
+
+      it "resolves the dropped position against the whole list, not the page" do
+        # Page 2 shows C and D; dropping D first on that page means global position 3.
+        put move_status_path(d, page: 2, per_page: 2),
+            params: { position: 1 },
+            as: :turbo_stream
+
+        expect(Status.order(:position).pluck(:name)).to eq(%w[A B D C E])
+      end
+    end
   end
 end

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -53,4 +53,51 @@ RSpec.describe "Statuses", :skip_csrf, type: :rails_request do
       end
     end
   end
+
+  describe "GET /statuses" do
+    context "with more statuses than fit a page", with_settings: { per_page_options: "2, 100" } do
+      shared_let(:statuses) { create_list(:status, 3) }
+
+      it "paginates" do
+        get statuses_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(statuses.first.name)
+        expect(response.body).not_to include(statuses.last.name)
+      end
+
+      it "serves the requested page" do
+        get statuses_path(page: 2)
+
+        expect(response.body).to include(statuses.last.name)
+        expect(response.body).not_to include(statuses.first.name)
+      end
+
+      it "keeps the whole list on one page when asked for a larger page size" do
+        get statuses_path(per_page: 100)
+
+        expect(response.body).to include(*statuses.map(&:name))
+      end
+    end
+  end
+
+  describe "PUT /statuses/:id/move" do
+    shared_let(:first) { create(:status, name: "First") }
+    shared_let(:second) { create(:status, name: "Second") }
+    shared_let(:third) { create(:status, name: "Third") }
+
+    it "moves the status to the requested relative position" do
+      put move_status_path(first), params: { move_to: "lowest" }, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(Status.order(:position).pluck(:name)).to eq(%w[Second Third First])
+    end
+
+    it "moves the status to an absolute position" do
+      put move_status_path(third), params: { position: 1 }, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(Status.order(:position).pluck(:name)).to eq(%w[Third First Second])
+    end
+  end
 end

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -35,6 +35,12 @@ module Pages
     class Statuses < ::Pages::Page
       def path = "/statuses"
 
+      def expect_header_to_display(text)
+        expect(page).to have_css("h2", text:)
+        expect(page).to have_css(".breadcrumb-item-selected", text:)
+        expect(page).to have_title("#{text} | Work packages | Administration | OpenProject")
+      end
+
       def expect_listed(*names)
         page.document.synchronize do
           found = page.all("#{row_selector} a").map(&:text)

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -54,6 +54,10 @@ module Pages
         end
       end
 
+      def drag_status(from_index:, to_index:)
+        drag_and_drop_list(from: from_index, to: to_index, elements: row_selector, handler: ".DragHandle")
+      end
+
       def go_to_page(number)
         within(".op-pagination--pages") { click_on number.to_s }
       end

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -54,8 +54,20 @@ module Pages
         end
       end
 
-      def drag_status(from_index:, to_index:)
-        drag_and_drop_list(from: from_index, to: to_index, elements: row_selector, handler: ".DragHandle")
+      def filter_by_type(*types)
+        apply_quick_filter("type-quick-filter", types)
+      end
+
+      def filter_by_role(*roles)
+        apply_quick_filter("role-quick-filter", roles)
+      end
+
+      def apply_quick_filter(selector, records)
+        within_test_selector(selector) do
+          find("button[id$='-button']").click
+          records.each { |record| find("[data-item-id='#{record.id}']").click }
+          click_on I18n.t(:button_apply)
+        end
       end
 
       def go_to_page(number)
@@ -64,6 +76,14 @@ module Pages
 
       def set_page_size(size)
         within(".op-pagination--options") { click_on size.to_s }
+      end
+
+      def expect_no_reordering
+        expect(page).to have_no_css(".DragHandle")
+      end
+
+      def drag_status(from_index:, to_index:)
+        drag_and_drop_list(from: from_index, to: to_index, elements: row_selector, handler: ".DragHandle")
       end
 
       private

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -28,59 +28,43 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Statuses
-  class RowComponent < ::RowComponent
-    def status
-      model
-    end
+require "support/pages/page"
 
-    def name
-      link_to status.name, edit_status_path(status)
-    end
+module Pages
+  module Admin
+    class Statuses < ::Pages::Page
+      def path = "/statuses"
 
-    def default?
-      checkmark(status.is_default?)
-    end
+      def expect_listed(*names)
+        page.document.synchronize do
+          found = page.all("#{row_selector} a").map(&:text)
 
-    def closed?
-      checkmark(status.is_closed?)
-    end
+          raise Capybara::ExpectationNotMet, "Expected #{names}, got #{found}" unless found == names
+        end
+      end
 
-    def readonly?
-      checkmark(status.is_readonly?)
-    end
+      def within_status(status, &)
+        within_test_selector("status-row-#{status.id}", &)
+      end
 
-    def excluded_from_totals?
-      checkmark(status.excluded_from_totals?)
-    end
+      def click_status_action(status, action:)
+        within_status(status) do
+          click_on accessible_name: I18n.t("statuses.index.status_actions")
+          click_on action
+        end
+      end
 
-    def color
-      helpers.icon_for_color status.color
-    end
+      def go_to_page(number)
+        within(".op-pagination--pages") { click_on number.to_s }
+      end
 
-    def done_ratio
-      h(status.default_done_ratio)
-    end
+      def set_page_size(size)
+        within(".op-pagination--options") { click_on size.to_s }
+      end
 
-    def sort
-      helpers.reorder_links "status",
-                            { action: "update", id: status },
-                            method: :patch
-    end
+      private
 
-    def button_links
-      [
-        delete_link
-      ]
-    end
-
-    def delete_link
-      link_to(
-        helpers.op_icon("icon icon-delete"),
-        status_path(status),
-        data: { turbo_method: :delete, turbo_confirm: I18n.t(:text_are_you_sure) },
-        title: t(:button_delete)
-      )
+      def row_selector = "[data-test-selector^='status-row-']"
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AUTOWORK-266

# What are you trying to accomplish?

- [x] Primerizing the table
   - [x] Administration → Work packages → Statuses primerized, modelled on Administration → Documents → Types
   - [x] % Complete shown only in status-based progress mode
   - [x] `Excluded from totals` left to the status form rather than given a column
- [x] Sort column replaced
   - [x] Move actions in the per-row action menu
   - [x] Order changed by drag and drop
- [x] Multi-select quick filters for type and role
- Opportunistic commit
   - Page title, breadcrumb and the crumb back from the forms read `Statuses`, like the menu item

## Screenshots

### Statuses list in status-based progress mode (all columns)

<img width="1006" height="948" alt="Screenshot of unfiltered status list" src="https://github.com/user-attachments/assets/efcda031-9eaa-4f02-991f-7803bc3d0219" />

### Filtered list, drag handles withdrawn

<img width="1006" height="609" alt="Screenshot of filtered list" src="https://github.com/user-attachments/assets/238e487f-51e8-4b19-9356-1ae04cd40938" />

# What approach did you choose and why?

- Type and role narrow one set of workflow transitions rather than filtering independently: statuses reach types and roles only through workflows, so Task + Member matches the Task/Member workflow alone, not the Task workflows + Member workflows.
- Reordering is withdrawn while filtered — positions are global and a filtered list is a non-contiguous subset. A page is contiguous, so a dropped row carries its page and its index resolves against the whole list.
- Both filters share one `with_filter_component` slot: `SubHeader` demands an "All filters" bottom pane past one `with_quick_filter`, and that needs a `Queries` object this page hasn't got. Same shape as the workflow matrix editor.
- `OpPrimer::QuickFilter::ParamSelectPanelComponent` is new: the plain-query-parameter sibling of the existing `Queries`-driven `SelectPanelComponent`.
- Open question: `Move to top` / `Move to bottom` read oddly on a paginated page. `Make it first` / `Make it last` may be less ambiguous. But they are the global `label_sort_*` keys shared with every admin list that reorders, so rewording needs status-scoped keys or a change across those lists — left alone here.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox)
