### PR TITLE
Use min_value, max_value for integer and float fields rather than lengths

### DIFF
--- a/app/forms/custom_fields/details_form.rb
+++ b/app/forms/custom_fields/details_form.rb
@@ -60,7 +60,7 @@ module CustomFields
         end
       end
 
-      if show_min_max_field?
+      if show_min_max_length_field?
         details_form.text_field(
           name: :min_length,
           type: :number,
@@ -74,6 +74,28 @@ module CustomFields
           type: :number,
           label: label(:max_length),
           caption: instructions(:min_max),
+          input_width: :small
+        )
+      end
+
+      if show_min_max_value_field?
+        details_form.text_field(
+          name: :min_value,
+          type: :number,
+          step: bound_step,
+          value: model.min_bound,
+          label: label(:min_value),
+          caption: instructions(:min_max_value),
+          input_width: :small
+        )
+
+        details_form.text_field(
+          name: :max_value,
+          type: :number,
+          step: bound_step,
+          value: model.max_bound,
+          label: label(:max_value),
+          caption: instructions(:min_max_value),
           input_width: :small
         )
       end
@@ -252,8 +274,16 @@ module CustomFields
       %w[calculated_value bool].exclude?(model.field_format)
     end
 
-    def show_min_max_field?
-      %w[list bool date user version link hierarchy weighted_item_list calculated_value].exclude?(model.field_format)
+    def show_min_max_length_field?
+      model.length_limits_possible?
+    end
+
+    def show_min_max_value_field?
+      model.numeric_bounds_possible?
+    end
+
+    def bound_step
+      model.field_format == "int" ? 1 : "any"
     end
 
     def show_regex_field?

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -74,6 +74,7 @@ class CustomField < ApplicationRecord
             uniqueness: { case_sensitive: false, scope: :type }
 
   validate :validate_field_format_inclusion
+  validate :validate_value_bounds
   validate :validate_default_value
   validate :validate_regex
 
@@ -81,7 +82,13 @@ class CustomField < ApplicationRecord
   validates :max_length, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :min_length,
             numericality: { less_than_or_equal_to: :max_length, message: :smaller_than_or_equal_to_max_length },
-            unless: Proc.new { |cf| cf.max_length.blank? }
+            if: -> { max_length.to_i.positive? }
+
+  validates :min_value, :max_value, absence: true, unless: :numeric_bounds_possible?
+  validates :min_value, :max_value,
+            numericality: true,
+            allow_nil: true,
+            if: :numeric_bounds_possible?
 
   validates :multi_value, absence: true, unless: :multi_value_possible?
   validates :allow_non_open_versions, absence: true, unless: :allow_non_open_versions_possible?
@@ -134,6 +141,25 @@ class CustomField < ApplicationRecord
     unless allowed.include?(field_format)
       errors.add(:field_format, :inclusion)
     end
+  end
+
+  def validate_value_bounds
+    return unless numeric_bounds_possible?
+
+    validate_integer_value_bounds if field_format == "int"
+    validate_value_bound_order
+  end
+
+  def validate_integer_value_bounds
+    { min_value:, max_value: }.each do |attribute, bound|
+      errors.add(attribute, :not_an_integer) if bound.present? && (bound % 1) != 0
+    end
+  end
+
+  def validate_value_bound_order
+    return unless min_value.present? && max_value.present?
+
+    errors.add(:min_value, :smaller_than_or_equal_to_max_value) if min_value > max_value
   end
 
   def validate_default_value
@@ -376,8 +402,20 @@ class CustomField < ApplicationRecord
   end
 
   def multi_value_possible?
-    OpenProject::CustomFieldFormat.find_by(name: field_format)&.multi_value_possible?
+    format_definition&.multi_value_possible?
   end
+
+  def numeric_bounds_possible?
+    format_definition&.numeric_bounds_possible? || false
+  end
+
+  def length_limits_possible?
+    format_definition&.length_limits_possible? || false
+  end
+
+  def min_bound = typed_bound(min_value)
+
+  def max_bound = typed_bound(max_value)
 
   def allow_non_open_versions_possible?
     version?
@@ -494,5 +532,15 @@ class CustomField < ApplicationRecord
     AttributeHelpText
       .where(attribute_name:)
       .destroy_all
+  end
+
+  def format_definition
+    OpenProject::CustomFieldFormat.find_by(name: field_format)
+  end
+
+  def typed_bound(bound)
+    return if bound.nil?
+
+    field_format == "int" ? bound.to_i : bound
   end
 end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -38,6 +38,7 @@ class CustomValue < ApplicationRecord
   validate :validate_format_of_value
   validate :validate_type_of_value
   validate :validate_length_of_value
+  validate :validate_range_of_value
 
   after_create :activate_custom_field_in_customized_project, if: -> { customized.is_a?(Project) }
 
@@ -51,6 +52,10 @@ class CustomValue < ApplicationRecord
            :is_for_all?,
            :max_length,
            :min_length,
+           :max_bound,
+           :min_bound,
+           :numeric_bounds_possible?,
+           :length_limits_possible?,
            :calculated_value?,
            to: :custom_field
 
