### PR TITLE
Support start and duration on seeded versions

### DIFF
--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -60,13 +60,25 @@ module DemoData
         name: config["name"],
         status: config["status"],
         sharing: config["sharing"],
-        project:
+        project:,
+        **date_attributes
       )
       seed_data.store_reference(config["reference"], version)
 
       set_wiki! version, config["wiki"]
 
       version
+    end
+
+    def date_attributes
+      return {} if config["start"].nil?
+
+      start_date = Date.current.monday + config["start"].days
+
+      {
+        start_date:,
+        effective_date: WorkPackages::Shared::AllDays.new.due_date(start_date, config["duration"])
+      }
     end
 
     def set_wiki!(version, config)

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -743,9 +743,11 @@ projects:
               1. *Invite new members to your project*: &rightarrow; Go to [Members]({{opSetting:base_url}}/projects/your-scrum-project/members) in the project navigation.
               2. *View your Product backlog and Sprint backlogs*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) in the project navigation.
               3. *Create a sprint*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) and click "+ Sprint" to create a new sprint. Move work packages from the backlog to the sprint to plan the work to be done. When ready, click "Start sprint".
-              4. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/your-scrum-project/work_packages/new).
-              5. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:scrum_project__query__project_plan) in the project navigation.
-              6. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/your-scrum-project/settings/modules).
+              4. *View your Sprint board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select Sprint Board.
+              5. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/your-scrum-project/work_packages/new).
+              6. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:scrum_project__query__project_plan) in the project navigation.
+              7. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/your-scrum-project/settings/modules).
+
 
               Here you will find our [User Guides](https://www.openproject.org/docs/user-guide/).
               Please let us know if you have any questions or need support. Contact us: [support[at]openproject.com](mailto:support@openproject.com).

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -742,7 +742,7 @@ projects:
 
               1. *Invite new members to your project*: &rightarrow; Go to [Members]({{opSetting:base_url}}/projects/your-scrum-project/members) in the project navigation.
               2. *View your Product backlog and Sprint backlogs*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) in the project navigation.
-              3. *View your Task board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select [Task Board](##sprint:scrum_project__version__sprint_1).
+              3. *View your Task board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select Task Board.
               4. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/your-scrum-project/work_packages/new).
               5. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:scrum_project__query__project_plan) in the project navigation.
               6. *Create a Sprint wiki*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) and open the sprint wiki from the right drop down menu in a sprint. You can edit the [wiki template]({{opSetting:base_url}}/projects/your-scrum-project/wiki/) based on your needs.

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -742,11 +742,10 @@ projects:
 
               1. *Invite new members to your project*: &rightarrow; Go to [Members]({{opSetting:base_url}}/projects/your-scrum-project/members) in the project navigation.
               2. *View your Product backlog and Sprint backlogs*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) in the project navigation.
-              3. *View your Task board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select Task Board.
+              3. *Create a sprint*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) and click "+ Sprint" to create a new sprint. Move work packages from the backlog to the sprint to plan the work to be done. When ready, click "Start sprint".
               4. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/your-scrum-project/work_packages/new).
               5. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:scrum_project__query__project_plan) in the project navigation.
-              6. *Create a Sprint wiki*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) and open the sprint wiki from the right drop down menu in a sprint. You can edit the [wiki template]({{opSetting:base_url}}/projects/your-scrum-project/wiki/) based on your needs.
-              7. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/your-scrum-project/settings/modules).
+              6. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/your-scrum-project/settings/modules).
 
               Here you will find our [User Guides](https://www.openproject.org/docs/user-guide/).
               Please let us know if you have any questions or need support. Contact us: [support[at]openproject.com](mailto:support@openproject.com).

--- a/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/spec/seeders/demo_data/project_seeder_spec.rb
@@ -63,6 +63,38 @@ RSpec.describe DemoData::ProjectSeeder do
     expect(seed_data.find_reference(:product_backlog)).to eq(created_version)
   end
 
+  it "creates versions without dates when start is not given" do
+    project_seeder.seed!
+
+    expect(Version.find_by!(name: "The product backlog"))
+      .to have_attributes(start_date: nil, effective_date: nil)
+  end
+
+  context "for a version with start and duration" do
+    before do
+      project_data.update(
+        "versions" => [
+          {
+            "name" => "1.0",
+            "reference" => :version_1_0,
+            "sharing" => "none",
+            "status" => "open",
+            "start" => 14,
+            "duration" => 5
+          }
+        ]
+      )
+    end
+
+    it "counts start from the Monday of the current week and duration in calendar days" do
+      project_seeder.seed!
+
+      expect(Version.find_by!(name: "1.0"))
+        .to have_attributes(start_date: Date.current.monday + 14.days,
+                            effective_date: Date.current.monday + 18.days)
+    end
+  end
+
   context "for a version with a wiki" do
     before do
       project_data.update(


### PR DESCRIPTION
Set ground for time-scoping of Versions. To be leveraged by https://github.com/opf/openproject/pull/25149 further up the stack.