### PR TITLE
[DREAM-817] Sprints are not clickable in timeline widget

### DIFF
--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.sass
@@ -131,6 +131,7 @@
     background-color: var(--bgColor-accent-muted)
     color: var(--fgColor-accent)
     border: 1px solid var(--borderColor-accent-muted)
+    cursor: pointer
 
     &.op-timeline-sprint--active
       background-color: var(--bgColor-accent-emphasis)

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.spec.ts
@@ -121,6 +121,7 @@ describe('ProjectTimelineGraphComponent', () => {
     endDate: '2024-01-14',
     status: 'active',
     row: 0,
+    href: '/projects/some-project/backlogs?sprint_ids%5B%5D=20',
   };
 
   let fixture:ComponentFixture<ProjectTimelineGraphComponent>;
@@ -258,6 +259,7 @@ describe('ProjectTimelineGraphComponent', () => {
       expect(item!.className).toContain('op-timeline-sprint');
       expect(item!.className).toContain('op-timeline-sprint--active');
       expect(item!.itemType).toBe('sprint');
+      expect(item!.href).toBe(sprint.href);
     });
 
     it('does not add the active class for non-active sprints', () => {

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-graph.component.ts
@@ -143,6 +143,8 @@ export class ProjectTimelineGraphComponent {
       const item = this.itemsDataset!.get(props.item);
       if (item?.itemType === 'milestone' && item.workPackageId) {
         window.location.href = this.pathHelper.workPackagePath(String(item.workPackageId));
+      } else if (item?.itemType === 'sprint' && item.href) {
+        window.location.href = item.href;
       }
     });
   }

--- a/frontend/src/app/shared/components/project-timeline-graph/project-timeline-item.builder.ts
+++ b/frontend/src/app/shared/components/project-timeline-graph/project-timeline-item.builder.ts
@@ -59,6 +59,7 @@ export interface ProjectSprintData {
   endDate:string;
   status:string;
   row:number;
+  href:string;
 }
 
 export interface ProjectTimelineItem {
@@ -76,6 +77,7 @@ export interface ProjectTimelineItem {
   definitionId?:number;
   typeId?:number;
   workPackageId?:number;
+  href?:string;
   isCluster?:boolean;
   items?:ProjectTimelineItem[];
 }
@@ -202,6 +204,7 @@ export class ProjectTimelineItemBuilder {
       type: 'range',
       className: `op-timeline-sprint${isActive ? ' op-timeline-sprint--active' : ''}`,
       itemType: 'sprint',
+      href: sprint.href,
     };
   }
 

--- a/modules/grids/app/components/grids/widgets/project_timeline.rb
+++ b/modules/grids/app/components/grids/widgets/project_timeline.rb
@@ -63,10 +63,7 @@ module Grids
         return [].to_json unless view_sprints_allowed?
 
         assign_sprint_rows(sprints_scope)
-          .map do |sprint, row|
-          { id: sprint.id, name: sprint.name, startDate: sprint.start_date.iso8601,
-            endDate: sprint.finish_date.iso8601, status: sprint.status, row: }
-        end
+          .map { |sprint, row| sprint_data(sprint, row) }
           .to_json
       end
 
@@ -167,6 +164,18 @@ module Grids
           end
           [sprint, row_index]
         end
+      end
+
+      def sprint_data(sprint, row)
+        {
+          id: sprint.id,
+          name: sprint.name,
+          startDate: sprint.start_date.iso8601,
+          endDate: sprint.finish_date.iso8601,
+          status: sprint.status,
+          row:,
+          href: helpers.project_backlogs_backlog_path(project, sprint_ids: [sprint.id])
+        }
       end
 
       def phase_data(phase) # rubocop:disable Metrics/AbcSize

--- a/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/project_timeline_spec.rb
@@ -240,7 +240,10 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
   describe "#sprints_data" do
     let!(:sprint) { create(:sprint, project:, start_date: Time.zone.today, finish_date: Time.zone.today + 14.days) }
 
-    subject(:data) { JSON.parse(component.sprints_data) }
+    subject(:data) do
+      render_inline(component)
+      JSON.parse(component.sprints_data)
+    end
 
     context "without view_sprints permission" do
       it { expect(data).to eq([]) }
@@ -265,7 +268,8 @@ RSpec.describe Grids::Widgets::ProjectTimeline, type: :component do
           "startDate" => sprint.start_date.iso8601,
           "endDate" => sprint.finish_date.iso8601,
           "status" => sprint.status,
-          "row" => 0
+          "row" => 0,
+          "href" => Rails.application.routes.url_helpers.project_backlogs_backlog_path(project, sprint_ids: [sprint.id])
         )
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-817

# What are you trying to accomplish?
Make sprints clickable in timeline widget. The link directs to the backlogs page with a filter for the given sprint.