@@ -120,10 +125,20 @@ class CustomValue < ApplicationRecord
   end
 
   def validate_length_of_value
+    return unless length_limits_possible?
+
     if value.present? && (min_length.present? || max_length.present?)
       validate_min_length_of_value
       validate_max_length_of_value
     end
+  end
+
+  def validate_range_of_value
+    return unless numeric_bounds_possible?
+    return if value.blank? || errors.include?(:value)
+
+    validate_min_bound_of_value
+    validate_max_bound_of_value
   end
 
   private
@@ -134,5 +149,13 @@ class CustomValue < ApplicationRecord
 
   def validate_max_length_of_value
     errors.add(:value, :too_long, count: max_length) if max_length > 0 && value.length > max_length
+  end
+
+  def validate_min_bound_of_value
+    errors.add(:value, :greater_than_or_equal_to, count: min_bound) if min_bound && typed_value < min_bound
+  end
+
+  def validate_max_bound_of_value
+    errors.add(:value, :less_than_or_equal_to, count: max_bound) if max_bound && typed_value > max_bound
   end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -521,6 +521,8 @@ class PermittedParams
           :is_required,
           :max_length,
           :min_length,
+          :max_value,
+          :min_value,
           :move_to,
           :name,
           :possible_values,

--- a/app/seeders/development_data/custom_fields_seeder.rb
+++ b/app/seeders/development_data/custom_fields_seeder.rb
@@ -39,7 +39,7 @@ module DevelopmentData
     end
 
     def all_cfs
-      %w(string text date list multilist int intrange float bool user version)
+      %w(string text date list multilist int intrange float floatrange bool user version)
     end
 
     def create_types!(cfs)
@@ -58,7 +58,7 @@ module DevelopmentData
       cfs = []
 
       # create some custom fields and add them to the project
