### PR TITLE
[JIM-203] Attachment cannot be created in OpenProject

### DIFF
--- a/app/services/import/jira_client.rb
+++ b/app/services/import/jira_client.rb
@@ -39,12 +39,17 @@ module Import
     class ParseError < Error; end
 
     class ApiError < Error
-      attr_reader :status, :response_body
+      attr_reader :status, :response_body, :response_headers
 
-      def initialize(message, status: nil, response_body: nil)
+      def initialize(message, status:, response_body:, response_headers:)
         super(message)
         @status = status
         @response_body = response_body
+        @response_headers = response_headers
+      end
+
+      def to_s
+        "#{super}. STATUS: #{@status} RESPONSE_BODY: #{@response_body} RESPONSE_HEADERS: #{@response_headers}"
       end
     end
 
@@ -54,7 +59,7 @@ module Import
     }.freeze
 
     def initialize(url:, personal_access_token:)
-      raise ApiError.new(I18n.t(:"admin.jira.test.token_error")) if personal_access_token.nil?
+      raise Error.new(I18n.t(:"admin.jira.test.token_error")) if personal_access_token.nil?
 
       @url = url.chomp("/")
       @headers = {
@@ -261,7 +266,10 @@ module Import
           yield tempfile
         else
           status = response.code.to_i
-          raise ApiError.new(I18n.t("admin.jira.client.api_error", status:), status:, response_body: response.body)
+          raise ApiError.new(I18n.t("admin.jira.client.api_error", status:),
+                             status:,
+                             response_body: response.body,
+                             response_headers: response.to_hash)
         end
       end
       nil
@@ -312,7 +320,8 @@ module Import
         raise ApiError.new(
           I18n.t("admin.jira.client.#{status}_error", status:, default: :"admin.jira.client.api_error"),
           status:,
-          response_body: response.body.to_s
+          response_body: response.body.to_s,
+          response_headers: response.to_hash
         )
       end
     end

--- a/app/workers/import/jira_create_project_work_package_attachments_job.rb
+++ b/app/workers/import/jira_create_project_work_package_attachments_job.rb
@@ -48,7 +48,7 @@ module Import
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable-next Metrics/AbcSize
     def build_enumerator(jira_import_id, jira_project_id, cursor:)
       @jira_import = Import::JiraImport.find(jira_import_id)
       jira = @jira_import.jira
@@ -70,9 +70,8 @@ module Import
         cursor: cursor
       )
     end
-    # rubocop:enable Metrics/AbcSize
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable-next Metrics/AbcSize
     def each_iteration(jira_issue, _jira_import_id, _jira_project_id)
       Journal::NotificationConfiguration.with(false) do
         Journal::EventConfiguration.with(false) do
@@ -90,10 +89,10 @@ module Import
         end
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
+    # rubocop:disable-next Metrics/AbcSize
     def create_attachment(work_package, attachment, author)
       filename = attachment["filename"]
       content_url = attachment["content"]
@@ -112,6 +111,16 @@ module Import
           raise call.message
         end
       end
+    rescue StandardError => e
+      app_backtrace = Rails.backtrace_cleaner.clean(e.backtrace)
+      project = work_package.project
+      jira_project_for_log = project.slice(:identifier)
+      jira_issue_for_log = work_package.slice(:identifier)
+      attachment_for_log = attachment.slice("id", "size", "self", "content", "filename", "mimeType")
+      OpenProject.logger.error(
+        "Error during jira import attachment creation. Error: #{e}. Jira Project: #{jira_project_for_log} " \
+        "Jira Issue: #{jira_issue_for_log}. Attachment: #{attachment_for_log}. Backtrace: #{app_backtrace}. "
+      )
     end
 
     def create_member(project, member)

--- a/spec/controllers/admin/import/jira/instances_controller_spec.rb
+++ b/spec/controllers/admin/import/jira/instances_controller_spec.rb
@@ -572,7 +572,9 @@ RSpec.describe Admin::Import::Jira::InstancesController do
 
     context "when Import::JiraClient raises ApiError" do
       before do
-        allow(jira_client).to receive(:server_info).and_raise(Import::JiraClient::ApiError.new("Unauthorized", status: 401))
+        allow(jira_client).to receive(:server_info).and_raise(
+          Import::JiraClient::ApiError.new("Unauthorized", status: 401, response_body: "", response_headers: {})
+        )
       end
 
       it "returns an API error message" do

--- a/spec/services/import/jira_client_spec.rb
+++ b/spec/services/import/jira_client_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Import::JiraClient do
       let(:personal_access_token) { nil }
 
       it "raises ApiError" do
