### PR TITLE
Improve comments generated for commit events

### DIFF
--- a/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
+++ b/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
@@ -83,9 +83,7 @@ module OpenProject::GithubIntegration
         return if notes.nil?
 
         work_packages.each do |work_package|
-          ::WorkPackages::UpdateService
-            .new(user:, model: work_package)
-            .call(journal_notes: notes, send_notifications: false)
+          ::AddWorkPackageNoteService.new(user:, work_package:).call(notes, send_notifications: false)
         end
       end
 

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/helper.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/helper.rb
@@ -98,9 +98,7 @@ module OpenProject::GitlabIntegration
         return if notes.nil?
 
         work_packages.each do |work_package|
-          ::WorkPackages::UpdateService
-            .new(user:, model: work_package)
-            .call(journal_notes: notes, send_notifications: false)
+          ::AddWorkPackageNoteService.new(user:, work_package:).call(notes, send_notifications: false)
         end
       end
 

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
@@ -57,7 +57,7 @@ module OpenProject::GitlabIntegration
       def generate_notes(commit, payload)
         commit_id = commit["id"]
         I18n.t("gitlab_integration.push_single_commit_comment_with_ref",
-               reference: payload.ref,
+               reference: payload.ref&.delete_prefix("refs/heads/"),
                commit_number: commit_id[0, 8],
                commit_note: commit["message"].presence || commit["title"],
                commit_url: commit["url"],

--- a/modules/gitlab_integration/spec/lib/open_project/gitlab_integration/notification_handler/push_hook_spec.rb
+++ b/modules/gitlab_integration/spec/lib/open_project/gitlab_integration/notification_handler/push_hook_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe OpenProject::GitlabIntegration::NotificationHandler::PushHook do
 
   context "with a regular push" do
     let(:comment) do
-      "**Pushed in refs/heads/main:** [Administrator]" \
+      "**Pushed in main:** [Administrator]" \
         "(https://www.gravatar.com/avatar/65a222b844ced567fe0ed2594c0b4abdf62efa1322a385c919c41e7bbc16d4fc?s=80&d=identicon) " \
         "pushed [a265d6b7](http://c7e7cd2d54c3/openprojecttest/test/-/commit/a265d6b7bcf836b77ed9e32f824b231585c6a355) " \
         "to [Test](http://c7e7cd2d54c3/openprojecttest/test) at 2024-07-22T11:18:29+02:00:" \
@@ -131,7 +131,7 @@ RSpec.describe OpenProject::GitlabIntegration::NotificationHandler::PushHook do
       end
 
       let(:comment) do
-        "**Pushed in refs/heads/main:** [Administrator]" \
+        "**Pushed in main:** [Administrator]" \
           "(https://www.gravatar.com/avatar/65a222b844ced567fe0ed2594c0b4abdf62efa1322a385c919c41e7bbc16d4fc?s=80&d=identicon) " \
           "pushed [a265d6b7](http://c7e7cd2d54c3/openprojecttest/test/-/commit/a265d6b7bcf836b77ed9e32f824b231585c6a355) " \
           "to [Test](http://c7e7cd2d54c3/openprojecttest/test) at 2024-07-22T11:18:29+02:00:\nMentioning OP##{work_package.id}\n"


### PR DESCRIPTION
* Make sure that the formatting included in the translation strings works as intended
* GitLab: shorten the ref to the user visible portion of the branch name

# Ticket
https://community.openproject.org/wp/OP-20142

# Screenshots

<img width="767" height="279" alt="image" src="https://github.com/user-attachments/assets/fc832a08-7d87-4e4d-aecb-e846887dda5a" />
