### PR TITLE
[FND-250] Task to fill Observed in versions with data from Bug found in version

### DIFF
--- a/lib/tasks/bug_found_in_version.rake
+++ b/lib/tasks/bug_found_in_version.rake
@@ -54,18 +54,29 @@ namespace :bug_found_in_version do
   def fetch_rows_data(batch, option_version_map) # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
     rows = batch.pluck(:customized_id, :value)
     work_packages = WorkPackage.where(id: rows.map(&:first)).includes(:project).index_by(&:id)
+    rows, orphaned = rows.partition { |work_package_id, _| work_packages[work_package_id]&.project }
+
     version_names = rows.filter_map { |_, value| option_version_map[value] }.uniq
     version_names_set = version_names.to_set
-    projects = work_packages.values.map(&:project).uniq
+    projects = rows.map { |work_package_id, _| work_packages.fetch(work_package_id).project }.uniq
 
-    versions = projects.each_with_object({}) do |project, result|
+    versions = {}
+    ambiguous = Set.new
+
+    projects.each do |project|
       project.assignable_versions(only_open: false)
         .select { |version| version_names_set.include?(version.name) }
         .group_by(&:name)
-        .each { |name, matches| result[[project.id, name]] = matches.first if matches.one? }
+        .each do |name, matches|
+          if matches.one?
+            versions[[project.id, name]] = matches.first
+          else
+            ambiguous << [project.id, name]
+          end
+        end
     end
 
-    [rows, work_packages, version_names, versions]
+    [rows, work_packages, version_names, versions, orphaned, ambiguous]
   end
 
   desc "Checks if all conditions are okay to copy Bug found in version to Observed in versions"
@@ -81,7 +92,8 @@ namespace :bug_found_in_version do
       puts "#{custom_options[option_id].value.inspect} -> #{version_name.inspect}"
     end
 
-    rows, work_packages, _version_names, versions = fetch_rows_data(custom_values, option_version_map)
+    rows, work_packages, _version_names, versions, orphaned, ambiguous =
+      fetch_rows_data(custom_values, option_version_map)
 
     existing_observed_in_ids = WorkPackageVersion
       .where(work_package_id: rows.map(&:first), kind: "observed_in")
@@ -90,6 +102,7 @@ namespace :bug_found_in_version do
       .transform_values { |pairs| pairs.map(&:last) }
 
     missing = []
+    ambiguous_pairs = []
     skipped_unmapped = 0
     to_create = 0
 
@@ -105,7 +118,8 @@ namespace :bug_found_in_version do
       version = versions[[work_package.project_id, version_name]]
 
       if version.nil?
-        missing << [work_package.project_id, version_name]
+        pair = [work_package.project_id, version_name]
+        ambiguous.include?(pair) ? ambiguous_pairs << pair : missing << pair
         next
       end
 
@@ -113,6 +127,7 @@ namespace :bug_found_in_version do
     end
 
     missing.uniq!
+    ambiguous_pairs.uniq!
 
     if missing.empty?
       puts " ALL MAPPED VERSIONS HAVE A MATCH "
@@ -120,12 +135,18 @@ namespace :bug_found_in_version do
       puts " (PROJECT_ID, VERSION NAME) PAIRS WITH NO MATCH: #{missing.inspect} "
     end
 
+    unless ambiguous_pairs.empty?
+      puts " (PROJECT_ID, VERSION NAME) PAIRS AMBIGUOUS - MULTIPLE VERSIONS SHARE THIS NAME, " \
+           "DEDUPE INSTEAD OF CREATING: #{ambiguous_pairs.inspect} "
+    end
+
     puts " #{skipped_unmapped} VALUES HAVE NO VERSION MAPPING (e.g. 'unreleased/dev') "
+    puts " #{orphaned.size} VALUES SKIPPED (WORK PACKAGE DELETED OR HAS NO PROJECT) "
     puts " #{to_create} RECORDS TO BE CREATED "
   end
 
   desc "Copy 'Bug found in version' values onto Observed in Versions (does not remove the original value)"
-  task copy: :environment do
+  task copy: %i[environment check] do
     puts " GATHERING DATA "
 
     _custom_options, custom_values, option_version_map = fetch_custom_fields_data
@@ -134,14 +155,17 @@ namespace :bug_found_in_version do
 
     copied = 0
     skipped_no_version = 0
