### PR TITLE
[OP-17199] Filter for status of past meetings

### DIFF
--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -47,6 +47,7 @@ module Meetings
         Queries::Meetings::Filters::AuthorFilter,
         Queries::Meetings::Filters::InvitedUserFilter,
         Queries::Meetings::Filters::RecurringFilter,
+        Queries::Meetings::Filters::StateFilter,
         Queries::Meetings::Filters::TimeFilter,
         Queries::Meetings::Filters::TitleFilter
       ]

--- a/modules/meeting/app/models/queries/meetings.rb
+++ b/modules/meeting/app/models/queries/meetings.rb
@@ -37,6 +37,7 @@ module Queries::Meetings
     filter Filters::DatesIntervalFilter
     filter Filters::RecurringFilter
     filter Filters::TitleFilter
+    filter Filters::StateFilter
 
     order Orders::DefaultOrder
   end

--- a/modules/meeting/app/models/queries/meetings/filters/state_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/state_filter.rb
@@ -28,26 +28,20 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Meetings
-  module Statuses
-    RECORD = Struct.new(:id, :color, keyword_init: true) do
-      def name = I18n.t("label_meeting_state_#{id}")
-    end
+class Queries::Meetings::Filters::StateFilter < Queries::Meetings::Filters::MeetingFilter
+  def type
+    :list
+  end
 
-    DRAFT = RECORD.new(id: "draft", color: Color.new(hexcode: "#BF3989"))
-    OPEN = RECORD.new(id: "open", color: Color.new(hexcode: "#006edb"))
-    IN_PROGRESS = RECORD.new(id: "in_progress", color: Color.new(hexcode: "#894ceb"))
-    CLOSED = RECORD.new(id: "closed", color: Color.new(hexcode: "#25292e"))
+  def allowed_values
+    Meetings::Statuses::AVAILABLE.map { [it.name, Meeting.states.fetch(it.id)] }
+  end
 
-    AVAILABLE = [
-      DRAFT,
-      OPEN,
-      IN_PROGRESS,
-      CLOSED
-    ].freeze
+  def human_name
+    I18n.t(:label_meeting_state)
+  end
 
-    def self.find_by_id(id)
-      AVAILABLE.find { |status| status.id == id }
-    end
+  def self.key
+    :state
   end
 end

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -194,6 +194,23 @@ RSpec.describe "Meetings", "Index", :js do
           meetings_page.expect_meetings_not_listed(tomorrows_meeting)
         end
 
+        context 'and the "Meeting status" filter' do
+          before do
+            yesterdays_meeting.update!(state: :closed)
+            meeting.update!(state: :in_progress)
+          end
+
+          it "narrows the past meetings down to the selected statuses" do
+            meetings_page.open_filters
+            meetings_page.set_filter("state", "Meeting status", "is (OR)", ["In progress", "Closed"])
+
+            wait_for_network_idle
+
+            meetings_page.expect_meetings_listed(meeting, yesterdays_meeting)
+            meetings_page.expect_meetings_not_listed(ongoing_meeting)
+          end
+        end
+
         it "keeps the past filter selected when changing advanced filters (Regression #61875)" do
           meetings_page.set_sidebar_filter "My meetings"
           meetings_page.set_quick_filter upcoming: false

