### PR TITLE
[COMMS-1008] Search by identifier in the project selector in the left menu should find the right project

### DIFF
--- a/app/controllers/header/projects_controller.rb
+++ b/app/controllers/header/projects_controller.rb
@@ -80,12 +80,17 @@ class Header::ProjectsController < ApplicationController
   def base_scope
     scope = Project.visible.active.order(:lft).limit(MAX_NUMBER_OF_PROJECTS)
     query.split.each do |term|
-      scope = scope.where("LOWER(name) LIKE LOWER(?)", "%#{ActiveRecord::Base.sanitize_sql_like(term)}%")
+      scope = name_and_identifier_filter(term).apply_to(scope)
     end
     if filter_mode == "favorited"
       scope = current_user.logged? ? scope.where(id: favorite_project_ids) : scope.none
     end
     scope
+  end
+
+  def name_and_identifier_filter(term)
+    sanitized = ActiveRecord::Base.sanitize_sql_like(term)
+    Queries::Projects::Filters::NameAndIdentifierFilter.create!(operator: "~", values: [sanitized])
   end
 
   def ensure_current_project_present(projects)

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -139,6 +139,32 @@ RSpec.describe Header::ProjectsController do
         parent_node = tree.find { |n| n[:project] == parent_project }
         expect(parent_node[:matches_query]).to be(false)
       end
+
+      context "with multiple search terms" do
+        subject(:make_request) { get :index, params: { query: "Beta Gamma" } }
+
+        it "requires every term to match" do
+          make_request
+          expect(assigns(:projects)).to be_empty
+        end
+      end
+    end
+
+    context "when searching by a term that only matches the identifier" do
+      shared_let(:identifier_project) { create(:project, name: "Delta Fourth", identifier: "top-secret-code") }
+
+      subject(:make_request) { get :index, params: { query: "secret" } }
+
+      before do
+        create(:member, principal: current_user, project: identifier_project, roles: [role])
+      end
+
+      it "returns the project whose identifier matches", :aggregate_failures do
+        make_request
+
+        expect(assigns(:projects)).to include(identifier_project)
+        expect(assigns(:projects)).not_to include(parent_project, child_project, other_project)
+      end
     end
 
     context "with filter_mode=favorited" do

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -88,11 +88,18 @@ RSpec.describe "Projects autocomplete page", :js do
     visit root_path
   end
 
-  it "allows to filter and select projects" do
-    retry_block do
-      top_menu.toggle unless top_menu.open?
-      top_menu.expect_open
+  describe "allows to filter and select projects" do
+    before do
+      retry_block do
+        top_menu.toggle unless top_menu.open?
+        top_menu.expect_open
 
+        # Wait until the component is fully loaded and ready
+        top_menu.expect_result project.name
+      end
+    end
+
+    it "displays the projects the user is allowed to see" do
       # projects are displayed initially
       top_menu.expect_result project.name
       # public project is displayed as it is public
@@ -101,79 +108,98 @@ RSpec.describe "Projects autocomplete page", :js do
       top_menu.expect_no_result non_member_project.name
     end
 
-    # Filter for projects
-    top_menu.search "<strong"
+    it "escapes HTML in the project name instead of rendering it" do
+      # Filter for projects
+      top_menu.search "<strong"
 
-    # Expect result is shown and HTML in the project name is escaped, not rendered
-    within(top_menu.search_results) do
-      expect(page).to have_no_css("strong")
+      # Only the matching project is left, i.e. the filter has been applied.
+      top_menu.expect_no_result "Plain project"
+
+      # Expect result is shown and HTML in the project name is escaped, not rendered
+      within(top_menu.search_results) do
+        expect(page).to have_no_css("strong")
+      end
     end
 