+    skipped_ambiguous = 0
     skipped_already_observed = 0
+    skipped_orphaned = 0
     failed = 0
 
     total = custom_values.count
     custom_values.in_batches(of: 1000).each_with_index do |batch, index|
       puts " HANDLING BATCH #{index + 1} OF #{(total / 1000.0).ceil} "
 
-      rows, work_packages, _version_names, versions = fetch_rows_data(batch, option_version_map)
+      rows, work_packages, _version_names, versions, orphaned, ambiguous = fetch_rows_data(batch, option_version_map)
+      skipped_orphaned += orphaned.size
 
       existing_observed_in_ids = WorkPackageVersion
         .where(work_package_id: rows.map(&:first), kind: "observed_in")
@@ -155,7 +179,11 @@ namespace :bug_found_in_version do
         version = version_name && versions[[work_package.project_id, version_name]]
 
         if version.nil?
-          skipped_no_version += 1
+          if version_name && ambiguous.include?([work_package.project_id, version_name])
+            skipped_ambiguous += 1
+          else
+            skipped_no_version += 1
+          end
           next
         end
 
@@ -165,14 +193,16 @@ namespace :bug_found_in_version do
         end
 
         begin
-          WorkPackageVersion.create!(work_package_id:, version_id: version.id, kind: "observed_in")
-          result = Journals::CreateService.new(work_package, User.system).call
-          raise "failed to create journal" if result.result.nil?
+          ActiveRecord::Base.transaction do
+            WorkPackageVersion.create!(work_package_id:, version_id: version.id, kind: "observed_in")
+            result = Journals::CreateService.new(work_package, User.system).call
+            raise "failed to create journal" if result.result.nil?
+          end
 
           copied += 1
         rescue StandardError => e
           failed += 1
-          puts "WP[#{work_package.id}] - FAILED: #{e.message}"
+          puts "WP[#{work_package_id}] - FAILED: #{e.message}"
         end
       end
     end
@@ -180,7 +210,9 @@ namespace :bug_found_in_version do
     puts " SUMMARY "
     puts "Copied: #{copied}"
     puts "Skipped (no matching version): #{skipped_no_version}"
+    puts "Skipped (ambiguous - multiple versions share the name): #{skipped_ambiguous}"
     puts "Skipped (already observed): #{skipped_already_observed}"
+    puts "Skipped (orphaned - work package deleted or has no project): #{skipped_orphaned}"
     puts "Failed: #{failed}"
   end
 end

--- a/lib/tasks/bug_found_in_version.rake
+++ b/lib/tasks/bug_found_in_version.rake
@@ -51,14 +51,19 @@ namespace :bug_found_in_version do
     [custom_options, custom_values, option_version_map]
   end
 
-  def fetch_rows_data(batch, option_version_map)
+  def fetch_rows_data(batch, option_version_map) # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
     rows = batch.pluck(:customized_id, :value)
-    work_packages = WorkPackage.where(id: rows.map(&:first)).index_by(&:id)
+    work_packages = WorkPackage.where(id: rows.map(&:first)).includes(:project).index_by(&:id)
     version_names = rows.filter_map { |_, value| option_version_map[value] }.uniq
-    project_ids = work_packages.values.map(&:project_id).uniq
-    versions = Version
-      .where(project_id: project_ids, name: version_names)
-      .index_by { |version| [version.project_id, version.name] }
+    version_names_set = version_names.to_set
+    projects = work_packages.values.map(&:project).uniq
+
+    versions = projects.each_with_object({}) do |project, result|
+      project.assignable_versions(only_open: false)
+        .select { |version| version_names_set.include?(version.name) }
+        .group_by(&:name)
+        .each { |name, matches| result[[project.id, name]] = matches.first if matches.one? }
+    end
 
     [rows, work_packages, version_names, versions]
   end
@@ -78,26 +83,52 @@ namespace :bug_found_in_version do
 
     rows, work_packages, _version_names, versions = fetch_rows_data(custom_values, option_version_map)
 
-    missing = rows.filter_map do |work_package_id, value|
+    existing_observed_in_ids = WorkPackageVersion
+      .where(work_package_id: rows.map(&:first), kind: "observed_in")
+      .pluck(:work_package_id, :version_id)
+      .group_by(&:first)
+      .transform_values { |pairs| pairs.map(&:last) }
+
+    missing = []
+    skipped_unmapped = 0
+    to_create = 0
+
+    rows.each do |work_package_id, value|
       version_name = option_version_map[value]