--- a/modules/meeting/spec/models/queries/meetings/filters/state_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/meetings/filters/state_filter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Meetings::Filters::StateFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :list }
+    let(:class_key) { :state }
+    let(:human_name) { "Meeting status" }
+
+    describe "#allowed_values" do
+      it "offers the statuses a meeting moves through, in lifecycle order" do
+        expect(instance.allowed_values)
+          .to eq([["Draft", 1], ["Open", 0], ["In progress", 3], ["Closed", 5]])
+      end
+
+      # Cancelled meetings are excluded by MeetingQuery#default_scope, so the
+      # value would never match anything.
+      it "omits cancelled" do
+        expect(instance.allowed_values.map(&:last)).not_to include(Meeting.states[:cancelled])
+      end
+    end
+  end
+
+  it_behaves_like "list query filter" do
+    let(:attribute) { :state }
+    let(:valid_values) { [Meeting.states[:closed].to_s] }
+  end
+
+  describe "#where clause" do
+    shared_let(:project) { create(:project) }
+    shared_let(:draft_meeting) { create(:meeting, project:, state: :draft) }
+    shared_let(:open_meeting) { create(:meeting, project:, state: :open) }
+    shared_let(:in_progress_meeting) { create(:meeting, project:, state: :in_progress) }
+    shared_let(:closed_meeting) { create(:meeting, project:, state: :closed) }
+
+    let(:instance) { described_class.create!(name: :state, operator:, values:) }
+
+    subject(:meetings) { Meeting.where(instance.where) }
+
+    context 'for "="' do
+      let(:operator) { "=" }
+      let(:values) { [Meeting.states[:in_progress].to_s, Meeting.states[:open].to_s] }
+
+      it "finds the meetings in any of the selected statuses" do
+        expect(meetings).to contain_exactly(open_meeting, in_progress_meeting)
+      end
+    end
+
+    context 'for "!"' do
+      let(:operator) { "!" }
+      let(:values) { [Meeting.states[:closed].to_s] }
+
+      it "finds the meetings in any other status" do
+        expect(meetings).to contain_exactly(draft_meeting, open_meeting, in_progress_meeting)
+      end
+    end
+  end
+end

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -611,8 +611,10 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
 
       within(cf_filter) do
         projects_page.expect_ng_value_label(select_value_id, list_custom_field.possible_values[2].value)
-        projects_page.set_autocomplete_filter list_custom_field.possible_values[3].value, clear: false
       end
+      projects_page.set_autocomplete_filter list_custom_field.possible_values[3].value,
+                                            filter_name: list_custom_field.column_name,
+                                            clear: false
       wait_for_reload
 
       projects_page.expect_projects_not_listed(development_project)

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -78,29 +78,38 @@ module Components
         # Classify the row before apply_operator re-renders it; the type and
         # autocomplete markers are fixed per filter, so selecting the operator
         # does not change them. Skipped when there is nothing to set.
-        kind = filter_kind(name) if values.any?
+        kind = values.any? ? filter_kind(name) : nil
 
         apply_operator(name, human_operator)
 
         return unless values.any?
 
-        # Re-find after apply_operator: selecting the operator re-renders the
-        # filter row, leaving an earlier reference stale (ObsoleteNode).
-        within(filter_selector(name)) do
-          set_advanced_filter_value(name, kind, human_operator, values, send_keys:)
+        set_advanced_filter_value(name, kind, human_operator, values, send_keys:)
+      end
+
+      # Every filter form using this helper submits on change and re-renders the
+      # row, so it is entered only once the operator has landed. The inputs each
+      # do a single interaction that finishes before that re-render, so one
+      # scope covers them. The autocompleter cannot use one: it picks its values one
+      # after the other, and every pick re-renders the row, so a scope held
+      # across them is dead by the second value (ObsoleteNode). It is handed the
+      # filter name and re-finds the row per pick instead.
+      def set_advanced_filter_value(name, kind, human_operator, values, send_keys:)
+        if boolean_filter?(name)
+          within_filter(name) { set_toggle_filter(values) }
+        elsif kind == :autocomplete
+          set_autocomplete_filter(values, filter_name: name)
+        elsif name == "created_at"
+          within_filter(name) { set_datetime_filter(name, human_operator, values, send_keys:) }
+        elsif kind == :date && human_operator == "on"
+          within_filter(name) { set_date_filter(values, send_keys) }
         end
       end
 
