### PR TITLE
Speed up baseline queries.

### DIFF
--- a/app/models/journable/historic_active_record_relation.rb
+++ b/app/models/journable/historic_active_record_relation.rb
@@ -111,9 +111,12 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
 
   private
 
+  # NOT MATERIALIZED: PostgreSQL inlines a CTE automatically only when it is referenced once, and
+  # `visible` and the custom field filters reference the model table again. Without the hint the
+  # planner builds a snapshot of every journable before any filter is applied.
   def add_historic_model_cte(arel)
     historic_models_cte = Arel::Nodes::As.new(Arel::Table.new(model.table_name),
-                                              historic_models_statement.arel)
+                                              Arel.sql("NOT MATERIALIZED (#{historic_models_statement.to_sql})"))
 
     if arel.ast.with
       arel.ast.with.expr.unshift(historic_models_cte)
@@ -182,8 +185,10 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
   def substitute_custom_values_join_in_predicate(predicate)
     return unless predicate.is_a? String
 
-    customizable_journals = Journal::CustomizableJournal.table_name
     custom_values = CustomValue.table_name
+    return unless predicate.include?(custom_values)
+
+    customizable_journals = Journal::CustomizableJournal.table_name
     models = model.table_name
 
     predicate.gsub! /JOIN (?<!_)#{custom_values}/,
@@ -201,8 +206,8 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
     # Replace all occurrences of `custom_values.value` within the WHERE clause.
     # This handles operators like "is empty" which generate multiple references:
     # e.g. `WHERE custom_values.value IS NULL OR custom_values.value = ''`
