### PR TITLE
[DREAM-831] Save button has the wrong colour in admin/user setttings

### DIFF
--- a/app/forms/custom_fields/details_form.rb
+++ b/app/forms/custom_fields/details_form.rb
@@ -229,7 +229,7 @@ module CustomFields
         )
       end
 
-      details_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :default)
+      details_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
     end
 
     def label(field)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-831

# What are you trying to accomplish?

The saving action is now the primary CTA on the page.

## Screenshots

<img width="986" height="721" alt="Screenshot 2026-09-11 at 09 10 13" src="https://github.com/user-attachments/assets/d5c61767-8a13-4785-8500-77d8a7725097" />

# What approach did you choose and why?

# Merge checklist

- [x] ~~Added/updated tests~~
- [x] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
