### PR TITLE
Bump omniauth to 2.0, introduce self-submitting form to switch to POST only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,8 @@ gem "connection_pool", "~> 3.0.2"
 gem "rdoc", ">= 2.4.2"
 
 gem "doorkeeper", "~> 5.9.6"
-# Maintain our own omniauth due to relative URL root issues
-# see upstream PR: https://github.com/omniauth/omniauth/pull/903
-gem "omniauth", git: "https://github.com/opf/omniauth", ref: "7eb21563ba047ef86d71f099975587b5ec88f9c9"
+gem "omniauth", "~> 2.1"
+gem "omniauth-rails_csrf_protection", "~> 2.0"
 gem "request_store", "~> 1.7.0"
 
 gem "warden", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,22 +35,13 @@ GIT
       ttfunk (~> 1.7.0)
 
 GIT
-  remote: https://github.com/opf/omniauth
-  revision: 7eb21563ba047ef86d71f099975587b5ec88f9c9
-  ref: 7eb21563ba047ef86d71f099975587b5ec88f9c9
-  specs:
-    omniauth (1.9.2)
-      hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
-
-GIT
   remote: https://github.com/opf/omniauth-openid-connect.git
-  revision: 825d06235b64f6bc872bba709f1c2d48fd5cede4
-  ref: 825d06235b64f6bc872bba709f1c2d48fd5cede4
+  revision: 21f27e8c0bf5b7523bd7c7caddf87dd68de3143a
+  ref: 21f27e8c0bf5b7523bd7c7caddf87dd68de3143a
   specs:
     omniauth-openid-connect (0.5.0)
       addressable (~> 2.5)
-      omniauth (~> 1.6)
+      omniauth (~> 2.1, >= 2.1.4)
       openid_connect (~> 2.2.0)
 
 GIT
@@ -84,13 +75,13 @@ PATH
   remote: modules/auth_plugins
   specs:
     openproject-auth_plugins (1.0.0)
-      omniauth (~> 1.0)
+      omniauth (~> 2.1)
 
 PATH
   remote: modules/auth_saml
   specs:
     openproject-auth_saml (1.0.0)
-      omniauth-saml (~> 1.10.6)
+      omniauth-saml (~> 2.2)
 
 PATH
   remote: modules/avatars
@@ -190,7 +181,6 @@ PATH
   remote: modules/openid_connect
   specs:
     openproject-openid_connect (1.0.0)
-      lobby_boy (~> 0.1.3)
       omniauth-openid_connect-providers (~> 0.1)
       openproject-auth_plugins
 
@@ -794,10 +784,6 @@ GEM
       logger
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lobby_boy (0.1.3)
-      omniauth (~> 1.1)
-      omniauth-openid-connect (>= 0.2.1)
-      rails (>= 3.2.21)
     logger (1.7.0)
     lograge (0.15.0)
       actionpack (>= 4)
@@ -881,8 +867,16 @@ GEM
       racc (~> 1.4)
     okcomputer (1.19.2)
       benchmark
-    omniauth-saml (1.10.6)
-      omniauth (~> 1.3, >= 1.3.2)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth-saml (2.2.5)
+      omniauth (~> 2.1)
       ruby-saml (~> 1.18)
     op-clamav-client (3.4.2)
     open4 (1.3.4)
@@ -1658,9 +1652,10 @@ DEPENDENCIES
   net-ldap (~> 0.20.0)
   nokogiri (~> 1.19.4)
   okcomputer (~> 1.19.1)
-  omniauth!
+  omniauth (~> 2.1)
   omniauth-openid-connect!
   omniauth-openid_connect-providers!
+  omniauth-rails_csrf_protection (~> 2.0)
   op-clamav-client (~> 3.4)
   openproject-auth_plugins!
   openproject-auth_saml!
@@ -1994,7 +1989,6 @@ CHECKSUMS
   letter_opener_web (3.0.0) sha256=3f391efe0e8b9b24becfab5537dfb17a5cf5eb532038f947daab58cb4b749860
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
-  lobby_boy (0.1.3) sha256=9460bb3c052aef158eb3f137b8f7679ca756b8e2983d140dbdc0caa85c018172
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   lograge (0.15.0) sha256=34072c1f50b95019dc185137f5fec1a6759f5a1b6d55c28163d0cba204e6df16
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
@@ -2033,10 +2027,11 @@ CHECKSUMS
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   okcomputer (1.19.2) sha256=d069aedf1e31b8ebe7e1fdf9e327dee158ea49b9fbdebebc2f1bed4690cb7a6d
-  omniauth (1.9.2)
+  omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
   omniauth-openid-connect (0.5.0)
   omniauth-openid_connect-providers (0.2.0)
