### PR TITLE
[AUTOWORK-266] Primerize Status administration (Queries variant)

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -19,6 +19,7 @@
 @import "projects/wizard/page_component"
 @import "shares/invite_user_form_component"
 @import "shares/modal_body_component"
+@import "statuses/index_component"
 @import "step_wizard/footer_component"
 @import "step_wizard/page_layout_component"
 @import "users/hover_card_component"

--- a/app/components/statuses/index_component.html.erb
+++ b/app/components/statuses/index_component.html.erb
@@ -31,7 +31,7 @@
 
 <%=
   component_wrapper do
-    flex_layout do |flex|
+    flex_layout(data: wrapper_data_attributes) do |flex|
       flex.with_row do
         render(Primer::OpenProject::SubHeader.new) do |subheader|
           subheader.with_action_button(
@@ -46,7 +46,7 @@
       end
 
       flex.with_row do
-        render(border_box_container) do |box|
+        render(border_box_container(data: drop_target_config)) do |box|
           box.with_header(font_weight: :bold) { render(Statuses::ListHeaderComponent.new) }
 
           if statuses.empty?
@@ -59,7 +59,7 @@
             end
           else
             statuses.each do |status|
-              box.with_row(test_selector: "status-row-#{status.id}") do
+              box.with_row(test_selector: "status-row-#{status.id}", data: draggable_item_config(status)) do
                 render(Statuses::ItemComponent.new(status:, max_position:, page_args:))
               end
             end

--- a/app/components/statuses/index_component.html.erb
+++ b/app/components/statuses/index_component.html.erb
@@ -1,0 +1,75 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    flex_layout do |flex|
+      flex.with_row do
+        render(Primer::OpenProject::SubHeader.new) do |subheader|
+          subheader.with_action_button(
+            scheme: :primary,
+            leading_icon: :plus,
+            label: t(:label_work_package_status_new),
+            tag: :a,
+            href: new_status_path,
+            test_selector: "add-status-button"
+          ) { t(:label_status) }
+        end
+      end
+
+      flex.with_row do
+        render(border_box_container) do |box|
+          box.with_header(font_weight: :bold) { render(Statuses::ListHeaderComponent.new) }
+
+          if statuses.empty?
+            box.with_row do
+              render(Primer::Beta::Blankslate.new(spacious: true)) do |blank_slate|
+                blank_slate.with_visual_icon(icon: :alert)
+                blank_slate.with_heading(tag: :h3) { empty_state_title }
+                blank_slate.with_description { empty_state_description }
+              end
+            end
+          else
+            statuses.each do |status|
+              box.with_row(test_selector: "status-row-#{status.id}") do
+                render(Statuses::ItemComponent.new(status:, max_position:, page_args:))
+              end
+            end
+          end
+        end
+      end
+
+      flex.with_row(mt: 3) do
+        helpers.pagination_links_full(statuses)
+      end
+    end
+  end
+%>

--- a/app/components/statuses/index_component.rb
+++ b/app/components/statuses/index_component.rb
@@ -35,6 +35,7 @@ module Statuses
     include OpTurbo::Streamable
 
     options :statuses
+    options :query
     options :page_args
 
     private
@@ -44,19 +45,33 @@ module Statuses
       Status.maximum(:position)
     end
 
+    # Positions are global while a filtered list shows a non-contiguous subset, so a
+    # drop would resolve against neighbours the list does not display.
+    def reorderable?
+      query.filters.empty?
+    end
+
     def empty_state_title
-      t("statuses.index.no_results_title_text")
+      if reorderable?
+        t("statuses.index.no_results_title_text")
+      else
+        t("statuses.index.no_filter_results_title_text")
+      end
     end
 
     def empty_state_description
-      t("statuses.index.no_results_content_text")
+      t("statuses.index.no_results_content_text") if reorderable?
     end
 
     def wrapper_data_attributes
+      return {} unless reorderable?
+
       { controller: "generic-drag-and-drop" }
     end
 
     def drop_target_config
+      return {} unless reorderable?
+
       {
         generic_drag_and_drop_target: "container",
         "target-container-accessor": ":scope > ul",
@@ -65,6 +80,8 @@ module Statuses
     end
 
     def draggable_item_config(status)
+      return {} unless reorderable?
+
       {
         "draggable-id": status.id,
         "draggable-type": "status",

--- a/app/components/statuses/index_component.rb
+++ b/app/components/statuses/index_component.rb
@@ -29,43 +29,27 @@
 #++
 
 module Statuses
-  class TableComponent < ::TableComponent
-    def initial_sort
-      %i[id asc]
+  class IndexComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+
+    options :statuses
+    options :page_args
+
+    private
+
+    # The list may show one page of statuses while positions run across all of them.
+    def max_position
+      Status.maximum(:position)
     end
 
-    def sortable?
-      false
+    def empty_state_title
+      t("statuses.index.no_results_title_text")
     end
 
-    def columns
-      headers.map(&:first)
-    end
-
-    def inline_create_link
-      link_to new_status_path,
-              aria: { label: t(:label_work_package_status_new) },
-              class: "wp-inline-create--add-link",
-              title: t(:label_work_package_status_new) do
-        helpers.op_icon("icon icon-add")
-      end
-    end
-
-    def empty_row_message
-      I18n.t :no_results_title_text
-    end
-
-    def headers
-      [
-        [:name, { caption: Status.human_attribute_name(:name) }],
-        [:color, { caption: Status.human_attribute_name(:color) }],
-        [:done_ratio, { caption: WorkPackage.human_attribute_name(:done_ratio) }],
-        [:default?, { caption: I18n.t("statuses.index.headers.is_default") }],
-        [:closed?, { caption: I18n.t("statuses.index.headers.is_closed") }],
-        [:readonly?, { caption: I18n.t("statuses.index.headers.is_readonly") }],
-        [:excluded_from_totals?, { caption: I18n.t("statuses.index.headers.excluded_from_totals") }],
-        [:sort, { caption: I18n.t(:label_sort) }]
-      ]
+    def empty_state_description
+      t("statuses.index.no_results_content_text")
     end
   end
 end

--- a/app/components/statuses/index_component.rb
+++ b/app/components/statuses/index_component.rb
@@ -51,5 +51,25 @@ module Statuses
     def empty_state_description
       t("statuses.index.no_results_content_text")
     end
+
+    def wrapper_data_attributes
+      { controller: "generic-drag-and-drop" }
+    end
+
+    def drop_target_config
+      {
+        generic_drag_and_drop_target: "container",
+        "target-container-accessor": ":scope > ul",
+        "target-allowed-drag-type": "status"
+      }
+    end
+
+    def draggable_item_config(status)
+      {
+        "draggable-id": status.id,
+        "draggable-type": "status",
+        "drop-url": move_status_path(status, **page_args.to_h)
+      }
+    end
   end
 end

--- a/app/components/statuses/index_component.sass
+++ b/app/components/statuses/index_component.sass
@@ -1,0 +1,27 @@
+.op-statuses-list--header,
+.op-statuses-list--item
+  display: grid
+  // Header and rows are separate grids, so every track must resolve to the same
+  // width in both: no content-sized tracks, and the same columns on each side.
+  grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
+  grid-template-areas: "name done-ratio is-default is-closed is-readonly actions"
+  column-gap: 8px
+
+  &_without-done-ratio
+    grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 40px
+    grid-template-areas: "name is-default is-closed is-readonly actions"
+
+  &--done-ratio,
+  &--is-default,
+  &--is-closed,
+  &--is-readonly
+    text-align: center
+
+  &--actions
+    justify-self: end
+
+@media screen and (max-width: $breakpoint-sm)
+  .op-statuses-list--header,
+  .op-statuses-list--item
+    grid-template-columns: minmax(0, 1fr) 40px
+    grid-template-areas: "name actions"

--- a/app/components/statuses/index_component.sass
+++ b/app/components/statuses/index_component.sass
@@ -3,13 +3,13 @@
   display: grid
   // Header and rows are separate grids, so every track must resolve to the same
   // width in both: no content-sized tracks, and the same columns on each side.
-  grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
-  grid-template-areas: "name done-ratio is-default is-closed is-readonly actions"
+  grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
+  grid-template-areas: "drag-handle name done-ratio is-default is-closed is-readonly actions"
   column-gap: 8px
 
   &_without-done-ratio
-    grid-template-columns: minmax(0, 2fr) 1fr 1fr 1fr 40px
-    grid-template-areas: "name is-default is-closed is-readonly actions"
+    grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 40px
+    grid-template-areas: "drag-handle name is-default is-closed is-readonly actions"
 
   &--done-ratio,
   &--is-default,
@@ -23,5 +23,5 @@
 @media screen and (max-width: $breakpoint-sm)
   .op-statuses-list--header,
   .op-statuses-list--item
-    grid-template-columns: minmax(0, 1fr) 40px
-    grid-template-areas: "name actions"
+    grid-template-columns: 20px minmax(0, 1fr) 40px
+    grid-template-areas: "drag-handle name actions"

--- a/app/components/statuses/index_component.sass
+++ b/app/components/statuses/index_component.sass
@@ -3,16 +3,15 @@
   display: grid
   // Header and rows are separate grids, so every track must resolve to the same
   // width in both: no content-sized tracks, and the same columns on each side.
-  grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 1fr 40px
-  grid-template-areas: "drag-handle name done-ratio is-default is-closed is-readonly actions"
+  grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 40px
+  grid-template-areas: "drag-handle name done-ratio is-closed is-readonly actions"
   column-gap: 8px
 
   &_without-done-ratio
-    grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 1fr 40px
-    grid-template-areas: "drag-handle name is-default is-closed is-readonly actions"
+    grid-template-columns: 20px minmax(0, 2fr) 1fr 1fr 40px
+    grid-template-areas: "drag-handle name is-closed is-readonly actions"
 
   &--done-ratio,
-  &--is-default,
   &--is-closed,
   &--is-readonly
     text-align: center

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -37,6 +37,10 @@
       align_items: :center,
       classes: grid_modifier_class("item")
     ) do |grid|
+      grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
+        render(Primer::OpenProject::DragHandle.new)
+      end
+
       grid.with_area(:name, tag: :div, classes: "ellipsis") do
         flex_layout(align_items: :center) do |flex|
           flex.with_column(mr: 2) do

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -38,7 +38,7 @@
       classes: grid_modifier_class("item")
     ) do |grid|
       grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
-        render(Primer::OpenProject::DragHandle.new)
+        render(Primer::OpenProject::DragHandle.new) if reorderable
       end
 
       grid.with_area(:name, tag: :div, classes: "ellipsis") do

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -1,0 +1,77 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    grid_layout(
+      "op-statuses-list--item",
+      tag: :div,
+      align_items: :center,
+      classes: grid_modifier_class("item")
+    ) do |grid|
+      grid.with_area(:name, tag: :div, classes: "ellipsis") do
+        flex_layout(align_items: :center) do |flex|
+          flex.with_column(mr: 2) do
+            helpers.icon_for_color(status.color)
+          end
+
+          flex.with_column(classes: "ellipsis") do
+            render(Primer::Beta::Link.new(href: edit_status_path(status), underline: false)) do
+              render(Primer::Beta::Text.new(font_weight: :bold)) { status.name }
+            end
+          end
+        end
+      end
+
+      if show_done_ratio?
+        grid.with_area(:"done-ratio", tag: :div, hide: :sm) do
+          render(Primer::Beta::Text.new(color: :subtle, test_selector: "done-ratio")) { done_ratio }
+        end
+      end
+
+      flag_columns.each do |column|
+        grid.with_area(column.area, tag: :div, hide: :sm) { checkmark(column) }
+      end
+
+      grid.with_area(:actions, tag: :div, classes: "hide-when-print") do
+        render(Primer::Alpha::ActionMenu.new(test_selector: "status-action-menu")) do |menu|
+          menu.with_show_button(
+            icon: "kebab-horizontal",
+            scheme: :invisible,
+            "aria-label": t("statuses.index.status_actions")
+          )
+
+          build_status_menu(menu)
+        end
+      end
+    end
+  end
+%>

--- a/app/components/statuses/item_component.html.erb
+++ b/app/components/statuses/item_component.html.erb
@@ -52,6 +52,14 @@
               render(Primer::Beta::Text.new(font_weight: :bold)) { status.name }
             end
           end
+
+          if status.is_default?
+            flex.with_column(ml: 2) do
+              render(Primer::Beta::Label.new(scheme: :primary, test_selector: "label-is-default")) do
+                t(:label_default)
+              end
+            end
+          end
         end
       end
 

--- a/app/components/statuses/item_component.rb
+++ b/app/components/statuses/item_component.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Statuses
+  class ItemComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+    include Statuses::ListColumns
+
+    options :status
+    options :max_position
+    options :page_args
+
+    private
+
+    def wrapper_uniq_by
+      status.id
+    end
+
+    def first_item?
+      status.position == 1
+    end
+
+    def last_item?
+      status.position == max_position
+    end
+
+    def done_ratio
+      helpers.number_to_percentage(status.default_done_ratio, precision: 0)
+    end
+
+    def checkmark(column)
+      return unless status.public_send(column.predicate)
+
+      render(Primer::Beta::Octicon.new(icon: :check, "aria-label": column.caption))
+    end
+
+    def build_status_menu(menu)
+      with_item_group(menu) { edit_status(menu) }
+      with_item_group(menu) do
+        unless first_item?
+          move_status(menu, :highest, I18n.t(:label_sort_highest), "move-to-top")
+          move_status(menu, :higher, I18n.t(:label_sort_higher), "chevron-up")
+        end
+        unless last_item?
+          move_status(menu, :lower, I18n.t(:label_sort_lower), "chevron-down")
+          move_status(menu, :lowest, I18n.t(:label_sort_lowest), "move-to-bottom")
+        end
+      end
+      with_item_group(menu) { delete_status(menu) }
+    end
+
+    def edit_status(menu)
+      menu.with_item(label: I18n.t(:button_edit),
+                     tag: :a,
+                     href: edit_status_path(status)) do |item|
+        item.with_leading_visual_icon(icon: :pencil)
+      end
+    end
+
+    def move_status(menu, move_to, label, icon)
+      menu.with_item(label:,
+                     tag: :button,
+                     href: move_status_path(status, **page_args.to_h),
+                     form_arguments: { method: :put, inputs: [{ name: "move_to", value: move_to.to_s }] }) do |item|
+        item.with_leading_visual_icon(icon:)
+      end
+    end
+
+    def delete_status(menu)
+      menu.with_item(label: I18n.t(:button_delete),
+                     tag: :button,
+                     scheme: :danger,
+                     href: status_path(status),
+                     content_arguments: { data: { turbo_confirm: I18n.t(:text_are_you_sure) } },
+                     form_arguments: { method: :delete }) do |item|
+        item.with_leading_visual_icon(icon: :trash)
+      end
+    end
+  end
+end

--- a/app/components/statuses/item_component.rb
+++ b/app/components/statuses/item_component.rb
@@ -37,6 +37,7 @@ module Statuses
 
     options :status
     options :max_position
+    options :reorderable
     options :page_args
 
     private
@@ -66,6 +67,8 @@ module Statuses
     def build_status_menu(menu)
       with_item_group(menu) { edit_status(menu) }
       with_item_group(menu) do
+        next unless reorderable
+
         unless first_item?
           move_status(menu, :highest, I18n.t(:label_sort_highest), "move-to-top")
           move_status(menu, :higher, I18n.t(:label_sort_higher), "chevron-up")

--- a/app/components/statuses/list_columns.rb
+++ b/app/components/statuses/list_columns.rb
@@ -29,58 +29,39 @@
 #++
 
 module Statuses
-  class RowComponent < ::RowComponent
-    def status
-      model
-    end
+  # Captions and row cells sit on two separate CSS grids, so they only stay
+  # aligned while both render the same columns. Both take the set from here.
+  module ListColumns
+    Column = Data.define(:area, :caption, :predicate)
 
-    def name
-      link_to status.name, edit_status_path(status)
-    end
-
-    def default?
-      checkmark(status.is_default?)
-    end
-
-    def closed?
-      checkmark(status.is_closed?)
-    end
-
-    def readonly?
-      checkmark(status.is_readonly?)
-    end
-
-    def excluded_from_totals?
-      checkmark(status.excluded_from_totals?)
-    end
-
-    def color
-      helpers.icon_for_color status.color
-    end
-
-    def done_ratio
-      h(status.default_done_ratio)
-    end
-
-    def sort
-      helpers.reorder_links "status",
-                            { action: "update", id: status },
-                            method: :patch
-    end
-
-    def button_links
+    def columns
       [
-        delete_link
+        column(:name, Status.human_attribute_name(:name)),
+        (column(:"done-ratio", WorkPackage.human_attribute_name(:done_ratio)) if show_done_ratio?),
+        *flag_columns
+      ].compact
+    end
+
+    def flag_columns
+      [
+        column(:"is-default", t("statuses.index.headers.is_default"), predicate: :is_default?),
+        column(:"is-closed", t("statuses.index.headers.is_closed"), predicate: :is_closed?),
+        column(:"is-readonly", t("statuses.index.headers.is_readonly"), predicate: :is_readonly?)
       ]
     end
 
-    def delete_link
-      link_to(
-        helpers.op_icon("icon icon-delete"),
-        status_path(status),
-        data: { turbo_method: :delete, turbo_confirm: I18n.t(:text_are_you_sure) },
-        title: t(:button_delete)
-      )
+    def show_done_ratio?
+      WorkPackage.status_based_mode?
+    end
+
+    def grid_modifier_class(element)
+      "op-statuses-list--#{element}_without-done-ratio" unless show_done_ratio?
+    end
+
+    private
+
+    def column(area, caption, predicate: nil)
+      Column.new(area:, caption:, predicate:)
     end
   end
 end

--- a/app/components/statuses/list_columns.rb
+++ b/app/components/statuses/list_columns.rb
@@ -44,7 +44,6 @@ module Statuses
 
     def flag_columns
       [
-        column(:"is-default", t("statuses.index.headers.is_default"), predicate: :is_default?),
         column(:"is-closed", t("statuses.index.headers.is_closed"), predicate: :is_closed?),
         column(:"is-readonly", t("statuses.index.headers.is_readonly"), predicate: :is_readonly?)
       ]

--- a/app/components/statuses/list_header_component.html.erb
+++ b/app/components/statuses/list_header_component.html.erb
@@ -1,0 +1,45 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  grid_layout(
+    "op-statuses-list--header",
+    tag: :div,
+    align_items: :center,
+    classes: grid_modifier_class("header")
+  ) do |grid|
+    columns.each do |column|
+      grid.with_area(column.area, tag: :div, hide: (:sm unless column.area == :name)) do
+        render(Primer::Beta::Text.new(font_weight: :semibold)) { column.caption }
+      end
+    end
+  end
+%>

--- a/app/components/statuses/list_header_component.rb
+++ b/app/components/statuses/list_header_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Statuses
+  class ListHeaderComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+    include Statuses::ListColumns
+  end
+end

--- a/app/components/statuses/role_filter_component.rb
+++ b/app/components/statuses/role_filter_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Statuses
+  class RoleFilterComponent < OpPrimer::QuickFilter::SelectPanelComponent
+    def initialize(query:)
+      super(name: Role.model_name.human, query:, filter_key: :role, path_args: [:statuses])
+
+      Workflow.eligible_roles.order(Arel.sql("builtin, position")).each do |role|
+        with_item(label: role.name, value: role.id)
+      end
+    end
+  end
+end

--- a/app/components/statuses/sub_header_component.html.erb
+++ b/app/components/statuses/sub_header_component.html.erb
@@ -30,37 +30,22 @@
 %>
 
 <%=
-  component_wrapper do
-    flex_layout(data: wrapper_data_attributes) do |flex|
-      flex.with_row do
-        render(Statuses::SubHeaderComponent.new(query:))
-      end
+  render(Primer::OpenProject::SubHeader.new(data: data_attributes)) do |subheader|
+    subheader.with_quick_filter { render(Statuses::TypeFilterComponent.new(query:)) }
+    subheader.with_quick_filter { render(Statuses::RoleFilterComponent.new(query:)) }
+    subheader.with_filter_component { render(Filter::FilterButtonComponent.new(query:)) }
 
-      flex.with_row do
-        render(border_box_container(data: drop_target_config)) do |box|
-          box.with_header(font_weight: :bold) { render(Statuses::ListHeaderComponent.new) }
-
-          if statuses.empty?
-            box.with_row do
-              render(Primer::Beta::Blankslate.new(spacious: true)) do |blank_slate|
-                blank_slate.with_visual_icon(icon: :alert)
-                blank_slate.with_heading(tag: :h3) { empty_state_title }
-                blank_slate.with_description { empty_state_description } if empty_state_description
-              end
-            end
-          else
-            statuses.each do |status|
-              box.with_row(test_selector: "status-row-#{status.id}", data: draggable_item_config(status)) do
-                render(Statuses::ItemComponent.new(status:, max_position:, reorderable: reorderable?, page_args:))
-              end
-            end
-          end
-        end
-      end
-
-      flex.with_row(mt: 3) do
-        helpers.pagination_links_full(statuses)
-      end
+    subheader.with_bottom_pane_component do
+      render(Filter::FilterComponent.new(query:))
     end
+
+    subheader.with_action_button(
+      scheme: :primary,
+      leading_icon: :plus,
+      label: t(:label_work_package_status_new),
+      tag: :a,
+      href: new_status_path,
+      test_selector: "add-status-button"
+    ) { t(:label_status) }
   end
 %>

--- a/app/components/statuses/sub_header_component.rb
+++ b/app/components/statuses/sub_header_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Statuses
+  class SubHeaderComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    options :query
+
+    private
+
+    def data_attributes
+      {
+        controller: "filter--filters-form",
+        "filter--filters-form-output-format-value": "json"
+      }
+    end
+  end
+end

--- a/app/components/statuses/type_filter_component.rb
+++ b/app/components/statuses/type_filter_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Statuses
+  class TypeFilterComponent < OpPrimer::QuickFilter::SelectPanelComponent
+    def initialize(query:)
+      super(name: ::Type.model_name.human, query:, filter_key: :type, path_args: [:statuses])
+
+      ::Type.order(:position).each { |type| with_item(label: type.name, value: type.id) }
+    end
+  end
+end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -119,7 +119,9 @@ class StatusesController < ApplicationController
     if move_to.in?(%w[highest higher lower lowest])
       { move_to: }
     elsif position
-      { position: }
+      # The dropped position is an index within the rendered page, while
+      # acts_as_list positions run across the whole list.
+      { position: position + ((page_param - 1) * per_page_param) }
     else
       {}
     end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -30,15 +30,15 @@
 
 class StatusesController < ApplicationController
   include PaginationHelper
+  include OpTurbo::ComponentStream
 
   layout "admin"
 
   before_action :require_admin
 
   def index
-    @statuses = Status.page(page_param).per_page(per_page_param)
-
-    render action: "index", layout: false if request.xhr?
+    @statuses = paginated_statuses
+    @page_args = page_args
   end
 
   def new
@@ -84,7 +84,46 @@ class StatusesController < ApplicationController
     redirect_to action: "index", status: :see_other
   end
 
+  def move
+    status = Status.find(params.expect(:id))
+
+    if status.update(move_params)
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
+    else
+      render_error_flash_message_via_turbo_stream(message: I18n.t("statuses.index.could_not_be_moved"))
+    end
+
+    replace_via_turbo_stream(component: index_component)
+
+    respond_with_turbo_streams
+  end
+
   protected
+
+  def index_component
+    Statuses::IndexComponent.new(statuses: paginated_statuses, page_args:)
+  end
+
+  def paginated_statuses
+    Status.page(page_param).per_page(per_page_param)
+  end
+
+  def page_args
+    { page: page_param, per_page: per_page_param }
+  end
+
+  def move_params
+    move_to = params[:move_to]
+    position = Integer(params[:position], exception: false)
+
+    if move_to.in?(%w[highest higher lower lowest])
+      { move_to: }
+    elsif position
+      { position: }
+    else
+      {}
+    end
+  end
 
   def recompute_progress_values
     attributes_triggering_recomputing = ["excluded_from_totals"]

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -37,6 +37,7 @@ class StatusesController < ApplicationController
   before_action :require_admin
 
   def index
+    @query = load_query
     @statuses = paginated_statuses
     @page_args = page_args
   end
@@ -93,6 +94,7 @@ class StatusesController < ApplicationController
       render_error_flash_message_via_turbo_stream(message: I18n.t("statuses.index.could_not_be_moved"))
     end
 
+    @query = load_query
     replace_via_turbo_stream(component: index_component)
 
     respond_with_turbo_streams
@@ -101,11 +103,15 @@ class StatusesController < ApplicationController
   protected
 
   def index_component
-    Statuses::IndexComponent.new(statuses: paginated_statuses, page_args:)
+    Statuses::IndexComponent.new(statuses: paginated_statuses, query: @query, page_args:)
+  end
+
+  def load_query
+    ParamsToQueryService.new(Status, current_user).call(params)
   end
 
   def paginated_statuses
-    Status.page(page_param).per_page(per_page_param)
+    @query.results.page(page_param).per_page(per_page_param)
   end
 
   def page_args

--- a/app/models/queries/statuses.rb
+++ b/app/models/queries/statuses.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries::Statuses
+  ::Queries::Register.register(StatusQuery) do
+    filter Filters::TypeFilter
+    filter Filters::RoleFilter
+  end
+end

--- a/app/models/queries/statuses/filters/role_filter.rb
+++ b/app/models/queries/statuses/filters/role_filter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Statuses::Filters::RoleFilter < Queries::Statuses::Filters::WorkflowFilter
+  # Role eager-loads its permissions, so plucking here would yield one entry per
+  # permission rather than per role.
+  def allowed_values
+    eligible_roles.map { |role| [role.name, role.id.to_s] }
+  end
+
+  def where
+    transition_where("role_id", values.map(&:to_i))
+  end
+
+  def human_name
+    Role.model_name.human
+  end
+
+  def eligible_roles
+    Workflow.eligible_roles.order(Arel.sql("builtin, position"))
+  end
+end

--- a/app/models/queries/statuses/filters/type_filter.rb
+++ b/app/models/queries/statuses/filters/type_filter.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Statuses::Filters::TypeFilter < Queries::Statuses::Filters::WorkflowFilter
+  def allowed_values
+    ::Type.order(:position).pluck(:name, :id).map { |name, id| [name, id.to_s] }
+  end
+
+  def where
+    transition_where("type_variant_id", ::TypeVariant.where(type_id: values).pluck(:id))
+  end
+
+  def human_name
+    ::Type.model_name.human
+  end
+end

--- a/app/models/queries/statuses/filters/workflow_filter.rb
+++ b/app/models/queries/statuses/filters/workflow_filter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Statuses reach types and roles only through the transitions naming them. Both
+# filters join through this one clause so that Rails collapses it to a single
+# join and their conditions land on the same transition: picking Task and Member
+# then matches the Task/Member workflow alone, rather than every status used by
+# some Task workflow and, separately, by some Member workflow.
+class Queries::Statuses::Filters::WorkflowFilter < Queries::Filters::Base
+  TRANSITION_JOIN = <<~SQL.squish
+    INNER JOIN workflows
+    ON workflows.old_status_id = statuses.id OR workflows.new_status_id = statuses.id
+  SQL
+
+  self.model = Status
+
+  def joins
+    TRANSITION_JOIN
+  end
+
+  def type
+    :list
+  end
+
+  def available_operators
+    [::Queries::Operators::Equals]
+  end
+
+  private
+
+  def transition_where(field, ids)
+    operator_strategy.sql_for_field(ids, "workflows", field)
+  end
+end

--- a/app/models/queries/statuses/status_query.rb
+++ b/app/models/queries/statuses/status_query.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Statuses::StatusQuery
+  include ::Queries::BaseQuery
+  include ::Queries::UnpersistedQuery
+
+  def self.model
+    Status
+  end
+
+  # The workflow filters join a status to many transitions, so the scope dedupes.
+  def default_scope
+    Status.distinct
+  end
+end

--- a/app/views/statuses/edit.html.erb
+++ b/app/views/statuses/edit.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       { href: statuses_path, text: t(:label_status) },
+       { href: statuses_path, text: t(:label_status_plural) },
        @status.name_was]
     )
   end

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -27,15 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), t(:label_work_package_plural), I18n.t(:label_status) -%>
+<% html_title t(:label_administration), t(:label_work_package_plural), I18n.t(:label_status_plural) -%>
 
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { I18n.t(:label_status) }
+    header.with_title { I18n.t(:label_status_plural) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       I18n.t(:label_status)]
+       I18n.t(:label_status_plural)]
     )
   end
 %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -39,18 +39,4 @@ See COPYRIGHT and LICENSE files for more details.
     )
   end
 %>
