### PR TITLE
[OP-20018] Add "required" option to filters to prevent them from being manually removed

### DIFF
--- a/app/forms/filters/inputs/base_filter_form.rb
+++ b/app/forms/filters/inputs/base_filter_form.rb
@@ -118,6 +118,8 @@ class Filters::Inputs::BaseFilterForm < ApplicationForm
   end
 
   def add_delete_button(group)
+    return if @filter.required?
+
     filter_name = @filter.name
     group.html_content do
       render(Primer::Beta::IconButton.new(

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -96,6 +96,10 @@ class Queries::Filters::Base
     true
   end
 
+  def required?
+    false
+  end
+
   def available_operators
     type_strategy.supported_operator_classes
   end

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -257,23 +257,6 @@ RSpec.describe "Meetings", "Index", :js do
         end
       end
 
-      context "when the time filter is removed via the all filters form" do
-        before do
-          meetings_page.set_quick_filter upcoming: true
-        end
-
-        it "re-applies the upcoming quick filter automatically" do
-          meetings_page.expect_quick_filter_selected "Upcoming"
-
-          meetings_page.open_filters
-          meetings_page.remove_filter "time"
-
-          wait_for_network_idle
-
-          meetings_page.expect_quick_filter_selected "Upcoming"
-        end
-      end
-
       context 'with the "Attendee" filter' do
         before do
           meetings_page.set_sidebar_filter "Attended"

--- a/modules/meeting/spec/models/queries/meetings/filters/time_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/meetings/filters/time_filter_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,40 +28,20 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Queries::Meetings::Filters::TimeFilter < Queries::Meetings::Filters::MeetingFilter
-  def available_operators
-    [Queries::Operators::Upcoming, Queries::Operators::Past]
-  end
+require "spec_helper"
 
-  def default_operator
-    Queries::Operators::Upcoming
-  end
+RSpec.describe Queries::Meetings::Filters::TimeFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :date }
+    let(:class_key) { :time }
+    let(:human_name) { Meeting.human_attribute_name(:start_time) }
 
-  def past?
-    operator.to_sym == Queries::Operators::Past.to_sym
-  end
-
-  def where
-    if past?
-      ['"meetings"."start_time" < ?', Time.current]
-    else
-      ['"meetings"."start_time" + "meetings"."duration" * interval \'1 hour\' >= ?', Time.current]
+    describe "#required?" do
+      it "is true" do
+        expect(instance).to be_required
+      end
     end
-  end
 
-  def human_name
-    Meeting.human_attribute_name(:start_time)
-  end
-
-  def type
-    :date
-  end
-
-  def self.key
-    :time
-  end
-
-  def required?
-    true
+    it_behaves_like "non ar filter"
   end
 end

--- a/spec/forms/filters/inputs/base_filter_form_spec.rb
+++ b/spec/forms/filters/inputs/base_filter_form_spec.rb
@@ -99,6 +99,18 @@ RSpec.describe Filters::Inputs::BaseFilterForm, type: :forms do
     end
   end
 
+  context "when the filter is required" do
+    before do
+      allow(filter).to receive(:required?).and_return(true)
+    end
+
+    it "does not render a delete button" do
+      expect(rendered_form).to have_element "data-filter--filters-form-target": "filter" do |row|
+        expect(row).to have_no_element "tool-tip", text: I18n.t("button_delete")
+      end
+    end
+  end
+
   context "when inactive" do
     let(:active) { false }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-20018

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