-      (all_cfs - %w(list multilist intrange)).each do |type|
+      (all_cfs - %w(list multilist intrange floatrange)).each do |type|
         cfs << CustomField.create!(name: "CF DEV #{type}",
                                    type: "WorkPackageCustomField",
                                    is_required: false,
@@ -85,9 +85,15 @@ module DevelopmentData
 
       cfs << CustomField.create!(name: "CF DEV intrange",
                                  type: "WorkPackageCustomField",
-                                 min_length: 2,
-                                 max_length: 5,
+                                 min_value: 10,
+                                 max_value: 99999,
                                  field_format: "int")
+
+      cfs << CustomField.create!(name: "CF DEV floatrange",
+                                 type: "WorkPackageCustomField",
+                                 min_value: -1.5,
+                                 max_value: 10.25,
+                                 field_format: "float")
 
       cfs
     end

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -31,10 +31,12 @@
 OpenProject::CustomFieldFormat.tap do |formats|
   formats.register("string",
                    label: :label_string,
+                   length_limits_possible: true,
                    order: 1)
   formats.register("text",
                    label: :label_text,
                    order: 2,
+                   length_limits_possible: true,
                    formatter: "CustomValue::FormattableStrategy")
   formats.register("link",
                    label: :label_link_url,
@@ -44,10 +46,12 @@ OpenProject::CustomFieldFormat.tap do |formats|
   formats.register("int",
                    label: :label_integer,
                    order: 4,
+                   numeric_bounds_possible: true,
                    formatter: "CustomValue::IntStrategy")
   formats.register("float",
                    label: :label_float,
                    order: 5,
+                   numeric_bounds_possible: true,
                    formatter: "CustomValue::FloatStrategy")
   formats.register("list",
                    label: :label_list,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,7 +137,9 @@ en:
         is_for_all: "For all projects"
         is_required: "Required"
         max_length: "Maximum length"
+        max_value: "Maximum value"
         min_length: "Minimum length"
+        min_value: "Minimum value"
         multi_value: "Allow multi-select"
         possible_values: "Possible values"
         regexp: "Regular expression"
@@ -583,6 +585,7 @@ en:
         regex_list_invalid: "Lines %{invalid_lines} could not be parsed as regular expression."
         regex_match_failed: "does not match the regular expression %{expression}."
         smaller_than_or_equal_to_max_length: "must be smaller than or equal to maximum length."
+        smaller_than_or_equal_to_max_value: "must be smaller than or equal to maximum value."
         ssrf_filtered: "violates the SSRF policy of this OpenProject instance."
         status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
         system_wide_non_working_day_exists: "conflicts with an existing system-wide non-working day for this date."
@@ -2517,6 +2520,9 @@ en:
       min_max:
         all: "0 means no restriction"
         project: "0 means no restriction"
+      min_max_value:
+        all: "Leave blank for no restriction"
+        project: "Leave blank for no restriction"
       multi_select:
         all: "Allows the user to assign multiple values to this custom field."
         project: "Allows the user to assign multiple values to this attribute."
@@ -3778,7 +3784,6 @@ en:
   label_message_new: "New message"
   label_message_plural: "Messages"
   label_message_posted: "Message added"
-  label_min_max_length: "Min - Max length"
   label_minute_plural: "minutes"
   label_missing_api_access_key: "Missing API access key"
   label_missing_feeds_access_key: "Missing RSS access key"

--- a/db/migrate/20260909140000_add_value_bounds_to_custom_fields.rb
+++ b/db/migrate/20260909140000_add_value_bounds_to_custom_fields.rb
@@ -28,40 +28,37 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module CustomFields
-  class BaseContract < ::ModelContract
-    include RequiresAdminGuard
+class AddValueBoundsToCustomFields < ActiveRecord::Migration[8.1]
+  # Convert at max 15 digits to try and get the correct range values
+  # A double precision column holds integers exactly up to 2^53, which is approximately 9e15.
+  # A longer length gives a bound that is not exact so we skip those
+  MAX_CONVERTIBLE_LENGTH = 15
 
-    attribute :admin_only
-    attribute :allow_non_open_versions
-    attribute :content_right_to_left
-    attribute :custom_field_section_id
-    attribute :default_value
-    attribute :editable
-    attribute :field_format
-    attribute :formula
-    attribute :has_comment
-    attribute :is_filter
-    attribute :is_for_all
-    attribute :is_required do
-      validate_non_true_for_some_formats
+  def up
+    change_table :custom_fields, bulk: true do |t|
+      t.float :min_value, null: true
+      t.float :max_value, null: true
     end
-    attribute :max_length
-    attribute :min_length
-    attribute :max_value
-    attribute :min_value
-    attribute :multi_value
-    attribute :name
-    attribute :possible_values
-    attribute :regexp
-    attribute :searchable
-    attribute :visible_on_user_card
-    attribute :type
 
-    def validate_non_true_for_some_formats
-      return unless %w[bool calculated_value].include?(field_format)
+    execute <<~SQL.squish
+      UPDATE custom_fields
+      SET min_value = CASE
+                        WHEN min_length BETWEEN 2 AND #{MAX_CONVERTIBLE_LENGTH}
+                        THEN power(10::double precision, min_length - 1)
+                      END,
+          max_value = CASE
+                        WHEN max_length BETWEEN 1 AND #{MAX_CONVERTIBLE_LENGTH}
+                        THEN power(10::double precision, max_length) - 1
+                      END,
+          min_length = 0,
+          max_length = 0
+      WHERE field_format IN ('int', 'float')
+    SQL
+  end
 
-      errors.add(:is_required, :cannot_be_true) if is_required == true
+  def down
+    change_table :custom_fields, bulk: true do |t|
+      t.remove :min_value, :max_value
     end
   end
 end

--- a/frontend/src/app/features/hal/interfaces.ts
+++ b/frontend/src/app/features/hal/interfaces.ts
@@ -44,6 +44,8 @@ export interface IOPFieldSchema {
   name?:string;
   minLength?:number,
   maxLength?:number,
+  minimum?:number,
+  maximum?:number,
   attributeGroup?:string;
   location?:'_meta'|'_links'|undefined;
   options:Record<string, unknown>;

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -71,6 +71,8 @@ module API
                     :attribute_group,
                     :min_length,
                     :max_length,
+                    :minimum,
+                    :maximum,
                     :regular_expression,
                     :options,
                     :formula,
@@ -87,6 +89,8 @@ module API
       property :attribute_group, exec_context: :decorator
       property :min_length, exec_context: :decorator
       property :max_length, exec_context: :decorator
+      property :minimum, exec_context: :decorator
+      property :maximum, exec_context: :decorator
       property :regular_expression, exec_context: :decorator
       property :deprecated, exec_context: :decorator
       property :options, exec_context: :decorator

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -61,6 +61,8 @@ module API
                    attribute_group: nil,
                    min_length: nil,
                    max_length: nil,
+                   minimum: nil,
+                   maximum: nil,
                    regular_expression: nil,
                    options: {},
                    formula: nil,
@@ -69,21 +71,23 @@ module API
                    deprecated: nil,
                    placeholder: nil)
           getter = ->(*) do
-            schema_property_getter(type,
-                                   name_source,
-                                   required,
-                                   has_default,
-                                   writable,
-                                   attribute_group,
-                                   min_length,
-                                   max_length,
-                                   regular_expression,
-                                   options,
-                                   formula,
-                                   location,
-                                   description,
-                                   deprecated,
-                                   placeholder)
+            schema_property_getter(type:,
+                                   name_source:,
+                                   required:,
+                                   has_default:,
+                                   writable:,
+                                   attribute_group:,
+                                   min_length:,
+                                   max_length:,
+                                   minimum:,
+                                   maximum:,
+                                   regular_expression:,
+                                   options:,
+                                   formula:,
+                                   location:,
+                                   description:,
+                                   deprecated:,
+                                   placeholder:)
           end
 
           schema_property(property,
@@ -299,25 +303,26 @@ module API
         []
       end
 
-      def schema_property_getter(type,
-                                 name_source,
-                                 required,
-                                 has_default,
-                                 writable,
-                                 attribute_group,
-                                 min_length,
-                                 max_length,
-                                 regular_expression,
-                                 options,
-                                 formula,
-                                 location,
-                                 description,
-                                 deprecated,
-                                 placeholder)
-        name = call_or_translate(name_source)
+      def schema_property_getter(type:,
+                                 name_source:,
+                                 required:,
+                                 has_default:,
+                                 writable:,
+                                 attribute_group:,
+                                 min_length:,
+                                 max_length:,
+                                 minimum:,
+                                 maximum:,
+                                 regular_expression:,
+                                 options:,
+                                 formula:,
+                                 location:,
+                                 description:,
+                                 deprecated:,
+                                 placeholder:)
         schema = ::API::Decorators::PropertySchemaRepresenter
                  .new(type: call_or_use(type),
-                      name:,
+                      name: call_or_translate(name_source),
                       location:,
                       description: call_or_use(description),
                       required: call_or_use(required),
@@ -326,11 +331,9 @@ module API
                       attribute_group: call_or_use(attribute_group),
                       deprecated:,
                       placeholder: call_or_use(placeholder))
-        schema.min_length = min_length
-        schema.max_length = max_length
-        schema.regular_expression = regular_expression
-        schema.options = options
-        schema.formula = formula
+
+        { min_length:, max_length:, minimum:, maximum:, regular_expression:, options:, formula: }
+          .each { |attribute, value| schema.public_send(:"#{attribute}=", value) }
 
         schema
       end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -207,6 +207,8 @@ module API
                         has_default: custom_field.default_value.present?,
                         min_length: cf_min_length(custom_field),
                         max_length: cf_max_length(custom_field),
+                        minimum: custom_field.min_bound,
+                        maximum: custom_field.max_bound,
                         regular_expression: cf_regexp(custom_field),
                         options: cf_options(custom_field),
                         formula: cf_formula(custom_field)

--- a/lib/open_project/custom_field_format.rb
+++ b/lib/open_project/custom_field_format.rb
@@ -42,6 +42,8 @@ module OpenProject
                    edit_as: name,
                    only: nil,
                    multi_value_possible: false,
+                   numeric_bounds_possible: false,
+                   length_limits_possible: false,
                    enterprise_feature: nil,
                    enabled: lambda { true },
                    formatter: "CustomValue::StringStrategy")
@@ -51,6 +53,8 @@ module OpenProject
       @edit_as = edit_as
       @class_names = only
       @multi_value_possible = multi_value_possible
+      @numeric_bounds_possible = numeric_bounds_possible
+      @length_limits_possible = length_limits_possible
       @enterprise_feature = enterprise_feature
       @enabled = enabled
       @formatter = formatter
@@ -58,6 +62,14 @@ module OpenProject
 
     def multi_value_possible?
       @multi_value_possible
+    end
+
+    def numeric_bounds_possible?
+      @numeric_bounds_possible
+    end
+
+    def length_limits_possible?
+      @length_limits_possible
     end
 
     def formatter

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -266,8 +266,8 @@ RSpec.describe RootSeeder,
     end
 
     it "creates 1 project with custom fields" do
-      # 12 development work package custom fields + 4 demo user custom fields
-      expect(CustomField.count).to eq 16
+      # 13 development work package custom fields + 4 demo user custom fields
+      expect(CustomField.count).to eq 17
     end
 
     it "creates 2 additional types for development" do

--- a/spec/contracts/custom_fields/create_contract_spec.rb
+++ b/spec/contracts/custom_fields/create_contract_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe CustomFields::CreateContract do
                       is_required: custom_field_is_required,
                       max_length: custom_field_max_length,
                       min_length: custom_field_min_length,
+                      max_value: custom_field_max_value,
+                      min_value: custom_field_min_value,
                       possible_values: custom_field_possible_values,
                       regexp: custom_field_regexp,
                       formula: custom_field_formula,

--- a/spec/contracts/custom_fields/shared_contract_examples.rb
+++ b/spec/contracts/custom_fields/shared_contract_examples.rb
@@ -45,6 +45,8 @@ RSpec.shared_examples_for "custom_field contract" do
   let(:custom_field_is_required) { true }
   let(:custom_field_max_length) { 0 }
   let(:custom_field_min_length) { 0 }
+  let(:custom_field_max_value) { nil }
+  let(:custom_field_min_value) { nil }
   let(:custom_field_possible_values) { [] }
   let(:custom_field_regexp) { nil }
   let(:custom_field_formula) { nil }

--- a/spec/contracts/custom_fields/update_contract_spec.rb
+++ b/spec/contracts/custom_fields/update_contract_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe CustomFields::UpdateContract do
                     is_required: custom_field_is_required,
                     max_length: custom_field_max_length,
                     min_length: custom_field_min_length,
+                    max_value: custom_field_max_value,
+                    min_value: custom_field_min_value,
                     possible_values: custom_field_possible_values,
                     regexp: custom_field_regexp,
                     formula: custom_field_formula,

--- a/spec/features/admin/custom_fields/shared_custom_field_expectations.rb
+++ b/spec/features/admin/custom_fields/shared_custom_field_expectations.rb
@@ -161,6 +161,8 @@ RSpec.shared_examples_for "expected fields for the custom field's format", :aggr
   let(:label_editable) { I18n.t("activerecord.attributes.custom_field.editable") } # Editable
   let(:label_min_length) { I18n.t("activerecord.attributes.custom_field.min_length") } # Minimum length
   let(:label_max_length) { I18n.t("activerecord.attributes.custom_field.max_length") } # Maximum length
+  let(:label_min_value) { I18n.t("activerecord.attributes.custom_field.min_value") } # Minimum value
+  let(:label_max_value) { I18n.t("activerecord.attributes.custom_field.max_value") } # Maximum value
   let(:label_regexp) { I18n.t("activerecord.attributes.custom_field.regexp") } # Regular expression
   let(:label_multi_value) { I18n.t("activerecord.attributes.custom_field.multi_value") } # Allow multi-select
   let(:label_allow_non_open_versions) do # Allow non-open versions
@@ -228,7 +230,7 @@ RSpec.shared_examples_for "expected fields for the custom field's format", :aggr
       expect(page).to have_no_label(label_admin_only)
     end
 
-    if format in "Text" | "Integer" | "Float" | "Long text"
+    if format in "Text" | "Long text"
       expect_page_to_have(fields: [
                             label_min_length,
                             label_max_length
@@ -240,7 +242,18 @@ RSpec.shared_examples_for "expected fields for the custom field's format", :aggr
                           ])
     end
 
-    # Integer and Float have min/max_len and regex as well which seems strange.
+    if format in "Integer" | "Float"
+      expect_page_to_have(fields: [
+                            label_min_value,
+                            label_max_value
+                          ])
+    else
+      expect_page_to_have(no_labels: [
+                            label_min_value,
+                            label_max_value
+                          ])
+    end
+
     if format in "Text" | "Integer" | "Float" | "Long text" | "Link"
       expect(page).to have_field(label_regexp)
     else

--- a/spec/features/admin/custom_fields/work_packages/float_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/float_spec.rb
@@ -52,5 +52,37 @@ RSpec.describe "custom fields", :js do
 
       expect(page).to have_text("New Field")
     end
+
+    it "round trips decimal value bounds" do
+      cf_page.click_to_create_new_custom_field("Float")
+
+      cf_page.set_name "Bounded Float"
+      cf_page.set_min_value "0.1234"
+      cf_page.set_max_value "10.25"
+      click_on "Save"
+
+      cf_page.expect_and_dismiss_flash(message: "Successful creation.")
+
+      custom_field = CustomField.find_by!(name: "Bounded Float")
+      expect(custom_field.min_value).to eq 0.1234
+      expect(custom_field.max_value).to eq 10.25
+
+      visit edit_custom_field_path(custom_field)
+
+      expect(page).to have_field("custom_field[min_value]", with: "0.1234")
+      expect(page).to have_field("custom_field[max_value]", with: "10.25")
+    end
+
+    it "rejects a minimum above the maximum" do
+      cf_page.click_to_create_new_custom_field("Float")
+
+      cf_page.set_name "Bad Bounds"
+      cf_page.set_min_value "10"
+      cf_page.set_max_value "1"
+      click_on "Save"
+
+      expect(page).to have_text("Minimum value must be smaller than or equal to maximum value.")
+      expect(CustomField.find_by(name: "Bad Bounds")).to be_nil
+    end
   end
 end

--- a/spec/features/admin/custom_fields/work_packages/int_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/int_spec.rb
@@ -54,5 +54,34 @@ RSpec.describe "custom fields", :js do
 
       expect(page).to have_text("New Field")
     end
+
+    it "round trips negative and zero value bounds" do
+      cf_page.set_name "Bounded Integer"
+      cf_page.set_min_value "-5"
+      cf_page.set_max_value "0"
+      click_on "Save"
+
+      cf_page.expect_and_dismiss_flash(message: "Successful creation.")
+
+      custom_field = CustomField.find_by!(name: "Bounded Integer")
+      expect(custom_field.min_value).to eq(-5)
+      expect(custom_field.max_value).to eq 0
+
+      visit edit_custom_field_path(custom_field)
+
+      expect(page).to have_field("custom_field[min_value]", with: "-5")
+      expect(page).to have_field("custom_field[max_value]", with: "0")
+    end
+
+    it "leaves the bounds unrestricted when blank" do
+      cf_page.set_name "Unbounded Integer"
+      click_on "Save"
+
+      cf_page.expect_and_dismiss_flash(message: "Successful creation.")
+
+      custom_field = CustomField.find_by!(name: "Unbounded Integer")
+      expect(custom_field.min_value).to be_nil
+      expect(custom_field.max_value).to be_nil
+    end
   end
 end

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -130,27 +130,35 @@ RSpec.describe "custom field inplace editor", :js do
     end
     let(:initial_custom_values) { { custom_field.id => 123 } }
 
-    context "with length restrictions" do
+    context "with value bounds" do
       let(:args) do
-        { min_length: 2, max_length: 5 }
+        { min_value: -5, max_value: 100 }
       end
 
       it "renders errors for invalid entries" do
         field.activate!
-        # exceeding max length
-        expect_update "123456",
+        # exceeding the maximum value
+        expect_update "101",
                       type: :error,
-                      message: "MyNumber is too long (maximum is 5 characters)."
+                      message: "MyNumber must be less than or equal to 100."
 
-        # below min length
-        expect_update "1",
+        # below the minimum value
+        expect_update "-6",
                       type: :error,
-                      message: "MyNumber is too short (minimum is 2 characters)."
+                      message: "MyNumber must be greater than or equal to -5."
+
+        # correct value: a negative value inside the bounds
+        expect_update "-5",
+                      message: I18n.t("js.notice_successful_update")
+        wp_page.expect_attributes property_name => "-5"
+
+        # Activate the field once more
+        field.activate!
 
         # Correct value
-        expect_update "9999",
+        expect_update "99",
                       message: I18n.t("js.notice_successful_update")
-        wp_page.expect_attributes property_name => "9999"
+        wp_page.expect_attributes property_name => "99"
       end
     end
 
@@ -221,6 +229,29 @@ RSpec.describe "custom field inplace editor", :js do
 
         work_package.reload
         expect(work_package.custom_value_for(custom_field).typed_value).to eq 10000.55
+      end
+    end
+
+    context "with decimal value bounds" do
+      let(:user) { create(:admin, language: "en") }
+      let(:args) { { min_value: 0.1234, max_value: 10.25 } }
+      let(:initial_custom_values) { { custom_field.id => 1.5 } }
+
+      it "renders errors for invalid entries" do
+        field.activate!
+        expect_update "10.26",
+                      type: :error,
+                      message: "MyFloat must be less than or equal to 10.25."
+
+        expect_update "0.1233",
+                      type: :error,
+                      message: "MyFloat must be greater than or equal to 0.1234."
+
+        expect_update "0.1234",
+                      message: I18n.t("js.notice_successful_update")
+
+        work_package.reload
+        expect(work_package.custom_value_for(custom_field).typed_value).to eq 0.1234
       end
     end
 

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -118,6 +118,30 @@ RSpec.shared_examples_for "indicates length requirements" do
   end
 end
 
+RSpec.shared_examples_for "indicates value bounds" do
+  it "indicates its minimum value" do
+    if defined?(minimum)
+      expect(subject)
+        .to be_json_eql(minimum.to_json)
+        .at_path("#{path}/minimum")
+    else
+      expect(subject)
+        .not_to have_json_path("#{path}/minimum")
+    end
+  end
+
+  it "indicates its maximum value" do
+    if defined?(maximum)
+      expect(subject)
+        .to be_json_eql(maximum.to_json)
+        .at_path("#{path}/maximum")
+    else
+      expect(subject)
+        .not_to have_json_path("#{path}/maximum")
+    end
+  end
+end
+
 RSpec.shared_examples_for "defines the placeholder to display" do
   it "shows the placeholder value" do
     expect(subject)

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -144,6 +144,40 @@ RSpec.describe API::V3::Utilities::CustomFieldInjector do
           let(:max_length) { 5 }
         end
       end
+
+      # meaning they won't as a string field cannot carry them
+      it_behaves_like "indicates value bounds"
+    end
+
+    describe "int custom field" do
+      let(:path) { cf_path }
+      let(:custom_field) { build(:custom_field, field_format: "int", min_value: -5, max_value: 10) }
+
+      it_behaves_like "indicates value bounds" do
+        let(:minimum) { -5 }
+        let(:maximum) { 10 }
+      end
+
+      it "does not advertise character lengths" do
+        expect(subject).not_to have_json_path("#{cf_path}/minLength")
+        expect(subject).not_to have_json_path("#{cf_path}/maxLength")
+      end
+
+      context "without bounds" do
+        let(:custom_field) { build(:custom_field, field_format: "int") }
+
+        it_behaves_like "indicates value bounds"
+      end
+    end
+
+    describe "float custom field" do
+      let(:path) { cf_path }
+      let(:custom_field) { build(:custom_field, field_format: "float", min_value: 0.1234, max_value: 10.25) }
+
+      it_behaves_like "indicates value bounds" do
+        let(:minimum) { 0.1234 }
+        let(:maximum) { 10.25 }
+      end
     end
 
     describe "version custom field" do

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -143,6 +143,160 @@ RSpec.describe CustomField do
       it { expect(field).not_to be_valid }
     end
 
+    describe "WITH a text field WITH a minimum length but no maximum length" do
+      before do
+        field.field_format = "text"
+        field.min_length = 2
+        field.max_length = 0
+      end
+
+      it { expect(field).to be_valid }
+    end
+
+    describe "value bounds" do
+      shared_examples "a numeric format" do |field_format|
+        describe "WITH a #{field_format} field WITHOUT bounds" do
+          before { field.field_format = field_format }
+
+          it { expect(field).to be_valid }
+        end
+
+        describe "WITH a #{field_format} field WITH a zero minimum value" do
+          before do
+            field.field_format = field_format
+            field.min_value = 0
+          end
+
+          it { expect(field).to be_valid }
+        end
+
+        describe "WITH a #{field_format} field WITH negative bounds" do
+          before do
+            field.field_format = field_format
+            field.min_value = -10
+            field.max_value = -5
+          end
+
+          it { expect(field).to be_valid }
+        end
+
+        describe "WITH a #{field_format} field WITH only a minimum value" do
+          before do
+            field.field_format = field_format
+            field.min_value = 5
+          end
+
+          it { expect(field).to be_valid }
+        end
+
+        describe "WITH a #{field_format} field WITH only a maximum value" do
+          before do
+            field.field_format = field_format
+            field.max_value = 5
+          end
+
+          it { expect(field).to be_valid }
+        end
+
+        describe "WITH a #{field_format} field WITH equal bounds" do
+          before do
+            field.field_format = field_format
+            field.min_value = 5
+            field.max_value = 5
+          end
+
+          it { expect(field).to be_valid }
+        end
+
+        describe "WITH a #{field_format} field WITH a minimum value above the maximum value" do
+          before do
+            field.field_format = field_format
+            field.min_value = 10
+            field.max_value = 5
+          end
+
+          it "is invalid" do
+            expect(field).not_to be_valid
+            expect(field.errors.symbols_for(:min_value)).to include(:smaller_than_or_equal_to_max_value)
+          end
+        end
+
+        describe "WITH a #{field_format} field WITH a non numeric bound" do
+          before do
+            field.field_format = field_format
+            field.min_value = "abc"
+          end
+
+          it "is invalid" do
+            expect(field).not_to be_valid
+            expect(field.errors.symbols_for(:min_value)).to include(:not_a_number)
+          end
+        end
+
+        describe "WITH a #{field_format} field WITH a blank bound" do
+          before do
+            field.field_format = field_format
+            field.min_value = ""
+          end
+
+          it "reads as unrestricted" do
+            expect(field).to be_valid
+            expect(field.min_value).to be_nil
+            expect(field.min_bound).to be_nil
+          end
+        end
+      end
+
+      it_behaves_like "a numeric format", "int"
+      it_behaves_like "a numeric format", "float"
+
+      describe "WITH an int field WITH a decimal bound" do
+        before do
+          field.field_format = "int"
+          field.min_value = 0.5
+        end
+
+        it "is invalid" do
+          expect(field).not_to be_valid
+          expect(field.errors.symbols_for(:min_value)).to include(:not_an_integer)
+        end
+      end
+
+      describe "WITH an int field WITH an integral bound" do
+        before do
+          field.field_format = "int"
+          field.min_value = 5
+        end
+
+        it "reads back as an integer" do
+          expect(field).to be_valid
+          expect(field.min_bound).to eq(5)
+          expect(field.min_bound).to be_a(Integer)
+        end
+      end
+
+      describe "WITH a float field WITH a decimal bound" do
+        before do
+          field.field_format = "float"
+          field.min_value = "0.1234"
+        end
+
+        it "keeps the decimal" do
+          expect(field).to be_valid
+          expect(field.min_bound).to eq(0.1234)
+        end
+      end
+
+      describe "WITH a text field WITH a value bound" do
+        before do
+          field.field_format = "text"
+          field.min_value = 5
+        end
+
+        it { expect(field).not_to be_valid }
+      end
+    end
+
     describe "WITH a text field WITH an invalid regexp" do
       before do
         field.field_format = "text"

--- a/spec/models/custom_value_spec.rb
+++ b/spec/models/custom_value_spec.rb
@@ -402,12 +402,14 @@ RSpec.describe CustomValue do
 
   describe "#valid?" do
     let(:custom_field) do
-      build_stubbed(:custom_field, field_format:, is_required:, min_length:, max_length:, regexp:)
+      build_stubbed(:custom_field, field_format:, is_required:, min_length:, max_length:, min_value:, max_value:, regexp:)
     end
     let(:custom_value) { described_class.new(custom_field:, value:) }
     let(:is_required) { false }
     let(:min_length) { 0 }
     let(:max_length) { 0 }
+    let(:min_value) { nil }
+    let(:max_value) { nil }
     let(:regexp) { nil }
 
     context "for a data custom field" do
@@ -554,6 +556,67 @@ RSpec.describe CustomValue do
       end
     end
 
+    shared_examples "enforces value bounds" do |below:, at_min:, within:, at_max:, above:|
+      let(:min_value) { -1.5 }
+      let(:max_value) { 10.25 }
+
+      context "with a value below the minimum" do
+        let(:value) { below }
+
+        it "is invalid" do
+          expect(custom_value).not_to be_valid
+          expect(custom_value.errors.symbols_for(:value)).to include(:greater_than_or_equal_to)
+        end
+      end
+
+      context "with a value at the minimum" do
+        let(:value) { at_min }
+
+        it { expect(custom_value).to be_valid }
+      end
+
+      context "with a value within the bounds" do
+        let(:value) { within }
+
+        it { expect(custom_value).to be_valid }
+      end
+
+      context "with a value at the maximum" do
+        let(:value) { at_max }
+
+        it { expect(custom_value).to be_valid }
+      end
+
+      context "with a value above the maximum" do
+        let(:value) { above }
+
+        it "is invalid" do
+          expect(custom_value).not_to be_valid
+          expect(custom_value.errors.symbols_for(:value)).to include(:less_than_or_equal_to)
+        end
+      end
+
+      context "with a blank value" do
+        let(:value) { "" }
+
+        it { expect(custom_value).to be_valid }
+      end
+
+      context "with only a minimum bound" do
+        let(:max_value) { nil }
+        let(:value) { above }
+
+        it { expect(custom_value).to be_valid }
+      end
+
+      context "with only a maximum bound" do
+        let(:min_value) { nil }
+        let(:value) { below }
+
+        it { expect(custom_value).to be_valid }
+      end
+    end
+
     context "for a list custom field" do
       let(:custom_option1) { build_stubbed(:custom_option, value: "value1") }
       let(:custom_option2) { build_stubbed(:custom_option, value: "value1") }
@@ -645,6 +708,39 @@ RSpec.describe CustomValue do
             .to be_valid
         end
       end
+
+      it_behaves_like "enforces value bounds",
+                      below: "-2", at_min: "-1", within: "0", at_max: "10", above: "11" do
+        let(:min_value) { -1 }
+        let(:max_value) { 10 }
+      end
+
+      context "with a non numeric value inside the bounds" do
+        let(:min_value) { -1 }
+        let(:max_value) { 10 }
+        let(:value) { "abc" }
+
+        it "reports only the type error" do
+          expect(custom_value).not_to be_valid
+          expect(custom_value.errors.symbols_for(:value)).to contain_exactly(:not_an_integer)
+        end
+      end
+
+      context "with a zero bound and a negative value" do
+        let(:min_value) { 0 }
+        let(:value) { "-1" }
+
+        it { expect(custom_value).not_to be_valid }
+      end
+
+      context "with a length limit left over from an older configuration" do
+        let(:min_length) { 4 }
+        let(:value) { "7" }
+
+        it "ignores the character length" do
+          expect(custom_value).to be_valid
+        end
+      end
     end
 
     context "for a float custom field" do
@@ -710,6 +806,18 @@ RSpec.describe CustomValue do
         it "is invalid" do
           expect(custom_value)
             .not_to be_valid
+        end
+      end
+
+      it_behaves_like "enforces value bounds",
+                      below: "-1.51", at_min: "-1.5", within: "0.1234", at_max: "10.25", above: "10.26"
+
+      context "with a non numeric value inside the bounds" do
+        let(:value) { "abc" }
+
+        it "reports only the type error" do
+          expect(custom_value).not_to be_valid
+          expect(custom_value.errors.symbols_for(:value)).to contain_exactly(:not_a_number)
         end
       end
     end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -403,5 +403,49 @@ RSpec.describe WorkPackage do
           .to eq "PIN is too long (maximum is 4 characters)."
       end
     end
+
+    describe "value bound error interpolation" do
+      include_context "project with custom field"
+
+      context "with an integer custom field" do
+        let :custom_field do
+          create(:work_package_custom_field,
+                 name: "Floor",
+                 field_format: "int",
+                 min_value: -5,
+                 max_value: 10)
+        end
+
+        it "names the custom field and the bound" do
+          work_package.custom_field_values.first.value = "11"
+          work_package.custom_values_to_validate = work_package.custom_field_values
+
+          expect { work_package.valid?(:saving_custom_fields) }.not_to raise_error
+          expect(work_package).not_to be_valid(:saving_custom_fields)
+
+          expect(work_package.errors.full_messages.first)
+            .to eq "Floor must be less than or equal to 10."
+        end
+      end
+
+      context "with a float custom field" do
+        let :custom_field do
+          create(:work_package_custom_field,
+                 name: "Ratio",
+                 field_format: "float",
+                 min_value: 0.1234)
+        end
+
+        it "keeps the decimal in the message" do
+          work_package.custom_field_values.first.value = "0.1"
+          work_package.custom_values_to_validate = work_package.custom_field_values
+
+          expect(work_package).not_to be_valid(:saving_custom_fields)
+
+          expect(work_package.errors.full_messages.first)
+            .to eq "Ratio must be greater than or equal to 0.1234."
+        end
+      end
+    end
   end
 end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -523,8 +523,8 @@ RSpec.describe RootSeeder,
     end
 
     it "creates 1 project with custom fields" do
-      # 12 development work package custom fields + 4 development user custom fields
-      expect(CustomField.count).to eq 16
+      # 13 development work package custom fields + 4 development user custom fields
+      expect(CustomField.count).to eq 17
     end
 
     include_examples "creates the company staff and the demo data referencing it"

--- a/spec/support/pages/custom_fields/index.rb
+++ b/spec/support/pages/custom_fields/index.rb
@@ -52,6 +52,14 @@ module Pages
         fill_in "custom_field[default_value]", with: value
       end
 
+      def set_min_value(value)
+        fill_in "custom_field[min_value]", with: value
+      end
+
+      def set_max_value(value)
+        fill_in "custom_field[max_value]", with: value
+      end
+
       def set_all_projects(value)
         find_by_id("is_for_all").set value
       end


### PR DESCRIPTION
https://community.openproject.org/work_packages/OP-20138

<img width="2748" height="1116" alt="2026-09-09_16-04-37@2x" src="https://github.com/user-attachments/assets/f929aa38-77ce-4e32-8921-6b51816929c0" />

Add new fields/columns for min_value, max_value that is used for float and integer custom fields rather than showing min_length and max_length. We try to guess the correct min/max value in a migration.