### PR TITLE
[JIM-189] Set work package created and updated date to timestamps of Jira issue & preserve journal timestamps

### DIFF
--- a/app/models/journal/caused_by_import.rb
+++ b/app/models/journal/caused_by_import.rb
@@ -29,15 +29,11 @@
 #++
 #
 class Journal::CausedByImport < CauseOfChange::Base
-  def initialize(author_name: nil, history: [], event: nil)
-    import_history = [
-      {
-        "event" => event,
-        "author_name" => author_name,
-        "items" => history
-      }.compact
-    ]
-    additional = { "import_history" => import_history }
+  def initialize(author_name: nil, history: [], migrated: false)
+    entry = { "author_name" => author_name, "items" => history.presence }.compact
+    additional = entry.present? ? { "import_history" => [entry] } : {}
+    additional["migrated"] = true if migrated
+
     super("import", additional)
   end
 end

--- a/app/services/attachments/import_create_service.rb
+++ b/app/services/attachments/import_create_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Attachments
+  # Creates an attachment without journalizing its container. Importers replay the source
+  # system's own history, so the container's journals are written by the importer instead.
+  class ImportCreateService < CreateService
+    private
+
+    def touch(_container) = nil
+  end
+end

--- a/app/services/import/jira_import_journals.rb
+++ b/app/services/import/jira_import_journals.rb
@@ -30,6 +30,9 @@
 
 module Import
   class JiraImportJournals
+    # Timestamps keep microseconds; a rational addition stays exact where a float loses a nanosecond.
+    TIMESTAMP_STEP = Rational(1, 1_000_000).seconds
+
     attr_reader :work_package
 
     def initialize(work_package:)
@@ -62,10 +65,10 @@ module Import
     end
 
     def call(updated_at: nil)
-      @pending_entries.sort_by { |e| e[:created] }.each do |entry|
+      monotonic_entries.each do |entry, date_time|
         case entry[:type]
-        when :history then create_history_journal(entry[:data])
-        when :comment then create_comment_journal(entry[:data], entry[:user])
+        when :history then create_history_journal(entry[:data], date_time)
+        when :comment then create_comment_journal(entry[:data], entry[:user], date_time)
         end
       end
 
@@ -106,6 +109,29 @@ module Import
         .where(journal_id: journal_ids)
         .pluck(:journal_id, :attachment_id)
         .to_set
+    end
+
+    # Journals::CreateService keeps the journals of a journable strictly ordered in time: a
+    # timestamp that is not newer than the preceding journal's is discarded in favour of the
+    # current time. Entries sharing a Jira timestamp, with each other or with the creation
+    # journal, would therefore be stamped with the import date, so they are spaced out by the
+    # smallest step a timestamp column can represent.
+    def monotonic_entries
+      previous = work_package.journals.maximum(:updated_at)
+
+      chronological_entries.map do |entry|
+        date_time = Time.zone.parse(entry[:created].to_s)
+        date_time = previous + TIMESTAMP_STEP if previous && date_time <= previous
+        previous = date_time
+
+        [entry, date_time]
+      end
+    end
+
+    def chronological_entries
+      @pending_entries.sort_by.with_index do |entry, index|
+        [Time.zone.parse(entry[:created].to_s), index]
+      end
     end
 
     # Journals inherit their timestamps from the journable, so the work package has to carry the
@@ -169,20 +195,20 @@ module Import
       (entry["items"] || []).any? { |item| item["field"]&.downcase == "description" }
     end
 
-    def create_history_journal(entry)
+    def create_history_journal(entry, date_time)
       author_name = entry.dig("author", "displayName")
       items = convert_history_items(entry["items"])
 
-      journalize_at(Time.zone.parse(entry["created"].to_s)) do
+      journalize_at(date_time) do
         cause = Journal::CausedByImport.new(author_name:, history: items)
         work_package.add_journal(user: User.system, notes: "", cause:)
       end
     end
 
