### PR TITLE
[INTERNAL-963] Route form groups by query param, not path

### DIFF
--- a/app/components/work_package_types/form_configuration/group_component.rb
+++ b/app/components/work_package_types/form_configuration/group_component.rb
@@ -88,6 +88,7 @@ module WorkPackageTypes
           group_type: @group[:type].to_s,
           group_key: @group[:key].to_s,
           group_query: @group[:query],
+          update_query_url: update_query_path,
           edit_mode: (true if edit_mode?)
         }.compact.merge(draggable_item_config)
       end
@@ -140,6 +141,10 @@ module WorkPackageTypes
 
       def destroy_path
         type_form_configuration_group_path(type_id: @variant.type_id, variant_id: @variant.id, key: @group[:key])
+      end
+
+      def update_query_path
+        update_query_type_form_configuration_group_path(type_id: @variant.type_id, variant_id: @variant.id, key: @group[:key])
       end
 
       def row_drop_path(attribute)

--- a/app/components/work_package_types/form_configuration/group_header_component.rb
+++ b/app/components/work_package_types/form_configuration/group_header_component.rb
@@ -106,7 +106,7 @@ module WorkPackageTypes
       end
 
       def create_path
-        type_form_configuration_groups_path(**@variant.path_args)
+        type_form_configuration_group_path(**@variant.path_args)
       end
 
       def move_action(menu:, href:, label:, icon:)

