### PR TITLE
[AUTOWORK-154] Dialog to switch to linked mode is too short  

### DIFF
--- a/app/components/work_package_types/configuration_links/dialog_component.html.erb
+++ b/app/components/work_package_types/configuration_links/dialog_component.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% dialog.with_header(variant: :large) %>
 
   <%= primer_form_with(url: confirm_path, method: :post) do |form| %>
-    <%= render(Primer::Alpha::Dialog::Body.new(classes: "Overlay-body_autocomplete_height")) do %>
+    <%= render(Primer::Alpha::Dialog::Body.new(classes: "Overlay-body_autocomplete_height--lg")) do %>
       <%= render(Primer::Beta::Text.new(tag: :p)) { t("types.edit.reuse_mode.inherited.dialog.description") } %>
       <%= render(WorkPackageTypes::ConfigurationLinks::SourceForm.new(form, variant:, aspect:)) %>
     <% end %>


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/AUTOWORK-154
