### PR TITLE
Switch `autocomplete_append_to` to in `dialog_id` in FilterComponent and also apply it to date pickers

### DIFF
--- a/app/components/filters/filter_form_component.rb
+++ b/app/components/filters/filter_form_component.rb
@@ -71,11 +71,10 @@
 # (`wrap_with_controller: true`); otherwise the host's controller wrapper
 # decides.
 #
-# `autocomplete_append_to:` forwards an `appendTo` selector (or DOM reference
-# string ng-select understands, e.g. `"#my-dialog"` or `"body"`) to every
-# autocompleter the component renders. Use this when the component is embedded
-# in a Primer dialog or another container that clips overflow, so the dropdown
-# portal renders outside that container instead of being clipped.
+# `dialog_id:` names the dialog hosting the form. Pass it when the component is
+# embedded in a Primer dialog so the overlays the filter inputs open (ng-select
+# dropdowns and flatpickr calendars) are portalled into the dialog instead of
+# being clipped by it or rendered behind it.
 class Filters::FilterFormComponent < ApplicationComponent
   include OpPrimer::AttributesHelper
   include Primer::FetchOrFallbackHelper
@@ -89,7 +88,7 @@ class Filters::FilterFormComponent < ApplicationComponent
                  wrap_with_controller: false,
                  hidden_input_name: nil,
                  output_format: nil,
-                 autocomplete_append_to: nil,
+                 dialog_id: nil,
                  **wrapper_arguments)
     super()
     @builder = builder
@@ -98,7 +97,7 @@ class Filters::FilterFormComponent < ApplicationComponent
     @wrap_with_controller = wrap_with_controller
     @hidden_input_name = hidden_input_name
     @output_format = fetch_or_fallback(OUTPUT_FORMATS, output_format.to_sym) if output_format
-    @autocomplete_append_to = autocomplete_append_to
+    @dialog_id = dialog_id
     @wrapper_arguments = wrapper_arguments
     @wrapper_arguments[:tag] ||= :div
     @wrapper_arguments[:classes] = class_names(
@@ -146,7 +145,7 @@ class Filters::FilterFormComponent < ApplicationComponent
   def sub_forms
     forms = map_filter do |filter, active, additional_attributes|
       filter_form_class(filter)
-        .new(@builder, filter:, additional_attributes:, active:)
+        .new(@builder, filter:, additional_attributes:, active:, dialog_id: @dialog_id)
     end
 
     forms << Filters::Inputs::AddFilterForm.new(
@@ -167,7 +166,7 @@ class Filters::FilterFormComponent < ApplicationComponent
 
   def additional_filter_attributes(filter)
     opts = filter.autocomplete_options
-    opts = opts.merge(appendTo: @autocomplete_append_to) if @autocomplete_append_to
+    opts = opts.merge(appendTo: "##{@dialog_id}") if @dialog_id
     opts.any? ? { autocomplete_options: opts } : {}
   end
 

--- a/app/forms/filters/inputs/base_filter_form.rb
+++ b/app/forms/filters/inputs/base_filter_form.rb
@@ -29,11 +29,12 @@
 #++
 
 class Filters::Inputs::BaseFilterForm < ApplicationForm
-  def initialize(filter:, additional_attributes:, active:)
+  def initialize(filter:, additional_attributes:, active:, dialog_id: nil)
     super()
     @filter = filter
     @additional_attributes = additional_attributes
     @active = active
+    @dialog_id = dialog_id
   end
 
   def self.inherited(subclass)

--- a/app/forms/filters/inputs/date_form.rb
+++ b/app/forms/filters/inputs/date_form.rb
@@ -96,7 +96,10 @@ class Filters::Inputs::DateForm < Filters::Inputs::BaseFilterForm
       hidden: value.nil?,
       leading_visual: { icon: :calendar },
       value: value || "",
-      datepicker_options: { input_attributes: { "data-filter--filters-form-target" => "singleDay" } },
+      datepicker_options: {
+        inDialog: @dialog_id,
+        input_attributes: { "data-filter--filters-form-target" => "singleDay" }
+      }.compact,
       data: { "filter-name": filter_name }
     )
   end
@@ -109,7 +112,10 @@ class Filters::Inputs::DateForm < Filters::Inputs::BaseFilterForm
       hidden: value.nil?,
       leading_visual: { icon: :calendar },
       value: value || "-",
-      datepicker_options: { input_attributes: { "data-filter--filters-form-target" => "dateRange" } },
+      datepicker_options: {
+        inDialog: @dialog_id,
+        input_attributes: { "data-filter--filters-form-target" => "dateRange" }
+      }.compact,
       data: { "filter-name": filter_name }
     )
   end