-<%=
-  render(Primer::OpenProject::SubHeader.new) do |subheader|
-    subheader.with_action_button(
-      scheme: :primary,
-      leading_icon: :plus,
-      label: t(:label_work_package_status_new),
-      tag: :a,
-      href: new_status_path
-    ) do
-      t(:label_status)
-    end
-  end
-%>
-
-<%= render ::Statuses::TableComponent.new(rows: @statuses) %>
+<%= render ::Statuses::IndexComponent.new(statuses: @statuses, page_args: @page_args) %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -39,4 +39,4 @@ See COPYRIGHT and LICENSE files for more details.
     )
   end
 %>
-<%= render ::Statuses::IndexComponent.new(statuses: @statuses, page_args: @page_args) %>
+<%= render ::Statuses::IndexComponent.new(statuses: @statuses, query: @query, page_args: @page_args) %>

--- a/app/views/statuses/new.html.erb
+++ b/app/views/statuses/new.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       { href: statuses_path, text: t(:label_status) },
+       { href: statuses_path, text: t(:label_status_plural) },
        t(:label_work_package_status_new)]
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6325,7 +6325,6 @@ en:
       could_not_be_moved: "Status could not be moved."
       headers:
         is_closed: "Closed"
-        is_default: "Default"
         is_readonly: "Read-only"
       no_filter_results_title_text: "No status matches the current filter."
       no_results_content_text: Add a new status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6322,13 +6322,14 @@ en:
         <br>
         <strong>Note</strong>: Inherited values (e.g., from children or relations) will still apply.
     index:
