### PR TITLE
[DREAM-815] Inconsistent usage for "built-in" labels

### DIFF
--- a/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
+++ b/app/components/work_package_types/form_configuration/group_attribute_row_component.html.erb
@@ -17,7 +17,11 @@
       end
       if @attribute[:field_format_label].present?
         left.with_column(ml: 2) do
-          render(Primer::Beta::Text.new(color: :muted, font_size: :small)) { @attribute[:field_format_label] }
+          if @attribute[:is_cf]
+            render(Primer::Beta::Text.new(color: :muted, font_size: :small)) { @attribute[:field_format_label] }
+          else
+            render(Primer::Beta::Label.new(scheme: :secondary, size: :medium)) { @attribute[:field_format_label] }
+          end
         end
       end
     end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -221,7 +221,7 @@ module ::TypesHelper
     if represented[:is_cf]
       label_for_custom_field_format(represented[:field_format])
     else
-      I18n.t("types.edit.form_configuration.builtin_field")
+      I18n.t("label_builtin")
     end
   end
 end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -309,7 +309,7 @@ class CustomField < ApplicationRecord
   end
 
   def self.custom_field_attribute?(attribute_name)
-    attribute_name.to_s =~ /custom_field_\d+/
+    /custom_field_\d+/.match?(attribute_name.to_s)
   end
 
   # to move in project_custom_field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6633,7 +6633,6 @@ en:
         add_query_group: "Related work packages table"
         blankslate_description: "Add groups using the button above or drag attributes from the left panel."
         blankslate_title: "No groups yet"
-        builtin_field: "Built-in field"
         confirm_delete_group: "Are you sure you want to delete this section? This action cannot be automatically reversed."
         confirm_reset: "Are you sure you want to reset the form?"
         custom_field: "Custom field"

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
   it "renders built-in attributes as secondary labels" do
     render_inline(described_class.new(attribute:, variant:, index: 0, total_count: 2, readonly: true))
 
-    expect(page).to have_css(".Label.Label--secondary", text: I18n.t("types.edit.form_configuration.builtin_field"))
+    expect(page).to have_css(".Label.Label--secondary", text: I18n.t("label_builtin"))
   end
 
   # The switch itself is covered by ExclusionToggleComponent; what matters here is that the row

--- a/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_attribute_row_component_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
     expect(page).to have_text("Assignee")
   end
 
+  it "renders built-in attributes as secondary labels" do
+    render_inline(described_class.new(attribute:, variant:, index: 0, total_count: 2, readonly: true))
+
+    expect(page).to have_css(".Label.Label--secondary", text: I18n.t("types.edit.form_configuration.builtin_field"))
+  end
+
   # The switch itself is covered by ExclusionToggleComponent; what matters here is that the row
   # hands it this attribute's key and label, and asks for it only in read-only mode.
   describe "the exclusion toggle" do
@@ -50,6 +56,18 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupAttributeRowComponent, 
 
       toggle = page.find("[data-test-selector='toggle-form-config-exclusion-assignee']")
       expect(toggle.find("button")["aria-label"]).to eq("Inherit Assignee")
+    end
+  end
+
+  describe "custom field" do
+    let(:attribute) do
+      { key: "custom_field_5", is_cf: true, is_required: false, translation: "Alt description", field_format_label: "Text" }
+    end
+
+    it "shows a muted field format label" do
+      render_inline(described_class.new(attribute:, variant:, index: 0, total_count: 2, readonly: true))
+
+      expect(page).to have_css(".color-fg-muted.text-small", text: attribute[:field_format_label])
     end
   end
 end

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe "form configuration", :js, :selenium do
         end
 
         it "shows field format labels beside attributes" do
-          builtin_label = I18n.t("types.edit.form_configuration.builtin_field")
+          builtin_label = I18n.t("label_builtin")
 
           expect(page.find(form.attribute_selector(:assignee))).to have_text(builtin_label)
           expect(page.find(form.attribute_selector(:date))).to have_text(builtin_label)

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe TypesHelper do
 
       it "returns 'Builtin field' for built-in attributes" do
         builtin = groups[:inactives].find { |a| a[:key] == "date" }
-        expect(builtin[:field_format_label]).to eq I18n.t("types.edit.form_configuration.builtin_field")
+        expect(builtin[:field_format_label]).to eq I18n.t("label_builtin")
       end
 
       context "with a custom field" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/DREAM/work_packages/DREAM-815/


# What are you trying to accomplish?

Align the built-in label of the work package type form configuration with that of the user attributes.

As a drive by, return a boolean from the `CustomField.custom_field_attribute?`. So far it returned `nil | Number`

## Screenshots

| Before | After |
|--------|--------|
| <img width="1512" height="863" alt="Screenshot 2026-09-09 at 15 29 11" src="https://github.com/user-attachments/assets/f43059da-1538-485c-91b2-7796bbb6d911" /> | <img width="1512" height="864" alt="Screenshot 2026-09-10 at 13 23 24" src="https://github.com/user-attachments/assets/4e521a97-7a3d-4fd5-8c24-a2bc711afa0f" /> | 

# What approach did you choose and why?

This is a plain replacement in the erb. I thought about adding a helper to the types_helper, which already takes care of some other cases around custom fields. But in the end, this is the only use case we seem to have. So abstracting it felt premature.

# Merge checklist

- [x] Added/updated tests
- ~~[ ] Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