--- a/lookbook/docs/patterns/11-filter-forms.md.erb
+++ b/lookbook/docs/patterns/11-filter-forms.md.erb
@@ -36,84 +36,15 @@ To restrict or reorder the advertised filters, subclass `Filter::FilterComponent
 and override `allowed_filters`:
 
 ```ruby
-class MyFiltersComponent < Filter::FilterComponent
+class MyFiltersComponent <Filter::FilterComponent
   def allowed_filters
     super
-      .grep_v(SomeNoisyFilter)
-      .sort_by(&:human_name)
-  end
-end
-```
-
-`turbo_requests?` toggles whether changes auto-submit via a turbo stream or
-require an explicit Apply click. `lazy_loaded_path` defers the actual filter
-rendering until the dropdown is opened (a skeleton is shown in the meantime).
-
+      .grep_v
 <%= embed OpenProject::Filter::FiltersComponentPreview, :default, panels: %i[preview source] %>
-
-## Filters::FilterFormComponent
-
-For everything that isn't a standard filter dropdown, render
-`FilterFormComponent` inside any `primer_form_with` block. It accepts the
-parent's primer form builder so its inputs sit at the top level of the
-surrounding form (field names like `operator_<filter>` and `<filter>_value`
-— same as `FilterComponent`).
-
-### Default usage
-
-`wrap_with_controller: true` makes the component emit its own
-`<div class="op-filters-form -expanded" data-controller="filter--filters-form">`
-wrapper. Use this in any standalone embed (a dialog body, a settings page,
-etc.) where there's no surrounding sub-header attaching the controller for
-you.
-
 <%= embed OpenProject::Filter::FilterFormPreview, :default, panels: %i[preview source] %>
-
-### With an active filter
-
-Pre-populate the query and the corresponding row is rendered visible with
-its operator/values filled in. Inactive filters still render but stay
-hidden until the user picks them from the "Add filter" select.
-
 <%= embed OpenProject::Filter::FilterFormPreview, :with_active_filter, panels: %i[preview source] %>
-
-### Submitting via a hidden field
-
-By default the component relies on the Stimulus controller to redirect via
-`sendForm` (the projects-index style). Inside a regular form you usually
-want the filter state to ride along with a normal submit instead. Pass
-`hidden_input_name:` and the component renders a hidden input whose value
-is kept in sync with the serialized filter selections.
-
-`output_format:` controls the serialization:
-
-* `:params` (default) — URL-style: `name ~ "foo"&login ! "bar"`.
-* `:json` — JSON array of `{name: {operator, values}}` objects, easier to
-  parse server-side.
-
-The host server receives the canonical string in
-`params[:<hidden_input_name>]` — no special routing or interception needed.
-
 <%= embed OpenProject::Filter::FilterFormPreview, :with_hidden_input, panels: %i[preview params] %>
-
-### Combining with non-filter inputs
-
-`FilterFormComponent` is rendered next to normal Primer form objects, not
-inside `Primer::Forms::FormList`. Render any regular form objects through
-a `FormList`, then render `FilterFormComponent` with the same builder. All
-fields still submit through the same surrounding `<form>`.
-
 <%= embed OpenProject::Filter::FilterFormPreview, :combined_with_other_inputs, panels: %i[preview source] %>
-
-### Inside a clipping container (dialogs)
-
-ng-select dropdowns are positioned by their parent; if the component lives
-inside a Primer dialog or any other overflow-clipping container, the
-dropdown gets cut off. Pass `autocomplete_append_to:` with a CSS selector
-that ng-select can resolve (typically the dialog id, or `"body"`) — the
-component forwards it as `appendTo` to every autocompleter it renders.
-
-```erb
 <%%= primer_form_with(...) do |f| %>
   <%%= render(
     Filters::FilterFormComponent.new(
@@ -121,51 +52,11 @@ component forwards it as `appendTo` to every autocompleter it renders.
       query: @query,
       wrap_with_controller: true,
       hidden_input_name: "filters",
-      autocomplete_append_to: "#my-dialog"
+      dialog_id: "my-dialog"
     )
   ) %>
 <%% end %>