+      could_not_be_moved: "Status could not be moved."
       headers:
-        excluded_from_totals: "Excluded from totals"
         is_closed: "Closed"
         is_default: "Default"
         is_readonly: "Read-only"
       no_results_content_text: Add a new status
       no_results_title_text: There are currently no work package statuses.
+      status_actions: "Status actions"
 
   # Used in array.to_sentence.
   support:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6327,6 +6327,7 @@ en:
         is_closed: "Closed"
         is_default: "Default"
         is_readonly: "Read-only"
+      no_filter_results_title_text: "No status matches the current filter."
       no_results_content_text: Add a new status
       no_results_title_text: There are currently no work package statuses.
       status_actions: "Status actions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,7 +308,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :statuses, except: :show
+  resources :statuses, except: :show do
+    member do
+      put :move
+    end
+  end
 
   get "custom_style/:digest/logo/:filename" => "custom_styles#logo_download",
       as: "custom_style_logo",

--- a/spec/components/statuses/index_component_spec.rb
+++ b/spec/components/statuses/index_component_spec.rb
@@ -33,11 +33,12 @@ require "rails_helper"
 RSpec.describe Statuses::IndexComponent, type: :component do
   subject(:rendered_component) do
     with_request_url("/statuses") do
-      render_inline(described_class.new(statuses:, page_args:))
+      render_inline(described_class.new(statuses:, query:, page_args:))
     end
   end
 
   let(:page_args) { { page: 1, per_page: 20 } }
