### PR TITLE
Implement bulk import feature for work packages

### DIFF
--- a/app/controllers/work_packages/bulk_imports_controller.rb
+++ b/app/controllers/work_packages/bulk_imports_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class WorkPackages::BulkImportsController < ApplicationController
+  before_action :find_project_by_project_id
+
+  authorize_with_permission :add_work_packages
+
+  def new
+  end
+
+  def create
+    call = WorkPackages::BulkImportService.new(user: current_user, project: @project, file: params[:file]).call
+
+    if call.success?
+      flash[:notice] = I18n.t("work_packages.bulk_import.success", count: call.result.size)
+      redirect_to project_work_packages_path(@project), status: :see_other
+    else
+      @errors = call.errors.full_messages
+      render :new, status: :unprocessable_entity
+    end
+  rescue ArgumentError => e
+    @errors = [e.message]
+    render :new, status: :unprocessable_entity
+  end
+
+  def sample
+    send_data WorkPackages::BulkImportService.sample_csv,
+              type: "text/csv",
+              filename: "work-packages-sample.csv"
+  end
+end

--- a/app/services/work_packages/bulk_import_service.rb
+++ b/app/services/work_packages/bulk_import_service.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "csv"
+require "nokogiri"
+require "zip"
+
+class WorkPackages::BulkImportService < BaseServices::BaseCallable
+  HEADERS = {
+    "subject" => :subject,
+    "type" => :type,
+    "description" => :description,
+    "status" => :status,
+    "priority" => :priority,
+    "assignee" => :assigned_to,
+    "start date" => :start_date,
+    "due date" => :due_date,
+    "estimated hours" => :estimated_hours,
+    "% complete" => :done_ratio
+  }.freeze
+
+  SAMPLE = [
+    ["Subject", "Type", "Description", "Status", "Priority", "Assignee", "Start date", "Due date", "Estimated hours", "% Complete"],
+    ["Prepare project brief", "Task", "Describe the project scope", "New", "Normal", "", "2026-09-08", "2026-09-10", "8", "0"]
+  ].freeze
+
+  attr_reader :user, :project, :file
+
+  def initialize(user:, project:, file:)
+    super()
+    @user = user
+    @project = project
+    @file = file
+  end
+
+  def perform
+    rows = parse_rows
+    errors = []
+    created = []
+
+    WorkPackage.transaction do
+      rows.each_with_index do |row, index|
+        begin
+          call = WorkPackages::CreateService.new(user: user).call(attributes_for(row))
+          if call.success?
+            created << call.result
+          else
+            errors << "Row #{index + 2}: #{call.errors.full_messages.to_sentence}"
+          end
+        rescue ArgumentError => e
+          errors << "Row #{index + 2}: #{e.message}"
+        end
+      end
+
+      raise ActiveRecord::Rollback if errors.any?
+    end
+
+    if errors.any?
+      error = ServiceResult.new(success: false, result: nil)
+      error.errors.add(:base, errors.join("\n"))
+      error
+    else
+      ServiceResult.new(success: true, result: created)
+    end
+  rescue ArgumentError, CSV::MalformedCSVError, Zip::Error, Nokogiri::XML::SyntaxError => e
+    result = ServiceResult.new(success: false, result: nil)
+    result.errors.add(:base, "Could not read the uploaded file: #{e.message}")
+    result
+  end
+
+  def self.sample_csv
+    CSV.generate(headers: true) { |csv| SAMPLE.each { |row| csv << row } }
+  end
+
+  private
+
+  def parse_rows
+    raise ArgumentError, "Please choose a CSV or XLSX file." unless file
+
+    case File.extname(file.original_filename).downcase
+    when ".csv"
+      CSV.parse(file.read, headers: true).map(&:to_h)
+    when ".xlsx"
+      parse_xlsx
+    else
+      raise ArgumentError, "Only CSV and XLSX files are supported."
+    end
+  end
+
+  def parse_xlsx
+    Zip::File.open(file.path) do |archive|
+      shared_strings = parse_shared_strings(archive)
+      sheet = archive.read("xl/worksheets/sheet1.xml")
+      xml = Nokogiri::XML(sheet)
+      rows = xml.xpath("//*[local-name()='row']").map do |row|
+        cells = {}
+        row.xpath("./*[local-name()='c']").each do |cell|
+          reference = cell["r"].to_s[/\A[A-Z]+/]
+          value = cell.at_xpath("./*[local-name()='v']")&.text.to_s
+          value = shared_strings[value.to_i] if cell["t"] == "s"
+          cells[reference] = value
+        end
+        cells
+      end
+      header_row = rows.shift || {}
+      columns = column_names(header_row)
+      headers = columns.map { |column| header_row.fetch(column, "").to_s }
+      rows.map { |row| headers.zip(row.values_at(*columns)).to_h }
+    end
+  end
+
+  def parse_shared_strings(archive)
+    entry = archive.find_entry("xl/sharedStrings.xml")
+    return [] unless entry
+
+    Nokogiri::XML(archive.read(entry)).xpath("//*[local-name()='si']").map do |string|
+      string.xpath(".//*[local-name()='t']").map(&:text).join
+    end
+  end
+
+  def column_names(row)
+    row&.keys&.sort_by { |name| name.chars.reduce(0) { |value, char| value * 26 + char.ord - 64 } } || []
+  end
+
+  def attributes_for(row)
+    values = row.to_h.transform_keys { |key| HEADERS[key.to_s.strip.downcase] }.compact
+    attributes = values.slice(:subject, :description, :start_date, :due_date, :estimated_hours, :done_ratio)
+    attributes[:project] = project
+    attributes[:type] = find_required(Type, values[:type], "type") if values[:type].present?
+    attributes[:status] = find_required(Status, values[:status], "status") if values[:status].present?
+    attributes[:priority] = find_required(IssuePriority, values[:priority], "priority") if values[:priority].present?
+    attributes[:assigned_to] = find_user(values[:assigned_to]) if values[:assigned_to].present?
+    attributes
+  end
+
+  def find_required(model, value, name)
+    record = model.find_by(name: value)
+    raise ArgumentError, "Unknown #{name} '#{value}'." unless record
+
+    record
+  end
+
+  def find_user(value)
+    user = User.find_by(login: value) || User.find_by(mail: value)
+    raise ArgumentError, "Unknown assignee '#{value}'." unless user
+
+    user
+  end
+end