-```
-
-## When to use which
-
-| You want…                                                | Use                       |
-|----------------------------------------------------------|---------------------------|
-| The standard OpenProject filter panel on an index page   | `Filter::FilterComponent` |
-| Filters inside a dialog or a non-filter form             | `Filters::FilterFormComponent` + `hidden_input_name:`   |
-
-## Stimulus controller placement
-
-The `filter--filters-form` controller has to sit on a **common ancestor**
-of every filter UI that should coordinate. It does two things callers tend
-to forget about:
-
-1. `parseFilters()` collects values from both the inline quick filter
-   (`simpleFilter` targets) and the advanced filter rows (`filter`
-   targets). If they live under different controller instances, typing in
-   the quick input won't include active advanced filters in the URL.
-2. The clear-button on a quick filter (`clearButtonIdValue`) hooks back
-   into the same controller.
-
-That's why `Filter::FilterComponent` does *not* attach the controller
-itself — the surrounding `IndexSubHeaderComponent` does, so quick filter
-and advanced form share one. For standalone embeds without a co-located
-quick filter, `FilterFormComponent`'s `wrap_with_controller: true` is the
-right default.
-
-## Compatibility with the legacy `Query` (work packages)
-
-`Filters::FilterFormComponent` reads three things off the query:
-`available_advanced_filters`, `filters`, and `find_active_filter(name)`.
-The first two come from the `Queries::Filters::AvailableFilters` concern,
-which the legacy work-package `Query` model also includes.
-`find_active_filter` is defined directly on `Queries::BaseQuery` and used
-to live only there — `Query` now mirrors it with the same signature, so
-passing a `Query` (or any of its subclasses) to `FilterFormComponent` works
-exactly like passing a `BaseQuery` subclass.
-
 <%= embed OpenProject::Filter::FilterFormPreview, :for_a_work_package_query, panels: %i[preview source] %>
-
 What `FilterFormComponent` does *not* do for you on the legacy side:
 parsing the form submission back into a `Query#filters` collection. The
 work-package filter pipeline still uses its own serialization (URL

--- a/modules/resource_management/app/components/resource_allocations/allocation_step/form_component.rb
+++ b/modules/resource_management/app/components/resource_allocations/allocation_step/form_component.rb
@@ -36,8 +36,8 @@ module ResourceAllocations
       include OpPrimer::ComponentHelpers
 
       # `dialog_id` names the dialog hosting the form (autocompleter dropdowns
-      # attach to it): the create wizard's by default, the edit dialog's when
-      # editing a persisted allocation.
+      # and date picker calendars attach to it): the create wizard's by default,
+      # the edit dialog's when editing a persisted allocation.
       def initialize(allocation:, project:, allocation_kind:,
                      dialog_id: ResourceAllocations::NewDialogComponent::DIALOG_ID,
                      view: nil)
@@ -87,7 +87,7 @@ module ResourceAllocations
                          wrap_with_controller: true,
                          hidden_input_name: "filters",
                          output_format: :json,
-                         autocomplete_append_to: "##{dialog_id}"
+                         dialog_id:
                        )
                      ]
                    else

--- a/modules/resource_management/app/components/resource_planner_views/configure_step/form_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/configure_step/form_component.html.erb
@@ -67,7 +67,7 @@
                   wrap_with_controller: true,
                   hidden_input_name: "filters",
                   output_format: :json,
-                  autocomplete_append_to: "##{@dialog_id}"
+                  dialog_id: @dialog_id
                 )
               )
             end

--- a/spec/components/filters/filter_form_component_spec.rb
+++ b/spec/components/filters/filter_form_component_spec.rb
@@ -240,9 +240,11 @@ RSpec.describe Filters::FilterFormComponent, type: :component do
     end
   end
 
