### PR TITLE
Run npm audit fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6304,16 +6304,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.24.0.tgz",
-      "integrity": "sha512-GTAsXAI32p4hEZgPzvUv2RPrObxamy9AFhmhG10fXSvN/cDUs8naEYVIqDV3Sh99jMwQEbTFKW1E1mcspsY6ow==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.3.tgz",
+      "integrity": "sha512-Cz50pvciQrxdSxgTkHOVz0uD0Yl/8Xt0QatGD6ILm47jW8EzyHR9RkUGs/D5IqzXKuVPntfw1ttaT926vXfiRg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.24.0"
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bold": {
@@ -7386,9 +7386,9 @@
       }
     },
     "node_modules/@xeokit/xeokit-sdk": {
-      "version": "2.6.113",
-      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-sdk/-/xeokit-sdk-2.6.113.tgz",
-      "integrity": "sha512-MjYGlu5qxbBrkZ0Z7ayieYx3xJA7mZKPh/Cw8OVdbKqvRaxp9R7N1oOYcTH9ilC8f+4ajsK9FZpTBxJpHYqlZg==",
+      "version": "2.6.114",
+      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-sdk/-/xeokit-sdk-2.6.114.tgz",
+      "integrity": "sha512-kWp35wehLwZfXYHsCom6FuF3D0VAlKeUyYV59yibCUY1eJOMZxJV398eg5P59hm3OpB33fhuY2bGJVSsYF3t7g==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@loaders.gl/core": "4.3.4",


### PR DESCRIPTION
Created by GitHub action.

## Impacted packages

### frontend
- `@loaders.gl/gltf` (high)
- `@loaders.gl/textures` (high)
- `@tiptap/core` (moderate)
- `@xeokit/xeokit-bim-viewer` (high)
- `@xeokit/xeokit-sdk` (high)
- `esbuild` (low)
- `image-size` (high)
- `texture-compressor` (high)