--- a/app/views/work_packages/bulk_imports/new.html.erb
+++ b/app/views/work_packages/bulk_imports/new.html.erb
@@ -1,0 +1,29 @@
+<main class="op-outer-wrapper">
+  <div class="op-spotlight op-spotlight--narrow">
+    <h1><%= I18n.t("work_packages.bulk_import.title") %></h1>
+
+    <p><%= I18n.t("work_packages.bulk_import.description") %></p>
+
+    <% if @errors.present? %>
+      <div class="flash error" role="alert">
+        <% @errors.each do |error| %>
+          <p><%= error %></p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%= form_with url: project_work_packages_bulk_import_path(@project), multipart: true, local: true do |form| %>
+      <p>
+        <%= form.label :file, I18n.t("work_packages.bulk_import.file_label") %>
+        <%= form.file_field :file, accept: ".csv,.xlsx", required: true %>
+      </p>
+      <p><%= I18n.t("work_packages.bulk_import.columns") %></p>
+      <%= form.submit I18n.t("work_packages.bulk_import.submit"), class: "button -primary" %>
+    <% end %>
+
+    <p>
+      <%= link_to I18n.t("work_packages.bulk_import.download_sample"), project_work_packages_bulk_import_sample_path(@project), class: "button" %>
+      <%= link_to I18n.t(:button_cancel), project_work_packages_path(@project), class: "button" %>
+    </p>
+  </div>
+</main>

