### PR TITLE
Experiment: Add meetings and wiki pages to global search

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -374,12 +374,28 @@ en:
       current_project_and_all_descendants: "In this project + subprojects"
       direct_hit_available: "Work package with exact ID found. Press Enter to open it."
       items_available: "%{count} items available"
+      quick_filters:
+        accountable: "Accountable"
+        any_time: "Any time"
+        attended: "Attended"
+        closed: "Closed"
+        invited: "Invited"
+        involvement: "Involvement"
+        meeting_date: "Meeting date"
+        open: "Open"
+        past: "Past"
+        past_30_days: "Past 30 days"
+        past_7_days: "Past 7 days"
+        past_year: "Past year"
+        upcoming: "Upcoming"
+        yesterday: "Yesterday"
       recently_viewed: "Recently viewed"
-      search_placeholder_expanded: "Search work packages by subject, project, type, status or ID"
+      search_placeholder_expanded: "Search work packages, meetings and wiki pages"
       title:
         all_projects: "all projects"
         project_and_subprojects: "and all subprojects"
         search_for: "Search for"
+      wiki_pages: "Wiki pages"
 
     hal:
       error:

--- a/docs/api/apiv3/components/schemas/wiki_page_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/wiki_page_collection_model.yml
@@ -1,0 +1,27 @@
+# Schema: WikiPageCollectionModel
+---
+allOf:
+  - $ref: './paginated_collection_model.yml'
+  - type: object
+    required:
+      - _embedded
+      - _links
+    properties:
+      _embedded:
+        type: object
+        required:
+          - elements
+        properties:
+          elements:
+            type: array
+            items:
+              $ref: './wiki_page_model.yml'
+      _links:
+        type: object
+        required:
+          - self
+        properties:
+          self:
+            allOf:
+              - $ref: './link.yml'
+              - description: The link to this wiki page collection resource.

--- a/docs/api/apiv3/components/schemas/wiki_page_model.yml
+++ b/docs/api/apiv3/components/schemas/wiki_page_model.yml
@@ -15,6 +15,11 @@ properties:
   _links:
     type: object
     properties:
+      showWikiPage:
+        allOf:
+        - "$ref": "./link.yml"
+        - description: Open this wiki page in the web application
+          readOnly: true
       addAttachment:
         allOf:
         - "$ref": "./link.yml"

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -569,6 +569,8 @@ paths:
     "$ref": "./paths/views.yml"
   "/api/v3/views/{id}":
     "$ref": "./paths/view.yml"
+  "/api/v3/wiki_pages":
+    "$ref": "./paths/wiki_pages.yml"
   "/api/v3/wiki_pages/{id}":
     "$ref": "./paths/wiki_page.yml"
   "/api/v3/wiki_pages/{id}/attachments":
@@ -1160,6 +1162,8 @@ components:
       "$ref": "./components/schemas/week_day_write_model.yml"
     Wiki_PageModel:
       "$ref": "./components/schemas/wiki_page_model.yml"
+    WikiPageCollectionModel:
+      "$ref": "./components/schemas/wiki_page_collection_model.yml"
     WorkPackageModel:
       "$ref": "./components/schemas/work_package_model.yml"
     WorkPackageFormModel:

--- a/docs/api/apiv3/paths/meetings.yml
+++ b/docs/api/apiv3/paths/meetings.yml
@@ -7,6 +7,30 @@ get:
     - Meetings
   description: |-
     Retrieve a paginated collection of meetings visible to the authenticated user.
+  parameters:
+    - name: offset
+      in: query
+      required: false
+      description: Page number inside the requested collection.
+      schema:
+        type: integer
+        default: 1
+    - name: pageSize
+      in: query
+      required: false
+      description: Number of elements to display per page.
+      schema:
+        type: integer
+    - name: filters
+      in: query
+      required: false
+      description: |-
+        JSON specifying filter conditions. The `search` filter with the `**` operator searches meeting titles,
+        agenda item titles and notes, and outcome notes. Results always remain restricted to meetings visible to
+        the authenticated user.
+      example: '[{ "search": { "operator": "**", "values": ["quarterly planning"] } }]'
+      schema:
+        type: string
   responses:
     '200':
       description: OK

--- a/docs/api/apiv3/paths/wiki_pages.yml
+++ b/docs/api/apiv3/paths/wiki_pages.yml
@@ -1,0 +1,41 @@
+# /api/v3/wiki_pages
+---
+get:
+  summary: List visible wiki pages
+  operationId: list_wiki_pages
+  tags:
+    - Wiki Pages
+  description: |-
+    Retrieve a paginated collection of wiki pages in projects where the authenticated user may view the wiki.
+  parameters:
+    - name: offset
+      in: query
+      required: false
+      description: Page number inside the requested collection.
+      schema:
+        type: integer
+        default: 1
+    - name: pageSize
+      in: query
+      required: false
+      description: Number of elements to display per page.
+      schema:
+        type: integer
+    - name: filters
+      in: query
+      required: false
+      description: |-
+        JSON specifying filter conditions. The `search` filter with the `**` operator searches wiki page titles
+        and text. Results always remain restricted to pages visible to the authenticated user.
+      example: '[{ "search": { "operator": "**", "values": ["release plan"] } }]'
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/wiki_page_collection_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"

--- a/docs/api/apiv3/tags/wiki_pages.yml
+++ b/docs/api/apiv3/tags/wiki_pages.yml
@@ -2,8 +2,6 @@
 description: |-
   Represents an individual page in a project's wiki.
 
-  *This resource is currently a stub*
-
   ## Actions
 
   | Link                | Description                                                          | Condition                                                                                                                        |
@@ -17,6 +15,7 @@ description: |-
   | self             | This wiki page                                         | WikiPage    | not null       | READ                 |
   | attachments      | The files attached to this wiki page                   | Collection  |                | READ                 |
   | project          | The project the wiki page belongs to                   | Project     | not null       | READ                 |
+  | showWikiPage     | Open the wiki page in the web application              | Link        | not null       | READ                 |
 
   ## Local Properties
 

