### PR TITLE
[OP-20129] Add a hint about possbility of needing to use SSO on failed login.

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -452,7 +452,7 @@ class AccountController < ApplicationController
         render status: :unprocessable_entity
       else
         # incorrect password
-        flash_and_log_invalid_credentials
+        flash_and_log_invalid_credentials(sso_hint: true)
         render status: :unprocessable_entity
       end
     elsif user.new_record?
@@ -465,7 +465,7 @@ class AccountController < ApplicationController
 
   def invited_account_not_activated(_user)
     flash_error_message(log_reason: "invited, NOT ACTIVATED", flash_now: false) do
-      "account.error_inactive_activation_by_mail"
+      I18n.t("account.error_inactive_activation_by_mail")
     end
   end
 

--- a/app/controllers/concerns/accounts/registration.rb
+++ b/app/controllers/concerns/accounts/registration.rb
@@ -184,9 +184,9 @@ module Accounts::Registration
   def account_not_activated(flash_now: true)
     flash_error_message(log_reason: "NOT ACTIVATED", flash_now:) do
       if Setting::SelfRegistration.by_email?
-        "account.error_inactive_activation_by_mail"
+        I18n.t("account.error_inactive_activation_by_mail")
       else
-        "account.error_inactive_manual_activation"
+        I18n.t("account.error_inactive_manual_activation")
       end
     end
   end

--- a/app/controllers/concerns/accounts/user_login.rb
+++ b/app/controllers/concerns/accounts/user_login.rb
@@ -44,18 +44,14 @@ module Accounts::UserLogin
   ##
   # Log an attempt to log in to a locked account or with invalid credentials
   # and show a flash message.
-  def flash_and_log_invalid_credentials(flash_now: true, is_logged_in: false)
+  def flash_and_log_invalid_credentials(flash_now: true, is_logged_in: false, sso_hint: false)
     if is_logged_in
       flash[:error] = I18n.t(:notice_account_wrong_password)
       return
     end
 
     flash_error_message(log_reason: "invalid credentials", flash_now:) do
-      if Setting.brute_force_block_after_failed_logins.to_i > 0
-        :notice_account_invalid_credentials_or_blocked
-      else
-        :notice_account_invalid_credentials
-      end
+      [invalid_credentials_message, (sso_login_hint if sso_hint)].compact.join(" ")
     end
   end
 
@@ -65,8 +61,22 @@ module Accounts::UserLogin
     logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip} " \
                 "at #{Time.now.utc}: #{log_reason}"
 
-    flash_message = yield
+    flash_hash[:error] = yield
+  end
 
-    flash_hash[:error] = I18n.t(flash_message)
+  private
+
+  def invalid_credentials_message
+    if Setting.brute_force_block_after_failed_logins.to_i > 0
+      I18n.t(:notice_account_invalid_credentials_or_blocked)
+    else
+      I18n.t(:notice_account_invalid_credentials)
+    end
+  end
+
+  def sso_login_hint
+    return unless Users::PasswordLogin.restricted?
+
+    I18n.t(:notice_account_invalid_credentials_sso_hint)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4698,6 +4698,7 @@ en:
   notice_account_already_activated: The account has already been activated.
   notice_account_invalid_credentials: "Invalid user or password"
   notice_account_invalid_credentials_or_blocked: "Invalid user or password or the account is blocked due to multiple failed login attempts. If so, it will be unblocked automatically in a short time."
+  notice_account_invalid_credentials_sso_hint: "If your account is set up for single sign-on, please use your identity provider to sign in instead."
   notice_account_invalid_token: Invalid activation token
   notice_account_lost_email_sent: "An email with instructions to choose a new password has been sent to you."
   notice_account_new_password_forced: "A new password is required."

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -156,6 +156,57 @@ RSpec.describe AccountController, :skip_2fa_stage do
         expect(response).to render_template "login"
         expect(flash[:error]).to include "Invalid user or password"
       end
+
+      context "with unrestricted password login", with_settings: { password_login: "all" } do
+        it "does not hint at single sign-on" do
+          post :login, params: { username: "admin", password: "bad" }
+
+          expect(flash[:error]).to include "Invalid user or password"
+          expect(flash[:error]).not_to include I18n.t(:notice_account_invalid_credentials_sso_hint)
+        end
+      end
+
+      context "with password login restricted to non-SSO accounts",
+              with_settings: { password_login: "except_sso" } do
+        it "hints that the account might be set up for single sign-on" do
+          post :login, params: { username: "admin", password: "bad" }
+
+          expect(flash[:error]).to include I18n.t(:notice_account_invalid_credentials_sso_hint)
+        end
+      end
+
+      context "with password login restricted to the bypass allowlist",
+              with_settings: { password_login: "none" } do
+        before do
+          Setting.password_login_bypass_principal_ids = [admin.id.to_s]
+        end
+
+        it "hints that the account might be set up for single sign-on" do
+          post :login, params: { username: admin.login, password: "bad" }
+
+          expect(flash[:error]).to include I18n.t(:notice_account_invalid_credentials_sso_hint)
+        end
+      end
+
+      context "when the account is connected to an authentication provider",
+              with_settings: { password_login: "except_sso" } do
+        shared_let(:auth_provider) { create(:oidc_provider) }
+        shared_let(:sso_user) do
+          create(:user,
+                 login: "sso_user",
+                 password: "adminADMIN!",
+                 password_confirmation: "adminADMIN!",
+                 authentication_provider: auth_provider)
+        end
+
+        it "hints at single sign-on even though the password is correct" do
+          post :login, params: { username: sso_user.login, password: "adminADMIN!" }
+
+          expect(response).to have_http_status :unprocessable_entity
+          expect(flash[:error]).to include "Invalid user or password"
+          expect(flash[:error]).to include I18n.t(:notice_account_invalid_credentials_sso_hint)
+        end
+      end
     end
 
     context "with first login" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-20129/activity

# What are you trying to accomplish?
- When password login is restricted due to SSO being enabled (new setting `password_login` being set to `none` or `except_sso`) extend the error message when trying to login with the password that the user might need to use SSO

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
