### PR TITLE
[JIM-147] Use OpPrimer::SpinnerButtonComponent

### DIFF
--- a/app/components/admin/import/jira/import_runs/job_status_component.rb
+++ b/app/components/admin/import/jira/import_runs/job_status_component.rb
@@ -49,7 +49,13 @@ module Admin::Import::Jira::ImportRuns
               # concat(render(Primer::Beta::Text.new) { "(36/45)" })
             end)
             concat(render(Primer::Box.new(display: :flex, align_items: :center, style: "gap: 8px;")) do
-              concat(render(Primer::Beta::Octicon.new(**job_status_icon(@job.status))))
+              concat(
+                if @job.status == :running
+                  render(OpPrimer::SpinnerIconComponent.new)
+                else
+                  render(Primer::Beta::Octicon.new(**job_status_icon(@job.status)))
+                end
+              )
               concat(
                 render(Primer::Beta::ProgressBar.new(size: :default, style: "min-width: 300px;")) do |c|
                   percentage = if @job.status == :succeeded

--- a/app/components/admin/import/jira/import_runs/select_projects/modal_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/select_projects/modal_component.html.erb
@@ -47,14 +47,13 @@
           end
         )
         modal_footer.with_component(
-          Primer::Beta::Button.new(
+          OpPrimer::SpinnerButtonComponent.new(
             scheme: :primary,
             tag: :a,
             hidden: true,
             data: { "admin--jira-projects-target": "spinnerButton" }
           )
-        ) do |spinner_button|
-          spinner_button.with_trailing_visual_icon(icon: :sync, animation: :rotate, style: "min-width: 2rem")
+        ) do
           I18n.t(:"admin.jira.run.wizard.select_projects.button_select")
         end
       end

--- a/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.html.erb
@@ -171,7 +171,7 @@ See COPYRIGHT and LICENSE files for more details.
             )
             concat(
               render(
-                Primer::Beta::Button.new(
+                OpPrimer::SpinnerButtonComponent.new(
                   scheme: :danger,
                   tag: :a,
                   size: :medium,
@@ -179,8 +179,7 @@ See COPYRIGHT and LICENSE files for more details.
                   disabled: true,
                   data: { turbo_stream: true }
                 )
-              ) do |button|
-                button.with_leading_visual_icon(icon: :sync, animation: :rotate)
+              ) do
                 I18n.t(:"admin.jira.run.wizard.button_abort")
               end
             )
@@ -202,12 +201,11 @@ See COPYRIGHT and LICENSE files for more details.
           render(Primer::Alpha::Stack.new(direction: :horizontal)) do
             concat(
               render(
-                Primer::Beta::Button.new(
+                OpPrimer::SpinnerButtonComponent.new(
                   scheme: :primary,
                   disabled: true
                 )
-              ) do |button|
-                button.with_leading_visual_icon(icon: :sync, animation: :rotate)
+              ) do
                 I18n.t(:"admin.jira.run.wizard.sections.confirm_import.button_importing")
               end
             )

--- a/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
@@ -98,14 +98,15 @@ See COPYRIGHT and LICENSE files for more details.
         end
       elsif model.in_state?(:instance_meta_fetching)
         box.with_row(display: :flex, align_items: :center) do
+          job_status = model.state_machine.last_transition_to(:instance_meta_fetching).actual_job.status
           concat(
             render(
-              Primer::Beta::Button.new(
+              (job_status == :running ? OpPrimer::SpinnerButtonComponent : Primer::Beta::Button).new(
                 tag: :a,
                 size: :medium
               )
             ) do |button|
-              button.with_leading_visual_icon(**job_status_icon(model.state_machine.last_transition_to(:instance_meta_fetching).actual_job.status))
+              button.with_leading_visual_icon(**job_status_icon(job_status)) unless job_status == :running
               I18n.t(:"admin.jira.run.wizard.sections.fetch_data.label_progress")
             end
           )

--- a/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.html.erb
@@ -129,13 +129,14 @@ See COPYRIGHT and LICENSE files for more details.
               I18n.t(:"admin.jira.run.wizard.sections.import_scope.button_select")
             end
           )
+          job_status = model.state_machine.last_transition_to(:projects_meta_fetching).actual_job.status
           concat(
             render(
-              Primer::Beta::Button.new(
+              (job_status == :running ? OpPrimer::SpinnerButtonComponent : Primer::Beta::Button).new(
                 size: :medium
               )
             ) do |button|
-              button.with_leading_visual_icon(**job_status_icon(model.state_machine.last_transition_to(:projects_meta_fetching).actual_job.status))
+              button.with_leading_visual_icon(**job_status_icon(job_status)) unless job_status == :running
               I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_progress")
             end
           )


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-147

# What are you trying to achieve?

Use the new SpinnerButton instead of the animated sync icon