+  let(:query) { Queries::Statuses::StatusQuery.new(user: User.current) }
   let(:statuses) { relation.page(page_args[:page]).per_page(page_args[:per_page]) }
 
   context "with statuses" do
@@ -108,6 +109,29 @@ RSpec.describe Statuses::IndexComponent, type: :component do
 
       expect(rendered_component).to have_css("#{row} button", text: "Move down")
       expect(rendered_component).to have_css("#{row} button", text: "Move to bottom")
+    end
+  end
+
+  context "when filtered" do
+    let!(:new_status) { create(:status, name: "New") }
+    let!(:task) { create(:type, name: "Task") }
+    let(:relation) { Status.where(id: new_status.id) }
+    let(:query) do
+      Queries::Statuses::StatusQuery.new(user: User.current).tap { it.where("type", "=", [task.id.to_s]) }
+    end
+
+    it "offers no reordering, since positions are global and the list is a subset" do
+      expect(rendered_component).to have_no_css("[data-generic-drag-and-drop-target='container']")
+      expect(rendered_component).to have_no_css(".Box-row[data-draggable-type='status']")
+    end
+
+    context "when the filter matches nothing" do
+      let(:relation) { Status.none }
+
+      it "says the filter came up empty rather than that no status exists" do
+        expect(rendered_component).to have_text("No status matches the current filter.")
+        expect(rendered_component).to have_no_text("There are currently no work package statuses.")
+      end
     end
   end
 