-      next if version_name.nil?
+
+      if version_name.nil?
+        skipped_unmapped += 1
+        next
+      end
 
       work_package = work_packages.fetch(work_package_id)
-      [work_package.project_id, version_name] unless versions.key?([work_package.project_id, version_name])
-    end.uniq
+      version = versions[[work_package.project_id, version_name]]
+
+      if version.nil?
+        missing << [work_package.project_id, version_name]
+        next
+      end
+
+      to_create += 1 unless (existing_observed_in_ids[work_package_id] || []).include?(version.id)
+    end
+
+    missing.uniq!
 
     if missing.empty?
-      puts " ALL VERSIONS HAVE A MATCH "
+      puts " ALL MAPPED VERSIONS HAVE A MATCH "
     else
       puts " (PROJECT_ID, VERSION NAME) PAIRS WITH NO MATCH: #{missing.inspect} "
     end
+
+    puts " #{skipped_unmapped} VALUES HAVE NO VERSION MAPPING (e.g. 'unreleased/dev') "
+    puts " #{to_create} RECORDS TO BE CREATED "
   end
 
   desc "Copy 'Bug found in version' values onto Observed in Versions (does not remove the original value)"
   task copy: :environment do
     puts " GATHERING DATA "
 
-    custom_options, custom_values, option_version_map = fetch_custom_fields_data
+    _custom_options, custom_values, option_version_map = fetch_custom_fields_data
 
     puts " DATA IS IN "
 
@@ -120,7 +151,6 @@ namespace :bug_found_in_version do
 
       rows.each do |work_package_id, value|
         work_package = work_packages.fetch(work_package_id)
-        option = custom_options[value]
         version_name = option_version_map[value]
         version = version_name && versions[[work_package.project_id, version_name]]
 
@@ -129,24 +159,20 @@ namespace :bug_found_in_version do
           next
         end
 
-        current_ids = existing_observed_in_ids[work_package_id] || []
-        if current_ids.include?(version.id)
+        if (existing_observed_in_ids[work_package_id] || []).include?(version.id)
           skipped_already_observed += 1
           next
         end
 
-        result = WorkPackages::UpdateService
-          .new(user: User.system, model: work_package)
-          .call(
-            observed_in_version_ids: (current_ids + [version.id]).uniq,
-            journal_notes: "Copied 'Bug found in version' #{option&.value} to 'Observed in version' #{version.name}."
-          )
+        begin
+          WorkPackageVersion.create!(work_package_id:, version_id: version.id, kind: "observed_in")
+          result = Journals::CreateService.new(work_package, User.system).call
+          raise "failed to create journal" if result.result.nil?
 
-        if result.success?
           copied += 1
-        else
+        rescue StandardError => e
           failed += 1
-          puts "WP[#{work_package.id}] - FAILED: #{result.errors.full_messages.to_sentence}"
+          puts "WP[#{work_package.id}] - FAILED: #{e.message}"
         end
       end
     end