--- a/frontend/src/app/core/apiv3/api-v3.service.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.ts
@@ -127,6 +127,9 @@ export class ApiV3Service {
   // /api/v3/meetings
   public readonly meetings = this.apiV3CollectionEndpoint('meetings');
 
+  // /api/v3/wiki_pages
+  public readonly wiki_pages = this.apiV3CollectionEndpoint('wiki_pages');
+
   // /api/v3/memberships
   public readonly memberships = this.apiV3CustomEndpoint(ApiV3MembershipsPaths);
 

--- a/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
@@ -114,8 +114,13 @@ export class ApiV3WorkPackagesPaths extends ApiV3Collection<WorkPackageResource,
    * @param idOnly
    * @param additionalParams Additional set of params to the API
    */
-  public filterByTypeaheadOrId(term:string, idOnly = false, additionalParams:Record<string, string> = {}):ApiV3WorkPackageCachedSubresource {
-    const filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
+  public filterByTypeaheadOrId(
+    term:string,
+    idOnly = false,
+    additionalParams:Record<string, string> = {},
+    additionalFilters:ApiV3FilterBuilder = new ApiV3FilterBuilder(),
+  ):ApiV3WorkPackageCachedSubresource {
+    const filters = additionalFilters.clone();
 
     if (idOnly) {
       filters.add('id', '=', [term]);

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -46,7 +46,7 @@
     [searchFn]="customSearchFn"
     [virtualScroll]="false"
     (focus)="onFocus()"
-    (blur)="onFocusOut()"
+    (blur)="onFocusOut($event)"
     (search)="search($event)"
     (close)="onClose()"
     (change)="followItem($event)"
@@ -62,29 +62,120 @@
       @if (!searchTerm && (hasRecentItems$ | async)) {
         <div>{{text.recently_viewed}}</div>
       }
+      <div class="global-search--toolbar">
+          <div class="global-search--tabs" role="tablist">
+            @for (resultType of resultTypes; track resultType) {
+              <button
+                type="button"
+                class="global-search--tab"
+                role="tab"
+                [class.-selected]="activeResultType === resultType"
+                [attr.aria-selected]="activeResultType === resultType"
+                (mousedown)="$event.preventDefault()"
+                (click)="$event.stopPropagation(); selectResultType(resultType)"
+              >{{ text[resultType] }}</button>
+            }
+          </div>
+          <select
+            class="global-search--project-scope-select"
+            [attr.aria-label]="text.project"
+            [value]="selectedProjectScope"
+            (mousedown)="onProjectScopeMouseDown($event)"
+            (click)="$event.stopPropagation()"
+            (blur)="onProjectScopeBlur()"
+            (change)="selectProjectScope($event)"
+          >
+            @for (projectScope of projectScopes; track projectScope) {
+              <option [value]="projectScope">{{ text[projectScope] }}</option>
+            }
+          </select>
+        </div>
+      <div class="global-search--quick-filters">
+            <div class="global-search--quick-filter-group">
+              <span class="global-search--quick-filter-label">{{ text.last_updated }}</span>
+              @for (filter of lastUpdatedFilters; track filter) {
+                <button
+                  type="button"
+                  class="global-search--quick-filter"
+                  [class.-selected]="selectedLastUpdatedFilter === filter"
+                  [attr.aria-pressed]="selectedLastUpdatedFilter === filter"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="$event.stopPropagation(); selectLastUpdatedFilter(filter)"
+                >{{ text[filter] }}</button>
+              }
+            </div>
+          @if (activeResultType === 'work_packages') {
+            <div class="global-search--quick-filter-group">
+              <span class="global-search--quick-filter-label">{{ text.status }}</span>
+              @for (filter of workPackageStatusFilters; track filter) {
+                <button
+                  type="button"
+                  class="global-search--quick-filter"
+                  [class.-selected]="selectedWorkPackageStatusFilter === filter"
+                  [attr.aria-pressed]="selectedWorkPackageStatusFilter === filter"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="$event.stopPropagation(); selectWorkPackageStatusFilter(filter)"
+                >{{ text[filter] }}</button>
+              }
+            </div>
+            <div class="global-search--quick-filter-group">
+              <span class="global-search--quick-filter-label">{{ text.involvement }}</span>
+              @for (filter of workPackageInvolvementFilters; track filter) {
+                <button
+                  type="button"
+                  class="global-search--quick-filter"
+                  [class.-selected]="selectedWorkPackageInvolvementFilter === filter"
+                  [attr.aria-pressed]="selectedWorkPackageInvolvementFilter === filter"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="$event.stopPropagation(); selectWorkPackageInvolvementFilter(filter)"
+                >{{ text[filter] }}</button>
+              }
+            </div>
+          }
+          @if (activeResultType === 'meetings') {
+            <div class="global-search--quick-filter-group">
+              <span class="global-search--quick-filter-label">{{ text.meeting_date }}</span>
+              @for (filter of meetingTimeFilters; track filter) {
+                <button
+                  type="button"
+                  class="global-search--quick-filter"
+                  [class.-selected]="selectedMeetingTimeFilter === filter"
+                  [attr.aria-pressed]="selectedMeetingTimeFilter === filter"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="$event.stopPropagation(); selectMeetingTimeFilter(filter)"
+                >{{ text[filter] }}</button>
+              }
+            </div>
+            <div class="global-search--quick-filter-group">
+              <span class="global-search--quick-filter-label">{{ text.involvement }}</span>
+              @for (filter of meetingInvolvementFilters; track filter) {
+                <button
+                  type="button"
+                  class="global-search--quick-filter"
+                  [class.-selected]="selectedMeetingInvolvementFilter === filter"
+                  [attr.aria-pressed]="selectedMeetingInvolvementFilter === filter"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="$event.stopPropagation(); selectMeetingInvolvementFilter(filter)"
+                >{{ text[filter] }}</button>
+              }
+            </div>
+          }
+      </div>
     </ng-template>
     <ng-template op-autocompleter-option-tmp let-item let-index="index" let-search="searchTerm">
-      @if (!item.id) {
-        <div>
-          <a tabindex="0"
-             href="#"
-             class="global-search--option"
-             (click)="$event.preventDefault(); followItem(item)"
-             (keydown.enter)="$event.preventDefault(); followItem(item)"
-             (keydown.space)="$event.preventDefault(); followItem(item)">
-            <div class="global-search--search-term">{{ currentValue }}</div>
-            <div class="global-search--project-scope" title="{{ item.projectScope }}">{{ item.text }} ↵</div>
-          </a>
-        </div>
-      } @else {
-        <a
-          class="global-search--option"
-          [href]="wpPath(item.displayId)"
-          (click)="redirectToWp(item.displayId, $event)"
-          style="line-height: 1"
-          >
-          <div class="global-search--option-meta">
-            <div class="global-search--wp-line">
+      <a
+        class="global-search--option global-search--result-card"
+        [href]="resultPath(item)"
+        (click)="redirectToResult(item, $event)"
+      >
+        <span class="global-search--result-icon" aria-hidden="true">
+          <svg octicon [icon]="resultIcon(item)" size="small"></svg>
+        </span>
+        <div class="global-search--option-meta">
+          <div class="global-search--result-kind-line">
+            <span class="global-search--result-kind">{{ resultTypeLabel(item) }}</span>
+            @if (isWorkPackage(item)) {
+              <span aria-hidden="true">·</span>
               <span [ngClass]="highlighting('type', item.type.id)">
                 {{ item.type.name }}
               </span>
@@ -92,20 +183,12 @@
               <span [ngClass]="statusHighlighting(item.status.id)">
                 {{ item.status.name }}
               </span>
-              <span>-</span>
-              <span
-                class="global-search--wp-project"
-                [attr.title]="item.project.name"
-                >
-                {{ item.project.name }}
-              </span>
-            </div>
-            <span class="global-search--wp-subject">
-              {{ item.subject }}
-            </span>
+            }
           </div>
-        </a>
-      }
+          <span class="global-search--result-title">{{ resultTitle(item) }}</span>
+          <span class="global-search--result-project">{{ item.project.name }}</span>
+        </div>
+      </a>
     </ng-template>
   </op-autocompleter>
 </div>

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -91,74 +91,94 @@
           </select>
         </div>
       <div class="global-search--quick-filters">
-            <div class="global-search--quick-filter-group">
-              <span class="global-search--quick-filter-label">{{ text.last_updated }}</span>
-              @for (filter of lastUpdatedFilters; track filter) {
-                <button
-                  type="button"
-                  class="global-search--quick-filter"
-                  [class.-selected]="selectedLastUpdatedFilter === filter"
-                  [attr.aria-pressed]="selectedLastUpdatedFilter === filter"
-                  (mousedown)="$event.preventDefault()"
-                  (click)="$event.stopPropagation(); selectLastUpdatedFilter(filter)"
-                >{{ text[filter] }}</button>
-              }
-            </div>
+          <label class="global-search--quick-filter-field">
+            <span class="global-search--quick-filter-label">{{ text.last_updated }}</span>
+            <span class="FormControl-select-wrap">
+              <select
+                class="FormControl-select FormControl-small"
+                [value]="selectedLastUpdatedFilter"
+                (mousedown)="onProjectScopeMouseDown($event)"
+                (click)="$event.stopPropagation()"
+                (blur)="onProjectScopeBlur()"
+                (change)="selectLastUpdatedFilter($event)"
+              >
+                @for (filter of lastUpdatedFilters; track filter) {
+                  <option [value]="filter">{{ text[filter] }}</option>
+                }
+              </select>
+            </span>
+          </label>
           @if (activeResultType === 'work_packages') {
-            <div class="global-search--quick-filter-group">
+            <label class="global-search--quick-filter-field">
               <span class="global-search--quick-filter-label">{{ text.status }}</span>
-              @for (filter of workPackageStatusFilters; track filter) {
-                <button
-                  type="button"
-                  class="global-search--quick-filter"
-                  [class.-selected]="selectedWorkPackageStatusFilter === filter"
-                  [attr.aria-pressed]="selectedWorkPackageStatusFilter === filter"
-                  (mousedown)="$event.preventDefault()"
-                  (click)="$event.stopPropagation(); selectWorkPackageStatusFilter(filter)"
-                >{{ text[filter] }}</button>
-              }
-            </div>
-            <div class="global-search--quick-filter-group">
+              <span class="FormControl-select-wrap">
+                <select
+                  class="FormControl-select FormControl-small"
+                  [value]="selectedWorkPackageStatusFilter"
+                  (mousedown)="onProjectScopeMouseDown($event)"
+                  (click)="$event.stopPropagation()"
+                  (blur)="onProjectScopeBlur()"
+                  (change)="selectWorkPackageStatusFilter($event)"
+                >
+                  @for (filter of workPackageStatusFilters; track filter) {
+                    <option [value]="filter">{{ text[filter] }}</option>
+                  }
+                </select>
+              </span>
+            </label>
+            <label class="global-search--quick-filter-field">
               <span class="global-search--quick-filter-label">{{ text.involvement }}</span>
-              @for (filter of workPackageInvolvementFilters; track filter) {
-                <button
-                  type="button"
-                  class="global-search--quick-filter"
-                  [class.-selected]="selectedWorkPackageInvolvementFilter === filter"
-                  [attr.aria-pressed]="selectedWorkPackageInvolvementFilter === filter"
-                  (mousedown)="$event.preventDefault()"
-                  (click)="$event.stopPropagation(); selectWorkPackageInvolvementFilter(filter)"
-                >{{ text[filter] }}</button>
-              }
-            </div>
+              <span class="FormControl-select-wrap">
+                <select
+                  class="FormControl-select FormControl-small"
+                  [value]="selectedWorkPackageInvolvementFilter"
+                  (mousedown)="onProjectScopeMouseDown($event)"
+                  (click)="$event.stopPropagation()"
+                  (blur)="onProjectScopeBlur()"
+                  (change)="selectWorkPackageInvolvementFilter($event)"
+                >
+                  @for (filter of workPackageInvolvementFilters; track filter) {
+                    <option [value]="filter">{{ text[filter] }}</option>
+                  }
+                </select>
+              </span>
+            </label>
           }
           @if (activeResultType === 'meetings') {
-            <div class="global-search--quick-filter-group">
+            <label class="global-search--quick-filter-field">
               <span class="global-search--quick-filter-label">{{ text.meeting_date }}</span>
-              @for (filter of meetingTimeFilters; track filter) {
-                <button
-                  type="button"
-                  class="global-search--quick-filter"
-                  [class.-selected]="selectedMeetingTimeFilter === filter"
-                  [attr.aria-pressed]="selectedMeetingTimeFilter === filter"
-                  (mousedown)="$event.preventDefault()"
-                  (click)="$event.stopPropagation(); selectMeetingTimeFilter(filter)"
-                >{{ text[filter] }}</button>
-              }
-            </div>
-            <div class="global-search--quick-filter-group">
+              <span class="FormControl-select-wrap">
+                <select
+                  class="FormControl-select FormControl-small"
+                  [value]="selectedMeetingTimeFilter"
+                  (mousedown)="onProjectScopeMouseDown($event)"
+                  (click)="$event.stopPropagation()"
+                  (blur)="onProjectScopeBlur()"
+                  (change)="selectMeetingTimeFilter($event)"
+                >
+                  @for (filter of meetingTimeFilters; track filter) {
+                    <option [value]="filter">{{ text[filter] }}</option>
+                  }
+                </select>
+              </span>
+            </label>
+            <label class="global-search--quick-filter-field">
               <span class="global-search--quick-filter-label">{{ text.involvement }}</span>
-              @for (filter of meetingInvolvementFilters; track filter) {
-                <button
-                  type="button"
-                  class="global-search--quick-filter"
-                  [class.-selected]="selectedMeetingInvolvementFilter === filter"
-                  [attr.aria-pressed]="selectedMeetingInvolvementFilter === filter"
-                  (mousedown)="$event.preventDefault()"
-                  (click)="$event.stopPropagation(); selectMeetingInvolvementFilter(filter)"
-                >{{ text[filter] }}</button>
-              }
-            </div>
+              <span class="FormControl-select-wrap">
+                <select
+                  class="FormControl-select FormControl-small"
+                  [value]="selectedMeetingInvolvementFilter"
+                  (mousedown)="onProjectScopeMouseDown($event)"
+                  (click)="$event.stopPropagation()"
+                  (blur)="onProjectScopeBlur()"
+                  (change)="selectMeetingInvolvementFilter($event)"
+                >
+                  @for (filter of meetingInvolvementFilters; track filter) {
+                    <option [value]="filter">{{ text[filter] }}</option>
+                  }
+                </select>
+              </span>
+            </label>
           }
       </div>
     </ng-template>

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -91,94 +91,44 @@
           </select>
         </div>
       <div class="global-search--quick-filters">
-          <label class="global-search--quick-filter-field">
-            <span class="global-search--quick-filter-label">{{ text.last_updated }}</span>
-            <span class="FormControl-select-wrap">
-              <select
-                class="FormControl-select FormControl-small"
-                [value]="selectedLastUpdatedFilter"
-                (mousedown)="onProjectScopeMouseDown($event)"
-                (click)="$event.stopPropagation()"
-                (blur)="onProjectScopeBlur()"
-                (change)="selectLastUpdatedFilter($event)"
-              >
-                @for (filter of lastUpdatedFilters; track filter) {
-                  <option [value]="filter">{{ text[filter] }}</option>
-                }
-              </select>
-            </span>
-          </label>
+          <op-global-search-quick-filter
+            [label]="text.last_updated"
+            [options]="lastUpdatedFilters"
+            [labels]="text"
+            [selectedValue]="selectedLastUpdatedFilter"
+            (valueChange)="selectLastUpdatedFilter($event)"
+          />
           @if (activeResultType === 'work_packages') {
-            <label class="global-search--quick-filter-field">
-              <span class="global-search--quick-filter-label">{{ text.status }}</span>
-              <span class="FormControl-select-wrap">
-                <select
-                  class="FormControl-select FormControl-small"
-                  [value]="selectedWorkPackageStatusFilter"
-                  (mousedown)="onProjectScopeMouseDown($event)"
-                  (click)="$event.stopPropagation()"
-                  (blur)="onProjectScopeBlur()"
-                  (change)="selectWorkPackageStatusFilter($event)"
-                >
-                  @for (filter of workPackageStatusFilters; track filter) {
-                    <option [value]="filter">{{ text[filter] }}</option>
-                  }
-                </select>
-              </span>
-            </label>
-            <label class="global-search--quick-filter-field">
-              <span class="global-search--quick-filter-label">{{ text.involvement }}</span>
-              <span class="FormControl-select-wrap">
-                <select
-                  class="FormControl-select FormControl-small"
-                  [value]="selectedWorkPackageInvolvementFilter"
-                  (mousedown)="onProjectScopeMouseDown($event)"
-                  (click)="$event.stopPropagation()"
-                  (blur)="onProjectScopeBlur()"
-                  (change)="selectWorkPackageInvolvementFilter($event)"
-                >
-                  @for (filter of workPackageInvolvementFilters; track filter) {
-                    <option [value]="filter">{{ text[filter] }}</option>
-                  }
-                </select>
-              </span>
-            </label>
+            <op-global-search-quick-filter
+              [label]="text.status"
+              [options]="workPackageStatusFilters"
+              [labels]="text"
+              [selectedValue]="selectedWorkPackageStatusFilter"
+              (valueChange)="selectWorkPackageStatusFilter($event)"
+            />
+            <op-global-search-quick-filter
+              [label]="text.involvement"
+              [options]="workPackageInvolvementFilters"
+              [labels]="text"
+              [selectedValue]="selectedWorkPackageInvolvementFilter"
+              (valueChange)="selectWorkPackageInvolvementFilter($event)"
+            />
           }
           @if (activeResultType === 'meetings') {
-            <label class="global-search--quick-filter-field">
-              <span class="global-search--quick-filter-label">{{ text.meeting_date }}</span>
-              <span class="FormControl-select-wrap">
-                <select
-                  class="FormControl-select FormControl-small"
-                  [value]="selectedMeetingTimeFilter"
-                  (mousedown)="onProjectScopeMouseDown($event)"
-                  (click)="$event.stopPropagation()"
-                  (blur)="onProjectScopeBlur()"
-                  (change)="selectMeetingTimeFilter($event)"
-                >
-                  @for (filter of meetingTimeFilters; track filter) {
-                    <option [value]="filter">{{ text[filter] }}</option>
-                  }
-                </select>
-              </span>
-            </label>
-            <label class="global-search--quick-filter-field">
-              <span class="global-search--quick-filter-label">{{ text.involvement }}</span>
-              <span class="FormControl-select-wrap">
-                <select
-                  class="FormControl-select FormControl-small"
-                  [value]="selectedMeetingInvolvementFilter"
-                  (mousedown)="onProjectScopeMouseDown($event)"
-                  (click)="$event.stopPropagation()"
-                  (blur)="onProjectScopeBlur()"
-                  (change)="selectMeetingInvolvementFilter($event)"
-                >
-                  @for (filter of meetingInvolvementFilters; track filter) {
-                    <option [value]="filter">{{ text[filter] }}</option>
-                  }
-                </select>
-              </span>
-            </label>
+            <op-global-search-quick-filter
+              [label]="text.meeting_date"
+              [options]="meetingTimeFilters"
+              [labels]="text"
+              [selectedValue]="selectedMeetingTimeFilter"
+              (valueChange)="selectMeetingTimeFilter($event)"
+            />
+            <op-global-search-quick-filter
+              [label]="text.involvement"
+              [options]="meetingInvolvementFilters"
+              [labels]="text"
+              [selectedValue]="selectedMeetingInvolvementFilter"
+              (valueChange)="selectMeetingInvolvementFilter($event)"
+            />
           }
       </div>
     </ng-template>

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -2,7 +2,7 @@
 
 // search bar has a min-width of 300px and should adapt to every screen size
 $search-input-width: calc(300px + 3vw)
-$search-input-width-expanded: 500px
+$search-input-width-expanded: min(740px, calc(100vw - 280px))
 $search-input-height: 30px
 
 .top-menu-search
@@ -109,6 +109,120 @@ $search-input-height: 30px
       &:empty
         display: none
 
+    .global-search--toolbar
+      display: flex
+      align-items: center
+      justify-content: space-between
+      margin: -0.5rem -0.75rem
+      padding: 0 var(--base-size-8) 0 var(--base-size-16)
+      border-bottom: 1px solid var(--borderColor-default)
+      text-transform: none
+
+    .global-search--tabs
+      display: flex
+      gap: var(--base-size-24)
+
+    .global-search--tab
+      @include unset-button-styles
+      padding: var(--base-size-12) 0 var(--base-size-8)
+      color: var(--fgColor-muted)
+      border-bottom: 2px solid transparent
+      font-weight: var(--base-text-weight-semibold)
+
+      &:hover
+        color: var(--fgColor-default)
+
+      &.-selected
+        color: var(--fgColor-default)
+        border-bottom-color: var(--borderColor-accent-emphasis)
+
+    .global-search--project-scope-select
+      max-width: 230px
+      padding: var(--base-size-4) var(--base-size-24) var(--base-size-4) var(--base-size-8)
+      color: var(--fgColor-default)
+      background-color: var(--bgColor-default)
+      border: 1px solid var(--borderColor-default)
+      border-radius: var(--borderRadius-small)
+      font-size: var(--text-body-size-small)
+
+    .global-search--quick-filters
+      display: flex
+      flex-direction: column
+      gap: var(--base-size-8)
+      margin: var(--base-size-8) -0.75rem -0.5rem
+      padding: var(--base-size-8) var(--base-size-16)
+      background-color: var(--bgColor-muted)
+      border-bottom: 1px solid var(--borderColor-default)
+      text-transform: none
+
+    .global-search--quick-filter-group
+      display: flex
+      align-items: center
+      flex-wrap: wrap
+      gap: var(--base-size-8)
+
+    .global-search--quick-filter-label
+      min-width: 105px
+      color: var(--fgColor-muted)
+      font-size: var(--text-body-size-small)
+      font-weight: var(--base-text-weight-semibold)
+
+    .global-search--quick-filter
+      @include unset-button-styles
+      padding: var(--base-size-4) var(--base-size-8)
+      color: var(--fgColor-muted)
+      background-color: var(--control-transparent-bgColor-rest)
+      border: 1px solid transparent
+      border-radius: 999px
+      font-size: var(--text-body-size-small)
+
+      &:hover
+        color: var(--fgColor-default)
+        background-color: var(--control-transparent-bgColor-hover)
+
+      &.-selected
+        color: var(--fgColor-accent)
+        background-color: var(--bgColor-accent-muted)
+        border-color: var(--borderColor-accent-emphasis)
+
+    .global-search--result-card,
+    .global-search--result-card:hover
+      display: flex
+      align-items: flex-start
+      gap: var(--base-size-12)
+      line-height: 1.25
+
+    .global-search--result-icon
+      display: flex
+      align-items: center
+      justify-content: center
+      width: var(--base-size-24)
+      min-width: var(--base-size-24)
+      height: var(--base-size-24)
+      margin-top: var(--base-size-4)
+      color: var(--fgColor-muted)
+
+    .global-search--result-kind-line
+      display: flex
+      align-items: center
+      gap: var(--base-size-4)
+      min-height: var(--base-size-20)
+      color: var(--fgColor-muted)
+      font-size: var(--text-body-size-small)
+
+    .global-search--result-kind
+      color: var(--fgColor-accent)
+      font-weight: var(--base-text-weight-semibold)
+      text-transform: uppercase
+
+    .global-search--result-title
+      color: var(--fgColor-default)
+      font-weight: var(--base-text-weight-medium)
+
+    .global-search--result-project
+      color: var(--fgColor-muted)
+      font-size: var(--text-body-size-small)
+
     .ng-dropdown-panel-items.scroll-host
       @include styled-scroll-bar
       max-height: 80vh
@@ -116,6 +230,8 @@ $search-input-height: 30px
 
     .ng-dropdown-panel
       width: $search-input-width-expanded !important
+      border-radius: 0 0 var(--borderRadius-medium) var(--borderRadius-medium)
+      box-shadow: var(--shadow-floating-small)
 
     .ng-option
       border-bottom: 1px solid var(--borderColor-default)

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -147,7 +147,7 @@ $search-input-height: 30px
 
     .global-search--quick-filters
       display: flex
-      align-items: flex-end
+      align-items: center
       flex-wrap: wrap
       gap: var(--base-size-8)
       margin: var(--base-size-8) -0.75rem -0.5rem
@@ -155,19 +155,6 @@ $search-input-height: 30px
       background-color: var(--bgColor-muted)
       border-bottom: 1px solid var(--borderColor-default)
       text-transform: none
-
-    .global-search--quick-filter-field
-      display: flex
-      flex-direction: column
-      gap: var(--base-size-4)
-
-      .FormControl-select-wrap
-        min-width: 150px
-
-    .global-search--quick-filter-label
-      color: var(--fgColor-muted)
-      font-size: var(--text-body-size-small)
-      font-weight: var(--base-text-weight-semibold)
 
     .global-search--result-card,
     .global-search--result-card:hover

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -147,7 +147,8 @@ $search-input-height: 30px
 
     .global-search--quick-filters
       display: flex
-      flex-direction: column
+      align-items: flex-end
+      flex-wrap: wrap
       gap: var(--base-size-8)
       margin: var(--base-size-8) -0.75rem -0.5rem
       padding: var(--base-size-8) var(--base-size-16)
@@ -155,35 +156,18 @@ $search-input-height: 30px
       border-bottom: 1px solid var(--borderColor-default)
       text-transform: none
 
-    .global-search--quick-filter-group
+    .global-search--quick-filter-field
       display: flex
-      align-items: center
-      flex-wrap: wrap
-      gap: var(--base-size-8)
+      flex-direction: column
+      gap: var(--base-size-4)
+
+      .FormControl-select-wrap
+        min-width: 150px
 
     .global-search--quick-filter-label
-      min-width: 105px
       color: var(--fgColor-muted)
       font-size: var(--text-body-size-small)
       font-weight: var(--base-text-weight-semibold)
-
-    .global-search--quick-filter
-      @include unset-button-styles
-      padding: var(--base-size-4) var(--base-size-8)
-      color: var(--fgColor-muted)
-      background-color: var(--control-transparent-bgColor-rest)
-      border: 1px solid transparent
-      border-radius: 999px
-      font-size: var(--text-body-size-small)
-
-      &:hover
-        color: var(--fgColor-default)
-        background-color: var(--control-transparent-bgColor-hover)
-
-      &.-selected
-        color: var(--fgColor-accent)
-        background-color: var(--bgColor-accent-muted)
-        border-color: var(--borderColor-accent-emphasis)
 
     .global-search--result-card,
     .global-search--result-card:hover

--- a/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
@@ -28,14 +28,80 @@
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { GlobalSearchInputComponent } from './global-search-input.component';
+import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
+import { WikiPageResource } from 'core-app/features/hal/resources/wiki-page-resource';
+import {
+  GlobalSearchInputComponent,
+  lastUpdatedRange,
+  searchResultMatchesType,
+} from './global-search-input.component';
+
+describe('lastUpdatedRange', () => {
+  const now = new Date(2026, 8, 5, 14, 30);
+  const startOfToday = new Date(2026, 8, 5);
+
+  it('does not add a range for any time', () => {
+    expect(lastUpdatedRange('any_time', now)).toBeUndefined();
+  });
+
+  it('uses the local start of today for today', () => {
+    expect(lastUpdatedRange('today', now)).toEqual([
+      startOfToday.toISOString(),
+      '',
+    ]);
+  });
+
+  it('bounds yesterday between two local midnights', () => {
+    expect(lastUpdatedRange('yesterday', now)).toEqual([
+      new Date(2026, 8, 4).toISOString(),
+      startOfToday.toISOString(),
+    ]);
+  });
+
+  it('uses rolling periods relative to the current time', () => {
+    expect(lastUpdatedRange('past_7_days', now)?.[0]).toBe(
+      new Date(2026, 7, 29, 14, 30).toISOString(),
+    );
+    expect(lastUpdatedRange('past_30_days', now)?.[0]).toBe(
+      new Date(2026, 7, 6, 14, 30).toISOString(),
+    );
+    expect(lastUpdatedRange('past_year', now)?.[0]).toBe(
+      new Date(2025, 8, 5, 14, 30).toISOString(),
+    );
+  });
+});
+
+describe('searchResultMatchesType', () => {
+  const workPackage = Object.create(WorkPackageResource.prototype) as WorkPackageResource;
+  const meeting = Object.create(MeetingResource.prototype) as MeetingResource;
+  const wikiPage = Object.create(WikiPageResource.prototype) as WikiPageResource;
+
+  it('shows every resource in the all tab', () => {
+    expect([workPackage, meeting, wikiPage].every((item) => searchResultMatchesType('all', item))).toBe(true);
+  });
+
+  it('shows only work packages in the work packages tab', () => {
+    expect(searchResultMatchesType('work_packages', workPackage)).toBe(true);
+    expect(searchResultMatchesType('work_packages', meeting)).toBe(false);
+    expect(searchResultMatchesType('work_packages', wikiPage)).toBe(false);
+  });
+
+  it('shows only the selected content type in the other tabs', () => {
+    expect(searchResultMatchesType('meetings', meeting)).toBe(true);
+    expect(searchResultMatchesType('meetings', wikiPage)).toBe(false);
+    expect(searchResultMatchesType('wiki_pages', wikiPage)).toBe(true);
+    expect(searchResultMatchesType('wiki_pages', meeting)).toBe(false);
+  });
+});
 
 // followItem is verified through the prototype against a stand-in context, avoiding
 // a real component instance whose many injected dependencies this branch never uses.
 describe('GlobalSearchInputComponent#followItem', () => {
   let wpPathArgs:string[];
-  let searchInScopeArgs:string[];
-  let context:Pick<GlobalSearchInputComponent, 'wpPath'|'selectedItem'> & { searchInScope:(scope:string) => void };
+  let context:Pick<
+    GlobalSearchInputComponent,
+    'wpPath'|'selectedItem'|'isWorkPackage'|'isMeeting'|'isWikiPage'
+  >;
 
   function callFollowItem(item:Parameters<GlobalSearchInputComponent['followItem']>[0]):void {
     GlobalSearchInputComponent.prototype.followItem.call(context, item);
@@ -43,7 +109,6 @@ describe('GlobalSearchInputComponent#followItem', () => {
 
   beforeEach(() => {
     wpPathArgs = [];
-    searchInScopeArgs = [];
     context = {
       wpPath: (id:string):string => {
         wpPathArgs.push(id);
@@ -51,9 +116,9 @@ describe('GlobalSearchInputComponent#followItem', () => {
         return '#stub';
       },
       selectedItem: undefined,
-      searchInScope: (scope:string):void => {
-        searchInScopeArgs.push(scope);
-      },
+      isWorkPackage: (item):item is WorkPackageResource => item instanceof WorkPackageResource,
+      isMeeting: (_item):_item is MeetingResource => false,
+      isWikiPage: (_item):_item is WikiPageResource => false,
     };
   });
 
@@ -97,19 +162,46 @@ describe('GlobalSearchInputComponent#followItem', () => {
     });
   });
 
-  describe('when item is a scope option (not a HalResource)', () => {
-    it('delegates to searchInScope and does not call wpPath', () => {
-      callFollowItem({ projectScope: 'current_project', text: 'In this project ↵' });
-      expect(searchInScopeArgs).toEqual(['current_project']);
-      expect(wpPathArgs).toEqual([]);
-    });
-  });
-
   describe('when item is undefined', () => {
     it('does nothing', () => {
       callFollowItem(undefined);
       expect(wpPathArgs).toEqual([]);
-      expect(searchInScopeArgs).toEqual([]);
     });
+  });
+});
+
+describe('GlobalSearchInputComponent#onFocusOut', () => {
+  it('keeps the search open when focus moves to the project scope selector', () => {
+    const componentElement = document.createElement('div');
+    const projectScopeSelect = document.createElement('select');
+    componentElement.append(projectScopeSelect);
+
+    let setOpenCalled = false;
+    const context = {
+      elementRef: { nativeElement: componentElement },
+      ngSelectComponent: {
+        ngSelectInstance: {
+          isOpen: {
+            set: (_value:boolean):void => {
+              setOpenCalled = true;
+            },
+          },
+        },
+      },
+    };
+    const event = { relatedTarget: null } as unknown as FocusEvent;
+    const mouseDownEvent = new MouseEvent('mousedown');
+
+    GlobalSearchInputComponent.prototype.onProjectScopeMouseDown.call(
+      context as unknown as GlobalSearchInputComponent,
+      mouseDownEvent,
+    );
+
+    GlobalSearchInputComponent.prototype.onFocusOut.call(
+      context as unknown as GlobalSearchInputComponent,
+      event,
+    );
+
+    expect(setOpenCalled).toBe(false);
   });
 });

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -27,8 +27,8 @@
 //++
 
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, Input, OnDestroy, ViewChild, ViewEncapsulation, inject } from '@angular/core';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { first, map, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, forkJoin, Observable, of } from 'rxjs';
+import { catchError, first, map, switchMap } from 'rxjs/operators';
 import { GlobalSearchService } from 'core-app/core/global_search/services/global-search.service';
 import { isClickedWithModifier } from 'core-app/shared/helpers/link-handling/link-handling';
 import {
@@ -55,26 +55,59 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { announce } from '@primer/live-region-element';
 import { NgOption } from '@ng-select/ng-select';
+import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
+import { WikiPageResource } from 'core-app/features/hal/resources/wiki-page-resource';
+import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 
-interface SearchResultItem {
-  id:string;
-  subject:string;
-  status:string;
-  statusId:string;
-  href:string;
-  project:string;
-  author:HalResource;
+export type SearchResultType = 'all'|'work_packages'|'meetings'|'wiki_pages';
+type GlobalSearchResult = WorkPackageResource|MeetingResource|WikiPageResource;
+type ProjectScope = 'all_projects'|'current_project'|'current_project_and_all_descendants';
+type LastUpdatedFilter = 'any_time'|'today'|'yesterday'|'past_7_days'|'past_30_days'|'past_year';
+type WorkPackageStatusFilter = 'all'|'open'|'closed';
+type WorkPackageInvolvementFilter = 'all'|'assigned_to_me'|'created_by_me'|'accountable';
+type MeetingTimeFilter = 'all'|'upcoming'|'past';
+type MeetingInvolvementFilter = 'all'|'invited'|'created_by_me'|'attended';
+
+export function lastUpdatedRange(
+  filter:LastUpdatedFilter,
+  now = new Date(),
+):[string, string]|undefined {
+  if (filter === 'any_time') {
+    return undefined;
+  }
+
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+
+  if (filter === 'today') {
+    return [startOfToday.toISOString(), ''];
+  }
+
+  if (filter === 'yesterday') {
+    const startOfYesterday = new Date(startOfToday);
+    startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+    return [startOfYesterday.toISOString(), startOfToday.toISOString()];
+  }
+
+  const start = new Date(now);
+  if (filter === 'past_year') {
+    start.setFullYear(start.getFullYear() - 1);
+  } else {
+    start.setDate(start.getDate() - (filter === 'past_7_days' ? 7 : 30));
+  }
+
+  return [start.toISOString(), ''];
 }
 
-interface SearchOptionItem {
-  projectScope:string;
-  text:string;
+export function searchResultMatchesType(resultType:SearchResultType, item:GlobalSearchResult):boolean {
+  return resultType === 'all'
+    || (resultType === 'work_packages' && item instanceof WorkPackageResource)
+    || (resultType === 'meetings' && item instanceof MeetingResource)
+    || (resultType === 'wiki_pages' && item instanceof WikiPageResource);
 }
 
-interface SearchResultItems {
-  items:SearchResultItem[]|SearchOptionItem[];
-  term:string;
-}
+type GlobalSearchItem = GlobalSearchResult;
 
 @Component({
   selector: 'opce-global-search',
@@ -101,6 +134,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   readonly cdRef = inject(ChangeDetectorRef);
   readonly halNotification = inject(HalResourceNotificationService);
   readonly recentItemsService = inject(RecentItemsService);
+  readonly currentUserService = inject(CurrentUserService);
 
   @Input() public placeholder:string;
 
@@ -111,6 +145,11 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   public expanded = false;
 
   private _searchTermInitialized = false;
+
+  private currentSearchResults:GlobalSearchResult[] = [];
+  private currentResultQuery = '';
+  private projectScopeInteraction = false;
+  private filterRefreshVersion = 0;
 
   // Computed placeholder that changes based on expanded state
   public get effectivePlaceholder():string {
@@ -127,7 +166,30 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     map((items) => (items.length > 0)),
   );
 
-  getAutocompleterData = ():Observable<unknown[]> => this.autocompleteWorkPackages();
+  public activeResultType:SearchResultType = 'all';
+  public readonly resultTypes:SearchResultType[] = ['all', 'work_packages', 'meetings', 'wiki_pages'];
+  public readonly lastUpdatedFilters:LastUpdatedFilter[] = [
+    'any_time', 'today', 'yesterday', 'past_7_days', 'past_30_days', 'past_year',
+  ];
+
+  public readonly workPackageStatusFilters:WorkPackageStatusFilter[] = ['all', 'open', 'closed'];
+  public readonly workPackageInvolvementFilters:WorkPackageInvolvementFilter[] = [
+    'all', 'assigned_to_me', 'created_by_me', 'accountable',
+  ];
+
+  public readonly meetingTimeFilters:MeetingTimeFilter[] = ['all', 'upcoming', 'past'];
+  public readonly meetingInvolvementFilters:MeetingInvolvementFilter[] = [
+    'all', 'invited', 'created_by_me', 'attended',
+  ];
+
+  public selectedLastUpdatedFilter:LastUpdatedFilter = 'any_time';
+  public selectedWorkPackageStatusFilter:WorkPackageStatusFilter = 'all';
+  public selectedWorkPackageInvolvementFilter:WorkPackageInvolvementFilter = 'all';
+  public selectedMeetingTimeFilter:MeetingTimeFilter = 'all';
+  public selectedMeetingInvolvementFilter:MeetingInvolvementFilter = 'all';
+  public selectedProjectScope:ProjectScope;
+
+  getAutocompleterData = ():Observable<unknown[]> => this.autocompleteGlobalSearch();
 
   public autocompleterOptions = {
     filters: [],
@@ -139,7 +201,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   /** Remember the item that best matches the query.
    * That way, it will be highlighted (as we manually mark the selected item) and we can handle enter.
    * */
-  public selectedItem:WorkPackageResource|SearchOptionItem|undefined = undefined;
+  public selectedItem:GlobalSearchItem|undefined = undefined;
 
   /** Remember the current value */
   public currentValue = '';
@@ -151,16 +213,43 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   private unregisterGlobalListener:(() => unknown)|undefined;
 
   public text:Record<string, string> = {
+    accountable: this.I18n.t('js.global_search.quick_filters.accountable'),
+    all: this.I18n.t('js.label_all_uppercase'),
     all_projects: this.I18n.t('js.global_search.all_projects'),
+    any_time: this.I18n.t('js.global_search.quick_filters.any_time'),
+    assigned_to_me: this.I18n.t('js.work_packages.default_queries.assigned_to_me'),
+    attended: this.I18n.t('js.global_search.quick_filters.attended'),
     close_search: this.I18n.t('js.global_search.close_search'),
+    closed: this.I18n.t('js.global_search.quick_filters.closed'),
+    created_by_me: this.I18n.t('js.work_packages.default_queries.created_by_me'),
     current_project_and_all_descendants: this.I18n.t('js.global_search.current_project_and_all_descendants'),
     current_project: this.I18n.t('js.global_search.current_project'),
     recently_viewed: this.I18n.t('js.global_search.recently_viewed'),
     search: this.I18n.t('js.autocompleter.search'),
+    work_packages: this.I18n.t('js.label_work_package_plural'),
+    meetings: this.I18n.t('js.label_meetings'),
+    meeting_date: this.I18n.t('js.global_search.quick_filters.meeting_date'),
+    involvement: this.I18n.t('js.global_search.quick_filters.involvement'),
+    invited: this.I18n.t('js.global_search.quick_filters.invited'),
+    last_updated: this.I18n.t('js.label_last_updated_on'),
+    open: this.I18n.t('js.global_search.quick_filters.open'),
+    past: this.I18n.t('js.global_search.quick_filters.past'),
+    past_7_days: this.I18n.t('js.global_search.quick_filters.past_7_days'),
+    past_30_days: this.I18n.t('js.global_search.quick_filters.past_30_days'),
+    past_year: this.I18n.t('js.global_search.quick_filters.past_year'),
+    project: this.I18n.t('js.label_project'),
+    status: this.I18n.t('js.work_packages.properties.status'),
+    today: this.I18n.t('js.label_today'),
+    upcoming: this.I18n.t('js.global_search.quick_filters.upcoming'),
+    wiki_pages: this.I18n.t('js.global_search.wiki_pages'),
+    yesterday: this.I18n.t('js.global_search.quick_filters.yesterday'),
   };
 
   constructor() {
     populateInputsFromDataset(this);
+    this.selectedProjectScope = this.currentProjectService.path
+      ? this.currentScope
+      : 'all_projects';
   }
 
   ngAfterViewInit():void {
@@ -205,7 +294,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
       } else if (this.searchTerm?.length === 0) {
         this.ngSelectComponent.ngSelectInstance.focus();
       } else {
-        this.submitNonEmptySearch('');
+        this.searchInScope(this.selectedProjectScope);
       }
     }
   }
@@ -235,7 +324,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     return Highlighting.inlineClass(property, id);
   }
 
-  public search(_$event:SearchResultItems):void {
+  public search(_$event:unknown):void {
+    this.filterRefreshVersion += 1;
     this.currentValue = this.searchTerm;
   }
 
@@ -250,7 +340,15 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     this.ngSelectComponent.openSelect();
   }
 
-  public onFocusOut():void {
+  public onFocusOut(event?:FocusEvent):void {
+    const nextFocusedElement = event?.relatedTarget;
+    if (
+      this.projectScopeInteraction
+      || (nextFocusedElement instanceof Node && this.elementRef.nativeElement.contains(nextFocusedElement))
+    ) {
+      return;
+    }
+
     if (!this.deviceService.isMobile) {
       this.expanded = (this.searchTerm !== null && this.searchTerm.length > 0);
       this.ngSelectComponent.ngSelectInstance.isOpen.set(false);
@@ -287,12 +385,14 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     return Highlighting.inlineClass('status', statusId);
   }
 
-  public followItem(item:WorkPackageResource|SearchOptionItem|undefined):void {
+  public followItem(item:GlobalSearchItem|undefined):void {
     this.selectedItem = item;
-    if (item instanceof WorkPackageResource) {
+    if (this.isWikiPage(item)) {
+      window.location.href = String(item.showWikiPagePath);
+    } else if (this.isWorkPackage(item)) {
       window.location.href = this.wpPath(item.displayId);
-    } else if (item) {
-      this.searchInScope(item.projectScope);
+    } else if (this.isMeeting(item)) {
+      window.location.href = this.pathHelperService.meetingPath(item.id!);
     }
   }
 
@@ -302,12 +402,128 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  // return all project scope items and all items which contain the search term
-  public customSearchFn(term:string, item:SearchResultItem):boolean {
-    return item.id === undefined || item.subject.toLowerCase().includes(term.toLowerCase());
+  public customSearchFn(term:string, item:GlobalSearchItem):boolean {
+    if (!(item instanceof HalResource)) {
+      return true;
+    }
+
+    if (!this.isActiveResult(item)) {
+      return false;
+    }
+
+    return !this.isWorkPackage(item)
+      || item.subject.toLowerCase().includes(term.toLowerCase());
   }
 
-  private autocompleteWorkPackages():Observable<(WorkPackageResource|SearchOptionItem)[]> {
+  public selectResultType(resultType:SearchResultType):void {
+    this.activeResultType = resultType;
+    this.refreshFilteredResults();
+  }
+
+  public selectLastUpdatedFilter(filter:LastUpdatedFilter):void {
+    this.selectedLastUpdatedFilter = filter;
+    this.refreshFilteredResults();
+  }
+
+  public selectWorkPackageStatusFilter(filter:WorkPackageStatusFilter):void {
+    this.selectedWorkPackageStatusFilter = filter;
+    this.refreshFilteredResults();
+  }
+
+  public selectWorkPackageInvolvementFilter(filter:WorkPackageInvolvementFilter):void {
+    this.selectedWorkPackageInvolvementFilter = filter;
+    this.refreshFilteredResults();
+  }
+
+  public selectMeetingTimeFilter(filter:MeetingTimeFilter):void {
+    this.selectedMeetingTimeFilter = filter;
+    this.refreshFilteredResults();
+  }
+
+  public selectMeetingInvolvementFilter(filter:MeetingInvolvementFilter):void {
+    this.selectedMeetingInvolvementFilter = filter;
+    this.refreshFilteredResults();
+  }
+
+  public selectProjectScope(event:Event):void {
+    this.selectedProjectScope = (event.target as HTMLSelectElement).value as ProjectScope;
+  }
+
+  public onProjectScopeMouseDown(event:MouseEvent):void {
+    this.projectScopeInteraction = true;
+    event.stopPropagation();
+  }
+
+  public onProjectScopeBlur():void {
+    this.projectScopeInteraction = false;
+  }
+
+  public get projectScopes():ProjectScope[] {
+    return this.currentProjectService.path
+      ? ['current_project_and_all_descendants', 'current_project', 'all_projects']
+      : ['all_projects'];
+  }
+
+  public resultPath(item:GlobalSearchResult):string {
+    if (this.isWikiPage(item)) {
+      return String(item.showWikiPagePath);
+    }
+
+    if (this.isWorkPackage(item)) {
+      return this.wpPath(item.displayId);
+    }
+
+    if (this.isMeeting(item)) {
+      return this.pathHelperService.meetingPath(item.id!);
+    }
+
+    return '#';
+  }
+
+  public resultTitle(item:GlobalSearchResult):string {
+    return this.isWorkPackage(item) ? item.subject : item.title;
+  }
+
+  public resultIcon(item:GlobalSearchResult):string {
+    if (this.isWorkPackage(item)) {
+      return 'op-view-list';
+    }
+
+    return this.isMeeting(item) ? 'comment-discussion' : 'book';
+  }
+
+  public resultTypeLabel(item:GlobalSearchResult):string {
+    if (this.isWorkPackage(item)) {
+      return this.text.work_packages;
+    }
+
+    return this.isMeeting(item) ? this.text.meetings : this.text.wiki_pages;
+  }
+
+  public isWorkPackage(item:GlobalSearchItem|undefined):item is WorkPackageResource {
+    return item instanceof WorkPackageResource;
+  }
+
+  public isMeeting(item:GlobalSearchItem|undefined):item is MeetingResource {
+    return item instanceof MeetingResource;
+  }
+
+  public isWikiPage(item:GlobalSearchItem|undefined):item is WikiPageResource {
+    return item instanceof WikiPageResource;
+  }
+
+  public redirectToResult(item:GlobalSearchResult, event:MouseEvent):boolean {
+    event.stopImmediatePropagation();
+    if (isClickedWithModifier(event)) {
+      return true;
+    }
+
+    window.location.href = this.resultPath(item);
+    event.preventDefault();
+    return false;
+  }
+
+  private autocompleteGlobalSearch():Observable<GlobalSearchItem[]> {
     // ng-select v21 initializes _searchTerm as null (signal). Treat null as '' so that
     // the initial typeahead emission triggers loadRecentItems() instead of returning empty.
     const query = this.searchTerm ?? '';
@@ -327,12 +543,39 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
     const hashFreeQuery = this.queryWithoutHash(query);
 
-    return this
-      .fetchSearchResults(hashFreeQuery, hashFreeQuery !== query)
-      .get()
-      .pipe(
-        map((collection) => this.searchResultsToOptions(collection.elements, hashFreeQuery))
-      );
+    const workPackageFilters = this.workPackageFilters();
+    const meetingFilters = new ApiV3FilterBuilder().add('search', '**', [query]);
+    const wikiPageFilters = new ApiV3FilterBuilder().add('search', '**', [query]);
+    this.applyLastUpdatedFilter(workPackageFilters);
+    this.applyLastUpdatedFilter(meetingFilters);
+    this.applyLastUpdatedFilter(wikiPageFilters);
+    this.applyMeetingQuickFilters(meetingFilters);
+    const params = { pageSize: '20' };
+
+    return forkJoin({
+      workPackages: this.fetchSearchResults(hashFreeQuery, hashFreeQuery !== query, workPackageFilters).get().pipe(
+        map((collection) => collection.elements),
+      ),
+      meetings: this.apiV3Service.meetings.filtered(meetingFilters, params).get().pipe(
+        map((collection:CollectionResource<HalResource>) => collection.elements.filter(
+          (item):item is MeetingResource => item instanceof MeetingResource,
+        )),
+        catchError(() => of([] as MeetingResource[])),
+      ),
+      wikiPages: this.apiV3Service.wiki_pages.filtered(wikiPageFilters, params).get().pipe(
+        map((collection:CollectionResource<HalResource>) => collection.elements.filter(
+          (item):item is WikiPageResource => item instanceof WikiPageResource,
+        )),
+        catchError(() => of([] as WikiPageResource[])),
+      ),
+    }).pipe(
+      map(({ workPackages, meetings, wikiPages }) => {
+        this.currentSearchResults = [...workPackages, ...meetings, ...wikiPages];
+        this.currentResultQuery = hashFreeQuery;
+
+        return this.searchResultsToOptions(this.currentSearchResults, this.currentResultQuery);
+      }),
+    );
   }
 
   private loadRecentItems() {
@@ -347,7 +590,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
         // Ensure we only load the five recent items
         // in case none of them are available in the cache
-        const filters = new ApiV3FilterBuilder().add('id', '=', wpIds);
+        const filters = this.workPackageFilters().add('id', '=', wpIds);
+        this.applyLastUpdatedFilter(filters);
         const params = {
           offset: '1',
           pageSize: '5',
@@ -363,7 +607,11 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
             map((collection) => {
               // In case none of the wpIds exist anymore or are not accessible
               // this API call would return five arbitrary work packages, as that's the way valid_subset works
-              return collection.elements.filter((wp) => wpIds.includes(wp.id!));
+              const recentWorkPackages = collection.elements.filter((wp) => wpIds.includes(wp.id!));
+              this.currentSearchResults = recentWorkPackages;
+              this.currentResultQuery = '';
+
+              return this.searchResultsToOptions(recentWorkPackages, '');
             })
           );
       }),
@@ -378,48 +626,117 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     return query;
   }
 
-  private fetchSearchResults(query:string, idOnly:boolean):ApiV3WorkPackageCachedSubresource {
+  private fetchSearchResults(
+    query:string,
+    idOnly:boolean,
+    filters:ApiV3FilterBuilder,
+  ):ApiV3WorkPackageCachedSubresource {
     return this
       .apiV3Service
       .work_packages
-      .filterByTypeaheadOrId(query, idOnly, { pageSize: '20' });
+      .filterByTypeaheadOrId(query, idOnly, { pageSize: '20' }, filters);
   }
 
-  private searchResultsToOptions(results:WorkPackageResource[], query:string) {
-    const searchOptions = this.detailedSearchOptions();
-    // If we have a direct hit, we choose it to be the selected element.
-    this.selectedItem = results.find((wp) => wp.id?.toString() === query) || searchOptions[0];
+  private refreshFilteredResults():void {
+    const refreshVersion = this.filterRefreshVersion + 1;
+    this.filterRefreshVersion = refreshVersion;
+    this.ngSelectComponent.loading$.next(true);
+    this.ngSelectComponent.updateItems([]);
 
-    if (this.selectedItem instanceof WorkPackageResource) {
+    this.autocompleteGlobalSearch().pipe(first()).subscribe({
+      next: (items) => {
+        if (refreshVersion !== this.filterRefreshVersion) {
+          return;
+        }
+
+        this.ngSelectComponent.updateItems(items);
+        this.ngSelectComponent.loading$.next(false);
+        this.cdRef.detectChanges();
+      },
+      error: () => {
+        if (refreshVersion === this.filterRefreshVersion) {
+          this.ngSelectComponent.loading$.next(false);
+          this.cdRef.detectChanges();
+        }
+      },
+    });
+  }
+
+  private workPackageFilters():ApiV3FilterBuilder {
+    const filters = new ApiV3FilterBuilder();
+    if (this.activeResultType !== 'work_packages') {
+      return filters;
+    }
+
+    if (this.selectedWorkPackageStatusFilter === 'open') {
+      filters.add('status', 'o', []);
+    } else if (this.selectedWorkPackageStatusFilter === 'closed') {
+      filters.add('status', 'c', []);
+    }
+
+    const involvementFilters = {
+      assigned_to_me: 'assignee',
+      created_by_me: 'author',
+      accountable: 'responsible',
+    } as const;
+    if (this.selectedWorkPackageInvolvementFilter !== 'all') {
+      filters.add(involvementFilters[this.selectedWorkPackageInvolvementFilter], '=', ['me']);
+    }
+
+    return filters;
+  }
+
+  private applyMeetingQuickFilters(filters:ApiV3FilterBuilder):void {
+    if (this.activeResultType !== 'meetings') {
+      return;
+    }
+
+    if (this.selectedMeetingTimeFilter !== 'all') {
+      filters.add('time', this.selectedMeetingTimeFilter, []);
+    }
+
+    const userId = this.currentUserService.userId;
+    const involvementFilters = {
+      invited: 'invitedUser',
+      created_by_me: 'author',
+      attended: 'attendedUser',
+    } as const;
+    if (userId && this.selectedMeetingInvolvementFilter !== 'all') {
+      filters.add(involvementFilters[this.selectedMeetingInvolvementFilter], '=', [userId]);
+    }
+  }
+
+  private applyLastUpdatedFilter(filters:ApiV3FilterBuilder):void {
+    const range = lastUpdatedRange(this.selectedLastUpdatedFilter);
+    if (range) {
+      filters.add('updatedAt', '<>d', range);
+    }
+  }
+
+  private searchResultsToOptions(results:GlobalSearchResult[], query:string) {
+    // If we have a direct hit, we choose it to be the selected element.
+    const visibleResults = results.filter((item) => this.isActiveResult(item));
+    const directHit = ['all', 'work_packages'].includes(this.activeResultType)
+      ? results.find((item) => item instanceof WorkPackageResource && item.id?.toString() === query)
+      : undefined;
+    this.selectedItem = directHit;
+
+    if (directHit) {
       void announce(this.I18n.t('js.global_search.direct_hit_available'), { politeness: 'polite' });
       this.setMarkedOption();
     }
     else {
-      const resultCount = results.length + searchOptions.length;
+      const resultCount = visibleResults.length;
       void announce(this.I18n.t('js.global_search.items_available', { count: resultCount }), { politeness: 'polite' });
     }
 
     return [
-      ...searchOptions,
-      ...results,
+      ...visibleResults,
     ];
   }
 
-  // set the possible 'search in scope' options for the current project path
-  private detailedSearchOptions():{ projectScope:string; text:string }[] {
-    const searchOptions = [];
-    // add all options when searching within a project
-    // otherwise search in 'all projects'
-    if (this.currentProjectService.path) {
-      searchOptions.push('current_project_and_all_descendants');
-      searchOptions.push('current_project');
-    }
-    if (this.currentScope === 'current_project') {
-      searchOptions.reverse();
-    }
-    searchOptions.push('all_projects');
-
-    return searchOptions.map((suggestion:string) => ({ projectScope: suggestion, text: this.text[suggestion] }));
+  private isActiveResult(item:GlobalSearchResult):boolean {
+    return searchResultMatchesType(this.activeResultType, item);
   }
 
   /*
@@ -456,7 +773,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     this.cdRef.detectChanges();
   }
 
-  private searchInScope(scope:string):void {
+  private searchInScope(scope:ProjectScope):void {
     switch (scope) {
       case 'all_projects': {
         this.submitNonEmptySearch('all');
@@ -478,14 +795,18 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   public submitNonEmptySearch(scope:string):void {
     if (this.currentValue.length > 0) {
       this.ngSelectComponent.ngSelectInstance.close();
-      this.globalSearchService.submitSearch(this.currentValue, scope);
+      this.globalSearchService.submitSearch(this.currentValue, scope, this.activeResultType);
     }
   }
 
-  private get currentScope():string {
+  private get currentScope():ProjectScope {
     const params = new URLSearchParams(window.location.search);
-    const serviceScope = params.get('scope') || '';
-    return (serviceScope === '') ? 'current_project_and_all_descendants' : serviceScope;
+    const serviceScope = params.get('scope');
+    return serviceScope === 'all' || serviceScope === 'all_projects'
+      ? 'all_projects'
+      : serviceScope === 'current_project'
+        ? 'current_project'
+        : 'current_project_and_all_descendants';
   }
 
   private get currentQuery():string|null {

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -420,28 +420,28 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     this.refreshFilteredResults();
   }
 
-  public selectLastUpdatedFilter(filter:LastUpdatedFilter):void {
-    this.selectedLastUpdatedFilter = filter;
+  public selectLastUpdatedFilter(filter:LastUpdatedFilter|Event):void {
+    this.selectedLastUpdatedFilter = this.filterValue<LastUpdatedFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectWorkPackageStatusFilter(filter:WorkPackageStatusFilter):void {
-    this.selectedWorkPackageStatusFilter = filter;
+  public selectWorkPackageStatusFilter(filter:WorkPackageStatusFilter|Event):void {
+    this.selectedWorkPackageStatusFilter = this.filterValue<WorkPackageStatusFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectWorkPackageInvolvementFilter(filter:WorkPackageInvolvementFilter):void {
-    this.selectedWorkPackageInvolvementFilter = filter;
+  public selectWorkPackageInvolvementFilter(filter:WorkPackageInvolvementFilter|Event):void {
+    this.selectedWorkPackageInvolvementFilter = this.filterValue<WorkPackageInvolvementFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectMeetingTimeFilter(filter:MeetingTimeFilter):void {
-    this.selectedMeetingTimeFilter = filter;
+  public selectMeetingTimeFilter(filter:MeetingTimeFilter|Event):void {
+    this.selectedMeetingTimeFilter = this.filterValue<MeetingTimeFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectMeetingInvolvementFilter(filter:MeetingInvolvementFilter):void {
-    this.selectedMeetingInvolvementFilter = filter;
+  public selectMeetingInvolvementFilter(filter:MeetingInvolvementFilter|Event):void {
+    this.selectedMeetingInvolvementFilter = this.filterValue<MeetingInvolvementFilter>(filter);
     this.refreshFilteredResults();
   }
 
@@ -660,6 +660,12 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
         }
       },
     });
+  }
+
+  private filterValue<T extends string>(filter:T|Event):T {
+    return (filter instanceof Event
+      ? (filter.target as HTMLSelectElement).value
+      : filter) as T;
   }
 
   private workPackageFilters():ApiV3FilterBuilder {

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -420,27 +420,27 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     this.refreshFilteredResults();
   }
 
-  public selectLastUpdatedFilter(filter:LastUpdatedFilter|Event):void {
+  public selectLastUpdatedFilter(filter:string|Event):void {
     this.selectedLastUpdatedFilter = this.filterValue<LastUpdatedFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectWorkPackageStatusFilter(filter:WorkPackageStatusFilter|Event):void {
+  public selectWorkPackageStatusFilter(filter:string|Event):void {
     this.selectedWorkPackageStatusFilter = this.filterValue<WorkPackageStatusFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectWorkPackageInvolvementFilter(filter:WorkPackageInvolvementFilter|Event):void {
+  public selectWorkPackageInvolvementFilter(filter:string|Event):void {
     this.selectedWorkPackageInvolvementFilter = this.filterValue<WorkPackageInvolvementFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectMeetingTimeFilter(filter:MeetingTimeFilter|Event):void {
+  public selectMeetingTimeFilter(filter:string|Event):void {
     this.selectedMeetingTimeFilter = this.filterValue<MeetingTimeFilter>(filter);
     this.refreshFilteredResults();
   }
 
-  public selectMeetingInvolvementFilter(filter:MeetingInvolvementFilter|Event):void {
+  public selectMeetingInvolvementFilter(filter:string|Event):void {
     this.selectedMeetingInvolvementFilter = this.filterValue<MeetingInvolvementFilter>(filter);
     this.refreshFilteredResults();
   }
@@ -662,7 +662,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  private filterValue<T extends string>(filter:T|Event):T {
+  private filterValue<T extends string>(filter:string|Event):T {
     return (filter instanceof Event
       ? (filter.target as HTMLSelectElement).value
       : filter) as T;

--- a/frontend/src/app/core/global_search/input/global-search-quick-filter.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-quick-filter.component.html
@@ -1,0 +1,150 @@
+<select-panel
+  #selectPanel
+  data-select-variant="multiple"
+  data-fetch-strategy="local"
+  anchor-align="start"
+  anchor-side="outside-bottom"
+  data-view-component="true"
+  [attr.id]="panelId"
+  (click)="$event.stopPropagation()"
+  (invokerClicked)="resetSelection()"
+  (itemActivated)="onItemActivated($event)"
+  (panelClosed)="resetSelection()"
+>
+  <dialog-helper>
+    <button
+      type="button"
+      class="Button Button--secondary Button--medium"
+      data-view-component="true"
+      aria-haspopup="dialog"
+      aria-expanded="false"
+      [attr.id]="buttonId"
+      [attr.aria-controls]="dialogId"
+    >
+      <span class="Button-content">
+        <span class="Button-label">{{ label() }}</span>
+        <span class="Button-visual Button-trailingAction">
+          <svg octicon [icon]="'triangle-down'" size="small"></svg>
+        </span>
+      </span>
+    </button>
+
+    <dialog
+      class="Overlay Overlay-whenNarrow Overlay--size-medium-portrait"
+      data-target="select-panel.dialog"
+      data-view-component="true"
+      style="position: absolute"
+      [attr.id]="dialogId"
+      [attr.aria-labelledby]="titleId"
+    >
+      <div class="Overlay-header Overlay-header--divided" data-view-component="true">
+        <div class="Overlay-headerContentWrap">
+          <div class="Overlay-titleWrap">
+            <h1 class="Overlay-title" [attr.id]="titleId">{{ label() }}</h1>
+          </div>
+          <div class="Overlay-actionWrap">
+            <button
+              type="button"
+              class="close-button Overlay-closeButton"
+              [attr.data-close-dialog-id]="dialogId"
+              [attr.aria-label]="closeLabel"
+            >
+              <svg octicon [icon]="'x'" size="small"></svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="Overlay-headerFilter" data-view-component="true">
+          <div data-target="select-panel.bannerErrorElement" hidden></div>
+          <remote-input data-target="select-panel.remoteInput" [attr.aria-owns]="bodyId">
+            <primer-text-field class="FormControl width-full FormControl--fullWidth">
+              <label class="sr-only FormControl-label position-absolute" [attr.for]="filterId">
+                {{ filterLabel }}
+              </label>
+              <div class="FormControl-input-wrap FormControl-input-wrap--leadingVisual">
+                <span class="FormControl-input-leadingVisualWrap">
+                  <svg
+                    octicon
+                    class="FormControl-input-leadingVisual"
+                    data-target="primer-text-field.leadingVisual"
+                    [icon]="'search'"
+                    size="small"
+                  ></svg>
+                </span>
+                <input
+                  type="search"
+                  name="filter"
+                  class="FormControl-input FormControl-medium"
+                  data-target="primer-text-field.inputElement select-panel.filterInputTextField"
+                  autocomplete="off"
+                  autofocus
+                  [attr.id]="filterId"
+                  [attr.aria-label]="filterLabel"
+                />
+              </div>
+            </primer-text-field>
+          </remote-input>
+        </div>
+      </div>
+
+      <div class="Overlay-body p-0 tmp-p-0" data-view-component="true">
+        <focus-group direction="vertical" mnemonics retain>
+          <live-region data-target="select-panel.liveRegion"></live-region>
+          <div data-fetch-strategy="local" data-target="select-panel.list" data-view-component="true">
+            <div [attr.id]="bodyId">
+              <action-list>
+                <div data-view-component="true">
+                  <ul
+                    class="ActionListWrap p-2 tmp-p-2"
+                    role="listbox"
+                    [attr.id]="listId"
+                    [attr.aria-label]="label()"
+                  >
+                    @for (option of options(); track option) {
+                      <li class="ActionListItem" role="none" data-view-component="true">
+                        <button
+                          type="button"
+                          class="ActionListContent"
+                          role="option"
+                          data-view-component="true"
+                          [attr.data-value]="option"
+                          [attr.aria-selected]="pendingValue() === option"
+                        >
+                          <span class="ActionListItem-visual ActionListItem-action--leading">
+                            <span class="FormControl-checkbox"></span>
+                          </span>
+                          <span class="ActionListItem-label" data-view-component="true">
+                            {{ labels()[option] }}
+                          </span>
+                        </button>
+                      </li>
+                    }
+                  </ul>
+                </div>
+              </action-list>
+            </div>
+            <div class="SelectPanel-emptyPanel" data-target="select-panel.noResults" hidden>
+              <h2 class="v-align-middle m-3 f5">{{ noResultsLabel }}</h2>
+            </div>
+          </div>
+        </focus-group>
+      </div>
+
+      <div
+        class="Overlay-footer Overlay-footer--alignEnd Overlay-footer--divided"
+        data-view-component="true"
+      >
+        <button
+          type="button"
+          class="Button Button--primary Button--medium"
+          data-view-component="true"
+          (click)="apply()"
+        >
+          <span class="Button-content">
+            <span class="Button-label">{{ applyLabel }}</span>
+          </span>
+        </button>
+      </div>
+    </dialog>
+  </dialog-helper>
+</select-panel>

--- a/frontend/src/app/core/global_search/input/global-search-quick-filter.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-quick-filter.component.ts
@@ -1,0 +1,125 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  ElementRef,
+  ViewChild,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import type { SelectPanelElement } from '@primer/view-components/app/components/primer/alpha/select_panel_element';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DynamicIconDirective } from 'core-app/shared/components/primer/dynamic-icon.directive';
+import { generateId } from 'core-app/shared/helpers/dom-helpers';
+
+interface SelectPanelItemActivatedEvent {
+  value:string;
+}
+
+@Component({
+  selector: 'op-global-search-quick-filter',
+  templateUrl: './global-search-quick-filter.component.html',
+  imports: [DynamicIconDirective],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GlobalSearchQuickFilterComponent {
+  private readonly I18n = inject(I18nService);
+
+  @ViewChild('selectPanel', { static: true }) selectPanel:ElementRef<SelectPanelElement>;
+
+  readonly label = input.required<string>();
+  readonly options = input.required<readonly string[]>();
+  readonly labels = input.required<Record<string, string>>();
+  readonly selectedValue = input.required<string>();
+  readonly valueChange = output<string>();
+
+  readonly panelId = generateId('global-search-quick-filter');
+  readonly pendingValue = signal('');
+  readonly filterLabel = this.I18n.t('js.toolbar.filter');
+  readonly applyLabel = this.I18n.t('js.modals.button_apply');
+  readonly closeLabel = this.I18n.t('js.button_close');
+  readonly noResultsLabel = this.I18n.t('js.label_no_data');
+
+  constructor() {
+    effect(() => this.pendingValue.set(this.selectedValue()));
+  }
+
+  get buttonId():string {
+    return `${this.panelId}-button`;
+  }
+
+  get dialogId():string {
+    return `${this.panelId}-dialog`;
+  }
+
+  get titleId():string {
+    return `${this.dialogId}-title`;
+  }
+
+  get filterId():string {
+    return `${this.panelId}-filter`;
+  }
+
+  get bodyId():string {
+    return `${this.panelId}-body`;
+  }
+
+  get listId():string {
+    return `${this.panelId}-list`;
+  }
+
+  onItemActivated(event:Event):void {
+    const value = (event as CustomEvent<SelectPanelItemActivatedEvent>).detail.value;
+    this.pendingValue.set(value);
+    this.synchronizeSelection(value);
+  }
+
+  resetSelection():void {
+    const value = this.selectedValue();
+    this.pendingValue.set(value);
+    this.synchronizeSelection(value);
+  }
+
+  apply():void {
+    this.valueChange.emit(this.pendingValue());
+    this.selectPanel.nativeElement.hide();
+  }
+
+  private synchronizeSelection(value:string):void {
+    this.selectPanel.nativeElement
+      .querySelectorAll<HTMLElement>('[role="option"]')
+      .forEach((item) => item.setAttribute('aria-selected', String(item.dataset.value === value)));
+  }
+}

--- a/frontend/src/app/core/global_search/openproject-global-search.module.ts
+++ b/frontend/src/app/core/global_search/openproject-global-search.module.ts
@@ -36,12 +36,14 @@ import {
 } from 'core-app/shared/components/autocompleter/openproject-autocompleter.module';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { RecentItemsService } from 'core-app/core/recent-items.service';
+import { DynamicIconDirective } from 'core-app/shared/components/primer/dynamic-icon.directive';
 
 @NgModule({
   imports: [
     OpSharedModule,
     OpenprojectWorkPackagesModule,
     OpenprojectAutocompleterModule,
+    DynamicIconDirective,
   ],
   providers: [
     GlobalSearchService,

--- a/frontend/src/app/core/global_search/openproject-global-search.module.ts
+++ b/frontend/src/app/core/global_search/openproject-global-search.module.ts
@@ -37,6 +37,7 @@ import {
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { RecentItemsService } from 'core-app/core/recent-items.service';
 import { DynamicIconDirective } from 'core-app/shared/components/primer/dynamic-icon.directive';
+import { GlobalSearchQuickFilterComponent } from 'core-app/core/global_search/input/global-search-quick-filter.component';
 
 @NgModule({
   imports: [
@@ -44,6 +45,7 @@ import { DynamicIconDirective } from 'core-app/shared/components/primer/dynamic-
     OpenprojectWorkPackagesModule,
     OpenprojectAutocompleterModule,
     DynamicIconDirective,
+    GlobalSearchQuickFilterComponent,
   ],
   providers: [
     GlobalSearchService,

--- a/frontend/src/app/core/global_search/services/global-search.service.ts
+++ b/frontend/src/app/core/global_search/services/global-search.service.ts
@@ -40,9 +40,9 @@ export class GlobalSearchService {
   protected currentProjectService = inject(CurrentProjectService);
 
 
-  public submitSearch(query:string, scope:string):void {
+  public submitSearch(query:string, scope:string, filter = 'work_packages'):void {
     const path = this.searchPath(scope);
-    const params = this.searchQueryParams(query, scope);
+    const params = this.searchQueryParams(query, scope, filter);
     window.location.href = `${path}?${params}`;
   }
 
@@ -54,14 +54,15 @@ export class GlobalSearchService {
     return `${searchPath}/search`;
   }
 
-  private searchQueryParams(query:string, scope:string):string {
+  private searchQueryParams(query:string, scope:string, filter:string):string {
     const params = new URLSearchParams(window.location.search);
     params.set('q', query);
     params.set('scope', scope);
 
-    // Filter work packages by default
-    if (!params.get('filter')) {
-      params.set('filter', 'work_packages');
+    if (filter === 'all') {
+      params.delete('filter');
+    } else {
+      params.set('filter', filter);
     }
 
     return params.toString();

--- a/frontend/src/app/features/hal/resources/meeting-resource.ts
+++ b/frontend/src/app/features/hal/resources/meeting-resource.ts
@@ -28,6 +28,7 @@
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { Attachable } from 'core-app/features/hal/resources/mixins/attachable-mixin';
+import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
 
 interface MeetingResourceLinks {
   addAttachment(attachment:HalResource):Promise<unknown>;
@@ -35,7 +36,8 @@ interface MeetingResourceLinks {
 
 class MeetingBaseResource extends HalResource {
   title:string;
-  project:HalResource;
+  project:ProjectResource;
+  updatedAt:Date;
   public $links:MeetingResourceLinks;
 }
 

--- a/frontend/src/app/features/hal/resources/wiki-page-resource.ts
+++ b/frontend/src/app/features/hal/resources/wiki-page-resource.ts
@@ -28,13 +28,24 @@
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { Attachable } from 'core-app/features/hal/resources/mixins/attachable-mixin';
+import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
 
 export interface WikiPageResourceLinks {
-  addAttachment(attachment:HalResource):Promise<any>;
+  addAttachment(attachment:HalResource):Promise<unknown>;
 }
 
 class WikiPageBaseResource extends HalResource {
+  title:string;
+  project:ProjectResource;
+  updatedAt:Date;
+  showWikiPage:HalResource;
   public $links:WikiPageResourceLinks;
+
+  public get showWikiPagePath():string {
+    return this.showWikiPage?.$link.href ?? '#';
+  }
 }
 
 export const WikiPageResource = Attachable(WikiPageBaseResource);
+
+export interface WikiPageResource extends WikiPageBaseResource, WikiPageResourceLinks {}

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -334,6 +334,10 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     }
   }
 
+  public updateItems(items:unknown[]):void {
+    this.items$.next(items as IOPAutocompleterOption[]);
+  }
+
   ngAfterViewInit():void {
     // Store ng-select instance on the host element for access from Stimulus controllers
     this.elementRef.nativeElement.ngSelectComponentInstance = this.ngSelectInstance;

--- a/frontend/src/app/shared/components/primer/dynamic-icon-map.ts
+++ b/frontend/src/app/shared/components/primer/dynamic-icon-map.ts
@@ -26,12 +26,24 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { circleSlashIconData, graphIconData, starIconData, SVGData, xIconData } from '@openproject/octicons-angular';
+import {
+  bookIconData,
+  circleSlashIconData,
+  commentDiscussionIconData,
+  graphIconData,
+  opViewListIconData,
+  starIconData,
+  SVGData,
+  xIconData,
+} from '@openproject/octicons-angular';
 
 export const ICON_MAP:Record<string, SVGData> = {
   x: xIconData,
   star: starIconData,
   'circle-slash': circleSlashIconData,
   graph: graphIconData,
+  book: bookIconData,
+  'comment-discussion': commentDiscussionIconData,
+  'op-view-list': opViewListIconData,
   // TODO add more icons
 };

--- a/frontend/src/app/shared/helpers/api-v3/api-v3-filter-builder.ts
+++ b/frontend/src/app/shared/helpers/api-v3/api-v3-filter-builder.ts
@@ -28,7 +28,7 @@
 
 import { pickBy } from 'lodash-es';
 
-export type FilterOperator = '='|'!*'|'!'|'~'|'o'|'>t-'|'<>d'|'**'|'ow';
+export type FilterOperator = '='|'!*'|'!'|'~'|'o'|'c'|'>t-'|'<>d'|'**'|'ow'|'upcoming'|'past';
 export const FalseValue = ['f'];
 export const TrueValue = ['t'];
 

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -34,10 +36,12 @@ module API
           def initialize(model:,
                          api_name: model.name.demodulize,
                          scope: nil,
+                         query_class: nil,
                          render_representer: nil,
                          self_path: api_name.underscore.pluralize)
             super(model:, api_name:, scope:, render_representer:)
 
+            self.query_class = query_class
             self.self_path = self_path
           end
 
@@ -53,7 +57,7 @@ module API
 
           def parse(request)
             ParamsToQueryService
-              .new(model, request.current_user)
+              .new(model, request.current_user, query_class:)
               .call(request.params)
           end
 
@@ -71,6 +75,7 @@ module API
           attr_accessor :model,
                         :api_name,
                         :scope,
+                        :query_class,
                         :render_representer,
                         :self_path
 

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -658,6 +658,12 @@ module API
             "#{root}/wiki_pages/#{id}"
           end
 
+          index :wiki_page
+
+          def self.show_wiki_page(project_identifier, slug)
+            project_wiki_path(project_identifier, slug)
+          end
+
           resources :work_package, except: :schema
 
           def self.work_package(id, timestamps: nil)

--- a/lib/api/v3/wiki_pages/wiki_page_collection_representer.rb
+++ b/lib/api/v3/wiki_pages/wiki_page_collection_representer.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -31,35 +31,7 @@
 module API
   module V3
     module WikiPages
-      class WikiPageRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::V3::Workspaces::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
-
-        self_link title_getter: ->(*) {}
-
-        link :showWikiPage do
-          next unless represented.project && represented.slug.present?
-
-          {
-            href: api_v3_paths.show_wiki_page(represented.project.identifier, represented.slug),
-            type: "text/html"
-          }
-        end
-
-        property :id
-
-        property :title
-
-        date_time_property :updated_at
-
-        associated_project
-
-        def _type
-          "WikiPage"
-        end
-      end
+      class WikiPageCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection; end
     end
   end
 end

--- a/lib/api/v3/wiki_pages/wiki_pages_api.rb
+++ b/lib/api/v3/wiki_pages/wiki_pages_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -31,6 +33,13 @@ module API
     module WikiPages
       class WikiPagesAPI < ::API::OpenProjectAPI
         resources :wiki_pages do
+          get &::API::V3::Utilities::Endpoints::Index
+            .new(
+              model: WikiPage,
+              query_class: ::Queries::Wikis::WikiPages::WikiPageQuery
+            )
+            .mount
+
           helpers do
             def wiki_page
               WikiPage.visible(current_user).find(params[:id])

--- a/modules/meeting/app/models/queries/meetings.rb
+++ b/modules/meeting/app/models/queries/meetings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -36,6 +37,8 @@ module Queries::Meetings
     filter Filters::AuthorFilter
     filter Filters::DatesIntervalFilter
     filter Filters::RecurringFilter
+    filter Filters::SearchFilter
+    filter Filters::UpdatedAtFilter
 
     order Orders::DefaultOrder
   end

--- a/modules/meeting/app/models/queries/meetings/filters/search_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/search_filter.rb
@@ -23,42 +23,45 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module WikiPages
-      class WikiPageRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::V3::Workspaces::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
+module Queries::Meetings
+  module Filters
+    class SearchFilter < MeetingFilter
+      def type = :search
 
-        self_link title_getter: ->(*) {}
+      def human_name = I18n.t("label_search")
 
-        link :showWikiPage do
-          next unless represented.project && represented.slug.present?
+      def apply_to(query_scope)
+        super.distinct
+      end
 
-          {
-            href: api_v3_paths.show_wiki_page(represented.project.identifier, represented.slug),
-            type: "text/html"
-          }
-        end
+      def where
+        values.first.split(/\s+/).map do |token|
+          condition = searchable_columns.map do |table, column|
+            ::Queries::Operators::Contains.sql_for_field([token], table, column)
+          end.join(" OR ")
 
-        property :id
+          "(#{condition})"
+        end.join(" AND ")
+      end
 
-        property :title
+      def left_outer_joins
+        { agenda_items: :outcomes }
+      end
 
-        date_time_property :updated_at
+      private
 
-        associated_project
-
-        def _type
-          "WikiPage"
-        end
+      def searchable_columns
+        [
+          [Meeting.table_name, "title"],
+          [MeetingAgendaItem.table_name, "title"],
+          [MeetingAgendaItem.table_name, "notes"],
+          [MeetingOutcome.table_name, "notes"]
+        ]
       end
     end
   end

--- a/modules/meeting/app/models/queries/meetings/filters/updated_at_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/updated_at_filter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Meetings::Filters::UpdatedAtFilter < Queries::Meetings::Filters::MeetingFilter
+  def type = :datetime_past
+end

--- a/modules/meeting/spec/models/queries/meetings/filters/updated_at_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/meetings/filters/updated_at_filter_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Meetings::Filters::UpdatedAtFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :datetime_past }
+    let(:class_key) { :updated_at }
+
+    describe "#available?" do
+      it "is true" do
+        expect(instance).to be_available
+      end
+    end
+
+    describe "#allowed_values" do
+      it "is nil" do
+        expect(instance.allowed_values).to be_nil
+      end
+    end
+
+    it_behaves_like "non ar filter"
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -48,6 +48,46 @@ RSpec.describe "API v3 Meeting resource", content_type: :json do
     login_as current_user
   end
 
+  describe "GET /api/v3/meetings" do
+    let(:path) { api_v3_paths.meetings }
+    let!(:matching_meeting) { create(:meeting, project:, title: "Quarterly planning") }
+    let!(:non_matching_meeting) { create(:meeting, project:, title: "Retrospective") }
+    let!(:invisible_meeting) { create(:meeting, project: other_project, title: "Quarterly planning") }
+    let!(:agenda_item) do
+      create(:meeting_agenda_item, meeting: matching_meeting, title: "Launch readiness", notes: "Review blockers")
+    end
+
+    before do
+      create(:meeting_outcome, meeting_agenda_item: agenda_item, notes: "Ship on Friday")
+      get path, filters: [{ search: { operator: "**", values: [search_term] } }].to_json
+    end
+
+    context "when the title matches" do
+      let(:search_term) { "quarterly" }
+
+      it "returns only matching visible meetings" do
+        expect(last_response).to have_http_status(:ok)
+        expect(JSON.parse(last_response.body).dig("_embedded", "elements").pluck("id")).to eq([matching_meeting.id])
+      end
+    end
+
+    context "when agenda content matches" do
+      let(:search_term) { "launch blockers" }
+
+      it "searches agenda titles and notes" do
+        expect(JSON.parse(last_response.body).dig("_embedded", "elements").pluck("id")).to eq([matching_meeting.id])
+      end
+    end
+
+    context "when an outcome matches" do
+      let(:search_term) { "ship Friday" }
+
+      it "searches outcome notes without duplicating meetings" do
+        expect(JSON.parse(last_response.body).dig("_embedded", "elements").pluck("id")).to eq([matching_meeting.id])
+      end
+    end
+  end
+
   describe "GET /api/v3/meetings/:id" do
     let(:meeting) { create(:meeting, project:, author: current_user) }
     let(:get_path) { api_v3_paths.meeting meeting.id }

--- a/modules/wikis/app/models/queries/wikis/wiki_pages/filter/search_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/wiki_pages/filter/search_filter.rb
@@ -23,41 +23,37 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
+module Queries
+  module Wikis
     module WikiPages
-      class WikiPageRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::V3::Workspaces::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
+      module Filter
+        class SearchFilter < Filters::Base
+          self.model = ::WikiPage
 
-        self_link title_getter: ->(*) {}
+          def type = :search
 
-        link :showWikiPage do
-          next unless represented.project && represented.slug.present?
+          def human_name = I18n.t("label_search")
 
-          {
-            href: api_v3_paths.show_wiki_page(represented.project.identifier, represented.slug),
-            type: "text/html"
-          }
-        end
+          def where
+            values.first.split(/\s+/).map do |token|
+              condition = searchable_columns.map do |column|
+                ::Queries::Operators::Contains.sql_for_field([token], ::WikiPage.table_name, column)
+              end.join(" OR ")
 
-        property :id
+              "(#{condition})"
+            end.join(" AND ")
+          end
 
-        property :title
+          private
 
-        date_time_property :updated_at
-
-        associated_project
-
-        def _type
-          "WikiPage"
+          def searchable_columns
+            %w[title text]
+          end
         end
       end
     end

--- a/modules/wikis/app/models/queries/wikis/wiki_pages/filter/updated_at_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/wiki_pages/filter/updated_at_filter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries
+  module Wikis
+    module WikiPages
+      module Filter
+        class UpdatedAtFilter < Filters::Base
+          self.model = ::WikiPage
+
+          def type = :datetime_past
+
+          def human_name = ::WikiPage.human_attribute_name(:updated_at)
+        end
+      end
+    end
+  end
+end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -83,6 +83,7 @@ module OpenProject::Wikis
 
       ::Queries::Register.register(::Queries::Wikis::WikiPages::WikiPageQuery) do
         filter ::Queries::Wikis::WikiPages::Filter::NameFilter
+        filter ::Queries::Wikis::WikiPages::Filter::SearchFilter
       end
     end
 

--- a/modules/wikis/spec/models/queries/wikis/wiki_pages/filter/updated_at_filter_spec.rb
+++ b/modules/wikis/spec/models/queries/wikis/wiki_pages/filter/updated_at_filter_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Wikis::WikiPages::Filter::UpdatedAtFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :datetime_past }
+    let(:class_key) { :updated_at }
+    let(:human_name) { WikiPage.human_attribute_name(:updated_at) }
+
+    describe "#available?" do
+      it "is true" do
+        expect(instance).to be_available
+      end
+    end
+
+    describe "#allowed_values" do
+      it "is nil" do
+        expect(instance.allowed_values).to be_nil
+      end
+    end
+
+    it_behaves_like "non ar filter"
+  end
+end

--- a/spec/requests/api/v3/wiki_pages_resource_spec.rb
+++ b/spec/requests/api/v3/wiki_pages_resource_spec.rb
@@ -56,6 +56,34 @@ RSpec.describe "API v3 wiki_pages resource" do
     login_as(current_user)
   end
 
+  describe "GET /api/v3/wiki_pages" do
+    let(:path) { api_v3_paths.wiki_pages }
+    let!(:matching_page) { create(:wiki_page, wiki:, title: "Release plan", text: "Launch checklist") }
+    let!(:non_matching_page) { create(:wiki_page, wiki:, title: "Retrospective", text: "Team notes") }
+    let!(:invisible_page) { create(:wiki_page, wiki: other_wiki, title: "Release plan") }
+
+    before do
+      get path, filters: [{ search: { operator: "**", values: [search_term] } }].to_json
+    end
+
+    context "when the title matches" do
+      let(:search_term) { "release" }
+
+      it "returns only matching visible wiki pages" do
+        expect(subject).to have_http_status(:ok)
+        expect(JSON.parse(subject.body).dig("_embedded", "elements").pluck("id")).to eq([matching_page.id])
+      end
+    end
+
+    context "when the body matches" do
+      let(:search_term) { "launch checklist" }
+
+      it "searches the page body" do
+        expect(JSON.parse(subject.body).dig("_embedded", "elements").pluck("id")).to eq([matching_page.id])
+      end
+    end
+  end
+
   describe "GET /api/v3/wiki_pages/:id" do
     let(:path) { api_v3_paths.wiki_page(wiki_page.id) }
 


### PR DESCRIPTION
## Summary

- extend the global search overlay with separate Work packages, Meetings, and Wiki pages tabs
- add API v3 collection/search support for wiki pages and full-text meeting search across titles, agenda items, and outcomes
- preserve project permission filtering and link results to their existing HTML views
- document the new endpoint and search filter in the API specification

## Tests

- 62 request specs covering the full meeting and wiki page API resource specs
- ESLint for the changed frontend files
- Angular application type-check with ngc
- RuboCop for the changed Ruby files
- YAML parsing for the changed API documentation