-    def create_comment_journal(comment, user)
+    def create_comment_journal(comment, user, date_time)
       notes = convert_rich_text(comment["body"])
 
-      journalize_at(Time.zone.parse(comment["created"].to_s)) do
+      journalize_at(date_time) do
         work_package.add_journal(user:, notes:, internal: false)
       end
     end

--- a/app/services/import/jira_import_journals.rb
+++ b/app/services/import/jira_import_journals.rb
@@ -44,7 +44,7 @@ module Import
       parsed = Time.zone.parse(date_time.to_s)
       work_package.update_column(:created_at, parsed)
 
-      creation_journal = work_package.journals.reload.first
+      creation_journal = work_package.journals.first
       return unless creation_journal
 
       creation_journal.update_columns(
@@ -96,7 +96,7 @@ module Import
       attachments = work_package.attachments.pluck(:id, :file)
       return [] if attachments.empty?
 
-      journal_ids = work_package.journals.reload.pluck(:id)
+      journal_ids = work_package.journals.pluck(:id)
       existing = recorded_attachable_pairs(journal_ids)
 
       journal_ids.product(attachments).filter_map do |journal_id, (attachment_id, filename)|

--- a/app/services/import/jira_import_journals.rb
+++ b/app/services/import/jira_import_journals.rb
@@ -37,11 +37,13 @@ module Import
       @pending_entries = []
     end
 
-    def update_creation_entry(date_time:)
+    def set_creation_time(date_time:)
+      parsed = Time.zone.parse(date_time.to_s)
+      work_package.update_column(:created_at, parsed)
+
       creation_journal = work_package.journals.reload.first
       return unless creation_journal
 
-      parsed = Time.zone.parse(date_time.to_s)
       creation_journal.update_columns(
         created_at: parsed,
         updated_at: parsed,
@@ -59,16 +61,34 @@ module Import
       @pending_entries << { type: :comment, data: comment, user:, created: comment["created"] }
     end
 
-    def call
+    def call(updated_at: nil)
       @pending_entries.sort_by { |e| e[:created] }.each do |entry|
         case entry[:type]
         when :history then create_history_journal(entry[:data])
         when :comment then create_comment_journal(entry[:data], entry[:user])
         end
       end
+
+      restore_update_time(updated_at)
     end
 
     private
+
+    # Journals inherit their timestamps from the journable, so the work package has to carry the
+    # Jira timestamp of the entry while it is being journalized.
+    def journalize_at(date_time)
+      work_package.update_column(:updated_at, date_time)
+      yield
+      work_package.save_journals
+    end
+
+    # Each journalized entry leaves its own timestamp on the work package, so the Jira update
+    # date is put back once every entry has been written.
+    def restore_update_time(date_time)
+      return if date_time.blank?
+
+      work_package.update_column(:updated_at, Time.zone.parse(date_time.to_s))
+    end
 
     def same_minute?(time1, time2)
       Time.zone.parse(time1.to_s).change(sec: 0) == Time.zone.parse(time2.to_s).change(sec: 0)
@@ -118,22 +138,19 @@ module Import
     def create_history_journal(entry)
       author_name = entry.dig("author", "displayName")
       items = convert_history_items(entry["items"])
-      date_time = Time.zone.parse(entry["created"].to_s)
 
-      work_package.update_column(:updated_at, date_time)
-
-      cause = Journal::CausedByImport.new(author_name:, history: items)
-      work_package.add_journal(user: User.system, notes: "", cause:)
-      work_package.save_journals
+      journalize_at(Time.zone.parse(entry["created"].to_s)) do
+        cause = Journal::CausedByImport.new(author_name:, history: items)
+        work_package.add_journal(user: User.system, notes: "", cause:)
+      end
     end
 
     def create_comment_journal(comment, user)
       notes = convert_rich_text(comment["body"])
-      date_time = Time.zone.parse(comment["created"].to_s)
 
-      work_package.update_column(:updated_at, date_time)
-      work_package.add_journal(user:, notes:, internal: false)
-      work_package.save_journals
+      journalize_at(Time.zone.parse(comment["created"].to_s)) do
+        work_package.add_journal(user:, notes:, internal: false)
+      end
     end
 
     def convert_history_items(items)

--- a/app/services/import/jira_import_journals.rb
+++ b/app/services/import/jira_import_journals.rb
@@ -72,6 +72,13 @@ module Import
       restore_update_time(updated_at)
     end
 
+    # Records the attachments in every existing journal, so that the import does not surface them
+    # as a change of its own: the replayed Jira changelog is the only record of them.
+    def backfill_attachments
+      rows = missing_attachable_rows
+      Journal::AttachableJournal.insert_all(rows) if rows.any?
+    end
+
     def add_migration_entry(updated_at: nil)
       journalize_at(Time.current) do
         work_package.add_journal(user: User.system, notes: "", cause: Journal::CausedByImport.new(migrated: true))
@@ -81,6 +88,25 @@ module Import
     end
 
     private
+
+    def missing_attachable_rows
+      attachments = work_package.attachments.pluck(:id, :file)
+      return [] if attachments.empty?
+
+      journal_ids = work_package.journals.reload.pluck(:id)
+      existing = recorded_attachable_pairs(journal_ids)
+
+      journal_ids.product(attachments).filter_map do |journal_id, (attachment_id, filename)|
+        { journal_id:, attachment_id:, filename: } unless existing.include?([journal_id, attachment_id])
+      end
+    end
+
+    def recorded_attachable_pairs(journal_ids)
+      Journal::AttachableJournal
+        .where(journal_id: journal_ids)
+        .pluck(:journal_id, :attachment_id)
+        .to_set
+    end
 
     # Journals inherit their timestamps from the journable, so the work package has to carry the
     # Jira timestamp of the entry while it is being journalized.

--- a/app/services/import/jira_import_journals.rb
+++ b/app/services/import/jira_import_journals.rb
@@ -72,6 +72,14 @@ module Import
       restore_update_time(updated_at)
     end
 
+    def add_migration_entry(updated_at: nil)
+      journalize_at(Time.current) do
+        work_package.add_journal(user: User.system, notes: "", cause: Journal::CausedByImport.new(migrated: true))
+      end
+
+      restore_update_time(updated_at)
+    end
+
     private
 
     # Journals inherit their timestamps from the journable, so the work package has to carry the
@@ -82,8 +90,8 @@ module Import
       work_package.save_journals
     end
 
-    # Each journalized entry leaves its own timestamp on the work package, so the Jira update
-    # date is put back once every entry has been written.
+    # The migration entry is journalized at import time, which must not leak into the work package
+    # itself: it keeps reporting the timestamps it had in Jira.
     def restore_update_time(date_time)
       return if date_time.blank?
 

--- a/app/workers/import/jira_create_project_work_package_attachments_job.rb
+++ b/app/workers/import/jira_create_project_work_package_attachments_job.rb
@@ -100,6 +100,7 @@ module Import
 
     private
 
+    # rubocop:disable-next Metrics/AbcSize
     def create_attachment(work_package, attachment, author)
       filename = attachment["filename"]
       content_url = attachment["content"]

--- a/app/workers/import/jira_create_project_work_package_attachments_job.rb
+++ b/app/workers/import/jira_create_project_work_package_attachments_job.rb
@@ -87,6 +87,12 @@ module Import
             create_member(@project, author) if author.present?
             create_attachment(work_package, attachment, author || User.system)
           end
+
+          # This is the last stage touching a work package, so the migration entry closes its
+          # activity behind everything the import journalized.
+          Import::JiraImportJournals
+            .new(work_package:)
+            .add_migration_entry(updated_at: jira_issue.payload.dig("fields", "updated"))
         end
       end
     end

--- a/app/workers/import/jira_create_project_work_package_attachments_job.rb
+++ b/app/workers/import/jira_create_project_work_package_attachments_job.rb
@@ -88,11 +88,11 @@ module Import
             create_attachment(work_package, attachment, author || User.system)
           end
 
+          journal_service = Import::JiraImportJournals.new(work_package:)
+          journal_service.backfill_attachments
           # This is the last stage touching a work package, so the migration entry closes its
           # activity behind everything the import journalized.
-          Import::JiraImportJournals
-            .new(work_package:)
-            .add_migration_entry(updated_at: jira_issue.payload.dig("fields", "updated"))
+          journal_service.add_migration_entry(updated_at: jira_issue.payload.dig("fields", "updated"))
         end
       end
     end
@@ -110,14 +110,25 @@ module Import
         tempfile.define_singleton_method(:original_filename) { filename }
         tempfile.define_singleton_method(:content_type) { mime_type }
         tempfile.define_singleton_method(:size) { size }
-        call = Attachments::CreateService
+        call = Attachments::ImportCreateService
                  .new(user: author, contract_class: EmptyContract)
                  .call(container: work_package, filename:, file: tempfile)
 
         call.on_failure do
           raise call.message
         end
+
+        backdate(call.result, attachment["created"])
       end
+    end
+
+    # Jira attachments cannot be replaced, so both timestamps take the date the file was
+    # attached in Jira rather than the date the import downloaded it.
+    def backdate(record, created)
+      return if created.blank?
+
+      attached_at = Time.zone.parse(created)
+      record.update_columns(created_at: attached_at, updated_at: attached_at)
     end
 
     def create_member(project, member)

--- a/app/workers/import/jira_create_project_work_packages_job.rb
+++ b/app/workers/import/jira_create_project_work_packages_job.rb
@@ -304,8 +304,7 @@ module Import
         journal_service.add_comment(comment:, user: author || User.system)
       end
 
-      jira_updated_at = jira_issue.payload.dig("fields", "updated")
-      journal_service.call(updated_at: jira_updated_at) if jira_updated_at.present?
+      journal_service.call(updated_at: jira_issue.payload.dig("fields", "updated"))
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/app/workers/import/jira_create_project_work_packages_job.rb
+++ b/app/workers/import/jira_create_project_work_packages_job.rb
@@ -291,7 +291,7 @@ module Import
       journal_service = Import::JiraImportJournals.new(work_package:)
 
       jira_created_at = jira_issue.payload.dig("fields", "created")
-      journal_service.update_creation_entry(date_time: jira_created_at) if jira_created_at.present?
+      journal_service.set_creation_time(date_time: jira_created_at) if jira_created_at.present?
 
       history = jira_issue.payload.dig("changelog", "histories")
       journal_service.add_history(history:) if history.present?
@@ -304,7 +304,8 @@ module Import
         journal_service.add_comment(comment:, user: author || User.system)
       end
 
-      journal_service.call
+      jira_updated_at = jira_issue.payload.dig("fields", "updated")
+      journal_service.call(updated_at: jira_updated_at) if jira_updated_at.present?
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3326,6 +3326,7 @@ en:
         field_set: "%{field} set to %{value}"
         field_updated: "%{field} updated"
         header: "changes by %{author}"
+        migrated: "from Jira"
         set_with_diff: "%{field} set (%{link})"
       meeting_cancelled: "(cancelled)"
       meeting_deleted: "(deleted)"

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -178,6 +178,8 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
   end
 
   def import_message
+    return I18n.t("journals.cause_descriptions.import.migrated") if cause["migrated"]
+
     entries = cause["import_history"]
     return "" if entries.blank?
 

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -843,6 +843,25 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
     end
 
+    context "when the work package was migrated" do
+      subject(:cause) do
+        { "type" => "import", "migrated" => true }
+      end
+
+      it "renders the migration message in HTML" do
+        expect(cause).to render_html_variant(
+          "<strong>#{I18n.t('journals.caused_changes.import')}</strong> " \
+          "#{I18n.t('journals.cause_descriptions.import.migrated')}"
+        )
+      end
+
+      it "renders the migration message in plain text" do
+        expect(cause).to render_raw_variant(
+          "#{I18n.t('journals.caused_changes.import')} #{I18n.t('journals.cause_descriptions.import.migrated')}"
+        )
+      end
+    end
+
     context "when import_history is empty" do
       subject(:cause) do
         {

--- a/spec/services/attachments/import_create_service_spec.rb
+++ b/spec/services/attachments/import_create_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Attachments::ImportCreateService do
+  subject(:service) { described_class.new(user:, contract_class: EmptyContract) }
+
+  let(:user) { create(:admin) }
+  let(:work_package) { create(:work_package) }
+  let(:file) { FileHelpers.mock_uploaded_file(name: "picture.png", content_type: "image/png") }
+
+  it "creates the attachment on the container" do
+    call = service.call(container: work_package, filename: "picture.png", file:)
+
+    expect(call).to be_success
+    expect(work_package.attachments.reload.map(&:filename)).to eq(["picture.png"])
+  end
+
+  it "does not journalize the container" do
+    expect { service.call(container: work_package, filename: "picture.png", file:) }
+      .not_to change { work_package.journals.reload.count }
+  end
+
+  it "does not touch the container" do
+    expect { service.call(container: work_package, filename: "picture.png", file:) }
+      .not_to change { work_package.reload.updated_at }
+  end
+end

--- a/spec/services/import/jira_import_journals_spec.rb
+++ b/spec/services/import/jira_import_journals_spec.rb
@@ -280,6 +280,65 @@ RSpec.describe Import::JiraImportJournals, "integration" do
       end
     end
 
+    # Regression: https://community.openproject.org/projects/JIM/work_packages/JIM-152
+    # Journals::CreateService only keeps the timestamp the importer put on the work
+    # package when it is strictly newer than the preceding journal. On a tie it falls back to
+    # statement_timestamp(), stamping the entry with the import date instead.
+    context "when a history entry and a comment share the same timestamp" do
+      let(:shared_time) { "2020-10-06T14:21:57.000+0200" }
+
+      before do
+        service.set_creation_time(date_time: "2020-09-01T10:00:00.000+0000")
+        service.add_history(history: [history_entry(created: shared_time)])
+        service.add_comment(comment: { "created" => shared_time, "body" => "Resolved." }, user: commenter)
+        service.call
+      end
+
+      it "creates a journal per entry" do
+        expect(work_package.journals.reload.count).to eq(3)
+      end
+
+      it "keeps the Jira timestamp on both entries" do
+        imported = work_package.journals.reload.order(:version).drop(1)
+
+        expect(imported.map(&:created_at))
+          .to all(be_within(1.second).of(Time.zone.parse(shared_time)))
+      end
+    end
+
+    context "when two comments share the same timestamp" do
+      let(:shared_time) { "2020-10-06T14:21:57.000+0200" }
+
+      before do
+        service.set_creation_time(date_time: "2020-09-01T10:00:00.000+0000")
+        service.add_comment(comment: { "created" => shared_time, "body" => "First." }, user: commenter)
+        service.add_comment(comment: { "created" => shared_time, "body" => "Second." }, user: commenter)
+        service.call
+      end
+
+      it "keeps the Jira timestamp on both comments" do
+        imported = work_package.journals.reload.order(:version).drop(1)
+
+        expect(imported.map(&:created_at))
+          .to all(be_within(1.second).of(Time.zone.parse(shared_time)))
+      end
+    end
+
+    context "when the first entry shares the work package creation timestamp" do
+      let(:creation_time) { "2020-10-06T14:21:57.000+0200" }
+
+      before do
+        service.set_creation_time(date_time: creation_time)
+        service.add_comment(comment: { "created" => creation_time, "body" => "Filed and closed." }, user: commenter)
+        service.call
+      end
+
+      it "keeps the Jira timestamp on the entry" do
+        expect(work_package.journals.reload.order(:version).last.created_at)
+          .to be_within(1.second).of(Time.zone.parse(creation_time))
+      end
+    end
+
     context "when history entries from the same author within the same minute are grouped" do
       let(:time1) { "2022-03-15T11:00:10.000+0000" }
       let(:time2) { "2022-03-15T11:00:50.000+0000" }

--- a/spec/services/import/jira_import_journals_spec.rb
+++ b/spec/services/import/jira_import_journals_spec.rb
@@ -70,6 +70,44 @@ RSpec.describe Import::JiraImportJournals, "integration" do
     end
   end
 
+  describe "#add_migration_entry" do
+    let(:jira_updated_at) { "2022-03-15T13:00:00.000+0000" }
+
+    before do
+      service.add_comment(
+        comment: { "created" => "2022-03-15T12:00:00.000+0000", "body" => "A comment." },
+        user: commenter
+      )
+      service.call
+    end
+
+    it "appends a migrated import entry after the imported journals" do
+      service.add_migration_entry(updated_at: jira_updated_at)
+
+      journals = work_package.journals.reload.order(:version)
+      expect(journals.count).to eq(3)
+      expect(journals.last.cause).to eq("type" => "import", "migrated" => true)
+    end
+
+    it "journalizes the entry at import time" do
+      service.add_migration_entry(updated_at: jira_updated_at)
+
+      expect(work_package.journals.reload.last.created_at).to be_within(1.minute).of(Time.current)
+    end
+
+    it "sets updated_at of the work package to the Jira timestamp instead of the import time" do
+      service.add_migration_entry(updated_at: jira_updated_at)
+
+      expect(work_package.reload.updated_at).to be_within(1.second).of(Time.zone.parse(jira_updated_at))
+    end
+
+    it "keeps the import time on the work package when no Jira timestamp is given" do
+      service.add_migration_entry
+
+      expect(work_package.reload.updated_at).to be_within(1.minute).of(Time.current)
+    end
+  end
+
   describe "#call" do
     context "with a jira update timestamp" do
       let(:jira_updated_at) { "2022-03-15T13:00:00.000+0000" }

--- a/spec/services/import/jira_import_journals_spec.rb
+++ b/spec/services/import/jira_import_journals_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe Import::JiraImportJournals, "integration" do
     }
   end
 
-  describe "#update_creation_entry" do
+  describe "#set_creation_time" do
     let(:import_date) { "2022-03-15T10:00:00.000+0000" }
 
     it "updates created_at, updated_at and validity_period of the first journal" do
-      service.update_creation_entry(date_time: import_date)
+      service.set_creation_time(date_time: import_date)
 
       journal = work_package.journals.reload.first
       expected_time = Time.zone.parse(import_date)
@@ -58,13 +58,32 @@ RSpec.describe Import::JiraImportJournals, "integration" do
       expect(journal.validity_period.begin).to be_within(1.second).of(expected_time)
     end
 
+    it "sets created_at of the work package" do
+      service.set_creation_time(date_time: import_date)
+
+      expect(work_package.reload.created_at).to be_within(1.second).of(Time.zone.parse(import_date))
+    end
+
     it "does not create extra journals" do
-      expect { service.update_creation_entry(date_time: import_date) }
+      expect { service.set_creation_time(date_time: import_date) }
         .not_to change { work_package.journals.reload.count }
     end
   end
 
   describe "#call" do
+    context "with a jira update timestamp" do
+      let(:jira_updated_at) { "2022-03-15T13:00:00.000+0000" }
+
+      it "sets updated_at of the work package without journalizing it" do
+        service.add_history(history: [history_entry(created: "2022-03-15T11:00:00.000+0000")])
+
+        expect { service.call(updated_at: jira_updated_at) }
+          .to change { work_package.journals.reload.count }.by(1)
+
+        expect(work_package.reload.updated_at).to be_within(1.second).of(Time.zone.parse(jira_updated_at))
+      end
+    end
+
     context "with a single history entry" do
       let(:history_items) do
         [{ "field" => "status", "fromString" => "Open", "toString" => "In Progress" }]

--- a/spec/services/import/jira_import_journals_spec.rb
+++ b/spec/services/import/jira_import_journals_spec.rb
@@ -70,6 +70,52 @@ RSpec.describe Import::JiraImportJournals, "integration" do
     end
   end
 
+  describe "#backfill_attachments" do
+    let!(:attachment) { create(:attachment, container: work_package) }
+
+    before do
+      service.add_comment(
+        comment: { "created" => "2022-03-15T12:00:00.000+0000", "body" => "A comment." },
+        user: commenter
+      )
+      service.call
+    end
+
+    it "records the attachment in every journal" do
+      service.backfill_attachments
+
+      expect(work_package.journals.reload.map { |journal| journal.attachable_journals.pluck(:attachment_id) })
+        .to all(eq([attachment.id]))
+    end
+
+    it "keeps the journals from reporting the attachment as a later change" do
+      service.backfill_attachments
+
+      expect(work_package.journals.reload.reject(&:initial?).flat_map { |journal| journal.details.keys })
+        .not_to include("attachments_#{attachment.id}")
+    end
+
+    it "creates no journal of its own" do
+      expect { service.backfill_attachments }
+        .not_to change { work_package.journals.reload.count }
+    end
+
+    it "can run again without duplicating the records" do
+      service.backfill_attachments
+
+      expect { service.backfill_attachments }
+        .not_to change { Journal::AttachableJournal.where(attachment_id: attachment.id).count }
+    end
+
+    context "without attachments" do
+      let!(:attachment) { nil }
+
+      it "does nothing" do
+        expect { service.backfill_attachments }.not_to change(Journal::AttachableJournal, :count)
+      end
+    end
+  end
+
   describe "#add_migration_entry" do
     let(:jira_updated_at) { "2022-03-15T13:00:00.000+0000" }
 

--- a/spec/workers/import/jira_create_project_work_package_attachments_job_spec.rb
+++ b/spec/workers/import/jira_create_project_work_package_attachments_job_spec.rb
@@ -61,7 +61,23 @@ RSpec.describe Import::JiraCreateProjectWorkPackageAttachmentsJob,
 
     it "journalizes the attachment on the work package" do
       expect { create_work_package_attachments }
-        .to change { WorkPackage.find("DPPP-6").journals.count }.by(1)
+        .to change { WorkPackage.find("DPPP-6").journals.count }.by(2)
+    end
+
+    it "closes the activity with a migration entry" do
+      create_work_package_attachments
+
+      journal = WorkPackage.find("DPPP-6").journals.order(:version).last
+      expect(journal.cause).to eq("type" => "import", "migrated" => true)
+      expect(journal.created_at).to be_within(1.minute).of(Time.current)
+    end
+
+    it "keeps the Jira timestamps on the work package" do
+      create_work_package_attachments
+
+      work_package = WorkPackage.find("DPPP-6")
+      expect(work_package.created_at).to eq(Time.zone.parse(jira_issue_payload["fields"]["created"]))
+      expect(work_package.updated_at).to eq(Time.zone.parse(jira_issue_payload["fields"]["updated"]))
     end
 
     it "adds the attachment author as a project member" do

--- a/spec/workers/import/jira_create_project_work_package_attachments_job_spec.rb
+++ b/spec/workers/import/jira_create_project_work_package_attachments_job_spec.rb
@@ -59,9 +59,46 @@ RSpec.describe Import::JiraCreateProjectWorkPackageAttachmentsJob,
       expect(work_package.attachments.first.filename).to eq("airplane-wing-over-cloudy-sky.jpg")
     end
 
-    it "journalizes the attachment on the work package" do
+    it "takes the attachment timestamps from the date it was attached in Jira" do
+      create_work_package_attachments
+
+      attached_at = Time.zone.parse(jira_issue_payload["fields"]["attachment"].sole["created"])
+      attachment = WorkPackage.find("DPPP-6").attachments.sole
+
+      expect(attachment.created_at).to eq(attached_at)
+      expect(attachment.updated_at).to eq(attached_at)
+    end
+
+    it "does not journalize the attachment, leaving the migration entry as the only addition" do
       expect { create_work_package_attachments }
-        .to change { WorkPackage.find("DPPP-6").journals.count }.by(2)
+        .to change { WorkPackage.find("DPPP-6").journals.count }.by(1)
+    end
+
+    it "records the attachment in every journal, so that none reports it as a later change" do
+      create_work_package_attachments
+
+      journals = WorkPackage.find("DPPP-6").journals.order(:version)
+      attachment = Attachment.sole
+
+      expect(journals.map { |journal| journal.attachable_journals.pluck(:attachment_id) })
+        .to all(eq([attachment.id]))
+      expect(journals.reject(&:initial?).flat_map { |journal| journal.details.keys })
+        .not_to include("attachments_#{attachment.id}")
+    end
+
+    it "keeps the imported Jira changelog as the only record of when it was attached" do
+      create_work_package_attachments
+
+      changelog_entry = jira_issue_payload["changelog"]["histories"].find do |history|
+        history["items"].any? { |item| item["field"] == "Attachment" }
+      end
+      journals = WorkPackage.find("DPPP-6").journals.order(:version).select do |journal|
+        journal.cause_import_history.to_a.any? do |entry|
+          entry["items"].to_a.any? { |item| item["field"] == "Attachment" }
+        end
+      end
+
+      expect(journals.map(&:created_at)).to eq([Time.zone.parse(changelog_entry["created"])])
     end
 
     it "closes the activity with a migration entry" do

--- a/spec/workers/import/jira_create_project_work_packages_job_spec.rb
+++ b/spec/workers/import/jira_create_project_work_packages_job_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe Import::JiraCreateProjectWorkPackagesJob,
           .to change(Import::JiraOpenProjectReference, :count).by_at_least(4)
       end
 
+      context "when the issue carries no updated timestamp" do
+        let(:jira_issue_payload) do
+          super().tap { |payload| payload["fields"].delete("updated") }
+        end
+
+        it "still replays the changelog and the comments" do
+          create_work_packages
+
+          work_package = WorkPackage.find("DPPP-6")
+          expect(work_package.journals.count).to be 17
+          expect(work_package.journals.where(notes: "Demo comment 2").count).to be 1
+        end
+      end
+
       context "if priority is nil or hidden in jira filed configuration" do
         let(:jira_issue_payload) { JSON.parse(Rails.root.join("spec/fixtures/import/jira/issue_without_priority.json").read) }
 

--- a/spec/workers/import/jira_create_project_work_packages_job_spec.rb
+++ b/spec/workers/import/jira_create_project_work_packages_job_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Import::JiraCreateProjectWorkPackagesJob,
         expect(work_package.semantic_aliases.pluck(:identifier).sort).to eq(["DP-6", "DPPP-1", "DPPP-6", "KIWNEU1-8"])
       end
 
+      it "takes the work package timestamps from the jira issue" do
+        create_work_packages
+
+        work_package = WorkPackage.find("DPPP-6")
+        expect(work_package.created_at).to eq(Time.zone.parse(jira_issue_payload["fields"]["created"]))
+        expect(work_package.updated_at).to eq(Time.zone.parse(jira_issue_payload["fields"]["updated"]))
+      end
+
       # rubocop:disable Layout/LineLength
       # rubocop:disable RSpec/ExampleLength
       it "creates appropriate comments on the work package" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-189

# What are you trying to achieve?

Date history of comments/activities was broken for certain combination of data.

# What approach did you choose and why?

- [x] set work_package `update_at` to `updated` from Jira
- [x] set work_package `created_at` to `created` from Jira
- [x] add a journal entry with datetime of the migration
- [x] suppress journal entries created by a later stage for attachment migration
- [x] set the date of all migrated attachments to their created datetime from Jira
- [x] ensure work package creation datetime and all journal entries datetime to be
   - [x]  ordered chronologically (not only by string comparission)
   - [x]  unique (journal requirement) by adding microseconds if they are equal (not visible in UI)

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
