### PR TITLE
Keep an explicit transaction option on the mutex

### DIFF
--- a/lib/open_project/mutex.rb
+++ b/lib/open_project/mutex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -58,7 +60,7 @@ module OpenProject
       lock_name = "mutex_on_#{entry.class.name}_#{entry.id}"
       lock_name << "_#{suffix}" if suffix
 
-      options[:transaction] ||= true
+      options.with_defaults!(transaction: true)
       ActiveRecord::Base.transaction do
         with_advisory_lock(entry.class, lock_name, options, &)
       end

--- a/spec/lib/open_project/mutex_spec.rb
+++ b/spec/lib/open_project/mutex_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::Mutex do
+  let(:entry) { build_stubbed(:work_package) }
+
+  before do
+    allow(WorkPackage).to receive(:with_advisory_lock) { |*, &block| block&.call }
+  end
+
+  it "defaults to a transaction-scoped lock" do
+    described_class.with_advisory_lock_transaction(entry) { :locked }
+
+    expect(WorkPackage)
+      .to have_received(:with_advisory_lock)
+      .with("mutex_on_WorkPackage_#{entry.id}", hash_including(transaction: true))
+  end
+
+  it "keeps an explicit transaction: false" do
+    described_class.with_advisory_lock_transaction(entry, nil, { transaction: false }) { :locked }
+
+    expect(WorkPackage)
+      .to have_received(:with_advisory_lock)
+      .with("mutex_on_WorkPackage_#{entry.id}", hash_including(transaction: false))
+  end
+
+  it "appends the suffix to the lock name" do
+    described_class.with_advisory_lock_transaction(entry, "backlogs") { :locked }
+
+    expect(WorkPackage)
+      .to have_received(:with_advisory_lock)
+      .with("mutex_on_WorkPackage_#{entry.id}_backlogs", anything)
+  end
+end


### PR DESCRIPTION
# Ticket

No dedicated work package; this is a small maintenance fix that came out of the review discussion on https://github.com/opf/openproject/pull/24778#discussion_r3952241376.

# What are you trying to accomplish?

`OpenProject::Mutex.with_advisory_lock_transaction` accepts an options hash that is forwarded to the `with_advisory_lock` gem, but it defaulted the transaction option with `options[:transaction] ||= true`. Since `false` is falsy, an explicitly passed `transaction: false` was silently replaced by `true`, so a session-scoped advisory lock could never be requested through the helper. Only an omitted key should fall back to the default.

Note that `transaction: false` selects a session-scoped lock, released when the lock block exits, rather than a transaction-scoped one held until the surrounding database transaction finishes. It does not remove the `ActiveRecord::Base.transaction` wrapper. No current caller passes the options hash, so this changes no existing behavior at the call sites; it makes the documented option usable.

# What approach did you choose and why?

`options.with_defaults(transaction: true)` keeps the default for an omitted key while letting any explicitly supplied value through, and it returns a new hash instead of mutating the caller's. Reworking the positional signature into keyword arguments would be the nicer API, but that touches every caller and is out of scope for this fix.

The helper had no spec, so this adds one covering the default, the explicit `transaction: false`, and the lock-name suffix. Reverting the one-line change fails the explicit-false example.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