--- a/spec/components/statuses/index_component_spec.rb
+++ b/spec/components/statuses/index_component_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Statuses::IndexComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/statuses") do
+      render_inline(described_class.new(statuses:, page_args:))
+    end
+  end
+
+  let(:page_args) { { page: 1, per_page: 20 } }
+  let(:statuses) { relation.page(page_args[:page]).per_page(page_args[:per_page]) }
+
+  context "with statuses" do
+    let!(:new_status) { create(:status, name: "New", is_default: true, default_done_ratio: 0) }
+    let!(:closed_status) { create(:status, name: "Closed", is_closed: true, default_done_ratio: 100) }
+    let(:relation) { Status.where(id: [new_status.id, closed_status.id]) }
+
+    it_behaves_like "rendering Box", row_count: 2
+
+    it "captions the columns through the list header" do
+      expect(rendered_component).to have_css(".Box-header .op-statuses-list--header")
+    end
+
+    # Header and rows are separate grids: they only stay aligned while both render
+    # and drop the same columns.
+    context "in status-based progress mode", with_settings: { work_package_done_ratio: "status" } do
+      it "lays header and rows out on the same columns", :aggregate_failures do
+        expect(rendered_component).to have_no_css(".op-statuses-list--header_without-done-ratio")
+        expect(rendered_component).to have_no_css(".op-statuses-list--item_without-done-ratio")
+      end
+    end
+
+    context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
+      it "narrows header and rows together", :aggregate_failures do
+        expect(rendered_component).to have_css(".op-statuses-list--header_without-done-ratio")
+        expect(rendered_component).to have_css(".op-statuses-list--item_without-done-ratio")
+      end
+    end
+
+    it "renders a row per status", :aggregate_failures do
+      expect(rendered_component).to have_css(".Box-row", text: "New")
+      expect(rendered_component).to have_css(".Box-row", text: "Closed")
+    end
+
+    it "links each status to its edit page" do
+      expect(rendered_component).to have_link("New", href: "/statuses/#{new_status.id}/edit")
+    end
+  end
+
+  describe "reordering across pages" do
+    let!(:first) { create(:status, name: "First") }
+    let!(:second) { create(:status, name: "Second") }
+    let!(:third) { create(:status, name: "Third") }
+    let(:relation) { Status.all }
+    let(:page_args) { { page: 1, per_page: 2 } }
+
+    it "keeps the downward moves on the last row of a page, which is not the last of the list" do
+      row = "[data-test-selector='status-row-#{second.id}']"
+
+      expect(rendered_component).to have_css("#{row} button", text: "Move down")
+      expect(rendered_component).to have_css("#{row} button", text: "Move to bottom")
+    end
+  end
+
+  context "without statuses" do
+    let(:relation) { Status.where(id: nil) }
+
+    it "says no status exists yet" do
+      expect(rendered_component).to have_text("There are currently no work package statuses.")
+    end
+  end
+end

--- a/spec/components/statuses/index_component_spec.rb
+++ b/spec/components/statuses/index_component_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Statuses::IndexComponent, type: :component do
     it "links each status to its edit page" do
       expect(rendered_component).to have_link("New", href: "/statuses/#{new_status.id}/edit")
     end
+
+    it "renders a drag-and-drop enabled container" do
+      expect(rendered_component).to have_css(".Box[data-generic-drag-and-drop-target='container']") do |box|
+        expect(box["data-target-container-accessor"]).to eq(":scope > ul")
+        expect(box["data-target-allowed-drag-type"]).to eq("status")
+      end
+    end
+
+    it "renders each status as a draggable row pointing at its drop URL", :aggregate_failures do
+      [new_status, closed_status].each do |status|
+        selector = ".Box-row[data-draggable-type='status'][data-draggable-id='#{status.id}']"
+
+        expect(rendered_component).to have_css(selector) do |row|
+          # The page travels with the drop so the server can resolve the dropped
+          # index against the whole list.
+          expect(row["data-drop-url"]).to eq("/statuses/#{status.id}/move?page=1&per_page=20")
+        end
+      end
+    end
   end
 
   describe "reordering across pages" do

--- a/spec/components/statuses/item_component_spec.rb
+++ b/spec/components/statuses/item_component_spec.rb
@@ -33,13 +33,14 @@ require "rails_helper"
 RSpec.describe Statuses::ItemComponent, type: :component do
   subject(:rendered_component) do
     with_request_url("/statuses") do
-      render_inline(described_class.new(status:, max_position:, page_args:))
+      render_inline(described_class.new(status:, max_position:, reorderable:, page_args:))
     end
   end
 
   let(:status) { create(:status, name: "In progress", default_done_ratio: 40) }
   let(:position) { 2 }
   let(:max_position) { 3 }
+  let(:reorderable) { true }
   let(:page_args) { { page: 1, per_page: 20 } }
 
   before { status.update_column(:position, position) }
@@ -106,6 +107,52 @@ RSpec.describe Statuses::ItemComponent, type: :component do
     context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
       it "omits % Complete, which has no effect in that mode" do
         expect(rendered_component).to have_no_test_selector("done-ratio")
+      end
+    end
+  end
+
+  describe "reordering" do
+    it "offers a drag handle and every move from the middle of the list", :aggregate_failures do
+      expect(rendered_component).to have_css(".DragHandle")
+      expect(rendered_component).to have_button("Move to top")
+      expect(rendered_component).to have_button("Move up")
+      expect(rendered_component).to have_button("Move down")
+      expect(rendered_component).to have_button("Move to bottom")
+    end
+
+    context "when the status is first" do
+      let(:position) { 1 }
+
+      it "offers the downward moves only", :aggregate_failures do
+        expect(rendered_component).to have_no_button("Move to top")
+        expect(rendered_component).to have_no_button("Move up")
+        expect(rendered_component).to have_button("Move down")
+        expect(rendered_component).to have_button("Move to bottom")
+      end
+    end
+
+    context "when the status is last" do
+      let(:position) { max_position }
+
+      it "offers the upward moves only", :aggregate_failures do
+        expect(rendered_component).to have_button("Move to top")
+        expect(rendered_component).to have_button("Move up")
+        expect(rendered_component).to have_no_button("Move down")
+        expect(rendered_component).to have_no_button("Move to bottom")
+      end
+    end
+
+    context "when reordering is not offered" do
+      let(:reorderable) { false }
+
+      it "drops the drag handle and every move, keeping edit and delete", :aggregate_failures do
+        expect(rendered_component).to have_no_css(".DragHandle")
+        expect(rendered_component).to have_no_button("Move to top")
+        expect(rendered_component).to have_no_button("Move up")
+        expect(rendered_component).to have_no_button("Move down")
+        expect(rendered_component).to have_no_button("Move to bottom")
+        expect(rendered_component).to have_link("Edit")
+        expect(rendered_component).to have_button("Delete")
       end
     end
   end

--- a/spec/components/statuses/item_component_spec.rb
+++ b/spec/components/statuses/item_component_spec.rb
@@ -55,15 +55,23 @@ RSpec.describe Statuses::ItemComponent, type: :component do
     expect(rendered_component).to have_css(".op-statuses-list--item--name .color--preview")
   end
 
-  describe "flag columns" do
+  describe "the default status" do
     context "when the status is the default one" do
       let(:status) { create(:status, name: "New", is_default: true) }
 
-      it "checks the default column" do
-        expect(rendered_component).to have_css("[aria-label='Default']")
+      it "labels it beside the name" do
+        expect(rendered_component).to have_test_selector("label-is-default", text: "Default")
       end
     end
 
