### PR TITLE
Ensure that resource tools receive no inputs

### DIFF
--- a/app/services/mcp_tools/resource_proxy_tool.rb
+++ b/app/services/mcp_tools/resource_proxy_tool.rb
@@ -41,6 +41,7 @@ module McpTools
 
       def resource_annotations
         annotations read_only: true, idempotent: true, destructive: false
+        input_schema additionalProperties: false
       end
     end
 


### PR DESCRIPTION
The resource proxy call method is implemented to
never accept any arguments, however the input schema was left undefined so far, so MCP clients might have tried to pass parameters to it and they would've been forwarded to the call method, causing a server error.

# Ticket
https://appsignal.com/openproject-gmbh/sites/673aff9f83eb6776b27e7743/exceptions/incidents/2011