--- a/lib/tasks/bug_found_in_version.rake
+++ b/lib/tasks/bug_found_in_version.rake
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+namespace :bug_found_in_version do
+  def bug_found_in_version_option_map(custom_field)
+    custom_options = custom_field.custom_options.index_by { |option| option.id.to_s }
+
+    version_names = custom_options.transform_values do |option|
+      next nil if option.value == "unreleased/dev"
+
+      option.value.sub(/\.x\z/, ".0")
+    end
+
+    [custom_options, version_names]
+  end
+
+  def fetch_custom_fields_data
+    custom_field = CustomField.find_by(name: "Bug found in version")
+    custom_options, option_version_map = bug_found_in_version_option_map(custom_field)
+    custom_values = CustomValue
+      .where(custom_field:, customized_type: "WorkPackage")
+      .where.not(value: nil)
+
+    [custom_options, custom_values, option_version_map]
+  end
+
+  def fetch_rows_data(batch, option_version_map)
+    rows = batch.pluck(:customized_id, :value)
+    work_packages = WorkPackage.where(id: rows.map(&:first)).index_by(&:id)
+    version_names = rows.filter_map { |_, value| option_version_map[value] }.uniq
+    project_ids = work_packages.values.map(&:project_id).uniq
+    versions = Version
+      .where(project_id: project_ids, name: version_names)
+      .index_by { |version| [version.project_id, version.name] }
+
+    [rows, work_packages, version_names, versions]
+  end
+
+  desc "Checks if all conditions are okay to copy Bug found in version to Observed in versions"
+  task check: :environment do
+    puts " GATHERING DATA "
+
+    custom_options, custom_values, option_version_map = fetch_custom_fields_data
+
+    puts " DATA IS IN "
+
+    puts " OPTION -> VERSION NAME MAPPING "
+    option_version_map.each do |option_id, version_name|
+      puts "#{custom_options[option_id].value.inspect} -> #{version_name.inspect}"
+    end
+
+    rows, work_packages, _version_names, versions = fetch_rows_data(custom_values, option_version_map)
+
+    missing = rows.filter_map do |work_package_id, value|
+      version_name = option_version_map[value]
+      next if version_name.nil?
+
+      work_package = work_packages.fetch(work_package_id)
+      [work_package.project_id, version_name] unless versions.key?([work_package.project_id, version_name])
+    end.uniq
+
+    if missing.empty?
+      puts " ALL VERSIONS HAVE A MATCH "
+    else
+      puts " (PROJECT_ID, VERSION NAME) PAIRS WITH NO MATCH: #{missing.inspect} "
+    end
+  end
+
+  desc "Copy 'Bug found in version' values onto Observed in Versions (does not remove the original value)"
+  task copy: :environment do
+    puts " GATHERING DATA "
+
+    custom_options, custom_values, option_version_map = fetch_custom_fields_data
+
+    puts " DATA IS IN "
+
+    copied = 0
+    skipped_no_version = 0
+    skipped_already_observed = 0
+    failed = 0
+
+    total = custom_values.count
+    custom_values.in_batches(of: 1000).each_with_index do |batch, index|
+      puts " HANDLING BATCH #{index + 1} OF #{(total / 1000.0).ceil} "
+
+      rows, work_packages, _version_names, versions = fetch_rows_data(batch, option_version_map)
+
+      existing_observed_in_ids = WorkPackageVersion
+        .where(work_package_id: rows.map(&:first), kind: "observed_in")
+        .pluck(:work_package_id, :version_id)
+        .group_by(&:first)
+        .transform_values { |pairs| pairs.map(&:last) }
+
+      rows.each do |work_package_id, value|
+        work_package = work_packages.fetch(work_package_id)
+        option = custom_options[value]
+        version_name = option_version_map[value]
+        version = version_name && versions[[work_package.project_id, version_name]]
+
+        if version.nil?
+          skipped_no_version += 1
+          next
+        end
+
+        current_ids = existing_observed_in_ids[work_package_id] || []
+        if current_ids.include?(version.id)
+          skipped_already_observed += 1
+          next
+        end
+
+        result = WorkPackages::UpdateService
+          .new(user: User.system, model: work_package)
+          .call(
+            observed_in_version_ids: (current_ids + [version.id]).uniq,
+            journal_notes: "Copied 'Bug found in version' #{option&.value} to 'Observed in version' #{version.name}."
+          )
+
+        if result.success?
+          copied += 1
+        else
+          failed += 1
+          puts "WP[#{work_package.id}] - FAILED: #{result.errors.full_messages.to_sentence}"
+        end
+      end
+    end
+
+    puts " SUMMARY "
+    puts "Copied: #{copied}"
+    puts "Skipped (no matching version): #{skipped_no_version}"
+    puts "Skipped (already observed): #{skipped_already_observed}"
+    puts "Failed: #{failed}"
+  end
+end

