### PR TITLE
[XWI-167] Move `redirect_url` field from the OAuth step to another step

### DIFF
--- a/modules/wikis/app/components/wikis/admin/forms/general_info_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/general_info_form_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <%=
   component_wrapper do
     flex_layout(mb: 3) do |general_info_row|

--- a/modules/wikis/app/components/wikis/admin/forms/oauth_application_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/oauth_application_form_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <%=
   component_wrapper do
     flex_layout(flex_items: :center) do |credentials_row|

--- a/modules/wikis/app/components/wikis/admin/forms/oauth_client_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/oauth_client_form_component.html.erb
@@ -40,22 +40,6 @@
           ))
         end
 
-        oauth_client_row.with_row(mb: 3) do
-          render(Primer::OpenProject::InputGroup.new(input_width: :large)) do |input_group|
-            input_group.with_text_input(
-              name: "oauth_client[redirect_uri]",
-              label: t(".redirect_uri"),
-              visually_hide_label: false,
-              value: resolved_oauth_client.redirect_uri
-            )
-            input_group.with_trailing_action_clipboard_copy_button(
-              value: resolved_oauth_client.redirect_uri,
-              aria: { label: t("button_copy_to_clipboard") }
-            )
-            input_group.with_caption { t(".redirect_uri_caption") }
-          end
-        end
-
         oauth_client_row.with_row do
           render(
             Wikis::Admin::SubmitOrCancelForm.new(

--- a/modules/wikis/app/components/wikis/admin/forms/oauth_client_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/oauth_client_form_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <%=
   component_wrapper do
     primer_form_with(

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
@@ -1,0 +1,37 @@
+<%=
+  component_wrapper do
+    primer_form_with(
+      model: oauth_client,
+      url: form_url,
+      method: :post
+    ) do |form|
+      flex_layout do |redirect_uri_row|
+        redirect_uri_row.with_row(mb: 3) do
+          render(Primer::OpenProject::InputGroup.new(input_width: :large)) do |input_group|
+            input_group.with_text_input(
+              name: :oauth_client_redirect_uri,
+              label: t(".redirect_uri"),
+              visually_hide_label: false,
+              value: redirect_uri
+            )
+            input_group.with_trailing_action_clipboard_copy_button(
+              value: redirect_uri,
+              aria: { label: t("button_copy_to_clipboard") }
+            )
+            input_group.with_caption { t(".redirect_uri_caption") }
+          end
+        end
+
+        redirect_uri_row.with_row do
+          render(
+            Wikis::Admin::SubmitOrCancelForm.new(
+              form, wiki_provider:,
+                    submit_button_options: { label: t(:button_finish_setup), disabled: is_complete },
+                    cancel_button_options: { href: cancel_button_path }
+            )
+          )
+        end
+      end
+    end
+  end
+%>

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <%=
   component_wrapper do
     primer_form_with(

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
@@ -23,13 +23,17 @@
         end
 
         redirect_uri_row.with_row do
-          render(
-            Wikis::Admin::SubmitOrCancelForm.new(
-              form, wiki_provider:,
-                    submit_button_options: { label: t(:button_finish_setup), disabled: is_complete },
-                    cancel_button_options: { href: cancel_button_path }
+          if read_only
+            render(Primer::Beta::Button.new(scheme: :primary, tag: :a, href: cancel_button_path)) { t(:button_close) }
+          else
+            render(
+              Wikis::Admin::SubmitOrCancelForm.new(
+                form, wiki_provider:,
+                      submit_button_options: { label: t(:button_finish_setup) },
+                      cancel_button_options: { href: cancel_button_path }
+              )
             )
-          )
+          end
         end
       end
     end

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.html.erb
@@ -10,7 +10,7 @@
           render(Primer::OpenProject::InputGroup.new(input_width: :large)) do |input_group|
             input_group.with_text_input(
               name: :oauth_client_redirect_uri,
-              label: t(".redirect_uri"),
+              label: t("wikis.admin.wiki_providers.oauth.redirect_uri"),
               visually_hide_label: false,
               value: redirect_uri
             )
@@ -18,7 +18,7 @@
               value: redirect_uri,
               aria: { label: t("button_copy_to_clipboard") }
             )
-            input_group.with_caption { t(".redirect_uri_caption") }
+            input_group.with_caption { t("wikis.admin.wiki_providers.oauth.redirect_uri_caption") }
           end
         end
 

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis::Admin::Forms
+  class RedirectUriFormComponent < Wikis::Admin::WikiProviderComponent
+    def self.wrapper_key = :wiki_provider_redirect_uri_section
+
+    delegate :oauth_client, to: :wiki_provider
+
+    options in_wizard: false,
+            is_complete: false
+
+    def form_url
+      query = in_wizard ? { continue_wizard: wiki_provider.id } : {}
+      url_helpers.finish_setup_admin_settings_wiki_provider_oauth_client_path(wiki_provider, query)
+    end
+
+    def cancel_button_path
+      url_helpers.edit_admin_settings_wiki_provider_path(wiki_provider)
+    end
+
+    def redirect_uri
+      oauth_client&.redirect_uri
+    end
+  end
+end

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
@@ -33,21 +33,16 @@ module Wikis::Admin::Forms
     def self.wrapper_key = :wiki_provider_redirect_uri_section
 
     delegate :oauth_client, to: :wiki_provider
+    delegate :redirect_uri, to: :oauth_client, allow_nil: true
 
-    options in_wizard: false,
-            read_only: false
+    options read_only: false
 
     def form_url
-      query = in_wizard ? { continue_wizard: wiki_provider.id } : {}
-      url_helpers.finish_setup_admin_settings_wiki_provider_oauth_client_path(wiki_provider, query)
+      url_helpers.finish_setup_admin_settings_wiki_provider_oauth_client_path(wiki_provider)
     end
 
     def cancel_button_path
       url_helpers.edit_admin_settings_wiki_provider_path(wiki_provider)
-    end
-
-    def redirect_uri
-      oauth_client&.redirect_uri
     end
   end
 end

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
@@ -35,7 +35,7 @@ module Wikis::Admin::Forms
     delegate :oauth_client, to: :wiki_provider
 
     options in_wizard: false,
-            is_complete: false
+            read_only: false
 
     def form_url
       query = in_wizard ? { continue_wizard: wiki_provider.id } : {}

--- a/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
+++ b/modules/wikis/app/components/wikis/admin/forms/redirect_uri_form_component.rb
@@ -38,11 +38,11 @@ module Wikis::Admin::Forms
     options read_only: false
 
     def form_url
-      url_helpers.finish_setup_admin_settings_wiki_provider_oauth_client_path(wiki_provider)
+      finish_setup_admin_settings_wiki_provider_oauth_client_path(wiki_provider)
     end
 
     def cancel_button_path
-      url_helpers.edit_admin_settings_wiki_provider_path(wiki_provider)
+      edit_admin_settings_wiki_provider_path(wiki_provider)
     end
   end
 end

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
@@ -1,0 +1,37 @@
+<%=
+  component_wrapper do
+    grid_layout("op-storage-view--row", tag: :div, align_items: :center) do |grid|
+      grid.with_area(:item, tag: :div, mr: 3) do
+        concat(render(Primer::Beta::Text.new(font_weight: :bold, mr: 1)) { t(".label_redirect_uri") })
+        if redirect_uri.present?
+          concat(render(Primer::Beta::Label.new(scheme: :success)) { t(:label_completed) })
+        else
+          concat(render(Primer::Beta::Label.new(scheme: :attention)) { t(:label_incomplete) })
+        end
+      end
+
+      grid.with_area(:description, classes: "wb-break-word", tag: :div, color: :subtle) do
+        render(Primer::Beta::Text.new) { redirect_uri.presence || t(".description") }
+      end
+
+      if redirect_uri.present?
+        grid.with_area(:"icon-button", tag: :div, color: :muted) do
+          flex_layout(justify_content: :flex_end) do |icons|
+            icons.with_column do
+              render(
+                Primer::Beta::IconButton.new(
+                  icon: :eye,
+                  scheme: :invisible,
+                  tag: :a,
+                  href: url_helpers.show_redirect_uri_admin_settings_wiki_provider_oauth_client_path(wiki_provider),
+                  aria: { label: t(".show_redirect_uri") },
+                  data: { turbo_stream: true }
+                )
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
@@ -11,7 +11,11 @@
       end
 
       grid.with_area(:description, classes: "wb-break-word", tag: :div, color: :subtle) do
-        render(Primer::Beta::Text.new) { redirect_uri.presence || t(".description") }
+        if redirect_uri.present?
+          render(Primer::Beta::Text.new) { "#{t('.label_uri')}: #{redirect_uri}" }
+        else
+          render(Primer::Beta::Text.new) { t(".description") }
+        end
       end
 
       if redirect_uri.present?

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <%=
   component_wrapper do
     grid_layout("op-storage-view--row", tag: :div, align_items: :center) do |grid|

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
@@ -39,7 +39,7 @@
                   icon: :eye,
                   scheme: :invisible,
                   tag: :a,
-                  href: url_helpers.show_redirect_uri_admin_settings_wiki_provider_oauth_client_path(wiki_provider),
+                  href: show_redirect_uri_admin_settings_wiki_provider_oauth_client_path(wiki_provider),
                   aria: { label: t(".show_redirect_uri") },
                   data: { turbo_stream: true }
                 )

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.html.erb
@@ -2,7 +2,11 @@
   component_wrapper do
     grid_layout("op-storage-view--row", tag: :div, align_items: :center) do |grid|
       grid.with_area(:item, tag: :div, mr: 3) do
-        concat(render(Primer::Beta::Text.new(font_weight: :bold, mr: 1)) { t(".label_redirect_uri") })
+        concat(
+          render(Primer::Beta::Text.new(font_weight: :bold, mr: 1)) do
+            t("wikis.admin.wiki_providers.oauth.redirect_uri")
+          end
+        )
         if redirect_uri.present?
           concat(render(Primer::Beta::Label.new(scheme: :success)) { t(:label_completed) })
         else
@@ -12,7 +16,15 @@
 
       grid.with_area(:description, classes: "wb-break-word", tag: :div, color: :subtle) do
         if redirect_uri.present?
-          render(Primer::Beta::Text.new) { "#{t('.label_uri')}: #{redirect_uri}" }
+          concat(render(Primer::Beta::Text.new) { "#{t('.label_uri')}: #{redirect_uri}" })
+          concat(
+            render(
+              Primer::Beta::ClipboardCopy.new(
+                value: redirect_uri,
+                aria: { label: t("button_copy_to_clipboard") }
+              )
+            )
+          )
         else
           render(Primer::Beta::Text.new) { t(".description") }
         end

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.rb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis::Admin
+  class RedirectUriInfoComponent < WikiProviderComponent
+    def self.wrapper_key = :wiki_provider_redirect_uri_section
+
+    delegate :oauth_client, to: :wiki_provider
+
+    def redirect_uri
+      oauth_client&.redirect_uri
+    end
+  end
+end

--- a/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.rb
+++ b/modules/wikis/app/components/wikis/admin/redirect_uri_info_component.rb
@@ -33,9 +33,6 @@ module Wikis::Admin
     def self.wrapper_key = :wiki_provider_redirect_uri_section
 
     delegate :oauth_client, to: :wiki_provider
-
-    def redirect_uri
-      oauth_client&.redirect_uri
-    end
+    delegate :redirect_uri, to: :oauth_client, allow_nil: true
   end
 end

--- a/modules/wikis/app/controllers/wikis/admin/oauth_clients_controller.rb
+++ b/modules/wikis/app/controllers/wikis/admin/oauth_clients_controller.rb
@@ -84,6 +84,19 @@ module Wikis
         @service_result.on_success { respond_for_success }
       end
 
+      def show_redirect_uri
+        update_via_turbo_stream(
+          component: Wikis::Admin::Forms::RedirectUriFormComponent.new(@wiki_provider, is_complete: true)
+        )
+        respond_with_turbo_streams
+      end
+
+      def finish_setup
+        flash[:op_primer_flash] = { message: I18n.t("wikis.admin.wiki_providers.successful_setup"), scheme: :success }
+
+        redirect_to edit_admin_settings_wiki_provider_path(@wiki_provider), status: :see_other
+      end
+
       private
 
       def save_oauth_client
@@ -107,6 +120,7 @@ module Wikis
           redirect_to new_admin_settings_wiki_provider_path(continue_wizard: @wiki_provider.id), status: :see_other
         else
           update_via_turbo_stream(component: Wikis::Admin::OAuthClientInfoComponent.new(@wiki_provider))
+          update_via_turbo_stream(component: Wikis::Admin::RedirectUriInfoComponent.new(@wiki_provider))
           respond_with_turbo_streams
         end
       end

--- a/modules/wikis/app/controllers/wikis/admin/oauth_clients_controller.rb
+++ b/modules/wikis/app/controllers/wikis/admin/oauth_clients_controller.rb
@@ -86,7 +86,7 @@ module Wikis
 
       def show_redirect_uri
         update_via_turbo_stream(
-          component: Wikis::Admin::Forms::RedirectUriFormComponent.new(@wiki_provider, is_complete: true)
+          component: Wikis::Admin::Forms::RedirectUriFormComponent.new(@wiki_provider, read_only: true)
         )
         respond_with_turbo_streams
       end
@@ -120,7 +120,7 @@ module Wikis
           redirect_to new_admin_settings_wiki_provider_path(continue_wizard: @wiki_provider.id), status: :see_other
         else
           update_via_turbo_stream(component: Wikis::Admin::OAuthClientInfoComponent.new(@wiki_provider))
-          update_via_turbo_stream(component: Wikis::Admin::RedirectUriInfoComponent.new(@wiki_provider))
+          update_via_turbo_stream(component: Wikis::Admin::Forms::RedirectUriFormComponent.new(@wiki_provider))
           respond_with_turbo_streams
         end
       end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/registry.rb
@@ -48,11 +48,13 @@ module Wikis
             register(:general_information, Wikis::Admin::GeneralInfoComponent)
             register(:oauth_application, Wikis::Admin::OAuthApplicationInfoComponent)
             register(:oauth_client, Wikis::Admin::OAuthClientInfoComponent)
+            register(:redirect_uri, Wikis::Admin::RedirectUriInfoComponent)
 
             namespace("forms") do
               register(:general_information, Wikis::Admin::Forms::GeneralInfoFormComponent)
               register(:oauth_application, Wikis::Admin::Forms::OAuthApplicationFormComponent)
               register(:oauth_client, Wikis::Admin::Forms::OAuthClientFormComponent)
+              register(:redirect_uri, Wikis::Admin::Forms::RedirectUriFormComponent)
             end
           end
 

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/wizard.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/wizard.rb
@@ -47,6 +47,15 @@ module Wikis
                if: ->(provider) { provider.authenticate_via_two_way_oauth2? },
                completed_if: ->(provider) { provider.oauth_client.present? }
 
+          step :redirect_uri,
+               section: :oauth_configuration,
+               if: ->(provider) { provider.authenticate_via_two_way_oauth2? },
+               # Nothing changes on the provider when the redirect URI is shown. The step only exists to
+               # show the OAuth client's redirect URI right after the client was created.
+               completed_if: lambda { |provider|
+                 provider.oauth_client&.persisted? && provider.oauth_client.created_at < 10.seconds.ago
+               }
+
           private
 
           def prepare_oauth_application(wiki_provider)

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
         oauth_client_form_component:
           client_id: Wiki OAuth Client ID
           client_secret: Wiki OAuth Client secret
+        redirect_uri_form_component:
           redirect_uri: Redirect URI
           redirect_uri_caption: Copy this value into the Redirect URI field of your XWiki OIDC client registration.
       health_status:
@@ -93,6 +94,10 @@ en:
         confirm_replace_oauth_client: This action will reset the current XWiki OAuth credentials. All users will need to reauthorize against XWiki. Are you sure you want to proceed?
         label_oauth_client_id: OAuth Client ID
         replace_oauth_client: Replace XWiki OAuth application
+      redirect_uri_info_component:
+        description: The redirect URI is generated once the wiki OAuth client is configured.
+        label_redirect_uri: Redirect URI
+        show_redirect_uri: Show redirect URI
       side_panel:
         health_status_component:
           last_check: 'Last check: %{datetime}'
@@ -114,6 +119,7 @@ en:
         name_caption: Give your wiki provider a name so that users can differentiate between multiple wiki platforms.
         name_placeholder: XWiki knowledge base
         new_provider_html: Read our documentation on [setting up an XWiki integration](docs_url) for more information.
+        successful_setup: Wiki provider connected successfully!
         oauth:
           openproject_oauth: OpenProject OAuth
         sections:

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -97,6 +97,7 @@ en:
       redirect_uri_info_component:
         description: The redirect URI is generated once the wiki OAuth client is configured.
         label_redirect_uri: Redirect URI
+        label_uri: URI
         show_redirect_uri: Show redirect URI
       side_panel:
         health_status_component:

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -67,9 +67,6 @@ en:
         oauth_client_form_component:
           client_id: Wiki OAuth Client ID
           client_secret: Wiki OAuth Client secret
-        redirect_uri_form_component:
-          redirect_uri: Redirect URI
-          redirect_uri_caption: Copy this value into the Redirect URI field of your XWiki OIDC client registration.
       health_status:
         show:
           actions:
@@ -96,7 +93,6 @@ en:
         replace_oauth_client: Replace XWiki OAuth application
       redirect_uri_info_component:
         description: The redirect URI is generated once the wiki OAuth client is configured.
-        label_redirect_uri: Redirect URI
         label_uri: URI
         show_redirect_uri: Show redirect URI
       side_panel:
@@ -123,6 +119,8 @@ en:
         successful_setup: Wiki provider connected successfully!
         oauth:
           openproject_oauth: OpenProject OAuth
+          redirect_uri: Redirect URI
+          redirect_uri_caption: Copy this value into the Redirect URI field of your XWiki OIDC client registration.
         sections:
           general_information: General information
           oauth_configuration: OAuth configuration

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -116,7 +116,7 @@ en:
         name_caption: Give your wiki provider a name so that users can differentiate between multiple wiki platforms.
         name_placeholder: XWiki knowledge base
         new_provider_html: Read our documentation on [setting up an XWiki integration](docs_url) for more information.
-        successful_setup: Wiki provider connected successfully!
+        successful_setup: Wiki provider configured successfully!
         oauth:
           openproject_oauth: OpenProject OAuth
           redirect_uri: Redirect URI

--- a/modules/wikis/config/routes.rb
+++ b/modules/wikis/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
 
         resource :oauth_client, controller: "/wikis/admin/oauth_clients", only: %i[new create] do
           patch :update, on: :member
+          get :show_redirect_uri
+          post :finish_setup
         end
       end
     end

--- a/modules/wikis/spec/components/wikis/admin/forms/redirect_uri_form_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/admin/forms/redirect_uri_form_component_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::Admin::Forms::RedirectUriFormComponent, type: :component do
+  let(:wiki_provider) { create(:xwiki_provider, :with_oauth_client) }
+
+  subject { render_inline(described_class.new(wiki_provider)) && page }
+
+  it "renders the redirect uri as a read only field" do
+    expect(subject).to have_field(type: "text", with: wiki_provider.oauth_client.redirect_uri, readonly: true)
+  end
+
+  it "renders a clipboard copy button for the redirect uri" do
+    expect(subject).to have_css("clipboard-copy[value='#{wiki_provider.oauth_client.redirect_uri}']")
+  end
+
+  it "submits to the finish setup endpoint" do
+    expect(subject).to have_css("form[method='post'][action$='oauth_client/finish_setup']")
+    expect(subject).to have_button(I18n.t(:button_finish_setup), disabled: false)
+  end
+
+  it "renders the copy instructions" do
+    expect(subject).to have_text(I18n.t("wikis.admin.wiki_providers.oauth.redirect_uri_caption"))
+  end
+
+  context "when rendered read only" do
+    subject { render_inline(described_class.new(wiki_provider, read_only: true)) && page }
+
+    it "renders a close button instead of the submit buttons" do
+      expect(subject).to have_css("a[href$='wiki_providers/#{wiki_provider.id}/edit']", text: I18n.t(:button_close))
+    end
+
+    it "renders no submit button" do
+      expect(subject).to have_no_button(type: "submit")
+    end
+  end
+end

--- a/modules/wikis/spec/components/wikis/admin/redirect_uri_info_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/admin/redirect_uri_info_component_spec.rb
@@ -60,8 +60,10 @@ RSpec.describe Wikis::Admin::RedirectUriInfoComponent, type: :component do
       expect(subject).to have_text(I18n.t(:label_completed))
     end
 
-    it "renders the redirect uri" do
-      expect(subject).to have_text(oauth_client.redirect_uri)
+    it "renders the labelled redirect uri" do
+      expect(subject).to have_text(
+        "#{I18n.t('wikis.admin.redirect_uri_info_component.label_uri')}: #{oauth_client.redirect_uri}"
+      )
     end
 
     it "renders the show redirect uri button" do

--- a/modules/wikis/spec/components/wikis/admin/redirect_uri_info_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/admin/redirect_uri_info_component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Wikis::Admin::RedirectUriInfoComponent, type: :component do
+  let(:wiki_provider) { create(:xwiki_provider) }
+  let(:oauth_client) { build(:oauth_client, integration: wiki_provider, client_id: "openproject-1234") }
+
+  subject { render_inline(described_class.new(wiki_provider)) && page }
+
+  context "without an oauth client" do
+    before { allow(wiki_provider).to receive(:oauth_client).and_return(nil) }
+
+    it "renders the incomplete label" do
+      expect(subject).to have_text(I18n.t(:label_incomplete))
+    end
+
+    it "renders the description instead of a redirect uri" do
+      expect(subject).to have_text(I18n.t("wikis.admin.redirect_uri_info_component.description"))
+    end
+
+    it "does not render the show redirect uri button" do
+      expect(subject).to have_no_css("a[href$='oauth_client/show_redirect_uri']")
+    end
+  end
+
+  context "with an oauth client configured" do
+    before { allow(wiki_provider).to receive(:oauth_client).and_return(oauth_client) }
+
+    it "renders the completed label" do
+      expect(subject).to have_text(I18n.t(:label_completed))
+    end
+
+    it "renders the redirect uri" do
+      expect(subject).to have_text(oauth_client.redirect_uri)
+    end
+
+    it "renders the show redirect uri button" do
+      expect(subject).to have_css("a[href$='oauth_client/show_redirect_uri'][data-turbo-stream='true']")
+    end
+
+    it "labels the show redirect uri button" do
+      expect(subject).to have_css("tool-tip",
+                                  text: I18n.t("wikis.admin.redirect_uri_info_component.show_redirect_uri"),
+                                  visible: :all)
+    end
+  end
+end

--- a/modules/wikis/spec/components/wikis/admin/redirect_uri_info_component_spec.rb
+++ b/modules/wikis/spec/components/wikis/admin/redirect_uri_info_component_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Wikis::Admin::RedirectUriInfoComponent, type: :component do
       expect(subject).to have_text(I18n.t("wikis.admin.redirect_uri_info_component.description"))
     end
 
+    it "does not render a clipboard copy" do
+      expect(subject).to have_no_css("clipboard-copy")
+    end
+
     it "does not render the show redirect uri button" do
       expect(subject).to have_no_css("a[href$='oauth_client/show_redirect_uri']")
     end
@@ -66,14 +70,16 @@ RSpec.describe Wikis::Admin::RedirectUriInfoComponent, type: :component do
       )
     end
 
+    it "renders a clipboard copy for the redirect uri" do
+      expect(subject).to have_css("clipboard-copy[value='#{oauth_client.redirect_uri}']")
+    end
+
     it "renders the show redirect uri button" do
       expect(subject).to have_css("a[href$='oauth_client/show_redirect_uri'][data-turbo-stream='true']")
     end
 
-    it "labels the show redirect uri button" do
-      expect(subject).to have_css("tool-tip",
-                                  text: I18n.t("wikis.admin.redirect_uri_info_component.show_redirect_uri"),
-                                  visible: :all)
+    it "does not repeat the copy instructions of the redirect uri form" do
+      expect(subject).to have_no_text(I18n.t("wikis.admin.wiki_providers.oauth.redirect_uri_caption"))
     end
   end
 end

--- a/modules/wikis/spec/requests/wikis/admin/oauth_clients_controller_spec.rb
+++ b/modules/wikis/spec/requests/wikis/admin/oauth_clients_controller_spec.rb
@@ -138,6 +138,63 @@ RSpec.describe "Admin wiki OAuth clients", :skip_csrf, type: :rails_request do
       it "updates the oauth client credentials" do
         expect(wiki_provider.reload.oauth_client.client_id).to eq("new-id")
       end
+
+      it "re-renders the redirect uri with the new client id" do
+        expect(response.body).to include(wiki_provider.reload.oauth_client.redirect_uri)
+      end
+
+      it "targets both the oauth client and the redirect uri rows" do
+        expect(response.body).to include('target="wiki_provider_oauth_client_section"',
+                                         'target="wiki_provider_redirect_uri_section"')
+      end
+    end
+  end
+
+  describe "GET /admin/settings/wiki_providers/:wiki_provider_id/oauth_client/show_redirect_uri" do
+    let!(:oauth_client) { create(:oauth_client, integration: wiki_provider) }
+    let(:send_request) do
+      get show_redirect_uri_admin_settings_wiki_provider_oauth_client_path(wiki_provider), headers: turbo_headers
+    end
+
+    it_behaves_like "an admin-only endpoint"
+
+    context "when admin" do
+      before do
+        login_as admin
+        send_request
+      end
+
+      it_behaves_like "a turbo stream response"
+
+      it "renders the redirect uri" do
+        expect(response.body).to include(oauth_client.redirect_uri)
+      end
+    end
+  end
+
+  describe "POST /admin/settings/wiki_providers/:wiki_provider_id/oauth_client/finish_setup" do
+    let!(:oauth_client) { create(:oauth_client, integration: wiki_provider) }
+    let(:send_request) do
+      post finish_setup_admin_settings_wiki_provider_oauth_client_path(wiki_provider)
+    end
+
+    it_behaves_like "an admin-only endpoint"
+
+    context "when admin" do
+      before do
+        login_as admin
+        send_request
+      end
+
+      it "redirects to the wiki provider edit page" do
+        expect(response).to redirect_to(edit_admin_settings_wiki_provider_path(wiki_provider))
+      end
+
+      it "sets a success flash" do
+        expect(flash[:op_primer_flash]).to eq(
+          { message: I18n.t("wikis.admin.wiki_providers.successful_setup"), scheme: :success }
+        )
+      end
     end
   end
 end

--- a/modules/wikis/spec/requests/wikis/admin/oauth_clients_controller_spec.rb
+++ b/modules/wikis/spec/requests/wikis/admin/oauth_clients_controller_spec.rb
@@ -143,6 +143,11 @@ RSpec.describe "Admin wiki OAuth clients", :skip_csrf, type: :rails_request do
         expect(response.body).to include(wiki_provider.reload.oauth_client.redirect_uri)
       end
 
+      it "re-renders the redirect uri with a live finish setup button" do
+        expect(response.body).to include(I18n.t(:button_finish_setup))
+        expect(response.body).not_to include(I18n.t(:button_close))
+      end
+
       it "targets both the oauth client and the redirect uri rows" do
         expect(response.body).to include('target="wiki_provider_oauth_client_section"',
                                          'target="wiki_provider_redirect_uri_section"')

--- a/modules/wikis/spec/requests/wikis/admin/oauth_clients_controller_spec.rb
+++ b/modules/wikis/spec/requests/wikis/admin/oauth_clients_controller_spec.rb
@@ -143,9 +143,8 @@ RSpec.describe "Admin wiki OAuth clients", :skip_csrf, type: :rails_request do
         expect(response.body).to include(wiki_provider.reload.oauth_client.redirect_uri)
       end
 
-      it "re-renders the redirect uri with a live finish setup button" do
+      it "re-renders the redirect uri with a finish setup button" do
         expect(response.body).to include(I18n.t(:button_finish_setup))
-        expect(response.body).not_to include(I18n.t(:button_close))
       end
 
       it "targets both the oauth client and the redirect uri rows" do
@@ -171,8 +170,8 @@ RSpec.describe "Admin wiki OAuth clients", :skip_csrf, type: :rails_request do
 
       it_behaves_like "a turbo stream response"
 
-      it "renders the redirect uri" do
-        expect(response.body).to include(oauth_client.redirect_uri)
+      it "renders the redirect uri read only" do
+        expect(response.body).to include(oauth_client.redirect_uri, I18n.t(:button_close))
       end
     end
   end


### PR DESCRIPTION
# Ticket
[XWI-167](https://community.openproject.org/projects/XWI/work_packages/XWI-167)

# What are you trying to accomplish?
- Removes `redirect_uri` from OAuth Wiki config to another step
- It was done because for now, `redirect_uri` is coupled with the client ID

## Screenshots
<img width="576" height="276" alt="Screenshot 2026-09-07 at 10 49 13" src="https://github.com/user-attachments/assets/18c09293-c0fb-4457-b113-bf22bcfdf805" />
<img width="666" height="555" alt="Screenshot 2026-09-07 at 10 49 20" src="https://github.com/user-attachments/assets/bfd95dae-0e49-478d-825f-9a87c58c9c8c" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