+    context "when the status is not the default one" do
+      it "carries no label" do
+        expect(rendered_component).to have_no_test_selector("label-is-default")
+      end
+    end
+  end
+
+  describe "flag columns" do
     context "when the status is closed" do
       let(:status) { create(:status, name: "Closed", is_closed: true) }
 
@@ -90,7 +98,6 @@ RSpec.describe Statuses::ItemComponent, type: :component do
 
     context "when the status carries no flag" do
       it "leaves every flag column unchecked", :aggregate_failures do
-        expect(rendered_component).to have_no_css("[aria-label='Default']")
         expect(rendered_component).to have_no_css("[aria-label='Closed']")
         expect(rendered_component).to have_no_css("[aria-label='Read-only']")
       end

--- a/spec/components/statuses/item_component_spec.rb
+++ b/spec/components/statuses/item_component_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Statuses::ItemComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/statuses") do
+      render_inline(described_class.new(status:, max_position:, page_args:))
+    end
+  end
+
+  let(:status) { create(:status, name: "In progress", default_done_ratio: 40) }
+  let(:position) { 2 }
+  let(:max_position) { 3 }
+  let(:page_args) { { page: 1, per_page: 20 } }
+
+  before { status.update_column(:position, position) }
+
+  it "renders the status name as a link to its edit page" do
+    expect(rendered_component).to have_link("In progress", href: "/statuses/#{status.id}/edit")
+  end
+
+  it "shows the colour beside the name rather than in a column of its own" do
+    status.update!(color: create(:color, name: "Blue", hexcode: "#1F83D6"))
+
+    expect(rendered_component).to have_css(".op-statuses-list--item--name .color--preview")
+  end
+
+  describe "flag columns" do
+    context "when the status is the default one" do
+      let(:status) { create(:status, name: "New", is_default: true) }
+
+      it "checks the default column" do
+        expect(rendered_component).to have_css("[aria-label='Default']")
+      end
+    end
+
+    context "when the status is closed" do
+      let(:status) { create(:status, name: "Closed", is_closed: true) }
+
+      it "checks the closed column" do
+        expect(rendered_component).to have_css("[aria-label='Closed']")
+      end
+    end
+
+    context "when the status is read-only", with_ee: %i[readonly_work_packages] do
+      let(:status) { create(:status, name: "Rejected", is_readonly: true) }
+
+      it "checks the read-only column" do
+        expect(rendered_component).to have_css("[aria-label='Read-only']")
+      end
+    end
+
+    context "when the status is read-only without an enterprise token", with_ee: false do
+      let(:status) { create(:status, name: "Rejected", is_readonly: true) }
+
+      it "leaves the read-only column unchecked, since the flag has no effect" do
+        expect(rendered_component).to have_no_css("[aria-label='Read-only']")
+      end
+    end
+
+    context "when the status carries no flag" do
+      it "leaves every flag column unchecked", :aggregate_failures do
+        expect(rendered_component).to have_no_css("[aria-label='Default']")
+        expect(rendered_component).to have_no_css("[aria-label='Closed']")
+        expect(rendered_component).to have_no_css("[aria-label='Read-only']")
+      end
+    end
+  end
+
+  describe "% Complete" do
+    context "in status-based progress mode", with_settings: { work_package_done_ratio: "status" } do
+      it "shows the default % Complete of the status" do
+        expect(rendered_component).to have_test_selector("done-ratio", text: "40%")
+      end
+    end
+
+    context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
+      it "omits % Complete, which has no effect in that mode" do
+        expect(rendered_component).to have_no_test_selector("done-ratio")
+      end
+    end
+  end
+end

--- a/spec/components/statuses/list_header_component_spec.rb
+++ b/spec/components/statuses/list_header_component_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Statuses::ListHeaderComponent, type: :component do
+  subject(:rendered_component) { render_inline(described_class.new) }
+
+  def captioned_areas
+    rendered_component.css("[class*='op-statuses-list--header--']").map do |cell|
+      cell["class"][/op-statuses-list--header--(\S+)/, 1]
+    end
+  end
+
+  context "in status-based progress mode", with_settings: { work_package_done_ratio: "status" } do
+    it "captions each column in the order the grid lays them out" do
+      expect(captioned_areas).to eq(%w[name done-ratio is-default is-closed is-readonly])
+    end
+
+    it "names the columns", :aggregate_failures do
+      expect(rendered_component).to have_text("Name")
+      expect(rendered_component).to have_text("% Complete")
+      expect(rendered_component).to have_text("Default")
+      expect(rendered_component).to have_text("Closed")
+      expect(rendered_component).to have_text("Read-only")
+    end
+
+    it "keeps the full grid" do
+      expect(rendered_component).to have_no_css(".op-statuses-list--header_without-done-ratio")
+    end
+  end
+
+  context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
+    it "drops the % Complete column, which has no effect in that mode" do
+      expect(captioned_areas).to eq(%w[name is-default is-closed is-readonly])
+    end
+
+    # Rows carry the matching modifier: the two grids only stay aligned while both
+    # drop the same column.
+    it "narrows the grid" do
+      expect(rendered_component).to have_css(".op-statuses-list--header_without-done-ratio")
+    end
+  end
+end

--- a/spec/components/statuses/list_header_component_spec.rb
+++ b/spec/components/statuses/list_header_component_spec.rb
@@ -41,13 +41,12 @@ RSpec.describe Statuses::ListHeaderComponent, type: :component do
 
   context "in status-based progress mode", with_settings: { work_package_done_ratio: "status" } do
     it "captions each column in the order the grid lays them out" do
-      expect(captioned_areas).to eq(%w[name done-ratio is-default is-closed is-readonly])
+      expect(captioned_areas).to eq(%w[name done-ratio is-closed is-readonly])
     end
 
     it "names the columns", :aggregate_failures do
       expect(rendered_component).to have_text("Name")
       expect(rendered_component).to have_text("% Complete")
-      expect(rendered_component).to have_text("Default")
       expect(rendered_component).to have_text("Closed")
       expect(rendered_component).to have_text("Read-only")
     end
@@ -59,7 +58,7 @@ RSpec.describe Statuses::ListHeaderComponent, type: :component do
 
   context "in work-based progress mode", with_settings: { work_package_done_ratio: "field" } do
     it "drops the % Complete column, which has no effect in that mode" do
-      expect(captioned_areas).to eq(%w[name is-default is-closed is-readonly])
+      expect(captioned_areas).to eq(%w[name is-closed is-readonly])
     end
 
     # Rows carry the matching modifier: the two grids only stay aligned while both

--- a/spec/components/statuses/sub_header_component_spec.rb
+++ b/spec/components/statuses/sub_header_component_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Statuses::SubHeaderComponent, type: :component do
+  subject(:rendered_component) do
+    with_request_url("/statuses") { render_inline(described_class.new(query:)) }
+  end
+
+  let(:query) { Queries::Statuses::StatusQuery.new(user: build(:admin)) }
+
+  shared_let(:task) { create(:type, name: "Task") }
+  shared_let(:manager) { create(:project_role, name: "Manager") }
+
+  it "offers a quick filter per workflow facet", :aggregate_failures do
+    expect(rendered_component).to have_css("[data-quick-filter--select-panel-filter-key-value='type']")
+    expect(rendered_component).to have_css("[data-quick-filter--select-panel-filter-key-value='role']")
+  end
+
+  it "lists the eligible values in each panel", :aggregate_failures do
+    expect(rendered_component).to have_css("[data-quick-filter--select-panel-filter-key-value='type'] [data-value]",
+                                           text: "Task")
+    expect(rendered_component).to have_css("[data-quick-filter--select-panel-filter-key-value='role'] [data-value]",
+                                           text: "Manager")
+  end
+
+  it "wires the filters-form Stimulus controller, which the panels navigate through" do
+    expect(rendered_component).to have_css("[data-controller='filter--filters-form']")
+  end
+
+  it "serializes the selection as JSON, which is what the controller parses" do
+    expect(rendered_component).to have_css("[data-filter--filters-form-output-format-value='json']")
+  end
+
+  it "links to the new status form" do
+    expect(rendered_component).to have_link(href: "/statuses/new")
+  end
+
+  context "with an active filter" do
+    before { query.where("type", "=", [task.id.to_s]) }
+
+    it "leaves the advanced panel collapsed, the quick filter already showing the selection" do
+      expect(rendered_component).to have_no_css(".op-filters-form.-expanded")
+      expect(rendered_component).to have_css("[data-quick-filter--select-panel-filter-key-value='type']")
+    end
+  end
+end

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -87,6 +87,37 @@ RSpec.describe "Statuses admin page", :js do
       statuses_page.expect_listed("In Progress", "Done", "New")
     end
 
