### PR TITLE
[AGILE-335] Spike: Cuprite drag-and-drop via CDP interception

### DIFF
--- a/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_bucket_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_relative "../../support/pages/backlog"
 
-RSpec.describe "Dragging work packages in backlog buckets", :js, :selenium do
+RSpec.describe "Dragging work packages in backlog buckets", :js do
   create_shared_association_defaults_for_work_package_factory
 
   shared_let(:project) do

--- a/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_relative "../../support/pages/backlog"
 
 RSpec.describe "Dragging work packages in the inbox",
-               :js, :selenium do
+               :js do
   create_shared_association_defaults_for_work_package_factory
 
   shared_let(:project) { create(:project) }

--- a/modules/backlogs/spec/features/work_packages/drag_in_sprint_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_sprint_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_relative "../../support/pages/backlog"
 
 RSpec.describe "Dragging work packages in and between sprints",
-               :js, :selenium, :settings_reset do
+               :js, :settings_reset do
   let!(:project) do
     create(:project,
            types: [type],

--- a/modules/backlogs/spec/features/work_packages/edit_in_split_view_after_move_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/edit_in_split_view_after_move_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Editing a work package in the split view after moving it",
     it_behaves_like "editing works after the move"
   end
 
-  context "when moving the work package by dragging it with the mouse", :selenium do
+  context "when moving the work package by dragging it with the mouse" do
     def move_work_package(target)
       backlogs_page.drag_work_package(work_package, into: target)
     end

--- a/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/readonly_card_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_relative "../../support/pages/backlog"
 
 RSpec.describe "A read-only work package card in Backlogs",
-               :js, :selenium, with_ee: %i[readonly_work_packages] do
+               :js, with_ee: %i[readonly_work_packages] do
   let!(:default_status) { create(:default_status) }
   let!(:rejected_status) { create(:status, :readonly, name: "Rejected") }
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -1031,7 +1031,21 @@ module Pages
     end
 
     def drag_backlogs_item(source:, target:, edge: nil)
-      selenium_drag_backlogs_item(source:, target:, edge:)
+      if using_cuprite?
+        cuprite_drag_backlogs_item(source:, target:, edge:)
+      else
+        selenium_drag_backlogs_item(source:, target:, edge:)
+      end
+    end
+
+    def cuprite_drag_backlogs_item(source:, target:, edge: nil)
+      install_backlogs_dnd_probe(source:, target:, edge:)
+
+      scroll_backlogs_source_into_view(source)
+      CdpDrag.drag(source: source.native, target: target.native, edge:)
+
+      expect(page).to have_no_css("[data-pdnd-honey-pot]", wait: 2, visible: :all)
+      clear_pragmatic_dnd_honey_pot
     end
 
     def pick_up_and_release_backlogs_item(source)

--- a/spec/support/cdp_drag_spike.rb
+++ b/spec/support/cdp_drag_spike.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Spike: real HTML5 drag via CDP drag interception.
+module CdpDrag
+  module_function
+
+  def ferrum_page
+    Capybara.current_session.driver.browser.page
+  end
+
+  def point(element, edge: nil)
+    rect = element.rect
+    offset = [6, rect["height"] / 4].min
+    y =
+      case edge
+      when :top then rect["y"] + offset
+      when :bottom then rect["y"] + rect["height"] - offset
+      else rect["y"] + (rect["height"] / 2)
+      end
+
+    [(rect["x"] + (rect["width"] / 2)).round, y.round]
+  end
+
+  def mouse_event(fpage, type, pos_x, pos_y, button: "left", buttons: 1, click_count: 0)
+    params = { type:, x: pos_x, y: pos_y, button:, buttons: }
+    params[:clickCount] = click_count if click_count.positive?
+    fpage.command("Input.dispatchMouseEvent", **params)
+  end
+
+  def drag(source:, target:, edge: nil)
+    fpage = ferrum_page
+    intercepted = Concurrent::AtomicReference.new(nil)
+    subscription = fpage.on("Input.dragIntercepted") { |params, _i, _t| intercepted.set(params["data"]) }
+    fpage.command("Input.setInterceptDrags", enabled: true)
+
+    sx, sy = point(source)
+    tx, ty = point(target, edge:)
+
+    mouse_event(fpage, "mouseMoved", sx, sy, button: "none", buttons: 0)
+    mouse_event(fpage, "mousePressed", sx, sy, click_count: 1)
+    # Chrome only starts a drag when the move carries `button`, not just the
+    # `buttons` bitmask that Ferrum::Mouse#move sends.
+    5.times { |i| mouse_event(fpage, "mouseMoved", sx, sy + ((i + 1) * 6)) }
+
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    sleep 0.05 while intercepted.get.nil? && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+    data = intercepted.get
+    raise "Chrome never intercepted a drag (no Input.dragIntercepted)" if data.nil?
+
+    %w[dragEnter dragOver dragOver drop].each do |type|
+      fpage.command("Input.dispatchDragEvent", type:, x: tx, y: ty, data:)
+    end
+
+    mouse_event(fpage, "mouseReleased", tx, ty, buttons: 0, click_count: 1)
+    # Pragmatic clears its honey-pot overlay on the next pointer move.
+    mouse_event(fpage, "mouseMoved", tx, ty + 1, button: "none", buttons: 0)
+  ensure
+    begin
+      fpage.command("Input.setInterceptDrags", enabled: false)
+    rescue StandardError
+      nil
+    end
+    fpage.off("Input.dragIntercepted", subscription) if subscription
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-335

# What are you trying to accomplish?

**Spike, not for merge.** Proves the backlogs drag specs can leave Selenium, and shows what upstream needs to change first.

Cuprite 0.18 added HTML5 drag-and-drop to `Node#drag_to`, but it does not drive Pragmatic drag-and-drop: the emulation fires `dragleave` on the target immediately before `drop` (tearing down Pragmatic's drop target), and dispatches the deciding `dragover`/`drop` at the target's centre with no offset parameter, so above/below edge resolution cannot be expressed. Capybara's Selenium `drag_to(html5: true)` fails identically — Cuprite's `drag.js` is a faithful port of Capybara's script — which is why these specs use ActionBuilder in the first place.

Driving CDP drag interception directly does work. `Input.setInterceptDrags`, then `Input.dispatchDragEvent` with explicit coordinates using the payload from `Input.dragIntercepted`. Chrome emits genuine, correctly ordered events and honours the coordinates.

Measured on `drag_in_sprint_spec.rb`, run under Cuprite instead of Selenium:

```
Selenium ActionBuilder:      mousedown, mousemove, dragstart, dragenter, dragover, drop, dragend
Cuprite drag_to(html5: true): mousedown, dragstart, dragenter, dragover, dragover, dragleave, drop  <- drop not handled
Cuprite via CDP interception: mousedown, mousemove, dragstart, dragenter, dragover x3, drop, dragend
```

`drag_in_sprint_spec.rb` is 7/7 green under Cuprite, twice consecutively, at 6.0s against Selenium's 9.2s. Across four backlogs drag files it is 22/24; both failures are `pick_up_and_release_backlogs_item`, which is still Selenium-only and was not ported.

# What approach did you choose and why?

`spec/support/cdp_drag_spike.rb` talks raw CDP from the spec suite, which is why this is a spike rather than a PR. The work belongs upstream:

- Ferrum: `Ferrum::Mouse#move` sends the `buttons` bitmask but omits `button:` on `mouseMoved`, so Chrome never starts a drag and interception never fires. Adding it is the single change that unblocks everything here.
- Cuprite: a real-drag path for `drag_to`, plus a way to aim at a point rather than the target's centre.

Upstream issues are filed and this branch is the reference implementation behind them: rubycdp/ferrum#635 (the blocking one-field fix) and rubycdp/cuprite#325. If upstream lands the primitives, the follow-up under [AGILE-335](https://community.openproject.org/wp/AGILE-335) replaces this file with the driver API and ports the remaining helper.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)