### PR TITLE
Update BlockNote extensions

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^4.3.0",
         "@hocuspocus/server": "^4.2.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
         "tsx": "^4.22.5"
       },
       "devDependencies": {
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@primer/octicons-react": {
-      "version": "19.28.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.28.0.tgz",
-      "integrity": "sha512-Xe3ZS/NtxRK/QXMlqh6Xn49nM4153VXgPQcwyIx6r2McZKkrAhP7xPe7yLhfx3X34rnxj6yimCnX7kswV30Vqw==",
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
-      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.2.tgz",
+      "integrity": "sha512-RX+R0VLg13IbvRuJSxnqykUFS9vQZTl8wYpWPCIUDWVrSGjsQywB5Y+pjzrkboxGAuYfJZVH1InFTdgBdxq6ug==",
       "funding": [
         {
           "type": "individual",
@@ -4168,14 +4168,14 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.3",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
-      "integrity": "sha512-wtkbqjIGECasx/cKkB016YVGIveO8/ezQJ+agTWNTUxqTfPjycAtag5xpdjW5poq22vkdHGU9lYfsluIPpiR/Q==",
+      "version": "0.3.0",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
+      "integrity": "sha512-ikgQ1iXUe4+TB5hpMJD7B1esPuyPlYPafZ5pwtxEYu1ziYOuxhFWvBm2zSIpsKXRFEkaDO0DBh4tU+vcDfEXog==",
       "dependencies": {
-        "@primer/octicons-react": "^19.20.0",
-        "i18next": "^26.3.5",
-        "react-i18next": "^17.0.11",
-        "styled-components": "^6.4.3",
+        "@primer/octicons-react": "^19.33.0",
+        "i18next": "^26.4.0",
+        "react-i18next": "^17.0.12",
+        "styled-components": "^6.5.3",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -4599,12 +4599,12 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
-      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.13.tgz",
+      "integrity": "sha512-Cc1PscmblIHA1kljTqDwrcVMI21ydgmUzw0UAeQBe7pAOgfuRLfzXze4EUBQoeDiICzFIXXhHFoZxuetNg5D0Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
@@ -4855,9 +4855,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.0.tgz",
-      "integrity": "sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.3.tgz",
+      "integrity": "sha512-vAX79sfpmUerP9fsTTxoTrBDE0RuO4ahjInyWYoohNgqrdg63Ms4q6FJ/o2Fyity82NU3cujOT8Ewl9TThBdwg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^4.3.0",
     "@hocuspocus/server": "^4.2.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
     "tsx": "^4.22.5"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -111,7 +111,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^22.0.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
         "openapi-explorer": "^2.4.801",
         "pako": "^2.2.0",
         "qr-creator": "^1.0.0",
@@ -2199,9 +2199,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5593,9 +5594,9 @@
       }
     },
     "node_modules/@primer/octicons-react": {
-      "version": "19.21.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.21.0.tgz",
-      "integrity": "sha512-KMWYYEIDKNIY0N3fMmNGPWJGHgoJF5NHkJllpOM3upDXuLtAe26Riogp1cfYdhp+sVjGZMt32DxcUhTX7ZhLOQ==",
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11023,9 +11024,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
-      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.2.tgz",
+      "integrity": "sha512-RX+R0VLg13IbvRuJSxnqykUFS9vQZTl8wYpWPCIUDWVrSGjsQywB5Y+pjzrkboxGAuYfJZVH1InFTdgBdxq6ug==",
       "funding": [
         {
           "type": "individual",
@@ -13063,14 +13064,14 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.2.3",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
-      "integrity": "sha512-wtkbqjIGECasx/cKkB016YVGIveO8/ezQJ+agTWNTUxqTfPjycAtag5xpdjW5poq22vkdHGU9lYfsluIPpiR/Q==",
+      "version": "0.3.0",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
+      "integrity": "sha512-ikgQ1iXUe4+TB5hpMJD7B1esPuyPlYPafZ5pwtxEYu1ziYOuxhFWvBm2zSIpsKXRFEkaDO0DBh4tU+vcDfEXog==",
       "dependencies": {
-        "@primer/octicons-react": "^19.20.0",
-        "i18next": "^26.3.5",
-        "react-i18next": "^17.0.11",
-        "styled-components": "^6.4.3",
+        "@primer/octicons-react": "^19.33.0",
+        "i18next": "^26.4.0",
+        "react-i18next": "^17.0.12",
+        "styled-components": "^6.5.3",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -14128,12 +14129,12 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
-      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.13.tgz",
+      "integrity": "sha512-Cc1PscmblIHA1kljTqDwrcVMI21ydgmUzw0UAeQBe7pAOgfuRLfzXze4EUBQoeDiICzFIXXhHFoZxuetNg5D0Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
@@ -15298,9 +15299,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.0.tgz",
-      "integrity": "sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.3.tgz",
+      "integrity": "sha512-vAX79sfpmUerP9fsTTxoTrBDE0RuO4ahjInyWYoohNgqrdg63Ms4q6FJ/o2Fyity82NU3cujOT8Ewl9TThBdwg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^22.0.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.2.3/op-blocknote-extensions-0.2.3.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.3.0/op-blocknote-extensions-0.3.0.tgz",
     "openapi-explorer": "^2.4.801",
     "pako": "^2.2.0",
     "qr-creator": "^1.0.0",


### PR DESCRIPTION
This includes:

- New translations (German, Ukrainian, Portuguese, Dutch, Spanish, French)
- [[BNE-146] Animate the picker lists and show the type colours in
  them](https://community.openproject.org/wp/BNE-146)
- [[BNE-146] Animate the create modal between its sizes](https://community.openproject.org/wp/BNE-146)
- [[BNE-135] Add multiselect field for multiselect required values](https://community.openproject.org/wp/BNE-135)
- [[BNE-137] Fit the created work package to what was selected](https://community.openproject.org/wp/BNE-137)
- [[BNE-147] Resizing menu of work package links cut off at the bottom of the
  document](https://community.openproject.org/wp/BNE-147)
- [[BNE-137] Create work package via text selection in a document](https://community.openproject.org/wp/BNE-137)
- deps: bump the other-minor-patch group with 10 updates
- [[BNE-134] Improve project select](https://community.openproject.org/wp/BNE-134)
- [[BNE-140] Remember filled in fields when type changes](https://community.openproject.org/wp/BNE-140)
- [[BNE-143] insert an inline wp instead of a block wp inside lists](https://community.openproject.org/wp/BNE-143)
- [[BNE-130] Keep a form that was answered in](https://community.openproject.org/wp/BNE-130)
- [[BNE-119] Reposition an anchored popover after the anchor animates
  in](https://community.openproject.org/wp/BNE-119)
- [[BNE-130] Prefill fields from previous selections](https://community.openproject.org/wp/BNE-130)
- [[BNE-119]: fix npm audit conflict](https://community.openproject.org/wp/BNE-119)
- [[BNE-144] Linking a work package inside a headline via slash command looks
  broken](https://community.openproject.org/wp/BNE-144)
- [[COMMS-870] Paragraph in Firefox document is infinite in width](https://community.openproject.org/wp/COMMS-870)
- [[BNE-119] Bind the original fetch to window in the dev fetch
  override](https://community.openproject.org/wp/BNE-119)
- [[BNE-124] Add the assignee link to the work package test fixtures](https://community.openproject.org/wp/BNE-124)
- deps: bump the other-minor-patch group across 1 directory with 23 updates
- [[BNE-124] Documents: overflow in the work package preview when the wp type is
  long](https://community.openproject.org/wp/BNE-124)
- [[BNE-104] Documents: two wps highlighted at once in wp dropdown on ios
  safari](https://community.openproject.org/wp/BNE-104)
- [[BNE-133] Show type colors in Type select](https://community.openproject.org/wp/BNE-133)
- [[BNE-126] Context menu scrolls over header on mobile](https://community.openproject.org/wp/BNE-126)
- [[BNE-127] Documents: issues with tiny work package link preview on mobile
  iOS](https://community.openproject.org/wp/BNE-127)
- [[BNE-129] Add create work package flow (simple)](https://community.openproject.org/wp/BNE-129)