--- a/app/components/work_package_types/form_configuration/main_content_component.html.erb
+++ b/app/components/work_package_types/form_configuration/main_content_component.html.erb
@@ -33,7 +33,7 @@
                 menu.with_item(
                   label: t("types.edit.form_configuration.add_attribute_group"),
                   tag: :a,
-                  href: add_group_type_form_configuration_groups_path(**@variant.path_args, group_type: :attribute),
+                  href: add_group_type_form_configuration_group_path(**@variant.path_args, group_type: :attribute),
                   content_arguments: {
                     data: { turbo_method: :post, turbo_stream: true }
                   }

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -79,10 +79,9 @@ module WorkPackageTypes
       {
         controller: "admin--type-form-configuration--main admin--type-form-configuration--rows-drag-and-drop",
         "admin--type-form-configuration--main-no-filter-query-value": @no_filter_query,
-        "admin--type-form-configuration--main-add-group-url-value": add_group_type_form_configuration_groups_path(
+        "admin--type-form-configuration--main-add-group-url-value": add_group_type_form_configuration_group_path(
           **@variant.path_args
         ),
-        "admin--type-form-configuration--main-groups-url-value": type_form_configuration_groups_path(**@variant.path_args),
         "admin--type-form-configuration--rows-drag-and-drop-handle-selector-value": ".attribute-handle"
       }
     end

--- a/app/controllers/work_package_types/form_configuration_groups_tab_controller.rb
+++ b/app/controllers/work_package_types/form_configuration_groups_tab_controller.rb
@@ -158,7 +158,7 @@ module WorkPackageTypes
     end
 
     def group_key_param
-      params[:key] || params[:id]
+      params[:key]
     end
 
     def temporary_group_key?(key)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,17 +178,12 @@ Rails.application.routes.draw do
 
     resource :form_configuration, only: %i[edit update], controller: "form_configuration_tab" do
       get :reset_dialog
-      resources :groups, only: %i[create edit update destroy], controller: "form_configuration_groups_tab", param: :key do
-        collection do
-          post :add_group
-        end
-
-        member do
-          post :cancel_edit
-          put :drop
-          put :move
-          patch :update_query
-        end
+      resource :group, only: %i[create edit update destroy], controller: "form_configuration_groups_tab" do
+        post :add_group
+        post :cancel_edit
+        put :drop
+        put :move
+        patch :update_query
       end
       resources :rows, only: %i[destroy], controller: "form_configuration_tab", param: :row_key do
         member do

--- a/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.spec.ts
@@ -73,13 +73,20 @@ describe('Type form configuration controller', () => {
     vi.restoreAllMocks();
   });
 
+  const updateQueryUrl = '/types/1/form_configuration/group/update_query?key=b%29+%3E+10.000+%2F+20.000+Nutzende';
+
   async function renderConfiguration() {
     await ctx.mount(`
       <div data-controller="admin--type-form-configuration--main"
-           data-admin--type-form-configuration--main-add-group-url-value="/types/1/form_configuration/groups"
-           data-admin--type-form-configuration--main-no-filter-query-value="{}"
-           data-admin--type-form-configuration--main-groups-url-value="/types/1/form_configuration/groups">
-        <div data-admin--type-form-configuration--main-target="groupsContainer"></div>
+           data-admin--type-form-configuration--main-add-group-url-value="/types/1/form_configuration/group/add_group"
+           data-admin--type-form-configuration--main-no-filter-query-value="{}">
+        <div data-admin--type-form-configuration--main-target="groupsContainer">
+          <div data-group-key="b) > 10.000 / 20.000 Nutzende"
+               data-group-query='{"filters":[]}'
+               data-update-query-url="${updateQueryUrl}">
+            <button type="button" data-test-selector="edit-query">Edit query</button>
+          </div>
+        </div>
       </div>
     `);
     return ctx.getController<TypeFormConfigurationControllerType>('admin--type-form-configuration--main');
@@ -110,13 +117,36 @@ describe('Type form configuration controller', () => {
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith(
-        '/types/1/form_configuration/groups',
+        '/types/1/form_configuration/group/add_group',
         expect.objectContaining({ method: 'POST' }),
       );
     });
     const body = (request.mock.calls[0][1] as { body:URLSearchParams }).body;
     expect(body.get('group_type')).toBe('query');
     expect(body.get('query')).toBe(JSON.stringify({ filters: [] }));
+  });
+
+  it('patches the query to the URL rendered on the group instead of building one from the key', async () => {
+    const controller = await renderConfiguration();
+    const button = document.querySelector<HTMLButtonElement>('[data-test-selector="edit-query"]')!;
+
+    controller.editQuery({ preventDefault: vi.fn(), currentTarget: button } as unknown as Event);
+
+    await waitFor(() => {
+      expect(show).toHaveBeenCalled();
+    });
+
+    const config = show.mock.calls[0][0] as QueryEditorConfig;
+    expect(config.currentQuery).toEqual({ filters: [] });
+
+    config.callback({ filters: [{ project: { operator: '=', values: ['1'] } }] });
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        updateQueryUrl,
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
   });
 
   it('does not open the query editor when disconnected before the context resolves', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/type-form-configuration/main.controller.ts
@@ -40,12 +40,10 @@ export default class TypeFormConfigurationController extends Controller {
   static values = {
     addGroupUrl: String,
     noFilterQuery: String,
-    groupsUrl: String,
   };
 
   declare readonly addGroupUrlValue:string;
   declare readonly noFilterQueryValue:string;
-  declare readonly groupsUrlValue:string;
 
   declare services:Promise<PickedServices<'turboRequests'|'externalRelationQueryConfiguration'>>;
 
@@ -76,10 +74,10 @@ export default class TypeFormConfigurationController extends Controller {
     if (!group) return;
 
     void this.openQueryEditor(group.dataset.groupQuery ?? this.noFilterQueryValue, (queryProps:unknown) => {
-      const key = group.dataset.groupKey;
-      if (!key) return;
+      const url = group.dataset.updateQueryUrl;
+      if (!url) return;
 
-      void this.postQueryUpdate(key, queryProps).then((success) => {
+      void this.postQueryUpdate(url, queryProps).then((success) => {
         if (success) {
           group.dataset.groupQuery = JSON.stringify(queryProps);
         }
@@ -107,10 +105,10 @@ export default class TypeFormConfigurationController extends Controller {
     });
   }
 
-  private async postQueryUpdate(groupKey:string, queryProps:unknown):Promise<boolean> {
+  private async postQueryUpdate(url:string, queryProps:unknown):Promise<boolean> {
     const { turboRequests } = await this.services;
 
-    await turboRequests.request(`${this.groupsUrlValue}/${encodeURIComponent(groupKey)}/update_query`, {
+    await turboRequests.request(url, {
       method: 'PATCH',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',

--- a/spec/components/work_package_types/form_configuration/group_component_spec.rb
+++ b/spec/components/work_package_types/form_configuration/group_component_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe WorkPackageTypes::FormConfiguration::GroupComponent, type: :compo
     expect(page).to have_test_selector("type-form-configuration-attribute-handle-assignee")
   end
 
+  it "renders the update-query URL for the group as data" do
+    render_inline(described_class.new(group:, variant:, ee_available: true, first: true, last: true))
+
+    expect(page).to have_css(
+      "[data-group-key='details'][data-update-query-url$='/form_configuration/group/update_query?key=details']"
+    )
+  end
+
   it "renders no handles, menus, or drag data when readonly", :aggregate_failures do
     render_inline(described_class.new(group:, variant:, ee_available: true, first: true, last: true, readonly: true))
 

--- a/spec/controllers/work_package_types/form_configuration_groups_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/form_configuration_groups_tab_controller_spec.rb
@@ -217,6 +217,21 @@ RSpec.describe WorkPackageTypes::FormConfigurationGroupsTabController do
     end
   end
 
+  describe "DELETE #destroy", with_ee: %i[edit_attribute_groups] do
+    let(:group_name) { "b) > 10.000 / 20.000 Nutzende" }
+
+    before do
+      variant.update_column(:attribute_groups, [[group_name, %w[priority]]])
+    end
+
+    it "deletes a group whose name contains special characters" do
+      delete :destroy, params: { type_id: type.id, key: group_name }, format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(variant.reload.attribute_groups.map(&:key)).not_to include(group_name)
+    end
+  end
+
   describe "PUT #drop", with_ee: %i[edit_attribute_groups] do
     it "reorders groups using the requested position" do
       variant.update_column(:attribute_groups, [

--- a/spec/features/types/form_configuration_query_spec.rb
+++ b/spec/features/types/form_configuration_query_spec.rb
@@ -140,6 +140,27 @@ RSpec.describe "form query configuration", :js do
       end
     end
 
+    it "updates the query of a group whose name contains special characters (Regression INTERNAL-963)" do
+      group_name = "b) > 10.000 / 20.000 Nutzende"
+      form.add_query_group(group_name, :children)
+      form.edit_query_group(group_name)
+
+      modal.switch_to "Filters"
+      filters.expect_filter_count 1
+      filters.add_filter_by("Project", "is (OR)", project.name)
+      filters.expect_filter_count 2
+      filters.save
+      wait_for_network_idle
+
+      visit edit_type_form_configuration_path(type_bug)
+      wait_for_network_idle
+      form.edit_query_group(group_name)
+
+      modal.switch_to "Filters"
+      filters.expect_filter_count 2
+      filters.expect_filter_by("Project", "is (OR)", project.name)
+    end
+
     context "with an archived project" do
       let!(:archived) { create(:project, name: "To be archived") }
 

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -324,6 +324,18 @@ RSpec.describe "form configuration", :js, :selenium do
         expect(page).to have_no_css("[data-group-key]", text: /\bRenamed group\b/)
       end
 
+      it "renames and deletes a group whose name contains special characters (Regression INTERNAL-963)" do
+        form.add_attribute_group("b) > 10.000 / 20.000 Nutzende")
+
+        visit edit_type_form_configuration_path(type)
+
+        form.rename_group("b) > 10.000 / 20.000 Nutzende", "b) > 20.000 / 30.000 Nutzende")
+        expect(persisted_group_order).to include("b) > 20.000 / 30.000 Nutzende")
+
+        form.remove_group("b) > 20.000 / 30.000 Nutzende")
+        expect(persisted_group_order).not_to include("b) > 20.000 / 30.000 Nutzende")
+      end
+
       it "shows only the edit action for query rows" do
         form.add_query_group("Subtasks", :children)
 

--- a/spec/routing/types_spec.rb
+++ b/spec/routing/types_spec.rb
@@ -37,6 +37,51 @@ RSpec.describe "types routes" do
                                                 id: "123")
   end
 
+  describe "form configuration groups (mounted on the type edit page)" do
+    let(:key) { "b) > 10.000 / 20.000 Nutzende" }
+    let(:query) { Rack::Utils.build_query(key:) }
+
+    it "carries the group key as a query param rather than a path segment" do
+      expect(delete("/types/42/form_configuration/group?#{query}"))
+        .to route_to("work_package_types/form_configuration_groups_tab#destroy", type_id: "42", key:)
+    end
+
+    it do
+      expect(patch("/types/42/form_configuration/group?#{query}"))
+        .to route_to("work_package_types/form_configuration_groups_tab#update", type_id: "42", key:)
+    end
+
+    it do
+      expect(get("/types/42/form_configuration/group/edit?#{query}"))
+        .to route_to("work_package_types/form_configuration_groups_tab#edit", type_id: "42", key:)
+    end
+
+    it do
+      expect(put("/types/42/form_configuration/group/move?#{query}&move_to=higher"))
+        .to route_to("work_package_types/form_configuration_groups_tab#move", type_id: "42", key:, move_to: "higher")
+    end
+
+    it do
+      expect(patch("/types/42/form_configuration/group/update_query?#{query}"))
+        .to route_to("work_package_types/form_configuration_groups_tab#update_query", type_id: "42", key:)
+    end
+
+    it do
+      expect(put("/types/42/form_configuration/group/drop?#{query}"))
+        .to route_to("work_package_types/form_configuration_groups_tab#drop", type_id: "42", key:)
+    end
+
+    it do
+      expect(post("/types/42/form_configuration/group/cancel_edit?#{query}"))
+        .to route_to("work_package_types/form_configuration_groups_tab#cancel_edit", type_id: "42", key:)
+    end
+
+    it do
+      expect(post("/types/42/form_configuration/group/add_group"))
+        .to route_to("work_package_types/form_configuration_groups_tab#add_group", type_id: "42")
+    end
+  end
+
   describe "workflow tab (mounted on the type edit page)" do
     it do
       expect(get("/types/42/workflow/edit"))


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/INTERNAL-963

# What are you trying to accomplish?

Renaming, moving or deleting a form-configuration section whose name contains a dot or a slash (e.g. `b) > 10.000 Nutzende`) answered with a 404, and editing the query of such a section built a broken URL client-side.

A section has no id of its own: its key is the user-typed name, persisted in the serialized `attribute_groups`. The routes put that key in a path segment, and Rails cannot carry arbitrary text there. A dot starts the format, a slash ends the segment, and a route constraint wide enough to admit both makes URL generation raise while the page renders.

## Screenshots

Section named `b) > 20.000 / 30.000 Nutzende` after rename and move, with every request answering 200:

<img width="1546" height="784" alt="Form configuration page with the renamed section b) > 20.000 / 30.000 Nutzende listed below People" src="https://github.com/user-attachments/assets/ab1f789f-d487-4ffc-90e4-b341985299df" />

# What approach did you choose and why?

The group routes become a singular `resource :group` and the key travels as a `?key=` query parameter, which survives any character. This mirrors how the workflow matrix carries its `tab`, and it keeps every existing route helper call untouched apart from the two collection helpers.

The one URL the Stimulus controller used to assemble from the key is now rendered on the group element as `data-update-query-url`, so no client code interpolates a group name into a path any more.

Sanitising the name with `parameterize` or friendly_id was considered and rejected: it is lossy for non-Latin names (`Детали` becomes empty) and collides on case and punctuation (`Foo Bar`, `foo-bar` and `FOO BAR` are all legal siblings). A stored, stable per-group id would be the proper long-term fix and would need a serialization change plus a migration, which does not belong on a release branch. It is proposed as a follow-up on dev.

Regression coverage is a routing spec (controller specs bypass route recognition and could not catch this), a controller and a component example, a Vitest example for the rendered update-query URL, and two feature scenarios covering rename, delete and query edit of such a section.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
