### PR TITLE
[AUTOWORK-279] Marking type as default not possible with feature flag off

### DIFF
--- a/app/controllers/work_package_types/details_tab_controller.rb
+++ b/app/controllers/work_package_types/details_tab_controller.rb
@@ -52,7 +52,7 @@ module WorkPackageTypes
     private
 
     def permitted_details_params
-      params.expect(type: %i[name color_id is_milestone is_in_roadmap])
+      params.expect(type: %i[name color_id is_milestone is_in_roadmap is_default])
     end
   end
 end

--- a/app/forms/work_package_types/details_form.rb
+++ b/app/forms/work_package_types/details_form.rb
@@ -62,6 +62,12 @@ module WorkPackageTypes
                              label: label(:is_in_roadmap),
                              disabled: inherited?,
                              caption: inherited_caption)
+
+      if offers_new_project_default?
+        details_form.check_box(name: :is_default,
+                               label: I18n.t("types.index.enabled_in_new_projects"),
+                               checked: model.is_default?)
+      end
     end
 
     private
@@ -69,6 +75,11 @@ module WorkPackageTypes
     def carries_parent? = model.new_record? && model.parent_id.present?
 
     def inherited? = model.variant?
+
+    # TODO: Remove with type_variants feature flag
+    def offers_new_project_default?
+      !inherited? && !OpenProject::FeatureDecisions.type_variants_active?
+    end
 
     def color_caption
       inherited? ? inherited_caption : I18n.t("types.edit.details.type_color_text")

--- a/app/services/work_package_types/update_service.rb
+++ b/app/services/work_package_types/update_service.rb
@@ -41,12 +41,36 @@ module WorkPackageTypes
         return result if result.failure?
       end
 
+      # TODO: Remove with type_variants feature flag
+      extract_new_project_default_param
+
       set_active_custom_fields
 
       super
     end
 
+    # TODO: Remove with type_variants feature flag
+    def after_perform(service_call)
+      return service_call if @new_project_default.nil?
+
+      service_call.merge!(toggle_default_in_new_projects(service_call.result))
+    end
+
     private
+
+    def extract_new_project_default_param
+      return unless params.key?(:is_default)
+
+      @new_project_default = ActiveRecord::Type::Boolean.new.cast(params.delete(:is_default))
+    end
+
+    def toggle_default_in_new_projects(type)
+      if @new_project_default
+        MakeDefaultService.new(type:, user:).call
+      else
+        RemoveDefaultService.new(type:, user:).call
+      end
+    end
 
     def default_contract_class = UpdateDetailsContract
 

--- a/spec/features/types/crud_spec.rb
+++ b/spec/features/types/crud_spec.rb
@@ -109,6 +109,28 @@ RSpec.describe "Types", :js do
     end
   end
 
+  it "toggles 'Active in new projects' from a type's 'Details' tab", with_flag: { type_variants: false } do
+    expect(existing_type.reload.is_default?).to be false
+
+    visit edit_type_details_path(type_id: existing_type.id)
+    expect(page).to have_unchecked_field("Active in new projects")
+
+    check "Active in new projects"
+    click_on "Save"
+
+    expect(page).to have_text I18n.t(:notice_successful_update)
+    expect(existing_type.reload.is_default?).to be true
+
+    visit edit_type_details_path(type_id: existing_type.id)
+    expect(page).to have_checked_field("Active in new projects")
+
+    uncheck "Active in new projects"
+    click_on "Save"
+
+    expect(page).to have_text I18n.t(:notice_successful_update)
+    expect(existing_type.reload.is_default?).to be false
+  end
+
   # Variants are only ever created through the creation wizard, so the create page
   # never offers a parent and always creates a root type.
   it "creates a root type with editable core settings", with_flag: { type_variants: true } do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/AUTOWORK-279

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