-      def set_advanced_filter_value(name, kind, human_operator, values, send_keys:)
-        if boolean_filter?(name)
-          set_toggle_filter(values)
-        elsif kind == :autocomplete
-          set_autocomplete_filter(values)
-        elsif name == "created_at"
-          set_datetime_filter(name, human_operator, values, send_keys:)
-        elsif kind == :date && human_operator == "on"
-          set_date_filter(values, send_keys)
-        end
+      def within_filter(name, &)
+        wait_for_network_idle
+
+        within(filter_selector(name), &)
       end
 
       def expect_autocomplete_options_for(custom_field, options, grouping: nil, results_selector: "body")
@@ -183,16 +192,23 @@ module Components
         end
       end
 
-      def set_autocomplete_filter(values, clear: true)
-        element = find('[data-filter-autocomplete="true"]')
-
-        ng_select_clear(element, raise_on_missing: false) if clear
+      def set_autocomplete_filter(values, filter_name:, clear: true)
+        ng_select_clear(autocomplete_element(filter_name), raise_on_missing: false) if clear
 
         Array(values).each do |query|
-          select_autocomplete element,
+          select_autocomplete autocomplete_element(filter_name),
                               query:,
                               results_selector: "body"
         end
+      end
+
+      # Re-found on every call, never captured in a local nor reached through an
+      # enclosing `within`: between one selected value and the next the row is
+      # gone, taking any reference to it along.
+      def autocomplete_element(filter_name)
+        wait_for_network_idle
+
+        page.find(filter_selector(filter_name)).find('[data-filter-autocomplete="true"]')
       end
 
       def set_list_filter(values)

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -78,9 +78,7 @@ module Pages
           unless page.has_css?(".advanced-filters--filter[data-filter-name='status']")
             select "Status", from: "add_filter_select"
           end
-          within(".advanced-filters--filter[data-filter-name='status']") do
-            set_autocomplete_filter([value])
-          end
+          set_autocomplete_filter([value], filter_name: "status")
 
           wait_for_network_idle
         end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -245,7 +245,7 @@ module Pages
 
         # Classify the row before apply_operator re-renders it. Skipped when
         # there is nothing to set.
-        kind = filter_kind(name) if values.any?
+        kind = values.any? ? filter_kind(name) : nil
 
         within(filter_selector(name)) do
           apply_operator(name, human_operator)
@@ -253,12 +253,12 @@ module Pages
 
         return unless values.any?
 
+        return set_autocomplete_filter(values, filter_name: name) if kind == :autocomplete
+
         # Re-find again as apply_operator may have triggered further DOM updates
         within(filter_selector(name)) do
           if boolean_filter?(name)
             set_toggle_filter(values)
-          elsif kind == :autocomplete
-            set_autocomplete_filter(values)
           elsif %i[date datetime_past].include?(kind)
             wait_for_network_idle
             set_datetime_filter(name, human_operator, values, send_keys:)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-17199

# What are you trying to accomplish?

- [x] A `Meeting status` filter can be added from the meetings index "All filters" form
- [x] Offers Draft, Open, In progress and Closed, in lifecycle order
- [x] Cancelled is not offered — the meetings index never lists cancelled meetings
- [x] Available in both the global and the project meetings index
- [x] Works with `is (OR)` and `is not`, single or multiple statuses

## Screenshots

<img width="811" height="457" alt="Screenshot for the filter" src="https://github.com/user-attachments/assets/6889fc11-a406-4927-a628-05934fbd4da9" />

# What approach did you choose and why?

- `Meetings::Statuses::RECORD` gained a `name` so the `label_meeting_state_*` lookup lives in one place; `Meetings::SidePanel::StatusButtonComponent` still builds its own labels and could adopt it in a later pass
- `set_autocomplete_filter` takes the filter name and re-finds the row for every value it picks; the three callers moved off their enclosing `within`. Each filter form using the helper submits on change, so a scope captured before the first value is stale by the second. This also fixes `spec/features/users/index_spec.rb`, which fails on `dev` roughly every other local run and passed 5 of 5 with the change

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome)