-    predicate.gsub!(/WHERE.*#{Regexp.escape(custom_values)}\.value.*/) do |match|
-      match.gsub!("#{custom_values}.value", "#{customizable_journals}.value")
+    predicate.gsub!(/WHERE.*#{Regexp.escape(custom_values)}\.value.*/m) do |match|
+      match.gsub("#{custom_values}.value", "#{customizable_journals}.value")
     end
   end
 

--- a/app/models/journable/with_historic_attributes.rb
+++ b/app/models/journable/with_historic_attributes.rb
@@ -164,15 +164,18 @@ class Journable::WithHistoricAttributes < SimpleDelegator
   end
 
   def matches_query_filters_at_timestamps
-    if query.present?
-      timestamps.select { |timestamp| loader.work_package_ids_of_query_at_timestamp(query:, timestamp:).include?(__getobj__.id) }
-    else
-      []
-    end
+    @matches_query_filters_at_timestamps ||=
+      if query.present?
+        timestamps.select do |timestamp|
+          loader.work_package_ids_of_query_at_timestamp(query:, timestamp:).include?(__getobj__.id)
+        end
+      else
+        []
+      end
   end
 
   def exists_at_timestamps
-    timestamps.select { |t| at_timestamp(t).present? }
+    @exists_at_timestamps ||= timestamps.select { |t| at_timestamp(t).present? }
   end
 
   def baseline_timestamp

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -95,16 +95,27 @@ class Journable::WithHistoricAttributes
       end
     end
 
+    # Dropping the sorting is only equivalent while every `sortable_join_statement` and
+    # `groupable_join` -- core's and every plugin's -- is a LEFT OUTER JOIN, as they are today. An
+    # INNER join in a sort would narrow the id set.
     def work_package_ids_of_query_at_timestamp_calculation(query, timestamp)
-      query = query.dup
-      query.timestamps = [timestamp] if timestamp
+      if timestamp.try(:historic?)
+        query.results.work_package_ids_at_timestamp(timestamp, ids: journable_ids)
+      else
+        scoped_query = query.dup
+        scoped_query.timestamps = [timestamp] if timestamp
 
-      query.results.work_packages.where(id: journables.map(&:id)).pluck(:id)
+        scoped_query.results.work_packages.where(id: journable_ids).pluck(:id)
+      end.to_set
+    end
+
+    def journable_ids
+      @journable_ids ||= journables.map(&:id)
     end
 
     def currently_visible_journables
       @currently_visible_journables ||= begin
-        visible_ids = journalized_class.visible.where(id: journables.map(&:id)).pluck(:id)
+        visible_ids = journalized_class.visible.where(id: journable_ids).pluck(:id)
         journables.select { |j| visible_ids.include?(j.id) }
       end
     end
@@ -114,7 +125,9 @@ class Journable::WithHistoricAttributes
     end
 
     def journalized_at_timestamp(tms)
-      journalized = (currently_invisible_journalized_at_timestamp(tms) + currently_visible_journalized_at_timestamp(tms))
+      journalized = currently_invisible_journables.any? ? currently_invisible_journalized_at_timestamp(tms).to_a : []
+      journalized.concat(currently_visible_journalized_at_timestamp(tms).to_a)
+
       load_journal_associations(journalized)
     end
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -55,6 +55,12 @@ class Query::Results
     end
   end
 
+  # Same semantics as the historic branch of #work_packages, minus the sorting: the caller only
+  # needs ids.
+  def work_package_ids_at_timestamp(timestamp, ids:)
+    visible_work_packages_at(timestamp, ids:).pluck(:id)
+  end
+
   private
 
   def sorted_work_packages_matching_the_filters_today
@@ -71,7 +77,14 @@ class Query::Results
   # ensure to not reveal information.
   def sorted_work_packages_matching_the_filters_at_any_of_the_given_timestamps
     sorted_work_packages
-      .where(id: filtered_work_packages.visible.at_timestamp(query.timestamps))
+      .where(id: visible_work_packages_at(query.timestamps))
+  end
+
+  def visible_work_packages_at(timestamps, ids: nil)
+    scope = filtered_work_packages.visible
+    scope = scope.where(id: ids) if ids
+
+    scope.at_timestamp(timestamps)
   end
 
   # Returns an active-record relation that applies the filters to find the matching

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -46,7 +46,7 @@ module API
                  .call(params, valid_subset:)
 
         if update.success?
-          representer = results_to_representer(params)
+          representer = results_to_representer(params, query.results)
 
           ServiceResult.success(result: representer)
         else
@@ -56,8 +56,10 @@ module API
 
       private
 
-      def results_to_representer(params)
-        results_scope = query.results.work_packages
+      # Query#results hands out a fresh Query::Results every time, so the one built in #call is
+      # threaded through rather than re-requested: everything it memoises would be thrown away.
+      def results_to_representer(params, results)
+        results_scope = results.work_packages
 
         if scope
           results_scope = results_scope.where(id: scope.select(:id))
@@ -66,8 +68,8 @@ module API
         collection_representer(results_scope,
                                params:,
                                project: query.project,
-                               groups: generate_groups,
-                               sums: generate_total_sums)
+                               groups: generate_groups(results),
+                               sums: generate_total_sums(results))
       end
 
       attr_accessor :query,
@@ -92,11 +94,10 @@ module API
           .to_h
       end
 
-      def generate_groups
+      def generate_groups(results)
         return unless query.grouped?
 
-        results = query.results
-        sums = generate_group_sums
+        sums = generate_group_sums(results)
 
         results.work_package_count_by_group.map do |group, count|
           ::API::V3::WorkPackages::WorkPackageAggregationGroup.new(
@@ -105,16 +106,16 @@ module API
         end
       end
 
-      def generate_total_sums
+      def generate_total_sums(results)
         return unless query.display_sums?
 
-        format_query_sums query.results.all_total_sums
+        format_query_sums results.all_total_sums
       end
 
-      def generate_group_sums
+      def generate_group_sums(results)
         return {} unless query.display_sums?
 
-        query.results.all_group_sums.transform_values do |v|
+        results.all_group_sums.transform_values do |v|
           format_query_sums(v)
         end
       end

--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -91,6 +91,8 @@ module API
       protected
 
       def total_count(models)
+        return page_row_count(models) if first_page_shorter_than_its_limit?
+
         models.count(:id)
       end
 
@@ -132,13 +134,29 @@ module API
         end
       end
 
+      # Fewer rows than the limit means the LIMIT was never exhausted, so nothing follows this page
+      # and `total` needs no COUNT.
+      def first_page_shorter_than_its_limit?
+        @page == 1 && @paged_ids && @paged_ids.size < @per_page
+      end
+
+      # `count(:id)` counts distinct ids only on an eager loading relation, where rails switches to
+      # COUNT(DISTINCT id); on any other relation it counts rows, joined duplicates included.
+      def page_row_count(models)
+        models.eager_loading? ? @paged_ids.uniq.size : @paged_ids.size
+      end
+
+      def paged_ids(models)
+        @paged_ids = models.pluck(:id)
+      end
+
       def eager_loaded_paged_models(models)
         # Whenever eager loading and limit is combined, rails switches to issuing two SQL statement.
         # This is done to avoid the potential duplicate records added by a 'LEFT JOIN' messing with the LIMIT.
         # What is unfortunate is that both statements will have the complete where conditions included.
         # This can be quite costly, especially when the where conditions are complex.
         # To avoid this, we fetch the ids and then fetch the actual records reapplying the order.
-        ids = models.pluck(:id)
+        ids = paged_ids(models)
 
         models
           .model

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -333,7 +333,7 @@ module API
           # The EagerLoadingWrapper uses the id to load the work packages with all the includes necessary.
           # It also reapplies the order.
           ::API::V3::WorkPackages::WorkPackageEagerLoadingWrapper
-            .wrap(models.pluck(:id), current_user, timestamps:, query:)
+            .wrap(paged_ids(models), current_user, timestamps:, query:)
         end
       end
     end

--- a/lib_static/open_project/database.rb
+++ b/lib_static/open_project/database.rb
@@ -57,8 +57,8 @@ module OpenProject
     # Get the database system requirements
     def self.required_version
       {
-        numeric: 100000, # PG_VERSION_NUM
-        string: "10.0.0"
+        numeric: 130000, # PG_VERSION_NUM
+        string: "13.0.0"
       }
     end
 

--- a/spec/lib/api/decorators/offset_paginated_collection_spec.rb
+++ b/spec/lib/api/decorators/offset_paginated_collection_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# `total` is user visible, in the API and in the work package table footer, so answering it from a
+# short first page instead of a COUNT has to agree with that COUNT in every case, not only in the
+# one it optimises.
+RSpec.describe API::Decorators::OffsetPaginatedCollection, "total without a COUNT" do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:user) { create(:user) }
+  shared_let(:work_packages) { create_list(:work_package, 5) }
+
+  let(:page) { nil }
+  let(:per_page) { nil }
+  let(:models) { WorkPackage.all }
+
+  # A representer that eager loads, which is the only case in which the number of rows the page
+  # returned is known without a second query.
+  let(:collection) do
+    API::V3::WorkPackages::WorkPackageCollectionRepresenter.new(
+      models,
+      self_link: "/api/v3/example",
+      query_params: {},
+      project: nil,
+      groups: nil,
+      total_sums: nil,
+      page:,
+      per_page:,
+      current_user: user,
+      embed_schemas: false,
+      timestamps: nil,
+      query: nil
+    )
+  end
+
+  def total_of(decorator)
+    decorator.instance_variable_get(:@total)
+  end
+
+  def count_of_all_work_packages
+    WorkPackage.count(:id)
+  end
+
+  current_user { user }
+
+  before { mock_permissions_for(user, &:allow_everything) }
+
+  context "when the first page is shorter than the page size" do
+    let(:page) { 1 }
+    let(:per_page) { 10 }
+
+    it "reports the number of rows it actually got" do
+      expect(total_of(collection)).to eq(5)
+    end
+
+    it "agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(count_of_all_work_packages)
+    end
+
+    it "does not issue a COUNT" do
+      counted = []
+      callback = ->(_, _, _, _, payload) { counted << payload[:sql] if payload[:sql]&.include?("COUNT") }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { total_of(collection) }
+
+      expect(counted).to be_empty
+    end
+  end
+
+  context "when the first page is exactly full" do
+    let(:page) { 1 }
+    let(:per_page) { 5 }
+
+    it "agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(count_of_all_work_packages)
+    end
+  end
+
+  context "when past the first page" do
+    let(:page) { 2 }
+    let(:per_page) { 3 }
+
+    it "agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(count_of_all_work_packages)
+    end
+  end
+
+  context "when the page size is zero" do
+    let(:page) { 1 }
+    let(:per_page) { 0 }
+
+    it "agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(count_of_all_work_packages)
+    end
+  end
+
+  # The eager loading wrapper plucks the ids and reloads them in a second query. A row deleted in
+  # between -- or collapsed by the `where(id:)` dedup -- makes the array shorter than the page
+  # actually was, and answering `total` from it would truncate the collection.
+  context "when eager loading returns fewer objects than the page held" do
+    let(:page) { 1 }
+    let(:per_page) { 10 }
+
+    before do
+      drop_all_but_two = ->(method, ids, *args, **kwargs) { method.call(ids.first(2), *args, **kwargs) }
+
+      allow(API::V3::WorkPackages::WorkPackageEagerLoadingWrapper)
+        .to receive(:wrap).and_wrap_original(&drop_all_but_two)
+    end
+
+    it "still agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(count_of_all_work_packages)
+    end
+  end
+
+  # Query::Results builds its relation with `eager_load`, so the COUNT being replaced is a
+  # COUNT(DISTINCT id) while plucking the page returns one row per joined association row.
+  context "when the relation eager loads a has-many" do
+    let(:page) { 1 }
+    let(:per_page) { 10 }
+    let(:models) { WorkPackage.eager_load(:time_entries) }
+
+    before { create_list(:time_entry, 2, entity: work_packages.first) }
+
+    it "agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(models.count(:id))
+    end
+
+    it "agrees with the number of elements on the page" do
+      expect(total_of(collection)).to eq(collection.represented.size)
+    end
+  end
+
+  # Without eager loading rails does not add the DISTINCT, so the COUNT being replaced counts the
+  # joined rows. Answering with the distinct count would make `total` depend on the page size.
+  context "when the relation joins a has-many without eager loading" do
+    let(:page) { 1 }
+    let(:per_page) { 10 }
+    let(:models) { WorkPackage.joins(:time_entries) }
+
+    before { create_list(:time_entry, 2, entity: work_packages.first) }
+
+    it "agrees with the COUNT it replaces" do
+      expect(total_of(collection)).to eq(models.count(:id))
+    end
+  end
+
+  # ProjectCollectionRepresenter and NotificationCollectionRepresenter hand the relation to their
+  # wrapper instead of plucking ids, so no row count is recorded and the COUNT stays.
+  context "with a representer that does not record a row count" do
+    shared_let(:projects) { create_list(:project, 3) }
+
+    let(:collection) do
+      API::V3::Projects::ProjectCollectionRepresenter.new(
+        Project.all,
+        self_link: "/api/v3/projects",
+        page: 1,
+        per_page: 10,
+        current_user: user
+      )
+    end
+
+    it "falls back to the COUNT" do
+      expect(total_of(collection)).to eq(Project.count(:id))
+    end
+  end
+end

--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -331,6 +331,22 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
             expect(subject).to include work_package_matching
             expect(subject).not_to include work_package
           end
+
+          # Operators referencing custom_values.value more than once put the later references
+          # wherever the filter value happens to leave them. The substitution has to reach those
+          # too, or the rewritten statement keeps a custom_values reference that the CTE, which
+          # joins customizable_journals instead, does not provide.
+          context "with a reference on a line of its own" do
+            let(:relation) do
+              sql = is_empty_filter.where
+
+              WorkPackage.where(sql.dup.insert(sql.rindex("custom_values.value"), "\n"))
+            end
+
+            it "substitutes that reference as well" do
+              expect(subject.to_sql).not_to include "custom_values.value"
+            end
+          end
         end
       end
 
@@ -578,6 +594,41 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
       it "has the typecasted value matching the journable class's data type" do
         expect(subject).to eq 0
       end
+    end
+  end
+
+  describe "the journals CTE" do
+    let(:cte_project) { create(:project) }
+    let!(:cte_work_package) do
+      create(:work_package,
+             project: cte_project,
+             subject: "Now",
+             journals: { monday => { subject: "On monday" } })
+    end
+
+    # PostgreSQL inlines a CTE automatically only when it is referenced once, and `visible` and the
+    # custom field filters reference the model table again. Without the hint the planner builds a
+    # snapshot of every journable before any filter is applied.
+    it "is marked NOT MATERIALIZED so PostgreSQL inlines it" do
+      expect(WorkPackage.at_timestamp(wednesday).to_sql)
+        .to include('WITH "work_packages" AS NOT MATERIALIZED (')
+    end
+
+    it "emits no bind placeholders into the CTE body" do
+      sql = WorkPackage.visible.at_timestamp(wednesday).where(id: [cte_work_package.id]).to_sql
+
+      expect(sql).not_to match(/\$\d/)
+      expect(sql).not_to include("?")
+    end
+
+    it "reconstructs the attributes of a restricted set" do
+      expect(WorkPackage.at_timestamp(monday).where(id: cte_work_package.id).pluck(:id, :subject))
+        .to contain_exactly([cte_work_package.id, "On monday"])
+    end
+
+    it "returns the complement for a negated restriction" do
+      expect(WorkPackage.at_timestamp(monday).where.not(id: cte_work_package.id).pluck(:id))
+        .not_to include(cte_work_package.id)
     end
   end
 end

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -821,4 +821,81 @@ RSpec.describe Journable::WithHistoricAttributes,
       end
     end
   end
+
+  describe "loader optimisations" do
+    let(:work_packages) { [work_package1, work_package2] }
+
+    describe "memoisation" do
+      let(:query) { build_query }
+      let(:search_term) { "original" }
+
+      # API::V3::WorkPackages::EagerLoading::HistoricAttributes#set_timestamp_attributes reads
+      # both of these 1 + T times per work package while rendering a collection.
+      it "asks the loader once per timestamp, however often the matches are read" do
+        wrapped = subject.first
+        allow(wrapped.loader).to receive(:work_package_ids_of_query_at_timestamp).and_call_original
+
+        3.times { wrapped.matches_query_filters_at_timestamps }
+
+        expect(wrapped.loader)
+          .to have_received(:work_package_ids_of_query_at_timestamp)
+          .exactly(timestamps.size).times
+      end
+
+      it "hands back the very same result on every read" do
+        wrapped = subject.first
+
+        matches = wrapped.matches_query_filters_at_timestamps
+        exists = wrapped.exists_at_timestamps
+
+        expect(wrapped.matches_query_filters_at_timestamps).to be(matches)
+        expect(wrapped.exists_at_timestamps).to be(exists)
+      end
+    end
+
+    # The invisible branch is a full snapshot reconstruction that matches nothing whenever every
+    # journable is currently visible, which is the common case.
+    describe "the currently invisible branch" do
+      it "is not run when every journable is currently visible" do
+        wrapped = subject
+        loader = wrapped.first.loader
+        allow(loader).to receive(:currently_invisible_journalized_at_timestamp).and_call_original
+
+        wrapped.each(&:exists_at_timestamps)
+
+        expect(loader).not_to have_received(:currently_invisible_journalized_at_timestamp)
+      end
+
+      context "when a journable is currently invisible" do
+        shared_let(:other_project) { create(:project) }
+        shared_let(:invisible_work_package) do
+          create(:work_package,
+                 subject: "The current invisible work package",
+                 project: other_project,
+                 journals: { Time.zone.parse("2021-12-31") => { subject: "The original invisible work package" } })
+        end
+
+        let(:work_packages) { [work_package1, invisible_work_package] }
+
+        it "is run" do
+          wrapped = subject
+          loader = wrapped.first.loader
+          allow(loader).to receive(:currently_invisible_journalized_at_timestamp).and_call_original
+
+          wrapped.each(&:exists_at_timestamps)
+
+          expect(loader).to have_received(:currently_invisible_journalized_at_timestamp).at_least(:once)
+        end
+
+        it "still wraps it, with no timestamp it is visible at" do
+          by_id = subject.index_by(&:id)
+
+          expect(by_id.keys).to contain_exactly(work_package1.id, invisible_work_package.id)
+          expect(by_id[invisible_work_package.id].exists_at_timestamps).to be_empty
+          expect(by_id[work_package1.id].exists_at_timestamps)
+            .to contain_exactly(Timestamp.parse("2022-01-01T00:00:00Z"), Timestamp.parse("PT0S"))
+        end
+      end
+    end
+  end
 end

--- a/spec/models/queries/filters/shared/custom_fields/base_spec.rb
+++ b/spec/models/queries/filters/shared/custom_fields/base_spec.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# The sub-select #where produces is rewritten for historic queries by
+# Journable::HistoricActiveRecordRelation, which swaps custom_values for customizable_journals.
+# These examples pin the rows each operator selects on both the current and the historic path.
+RSpec.describe Queries::Filters::Shared::CustomFields::Base, "#where" do
+  describe "for a work package custom field" do
+    shared_let(:type) { create(:type_task) }
+    shared_let(:project) { create(:project, types: [type]) }
+
+    shared_let(:string_cf) { create(:string_wp_custom_field, types: [type], projects: [project]) }
+    shared_let(:list_cf) { create(:list_wp_custom_field, types: [type], projects: [project]) }
+    shared_let(:int_cf) { create(:integer_wp_custom_field, types: [type], projects: [project]) }
+    shared_let(:date_cf) { create(:date_wp_custom_field, types: [type], projects: [project]) }
+    # is_for_all skips the custom_fields_projects join, which is a separate code path
+    shared_let(:for_all_cf) { create(:string_wp_custom_field, is_for_all: true, types: [type]) }
+
+    shared_let(:option_ids) { list_cf.custom_options.map { |option| option.id.to_s } }
+
+    shared_let(:alpha) do
+      create(:work_package, project:, type:).tap do |wp|
+        wp.custom_field_values = { string_cf.id => "alpha", list_cf.id => option_ids.first,
+                                   int_cf.id => "5", date_cf.id => "2026-01-01",
+                                   for_all_cf.id => "alpha" }
+        wp.save!
+      end
+    end
+
+    shared_let(:beta) do
+      create(:work_package, project:, type:).tap do |wp|
+        wp.custom_field_values = { string_cf.id => "beta", list_cf.id => option_ids.last,
+                                   int_cf.id => "50", date_cf.id => "2026-06-01",
+                                   for_all_cf.id => "beta" }
+        wp.save!
+      end
+    end
+
+    shared_let(:blank) { create(:work_package, project:, type:) }
+
+    before { [alpha, beta, blank] }
+
+    def filter_for(custom_field, operator, values, historic: false)
+      query = build_stubbed(:query, project:)
+      query.timestamps = ["2022-08-01T00:00:00Z"] if historic
+
+      Queries::WorkPackages::Filter::CustomFieldFilter.create!(
+        name: custom_field.column_name,
+        context: query,
+        operator:,
+        values:
+      )
+    end
+
+    # Runs both forms and holds them to the same rows. The correlated one is returned because it is
+    # the form a baseline query uses.
+    def matching(custom_field, operator, values = [])
+      filter = filter_for(custom_field, operator, values)
+      expect(filter).to be_valid, filter.errors.full_messages.join(", ")
+
+      sub_select = WorkPackage.where(filter.where)
+      correlated = WorkPackage.where(filter_for(custom_field, operator, values, historic: true).where)
+
+      expect(correlated.pluck(:id)).to match_array(sub_select.pluck(:id))
+
+      correlated
+    end
+
+    describe "a string custom field" do
+      it "finds the work package holding the value" do
+        expect(matching(string_cf, "=", %w[alpha])).to contain_exactly(alpha)
+      end
+
+      it "finds the work packages not holding the value" do
+        expect(matching(string_cf, "!", %w[alpha])).to contain_exactly(beta, blank)
+      end
+
+      it "finds the work package by a substring" do
+        expect(matching(string_cf, "~", %w[lph])).to contain_exactly(alpha)
+      end
+
+      # The anchor is what keeps the LEFT OUTER JOIN on the custom values producing a NULL row,
+      # which is the only thing "is empty" and the negating operators can match on.
+      it "finds the work packages without a value" do
+        expect(matching(string_cf, "!*")).to contain_exactly(blank)
+      end
+
+      it "finds the work packages with a value" do
+        expect(matching(string_cf, "*")).to contain_exactly(alpha, beta)
+      end
+    end
+
+    describe "a list custom field" do
+      it "finds the work package holding the option" do
+        expect(matching(list_cf, "=", [option_ids.first])).to contain_exactly(alpha)
+      end
+
+      it "finds the work packages not holding the option" do
+        expect(matching(list_cf, "!", [option_ids.first])).to contain_exactly(beta, blank)
+      end
+
+      it "finds the work packages without a value" do
+        expect(matching(list_cf, "!*")).to contain_exactly(blank)
+      end
+    end
+
+    describe "an integer custom field" do
+      it "finds the work package holding the value" do
+        expect(matching(int_cf, "=", %w[5])).to contain_exactly(alpha)
+      end
+
+      it "finds the work package above a bound" do
+        expect(matching(int_cf, ">=", %w[10])).to contain_exactly(beta)
+      end
+
+      it "finds the work packages without a value" do
+        expect(matching(int_cf, "!*")).to contain_exactly(blank)
+      end
+    end
+
+    describe "a date custom field" do
+      it "finds the work package holding the date" do
+        expect(matching(date_cf, "=d", %w[2026-01-01])).to contain_exactly(alpha)
+      end
+
+      it "finds the work package within an interval" do
+        expect(matching(date_cf, "<>d", %w[2026-05-01 2026-07-01])).to contain_exactly(beta)
+      end
+
+      it "finds the work packages without a value" do
+        expect(matching(date_cf, "!*")).to contain_exactly(blank)
+      end
+    end
+
+    # Without the custom_fields_projects join the query has one join fewer to anchor on.
+    describe "a custom field activated for all projects" do
+      it "finds the work package holding the value" do
+        expect(matching(for_all_cf, "=", %w[alpha])).to contain_exactly(alpha)
+      end
+
+      it "finds the work packages without a value" do
+        expect(matching(for_all_cf, "!*")).to contain_exactly(blank)
+      end
+    end
+
+    # The CTE built for a baseline query holds one row per matching journal, so `id` is not unique
+    # there: any row of an id would satisfy the sub-select form, while the correlated form only
+    # lets the row whose own journal matches. The set of ids -- the only thing the historic
+    # relation is consumed for -- has to be the same either way.
+    describe "in a baseline query spanning two timestamps" do
+      let(:monday) { "2022-08-01".to_datetime }
+      let(:friday) { "2022-08-05".to_datetime }
+
+      let!(:changed) do
+        create(:work_package, project:, type:, journals: { monday => {}, friday => {} })
+      end
+
+      # matches on Monday only: on Friday the value is gone
+      let!(:monday_value) do
+        create(:journal_customizable_journal,
+               journal: changed.journals.find_by(created_at: monday),
+               custom_field: string_cf,
+               value: "alpha")
+      end
+
+      def historic_ids(operator, values = [])
+        WorkPackage
+          .where(filter_for(string_cf, operator, values, historic: true).where)
+          .at_timestamp([monday, friday])
+          .pluck(:id)
+          .uniq
+      end
+
+      it "finds the work package that only matched at the earlier timestamp" do
+        expect(historic_ids("=", %w[alpha])).to include(changed.id)
+      end
+
+      it "does not find it for a value it never held" do
+        expect(historic_ids("=", %w[gamma])).not_to include(changed.id)
+      end
+
+      it "finds it as empty, because it held no value on Friday" do
+        expect(historic_ids("!*")).to include(changed.id)
+      end
+    end
+  end
+
+  # The switch lives on the shared base, so it applies to every custom field context. A project or
+  # user query has no #historic? and therefore no CTE to inline, so both keep the sub-select form;
+  # the requirement is that neither regresses.
+  describe "for a project custom field" do
+    shared_let(:project_cf) { create(:string_project_custom_field) }
+    shared_let(:admin) { create(:admin) }
+    shared_let(:matching_project) do
+      create(:project).tap do |project|
+        create(:custom_value, custom_field: project_cf, customized: project, value: "alpha")
+      end
+    end
+    shared_let(:other_project) do
+      create(:project).tap do |project|
+        create(:custom_value, custom_field: project_cf, customized: project, value: "beta")
+      end
+    end
+
+    # where_subselect_conditions gates on the current user's view_project_attributes.
+    current_user { admin }
+
+    def matching(operator, values = [])
+      filter = Queries::Projects::Filters::CustomFieldFilter.create!(
+        name: project_cf.column_name, operator:, values:
+      )
+
+      Project.where(filter.where)
+    end
+
+    it "finds the project by its custom value" do
+      expect(matching("=", %w[alpha])).to contain_exactly(matching_project)
+    end
+
+    it "finds the projects not holding the value" do
+      expect(matching("!", %w[alpha])).to include(other_project)
+      expect(matching("!", %w[alpha])).not_to include(matching_project)
+    end
+
+    it "finds the projects with a value" do
+      expect(matching("*")).to contain_exactly(matching_project, other_project)
+    end
+  end
+
+  describe "for a user custom field" do
+    shared_let(:user_cf) { create(:user_custom_field, :string) }
+    shared_let(:admin) { create(:admin) }
+    shared_let(:matching_user) do
+      create(:user).tap { |user| create(:custom_value, custom_field: user_cf, customized: user, value: "alpha") }
+    end
+    shared_let(:other_user) do
+      create(:user).tap { |user| create(:custom_value, custom_field: user_cf, customized: user, value: "beta") }
+    end
+
+    current_user { admin }
+
+    def matching(operator, values = [])
+      filter = Queries::Users::Filters::CustomFieldFilter.create!(
+        name: user_cf.column_name, operator:, values:
+      )
+
+      User.where(filter.where)
+    end
+
+    it "finds the user by their custom value" do
+      expect(matching("=", %w[alpha])).to contain_exactly(matching_user)
+    end
+
+    it "finds the users with a value" do
+      expect(matching("*")).to contain_exactly(matching_user, other_user)
+    end
+  end
+end

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -592,4 +592,149 @@ RSpec.describe Query::Results do
       end
     end
   end
+
+  # A query carrying both a historic and the current timestamp is historic?, so #work_packages
+  # takes the historic branch and reconstructs every timestamp, the current one included, from
+  # the journals. `filter_merges` is applied only by the "today" branch and so reaches neither.
+  #
+  # with_ee is required: without it Timestamp.allowed drops a timestamp this old, the query turns
+  # invalid and its statement collapses to 1=0, which would make every expectation vacuous.
+  describe "#work_packages with a mix of historic and current timestamps",
+           with_ee: %i[baseline_comparison] do
+    let(:historic_time) { "2022-08-01".to_datetime }
+    let(:recent_time) { 1.hour.ago }
+    let(:baseline_project) { create(:project) }
+    let(:baseline_user) do
+      create(:user, member_with_permissions: { baseline_project => %i[view_work_packages] })
+    end
+    let!(:baseline_work_package) do
+      create(:work_package,
+             subject: "Current subject",
+             project: baseline_project,
+             journals: {
+               historic_time => { subject: "Historic subject" },
+               recent_time => { subject: "Current subject" }
+             })
+    end
+    let(:search_term) { "Current" }
+    let(:query) do
+      login_as(baseline_user)
+
+      build(:query, user: baseline_user, project: nil).tap do |query|
+        query.filters.clear
+        query.add_filter "subject", "~", search_term
+        query.timestamps = [historic_time, Timestamp.now]
+      end
+    end
+
+    subject(:work_packages) { query_results.work_packages }
+
+    it "returns work packages matching the current state" do
+      expect(work_packages).to contain_exactly(baseline_work_package)
+    end
+
+    context "when only the historic state matches" do
+      let(:search_term) { "Historic" }
+
+      it "returns work packages matching the historic state" do
+        expect(work_packages).to contain_exactly(baseline_work_package)
+      end
+    end
+
+    context "when nothing matches at either timestamp" do
+      let(:search_term) { "Neither" }
+
+      it "returns nothing" do
+        expect(work_packages).to be_empty
+      end
+    end
+
+    # `shared_with_user` contributes nothing but "1=1" to Query#statement; it applies itself in
+    # #apply_to, which only reaches the query through `filter_merges`. The historic branch never
+    # merges those, so the filter narrows nothing and every work package visible at either
+    # timestamp keeps matching.
+    context "with a filter that only applies itself through filter_merges" do
+      let(:baseline_user) do
+        create(:user,
+               member_with_permissions: {
+                 baseline_project => %i[view_work_packages view_shared_work_packages]
+               })
+      end
+      # A user outside every project the baseline user can see is not in
+      # PrincipalBaseFilter#allowed_values, which makes the filter and with it the whole query
+      # invalid. Query#statement then collapses to 1=0 and both branches go empty for a reason
+      # that has nothing to do with the behaviour under test.
+      let(:sharer) do
+        create(:user, member_with_permissions: { baseline_project => %i[view_work_packages] })
+      end
+      let(:query) do
+        login_as(baseline_user)
+
+        build(:query, user: baseline_user, project: nil).tap do |query|
+          query.filters.clear
+          query.add_filter "shared_with_user", "=", [sharer.id.to_s]
+          query.timestamps = [historic_time, Timestamp.now]
+        end
+      end
+
+      it "is a valid query whose filter contributes no SQL of its own" do
+        expect(query).to be_valid
+        expect(query.filters.map(&:name)).to include(:shared_with_user)
+        expect(query.filters.find { |f| f.name == :shared_with_user }.where).to eq("1=1")
+      end
+
+      it "does not narrow the historic branch" do
+        expect(work_packages).to contain_exactly(baseline_work_package)
+      end
+    end
+  end
+
+  describe "#work_package_ids_at_timestamp", with_ee: %i[baseline_comparison] do
+    let(:historic_time) { "2022-08-01".to_datetime }
+    let(:ids_project) { create(:project) }
+    let(:ids_user) do
+      create(:user, member_with_permissions: { ids_project => %i[view_work_packages] })
+    end
+    let!(:matching_work_package) do
+      create(:work_package,
+             subject: "Now",
+             project: ids_project,
+             journals: { historic_time => { subject: "Then" } })
+    end
+    let!(:other_work_package) do
+      create(:work_package,
+             subject: "Other",
+             project: ids_project,
+             journals: { historic_time => { subject: "Other" } })
+    end
+    let(:query) do
+      login_as(ids_user)
+
+      build(:query, user: ids_user, project: nil).tap do |query|
+        query.filters.clear
+        query.add_filter "subject", "~", ["Then"]
+        query.timestamps = [historic_time]
+      end
+    end
+
+    it "returns the ids matching the filters at that timestamp, restricted to the given ids" do
+      expect(query_results.work_package_ids_at_timestamp(Timestamp.new(historic_time),
+                                                         ids: [matching_work_package.id, other_work_package.id]))
+        .to eq([matching_work_package.id])
+    end
+
+    it "returns nothing when the restriction excludes the match" do
+      expect(query_results.work_package_ids_at_timestamp(Timestamp.new(historic_time),
+                                                         ids: [other_work_package.id]))
+        .to be_empty
+    end
+
+    it "builds an inlineable journals CTE" do
+      relation = query_results.send(:visible_work_packages_at,
+                                    Timestamp.new(historic_time),
+                                    ids: [matching_work_package.id])
+
+      expect(relation.to_sql).to include('WITH "work_packages" AS NOT MATERIALIZED (')
+    end
+  end
 end

--- a/spec/requests/api/v3/work_packages/baseline_shared_with_user_spec.rb
+++ b/spec/requests/api/v3/work_packages/baseline_shared_with_user_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+# Characterization of a known gap, not of intended behaviour.
+#
+# `shared_with_user` contributes nothing but "1=1" to Query#statement and applies itself in
+# #apply_to, which reaches the query only through `filter_merges`. Query::Results merges those
+# in its "today" branch alone, so at a baseline timestamp the filter matches every visible work
+# package.
+#
+# The frontend derives every row's baseline badge from the two `_meta` flags asserted here
+# (frontend/src/app/features/work-packages/components/wp-baseline/baseline-helpers.ts:92).
+#
+# When the gap is closed these expectations have to be inverted.
+RSpec.describe "API v3 work packages baseline with a sharedWithUser filter",
+               content_type: :json,
+               with_ee: %i[baseline_comparison] do
+  include API::V3::Utilities::PathHelper
+
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) { create(:project) }
+  shared_let(:work_package_role) { create(:view_work_package_role) }
+
+  shared_let(:baseline_time) { Timestamp.parse("2015-01-01T00:00:00Z") }
+  shared_let(:created_at) { baseline_time.to_time - 1.day }
+
+  # A user outside every project the current user can see is not in
+  # PrincipalBaseFilter#allowed_values, which makes the filter and with it the whole query
+  # invalid. Query#statement then collapses to 1=0 and every expectation goes vacuous.
+  shared_let(:sharer) do
+    create(:user, member_with_permissions: { project => %i[view_work_packages] })
+  end
+
+  shared_let(:shared_work_package) do
+    create(:work_package,
+           project:,
+           subject: "Shared before the baseline",
+           created_at:,
+           journals: { created_at => {} }) do |wp|
+      create(:member, user: sharer, project:, entity: wp, roles: [work_package_role])
+    end
+  end
+
+  shared_let(:unrelated_work_package) do
+    create(:work_package,
+           project:,
+           subject: "Never shared with anyone",
+           created_at:,
+           journals: { created_at => {} })
+  end
+
+  shared_let(:newly_shared_work_package) do
+    create(:work_package,
+           project:,
+           subject: "Shared after the baseline",
+           created_at:,
+           journals: { created_at => {} }) do |wp|
+      create(:member, user: sharer, project:, entity: wp, roles: [work_package_role])
+    end
+  end
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_work_packages view_shared_work_packages]
+           })
+  end
+
+  subject(:api_response) do
+    get path
+    last_response
+  end
+
+  let(:filters) do
+    [{ sharedWithUser: { operator: "=", values: [sharer.id.to_s] } }]
+  end
+  let(:timestamps) { [baseline_time, Timestamp.now] }
+
+  # The frontend joins the query's timestamps verbatim (url-params-helper.ts:209), so the current
+  # one stays the relative "PT0S". api_v3_paths.path_for would absolutize it, which turns it
+  # historic and moves the Loader to its historic branch; see the describe block at the bottom.
+  let(:path) do
+    "#{api_v3_paths.work_packages}?" \
+      "#{{ filters: filters.to_json, timestamps: timestamps.join(',') }.to_query}"
+  end
+
+  def element_index_of(work_package)
+    ids = JSON.parse(api_response.body).dig("_embedded", "elements").pluck("id")
+    ids.index(work_package.id) or raise "#{work_package.id} not among #{ids.inspect}"
+  end
+
+  def meta_at(work_package, timestamp_index)
+    JSON.parse(api_response.body)
+        .dig("_embedded", "elements", element_index_of(work_package),
+             "_embedded", "attributesByTimestamp", timestamp_index, "_meta")
+  end
+
+  def self_link_timestamps
+    href = JSON.parse(api_response.body).dig("_links", "self", "href")
+    CGI.parse(URI.parse(href).query.to_s)["timestamps"].first
+  end
+
+  describe "without timestamps (control)" do
+    let(:path) { "#{api_v3_paths.work_packages}?#{{ filters: filters.to_json }.to_query}" }
+
+    it "returns only the work packages actually shared with the filtered user" do
+      expect(api_response.status).to be 200
+      expect(JSON.parse(api_response.body)["total"]).to eq 2
+      expect(JSON.parse(api_response.body).dig("_embedded", "elements").pluck("id"))
+        .to contain_exactly(shared_work_package.id, newly_shared_work_package.id)
+    end
+  end
+
+  describe "with a baseline timestamp" do
+    it "succeeds" do
+      expect(api_response.status).to be 200
+    end
+
+    it "returns every visible work package, not only the shared ones" do
+      expect(JSON.parse(api_response.body)["total"]).to eq 3
+      expect(JSON.parse(api_response.body).dig("_embedded", "elements").pluck("id"))
+        .to contain_exactly(shared_work_package.id,
+                            unrelated_work_package.id,
+                            newly_shared_work_package.id)
+    end
+
+    # base.matchesFilters && !compare.matchesFilters renders the row as "removed"
+    # (baseline-helpers.ts:101), claiming a share was revoked that never existed.
+    it "reports a never-shared work package as matching the filters at the baseline timestamp" do
+      expect(meta_at(unrelated_work_package, 0)["matchesFilters"]).to be true
+      expect(meta_at(unrelated_work_package, 0)["exists"]).to be true
+      expect(meta_at(unrelated_work_package, 1)["matchesFilters"]).to be false
+    end
+
+    # "added" requires !base.matchesFilters (baseline-helpers.ts:99), so a share created since
+    # the baseline is not marked as added.
+    it "reports a work package shared after the baseline as already matching at the baseline" do
+      expect(meta_at(newly_shared_work_package, 0)["matchesFilters"]).to be true
+      expect(meta_at(newly_shared_work_package, 0)["exists"]).to be true
+      expect(meta_at(newly_shared_work_package, 1)["matchesFilters"]).to be true
+    end
+
+    it "hands back absolute timestamps in its own self link" do
+      expect(self_link_timestamps).not_to include("PT0S")
+    end
+  end
+
+  # A work package created after the baseline is the case where applying `filter_merges` to the
+  # current timestamp would remove a row rather than only mislabel one: it exists at the current
+  # timestamp only, so whether the filter narrows that timestamp decides whether it appears at all.
+  describe "with a work package created after the baseline" do
+    let!(:created_after_baseline) do
+      create(:work_package,
+             project:,
+             subject: "Created after the baseline, never shared",
+             created_at: baseline_time.to_time + 1.day,
+             journals: { baseline_time.to_time + 1.day => {} })
+    end
+
+    it "returns it, because the filter narrows neither timestamp" do
+      expect(JSON.parse(api_response.body)["total"]).to eq 4
+      expect(JSON.parse(api_response.body).dig("_embedded", "elements").pluck("id"))
+        .to include(created_after_baseline.id)
+    end
+
+    it "reports it as not existing at the baseline" do
+      expect(meta_at(created_after_baseline, 0)["exists"]).to be false
+    end
+  end
+
+  # The collection absolutizes both timestamps for its self and pagination links
+  # (work_package_collection_representer.rb:60). An absolute "now" is `historic?`, so following
+  # such a link evaluates the current timestamp through the journals as well and drops
+  # `filter_merges` from that side too. The badge computed for the very same row therefore
+  # differs between the response and the links that response hands back.
+  describe "with the absolute timestamps the collection's own links carry" do
+    let(:timestamps) { [baseline_time, Timestamp.now].map(&:absolute) }
+
+    it "reports a never-shared work package as matching at both timestamps" do
+      expect(meta_at(unrelated_work_package, 0)["matchesFilters"]).to be true
+      expect(meta_at(unrelated_work_package, 1)["matchesFilters"]).to be true
+    end
+  end
+end

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -461,4 +461,34 @@ RSpec.describe API::V3::WorkPackageCollectionFromQueryService,
       end
     end
   end