--- a/spec/rake/task_bug_found_in_version_spec.rb
+++ b/spec/rake/task_bug_found_in_version_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Rake::Task do
+  shared_let(:custom_field) do
+    create(:wp_custom_field, :list, name: "Bug found in version", possible_values: %w[1.0.x 2.0.x])
+  end
+
+  def observe(work_package, option_value)
+    create(:custom_value,
+           custom_field:,
+           customized: work_package,
+           value: custom_field.value_of(option_value).to_s)
+  end
+
+  def observed_in_version_ids(work_package)
+    WorkPackageVersion.where(work_package:, kind: "observed_in").pluck(:version_id)
+  end
+
+  describe "bug_found_in_version:copy" do
+    include_context "rake" do
+      let(:task_name) { "bug_found_in_version:copy" }
+    end
+
+    it "copies a version found in the same project" do
+      project = create(:project)
+      version = create(:version, project:, name: "1.0.0")
+      work_package = create(:work_package, project:)
+      observe(work_package, "1.0.x")
+
+      expect { subject.invoke }.to output(/Copied: 1/).to_stdout
+
+      expect(observed_in_version_ids(work_package)).to contain_exactly(version.id)
+    end
+
+    it "does not copy a version from another, unshared project" do
+      project = create(:project)
+      other_project = create(:project)
+      create(:version, project: other_project, name: "1.0.0") # sharing: "none" by default
+      work_package = create(:work_package, project:)
+      observe(work_package, "1.0.x")
+
+      expect { subject.invoke }.to output(/Copied: 0.*Skipped \(no matching version\): 1/m).to_stdout
+
+      expect(observed_in_version_ids(work_package)).to be_empty
+    end
+
+    it "copies a version shared from another project" do
+      project = create(:project)
+      other_project = create(:project)
+      version = create(:version, project: other_project, name: "1.0.0", sharing: "system")
+      work_package = create(:work_package, project:)
+      observe(work_package, "1.0.x")
+
+      expect { subject.invoke }.to output(/Copied: 1/).to_stdout
+
+      expect(observed_in_version_ids(work_package)).to contain_exactly(version.id)
+    end
+
+    it "skips when the version name is ambiguous between two assignable versions" do
+      project = create(:project)
+      other_project = create(:project)
+      create(:version, project:, name: "1.0.0")
+      create(:version, project: other_project, name: "1.0.0", sharing: "system")
+      work_package = create(:work_package, project:)
+      observe(work_package, "1.0.x")
+
+      expect { subject.invoke }
+        .to output(/Copied: 0.*Skipped \(ambiguous - multiple versions share the name\): 1/m).to_stdout
+
+      expect(observed_in_version_ids(work_package)).to be_empty
+    end
+
+    it "skips a work package that already has the matching observed_in_versions version" do
+      project = create(:project)
+      version = create(:version, project:, name: "1.0.0")
+      work_package = create(:work_package, project:)
+      observe(work_package, "1.0.x")
+      create(:work_package_version, work_package:, version:, kind: "observed_in")
+
+      expect { subject.invoke }.to output(/Copied: 0.*Skipped \(already observed\): 1/m).to_stdout
+
+      expect(observed_in_version_ids(work_package)).to contain_exactly(version.id)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.com/wp/FND-250

# What are you trying to accomplish?
Implement a one time solution for copying data from one field to another in order to allow the "community" instance to use Observed in versions instead of the custom field.

# Usage

Check will give a report on which Bug found in version values will be translated into which versions
```
rake bug_found_in_version:check
```

Copy will copy the values to the matching version in batches
```
rake bug_found_in_version:copy
```

# How I tested this

- Create a custom field called "Bug found in version"
- Set some values mimicing community (e.g. 17.7.x, unrelease/dev, etc)
- Create versions matching (and not matching) the values from Bug found in version (e.g. 17.7.0, 17.7.1)
- Set some (or all) of these versions as shared
- Create work packages with Bug found in version populated in different projects and subprojects

```ruby
custom_field = WorkPackageCustomField.find_by!(name: "Bug found in version")
options = custom_field.custom_options.to_a

project = Project.find(1) # demo
type = Type.find(7) # Bug
author = User.system # system
priority = IssuePriority.find(8) # normal
status = Status.find(1) # new

ActiveRecord::Base.transaction do
  100.times do |i|
    work_package = WorkPackage.new(
      project:,
      type:,
      subject: "Bug found in version seed ##{i + 1}",
      author:,
      status:,
      priority:
    )
    work_package.custom_field_values = { custom_field.id => options.sample.id }
    work_package.save!
  end
end
```

Then finally run `docker compose run --rm -e SILENCE_SQL_LOGS=true backend rake bug_found_in_version:check` and `docker compose run --rm -e SILENCE_SQL_LOGS=true backend rake bug_found_in_version:copy`.