-  describe "autocomplete_append_to:" do
-    # `appendTo` arrives at the angular component as a JSON-encoded data
-    # attribute (`angular_component_tag` json-encodes its `inputs:` hash).
+  describe "dialog_id:" do
+    let!(:date_field) { create(:user_custom_field, field_format: "date") }
+
+    # The overlay targets arrive at the angular components as JSON-encoded data
+    # attributes (`angular_component_tag` json-encodes its `inputs:` hash).
     def append_to_value_in(filter_name)
       page.find(:element,
                 "data-filter-name": filter_name,
@@ -252,15 +254,30 @@ RSpec.describe Filters::FilterFormComponent, type: :component do
           .then { |v| JSON.parse(v) }
     end
 
-    it "forwards the selector into the autocomplete options of ListForm filters" do
-      render_form(query:, autocomplete_append_to: "#dialog-x")
+    def in_dialog_values_in(filter_name)
+      page.find(:element,
+                "data-filter--filters-form-target": /filterValueContainer/,
+                "data-filter-name": filter_name,
+                visible: :all)
+          .all(:element, "data-in-dialog": /.*/, visible: :all)
+          .map { |picker| JSON.parse(picker["data-in-dialog"]) }
+    end
+
+    it "forwards the dialog selector into the autocomplete options of ListForm filters" do
+      render_form(query:, dialog_id: "dialog-x")
 
       # :status is a list filter (no native autocomplete_options) and is
       # routed to ListForm.
       expect(append_to_value_in("status")).to eq("#dialog-x")
     end
 
-    it "is absent from autocomplete data when not set" do
+    it "forwards the dialog id to the date pickers of DateForm filters" do
+      render_form(query:, dialog_id: "dialog-x")
+
+      expect(in_dialog_values_in("cf_#{date_field.id}")).to eq(%w[dialog-x dialog-x])
+    end
+
+    it "is absent from autocomplete and date picker data when not set" do
       render_form
 
       expect(page).to have_element "data-filter-name": "status",
@@ -268,6 +285,7 @@ RSpec.describe Filters::FilterFormComponent, type: :component do
                                    visible: :all do |wrapper|
         expect(wrapper).to have_no_element "data-append-to": /.*/, visible: :all
       end
+      expect(in_dialog_values_in("cf_#{date_field.id}")).to be_empty
     end
   end
 

--- a/spec/forms/filters/inputs/date_form_spec.rb
+++ b/spec/forms/filters/inputs/date_form_spec.rb
@@ -91,4 +91,27 @@ RSpec.describe Filters::Inputs::DateForm, type: :forms do
       expect(days_input["hidden"]).to eq("hidden")
     end
   end
+
+  # `inDialog` reaches the angular picker as a JSON-encoded data attribute.
+  describe "dialog_id" do
+    context "when given" do
+      let(:dialog_id) { "my-dialog" }
+
+      it "attaches both pickers to the dialog so the calendar is not clipped by it" do
+        expect(rendered_form).to have_element "opce-basic-single-date-picker",
+                                              "data-in-dialog": '"my-dialog"',
+                                              visible: :all
+        expect(rendered_form).to have_element "opce-range-date-picker",
+                                              "data-in-dialog": '"my-dialog"',
+                                              visible: :all
+      end
+    end
+
+    context "when not given" do
+      it "leaves the pickers without a dialog target" do
+        expect(rendered_form).to have_element "opce-basic-single-date-picker", visible: :all
+        expect(rendered_form).to have_no_element "data-in-dialog": /.*/, visible: :all
+      end
+    end
+  end
 end

--- a/spec/support/forms/rendered_filter_input_form.rb
+++ b/spec/support/forms/rendered_filter_input_form.rb
@@ -33,16 +33,19 @@ RSpec.shared_context "with rendered filter input form" do
 
   let(:additional_attributes) { {} }
   let(:active) { true }
+  let(:dialog_id) { nil }
 
   def vc_render_filter_form(
     form_class = described_class,
     filter: self.filter,
     additional_attributes: self.additional_attributes,
-    active: self.active
+    active: self.active,
+    dialog_id: self.dialog_id
   )
-    render_in_view_context(form_class, filter, additional_attributes, active) do |form_class, filter, attrs, active|
+    render_in_view_context(form_class, filter, additional_attributes, active,
+                           dialog_id) do |form_class, filter, attrs, active, dialog|
       primer_form_with(url: "/test", method: :post) do |f|
-        render(form_class.new(f, filter:, additional_attributes: attrs, active:))
+        render(form_class.new(f, filter:, additional_attributes: attrs, active:, dialog_id: dialog))
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/RESMA/work_packages/RESMA-72/activity

# What are you trying to accomplish?
- We already handled properly setting the `appendTo` for autocompleters when using the `FilterComponent` in a dialog. 
- For date pickers we did not do that so a date picker (i.e. in a *Created on* filter) was rendered behind the modal

## Screenshots
<img width="788" height="689" alt="image" src="https://github.com/user-attachments/assets/395a2d41-7e9d-4c8e-a627-1dbaf65dc5bc" />

# What approach did you choose and why?
- Remove `autocomplete_append_to` param for the `FilterComponent` and replace it with a `dialog_id` and properly forward it to the Flatpickr and the ng-select

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