+
+  # Query#results hands out a fresh Query::Results every time, and four code paths in #call need
+  # one. Everything Results memoises would be thrown away in between.
+  describe "reusing one Query::Results" do
+    before do
+      stub_const("::API::V3::WorkPackages::WorkPackageCollectionRepresenter", mock_wp_representer)
+      stub_const("::API::V3::WorkPackages::WorkPackageAggregationGroup", mock_aggregation_representer)
+
+      allow(API::V3::UpdateQueryFromV3ParamsService)
+        .to receive(:new)
+        .with(query, user)
+        .and_return(mock_update_query_service)
+
+      query.display_sums = true
+      query.group_by = "status"
+    end
+
+    it "asks the query for its results once, although four code paths need them" do
+      instance.call(params)
+
+      expect(query).to have_received(:results).once
+    end
+
+    it "asks again on the next call, which may have changed the query" do
+      instance.call(params)
+      instance.call(params)
+
+      expect(query).to have_received(:results).twice
+    end
+  end
 end


### PR DESCRIPTION
# What are you trying to accomplish?

Speed up "baseline" / timestamp work package queries by fixing how PostgreSQL plans the historic-snapshot CTE they're built on.

Previously, the CTE holding the historic snapshot of journable attributes was referenced multiple times per query (once by `visible`, once more by custom-field filter joins). PostgreSQL only inlines a CTE automatically when it has exactly one reference; with more than one, it falls back to materializing the entire historic snapshot before any filter runs, even when the query only ultimately needs a handful of rows.

