### PR TITLE
[OP-20020] Creating a child-group does not inherit parents memberships

### DIFF
--- a/app/services/groups/ancestor_membership_propagation.rb
+++ b/app/services/groups/ancestor_membership_propagation.rb
@@ -29,13 +29,23 @@
 #++
 
 module Groups
-  class DeleteService < BaseServices::Delete
-    protected
+  module AncestorMembershipPropagation
+    extend ActiveSupport::Concern
 
-    def destroy(group) # rubocop:disable Naming/PredicateMethod
-      group.update_column(:status, Group.statuses[:deleted])
-      ::Principals::DeleteJob.perform_later(group)
-      true
+    private
+
+    # Inherited memberships are materialized as member_roles pointing back at the ancestor's
+    # member_role, so they have to be (re)created whenever a group's set of ancestors changes.
+    # Both the groups in the subtree and their users receive them.
+    def propagate_ancestor_memberships(group)
+      subtree = group.self_and_descendants.to_a
+      principal_ids = (subtree.flat_map(&:user_ids) + subtree.map(&:id)).uniq
+
+      group.ancestors.each do |ancestor|
+        Groups::CreateInheritedRolesService
+          .new(ancestor, current_user: user)
+          .call(user_ids: principal_ids)
+      end
     end
   end
 end

--- a/app/services/groups/cleanup_inherited_roles_service.rb
+++ b/app/services/groups/cleanup_inherited_roles_service.rb
@@ -37,7 +37,7 @@
 
 module Groups
   class CleanupInheritedRolesService < ::BaseServices::BaseContracted
-    include Groups::Concerns::MembershipManipulation
+    include MembershipManipulation
 
     def initialize(group, current_user:, contract_class: AdminOnlyContract)
       self.model = group

--- a/app/services/groups/create_inherited_roles_service.rb
+++ b/app/services/groups/create_inherited_roles_service.rb
@@ -33,7 +33,7 @@ module Groups
   # This can be scoped to only a certain project which results in considerably better performance.
   class CreateInheritedRolesService < ::BaseServices::BaseContracted
     using CoreExtensions::SquishSql
-    include Groups::Concerns::MembershipManipulation
+    include MembershipManipulation
 
     def initialize(group, current_user:, contract_class: AdminOnlyContract)
       self.model = group

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -28,4 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Groups::CreateService < BaseServices::Create; end
+module Groups
+  class CreateService < BaseServices::Create
+    include AncestorMembershipPropagation
+
+    protected
+
+    def after_perform(call)
+      group = call.result
+      propagate_ancestor_memberships(group) if group.parent_id.present?
+
+      call
+    end
+  end
+end

--- a/app/services/groups/membership_manipulation.rb
+++ b/app/services/groups/membership_manipulation.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Groups::Concerns
+module Groups
   module MembershipManipulation
     extend ActiveSupport::Concern
 

--- a/app/services/groups/update_roles_service.rb
+++ b/app/services/groups/update_roles_service.rb
@@ -32,7 +32,7 @@
 
 module Groups
   class UpdateRolesService < ::BaseServices::BaseContracted
-    include Groups::Concerns::MembershipManipulation
+    include MembershipManipulation
 
     def initialize(group, current_user:, contract_class: AdminOnlyContract)
       self.model = group

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -28,133 +28,124 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Groups::UpdateService < BaseServices::Update
-  protected
+module Groups
+  class UpdateService < BaseServices::Update
+    include AncestorMembershipPropagation
 
-  def persist(call)
-    removed_users = groups_removed_users(call.result)
-    member_roles = member_roles_to_prune(removed_users)
-    project_ids = member_roles.pluck(:project_id)
-    member_role_ids = member_roles.pluck(:id)
+    protected
 
-    former_parent_id = model.detail&.parent_id_in_database
+    def persist(call)
+      removed_users = groups_removed_users(call.result)
+      member_roles = member_roles_to_prune(removed_users)
+      project_ids = member_roles.pluck(:project_id)
+      member_role_ids = member_roles.pluck(:id)
 
-    call = super
+      former_parent_id = model.detail&.parent_id_in_database
 
-    remove_member_roles(member_role_ids)
-    cleanup_members(removed_users, project_ids)
-    handle_parent_change(former_parent_id)
+      call = super
 
-    call
-  end
+      remove_member_roles(member_role_ids)
+      cleanup_members(removed_users, project_ids)
+      handle_parent_change(former_parent_id)
 
-  def after_perform(call)
-    new_user_ids = call.result.group_users.select(&:saved_changes?).map(&:user_id)
-
-    if new_user_ids.any?
-      db_call = ::Groups::AddUsersService
-                  .new(call.result, current_user: user)
-                  .call(ids: new_user_ids)
-
-      call.add_dependent!(db_call)
+      call
     end
 
-    call
-  end
+    def after_perform(call)
+      new_user_ids = call.result.group_users.select(&:saved_changes?).map(&:user_id)
 
