### PR TITLE
[COMMS-907] Updating a document title does not update the browser page title

### DIFF
--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -154,6 +154,11 @@ module OpTurbo
         .render_in(view_context)
     end
 
+    # Takes the same parts the page passes to +html_title+.
+    def set_page_title_via_turbo_stream(*parts, project: nil)
+      turbo_streams << turbo_stream.set_title(title: helpers.page_title_with_project(*parts, project:))
+    end
+
     def reload_page_via_turbo_stream
       turbo_streams << OpTurbo::StreamComponent.new(action: :reloadPage, target: nil).render_in(view_context)
     end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -39,6 +39,12 @@ module MetaTagsHelper
     (parts.reverse + [Setting.app_title]).join(" | ")
   end
 
+  # Unescaped counterpart of +html_title_parts+ for callers that assemble a title outside
+  # of a page render, where neither @html_title nor @project is set.
+  def page_title_with_project(*parts, project: nil)
+    page_title(*[project&.name, *parts].compact_blank.map(&:to_s))
+  end
+
   def initializer_meta_tag
     tag :meta,
         name: :openproject_initializer,

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -36,6 +36,8 @@ class DocumentsController < ApplicationController
 
   default_search_scope :documents
 
+  helper_method :document_html_title_parts
+
   before_action :find_project_by_project_id, only: %i[index search new create]
   before_action :find_document, except: %i[index search new create]
   before_action :authorize
@@ -128,6 +130,7 @@ class DocumentsController < ApplicationController
 
     state = call.success? ? :show : :edit
     update_header_component_via_turbo_stream(state:)
+    set_page_title_via_turbo_stream(*document_html_title_parts, project: @project) if call.success?
 
     respond_with_turbo_streams
   end
@@ -170,6 +173,10 @@ class DocumentsController < ApplicationController
   end
 
   private
+
+  def document_html_title_parts
+    [I18n.t(:label_document_plural), @document.title]
+  end
 
   def find_document
     @document = Document.visible.find(params[:id])

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -29,7 +29,7 @@
   ++#
 %>
 
-<% html_title(t(:label_document_plural), @document.title) %>
+<% html_title(*document_html_title_parts) %>
 
 <% if @document.collaborative? %>
   <% if Setting.real_time_text_collaboration_enabled? %>

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -239,6 +239,27 @@ RSpec.describe DocumentsController do
     end
   end
 
+  describe "#update_title" do
+    subject(:rendered_title) do
+      Nokogiri::HTML5.fragment(response.body).at_css('turbo-stream[action="set_title"]')&.[]("title")
+    end
+
+    it "keeps the browser title in sync with the renamed document" do
+      put :update_title, params: { id: document.id, document: { title: "Renamed document" } }, format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.title).to eq("Renamed document")
+      expect(rendered_title).to eq("Renamed document | Documents | Test Project | #{Setting.app_title}")
+    end
+
+    it "leaves the browser title alone when the rename is rejected" do
+      put :update_title, params: { id: document.id, document: { title: "" } }, format: :turbo_stream
+
+      expect(document.reload.title).to eq("Sample Document")
+      expect(rendered_title).to be_nil
+    end
+  end
+
   describe "#render_avatars" do
     let(:user) { create(:user, member_with_permissions: { project => [:view_documents] }) }
     let!(:non_member) { create(:user) }

--- a/modules/documents/spec/features/document_title_spec.rb
+++ b/modules/documents/spec/features/document_title_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Document title", :js,
+               with_settings: { real_time_text_collaboration_enabled: true } do
+  let(:project) { create(:project, name: "Test Project") }
+  let(:document) { create(:document, :collaborative, title: "Sample Document", project:) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => %i[view_documents manage_documents] })
+  end
+
+  before do
+    login_as(user)
+    visit document_path(document)
+  end
+
+  it "renames the browser tab along with the page header" do
+    expect(page).to have_title("Sample Document | Documents | Test Project | #{Setting.app_title}")
+
+    within_test_selector("document-page-header") do
+      find("action-menu > button").click
+      click_on "Edit title"
+
+      fill_in "Title", with: "Renamed document"
+      click_on "Save"
+
+      expect(page).to have_text("Renamed document")
+    end
+
+    expect(page).to have_title("Renamed document | Documents | Test Project | #{Setting.app_title}")
+  end
+
+  it "keeps the browser tab unchanged when the new title is rejected" do
+    within_test_selector("document-page-header") do
+      find("action-menu > button").click
+      click_on "Edit title"
+
+      fill_in "Title", with: "x" * 256
+      click_on "Save"
+    end
+
+    expect(page).to have_title("Sample Document | Documents | Test Project | #{Setting.app_title}")
+  end
+end