-  omniauth-saml (1.10.6) sha256=13dde22f4fd1beff0ef2d6dae576f7b68594f159990e8e886d8a02b32397afbd
+  omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
+  omniauth-saml (2.2.5) sha256=552ad464564d711f0dfd169e0ad801de809cf3ac71c4bc9094f152d5a0d7ab59
   op-clamav-client (3.4.2) sha256=f28d697d11758a2ba3dc530cfdf4871a00ecd517631e8bac30dee30cd6012964
   open4 (1.3.4) sha256=a1df037310624ecc1ea1d81264b11c83e96d0c3c1c6043108d37d396dcd0f4b1
   openid_connect (2.2.1) sha256=31264e85b5a36e33dff5e31560cc176175c26f30c260d7e95af93ff0065f3101

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -8,7 +8,7 @@ gem 'omniauth-openid_connect-providers',
 
 gem 'omniauth-openid-connect',
     git: 'https://github.com/opf/omniauth-openid-connect.git',
-    ref: '825d06235b64f6bc872bba709f1c2d48fd5cede4'
+    ref: '21f27e8c0bf5b7523bd7c7caddf87dd68de3143a'
 
 group :opf_plugins do
     # included so that engines can reference OpenProject::Version

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -401,10 +401,8 @@ class AccountController < ApplicationController
 
   def direct_login(user)
     if !flash_message_pending?
-      ps = {}
-      ps[:origin] = params[:back_url] if params[:back_url]
-
-      redirect_to direct_login_provider_url(ps)
+      @direct_login_origin = params[:back_url]
+      render :omniauth_direct_login
     elsif Setting.login_required?
       # I'm not sure why it is considered an error if we don't have the anonymous user here.
       # Before the line read `user.active? || flash[:error]` but since a recent

--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -56,7 +56,6 @@ class RegistrationForm < ApplicationForm
 
     f.submit(name: :submit, label: I18n.t(:button_create), scheme: :primary)
 
-    authentication_providers(f) unless model.uses_external_authentication?
     registration_footer(f)
   end
 
@@ -135,12 +134,6 @@ class RegistrationForm < ApplicationForm
                             helpers.content_tag(:span, message)
                           ])
       end
-    end
-  end
-
-  def authentication_providers(form)
-    form.html_content do
-      render("account/auth_providers", omniauth_title: I18n.t("account.signup_with_external_account"), wide: true)
     end
   end
 

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -33,8 +33,25 @@ module OmniauthHelper
     direct_login_provider.is_a? String
   end
 
-  def direct_login_provider_url(params = {})
-    omni_auth_start_url(direct_login_provider, params)
+  def omniauth_start_url_options
+    { script_name: OpenProject::Configuration.rails_relative_url_root }.compact
+  end
+
+  def omniauth_provider_button(name, display_name: nil, icon: false)
+    classes = ["auth-provider", "auth-provider-#{name}", "button"]
+    classes << "auth-provider--imaged" if icon
+
+    url_opts = omniauth_start_url_options
+    url_opts[:origin] = params["back_url"] if params["back_url"]
+
+    button_to(
+      omni_auth_start_path(name, url_opts),
+      method: :post,
+      data: { turbo: false },
+      class: classes.join(" ")
+    ) do
+      tag.span(display_name.presence || name, class: "auth-provider-name")
+    end
   end
 
   ##
@@ -45,8 +62,9 @@ module OmniauthHelper
   # used for direct login. Meaning that the login provider selection is skipped and
   # the configured provider is used directly instead.
   #
-  # If this option is active /login will lead directly to the configured omniauth provider
-  # and so will a click on 'Sign in' (as opposed to opening the drop down menu).
+  # If this option is active /login will lead directly to the configured omniauth provider,
+  # with a temporary form in between so that we can ensure we only POST to the provider (CVE-2015-9284).
+  # a click on 'Sign in' (as opposed to opening the drop down menu) brings them directly there using POST
   def direct_login_provider
     Setting.omniauth_direct_login_provider.presence
   end