-  def groups_removed_users(group)
-    group.group_users.select(&:marked_for_destruction?).filter_map(&:user)
-  end
+      if new_user_ids.any?
+        db_call = ::Groups::AddUsersService
+                    .new(call.result, current_user: user)
+                    .call(ids: new_user_ids)
 
-  def remove_member_roles(member_role_ids)
-    ::Groups::CleanupInheritedRolesService
-      .new(model, current_user: user)
-      .call(member_role_ids:)
-  end
+        call.add_dependent!(db_call)
+      end
 
-  def member_roles_to_prune(users) # rubocop:disable Metrics/AbcSize
-    return MemberRole.none if users.empty?
+      call
+    end
 
-    user_ids = users.map(&:id)
+    def groups_removed_users(group)
+      group.group_users.select(&:marked_for_destruction?).filter_map(&:user)
+    end
 
-    direct_ids = MemberRole
-      .joins(:member)
-      .where(inherited_from: model.members.joins(:member_roles).select("member_roles.id"))
-      .where(members: { user_id: user_ids })
-      .pluck(:id)
+    def remove_member_roles(member_role_ids)
+      ::Groups::CleanupInheritedRolesService
+        .new(model, current_user: user)
+        .call(member_role_ids:)
+    end
 
-    ancestor_ids = ancestor_member_role_ids_to_prune(users)
+    def member_roles_to_prune(users) # rubocop:disable Metrics/AbcSize
+      return MemberRole.none if users.empty?
 
-    all_ids = (direct_ids + ancestor_ids).uniq
-    return MemberRole.none if all_ids.empty?
+      user_ids = users.map(&:id)
 
-    MemberRole.joins(:member).where(id: all_ids)
-  end
-
-  def ancestor_member_role_ids_to_prune(users)
-    model.ancestors.flat_map do |ancestor|
-      users_not_in_ancestor = users.reject { |u| ancestor.user_ids.include?(u.id) }
-      next [] if users_not_in_ancestor.empty?
-
-      MemberRole
+      direct_ids = MemberRole
         .joins(:member)
-        .where(inherited_from: ancestor.members.joins(:member_roles).select("member_roles.id"))
-        .where(members: { user_id: users_not_in_ancestor.map(&:id) })
-        .pluck(:id)
-    end
-  end
-
-  def handle_parent_change(former_parent_id)
-    new_parent_id = model.detail&.parent_id
-    return if former_parent_id == new_parent_id
-
-    propagate_ancestor_memberships if new_parent_id.present?
-    cleanup_former_ancestor_memberships(former_parent_id) if former_parent_id.present?
-  end
-
-  def propagate_ancestor_memberships
-    group_ids = model.self_and_descendants.pluck(:id)
-    user_ids = model.self_and_descendants.flat_map(&:user_ids).uniq
-    principal_ids = (user_ids + group_ids).uniq
-    return if principal_ids.empty?
-
-    model.ancestors.each do |ancestor|
-      Groups::CreateInheritedRolesService
-        .new(ancestor, current_user: user)
-        .call(user_ids: principal_ids)
-    end
-  end
-
-  def cleanup_former_ancestor_memberships(former_parent_id) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
-    former_parent = Group.find_by(id: former_parent_id)
-    return unless former_parent
-
-    affected_users = model.self_and_descendants.flat_map(&:users).uniq
-    affected_group_ids = model.self_and_descendants.pluck(:id)
-    return if affected_users.empty? && affected_group_ids.empty?
-
-    former_parent.self_and_ancestors.each do |ancestor|
-      users_not_in_ancestor = affected_users.reject { |u| ancestor.user_ids.include?(u.id) }
-      principal_ids_to_clean = users_not_in_ancestor.map(&:id) + affected_group_ids
-      next if principal_ids_to_clean.empty?
-
-      role_ids_to_clean = MemberRole
-        .joins(:member)
-        .where(inherited_from: ancestor.members.joins(:member_roles).select("member_roles.id"))
-        .where(members: { user_id: principal_ids_to_clean })
+        .where(inherited_from: model.members.joins(:member_roles).select("member_roles.id"))
+        .where(members: { user_id: user_ids })
         .pluck(:id)
 
-      next if role_ids_to_clean.empty?
+      ancestor_ids = ancestor_member_role_ids_to_prune(users)
 
-      Groups::CleanupInheritedRolesService
-        .new(ancestor, current_user: user)
-        .call(member_role_ids: role_ids_to_clean)
+      all_ids = (direct_ids + ancestor_ids).uniq
+      return MemberRole.none if all_ids.empty?
+
+      MemberRole.joins(:member).where(id: all_ids)
     end
-  end
 