--- a/spec/controllers/concerns/op_turbo/component_stream_spec.rb
+++ b/spec/controllers/concerns/op_turbo/component_stream_spec.rb
@@ -8,10 +8,16 @@ RSpec.describe OpTurbo::ComponentStream do
   controller(ApplicationController) do
     include described_module
 
-    no_authorization_required! :update
+    no_authorization_required! :update, :set_page_title
 
     def update
       dispatch_event_via_turbo_stream(params[:event_name], detail: { work_package_id: 42 })
+      respond_to_with_turbo_streams
+    end
+
+    def set_page_title
+      project = Project.new(name: params[:project_name]) if params[:project_name].present?
+      set_page_title_via_turbo_stream(*params[:parts], project:)
       respond_to_with_turbo_streams
     end
   end
@@ -19,7 +25,10 @@ RSpec.describe OpTurbo::ComponentStream do
   current_user { build_stubbed(:user) }
 
   before do
-    routes.draw { get "update" => "anonymous#update" }
+    routes.draw do
+      get "update" => "anonymous#update"
+      get "set_page_title" => "anonymous#set_page_title"
+    end
   end
 
   describe "#dispatch_event_via_turbo_stream" do
@@ -47,6 +56,32 @@ RSpec.describe OpTurbo::ComponentStream do
         expect { get :update, params: { event_name: "op:theme-changed" }, as: :turbo_stream }
           .to raise_error(ArgumentError)
       end
+    end
+  end
+
+  describe "#set_page_title_via_turbo_stream" do
+    subject(:rendered_title) do
+      Nokogiri::HTML5.fragment(response.body).at_css('turbo-stream[action="set_title"]')&.[]("title")
+    end
+
+    it "renders the title a full page load of the same parts would produce" do
+      get :set_page_title, params: { parts: ["Documents", "Renamed document"], project_name: "Demo project" },
+                           as: :turbo_stream
+
+      expect(response.body).to have_turbo_stream(action: "set_title")
+      expect(rendered_title).to eq("Renamed document | Documents | Demo project | #{Setting.app_title}")
+    end
+
+    it "omits the project segment outside of a project context" do
+      get :set_page_title, params: { parts: ["My account"] }, as: :turbo_stream
+
+      expect(rendered_title).to eq("My account | #{Setting.app_title}")
+    end
+
+    it "does not emit empty segments" do
+      get :set_page_title, params: { parts: ["Documents", ""] }, as: :turbo_stream
+
+      expect(rendered_title).to eq("Documents | #{Setting.app_title}")
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-907

# What are you trying to accomplish?
Renaming a document from the page header updated the heading and the breadcrumb, but the browser tab kept the old title until the page was reloaded.

The rename responds with a turbo stream that re-renders the page header only. Nothing touches `<title>` in `<head>`, and there is no full page load to rebuild it.

## Screenshots

https://github.com/user-attachments/assets/9a98be55-706b-44c6-91c0-74303af05049

# What approach did you choose and why?
Rather than patching the title into the header stream, the fix is split into a reusable piece and a small per-page one:

1. `MetaTagsHelper#page_title_with_project` assembles the exact string a full page render produces (project segment, reversed parts, app title), so the composition rule stays next to `page_title` / `html_title_parts`. It deliberately does not reuse `html_title_parts`: that one reads `@html_title` / `@project`, which a turbo stream response does not have, and escapes the project name with `h()` for meta-tags, while `set_title` assigns `textContent`.

2. `OpTurbo::ComponentStream#set_page_title_via_turbo_stream` takes the same parts a page passes to `html_title` and emits `turbo_stream.set_title`. The client-side action was already registered in `frontend/src/turbo/setup.ts`. Any controller that renames its subject in place can use it - `MeetingsController#update_title` has the same defect and is now one line away from being fixed too (left out of this PR as it is a different module and ticket).

3. In `DocumentsController` the title segments moved into `document_html_title_parts` (exposed as a `helper_method`), so `show.html.erb` and the turbo stream read them from one place and cannot drift apart. The stream is only queued on success, so a rejected rename leaves the tab untouched.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
