### PR TITLE
[BNE-152] Favorites not found in the project picker on QA edge

### DIFF
--- a/app/models/queries/projects/filters/favorited_filter.rb
+++ b/app/models/queries/projects/filters/favorited_filter.rb
@@ -56,22 +56,20 @@ class Queries::Projects::Filters::FavoritedFilter < Queries::Projects::Filters::
     User.current.logged?
   end
 
-  def apply_to(_query_scope)
-    if filtering_for_true?
-      super.where(id: favorited_project_ids)
-    else
-      super.where.not(id: favorited_project_ids)
-    end
-  end
-
-  # Handled by scope
+  # A condition on `id` does not survive here: endpoints like
+  # /work_packages/available_projects merge an id-restricting scope onto the
+  # query, and that merge drops the query's own conditions on the same column.
   def where
-    nil
+    exists = favorites_of_current_user.arel.exists
+
+    filtering_for_true? ? exists : exists.not
   end
 
-  def favorited_project_ids
+  private
+
+  def favorites_of_current_user
     Favorite
       .where(favorited_type: "Project", user_id: User.current.id)
-      .select(:favorited_id)
+      .where(Favorite.arel_table[:favorited_id].eq(Project.arel_table[:id]))
   end
 end

--- a/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
@@ -69,6 +69,28 @@ RSpec.describe API::V3::WorkPackages::AvailableProjectsOnCreateAPI do
     end
   end
 
+  context "with a favored filter present" do
+    let(:favored_project) { create(:project) }
+    let(:member) do
+      create(:member, principal: current_user, project: favored_project, roles: [add_role])
+    end
+
+    before do
+      project
+      member
+      Favorite.create!(user: current_user, favorited: favored_project)
+
+      params = [{ favored: { operator: "=", values: ["t"] } }]
+      escaped = CGI.escape(JSON.dump(params))
+
+      get "#{api_v3_paths.available_projects_on_create}?filters=#{escaped}"
+    end
+
+    it_behaves_like "API V3 collection response", 1, 1, "Project" do
+      let(:elements) { [favored_project] }
+    end
+  end
+
   describe "with a single project" do
     before do
       project


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-152

# What are you trying to accomplish?
Favorites are missing from the project picker of the create work package form in documents - the "Favorites" tab answers "No results" on instances with more projects than one API page.

`/api/v3/work_packages/available_projects` silently ignores the `favored` filter. The endpoint ends in `query.results.merge(Project.allowed_to(user, :add_work_packages))`, and `merge` is override semantics: the left predicate is dropped when the scope conditions the same column. The scope conditions `projects.id`, the filter was `where(id: favorited_project_ids)` - so it vanished, with a 200 and no warning, and the endpoint answered with the first page of all projects.

It looks healthy locally because the picker re-filters that page in the browser by `favorited`, which is correct as long as everything fits into one page.

# What approach did you choose and why?
`FavoritedFilter` now states its restriction as a correlated `EXISTS` from the regular `where` hook instead of overriding `apply_to` with a condition on `id`. An Exists node is not an equality node, so the merge has nothing to override. Same shape as `FilterOnProjectType`. Bonus: `NOT EXISTS` instead of `id NOT IN (subquery)`, and it fits the unique index on `favorites`.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