-        expect { client }.to raise_error(Import::JiraClient::ApiError)
+        expect { client }.to raise_error(Import::JiraClient::Error)
       end
     end
   end

--- a/spec/workers/import/jira_create_project_work_package_attachments_job_spec.rb
+++ b/spec/workers/import/jira_create_project_work_package_attachments_job_spec.rb
@@ -71,18 +71,36 @@ RSpec.describe Import::JiraCreateProjectWorkPackageAttachmentsJob,
       expect(project.users).to include(op_user)
     end
 
-    context "when the attachment download fails" do
+    context "when the attachment download fails with a redirect" do
       before do
-        stub_request(:get, download_attachment_url).to_return(status: 404, body: "Not Found")
+        stub_request(:get, download_attachment_url).to_return(
+          status: 302, body: "Redirect body.", headers: { "Location" => "https://login.example.com" }
+        )
+        allow(OpenProject.logger).to receive(:error)
       end
 
-      it "fails the job so that the import run reports the error" do
-        expect { create_work_package_attachments }
-          .to raise_error(Import::JiraClient::ApiError, "Jira API returned error status 404")
+      it "logs the error with context details" do
+        create_work_package_attachments
+
+        # rubocop:disable-next Layout/LineLength
+        expect(OpenProject.logger).to have_received(:error).with(
+          a_string_including(
+            "Error during jira import attachment creation. Error: Jira API returned error status 302.",
+            "STATUS: 302 RESPONSE_BODY: Redirect body. RESPONSE_HEADERS: {\"location\" => [\"https://login.example.com\"]}.",
+            "Jira Project: {\"identifier\" => \"DPPP\"}",
+            "Jira Issue: {\"identifier\" => \"DPPP-6\"}.",
+            "Attachment: {\"id\" => \"10100\", \"size\" => 136426, \"self\" => \"https://jira-dc.openproject.org/rest/api/2/attachment/10100\", \"content\" => \"https://jira-dc.openproject.org/secure/attachment/10100/airplane-wing-over-cloudy-sky.jpg\", \"filename\" => \"airplane-wing-over-cloudy-sky.jpg\", \"mimeType\" => \"image/jpeg\"}.",
+            "Backtrace: "
+          )
+        )
+      end
+
+      it "does not interrupt the import" do
+        expect { create_work_package_attachments }.not_to raise_error
       end
 
       it "does not create an attachment" do
-        expect { create_work_package_attachments }.to raise_error(Import::JiraClient::ApiError)
+        create_work_package_attachments
 
         expect(WorkPackage.find("DPPP-6").attachments).to be_empty
       end
@@ -90,10 +108,9 @@ RSpec.describe Import::JiraCreateProjectWorkPackageAttachmentsJob,
 
     context "when the import is aborting" do
       before do
-        # rubocop:disable RSpec/AnyInstance
+        # rubocop:disable-next RSpec/AnyInstance
         allow_any_instance_of(Import::JiraImport)
           .to receive(:in_state?).with(:import_aborting).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
       end
 
       it "stops iterating and reports the abortion" do

--- a/spec/workers/import/jira_fetch_users_job_spec.rb
+++ b/spec/workers/import/jira_fetch_users_job_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Import::JiraFetchUsersJob do
     end
 
     context "when a mentioned user does not exist in Jira" do
-      let(:api_error) { Import::JiraClient::ApiError.new("User not found", status: 404) }
+      let(:api_error) { Import::JiraClient::ApiError.new("User not found", status: 404, response_body: "", response_headers: {}) }
 
       before do
         allow(jira_client).to receive(:user_by_username).with(username: "alice").and_return({ "key" => "JIRAUSER100" })
@@ -155,7 +155,7 @@ RSpec.describe Import::JiraFetchUsersJob do
     end
 
     context "when resolving a mentioned user fails with a non-404 error" do
-      let(:api_error) { Import::JiraClient::ApiError.new("Boom", status: 500) }
+      let(:api_error) { Import::JiraClient::ApiError.new("Boom", status: 500, response_body: "", response_headers: {}) }
 
       before do
         allow(jira_client).to receive(:user_by_username).with(username: "alice").and_raise(api_error)
@@ -163,7 +163,7 @@ RSpec.describe Import::JiraFetchUsersJob do
 
       it "raises an error" do
         expect { job.send(:resolve_mention_user_keys, %w[alice], user_keys, jira_client) }
-          .to raise_error("Could not resolve mentioned user 'alice': Boom")
+          .to raise_error(/Could not resolve mentioned user 'alice': Boom/)
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/JIM-203

- Log the error and context details. 
- Does not interrupt the import if attachment download fails.