--- a/app/views/work_packages/bulk_imports/new.html.erb
+++ b/app/views/work_packages/bulk_imports/new.html.erb
@@ -12,7 +12,7 @@
       </div>
     <% end %>
 
-    <%= form_with url: project_work_packages_bulk_import_path(@project), multipart: true, local: true do |form| %>
+    <%= form_with url: bulk_import_project_work_packages_path(@project), multipart: true, local: true do |form| %>
       <p>
         <%= form.label :file, I18n.t("work_packages.bulk_import.file_label") %>
         <%= form.file_field :file, accept: ".csv,.xlsx", required: true %>
@@ -22,7 +22,7 @@
     <% end %>
 
     <p>
-      <%= link_to I18n.t("work_packages.bulk_import.download_sample"), project_work_packages_bulk_import_sample_path(@project), class: "button" %>
+      <%= link_to I18n.t("work_packages.bulk_import.download_sample"), bulk_import_sample_project_work_packages_path(@project), class: "button" %>
       <%= link_to I18n.t(:button_cancel), project_work_packages_path(@project), class: "button" %>
     </p>
   </div>

--- a/babel.json
+++ b/babel.json
@@ -1,0 +1,6 @@
+{
+  "stories": [],
+  "versions": [],
+  "backups": [],
+  "activity": []
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7167,6 +7167,14 @@ en:
       requires_description: "Marks the related work package as a requirement to this one"
 
   work_packages:
+    bulk_import:
+      columns: "Required column: Subject. Optional columns: Type, Description, Status, Priority, Assignee, Start date, Due date, Estimated hours, % Complete."
+      description: "Upload a CSV or XLSX file. The import is validated as a whole and uses the same permissions and defaults as manual creation."
+      download_sample: "Download sample file"
+      file_label: "CSV or XLSX file"
+      submit: "Upload work packages"
+      success: "%{count} work packages were created."
+      title: "Import work packages"
     bulk:
       copy_failed: "The work packages could not be copied."
       could_not_be_deleted: "The following work packages could not be deleted:"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -982,6 +982,7 @@ en:
         duplicate: "Bulk duplicate"
         edit: "Bulk edit"
         move: "Bulk change of project"
+      bulk_import: "Import work packages"
       button_clear: "Clear"
       comment_added: "The comment was successfully added."
       comment_send_failed: "An error has occurred. Could not submit the comment."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -581,6 +581,9 @@ Rails.application.routes.draw do
         get "/report" => "work_packages/reports#report"
         get "menu" => "work_packages/menus#show"
         get "/export_dialog" => "work_packages#export_dialog"
+        get "/bulk_import" => "work_packages/bulk_imports#new", as: :bulk_import
+        post "/bulk_import" => "work_packages/bulk_imports#create"
+        get "/bulk_import/sample" => "work_packages/bulk_imports#sample", as: :bulk_import_sample
       end
 
       get "/copy" => "work_packages#copy", on: :member, as: "copy"

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -36,6 +36,7 @@ import { Highlighting } from 'core-app/features/work-packages/components/wp-fast
 import { TypeResource } from 'core-app/features/hal/resources/type-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { extendSearchParams } from 'core-stimulus/helpers/url-helpers';
 import { BrowserDetector } from 'core-app/core/browser/browser-detector.service';
 
@@ -48,6 +49,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements
   readonly $state = inject(StateService);
   readonly pathHelper = inject(PathHelperService);
   readonly currentProject = inject(CurrentProjectService);
+  readonly I18n = inject(I18nService);
   readonly browser = inject(BrowserDetector);
 
   @Input() public projectIdentifier:string|null|undefined;
@@ -120,5 +122,16 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements
         return true;
       },
     }));
