### PR TITLE
Implementation/agile 417 display a loading state when the backlog frame is filtered refreshed

### DIFF
--- a/frontend/src/global_styles/content/modules/_backlogs.sass
+++ b/frontend/src/global_styles/content/modules/_backlogs.sass
@@ -45,12 +45,6 @@
   container-name: backlogsListsContainer
   container-type: inline-size
 
-// Disable interaction while the #backlogs_container is loading
-turbo-frame#backlogs_container[busy]
-  opacity: 0.4
-  pointer-events: none
-  cursor: progress
-
 // Display the loading indicator while the #backlogs_container is loading
 body:has(turbo-frame#backlogs_container[busy]) #global-loading-indicator
   display: block !important

--- a/frontend/src/global_styles/content/modules/_backlogs.sass
+++ b/frontend/src/global_styles/content/modules/_backlogs.sass
@@ -45,6 +45,16 @@
   container-name: backlogsListsContainer
   container-type: inline-size
 
+// Disable interaction while the #backlogs_container is loading
+turbo-frame#backlogs_container[busy]
+  opacity: 0.4
+  pointer-events: none
+  cursor: progress
+
+// Display the loading indicator while the #backlogs_container is loading
+body:has(turbo-frame#backlogs_container[busy]) #global-loading-indicator
+  display: block !important
+
 .op-sprint-planning-container
   display: flex
   flex-direction: row

--- a/frontend/src/turbo/turbo-navigation-patch.spec.ts
+++ b/frontend/src/turbo/turbo-navigation-patch.spec.ts
@@ -28,7 +28,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Turbo from '@hotwired/turbo';
-import { applyTurboNavigationPatch } from './turbo-navigation-patch';
+import { applyTurboNavigationPatch, stripStaleBusyState } from './turbo-navigation-patch';
 
 // The FrameController prototype the patch reaches into. Internal Turbo API,
 // not part of the public types, hence the casts.
@@ -60,5 +60,33 @@ describe('turbo-navigation-patch (tripwire for hotwired/turbo#1300)', () => {
     const patched = proto.proposeVisitIfNavigatedWithAction;
     expect(patched).not.toBe(original);
     expect(String(patched)).toContain('ownerDocument');
+  });
+});
+
+describe('stripStaleBusyState', () => {
+  it('removes busy and aria-busy from every busy turbo-frame in the subtree', () => {
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <turbo-frame id="a" busy aria-busy="true"></turbo-frame>
+      <div><turbo-frame id="b" busy aria-busy="true"></turbo-frame></div>
+      <turbo-frame id="c"></turbo-frame>
+    `;
+
+    stripStaleBusyState(root);
+
+    expect(root.querySelector('#a')!.hasAttribute('busy')).toBe(false);
+    expect(root.querySelector('#a')!.hasAttribute('aria-busy')).toBe(false);
+    expect(root.querySelector('#b')!.hasAttribute('busy')).toBe(false);
+    expect(root.querySelector('#b')!.hasAttribute('aria-busy')).toBe(false);
+    expect(root.querySelector('#c')!.hasAttribute('busy')).toBe(false);
+  });
+
+  it('leaves unrelated content untouched', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<turbo-frame id="a" busy aria-busy="true"><p>content</p></turbo-frame>';
+
+    stripStaleBusyState(root);
+
+    expect(root.querySelector('p')!.textContent).toBe('content');
   });
 });

--- a/frontend/src/turbo/turbo-navigation-patch.ts
+++ b/frontend/src/turbo/turbo-navigation-patch.ts
@@ -31,6 +31,20 @@
 // part of the public type surface, so every access below is untyped.
 import * as Turbo from '@hotwired/turbo';
 
+// Turbo marks a turbo-frame `busy`/`aria-busy` for the duration of a
+// navigation, but for a form-submission-driven navigation it doesn't clear
+// that state until well after `proposeVisitIfNavigatedWithAction` below has
+// already cloned the frame into the history-cache snapshot -- so the clone
+// freezes the frame as permanently busy. `turbo:before-cache` fires too late
+// to fix this: by then the clone is already a detached copy, disconnected
+// from the live DOM. Exported for direct unit testing.
+export function stripStaleBusyState(root: ParentNode): void {
+  root.querySelectorAll('turbo-frame[busy]').forEach((frame) => {
+    frame.removeAttribute('busy');
+    frame.removeAttribute('aria-busy');
+  });
+}
+
 /**
  * Workaround for https://github.com/hotwired/turbo/issues/1300: with a
  * `<turbo-frame data-turbo-action="advance">`, the URL advances but the
@@ -42,10 +56,13 @@ import * as Turbo from '@hotwired/turbo';
  * ships in a release we depend on, drop this patch in favour of it.
  *
  * This is a verbatim fork of `FrameController.proposeVisitIfNavigatedWithAction`
- * with a single divergence: the history snapshot is built from the live
- * document (`frame.ownerDocument.documentElement.outerHTML`) instead of the
- * fetch response (`await fetchResponse.responseHTML`), so the restored snapshot
- * reflects the fully rendered page rather than the bare frame fragment.
+ * with two divergences:
+ * - The history snapshot is built from the live document
+ *   (`frame.ownerDocument.documentElement.outerHTML`) instead of the fetch
+ *   response (`await fetchResponse.responseHTML`), so the restored snapshot
+ *   reflects the fully rendered page rather than the bare frame fragment.
+ * - `stripStaleBusyState` clears any frame left stuck `busy` in that snapshot
+ *   (see its own comment above).
  *
  * Pinned to @hotwired/turbo 8.0.x. `turbo-navigation-patch.spec.ts` is a
  * tripwire: it fails if Turbo renames the patched method or stops sourcing the
@@ -58,6 +75,16 @@ export function applyTurboNavigationPatch() {
 
     if (this.action) {
       const pageSnapshot = Turbo.PageSnapshot.fromElement(frame).clone();
+
+      // Form submission cycle:
+      // Form marked busy, frame marked busy -> Request starts -> Request Completes -> proposeVisit called ->
+      // it caches the pageSnapshot which is still marked busy -> Issues a visit -> visitCachedSnapshot
+      // will update the stale pageSnapshot with the current previousFrameElement to keep a fresh copy.
+      // But the pageSnapshot busy attribute is untouched. Ideally visitCacheSnapshot would remove the
+      // busy attribute from the pageSnapshot, but since that is not happening, the busy state is stripped
+      // from the pageSnapshot here.
+      stripStaleBusyState(pageSnapshot.element);
+
       const { visitCachedSnapshot } = frame.delegate;
 
       // Kept `async` to mirror upstream's method shape even though the body no

--- a/modules/backlogs/spec/features/backlogs/filters_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filters_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe "Backlog quick search and advanced filters", :js do
     backlogs_page.expect_inbox_work_package_count(1)
   end
 
+  it "shows the loading spinner on the backlogs container while the subject quick search is in flight" do
+    expect(page).to have_no_css("turbo-frame#backlogs_container[busy]")
+    expect(page).to have_no_css("#global-loading-indicator", visible: :visible)
+
+    # Not using `apply_subject_filter`, as it waits for the network to go
+    # idle, which would hide the very state under test here.
+    fill_in "Search work packages by subject", with: "Needle"
+
+    expect(page).to have_css("turbo-frame#backlogs_container[busy]")
+    expect(page).to have_css("#global-loading-indicator", visible: :visible)
+
+    expect(page).to have_no_css("turbo-frame#backlogs_container[busy]")
+    expect(page).to have_no_css("#global-loading-indicator", visible: :visible)
+  end
+
   it "narrows the listings when an advanced filter is applied" do
     backlogs_page.expect_bucket_items(bucket, items: status_b_bucket_wp)
     backlogs_page.expect_sprint_items(sprint, items: status_b_sprint_wp)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-417

# What are you trying to accomplish?
Display a loading screen when the backlog is being updated, either via filters, or other actions such as drag and drop.

# What approach did you choose and why?
Display the loading spinner and make backlogs opaque while loading. Hook the loading state to the `#backlogs_container` turbo frame `[busy]` state.

Provide a turbo fix for back button navigation from a filter form submission. It erroneously keeps the frame's `[busy]` state stored. Normal `Turbo.visit` request are not affected by this, only form submissions. The reason is, turbo creates and stores a snapshot cache of the page navigated from, and in case a form has initiated the navigation, the snapshot is taken only after the frame is marked in progress.
In case of a `Turbo.visit`, the following happens: Snapshot taken -> Busy state set -> Request initiated.
In case of a form submission: Form submitted -> Busy state set -> When response arrives a dry `Turbo.visit` is initiated which takes the snapshot described above. When `Turbo.visit` takes the snapshot, the page is already in `[busy]` state.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