+    describe "quick filters" do
+      shared_let(:task) { create(:type, name: "Task") }
+      shared_let(:manager) { create(:project_role, name: "Manager") }
+      shared_let(:member) { create(:project_role, name: "Member") }
+      shared_let(:task_manager_transition) do
+        create(:workflow, type: task, role: manager, old_status: status_new, new_status: status_in_progress)
+      end
+
+      it "narrows the list to the statuses of the selected type and role" do
+        statuses_page.visit!
+        statuses_page.expect_listed("New", "In Progress", "Done")
+
+        statuses_page.quick_filter_by("type", "Type", "Task")
+
+        statuses_page.expect_listed("New", "In Progress")
+
+        statuses_page.quick_filter_by("role", "Role", "Member")
+
+        statuses_page.expect_listed
+      end
+
+      it "offers no reordering while filtered, since positions are global" do
+        statuses_page.visit!
+        expect(page).to have_css(".DragHandle")
+
+        statuses_page.quick_filter_by("type", "Type", "Task")
+
+        statuses_page.expect_no_reordering
+      end
+    end
+
     describe "pagination", with_settings: { per_page_options: "2, 100" } do
       it "pages the list, and a larger page size widens what drag and drop can reach" do
         statuses_page.visit!

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe "Statuses admin page", :js do
 
     let(:statuses_page) { Pages::Admin::Statuses.new }
 
+    it "names the page for the collection it lists" do
+      statuses_page.visit!
+
+      statuses_page.expect_header_to_display("Statuses")
+    end
+
     it "reorders statuses through the action menu" do
       statuses_page.visit!
 

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -75,8 +75,20 @@ RSpec.describe "Statuses admin page", :js do
       end
     end
 
+    it "reorders statuses by dragging them" do
+      statuses_page.visit!
+
+      statuses_page.drag_status(from_index: 0, to_index: 2)
+      wait_for_network_idle
+
+      statuses_page.expect_listed("In Progress", "Done", "New")
+
+      statuses_page.reload!
+      statuses_page.expect_listed("In Progress", "Done", "New")
+    end
+
     describe "pagination", with_settings: { per_page_options: "2, 100" } do
-      it "pages the list, and shows it whole at a larger page size" do
+      it "pages the list, and a larger page size widens what drag and drop can reach" do
         statuses_page.visit!
 
         statuses_page.expect_listed("New", "In Progress")
@@ -84,6 +96,11 @@ RSpec.describe "Statuses admin page", :js do
         statuses_page.set_page_size(100)
 
         statuses_page.expect_listed("New", "In Progress", "Done")
+
+        statuses_page.drag_status(from_index: 0, to_index: 2)
+        wait_for_network_idle
+
+        statuses_page.expect_listed("In Progress", "Done", "New")
       end
 
       it "keeps the reader on their page after a move" do

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -40,6 +40,66 @@ RSpec.describe "Statuses admin page", :js do
     login_as(admin)
   end
 
+  describe "index page" do
+    # Reordering persists across examples, so each one starts from a known order.
+    before do
+      [status_new, status_in_progress, status_done].each_with_index do |status, index|
+        status.update_column(:position, index + 1)
+      end
+    end
+
+    let(:statuses_page) { Pages::Admin::Statuses.new }
+
+    it "reorders statuses through the action menu" do
+      statuses_page.visit!
+
+      statuses_page.expect_listed("New", "In Progress", "Done")
+
+      statuses_page.click_status_action(status_new, action: "Move to bottom")
+
+      expect(page).to have_text("Successful update.")
+      statuses_page.expect_listed("In Progress", "Done", "New")
+
+      statuses_page.click_status_action(status_done, action: "Move up")
+
+      statuses_page.expect_listed("Done", "In Progress", "New")
+    end
+
+    it "offers no upward move on the first status" do
+      statuses_page.visit!
+
+      statuses_page.within_status(status_new) do
+        click_on accessible_name: "Status actions"
+        expect(page).to have_no_button("Move to top")
+        expect(page).to have_button("Move to bottom")
+      end
+    end
+
+    describe "pagination", with_settings: { per_page_options: "2, 100" } do
+      it "pages the list, and shows it whole at a larger page size" do
+        statuses_page.visit!
+
+        statuses_page.expect_listed("New", "In Progress")
+
+        statuses_page.set_page_size(100)
+
+        statuses_page.expect_listed("New", "In Progress", "Done")
+      end
+
+      it "keeps the reader on their page after a move" do
+        statuses_page.visit!
+        statuses_page.go_to_page(2)
+
+        statuses_page.expect_listed("Done")
+
+        statuses_page.click_status_action(status_done, action: "Move up")
+
+        statuses_page.expect_listed("In Progress")
+        expect(Status.order(:position).pluck(:name)).to eq(["New", "Done", "In Progress"])
+      end
+    end
+  end
+
   describe "create page" do
     context "with enterprise edition", with_ee: %i[readonly_work_packages] do
       it "has 'is read-only' checkbox unchecked and disabled only when 'is default' is checked (mutually exclusive)" do

--- a/spec/features/statuses/statuses_administration_spec.rb
+++ b/spec/features/statuses/statuses_administration_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe "Statuses administration" do
     context "without any statuses" do
       it 'displays the "no results" text' do
         visit statuses_path
-        expect(page).to have_content(I18n.t("no_results_title_text"))
+        expect(page).to have_text("There are currently no work package statuses.")
+        expect(page).to have_text("Add a new status")
       end
     end
 

--- a/spec/models/queries/statuses/filters/role_filter_spec.rb
+++ b/spec/models/queries/statuses/filters/role_filter_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Statuses::Filters::RoleFilter do
+  subject(:filter) { described_class.create!(name: "role", operator: "=") }
+
+  shared_let(:manager) do
+    create(:project_role, name: "Manager", permissions: %i[view_work_packages edit_work_packages])
+  end
+  shared_let(:member) do
+    create(:project_role, name: "Member", permissions: %i[view_work_packages add_work_packages])
+  end
+
+  describe "#allowed_values" do
+    it "offers each eligible role once, however many permissions it carries" do
+      expect(filter.allowed_values).to contain_exactly(["Manager", manager.id.to_s], ["Member", member.id.to_s])
+    end
+  end
+end