-  def cleanup_members(users, project_ids)
-    Members::CleanupService
-      .new(users, project_ids)
-      .call
+    def ancestor_member_role_ids_to_prune(users)
+      model.ancestors.flat_map do |ancestor|
+        users_not_in_ancestor = users.reject { |u| ancestor.user_ids.include?(u.id) }
+        next [] if users_not_in_ancestor.empty?
+
+        MemberRole
+          .joins(:member)
+          .where(inherited_from: ancestor.members.joins(:member_roles).select("member_roles.id"))
+          .where(members: { user_id: users_not_in_ancestor.map(&:id) })
+          .pluck(:id)
+      end
+    end
+
+    def handle_parent_change(former_parent_id)
+      new_parent_id = model.detail&.parent_id
+      return if former_parent_id == new_parent_id
+
+      propagate_ancestor_memberships(model) if new_parent_id.present?
+      cleanup_former_ancestor_memberships(former_parent_id) if former_parent_id.present?
+    end
+
+    def cleanup_former_ancestor_memberships(former_parent_id) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+      former_parent = Group.find_by(id: former_parent_id)
+      return unless former_parent
+
+      affected_users = model.self_and_descendants.flat_map(&:users).uniq
+      affected_group_ids = model.self_and_descendants.pluck(:id)
+      return if affected_users.empty? && affected_group_ids.empty?
+
+      former_parent.self_and_ancestors.each do |ancestor|
+        users_not_in_ancestor = affected_users.reject { |u| ancestor.user_ids.include?(u.id) }
+        principal_ids_to_clean = users_not_in_ancestor.map(&:id) + affected_group_ids
+        next if principal_ids_to_clean.empty?
+
+        role_ids_to_clean = MemberRole
+          .joins(:member)
+          .where(inherited_from: ancestor.members.joins(:member_roles).select("member_roles.id"))
+          .where(members: { user_id: principal_ids_to_clean })
+          .pluck(:id)
+
+        next if role_ids_to_clean.empty?
+
+        Groups::CleanupInheritedRolesService
+          .new(ancestor, current_user: user)
+          .call(member_role_ids: role_ids_to_clean)
+      end
+    end
+
+    def cleanup_members(users, project_ids)
+      Members::CleanupService
+        .new(users, project_ids)
+        .call
+    end
   end
 end

--- a/spec/services/groups/hierarchy_membership_integration_spec.rb
+++ b/spec/services/groups/hierarchy_membership_integration_spec.rb
@@ -249,6 +249,73 @@ RSpec.describe "Group hierarchy membership propagation", type: :model do
   end
 
   # ---------------------------------------------------------------------------
+  # Groups::CreateService — a group created with a parent already set inherits
+  #                         that parent's memberships right away
+  # ---------------------------------------------------------------------------
+
+  describe "Groups::CreateService — parent set on creation" do
+    let!(:root_group) { create(:group, members: [root_user]) }
+
+    before do
+      Members::CreateService
+        .new(user: admin)
+        .call(principal: root_group, project_id: project.id, role_ids: [role.id])
+    end
+
+    def create_subgroup(name, parent)
+      Groups::CreateService
+        .new(user: admin)
+        .call(lastname: name, parent_id: parent.id)
+        .result
+    end
+
+    it "gives the new subgroup the memberships of its parent" do
+      subgroup = create_subgroup("Subgroup", root_group)
+
+      expect(subgroup.memberships.find_by(project:)&.roles).to contain_exactly(role)
+    end
+
+    it "marks the subgroup's membership as inherited from the parent" do
+      subgroup = create_subgroup("Subgroup", root_group)
+      parent_member_role_ids = root_group.members.find_by(project:).member_roles.ids
+
+      member_roles = subgroup.members.find_by(project:)&.member_roles
+
+      expect(member_roles&.pluck(:inherited_from)).to match_array(parent_member_role_ids)
+    end
+
+    it "gives the new subgroup the memberships of every ancestor, not just the direct parent" do
+      mid_role = create(:project_role)
+      mid_group = create_subgroup("Mid", root_group)
+      Members::CreateService
+        .new(user: admin)
+        .call(principal: mid_group, project_id: project.id, role_ids: [mid_role.id])
+
+      leaf_group = create_subgroup("Leaf", mid_group)
+
+      expect(leaf_group.memberships.find_by(project:)&.roles).to contain_exactly(role, mid_role)
+    end
+
+    it "gives a user added to the subgroup afterwards the memberships of the parent" do
+      subgroup = create_subgroup("Subgroup", root_group)
+
+      Groups::AddUsersService
+        .new(subgroup, current_user: admin)
+        .call(ids: [leaf_user.id])
+
+      expect(leaf_user.memberships.find_by(project:)&.roles).to contain_exactly(role)
+    end
+
+    it "does not assign the parent's memberships to unrelated groups" do
+      other_group = create(:group, members: [mid_user])
+      create_subgroup("Subgroup", root_group)
+
+      expect(other_group.memberships.find_by(project:)).to be_nil
+      expect(mid_user.memberships.find_by(project:)).to be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Groups::UpdateService — changing the parent propagates/cleans up memberships
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-20020/activity

# What are you trying to accomplish?
- `Groups::UpdateService` checks if the parent was changed and inherits all memberships of the parent. This was missing from the `CreateService`.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