-    # Expect fuzzy matches for multiple substrings
-    top_menu.search "Plain pr"
-    top_menu.expect_result "Plain project"
-    top_menu.expect_result "Plain other project"
-    top_menu.expect_no_result "Project with different name and identifier"
-
-    # Expect search to match names only and not the identifier
-    top_menu.clear_search
-
-    top_menu.search "plain"
-    top_menu.expect_result "Plain project"
-    top_menu.expect_result "Plain other project"
-    top_menu.expect_no_result "Project with different name and identifier"
-
-    # Expect hierarchy
-    top_menu.clear_search
-
-    # The unfiltered tree collapses back to its initial state, so the child is
-    # hidden until its ancestor is expanded. Waiting for it to disappear also
-    # keeps the assertions below from reading the still-filtered tree, which
-    # lingers for the duration of the search debounce.
-    top_menu.expect_no_result "Plain other project"
-
-    top_menu.expect_result "Plain project"
-    # Nothing is filtered out without a query, so the ancestor is selectable.
-    top_menu.expect_result "<strong>foobar</strong>"
-
-    top_menu.expand_node_for "<strong>foobar</strong>"
-    top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
-                                              item_name: "Plain other project"
-
-    # Show hierarchy of project
-    top_menu.search "Plain other project"
-
-    top_menu.expect_result "<strong>foobar</strong>", disabled: true
-    top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
-                                              item_name: "Plain other project"
-
-    # find terms at the end of project names
-    top_menu.search "END"
-    top_menu.expect_result "Very long project name with term at the END"
-
-    # Find literal matches exclusively if present
-    top_menu.search "INK15"
-    top_menu.expect_result "INK15 - Bar"
-    top_menu.expect_no_result "INK14 - Foo"
-    top_menu.expect_no_result "INK16 - Baz"
-
-    # Visit a project
-    top_menu.search_and_select "<strong"
-    top_menu.expect_current_project project2.name
-
-    # Keeps the current module
-    visit project_news_index_path(project2)
-    expect(page).to have_css(".news-menu-item.selected")
-
-    retry_block do
-      top_menu.toggle
-      top_menu.expect_open
-      top_menu.search_and_select "Plain project"
+    it "expects fuzzy matches for multiple substrings" do
+      top_menu.search "Plain pr"
+      top_menu.expect_result "Plain project"
+      top_menu.expect_result "Plain other project"
     end
 
-    expect(page).to have_current_path(project_news_index_path(project),
-                                      ignore_query: true)
-    expect(page).to have_css(".news-menu-item.selected")
+    it "expects every term to match, not just one of them" do
+      top_menu.search "Plain other"
+      top_menu.expect_result "Plain other project"
+      top_menu.expect_no_result "Plain project"
+    end
+
+    it "expects search to match the identifier as well as the name" do
+      top_menu.search "plain"
+      top_menu.expect_result "Plain project"
+      top_menu.expect_result "Plain other project"
+      top_menu.expect_result "Project with different name and identifier"
+    end
+
+    it "expects hierarchy" do
+      # Filtering expands the tree, so filter first to be able to tell the
+      # collapsed tree apart from the filtered one.
+      top_menu.search "plain"
+      top_menu.expect_result "Plain other project"
+
+      top_menu.clear_search
+
+      # The unfiltered tree collapses back to its initial state, so the child is
+      # hidden until its ancestor is expanded.
+      top_menu.expect_no_result "Plain other project"
+
+      top_menu.expect_result "Plain project"
+      # Nothing is filtered out without a query, so the ancestor is selectable.
+      top_menu.expect_result "<strong>foobar</strong>"
+
+      top_menu.expand_node_for "<strong>foobar</strong>"
+      top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
+                                                item_name: "Plain other project"
+    end
+
+    it "shows hierarchy of project" do
+      top_menu.search "Plain other project"
+
+      top_menu.expect_result "<strong>foobar</strong>", disabled: true
+      top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
+                                                item_name: "Plain other project"
+    end
+
+    it "finds terms at the end of project names" do
+      top_menu.search "END"
+      top_menu.expect_result "Very long project name with term at the END"
+    end
+
+    it "finds literal matches exclusively if present" do
+      top_menu.search "INK15"
+      top_menu.expect_result "INK15 - Bar"
+      top_menu.expect_no_result "INK14 - Foo"
+      top_menu.expect_no_result "INK16 - Baz"
+    end
+
+    it "visits a project" do
+      top_menu.search_and_select "<strong"
+      top_menu.expect_current_project project2.name
+    end
+
+    it "keeps the current module" do
+      visit project_news_index_path(project2)
+      expect(page).to have_css(".news-menu-item.selected")
+
+      retry_block do
+        top_menu.toggle
+        top_menu.expect_open
+        top_menu.search_and_select "Plain project"
+      end
+
+      expect(page).to have_current_path(project_news_index_path(project),
+                                        ignore_query: true)
+      expect(page).to have_css(".news-menu-item.selected")
+    end
   end
 
   it "navigates to the first project upon hitting enter in the search bar" do

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -81,8 +81,7 @@ module Components
       end
 
       def clear_search
-        search_field.set ""
-        search_field.send_keys :backspace
+        clear_input_field_contents(search_field)
       end
 
       def search_and_select(query)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-1008

# What are you trying to accomplish?
Make the project search in the left menu find the right project by its identifier. Other pickers will be implemented separately.

## Screenshots
<img width="483" height="110" alt="image" src="https://github.com/user-attachments/assets/73130dfe-5028-43c0-9fc5-216b324e01a4" />

# What approach did you choose and why?
- Reuse the existing `Queries::Projects::Filters::NameAndIdentifierFilter` 
- Also refactor some tests for better reporting when a test fails (so that it's clear which part is failing)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