## Approach

- **CTE inlining (`Journable::HistoricActiveRecordRelation#add_historic_model_cte`)**: the historic snapshot CTE is now built with an explicit `NOT MATERIALIZED` hint. This only helps once reference counts are also reduced - PostgreSQL still forces materialization above one reference regardless of the hint.
- **Reference-count reduction / conditional optimization**: `Journable::WithHistoricAttributes::Loader#work_package_ids_of_query_at_timestamp_calculation` now special-cases historic timestamps (`timestamp.try(:historic?)`) to call a new, narrower `Query::Results#work_package_ids_at_timestamp(timestamp, ids:)` instead of running the full `query.results.work_packages` pipeline. This new method reuses the same visibility/filter logic as the existing "today" path but skips sorting and scopes to only the ids already known to be relevant, cutting it down to the one CTE reference PostgreSQL needs to inline.
- **Minor correctness/robustness fixes needed to land the above safely**:
  - `substitute_custom_values_join_in_predicate`: short-circuits when the predicate doesn't reference `custom_values` at all, and fixes the historic-JOIN-rewrite regex to use multiline mode (`/m`) so it correctly rewrites predicates whose `WHERE` clause spans multiple lines - previously such predicates could be missed silently.
  - `Journable::WithHistoricAttributes#matches_query_filters_at_timestamps` / `#exists_at_timestamps`: now memoized, since they're called repeatedly per journable in the hot serialization path.
  - `Loader#journalized_at_timestamp`: skips building the "currently invisible" branch entirely when there are no currently-invisible journables, instead of always querying it and concatenating an empty result.
  - `API::V3::WorkPackageCollectionFromQueryService`: the `Query::Results` instance built once in `#call` is now threaded through `results_to_representer`/`generate_groups`/`generate_total_sums`/`generate_group_sums` instead of each method independently calling `query.results` (which returns a fresh, unmemoized instance every time - silently discarding the ids/sums it had just computed).
  - `API::Decorators::OffsetPaginatedCollection#total_count`: when the fetched page came back shorter than its own limit, the `LIMIT` was never exhausted, so there is provably no next page and `total` can be derived from the already-fetched id list instead of running a second `COUNT(:id)` query. Added `page_row_count`/`paged_ids` helpers; `work_package_collection_representer.rb` now reuses the already-pluck'd `paged_ids` instead of plucking ids from `models` a second time.
  - `lib_static/open_project/database.rb`: bumps the minimum required PostgreSQL version from 10.0 to 13.0 because of `NOT MATERIALIZED`.

## Benchmarks
- Validated using synthetic performance data seeded in a local dev database (~200k work packages across ~300 projects)
- Baseline/timestamp queries: **2.0x-6.3x faster** 