### PR TITLE
[COMMS-1013] Seed observed_in_versions on work packages

### DIFF
--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -89,6 +89,7 @@ module DemoData
       wp_attr = base_work_package_attributes attributes
 
       set_target_versions! wp_attr, attributes
+      set_observed_in_versions! wp_attr, attributes
       set_time_tracking_attributes! wp_attr, attributes
       set_backlogs_attributes! wp_attr, attributes
 
@@ -173,11 +174,19 @@ module DemoData
     end
 
     def set_target_versions!(wp_attr, attributes)
-      version_ids = Array(attributes["target_versions"]).filter_map do |reference|
-        seed_data.find_reference(reference)&.id
-      end
+      version_ids = version_ids_for(attributes, "target_versions")
 
       wp_attr[:target_version_ids_replacements] = version_ids if version_ids.any?
+    end
+
+    def set_observed_in_versions!(wp_attr, attributes)
+      version_ids = version_ids_for(attributes, "observed_in_versions")
+
+      wp_attr[:observed_in_version_ids_replacements] = version_ids if version_ids.any?
+    end
+
+    def version_ids_for(attributes, key)
+      seed_data.find_references(attributes[key]).filter_map { it&.id }
     end
 
     def set_time_tracking_attributes!(wp_attr, attributes)

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -759,6 +759,8 @@ projects:
         type: :default_type_bug
         target_versions:
           - :scrum_project__version__1_1
+        observed_in_versions:
+          - :scrum_project__version__1_0
         position: 1
       - t_subject: New website
         reference: :new_website
@@ -825,6 +827,9 @@ projects:
         reference: :wrong_hover_color
         status: :default_status_rejected
         type: :default_type_bug
+        observed_in_versions:
+          - :scrum_project__version__1_0
+          - :scrum_project__version__1_1
         position: 4
         story_points: 1
         start: 21

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe DemoData::WorkPackageSeeder do
     end
   end
 
-  describe "target_versions" do
+  describe "versions" do
     let(:version_alpha) { create(:version, project:, name: "Alpha") }
     let(:version_beta) { create(:version, project:, name: "Beta") }
     let(:seed_data) do
@@ -399,7 +399,7 @@ RSpec.describe DemoData::WorkPackageSeeder do
       seed_data
     end
 
-    context "without target_versions" do
+    context "without any version reference" do
       let(:work_packages_data) do
         [work_package_data(subject: "no versions")]
       end
@@ -434,6 +434,33 @@ RSpec.describe DemoData::WorkPackageSeeder do
         expect(wp.work_package_versions.pluck(:kind, :version_id))
           .to contain_exactly(["target", version_alpha.id], ["target", version_beta.id])
         expect(wp.target_versions).to contain_exactly(version_alpha, version_beta)
+      end
+    end
+
+    context "with observed_in_versions references" do
+      let(:work_packages_data) do
+        [work_package_data(subject: "observed", observed_in_versions: %i[version_alpha version_beta])]
+      end
+
+      it "creates one kind: 'observed_in' row per resolved version" do
+        wp = WorkPackage.find_by(subject: "observed")
+        expect(wp.work_package_versions.pluck(:kind, :version_id))
+          .to contain_exactly(["observed_in", version_alpha.id], ["observed_in", version_beta.id])
+        expect(wp.observed_in_versions).to contain_exactly(version_alpha, version_beta)
+      end
+    end
+
+    context "with both target_versions and observed_in_versions references" do
+      let(:work_packages_data) do
+        [work_package_data(subject: "both",
+                           target_versions: [:version_beta],
+                           observed_in_versions: [:version_alpha])]
+      end
+
+      it "keeps the two kinds apart" do
+        wp = WorkPackage.find_by(subject: "both")
+        expect(wp.target_versions).to contain_exactly(version_beta)
+        expect(wp.observed_in_versions).to contain_exactly(version_alpha)
       end
     end
   end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe RootSeeder,
       expect(count_by_version).to eq("1.0" => 9, "1.1" => 5, "2.0" => 5)
     end
 
+    it "links bugs to the versions they were observed in" do
+      count_by_version = WorkPackage.joins(:observed_in_versions).group("versions.name").count
+
+      expect(count_by_version).to eq("1.0" => 2, "1.1" => 1)
+    end
+
     it "adds the backlogs, board, costs, meetings, and reporting modules to the default_projects_modules setting" do
       default_modules = Setting.find_by(name: "default_projects_modules").value
       expect(default_modules).to include("backlogs")


### PR DESCRIPTION
Add some data for our flashy new `WorkPackage.observed_versions` field.