--- a/spec/models/queries/statuses/status_query_spec.rb
+++ b/spec/models/queries/statuses/status_query_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Statuses::StatusQuery do
+  shared_let(:user) { create(:admin) }
+
+  shared_let(:task) { create(:type, name: "Task") }
+  shared_let(:bug) { create(:type, name: "Bug") }
+  shared_let(:manager) { create(:project_role, name: "Manager") }
+  shared_let(:member) { create(:project_role, name: "Member") }
+
+  shared_let(:new_status) { create(:status, name: "New") }
+  shared_let(:in_progress) { create(:status, name: "In progress") }
+  shared_let(:rejected) { create(:status, name: "Rejected") }
+  shared_let(:unused) { create(:status, name: "Unused") }
+
+  shared_let(:task_manager_transition) do
+    create(:workflow, type: task, role: manager, old_status: new_status, new_status: in_progress)
+  end
+  shared_let(:bug_member_transition) do
+    create(:workflow, type: bug, role: member, old_status: rejected, new_status: new_status)
+  end
+
+  subject(:query) { described_class.new(user:) }
+
+  def results_for(types: [], roles: [])
+    query.where("type", "=", types.map { it.id.to_s }) if types.any?
+    query.where("role", "=", roles.map { it.id.to_s }) if roles.any?
+    query.results
+  end
+
+  it "returns every status when nothing is filtered" do
+    expect(results_for).to contain_exactly(new_status, in_progress, rejected, unused)
+  end
+
+  it "returns statuses on either side of a transition" do
+    expect(results_for(types: [task], roles: [manager])).to contain_exactly(new_status, in_progress)
+  end
+
+  it "filters on the type alone" do
+    expect(results_for(types: [bug])).to contain_exactly(rejected, new_status)
+  end
+
+  it "filters on the role alone" do
+    expect(results_for(roles: [manager])).to contain_exactly(new_status, in_progress)
+  end
+
+  it "unions the selected types and roles" do
+    expect(results_for(types: [task, bug], roles: [manager, member]))
+      .to contain_exactly(new_status, in_progress, rejected)
+  end
+
+  it "matches a type and a role only when the same workflow pairs them" do
+    # Task/Manager and Bug/Member exist; Task/Member does not, so nothing matches it
+    # even though both sides are used elsewhere.
+    expect(results_for(types: [task], roles: [member])).to be_empty
+  end
+
+  it "returns a status once however many transitions name it" do
+    create(:workflow, type: task, role: manager, old_status: in_progress, new_status: new_status)
+
+    expect(results_for(types: [task], roles: [manager]).to_a.size).to eq(2)
+  end
+
+  it "returns nothing for a type that has no variants to reach a workflow through" do
+    variantless = create(:type, name: "Variantless")
+    TypeVariant.where(type_id: variantless.id).delete_all
+
+    expect(results_for(types: [variantless])).to be_empty
+  end
+end

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -99,5 +99,24 @@ RSpec.describe "Statuses", :skip_csrf, type: :rails_request do
       expect(response).to have_http_status(:ok)
       expect(Status.order(:position).pluck(:name)).to eq(%w[Third First Second])
     end
+
+    context "when the list is paginated", with_settings: { per_page_options: "2, 100" } do
+      before { Status.delete_all }
+
+      let!(:a) { create(:status, name: "A") }
+      let!(:b) { create(:status, name: "B") }
+      let!(:c) { create(:status, name: "C") }
+      let!(:d) { create(:status, name: "D") }
+      let!(:e) { create(:status, name: "E") }
+
+      it "resolves the dropped position against the whole list, not the page" do
+        # Page 2 shows C and D; dropping D first on that page means global position 3.
+        put move_status_path(d, page: 2, per_page: 2),
+            params: { position: 1 },
+            as: :turbo_stream
+
+        expect(Status.order(:position).pluck(:name)).to eq(%w[A B D C E])
+      end
+    end
   end
 end

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -53,4 +53,51 @@ RSpec.describe "Statuses", :skip_csrf, type: :rails_request do
       end
     end
   end
+
+  describe "GET /statuses" do
+    context "with more statuses than fit a page", with_settings: { per_page_options: "2, 100" } do
+      shared_let(:statuses) { create_list(:status, 3) }
+
+      it "paginates" do
+        get statuses_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(statuses.first.name)
+        expect(response.body).not_to include(statuses.last.name)
+      end
+
+      it "serves the requested page" do
+        get statuses_path(page: 2)
+
+        expect(response.body).to include(statuses.last.name)
+        expect(response.body).not_to include(statuses.first.name)
+      end
+
+      it "keeps the whole list on one page when asked for a larger page size" do
+        get statuses_path(per_page: 100)
+
+        expect(response.body).to include(*statuses.map(&:name))
+      end
+    end
+  end
+
+  describe "PUT /statuses/:id/move" do
+    shared_let(:first) { create(:status, name: "First") }
+    shared_let(:second) { create(:status, name: "Second") }
+    shared_let(:third) { create(:status, name: "Third") }
+
+    it "moves the status to the requested relative position" do
+      put move_status_path(first), params: { move_to: "lowest" }, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(Status.order(:position).pluck(:name)).to eq(%w[Second Third First])
+    end
+
+    it "moves the status to an absolute position" do
+      put move_status_path(third), params: { position: 1 }, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(Status.order(:position).pluck(:name)).to eq(%w[Third First Second])
+    end
+  end
 end

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -35,6 +35,12 @@ module Pages
     class Statuses < ::Pages::Page
       def path = "/statuses"
 
+      def expect_header_to_display(text)
+        expect(page).to have_css("h2", text:)
+        expect(page).to have_css(".breadcrumb-item-selected", text:)
+        expect(page).to have_title("#{text} | Work packages | Administration | OpenProject")
+      end
+
       def expect_listed(*names)
         page.document.synchronize do
           found = page.all("#{row_selector} a").map(&:text)

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -54,6 +54,14 @@ module Pages
         end
       end
 
+      def expect_no_reordering
+        expect(page).to have_no_css(".DragHandle")
+      end
+
+      def drag_status(from_index:, to_index:)
+        drag_and_drop_list(from: from_index, to: to_index, elements: row_selector, handler: ".DragHandle")
+      end
+
       def go_to_page(number)
         within(".op-pagination--pages") { click_on number.to_s }
       end

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module Admin
+    class Statuses < ::Pages::Page
+      def path = "/statuses"
+
+      def expect_listed(*names)
+        page.document.synchronize do
+          found = page.all("#{row_selector} a").map(&:text)
+
+          raise Capybara::ExpectationNotMet, "Expected #{names}, got #{found}" unless found == names
+        end
+      end
+
+      def within_status(status, &)
+        within_test_selector("status-row-#{status.id}", &)
+      end
+
+      def click_status_action(status, action:)
+        within_status(status) do
+          click_on accessible_name: "Status actions"
+          click_on action
+        end
+      end
+
+      def go_to_page(number)
+        within(".op-pagination--pages") { click_on number.to_s }
+      end
+
+      def set_page_size(size)
+        within(".op-pagination--options") { click_on size.to_s }
+      end
+
+      private
+
+      def row_selector = "[data-test-selector^='status-row-']"
+    end
+  end
+end

--- a/spec/support/pages/admin/statuses.rb
+++ b/spec/support/pages/admin/statuses.rb
@@ -54,6 +54,19 @@ module Pages
         end
       end
 
+      def quick_filter_by(filter_key, button_label, value)
+        within("[data-quick-filter--select-panel-filter-key-value='#{filter_key}']") do
+          click_on button_label
+
+          within("select-panel") do
+            find("[data-value]", text: value).click
+            click_on "Apply"
+          end
+        end
+
+        wait_for_network_idle
+      end
+
       def expect_no_reordering
         expect(page).to have_no_css(".DragHandle")
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AUTOWORK-266

# What are you trying to accomplish?

- [x] Primerizing the table
   - [x] Administration → Work packages → Statuses primerized, modelled on Administration → Documents → Types
   - [x] % Complete shown only in status-based progress mode
   - [x] `Excluded from totals` left to the status form rather than given a column
- [x] Sort column replaced
   - [x] Move actions in the per-row action menu
   - [x] Order changed by drag and drop
- [x] Multi-select quick filters for type and role
   - [x] Built on `Queries::Statuses::StatusQuery`, so the stock `SelectPanelComponent` and filters form apply
   - [x] "All filters" panel offers the same two filters
- Opportunistic commit
   - Page title, breadcrumb and the crumb back from the forms read `Statuses`, like the menu item

## Screenshots

### Statuses list in status-based progress mode (all columns)

<img width="1006" height="963" alt="Screenshot of status list" src="https://github.com/user-attachments/assets/00f54711-d518-4fcd-b51a-7229f24450a5" />

### Filtered list, drag handles withdrawn

<img width="1006" height="967" alt="Screenshot of filtered list" src="https://github.com/user-attachments/assets/1582e56f-ea97-4fc6-8587-71d72cc68ddf" />

# What approach did you choose and why?

- Type and role narrow one set of workflow transitions rather than filtering independently: statuses reach types and roles only through workflows, so Task + Member matches the Task/Member workflow alone, not the Task workflows + Member workflows.
- Reordering is withdrawn while filtered — positions are global and a filtered list is a non-contiguous subset. A page is contiguous, so a dropped row carries its page and its index resolves against the whole list.
- Open question: `Move to top` / `Move to bottom` read oddly on a paginated page. `Make it first` / `Make it last` may be less ambiguous. But they are the global `label_sort_*` keys shared with every admin list that reorders, so rewording needs status-scoped keys or a change across those lists — left alone here.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) — nothing to add.
- [x] Tested major browsers (Chrome, Firefox)


