### PR TITLE
[COMMS-809] Documents: tooltip on user's cursor cut off

### DIFF
--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -29,6 +29,7 @@
 import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
 import { ExternalLinkA11yExtension } from '../extensions/external-link-a11y';
 import { ExternalLinkCaptureExtension } from '../extensions/external-link-capture';
+import { CollaborationCursorLabelFitExtension } from '../extensions/collaboration-cursor-label-fit';
 import { User } from '@blocknote/core/comments';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
 import { BlockNoteView } from '@blocknote/mantine';
@@ -120,6 +121,7 @@ export function OpBlockNoteEditor({
       extensions: [
         ExternalLinkA11yExtension,
         ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
+        ...(hocuspocusProvider ? [CollaborationCursorLabelFitExtension] : []),
       ],
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);

--- a/frontend/src/react/extensions/collaboration-cursor-label-fit.spec.ts
+++ b/frontend/src/react/extensions/collaboration-cursor-label-fit.spec.ts
@@ -26,61 +26,285 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { EditorView } from 'prosemirror-view';
+import { vi } from 'vitest';
 import {
+  BELOW_ATTRIBUTE,
+  CollaborationCursorLabelFitExtension,
   fitCollaborationCursorLabels,
   FLIPPED_ATTRIBUTE,
 } from './collaboration-cursor-label-fit';
 
 const EDITOR_WIDTH = 300;
+const EDITOR_HEIGHT = 200;
+const TABLE_WIDTH = 150;
 
-function buildEditor(caretLeft:number):{ editor:HTMLElement, base:HTMLElement } {
+const OPEN_SPACE = { left: 10, top: 60 };
+// Wider than the 20rem BlockNote will ever draw a label at.
+const LONG_NAME = 'Ivana Dubas '.repeat(30);
+const AGAINST_RIGHT = { ...OPEN_SPACE, left: EDITOR_WIDTH - 20 };
+const AGAINST_TOP = { ...OPEN_SPACE, top: 5 };
+
+function buildEditor(width:number = EDITOR_WIDTH):HTMLElement {
   const editor = document.createElement('div');
   editor.className = 'bn-editor';
-  editor.setAttribute('style', `position: relative; width: ${EDITOR_WIDTH}px; overflow: hidden; font: 12px sans-serif`);
+  editor.setAttribute('style', `position: relative; width: ${width}px; height: ${EDITOR_HEIGHT}px; overflow: hidden; font: 12px sans-serif`);
+  document.body.appendChild(editor);
 
+  return editor;
+}
+
+// A table's scroll container: narrower than the editor and clipping on both axes, so
+// it - not the editor - is the box a label inside it has to fit. Sits 80px down, which
+// leaves every position inside it well clear of the editor's own edges.
+function buildTableWrapper(editor:HTMLElement):HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'tableWrapper';
+  wrapper.setAttribute('style', `position: absolute; left: 0; top: 80px; width: ${TABLE_WIDTH}px; height: 60px; overflow-x: auto; overflow-y: hidden`);
+  editor.appendChild(wrapper);
+
+  return wrapper;
+}
+
+// BlockNote collapses an idle label to a nub and expands it while its author is typing.
+// Both states have to reach the same verdict, so tests can ask for either.
+const COLLAPSED_LABEL = 'top: -1px; max-width: 4px; padding: 0';
+const EXPANDED_LABEL = 'top: -17px; max-width: 20rem; padding: 0.1rem 0.3rem';
+
+interface CursorOptions {
+  expanded?:boolean;
+  name?:string;
+}
+
+function addCursor(
+  parent:HTMLElement,
+  { left, top }:{ left:number, top:number },
+  { expanded = false, name = 'Ivana Dubas' }:CursorOptions = {},
+):HTMLElement {
   const base = document.createElement('span');
   base.className = 'bn-collaboration-cursor__base';
-  base.setAttribute('style', `position: absolute; left: ${caretLeft}px; top: 20px`);
+  base.setAttribute('style', `position: absolute; left: ${left}px; top: ${top}px`);
 
   const label = document.createElement('span');
   label.className = 'bn-collaboration-cursor__label';
-  label.setAttribute('style', 'position: absolute; left: 0; top: -17px; white-space: nowrap; overflow: hidden; max-width: 4px; padding: 0');
-  label.textContent = 'Ivana Dubas';
+  label.setAttribute('style', `position: absolute; left: 0; white-space: nowrap; overflow: hidden; ${expanded ? EXPANDED_LABEL : COLLAPSED_LABEL}`);
+  label.textContent = name;
 
   base.appendChild(label);
-  editor.appendChild(base);
-  document.body.appendChild(editor);
+  parent.appendChild(base);
 
-  return { editor, base };
+  return base;
+}
+
+function textWidthOf(base:HTMLElement):number {
+  return (base.firstElementChild as HTMLElement).scrollWidth;
+}
+
+function nextFrame():Promise<void> {
+  return new Promise((resolve) => { requestAnimationFrame(() => resolve()); });
 }
 
 describe('fitCollaborationCursorLabels', () => {
+  let editor:HTMLElement;
+
+  beforeEach(() => {
+    editor = buildEditor();
+  });
+
   afterEach(() => {
     document.querySelectorAll('.bn-editor').forEach((node) => node.remove());
+    document.documentElement.style.fontSize = '';
   });
 
-  it('flips a label that would run past the editor', () => {
-    const { editor, base } = buildEditor(EDITOR_WIDTH - 20);
+  describe('at the right edge', () => {
+    it('flips a label that would run past the editor', () => {
+      const base = addCursor(editor, AGAINST_RIGHT);
 
-    fitCollaborationCursorLabels(editor);
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(true);
+    });
+
+    it('leaves a label that fits where BlockNote put it', () => {
+      const base = addCursor(editor, OPEN_SPACE);
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+    });
+
+    it('counts the padding of an expanded label once', () => {
+      const collapsed = addCursor(editor, OPEN_SPACE);
+      const textWidth = textWidthOf(collapsed);
+      collapsed.remove();
+
+      // Room for the label's own padding and four pixels to spare, so it only overflows
+      // if that padding - which `scrollWidth` already carries here - is counted twice.
+      const base = addCursor(editor, { ...OPEN_SPACE, left: EDITOR_WIDTH - textWidth - 15 }, { expanded: true });
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+    });
+
+    it('reserves no more than the width BlockNote caps a label at', () => {
+      const wide = buildEditor(600);
+      const base = addCursor(wide, OPEN_SPACE, { expanded: true, name: LONG_NAME });
+
+      fitCollaborationCursorLabels(wide);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+    });
+
+    it('reads that cap in rem, as a reader with a larger default font gets it', () => {
+      // 20rem of label clears a 380px editor at the browser default, but not at 20px.
+      document.documentElement.style.fontSize = '20px';
+      const wide = buildEditor(380);
+      const base = addCursor(wide, OPEN_SPACE, { expanded: true, name: LONG_NAME });
+
+      fitCollaborationCursorLabels(wide);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(true);
+    });
+
+    it('unflips once the cursor moves back into open space', () => {
+      const base = addCursor(editor, AGAINST_RIGHT);
+      fitCollaborationCursorLabels(editor);
+
+      base.style.left = `${OPEN_SPACE.left}px`;
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+    });
+  });
+
+  describe('at the top edge', () => {
+    it('drops a label that would run above the editor below the caret', () => {
+      const base = addCursor(editor, AGAINST_TOP);
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(true);
+    });
+
+    it('leaves a label with room above it where BlockNote put it', () => {
+      const base = addCursor(editor, OPEN_SPACE);
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(false);
+    });
+
+    it('lifts the label back once the cursor moves down', () => {
+      const base = addCursor(editor, AGAINST_TOP);
+      fitCollaborationCursorLabels(editor);
+
+      base.style.top = `${OPEN_SPACE.top}px`;
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(false);
+    });
+
+    it('flips both ways in the top right corner', () => {
+      const base = addCursor(editor, { left: AGAINST_RIGHT.left, top: AGAINST_TOP.top });
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(true);
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(true);
+    });
+  });
+
+  describe('inside a table', () => {
+    let wrapper:HTMLElement;
+
+    beforeEach(() => {
+      wrapper = buildTableWrapper(editor);
+    });
+
+    it('measures against the table, not the editor, on the right', () => {
+      // The label still fits the 300px editor from here, but not the 150px table.
+      const base = addCursor(wrapper, { left: TABLE_WIDTH - 50, top: 30 });
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(true);
+    });
+
+    it('measures against the table, not the editor, on top', () => {
+      const base = addCursor(wrapper, { left: 10, top: 2 });
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(true);
+    });
+
+    it('keeps a first row\'s label above, where it fits by a hair', () => {
+      // A real first row leaves the label its full 17px rise and not a pixel more (9px
+      // of table-wrapper padding, 5px of cell padding, 1px of border, 2px of line box),
+      // so rounding alone must not throw the label under the caret.
+      const base = addCursor(wrapper, { left: 10, top: 16 });
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(false);
+    });
+
+    it('leaves a cursor with room inside the table alone', () => {
+      const base = addCursor(wrapper, { left: 10, top: 30 });
+
+      fitCollaborationCursorLabels(editor);
+
+      expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+      expect(base.hasAttribute(BELOW_ATTRIBUTE)).toBe(false);
+    });
+  });
+});
+
+describe('CollaborationCursorLabelFitExtension', () => {
+  let editor:HTMLElement;
+
+  function mountPlugin():{ update:() => void, destroy:() => void } {
+    const [plugin] = CollaborationCursorLabelFitExtension({} as never).prosemirrorPlugins ?? [];
+    const view = plugin.spec.view?.({ dom: editor } as unknown as EditorView);
+
+    return view as unknown as { update:() => void, destroy:() => void };
+  }
+
+  beforeEach(() => {
+    editor = buildEditor();
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('.bn-editor').forEach((node) => node.remove());
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces a burst of updates into a single measurement', async () => {
+    const base = addCursor(editor, AGAINST_RIGHT);
+    const plugin = mountPlugin();
+    const frames = vi.spyOn(window, 'requestAnimationFrame');
+
+    plugin.update();
+    plugin.update();
+    plugin.update();
+
+    expect(frames).toHaveBeenCalledTimes(1);
+
+    await nextFrame();
 
     expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(true);
+
+    plugin.destroy();
   });
 
-  it('leaves a label that fits alone', () => {
-    const { editor, base } = buildEditor(10);
+  it('stops measuring once the view is destroyed', async () => {
+    const base = addCursor(editor, AGAINST_RIGHT);
+    const plugin = mountPlugin();
 
-    fitCollaborationCursorLabels(editor);
-
-    expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
-  });
-
-  it('unflips once the cursor moves back into open space', () => {
-    const { editor, base } = buildEditor(EDITOR_WIDTH - 20);
-    fitCollaborationCursorLabels(editor);
-
-    base.style.left = '10px';
-    fitCollaborationCursorLabels(editor);
+    plugin.update();
+    plugin.destroy();
+    await nextFrame();
 
     expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
   });

--- a/frontend/src/react/extensions/collaboration-cursor-label-fit.spec.ts
+++ b/frontend/src/react/extensions/collaboration-cursor-label-fit.spec.ts
@@ -1,0 +1,87 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  fitCollaborationCursorLabels,
+  FLIPPED_ATTRIBUTE,
+} from './collaboration-cursor-label-fit';
+
+const EDITOR_WIDTH = 300;
+
+function buildEditor(caretLeft:number):{ editor:HTMLElement, base:HTMLElement } {
+  const editor = document.createElement('div');
+  editor.className = 'bn-editor';
+  editor.setAttribute('style', `position: relative; width: ${EDITOR_WIDTH}px; overflow: hidden; font: 12px sans-serif`);
+
+  const base = document.createElement('span');
+  base.className = 'bn-collaboration-cursor__base';
+  base.setAttribute('style', `position: absolute; left: ${caretLeft}px; top: 20px`);
+
+  const label = document.createElement('span');
+  label.className = 'bn-collaboration-cursor__label';
+  label.setAttribute('style', 'position: absolute; left: 0; top: -17px; white-space: nowrap; overflow: hidden; max-width: 4px; padding: 0');
+  label.textContent = 'Ivana Dubas';
+
+  base.appendChild(label);
+  editor.appendChild(base);
+  document.body.appendChild(editor);
+
+  return { editor, base };
+}
+
+describe('fitCollaborationCursorLabels', () => {
+  afterEach(() => {
+    document.querySelectorAll('.bn-editor').forEach((node) => node.remove());
+  });
+
+  it('flips a label that would run past the editor', () => {
+    const { editor, base } = buildEditor(EDITOR_WIDTH - 20);
+
+    fitCollaborationCursorLabels(editor);
+
+    expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(true);
+  });
+
+  it('leaves a label that fits alone', () => {
+    const { editor, base } = buildEditor(10);
+
+    fitCollaborationCursorLabels(editor);
+
+    expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+  });
+
+  it('unflips once the cursor moves back into open space', () => {
+    const { editor, base } = buildEditor(EDITOR_WIDTH - 20);
+    fitCollaborationCursorLabels(editor);
+
+    base.style.left = '10px';
+    fitCollaborationCursorLabels(editor);
+
+    expect(base.hasAttribute(FLIPPED_ATTRIBUTE)).toBe(false);
+  });
+});

--- a/frontend/src/react/extensions/collaboration-cursor-label-fit.ts
+++ b/frontend/src/react/extensions/collaboration-cursor-label-fit.ts
@@ -1,0 +1,87 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { createExtension } from '@blocknote/core';
+import { Plugin, PluginKey } from 'prosemirror-state';
+
+const pluginKey = new PluginKey('collaborationCursorLabelFit');
+
+const BASE_SELECTOR = '.bn-collaboration-cursor__base';
+const LABEL_SELECTOR = '.bn-collaboration-cursor__label';
+export const FLIPPED_ATTRIBUTE = 'data-op-label-flipped';
+
+// Inline padding BlockNote gives an expanded label (2 * 0.3rem), plus a pixel of slack.
+const LABEL_PADDING = 11;
+
+export function fitCollaborationCursorLabels(editorDom:HTMLElement):void {
+  const bases = editorDom.querySelectorAll<HTMLElement>(BASE_SELECTOR);
+  if (bases.length === 0) return;
+
+  const editorRight = editorDom.getBoundingClientRect().right;
+
+  bases.forEach((base) => {
+    const label = base.querySelector<HTMLElement>(LABEL_SELECTOR);
+    if (!label) return;
+
+    const labelRight = base.getBoundingClientRect().left + label.scrollWidth + LABEL_PADDING;
+
+    base.toggleAttribute(FLIPPED_ATTRIBUTE, labelRight > editorRight);
+  });
+}
+
+export const CollaborationCursorLabelFitExtension = createExtension({
+  key: 'collaborationCursorLabelFit',
+
+  prosemirrorPlugins: [
+    new Plugin({
+      key: pluginKey,
+      view: (view) => {
+        let frame:number|null = null;
+
+        const schedule = ():void => {
+          if (frame !== null) return;
+          frame = requestAnimationFrame(() => {
+            frame = null;
+            fitCollaborationCursorLabels(view.dom);
+          });
+        };
+
+        const resizeObserver = new ResizeObserver(schedule);
+        resizeObserver.observe(view.dom);
+
+        return {
+          update: schedule,
+          destroy: () => {
+            resizeObserver.disconnect();
+            if (frame !== null) cancelAnimationFrame(frame);
+          },
+        };
+      },
+    }),
+  ],
+});

--- a/frontend/src/react/extensions/collaboration-cursor-label-fit.ts
+++ b/frontend/src/react/extensions/collaboration-cursor-label-fit.ts
@@ -34,23 +34,68 @@ const pluginKey = new PluginKey('collaborationCursorLabelFit');
 const BASE_SELECTOR = '.bn-collaboration-cursor__base';
 const LABEL_SELECTOR = '.bn-collaboration-cursor__label';
 export const FLIPPED_ATTRIBUTE = 'data-op-label-flipped';
+export const BELOW_ATTRIBUTE = 'data-op-label-below';
 
 // Inline padding BlockNote gives an expanded label (2 * 0.3rem), plus a pixel of slack.
 const LABEL_PADDING = 11;
+// Ceiling BlockNote puts on an expanded label (`max-width: 20rem`); a longer name is cut.
+// In rem, so a reader's larger default font raises it and the label is measured as wide
+// as it will actually be drawn.
+const LABEL_MAX_WIDTH_REM = 20;
+// How far above the caret BlockNote lifts an expanded label (`top: -17px`).
+const LABEL_RISE = 17;
+// A table's first row leaves a label exactly that rise and nothing more, so rounding
+// alone would decide its fit. Flip only for a clip deeper than the label's corner.
+const CLIP_TOLERANCE = 2;
+
+interface LabelFit {
+  base:HTMLElement;
+  flipped:boolean;
+  below:boolean;
+}
+
+function clippingRect(base:HTMLElement, editorDom:HTMLElement):DOMRect {
+  for (let node = base.parentElement; node && node !== editorDom; node = node.parentElement) {
+    const { overflowX, overflowY } = window.getComputedStyle(node);
+
+    if (overflowX !== 'visible' || overflowY !== 'visible') return node.getBoundingClientRect();
+  }
+
+  return editorDom.getBoundingClientRect();
+}
+
+function expandedLabelWidth(label:HTMLElement):number {
+  const { paddingLeft, paddingRight } = window.getComputedStyle(label);
+  const text = label.scrollWidth - parseFloat(paddingLeft) - parseFloat(paddingRight);
+  const rem = parseFloat(window.getComputedStyle(document.documentElement).fontSize);
+
+  return Math.min(text + LABEL_PADDING, LABEL_MAX_WIDTH_REM * rem);
+}
+
+function measureLabelFit(base:HTMLElement, editorDom:HTMLElement):LabelFit|null {
+  const label = base.querySelector<HTMLElement>(LABEL_SELECTOR);
+  if (!label) return null;
+
+  const bounds = clippingRect(base, editorDom);
+  const caret = base.getBoundingClientRect();
+
+  return {
+    base,
+    flipped: caret.left + expandedLabelWidth(label) > bounds.right,
+    below: caret.top - LABEL_RISE < bounds.top - CLIP_TOLERANCE,
+  };
+}
 
 export function fitCollaborationCursorLabels(editorDom:HTMLElement):void {
-  const bases = editorDom.querySelectorAll<HTMLElement>(BASE_SELECTOR);
-  if (bases.length === 0) return;
+  const bases = Array.from(editorDom.querySelectorAll<HTMLElement>(BASE_SELECTOR));
 
-  const editorRight = editorDom.getBoundingClientRect().right;
+  const fits = bases
+    .map((base) => measureLabelFit(base, editorDom))
+    .filter((fit):fit is LabelFit => fit !== null);
 
-  bases.forEach((base) => {
-    const label = base.querySelector<HTMLElement>(LABEL_SELECTOR);
-    if (!label) return;
-
-    const labelRight = base.getBoundingClientRect().left + label.scrollWidth + LABEL_PADDING;
-
-    base.toggleAttribute(FLIPPED_ATTRIBUTE, labelRight > editorRight);
+  fits.forEach(({ base, flipped, below }) => {
+    base.toggleAttribute(FLIPPED_ATTRIBUTE, flipped);
+    base.toggleAttribute(BELOW_ATTRIBUTE, below);
   });
 }
 

--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -33,8 +33,9 @@ $blocknote-side-menu-gutter: 48px // Left lane for BlockNote's side menu (drag h
     padding-left: $blocknote-side-menu-gutter
     font-size: var(--body-font-size)
 
-    // Mirrors a collaborator's name label onto the caret's left, for the cursors
-    // `CollaborationCursorLabelFitExtension` flags as clipped.
+    // Mirrors a collaborator's name label onto the caret's other side - left, below or both -
+    // for the cursors `CollaborationCursorLabelFitExtension` flags as clipped. The flat
+    // corner travels with it, so the label keeps meeting the caret.
     .bn-collaboration-cursor__base[data-op-label-flipped] .bn-collaboration-cursor__label
       left: auto
       right: 0
@@ -42,6 +43,16 @@ $blocknote-side-menu-gutter: 48px // Left lane for BlockNote's side menu (drag h
 
     .bn-collaboration-cursor__base[data-op-label-flipped][data-active] .bn-collaboration-cursor__label
       border-radius: 3px 3px 0 3px
+
+    // BlockNote draws the caret to 2px past the base box, so the label starts at its tip.
+    .bn-collaboration-cursor__base[data-op-label-below] .bn-collaboration-cursor__label
+      top: calc(100% + 2px)
+
+    .bn-collaboration-cursor__base[data-op-label-below][data-active] .bn-collaboration-cursor__label
+      border-radius: 0 3px 3px 3px
+
+    .bn-collaboration-cursor__base[data-op-label-below][data-op-label-flipped][data-active] .bn-collaboration-cursor__label
+      border-radius: 3px 0 3px 3px
   > .bn-default-styles
     font-family: var(--body-font-family)
 

--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -32,6 +32,16 @@ $blocknote-side-menu-gutter: 48px // Left lane for BlockNote's side menu (drag h
     padding-inline: 0 // Drop BlockNote's default 54px inline padding
     padding-left: $blocknote-side-menu-gutter
     font-size: var(--body-font-size)
+
+    // Mirrors a collaborator's name label onto the caret's left, for the cursors
+    // `CollaborationCursorLabelFitExtension` flags as clipped.
+    .bn-collaboration-cursor__base[data-op-label-flipped] .bn-collaboration-cursor__label
+      left: auto
+      right: 0
+      border-radius: 1.5px 0 0 1.5px
+
+    .bn-collaboration-cursor__base[data-op-label-flipped][data-active] .bn-collaboration-cursor__label
+      border-radius: 3px 3px 0 3px
   > .bn-default-styles
     font-family: var(--body-font-family)
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-809
# What are you trying to accomplish?
A remote collaborator's cursor label is cut off at the right edge of the editor.

BlockNote pins the label to the caret's left edge and lets it grow rightwards(`.bn-collaboration-cursor__label { position: absolute; left: 0 }`). Documents drop the editor's inline padding (`.bn-editor { padding-inline: 0 }`), so a caret sitting at the end of a full line puts the label past the editor box, where the page layout's scroll container clips it - the name ends mid-word. The vertical variant of the same problem is already worked around with `padding-top: 10px` on `.bn-editor`; there is no equivalent room to the right, and a label needs up to 20rem of it.

This PR keeps the label inside the editor by mirroring it onto the caret's left side when it does not fit on the right.
## Screenshots
<img width="239" height="176" alt="image" src="https://github.com/user-attachments/assets/eaecab74-009e-4112-9fa1-25b10e4e21d5" />

# What approach did you choose and why?
`CollaborationCursorLabelFitExtension` - a BlockNote extension whose ProseMirror plugin measures each remote cursor and sets `data-op-label-flipped` on the ones whose label would
run past the editor's right edge. CSS in the documents stylesheet mirrors those labels (`left: auto; right: 0`) with the flat corner moved to the other side.

- **Why JS and not CSS alone.** The decision needs the label's rendered text width against the editor's right edge. CSS anchor positioning (`position-try-fallbacks: flip-inline`) expresses exactly this, but is not available in Firefox, so it cannot carry the fix.
- **Why `scrollWidth`.** While a cursor is idle BlockNote collapses its label to a few-pixel nub, so a bounding rect reports 4px. `scrollWidth` reports the width the label will take once it expands, which means the decision is made before it expands - it never animates into a clipped position and jumps afterwards.
- **When it runs.** Remote cursor moves reach ProseMirror as awareness transactions (y-prosemirror dispatches a meta transaction on `awareness.on('change')`), so the plugin's `update` covers them; a `ResizeObserver` on the editor covers a label left in place while the column changes width. Both coalesce into one `requestAnimationFrame`, so a burst of remote keystrokes forces layout once.
- **Boundary chosen.** The editor box (`view.dom`), not the scroll container. When the column is wider than the editor's 800px max-width the flip happens slightly earlier than strictly necessary, which keeps the label inside the text column instead of floating beside it.
- The extension is registered only when a collaboration provider is wired up.

Measuring against the right edge stays correct in RTL, because BlockNote positions the label with a physical `left`, so it always grows rightwards regardless of text direction.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