--- a/app/views/account/omniauth_direct_login.html.erb
+++ b/app/views/account/omniauth_direct_login.html.erb
@@ -27,6 +27,20 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% unless Rails.env.production? %>
-  <%= omniauth_provider_button(:developer, display_name: "Omniauth Developer") %>
-<% end %>
+<% html_title t(:label_login) %>
+
+<div id="login-form" class="form -bordered">
+  <h1><%= I18n.t(:label_login) %></h1>
+  <hr class="form--separator">
+  <p><%= t("account.omniauth_direct_login_redirecting") %></p>
+  <%= form_tag omni_auth_start_path(direct_login_provider, omniauth_start_url_options),
+               method: :post,
+               authenticity_token: true,
+               id: "omniauth-direct-login-form",
+               data: { turbo: false, controller: "omniauth-direct-login" } do %>
+    <% if @direct_login_origin.present? %>
+      <%= hidden_field_tag :origin, @direct_login_origin %>
+    <% end %>
+    <%= submit_tag t("account.omniauth_direct_login_continue"), class: "button -highlight" %>
+  <% end %>
+</div>

--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -53,6 +53,10 @@ See COPYRIGHT and LICENSE files for more details.
     <%= render(RegistrationForm.new(form)) %>
   <% end %>
 
+  <% unless @user.uses_external_authentication? %>
+    <%= render("account/auth_providers", omniauth_title: I18n.t("account.signup_with_external_account"), wide: true) %>
+  <% end %>
+
   <div class="op-account-registration--signin">
     <%= link_to t(:button_login), signin_path %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,8 @@ en:
       User registration is limited for the Single sign-on provider '%{name}'. Please ask an administrator to activate the
       account for you or change the self registration limit for this provider.
     login_with_auth_provider: "or sign in with your existing account"
+    omniauth_direct_login_continue: "Continue to sign in"
+    omniauth_direct_login_redirecting: "Redirecting you to your identity provider…"
     omniauth_login: Please login to activate your account.
     signup_title: "Create an account in %{app_title}"
     signup_with_external_account: "Sign up with an external account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
   # Add catch method for Rack OmniAuth to allow route helpers
   # Note: This renders a 404 in rails but is caught by omniauth in Rack before
   get "/auth/failure", to: "omni_auth_login#failure", as: "omni_auth_failure"
-  get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start"
+  match "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start", via: %i[get post]
   match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omni_auth_callback", via: %i[get post]
 
   scope ".well-known" do

--- a/frontend/src/global_styles/content/_accounts.sass
+++ b/frontend/src/global_styles/content/_accounts.sass
@@ -64,7 +64,7 @@
   width: auto
   text-align: center
 
-  a.auth-provider
+  .auth-provider
     float: none
     display: inline-block
 
@@ -114,7 +114,11 @@
     @include prevent-float-collapse
     margin-top: 1em
 
-  a.auth-provider:hover
+    form.button_to
+      display: inline-block
+      margin: 0
+
+  .auth-provider:hover
     text-decoration: none
 
 #nav-login-content .login-auth-providers

--- a/frontend/src/global_styles/content/modules/_auth_plugins.sass
+++ b/frontend/src/global_styles/content/modules/_auth_plugins.sass
@@ -18,14 +18,14 @@
 // See doc/COPYRIGHT.md for more details.
 
 #content,
-.login-auth-providers a.auth-provider
+.login-auth-providers .auth-provider
   background-repeat: no-repeat
   background-size: 18px 18px
   background-position-x: 8px
   background-position-y: center
   background-color: var(--body-background)
 
-.login-auth-providers a.auth-provider
+.login-auth-providers .auth-provider
   padding: 9px 12px 9px 12px
 
   &.auth-provider--imaged