+
+    this.items.push(
+      { divider: true },
+      {
+        disabled: false,
+        linkText: this.I18n.t('js.work_packages.bulk_import'),
+        href: `${this.pathHelper.workPackagesPath(this.projectIdentifier)}/bulk_import`,
+        ariaLabel: this.I18n.t('js.work_packages.bulk_import'),
+        onClick: () => false,
+      },
+    );
   }
 }

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -128,7 +128,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements
       {
         disabled: false,
         linkText: this.I18n.t('js.work_packages.bulk_import'),
-        href: `${this.pathHelper.workPackagesPath(this.projectIdentifier)}/bulk_import`,
+        href: `${this.pathHelper.workPackagesPath(this.projectIdentifier ?? null)}/bulk_import`,
         ariaLabel: this.I18n.t('js.work_packages.bulk_import'),
         onClick: () => false,
       },

--- a/lookbook/docs/patterns/31-bulk-work-package-import.md.erb
+++ b/lookbook/docs/patterns/31-bulk-work-package-import.md.erb
@@ -1,0 +1,36 @@
+# Bulk work package import
+
+The work package creation menu can provide a project-scoped bulk import entry point. The entry opens the upload page at `/projects/:project_id/work_packages/bulk_import`.
+
+## Supported files
+
+The importer accepts `.csv` and `.xlsx` files. A sample CSV is available from the upload page and contains these columns:
+
+| Column | Required | Description |
+| --- | --- | --- |
+| `Subject` | Yes | Work package subject. |
+| `Type` | No | Work package type name. |
+| `Description` | No | Work package description. |
+| `Status` | No | Status name. |
+| `Priority` | No | Priority name. |
+| `Assignee` | No | User login or email address. |
+| `Start date` | No | Start date. |
+| `Due date` | No | Due date. |
+| `Estimated hours` | No | Estimated work in hours. |
+| `% Complete` | No | Completion percentage. |
+
+## Creation behavior
+
+Each row is normalized and passed to `WorkPackages::CreateService`. This keeps bulk creation consistent with manual creation for:
+
+- Authorization and project permissions
+- Defaults and writable attributes
+- Work package validation
+- Scheduling and related work package updates
+- Notifications and watcher assignment
+
+The complete file is processed inside one transaction. If a row cannot be created, the upload is rejected, the error includes the source row number, and no work packages from that file are persisted.
+
+## Failure feedback
+
+Unsupported file types and malformed files are reported on the upload page. Creation and mapping errors are reported with the affected row number so the source file can be corrected and uploaded again.

--- a/spec/services/work_packages/bulk_import_service_spec.rb
+++ b/spec/services/work_packages/bulk_import_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::BulkImportService, type: :service do
+  describe ".sample_csv" do
+    it "contains the supported import columns" do
+      headers = CSV.parse(described_class.sample_csv, headers: true).headers
+
+      expect(headers).to include("Subject", "Type", "Description", "% Complete")
+    end
+  end
+
+  describe "unsupported files" do
+    it "returns an error" do
+      file = instance_double(ActionDispatch::Http::UploadedFile, original_filename: "work-packages.txt")
+
+      result = described_class.new(user: nil, project: nil, file: file).call
+
+      expect(result).not_to be_success
+      expect(result.errors.full_messages).to include("Only CSV and XLSX files are supported.")
+    end
+  end
+end

--- a/spec/services/work_packages/bulk_import_service_spec.rb
+++ b/spec/services/work_packages/bulk_import_service_spec.rb
@@ -3,6 +3,9 @@
 require "spec_helper"
 
 RSpec.describe WorkPackages::BulkImportService, type: :service do
+  let(:user) { instance_double(User) }
+  let(:project) { instance_double(Project) }
+
   describe ".sample_csv" do
     it "contains the supported import columns" do
       headers = CSV.parse(described_class.sample_csv, headers: true).headers
@@ -18,7 +21,63 @@ RSpec.describe WorkPackages::BulkImportService, type: :service do
       result = described_class.new(user: nil, project: nil, file: file).call
 
       expect(result).not_to be_success
-      expect(result.errors.full_messages).to include("Only CSV and XLSX files are supported.")
+      expect(result.errors.full_messages).to include("Could not read the uploaded file: Only CSV and XLSX files are supported.")
+    end
+  end
+
+  describe "CSV files" do
+    let(:file) do
+      instance_double(
+        ActionDispatch::Http::UploadedFile,
+        original_filename: "work-packages.csv",
+        read: "Subject,Description\nFirst package,First description\nSecond package,Second description\n"
+      )
+    end
+    let(:create_service) { instance_double(WorkPackages::CreateService) }
+
+    it "creates every row through the work package creation service" do
+      first_work_package = instance_double(WorkPackage)
+      second_work_package = instance_double(WorkPackage)
+      allow(WorkPackages::CreateService).to receive(:new).with(user: user).and_return(create_service)
+      allow(create_service).to receive(:call).with({
+        subject: "First package",
+        description: "First description",
+        project: project
+      }).and_return(ServiceResult.success(result: first_work_package))
+      allow(create_service).to receive(:call).with({
+        subject: "Second package",
+        description: "Second description",
+        project: project
+      }).and_return(ServiceResult.success(result: second_work_package))
+
+      result = described_class.new(user: user, project: project, file: file).call
+
+      expect(result).to be_success
+      expect(result.result).to contain_exactly(first_work_package, second_work_package)
+    end
+
+    it "reports row errors and does not return created work packages" do
+      valid_work_package = instance_double(WorkPackage)
+      invalid_work_package = WorkPackage.new
+      invalid_work_package.errors.add(:subject, "is invalid")
+      failure = ServiceResult.failure(result: invalid_work_package)
+      allow(WorkPackages::CreateService).to receive(:new).with(user: user).and_return(create_service)
+      allow(create_service).to receive(:call).with({
+        subject: "First package",
+        description: "First description",
+        project: project
+      }).and_return(ServiceResult.success(result: valid_work_package))
+      allow(create_service).to receive(:call).with({
+        subject: "Second package",
+        description: "Second description",
+        project: project
+      }).and_return(failure)
+
+      result = described_class.new(user: user, project: project, file: file).call
+
+      expect(result).not_to be_success
+      expect(result.result).to be_nil
+      expect(result.errors.full_messages.join).to include("Row 3", "Subject is invalid")
     end
   end
 end


### PR DESCRIPTION
# Ticket
No work package link was provided for this change.

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add a project-scoped bulk work package import workflow. Users can open the import action from the existing work package creation menu, upload a CSV or XLSX file, download a sample CSV, and create multiple work packages in one operation.

The import reports row-level validation errors and rolls back the complete upload if any row fails.

## Screenshots
<img width="2560" height="1440" alt="Screenshot 2026-09-08 at 1 11 20 AM" src="https://github.com/user-attachments/assets/74754a56-ca88-4c46-91c4-26a64881fa1a" />
<img width="2560" height="1440" alt="Screenshot 2026-09-08 at 1 11 23 AM" src="https://github.com/user-attachments/assets/83abb219-e023-4547-b9d7-a75a39bcc6aa" />
<img width="1514" height="971" alt="Screenshot 2026-09-08 at 1 11 39 AM" src="https://github.com/user-attachments/assets/5c7a2974-d795-41c3-b4c4-892692a7dce8" />


# What approach did you choose and why?
The implementation adds a project-scoped upload endpoint and import service. CSV parsing uses Ruby's CSV library; XLSX parsing uses the already available ZIP and Nokogiri dependencies.

Each row is normalized and passed to `WorkPackages::CreateService`, preserving the existing authorization, defaults, validation, scheduling, notifications, and watcher behavior used by manual creation. The import runs inside a transaction so partial imports are not persisted.

The create dropdown links to the upload page, and the page provides the sample CSV download and supported column guidance. Route helper names and frontend nullable project handling were corrected during verification.

Validation performed:
- `bundle exec rspec spec/services/work_packages/bulk_import_service_spec.rb`
- Result: 4 examples, 0 failures
- Ruby syntax checks and `git diff --check` passed

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, Safari) 