--- a/frontend/src/stimulus/controllers/dynamic/omniauth-direct-login.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/omniauth-direct-login.controller.spec.ts
@@ -1,0 +1,57 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi } from 'vitest';
+
+import OmniauthDirectLoginController from './omniauth-direct-login.controller';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+
+describe('OmniauthDirectLoginController', () => {
+  let ctx:StimulusTestContext;
+
+  beforeEach(async () => {
+    ctx = await setupStimulusTest({
+      controllers: { 'omniauth-direct-login': OmniauthDirectLoginController },
+    });
+  });
+
+  afterEach(() => ctx.dispose());
+
+  it('submits the form on connect', async () => {
+    const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => undefined);
+
+    await ctx.mount(`
+      <form data-controller="omniauth-direct-login" method="post" action="/auth/some_provider">
+        <button type="submit">Continue</button>
+      </form>
+    `);
+
+    expect(submitSpy).toHaveBeenCalledOnce();
+    submitSpy.mockRestore();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/omniauth-direct-login.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/omniauth-direct-login.controller.ts
@@ -1,0 +1,35 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class OmniauthDirectLoginController extends Controller<HTMLFormElement> {
+  connect():void {
+    this.element.submit();
+  }
+}

--- a/modules/auth_plugins/app/views/hooks/login/_providers.html.erb
+++ b/modules/auth_plugins/app/views/hooks/login/_providers.html.erb
@@ -28,16 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% OpenProject::Plugins::AuthPlugin.providers.each do |provider| %>
-  <%
-    opts = { script_name: OpenProject::Configuration.rails_relative_url_root }
-
-    if params["back_url"]
-      opts[:origin] = params["back_url"]
-    end
-  %>
-  <a
-    href="<%= omni_auth_start_path(provider[:name], opts) %>"
-    class="auth-provider auth-provider-<%= provider[:name] %> <%= provider[:icon] ? "auth-provider--imaged" : "" %> button">
-    <span class="auth-provider-name"><%= provider[:display_name] || provider[:name] %></span>
-  </a>
+  <%= omniauth_provider_button(
+        provider[:name],
+        display_name: provider[:display_name],
+        icon: provider[:icon].present?
+      ) %>
 <% end %>

--- a/modules/auth_plugins/app/views/hooks/login/_providers_css.html.erb
+++ b/modules/auth_plugins/app/views/hooks/login/_providers_css.html.erb
@@ -30,13 +30,13 @@ See COPYRIGHT and LICENSE files for more details.
 <% OpenProject::Plugins::AuthPlugin.providers.each do |provider| %>
   <% if provider[:icon] %>
     <style type="text/css">
-      #content .login-auth-providers a.auth-provider.auth-provider-<%= provider[:name] %> {
+      #content .login-auth-providers .auth-provider.auth-provider-<%= provider[:name] %> {
         background-image: url('<%= asset_path(provider[:icon]) %>');
       }
-      .op-app-header #nav-login-content .login-auth-providers a.auth-provider.auth-provider-<%= provider[:name] %> {
+      .op-app-header #nav-login-content .login-auth-providers .auth-provider.auth-provider-<%= provider[:name] %> {
         background-image:  url('<%= asset_path(provider[:icon]) %>') ;
       }
-      .login-auth-providers a.auth-provider.auth-provider-<%= provider[:name] %> {
+      .login-auth-providers .auth-provider.auth-provider-<%= provider[:name] %> {
         background-image: url('<%= asset_path(provider[:icon]) %>') ;
       }
     </style>

--- a/modules/auth_plugins/lib/omni_auth/flexible_builder.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_builder.rb
@@ -28,7 +28,7 @@
 
 module OmniAuth
   class FlexibleBuilder < Builder
-    def use(middleware, *, &)
+    def use(middleware, *, **, &)
       middleware.extend FlexibleStrategyClass
       super
     end

--- a/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
@@ -34,6 +34,18 @@ module OmniAuth
       possible_auth_path? && (match_provider! || false) && super
     end
 
+    # OmniAuth 2 switch to memoizing request_path during +warn_if_using_get_on_request_path+,
+    # before we can consider the provider name.
+    #
+    # As a result, we need to match the provider using the following two methods.
+    def on_request_path?
+      possible_auth_path? && match_provider! && super
+    end
+
+    def on_callback_path?
+      possible_auth_path? && match_provider! && super
+    end
+
     ##
     # Tries to match the request path of the current request with one of the registered providers.
     # If a match is found the strategy is initialised with that provider to handle the request.
@@ -46,6 +58,8 @@ module OmniAuth
 
       if @provider
         options.merge! provider.to_hash
+        @request_path = nil
+        @callback_path = nil
       end
 
       @provider
@@ -90,7 +104,7 @@ module OmniAuth
   end
 
   module FlexibleStrategyClass
-    def new(app, *args, &)
+    def new(app, *, **, &)
       super.tap do |strategy|
         strategy.extend FlexibleStrategy
       end

--- a/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
@@ -29,15 +29,12 @@
 require "open_project/plugins/auth_plugin"
 
 module OmniAuth
+  # OmniAuth decides request vs callback by comparing
+  # the current path to +request_path+ / +callback_path+, which it derives from
+  # +name+ and then memoizes later on.
+  # For this reason, we need to verride the on_request_path and on_callback_path? methods
+  # to make sure we match our provider strategy class from the request (e.g., /auth/saml)
   module FlexibleStrategy
-    def on_auth_path?
-      possible_auth_path? && (match_provider! || false) && super
-    end
-
-    # OmniAuth 2 switch to memoizing request_path during +warn_if_using_get_on_request_path+,
-    # before we can consider the provider name.
-    #
-    # As a result, we need to match the provider using the following two methods.
     def on_request_path?
       possible_auth_path? && match_provider! && super
     end

--- a/modules/auth_plugins/openproject-auth_plugins.gemspec
+++ b/modules/auth_plugins/openproject-auth_plugins.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + %w(doc/CHANGELOG.md README.md)
 
-  s.add_dependency "omniauth", "~> 1.0"
+  s.add_dependency "omniauth", "~> 2.1"
 
   s.add_development_dependency "rspec", "~> 3.13"
   s.metadata["rubygems_mfa_required"] = "true"

--- a/modules/auth_plugins/spec/features/auth_provider_spec.rb
+++ b/modules/auth_plugins/spec/features/auth_provider_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe "rendering the login buttons", :js do
       visit project_path(public_project)
 
       click_link_or_button "Sign in"
-      item = page.find("a.auth-provider", text: "mock_auth")
-      expect(item[:href]).to end_with "/auth/mock_auth"
+      item = page.find("button.auth-provider", text: "mock_auth")
+      form = item.ancestor("form")
+      expect(form[:action]).to end_with "/auth/mock_auth"
+      expect(form[:method]).to eq "post"
     end
   end
 end

--- a/modules/auth_plugins/spec/requests/flexible_strategy_spec.rb
+++ b/modules/auth_plugins/spec/requests/flexible_strategy_spec.rb
@@ -56,9 +56,17 @@ RSpec.describe OmniAuth::FlexibleStrategy do
   end
 
   describe "request call" do
+    around do |example|
+      phase = OmniAuth.config.request_validation_phase
+      OmniAuth.config.request_validation_phase = nil
+      example.run
+    ensure
+      OmniAuth.config.request_validation_phase = phase
+    end
+
     it "matches the registered providers" do
       [provider_a, provider_b].each do |pro|
-        code, env = middleware.call env_for("http://www.example.com/auth/#{pro[:name]}")
+        _code, env = middleware.call env_for("http://www.example.com/auth/#{pro[:name]}", method: "POST")
         strategy = env["omniauth.strategy"]
 
         # check that the correct provider has been initialised
@@ -67,7 +75,7 @@ RSpec.describe OmniAuth::FlexibleStrategy do
     end
 
     it "does not match other paths" do
-      code, env = middleware.call env_for("http://www.example.com/auth/other_provider")
+      _code, env = middleware.call env_for("http://www.example.com/auth/other_provider", method: "POST")
 
       expect(env).not_to include "omniauth.strategy" # no hit
     end

--- a/modules/auth_plugins/spec/requests/flexible_strategy_spec.rb
+++ b/modules/auth_plugins/spec/requests/flexible_strategy_spec.rb
@@ -69,9 +69,15 @@ RSpec.describe OmniAuth::FlexibleStrategy do
         _code, env = middleware.call env_for("http://www.example.com/auth/#{pro[:name]}", method: "POST")
         strategy = env["omniauth.strategy"]
 
-        # check that the correct provider has been initialised
         expect(strategy.options.identifier).to eq pro[:identifier]
       end
+    end
+
+    it "does not start the request phase for GET" do
+      code, env = middleware.call env_for("http://www.example.com/auth/provider_a", method: "GET")
+
+      expect(code).to eq 200
+      expect(env["rack.session"]).not_to include("omniauth.params")
     end
 
     it "does not match other paths" do

--- a/modules/auth_plugins/spec/views/hooks/login/_providers.html.erb_spec.rb
+++ b/modules/auth_plugins/spec/views/hooks/login/_providers.html.erb_spec.rb
@@ -29,6 +29,7 @@
 require "spec_helper"
 
 RSpec.describe "rendering the login buttons for all providers" do
+  helper OmniauthHelper
   let(:providers) do
     [
       { name: "mock_auth" },
@@ -49,6 +50,10 @@ RSpec.describe "rendering the login buttons for all providers" do
 
   it "shows the test_auth button with the given display_name as its label" do
     expect(rendered).to match /#{providers[1][:display_name]}/
+  end
+
+  it "posts to the OmniAuth request phase" do
+    expect(rendered).to have_css("form.button_to[action='/auth/mock_auth'][method='post']")
   end
 
   context "with relative url root", with_config: { rails_relative_url_root: "/foobar" } do

--- a/modules/auth_saml/openproject-auth_saml.gemspec
+++ b/modules/auth_saml/openproject-auth_saml.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*"] + %w(README.md)
 
-  s.add_dependency "omniauth-saml", "~> 1.10.6"
+  s.add_dependency "omniauth-saml", "~> 2.2"
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/modules/openid_connect/openproject-openid_connect.gemspec
+++ b/modules/openid_connect/openproject-openid_connect.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + %w(CHANGELOG.md README.md)
 
-  s.add_dependency "lobby_boy", "~> 0.1.3"
   s.add_dependency "omniauth-openid_connect-providers", "~> 0.1"
   s.add_dependency "openproject-auth_plugins"
   s.metadata["rubygems_mfa_required"] = "true"

--- a/modules/openid_connect/spec/requests/openid_connect_spec.rb
+++ b/modules/openid_connect/spec/requests/openid_connect_spec.rb
@@ -35,7 +35,7 @@ RSpec.configure do |c|
   c.include OpenIDConnectSpecHelpers
 end
 
-RSpec.describe "OpenID Connect", :skip_2fa_stage, # Prevent redirects to 2FA stage
+RSpec.describe "OpenID Connect", :skip_2fa_stage, :skip_csrf, # Prevent redirects to 2FA stage
                type: :rails_request,
                with_ee: %i[sso_auth_providers] do
   let(:host) { "keycloak.local" }

--- a/modules/openid_connect/spec/requests/openid_connect_spec_helpers.rb
+++ b/modules/openid_connect/spec/requests/openid_connect_spec_helpers.rb
@@ -40,7 +40,6 @@ module OpenIDConnectSpecHelpers
   end
 
   def click_on_signin(pro_name = "heroku")
-    # Emulate click on sign-in for that particular provider
-    get "/auth/#{pro_name}"
+    post "/auth/#{pro_name}"
   end
 end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -441,10 +441,14 @@ RSpec.describe AccountController, :skip_2fa_stage do
   describe "#login with omniauth_direct_login enabled",
            with_config: { omniauth_direct_login_provider: "some_provider" } do
     describe "GET" do
-      it "redirects to some_provider" do
+      render_views
+
+      it "renders an auto-submitting POST form to some_provider" do
         get :login
 
-        expect(response).to redirect_to "/auth/some_provider"
+        expect(response).to render_template "omniauth_direct_login"
+        expect(response.body).to include('action="/auth/some_provider"')
+        expect(response.body).to include('method="post"')
       end
     end
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -449,6 +449,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
         expect(response).to render_template "omniauth_direct_login"
         expect(response.body).to include('action="/auth/some_provider"')
         expect(response.body).to include('method="post"')
+        expect(response.body).to include('data-controller="omniauth-direct-login"')
       end
     end
 

--- a/spec/features/auth/auth_stages_spec.rb
+++ b/spec/features/auth/auth_stages_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Authentication Stages", :skip_2fa_stage do
     end
 
     it "redirects to authentication stage after registration via omniauth too" do
-      visit "/auth/developer"
+      start_omniauth_developer
 
       fill_in "first_name", with: "Adam"
       fill_in "last_name", with: "Apfel"

--- a/spec/features/auth/omniauth_post_login_spec.rb
+++ b/spec/features/auth/omniauth_post_login_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "OmniAuth POST login", :js do
+  OpenProject::Hooks::ViewAccountLoginAuthProvider
+
+  let(:user_menu) { Components::UserMenu.new }
+
+  let(:user) do
+    create(:user,
+           force_password_change: false,
+           firstname: "omni",
+           lastname: "bob",
+           mail: "omnibob@example.com")
+  end
+
+  it "signs in through a POST to the provider" do
+    visit signin_path
+
+    form = find("button.auth-provider-developer").ancestor("form")
+    expect(form[:method]).to eq "post"
+    expect(form[:action]).to end_with "/auth/developer"
+
+    click_button "Omniauth Developer"
+
+    fill_in "first_name", with: user.firstname
+    fill_in "last_name", with: user.lastname
+    fill_in "email", with: user.mail
+    click_button "Sign In"
+
+    user_menu.expect_user_shown "omni bob"
+  end
+
+  context "with direct login",
+          with_settings: { omniauth_direct_login_provider: "developer" } do
+    it "auto-submits a POST form to the provider" do
+      visit signin_path
+
+      expect(page).to have_field("first_name")
+      expect(page).to have_no_css("#omniauth-direct-login-form")
+    end
+  end
+end

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Omniauth authentication" do
   end
   let(:user_menu) { Components::UserMenu.new }
 
+  # rubocop:disable RSpec/InstanceVariable
   before do
     @omniauth_test_mode = OmniAuth.config.test_mode
     @capybara_ignore_elements = Capybara.ignore_hidden_elements
@@ -61,11 +62,12 @@ RSpec.describe "Omniauth authentication" do
     Capybara.ignore_hidden_elements = @capybara_ignore_elements
     OmniAuth.config.logger = @omniauth_logger
   end
+  # rubocop:enable RSpec/InstanceVariable
 
   describe "existing user sign in" do
     it "redirects to back url" do
       visit account_lost_password_path
-      click_link("Omniauth Developer", match: :first, visible: :all)
+      click_link_or_button("Omniauth Developer", match: :first, visible: :all)
 
       SeleniumHubWaiter.wait
       fill_in("first_name", with: user.firstname)
@@ -77,7 +79,7 @@ RSpec.describe "Omniauth authentication" do
     end
 
     it "signs in user" do
-      visit "/auth/developer"
+      start_omniauth_developer
 
       SeleniumHubWaiter.wait
       fill_in("first_name", with: user.firstname)
@@ -93,7 +95,7 @@ RSpec.describe "Omniauth authentication" do
             with_settings: { omniauth_direct_login_provider: "developer" } do
       it "goes directly to the developer sign in and then redirect to the back url" do
         visit my_account_path
-        # requires login, redirects to developer login which is why we see the login form now
+        start_omniauth_developer
 
         SeleniumHubWaiter.wait
         fill_in("first_name", with: user.firstname)
@@ -101,7 +103,7 @@ RSpec.describe "Omniauth authentication" do
         fill_in("email", with: user.mail)
         click_link_or_button "Sign In"
 
-        expect(current_path).to eql my_account_path
+        expect(page).to have_current_path(my_account_path)
 
         # Expect the dropdown menu to be the logged in one
         expect(page).to have_test_selector "op-app-header--user-menu-button"
@@ -114,16 +116,17 @@ RSpec.describe "Omniauth authentication" do
     it "shows a notice that the user has been logged out" do
       visit signout_path
 
-      expect(page).to have_content(I18n.t(:notice_logged_out))
-      expect(page).to have_content "You can sign in again by clicking"
+      expect(page).to have_text(I18n.t(:notice_logged_out))
+      expect(page).to have_text "You can sign in again by clicking"
     end
 
     it "sign-in after previous sign-out shows my page" do
       visit signout_path
 
-      expect(page).to have_content(I18n.t(:notice_logged_out))
+      expect(page).to have_text(I18n.t(:notice_logged_out))
 
       click_on "here"
+      start_omniauth_developer
 
       SeleniumHubWaiter.wait
       fill_in("first_name", with: user.firstname)
@@ -138,7 +141,7 @@ RSpec.describe "Omniauth authentication" do
   shared_examples "omniauth user registration" do
     it "registers new user" do
       visit "/"
-      click_link("Omniauth Developer", match: :first)
+      start_omniauth_developer
 
       SeleniumHubWaiter.wait
       # login form developer strategy
@@ -147,7 +150,7 @@ RSpec.describe "Omniauth authentication" do
       fill_in("email", with: mail)
       click_link_or_button "Sign In"
 
-      expect(page).to have_content "Last name can't be blank"
+      expect(page).to have_text "Last name can't be blank"
       # on register form, we are prompted for a last name
       within("#content") do
         SeleniumHubWaiter.wait
@@ -155,7 +158,7 @@ RSpec.describe "Omniauth authentication" do
         click_link_or_button "Create"
       end
 
-      expect(page).to have_content(I18n.t(:notice_account_registered_and_logged_in))
+      expect(page).to have_text(I18n.t(:notice_account_registered_and_logged_in))
       expect(page).to have_link("Sign out")
     end
   end
@@ -169,7 +172,7 @@ RSpec.describe "Omniauth authentication" do
 
     it "redirects to homescreen" do
       visit account_lost_password_path
-      click_link("Omniauth Developer", match: :first)
+      start_omniauth_developer
 
       SeleniumHubWaiter.wait
       # login form developer strategy
@@ -207,6 +210,7 @@ RSpec.describe "Omniauth authentication" do
     shared_examples "registration with registration by email" do
       it "still automatically activates the omniauth account" do
         visit login_path
+        start_omniauth_developer unless page.has_field?("email")
 
         SeleniumHubWaiter.wait
         # login form developer strategy
@@ -219,13 +223,13 @@ RSpec.describe "Omniauth authentication" do
     end
 
     it_behaves_like "registration with registration by email" do
-      let(:login_path) { "/auth/developer" }
+      let(:login_path) { signin_path }
     end
 
     context "with direct login enabled and login required",
             with_settings: { omniauth_direct_login_provider: "developer", login_required: true } do
       it_behaves_like "registration with registration by email" do
-        let(:login_path) { "/auth/developer" }
+        let(:login_path) { signin_path }
       end
 
       context "when authorizing an external OAuth app" do
@@ -238,6 +242,8 @@ RSpec.describe "Omniauth authentication" do
             response_type: "code",
             prompt: "login"
           )
+
+          start_omniauth_developer unless page.has_field?("email")
 
           SeleniumHubWaiter.wait
           fill_in "email", with: user.mail # login form developer strategy
@@ -260,20 +266,25 @@ RSpec.describe "Omniauth authentication" do
         OmniAuth.config.mock_auth[:developer] = :invalid_credentials
         # seems like this default behaviour is removed when running the full
         # test suite, so let's set it back when running this test
+        original_on_failure = OmniAuth.config.on_failure
         OmniAuth.config.on_failure = Proc.new do |env|
           OmniAuth::FailureEndpoint.new(env).redirect_to_failure
         end
         visit login_path
-        expect(page).to have_content(I18n.t(:error_external_authentication_failed_message, message: "Unknown error"))
+        error_message = I18n.t(:error_external_authentication_failed_message, message: "Unknown error")
+        start_omniauth_developer unless page.has_content?(error_message)
+        expect(page).to have_text(error_message)
 
         if defined? instructions
-          expect(page).to have_content instructions
+          expect(page).to have_text instructions
         end
+      ensure
+        OmniAuth.config.on_failure = original_on_failure
       end
     end
 
     it_behaves_like "omniauth signin error" do
-      let(:login_path) { "/auth/developer" }
+      let(:login_path) { signin_path }
     end
 
     context "with direct login and login required",

--- a/spec/requests/auth/omniauth_request_phase_spec.rb
+++ b/spec/requests/auth/omniauth_request_phase_spec.rb
@@ -28,18 +28,32 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "omniauth/rails_csrf_protection"
+require "spec_helper"
 
-OmniAuth.config.logger = Rails.logger
-# Disable GET as an allowed request method to prevent CVE-2015-9284
-OmniAuth.config.allowed_request_methods = %i[post]
+RSpec.describe "OmniAuth request phase", type: :rails_request do
+  describe "GET /auth/developer" do
+    it "does not start authentication" do
+      get "/auth/developer"
 
-OmniAuth.config.on_failure = Proc.new do |env|
-  OmniAuthLoginController.action(:failure).call(env)
-end
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 
-Rails.application.config.middleware.use OmniAuth::Builder do
-  unless Rails.env.production?
-    provider :developer, fields: %i[first_name last_name email]
+  describe "POST /auth/developer without an authenticity token" do
+    it "rejects the request" do
+      post "/auth/developer"
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(signin_path)
+    end
+  end
+
+  describe "POST /auth/developer with an authenticity token", :skip_csrf do
+    it "starts the developer request phase" do
+      post "/auth/developer"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("first_name")
+    end
   end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
+module OmniauthSpecHelpers
+  def start_omniauth_developer
+    visit signin_path unless page.has_css?(".auth-provider-developer, #omniauth-direct-login-form") ||
+      page.has_field?("first_name")
+
+    if page.has_button?(I18n.t("account.omniauth_direct_login_continue"))
+      click_button I18n.t("account.omniauth_direct_login_continue")
+    elsif page.has_button?("Omniauth Developer") || page.has_link?("Omniauth Developer")
+      click_link_or_button "Omniauth Developer", match: :first
+    end
+  end
+end
+
 RSpec.configure do |config|
+  config.include OmniauthSpecHelpers, type: :feature
+
   config.before :each, type: :feature do
     OmniAuth.config.mock_auth[:developer] = nil
   end


### PR DESCRIPTION
Bump OmniAuth to 2.x version, which allows us to enforce POST-only request flows to mitigate CVE-2015-9284.

As we previously used redirects for direct login SSO providers, this PR introduces an intermediate login form that is shown for a second to be able to redirect using a POST. The provider SSO buttons have been updated to a form POST. (Screenshot is mixed language due to missing translations)

<img width="1935" height="931" alt="2026-09-08_13-42-34 2@2x" src="https://github.com/user-attachments/assets/076ba1ad-2ca8-4ea3-93a2-60f5b0e0dc40" />


https://community.openproject.org/work_packages/SC-278

OIDC gem PR: https://github.com/opf/omniauth-openid-connect/pull/19