### PR TITLE
[OP-20147] Consolidate Turbo request handling

### DIFF
--- a/frontend/src/app/core/turbo/turbo-requests.service.spec.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.spec.ts
@@ -1,0 +1,270 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { TestBed } from '@angular/core/testing';
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { ToastService } from 'core-app/shared/components/toaster/toast.service';
+import { TurboHelpers } from 'core-turbo/helpers';
+import { TurboRequestError } from 'core-turbo/turbo-request-error';
+import { TurboRequestsService } from './turbo-requests.service';
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const STREAM_HTML = '<turbo-stream action="append" target="service-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse(status = 200, html = '<p>Plain page</p>'):Response {
+  return new Response(html, { status, headers: { 'Content-Type': 'text/html; charset=utf-8', 'X-Custom': 'yes' } });
+}
+
+describe('TurboRequestsService', () => {
+  let service:TurboRequestsService;
+  let fetchSpy:Mock;
+  let addError:Mock;
+  let target:HTMLElement;
+  let csrfMeta:HTMLMetaElement;
+
+  beforeEach(() => {
+    addError = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        TurboRequestsService,
+        { provide: ToastService, useValue: { addError } },
+      ],
+    });
+    service = TestBed.inject(TurboRequestsService);
+
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(htmlResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'service-target';
+    document.body.appendChild(target);
+
+    csrfMeta = document.createElement('meta');
+    csrfMeta.name = 'csrf-token';
+    csrfMeta.content = 'token-123';
+    document.head.appendChild(csrfMeta);
+  });
+
+  afterEach(() => {
+    target.remove();
+    csrfMeta.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const lastInit = () => fetchSpy.mock.lastCall?.[1] as RequestInit & { headers:Headers };
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  describe('request', () => {
+    it('resolves with the response text and headers', async () => {
+      const result = await service.request('/page');
+
+      expect(result.html).toBe('<p>Plain page</p>');
+      expect(result.headers.get('X-Custom')).toBe('yes');
+      expect(renderedChunks()).toBe(0);
+    });
+
+    it('sends legacy requests with browser defaults and the CSRF token on unsafe methods', async () => {
+      await service.request('/page', { method: 'POST' });
+
+      expect(lastInit().method).toBe('POST');
+      expect(lastInit().headers.get('X-CSRF-Token')).toBe('token-123');
+      expect(lastInit().headers.has('Accept')).toBe(false);
+      expect(lastInit().headers.has('X-Requested-With')).toBe(false);
+
+      await service.request('/page');
+
+      expect(lastInit().headers.has('X-CSRF-Token')).toBe(false);
+    });
+
+    it('renders a successful stream once and resolves', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse());
+
+      const result = await service.request('/dialog');
+
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await flush();
+      expect(renderedChunks()).toBe(1);
+      expect(result.html).toBe(STREAM_HTML);
+    });
+
+    it('renders a 422 stream once and rejects with the status', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(422));
+
+      const pending = service.request('/form');
+
+      await expect(pending).rejects.toBeInstanceOf(TurboRequestError);
+      await expect(pending).rejects.toMatchObject({ status: 422 });
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await flush();
+      expect(renderedChunks()).toBe(1);
+      expect(addError).toHaveBeenCalledOnce();
+    });
+
+    it('renders other error streams once and rejects with the status', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(500));
+
+      await expect(service.request('/form')).rejects.toMatchObject({ status: 500 });
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await flush();
+      expect(renderedChunks()).toBe(1);
+    });
+
+    it('rejects non-stream HTTP errors with a TurboRequestError', async () => {
+      fetchSpy.mockResolvedValueOnce(htmlResponse(404));
+
+      await expect(service.request('/missing')).rejects.toMatchObject({ status: 404, name: 'TurboRequestError' });
+      expect(renderedChunks()).toBe(0);
+    });
+
+    it('logs instead of toasting when the toast is suppressed', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      fetchSpy.mockResolvedValueOnce(htmlResponse(500));
+
+      await expect(service.request('/missing', {}, true)).rejects.toMatchObject({ status: 500 });
+
+      expect(addError).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledOnce();
+    });
+
+    it('does not treat an authentication challenge as a redirect', async () => {
+      const href = window.location.href;
+      fetchSpy.mockResolvedValueOnce(new Response('', { status: 401, headers: { 'WWW-Authenticate': 'Bearer realm="OpenProject API"' } }));
+
+      await expect(service.request('/protected')).rejects.toMatchObject({ status: 401 });
+
+      expect(window.location.href).toBe(href);
+    });
+  });
+
+  describe('cancellation', () => {
+    function pendingFetch() {
+      let signal:AbortSignal|undefined;
+      let reject!:(error:Error) => void;
+      fetchSpy.mockImplementationOnce((_url:string, init:RequestInit) => {
+        signal = init.signal ?? undefined;
+
+        return new Promise<Response>((_resolve, rej) => { reject = rej; });
+      });
+
+      return {
+        get signal() { return signal; },
+        abort: () => reject(new DOMException('The operation was aborted.', 'AbortError')),
+      };
+    }
+
+    it('aborts the previous request with the same id', async () => {
+      const first = pendingFetch();
+      const firstRequest = service.request('/a', {}, false, 'slot');
+      const second = pendingFetch();
+      const secondRequest = service.request('/a', {}, false, 'slot');
+
+      expect(first.signal?.aborted).toBe(true);
+      expect(second.signal?.aborted).toBe(false);
+
+      first.abort();
+      await expect(firstRequest).rejects.toMatchObject({ name: 'AbortError' });
+      expect(addError).not.toHaveBeenCalled();
+
+      second.abort();
+      await expect(secondRequest).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    it('keeps the replacement request abortable after the replaced one settles', async () => {
+      const first = pendingFetch();
+      const firstRequest = service.request('/a', {}, false, 'slot');
+      const second = pendingFetch();
+      const secondRequest = service.request('/a', {}, false, 'slot');
+
+      first.abort();
+      await expect(firstRequest).rejects.toMatchObject({ name: 'AbortError' });
+
+      service.abortRequest('slot');
+
+      expect(second.signal?.aborted).toBe(true);
+
+      second.abort();
+      await expect(secondRequest).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    it('aborts every tracked request', async () => {
+      const first = pendingFetch();
+      const firstRequest = service.request('/a', {}, false, 'one');
+      const second = pendingFetch();
+      const secondRequest = service.request('/b', {}, false, 'two');
+
+      service.abortAll();
+
+      expect(first.signal?.aborted).toBe(true);
+      expect(second.signal?.aborted).toBe(true);
+
+      first.abort();
+      second.abort();
+      await expect(firstRequest).rejects.toMatchObject({ name: 'AbortError' });
+      await expect(secondRequest).rejects.toMatchObject({ name: 'AbortError' });
+    });
+  });
+
+  describe('requestStream', () => {
+    it('asks for a stream and shows progress for the whole request', async () => {
+      const showSpy = vi.spyOn(TurboHelpers, 'showProgressBar').mockImplementation(() => undefined);
+      const hideSpy = vi.spyOn(TurboHelpers, 'hideProgressBar').mockImplementation(() => undefined);
+      fetchSpy.mockResolvedValueOnce(streamResponse());
+
+      await service.requestStream('/dialog');
+
+      expect(lastInit().headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+      expect(lastInit().credentials).toBe('same-origin');
+      expect(showSpy).toHaveBeenCalledOnce();
+      expect(hideSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('submitForm', () => {
+    it('posts the form data to the form action with extra params', async () => {
+      const form = document.createElement('form');
+      form.method = 'post';
+      form.action = '/forms/1';
+      form.innerHTML = '<input name="title" value="Sprint">';
+      document.body.appendChild(form);
+
+      await service.submitForm(form, new URLSearchParams({ preview: 'true' }));
+
+      const [url, init] = fetchSpy.mock.lastCall as [string, RequestInit];
+      expect(url).toBe(`${form.action}?preview=true`);
+      expect(init.method).toBe('POST');
+      expect((init.body as FormData).get('title')).toBe('Sprint');
+      form.remove();
+    });
+  });
+});

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -27,12 +27,11 @@
 //++
 
 import { Injectable, inject } from '@angular/core';
-import { renderStreamMessage } from '@hotwired/turbo';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { TurboHelpers } from 'core-turbo/helpers';
+import { renderErrorStream, request, type TurboRequestInit } from 'core-turbo/requests';
 import { TurboRequestError } from 'core-turbo/turbo-request-error';
-import { getMetaContent } from '../setup/globals/global-helpers';
 
 @Injectable({ providedIn: 'root' })
 export class TurboRequestsService {
@@ -42,54 +41,32 @@ export class TurboRequestsService {
 
   public request(
     url:string,
-    init:RequestInit = {},
+    init:TurboRequestInit = {},
     suppressErrorToast = false,
     requestId?:string,
   ):Promise<{
     html:string,
     headers:Headers
   }> {
+    let controller:AbortController|undefined;
     if (requestId) {
       this.abortRequest(requestId);
 
-      const controller = new AbortController();
+      controller = new AbortController();
       this.#controllers.set(requestId, controller);
-      init.signal = controller.signal;
     }
 
-    const defaultHeaders:{'X-CSRF-Token'?:string} = {};
-    if(init.method && !(init.method === 'GET' || init.method === 'HEAD')) {
-      defaultHeaders['X-CSRF-Token'] = getMetaContent('csrf-token');
-    }
+    return request(url, controller ? { ...init, signal: controller.signal } : init)
+      .then(async (response) => {
+        const html = await response.responseText;
+        await renderErrorStream(response, html);
 
-    init.headers = {
-      ...defaultHeaders,
-      ...init.headers,
-    };
-
-    return fetch(url, init)
-      .then((response) => {
-        return response.text().then((html) => ({
-          html,
-          headers: response.headers,
-          response,
-        }));
-      })
-      .then((result) => {
-        const contentType = result.response.headers.get('Content-Type') || '';
-        const isTurboStream = contentType.includes('text/vnd.turbo-stream.html');
-
-        // only render the stream message if we are in a turbo stream response
-        if (isTurboStream) {
-          renderStreamMessage(result.html);
+        if (response.failed) {
+          throw new TurboRequestError(response.statusCode, response.response.statusText);
         }
 
-        if (!result.response.ok) {
-          throw new TurboRequestError(result.response.status, result.response.statusText);
-        } else {
-          // enable further processing of the html and headers in the calling function
-          return { html: result.html, headers: result.headers };
-        }
+        // enable further processing of the html and headers in the calling function
+        return { html, headers: response.response.headers };
       })
       .catch((error) => {
         if (requestId && error instanceof DOMException && error.name === 'AbortError') {
@@ -105,7 +82,8 @@ export class TurboRequestsService {
         throw error;
       })
       .finally(() => {
-        if (requestId) {
+        // A replacement request under the same id may already own the slot.
+        if (requestId && this.#controllers.get(requestId) === controller) {
           this.#controllers.delete(requestId);
         }
       });
@@ -141,9 +119,7 @@ export class TurboRequestsService {
       url,
       {
         method: 'GET',
-        headers: {
-          Accept: 'text/vnd.turbo-stream.html',
-        },
+        responseKind: 'turbo-stream',
         credentials: 'same-origin',
       },
       false,

--- a/frontend/src/stimulus/controllers/async-dialog.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.spec.ts
@@ -1,0 +1,175 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import * as Turbo from '@hotwired/turbo';
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import AsyncDialogController from './async-dialog.controller';
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const STREAM_HTML = '<turbo-stream action="append" target="dialog-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+describe('AsyncDialogController', () => {
+  const progressBar = (Turbo.session.adapter as Turbo.BrowserAdapter).progressBar;
+  let ctx:StimulusTestContext;
+  let fetchSpy:Mock;
+  let hideSpy:ReturnType<typeof vi.spyOn>;
+  let target:HTMLElement;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+    vi.spyOn(progressBar, 'setValue').mockImplementation(() => undefined);
+    vi.spyOn(progressBar, 'show').mockImplementation(() => undefined);
+    hideSpy = vi.spyOn(progressBar, 'hide').mockImplementation(() => undefined);
+
+    target = document.createElement('div');
+    target.id = 'dialog-target';
+    document.body.appendChild(target);
+
+    ctx = await setupStimulusTest({ controllers: { 'async-dialog': AsyncDialogController } });
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  // Streams render on the next repaint; let a test's last one land in its
+  // own target instead of the next test's.
+  afterEach(async () => {
+    await flush();
+    ctx.dispose();
+    target.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function mountLink(attributes = ''):Promise<HTMLAnchorElement> {
+    await ctx.mount(`<a href="/dialogs/new" data-controller="async-dialog" ${attributes}>Open</a>`);
+
+    return ctx.container.querySelector('a')!;
+  }
+
+  it('requests the stream on click and renders it', async () => {
+    const link = await mountLink('data-turbo-method="post"');
+
+    link.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+    expect(url).toBe(link.href);
+    expect(init.method).toBe('POST');
+    expect(init.headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+    expect(init.headers.has('X-Requested-With')).toBe(false);
+  });
+
+  it('disables the trigger while loading and re-enables it afterwards', async () => {
+    let resolveFetch!:(response:Response) => void;
+    fetchSpy.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+    const link = await mountLink();
+
+    link.click();
+    link.click();
+
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    resolveFetch(streamResponse());
+
+    await waitFor(() => { expect(link.hasAttribute('aria-disabled')).toBe(false); });
+    expect(hideSpy).toHaveBeenCalledOnce();
+  });
+
+  it.each([422, 500])('renders an HTTP %s stream exactly once', async (status) => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(status));
+    const link = await mountLink();
+
+    link.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await flush();
+    expect(renderedChunks()).toBe(1);
+    expect(link.hasAttribute('aria-disabled')).toBe(false);
+  });
+
+  it('logs and cleans up when the response is not a stream', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockResolvedValueOnce(new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html' } }));
+    const link = await mountLink();
+
+    link.click();
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(renderedChunks()).toBe(0);
+    expect(link.hasAttribute('aria-disabled')).toBe(false);
+    expect(hideSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logs and cleans up when the request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const link = await mountLink();
+
+    link.click();
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(link.hasAttribute('aria-disabled')).toBe(false);
+    expect(hideSpy).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the progress bar until every concurrent dialog request has settled', async () => {
+    const resolvers:((response:Response) => void)[] = [];
+    fetchSpy.mockImplementation(() => new Promise<Response>((resolve) => { resolvers.push(resolve); }));
+    const link = await mountLink('data-async-dialog-disable-during-load-value="false"');
+
+    link.click();
+    link.click();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    resolvers[0](streamResponse());
+    await flush();
+
+    expect(hideSpy).not.toHaveBeenCalled();
+
+    resolvers[1](streamResponse());
+    await waitFor(() => { expect(hideSpy).toHaveBeenCalledOnce(); });
+  });
+
+  it('opens a dialog for a custom URL from an event', async () => {
+    await mountLink();
+    const controller = ctx.getController<AsyncDialogController>('async-dialog');
+
+    controller.handleOpenDialog(new CustomEvent('open', { detail: { url: '/dialogs/42/edit' } }));
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledWith('/dialogs/42/edit', expect.anything()); });
+  });
+});

--- a/frontend/src/stimulus/controllers/async-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.ts
@@ -27,8 +27,9 @@
 //++
 
 import { ApplicationController } from 'stimulus-use';
-import { renderStreamMessage } from '@hotwired/turbo';
 import { TurboHelpers } from 'core-turbo/helpers';
+import { request } from 'core-turbo/requests';
+import { handleDialogResponse } from 'core-stimulus/helpers/request-helpers';
 
 export default class AsyncDialogController extends ApplicationController {
   static values = { disableDuringLoad: { type: Boolean, default: true } };
@@ -67,29 +68,16 @@ export default class AsyncDialogController extends ApplicationController {
     }
     TurboHelpers.showProgressBar();
 
-    void fetch(url, {
-      method: this.method,
-      headers: {
-        Accept: 'text/vnd.turbo-stream.html',
-      },
-    }).then((response) => {
-      const contentType = response.headers.get('Content-Type') ?? '';
-      const isTurboStream = contentType.includes('text/vnd.turbo-stream.html');
-
-      if (!isTurboStream) {
-        return Promise.reject(new Error('Response is not a Turbo Stream'));
-      }
-
-      return response.text();
-    }).then((html) => {
-      renderStreamMessage(html);
-    }).finally(() => {
-      if (this.disableDuringLoadValue) {
-        this.loading = false;
-        (this.element as HTMLElement).removeAttribute('aria-disabled');
-      }
-      TurboHelpers.hideProgressBar();
-    });
+    void request(url, { method: this.method, responseKind: 'turbo-stream' })
+      .then(handleDialogResponse)
+      .catch((error) => { console.error(error); })
+      .finally(() => {
+        if (this.disableDuringLoadValue) {
+          this.loading = false;
+          (this.element as HTMLElement).removeAttribute('aria-disabled');
+        }
+        TurboHelpers.hideProgressBar();
+      });
   }
 
   handleOpenDialog(event:CustomEvent<{ url:string }>):void {

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
@@ -27,7 +27,7 @@
 //++
 
 import { waitFor } from '@testing-library/dom';
-import { vi } from 'vitest';
+import { vi, type Mock } from 'vitest';
 
 import GenericDragAndDropController from './generic-drag-and-drop.controller';
 import { createControllerInstance, setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
@@ -240,6 +240,74 @@ describe('GenericDragAndDropController', () => {
       await ctx.nextFrame();
 
       expect(FakeAutoscroll.constructedWith).toHaveLength(0);
+    });
+  });
+
+  describe('drop', () => {
+    let fetchSpy:Mock;
+    let source:HTMLUListElement;
+    let target:HTMLUListElement;
+    let row:HTMLLIElement;
+
+    const callDrop = () => {
+      const drop = Reflect.get(controller, 'drop') as (this:GenericDragAndDropController, el:Element, target:Element) => Promise<void>;
+
+      return drop.call(controller, row, target);
+    };
+
+    beforeEach(() => {
+      fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(new Response('', { status: 200 })));
+      vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+      source = document.createElement('ul');
+      target = document.createElement('ul');
+      target.dataset.targetId = '7';
+      row = draggableRow();
+      source.append(row);
+      document.body.append(source, target);
+
+      // Mirror the drag callbacks: the row now sits in the target, and the
+      // controller remembers where it came from.
+      target.append(row);
+      Reflect.set(controller, 'dragOriginSource', source);
+      Reflect.set(controller, 'dragOriginNextSibling', null);
+      Reflect.set(controller, 'targetConfigs', [{ container: target, allowedDragType: 'story', targetId: '7' }]);
+      Object.defineProperty(controller, 'positionModeValue', { value: 'index', configurable: true });
+    });
+
+    afterEach(() => {
+      source.remove();
+      target.remove();
+      vi.restoreAllMocks();
+    });
+
+    it('puts the new position as form data with Request.JS stream headers', async () => {
+      await callDrop();
+
+      const [url, init] = fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+      expect(url).toBe('/drop');
+      expect(init.method).toBe('PUT');
+      expect((init.body as FormData).get('position')).toBe('1');
+      expect((init.body as FormData).get('target_id')).toBe('7');
+      expect(init.headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+      expect(init.headers.get('X-Requested-With')).toBe('XMLHttpRequest');
+      expect(row.parentElement).toBe(target);
+    });
+
+    it('reverts the drop when the server rejects it', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response('', { status: 422 }));
+
+      await callDrop();
+
+      expect(row.parentElement).toBe(source);
+    });
+
+    it('reverts the drop when the request fails', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      await callDrop();
+
+      expect(row.parentElement).toBe(source);
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -27,12 +27,12 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
-import { FetchRequest } from '@rails/request.js';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { closestDragBlockingElement } from 'core-stimulus/helpers/interactive-element-helper';
 import type { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-autoscroll.service';
 import type { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import { useAngularServices } from 'core-stimulus/mixins/use-angular-services';
+import { request } from 'core-turbo/requests';
 import dragula, { Drake } from 'dragula';
 import invariant from 'tiny-invariant';
 
@@ -205,10 +205,14 @@ export default class GenericDragAndDropController extends Controller {
     }
 
     try {
-      const request = new FetchRequest('put', dropUrl, { body: data, responseKind: 'turbo-stream' });
-      const response = await request.perform();
+      const response = await request(dropUrl, {
+        method: 'PUT',
+        body: data,
+        responseKind: 'turbo-stream',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
 
-      if (!response.ok) {
+      if (response.failed) {
         this.revertDrop(el);
         debugLog(`Failed to sort item: ${response.statusCode}`);
       }

--- a/frontend/src/stimulus/controllers/dynamic/resource-management/resource-timeline.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/resource-management/resource-timeline.controller.spec.ts
@@ -26,7 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { vi } from 'vitest';
+import * as Turbo from '@hotwired/turbo';
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import ResourceTimelineController from './resource-timeline.controller';
 
@@ -93,5 +95,84 @@ describe('ResourceTimelineController', () => {
 
     expect(calendar.refetchResources).not.toHaveBeenCalled();
     expect(calendar.refetchEvents).not.toHaveBeenCalled();
+  });
+  describe('openDialog', () => {
+    const progressBar = (Turbo.session.adapter as Turbo.BrowserAdapter).progressBar;
+    const STREAM_HTML = '<turbo-stream action="append" target="timeline-dialog-target"><template><span class="chunk"></span></template></turbo-stream>';
+    let fetchSpy:Mock;
+    let hideSpy:ReturnType<typeof vi.spyOn>;
+    let target:HTMLElement;
+
+    const streamResponse = (status = 200) => new Response(STREAM_HTML, {
+      status,
+      headers: { 'Content-Type': 'text/vnd.turbo-stream.html; charset=utf-8' },
+    });
+    const renderedChunks = () => target.querySelectorAll('.chunk').length;
+    const openDialog = (url:string) => {
+      const controller = ctx.getController<ResourceTimelineController>('resource-management--resource-timeline');
+      const method = Reflect.get(controller, 'openDialog') as (this:ResourceTimelineController, url:string) => void;
+
+      method.call(controller, url);
+    };
+
+    beforeEach(async () => {
+      fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+      vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+      vi.spyOn(progressBar, 'setValue').mockImplementation(() => undefined);
+      vi.spyOn(progressBar, 'show').mockImplementation(() => undefined);
+      hideSpy = vi.spyOn(progressBar, 'hide').mockImplementation(() => undefined);
+
+      target = document.createElement('div');
+      target.id = 'timeline-dialog-target';
+      document.body.appendChild(target);
+
+      await mountTimeline();
+    });
+
+    afterEach(() => {
+      target.remove();
+    });
+
+    it('requests the dialog as a stream and renders it', async () => {
+      openDialog('/allocations/new?start_date=2026-09-01');
+
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      const [url, init] = fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+      expect(url).toBe('/allocations/new?start_date=2026-09-01');
+      expect(init.method).toBe('GET');
+      expect(init.headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+      expect(init.headers.has('X-CSRF-Token')).toBe(false);
+      await waitFor(() => { expect(hideSpy).toHaveBeenCalledOnce(); });
+    });
+
+    it('renders error streams for failed requests', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(403));
+
+      openDialog('/allocations/1/edit');
+
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await waitFor(() => { expect(hideSpy).toHaveBeenCalledOnce(); });
+    });
+
+    it('logs and hides progress when the response is not a stream', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      fetchSpy.mockResolvedValueOnce(new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html' } }));
+
+      openDialog('/allocations/1/edit');
+
+      await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+      expect(renderedChunks()).toBe(0);
+      expect(hideSpy).toHaveBeenCalledOnce();
+    });
+
+    it('logs and hides progress when the request fails', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      openDialog('/allocations/1/edit');
+
+      await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+      expect(hideSpy).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/resource-management/resource-timeline.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/resource-management/resource-timeline.controller.ts
@@ -32,8 +32,9 @@ import interactionPlugin from '@fullcalendar/interaction';
 import resourceTimelinePlugin from '@fullcalendar/resource-timeline';
 import { ResourceInput } from '@fullcalendar/resource';
 import allLocales from '@fullcalendar/core/locales-all';
-import { renderStreamMessage } from '@hotwired/turbo';
 import { TurboHelpers } from 'core-turbo/helpers';
+import { request } from 'core-turbo/requests';
+import { handleDialogResponse } from 'core-stimulus/helpers/request-helpers';
 import moment from 'moment';
 
 // Every granularity view shares the same shape, only the unit changes: a fixed
@@ -326,9 +327,9 @@ export default class ResourceTimelineController extends Controller {
   private openDialog(url:string):void {
     TurboHelpers.showProgressBar();
 
-    void fetch(url, { headers: { Accept: 'text/vnd.turbo-stream.html' } })
-      .then((response) => response.text())
-      .then((html) => { renderStreamMessage(html); })
+    void request(url, { responseKind: 'turbo-stream' })
+      .then(handleDialogResponse)
+      .catch((error) => { console.error(error); })
       .finally(() => { TurboHelpers.hideProgressBar(); });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.spec.ts
@@ -77,7 +77,6 @@ describe('Sortable lists controller', () => {
   let ctx:StimulusTestContext;
   let fixture:HTMLElement;
   let fetchMock:Mock;
-  let renderStreamMessageMock:Mock;
   // `ReturnType<typeof vi.spyOn>` collapses to a call signature TypeScript
   // cannot resolve `.mock.calls`'s element type from; pin the spied method's
   // own signature instead so calls stay typed.
@@ -360,12 +359,7 @@ describe('Sortable lists controller', () => {
     vi.spyOn(document, 'elementsFromPoint').mockReturnValue([]);
 
     fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 200 })));
-    renderStreamMessageMock = vi.fn(() => Promise.resolve());
     vi.stubGlobal('fetch', fetchMock);
-    vi.stubGlobal('Turbo', {
-      fetch: fetchMock,
-      renderStreamMessage: renderStreamMessageMock,
-    });
 
     document.body.appendChild(document.createElement('live-region'));
     announceSpy = vi.spyOn(LiveRegionElement.prototype, 'announce');
@@ -739,6 +733,39 @@ describe('Sortable lists controller', () => {
     })).toBe(false);
   });
 
+  it('keeps a pending move blocking across a root reconnect', async () => {
+    let resolveMove:(response:Response) => void;
+    fetchMock.mockImplementationOnce(() => new Promise<Response>((resolve) => {
+      resolveMove = resolve;
+    }));
+
+    const { root, targetList, firstSourceItem } = renderFixture();
+
+    await ctx.nextFrame();
+    await dropCurrentItemOnList(firstSourceItem, targetList);
+
+    expect(root.hasAttribute('data-sortable-lists-busy')).toBe(true);
+
+    const parent = root.parentElement!;
+    root.remove();
+    await ctx.nextFrame();
+
+    expect(fetchMock.mock.lastCall?.[1]).not.toHaveProperty('signal');
+
+    parent.append(root);
+    await ctx.nextFrame();
+
+    const controller = ctx.getController<SortableListsControllerType>('sortable-lists', root);
+    expect(controller.busy).toBe(true);
+    expect(root.hasAttribute('data-sortable-lists-busy')).toBe(true);
+
+    resolveMove!(new Response('', { status: 200 }));
+    await flushPromises();
+
+    expect(controller.busy).toBe(false);
+    expect(root.hasAttribute('data-sortable-lists-busy')).toBe(false);
+  });
+
   it('dispatches an error toast when the move request rejects', async () => {
     const toastEvents:CustomEvent[] = [];
     const onToast = (event:Event) => toastEvents.push(event as CustomEvent);
@@ -948,10 +975,13 @@ describe('Sortable lists controller', () => {
     const onToast = (event:Event) => toastEvents.push(event as CustomEvent);
 
     window.addEventListener('op:toasters:add', onToast);
-    fetchMock.mockResolvedValueOnce(new Response('', {
-      headers: { 'Content-Type': 'text/vnd.turbo-stream.html' },
-      status: 422,
-    }));
+    const flash = document.createElement('div');
+    flash.id = 'move-flash';
+    document.body.appendChild(flash);
+    fetchMock.mockResolvedValueOnce(new Response(
+      '<turbo-stream action="update" target="move-flash"><template>Cannot move</template></turbo-stream>',
+      { headers: { 'Content-Type': 'text/vnd.turbo-stream.html' }, status: 422 },
+    ));
 
     const { sourceList, targetList, firstSourceItem } = renderFixture();
 
@@ -962,10 +992,11 @@ describe('Sortable lists controller', () => {
     await waitFor(() => {
       expect(itemIds(sourceList)).toEqual(['1', '2', '3']);
       expect(itemIds(targetList)).toEqual(['4', '5']);
-      expect(renderStreamMessageMock).toHaveBeenCalledOnce();
+      expect(flash.textContent).toBe('Cannot move');
     });
     expect(toastEvents).toHaveLength(0);
 
+    flash.remove();
     window.removeEventListener('op:toasters:add', onToast);
   });
 
@@ -1444,15 +1475,26 @@ describe('Sortable lists controller', () => {
   // An unconsumed modified gesture would reach the card's own click handler
   // and open the details pane on a selection toggle.
   it('consumes a modified click during a busy move without changing the selection', async () => {
-    const { root, items } = renderSelectableRoot();
+    let resolveMove!:(response:Response) => void;
+    fetchMock.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveMove = resolve; }));
+    const { root, items, firstSourceItem, targetList } = renderSelectableRoot();
     await ctx.nextFrame();
-    root.setAttribute('data-sortable-lists-busy', 'true');
-    const event = new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true });
+    await dropCurrentItemOnList(firstSourceItem, targetList);
 
-    items[0].dispatchEvent(event);
+    try {
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(root.dataset.sortableListsBusy).toBe('true');
+      expect(items.some(isSelected)).toBe(false);
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true });
 
-    expect(event.defaultPrevented).toBe(true);
-    expect(items.some(isSelected)).toBe(false);
+      items[0].dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(items.some(isSelected)).toBe(false);
+    } finally {
+      resolveMove(new Response('', { status: 200 }));
+      await flushPromises();
+    }
   });
 
   it('toggles a card without navigating on a modified click', async () => {

--- a/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/sortable-lists.controller.ts
@@ -31,11 +31,12 @@ import {
   type ElementEventPayloadMap,
 } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { Controller } from '@hotwired/stimulus';
-import { FetchRequest } from '@rails/request.js';
 import { announce } from '@primer/live-region-element';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { OPToastEvent } from 'core-app/shared/components/toaster/toast-event';
 import { flipMove } from 'core-stimulus/helpers/flip-helper';
+import { TurboRequestScope } from 'core-turbo/request-scope';
+import { isUnprocessableEntity, request } from 'core-turbo/requests';
 import { parseTemplate } from 'url-template';
 import {
   buildMoveFormData,
@@ -100,7 +101,14 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   private healScheduled = false;
   private reconcileScheduled = false;
 
+  // Outlives disconnects: a move in flight when the root is detached keeps
+  // running and blocks new moves again once the root reconnects.
+  private readonly moves = new TurboRequestScope();
+  private unsubscribeMoves?:CleanupFn;
+
   connect():void {
+    this.unsubscribeMoves = this.moves.subscribe(this.projectBusyState);
+    this.projectBusyState();
     this.monitorCleanupFn = monitorForElements({
       canMonitor: ({ source }) => !this.busy
         && isSortableItemData(source.data)
@@ -120,6 +128,8 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   }
 
   disconnect():void {
+    this.unsubscribeMoves?.();
+    this.unsubscribeMoves = undefined;
     this.element.removeEventListener('turbo:morph-element', this.scheduleRegistrationHeal);
     this.teardownSelection();
     this.monitorCleanupFn?.();
@@ -311,7 +321,7 @@ export default class SortableListsController extends Controller<HTMLElement> imp
   }
 
   get busy():boolean {
-    return this.element.hasAttribute(sortableListsBusyAttribute);
+    return this.moves.busy;
   }
 
   // A direction is offered exactly when the move resolver can produce a
@@ -545,45 +555,50 @@ export default class SortableListsController extends Controller<HTMLElement> imp
     previousItemId:string|null;
     moveUrl:string;
   }):Promise<MoveResult> {
-    const request = new FetchRequest(
-      'put',
-      moveUrl,
-      {
-        body: buildMoveFormData({
-          listId: listData.listId,
-          previousItemId,
-          type: listData.type,
-        }),
-        responseKind: 'turbo-stream',
-      },
-    );
+    const body = buildMoveFormData({
+      listId: listData.listId,
+      previousItemId,
+      type: listData.type,
+    });
 
-    this.setBusy(true);
     try {
-      const response = await request.perform();
+      const response = await request(
+        moveUrl,
+        {
+          method: 'PUT',
+          body,
+          responseKind: 'turbo-stream',
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          scope: this.moves,
+        },
+      );
 
-      if (!response.ok) {
+      if (response.failed) {
         debugLog(`Failed to move sortable list item: ${response.statusCode}`);
       }
 
-      return response.ok
+      return response.succeeded
         ? { ok: true }
-        : { ok: false, showToast: response.statusCode !== 422 };
+        : { ok: false, showToast: !isUnprocessableEntity(response) };
     } catch (error) {
       debugLog('Failed to move sortable list item due to request error', error);
       return { ok: false, showToast: true };
-    } finally {
-      this.setBusy(false);
     }
   }
 
-  private setBusy(busy:boolean):void {
-    if (busy) {
+  // Mirrors the scope onto the root element for styling and child guards;
+  // only while connected, so a detached root is never touched.
+  private projectBusyState = ():void => {
+    if (!this.element.isConnected) {
+      return;
+    }
+
+    if (this.moves.busy) {
       this.element.setAttribute(sortableListsBusyAttribute, 'true');
     } else {
       this.element.removeAttribute(sortableListsBusyAttribute);
     }
-  }
+  };
 
   private dispatchErrorToast():void {
     window.dispatchEvent(new CustomEvent(OPToastEvent, {

--- a/frontend/src/stimulus/controllers/dynamic/users/non-working-times.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/users/non-working-times.controller.spec.ts
@@ -1,0 +1,129 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import * as Turbo from '@hotwired/turbo';
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import NonWorkingTimesController from './non-working-times.controller';
+
+const STREAM_HTML = '<turbo-stream action="append" target="non-working-dialog-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': 'text/vnd.turbo-stream.html; charset=utf-8' } });
+}
+
+describe('NonWorkingTimesController', () => {
+  const progressBar = (Turbo.session.adapter as Turbo.BrowserAdapter).progressBar;
+  const calendar = { destroy: vi.fn() };
+  let ctx:StimulusTestContext;
+  let fetchSpy:Mock;
+  let hideSpy:ReturnType<typeof vi.spyOn>;
+  let target:HTMLElement;
+
+  beforeEach(async () => {
+    vi.spyOn(NonWorkingTimesController.prototype, 'initializeCalendar')
+      .mockImplementation(function stubInitializeCalendar(this:{ calendar:unknown }) {
+        this.calendar = calendar;
+      });
+
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+    vi.spyOn(progressBar, 'setValue').mockImplementation(() => undefined);
+    vi.spyOn(progressBar, 'show').mockImplementation(() => undefined);
+    hideSpy = vi.spyOn(progressBar, 'hide').mockImplementation(() => undefined);
+
+    target = document.createElement('div');
+    target.id = 'non-working-dialog-target';
+    document.body.appendChild(target);
+
+    ctx = await setupStimulusTest({ controllers: { 'users--non-working-times': NonWorkingTimesController } });
+    await ctx.mount(`
+      <div data-controller="users--non-working-times"
+           data-users--non-working-times-year-value="2026"
+           data-users--non-working-times-locale-value="en">
+        <div data-users--non-working-times-target="calendar"></div>
+      </div>
+    `);
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+    target.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const openDialog = (url:string) => {
+    const controller = ctx.getController<NonWorkingTimesController>('users--non-working-times');
+    const method = Reflect.get(controller, 'openDialog') as (this:NonWorkingTimesController, url:string) => void;
+
+    method.call(controller, url);
+  };
+
+  it('requests the dialog as a stream and renders it', async () => {
+    openDialog('/non_working_days/new?start_date=2026-12-24');
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+    expect(url).toBe('/non_working_days/new?start_date=2026-12-24');
+    expect(init.method).toBe('GET');
+    expect(init.headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+    await waitFor(() => { expect(hideSpy).toHaveBeenCalledOnce(); });
+  });
+
+  it('renders error streams for failed requests', async () => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(500));
+
+    openDialog('/non_working_days/1/edit');
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await waitFor(() => { expect(hideSpy).toHaveBeenCalledOnce(); });
+  });
+
+  it('logs and hides progress when the response is not a stream', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockResolvedValueOnce(new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html' } }));
+
+    openDialog('/non_working_days/1/edit');
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(renderedChunks()).toBe(0);
+    expect(hideSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logs and hides progress when the request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    openDialog('/non_working_days/1/edit');
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(hideSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/users/non-working-times.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/users/non-working-times.controller.ts
@@ -31,8 +31,9 @@ import { Calendar } from '@fullcalendar/core';
 import interactionPlugin from '@fullcalendar/interaction';
 import multiMonthPlugin from '@fullcalendar/multimonth';
 import allLocales from '@fullcalendar/core/locales-all';
-import { renderStreamMessage } from '@hotwired/turbo';
 import { TurboHelpers } from 'core-turbo/helpers';
+import { request } from 'core-turbo/requests';
+import { handleDialogResponse } from 'core-stimulus/helpers/request-helpers';
 import moment from 'moment';
 
 interface NonWorkingDayEvent {
@@ -123,11 +124,9 @@ export default class NonWorkingTimesController extends Controller {
   private openDialog(url:string):void {
     TurboHelpers.showProgressBar();
 
-    void fetch(url, {
-      headers: { Accept: 'text/vnd.turbo-stream.html' },
-    })
-      .then((response) => response.text())
-      .then((html) => { renderStreamMessage(html); })
+    void request(url, { responseKind: 'turbo-stream' })
+      .then(handleDialogResponse)
+      .catch((error) => { console.error(error); })
       .finally(() => { TurboHelpers.hideProgressBar(); });
   }
 

--- a/frontend/src/stimulus/controllers/refresh-on-form-changes.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/refresh-on-form-changes.controller.spec.ts
@@ -36,8 +36,6 @@ describe('Refresh on form changes controller', () => {
   let ctx:StimulusTestContext;
   let RefreshOnFormChangesController:typeof RefreshOnFormChangesControllerType;
   let fetchSpy:Mock;
-  let renderStreamMessage:Mock;
-  let originalTurbo:typeof window.Turbo;
 
   beforeAll(async () => {
     ({ default: RefreshOnFormChangesController } = await import('./refresh-on-form-changes.controller'));
@@ -45,14 +43,6 @@ describe('Refresh on form changes controller', () => {
 
   beforeEach(async () => {
     fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(turboStreamResponse()));
-    renderStreamMessage = vi.fn().mockResolvedValue(undefined);
-
-    originalTurbo = window.Turbo;
-    window.Turbo = {
-      ...originalTurbo,
-      fetch: fetchSpy,
-      renderStreamMessage,
-    } as typeof window.Turbo;
     vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
 
     ctx = await setupStimulusTest({
@@ -62,16 +52,17 @@ describe('Refresh on form changes controller', () => {
 
   afterEach(() => {
     ctx.dispose();
-    window.Turbo = originalTurbo;
     vi.restoreAllMocks();
   });
 
-  function turboStreamResponse(html = '<turbo-stream action="update" target="sprint-dialog-form"></turbo-stream>') {
-    return new Response(html, {
-      status: 200,
-      headers: { 'Content-Type': 'text/vnd.turbo-stream.html' },
-    });
+  function turboStreamResponse(status = 200, content = 'Refreshed') {
+    return new Response(
+      `<turbo-stream action="update" target="sprint-dialog-form"><template>${content}</template></turbo-stream>`,
+      { status, headers: { 'Content-Type': 'text/vnd.turbo-stream.html' } },
+    );
   }
+
+  const refreshedContent = () => ctx.container.querySelector('#sprint-dialog-form')?.textContent;
 
   async function renderForm() {
     await ctx.mount(`
@@ -80,6 +71,7 @@ describe('Refresh on form changes controller', () => {
             data-refresh-on-form-changes-turbo-stream-url-value="/refresh">
         <input name="sprint[name]" value="Created sprint">
         <textarea name="sprint[goal][text]">Deliver the first MVP scope.</textarea>
+        <div id="sprint-dialog-form"></div>
       </form>
     `);
 
@@ -95,7 +87,7 @@ describe('Refresh on form changes controller', () => {
       expect(fetchSpy).toHaveBeenCalled();
     });
 
-    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit & { headers:Headers }];
     const parsedUrl = new URL(url, window.location.origin);
 
     expect(parsedUrl.pathname).toBe('/refresh');
@@ -105,13 +97,37 @@ describe('Refresh on form changes controller', () => {
     expect(body).toBeInstanceOf(FormData);
     expect(body.get('sprint[name]')).toBe('Created sprint');
     expect(body.get('sprint[goal][text]')).toBe('Deliver the first MVP scope.');
-    expect(init).toEqual(expect.objectContaining({ method: 'POST', credentials: 'same-origin' }));
+    expect(init.method).toBe('POST');
+    expect(init.headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+    expect(init.headers.get('X-Requested-With')).toBe('XMLHttpRequest');
 
     await waitFor(() => {
-      expect(renderStreamMessage).toHaveBeenCalledWith(
-        '<turbo-stream action="update" target="sprint-dialog-form"></turbo-stream>',
-      );
+      expect(refreshedContent()).toBe('Refreshed');
     });
+  });
+
+  it('renders the stream of a 422 response', async () => {
+    fetchSpy.mockResolvedValueOnce(turboStreamResponse(422, 'Invalid'));
+    const controller = await renderForm();
+
+    controller.triggerTurboStream();
+
+    await waitFor(() => {
+      expect(refreshedContent()).toBe('Invalid');
+    });
+  });
+
+  it('logs other HTTP errors instead of rendering them', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockResolvedValueOnce(turboStreamResponse(500, 'Broken'));
+    const controller = await renderForm();
+
+    controller.triggerTurboStream();
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('Form refresh failed (HTTP 500)');
+    });
+    expect(refreshedContent()).toBe('');
   });
 
   it('drops the _method override so the refresh stays a POST', async () => {
@@ -195,7 +211,7 @@ describe('Refresh on form changes controller', () => {
     firstReject(new DOMException('The operation was aborted.', 'AbortError'));
 
     await waitFor(() => {
-      expect(renderStreamMessage).toHaveBeenCalledOnce();
+      expect(refreshedContent()).toBe('Refreshed');
     });
   });
 

--- a/frontend/src/stimulus/controllers/refresh-on-form-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/refresh-on-form-changes.controller.ts
@@ -27,8 +27,8 @@
 //++
 
 import { ApplicationController, useDebounce } from 'stimulus-use';
-import { FetchRequest } from '@rails/request.js';
 import { filterFormData } from 'core-stimulus/helpers/form-data-helper';
+import { isUnprocessableEntity, request } from 'core-turbo/requests';
 
 const TURBO_STREAM_REFRESH_DELAY = 50;
 
@@ -98,16 +98,16 @@ export default class RefreshOnFormChangesController extends ApplicationControlle
         this.formTarget,
         (value, key) => typeof value === 'string' && key !== '_method',
       );
-      const request = new FetchRequest('post', this.turboStreamUrlValue, {
+      const response = await request(this.turboStreamUrlValue, {
+        method: 'POST',
         body,
         responseKind: 'turbo-stream',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
         signal: abortController.signal,
       });
-      // perform() resolves (never rejects) on HTTP error statuses and only
-      // renders the stream for 2xx/422. Surface anything else so a failed
-      // refresh is not swallowed, leaving the form showing stale options.
-      const response = await request.perform();
-      if (!response.ok && response.statusCode !== 422) {
+      // The stream only renders for 2xx/422. Surface anything else so a
+      // failed refresh is not swallowed, leaving the form showing stale options.
+      if (response.failed && !isUnprocessableEntity(response)) {
         console.error(`Form refresh failed (HTTP ${response.statusCode})`);
       }
     } catch (error) {

--- a/frontend/src/stimulus/helpers/request-helpers.spec.ts
+++ b/frontend/src/stimulus/helpers/request-helpers.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import type { FetchResponse } from '@rails/request.js';
+import type { FetchResponse } from '@hotwired/turbo';
 import { TurboHelpers } from 'core-turbo/helpers';
 
 import { withLoadingIndicator, withProgressBar } from './request-helpers';

--- a/frontend/src/stimulus/helpers/request-helpers.ts
+++ b/frontend/src/stimulus/helpers/request-helpers.ts
@@ -26,9 +26,11 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { FetchRequest, FetchResponse, Options } from '@rails/request.js';
+import type { FetchResponse } from '@hotwired/turbo';
+import { FetchRequest, type Options } from '@rails/request.js';
 import { hideElement, showElement } from 'core-app/shared/helpers/dom-helpers';
 import { TurboHelpers } from 'core-turbo/helpers';
+import { isTurboStream, renderErrorStream } from 'core-turbo/requests';
 import invariant from 'tiny-invariant';
 
 export function post(url:string|URL, options?:Options) {
@@ -36,7 +38,15 @@ export function post(url:string|URL, options?:Options) {
   return withLoadingIndicator(request.perform());
 }
 
-export function withLoadingIndicator(request:Promise<FetchResponse>) {
+export async function handleDialogResponse(response:FetchResponse):Promise<void> {
+  if (!isTurboStream(response)) {
+    throw new Error(`Expected a Turbo Stream response but got "${response.contentType}" instead`);
+  }
+
+  await renderErrorStream(response);
+}
+
+export function withLoadingIndicator<T>(request:Promise<T>):Promise<T> {
   const loadingIndicator = document.querySelector<HTMLElement>('#global-loading-indicator');
   invariant(loadingIndicator, 'Expected an Element with id global-loading-indicator to be present');
   showElement(loadingIndicator);
@@ -46,7 +56,7 @@ export function withLoadingIndicator(request:Promise<FetchResponse>) {
   });
 }
 
-export function withProgressBar(request:Promise<FetchResponse>) {
+export function withProgressBar<T>(request:Promise<T>):Promise<T> {
   TurboHelpers.showProgressBar();
 
   return request.finally(() => {

--- a/frontend/src/turbo/helpers.spec.ts
+++ b/frontend/src/turbo/helpers.spec.ts
@@ -80,9 +80,48 @@ describe('TurboHelpers.showProgressBar / hideProgressBar', () => {
     vi.advanceTimersByTime(200);
 
     expect(showSpy).toHaveBeenCalledOnce();
+
+    TurboHelpers.hideProgressBar();
+    TurboHelpers.hideProgressBar();
+  });
+
+  it('keeps the bar until every overlapping operation has hidden it', () => {
+    TurboHelpers.showProgressBar();
+    TurboHelpers.showProgressBar();
+
+    TurboHelpers.hideProgressBar();
+
+    expect(hideSpy).not.toHaveBeenCalled();
+
+    TurboHelpers.hideProgressBar();
+
+    expect(hideSpy).toHaveBeenCalledOnce();
+    expect(setValueSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('does not restart the bar for an operation joining a pending one', () => {
+    TurboHelpers.showProgressBar();
+    vi.advanceTimersByTime(200);
+    setValueSpy.mockClear();
+
+    TurboHelpers.showProgressBar();
+
+    expect(setValueSpy).not.toHaveBeenCalled();
+    expect(showSpy).toHaveBeenCalledOnce();
+
+    TurboHelpers.hideProgressBar();
+    TurboHelpers.hideProgressBar();
+  });
+
+  it('ignores hide without a matching show', () => {
+    TurboHelpers.hideProgressBar();
+
+    expect(hideSpy).not.toHaveBeenCalled();
+    expect(setValueSpy).not.toHaveBeenCalled();
   });
 
   it('sets value to 1 and calls hide()', () => {
+    TurboHelpers.showProgressBar();
     TurboHelpers.hideProgressBar();
 
     expect(setValueSpy).toHaveBeenCalledWith(1);

--- a/frontend/src/turbo/request-scope.spec.ts
+++ b/frontend/src/turbo/request-scope.spec.ts
@@ -1,0 +1,142 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { vi } from 'vitest';
+import { TurboRequestScope } from './request-scope';
+
+describe('TurboRequestScope', () => {
+  function deferred<T>() {
+    let resolve!:(value:T) => void;
+    let reject!:(error:Error) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    return { promise, resolve, reject };
+  }
+
+  it('starts idle', () => {
+    expect(new TurboRequestScope().busy).toBe(false);
+  });
+
+  it('is busy while a tracked operation is pending', async () => {
+    const scope = new TurboRequestScope();
+    const operation = deferred<string>();
+
+    const tracked = scope.track(() => operation.promise);
+
+    expect(scope.busy).toBe(true);
+
+    operation.resolve('done');
+
+    await expect(tracked).resolves.toBe('done');
+    expect(scope.busy).toBe(false);
+  });
+
+  it('stays busy until every overlapping operation has settled', async () => {
+    const scope = new TurboRequestScope();
+    const first = deferred<void>();
+    const second = deferred<void>();
+
+    const trackedFirst = scope.track(() => first.promise);
+    const trackedSecond = scope.track(() => second.promise);
+
+    first.resolve();
+    await trackedFirst;
+
+    expect(scope.busy).toBe(true);
+
+    second.resolve();
+    await trackedSecond;
+
+    expect(scope.busy).toBe(false);
+  });
+
+  it('releases on rejection and rethrows', async () => {
+    const scope = new TurboRequestScope();
+    const operation = deferred<void>();
+
+    const tracked = scope.track(() => operation.promise);
+    operation.reject(new Error('boom'));
+
+    await expect(tracked).rejects.toThrow('boom');
+    expect(scope.busy).toBe(false);
+  });
+
+  it('keeps scopes independent', async () => {
+    const one = new TurboRequestScope();
+    const other = new TurboRequestScope();
+    const operation = deferred<void>();
+
+    const tracked = one.track(() => operation.promise);
+
+    expect(other.busy).toBe(false);
+
+    operation.resolve();
+    await tracked;
+  });
+
+  it('notifies subscribers on busy transitions only', async () => {
+    const scope = new TurboRequestScope();
+    const listener = vi.fn();
+    const first = deferred<void>();
+    const second = deferred<void>();
+
+    scope.subscribe(listener);
+    const trackedFirst = scope.track(() => first.promise);
+    const trackedSecond = scope.track(() => second.promise);
+
+    expect(listener).toHaveBeenCalledOnce();
+
+    first.resolve();
+    await trackedFirst;
+
+    expect(listener).toHaveBeenCalledOnce();
+
+    second.resolve();
+    await trackedSecond;
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops notifying after unsubscribe', async () => {
+    const scope = new TurboRequestScope();
+    const listener = vi.fn();
+    const operation = deferred<void>();
+
+    const unsubscribe = scope.subscribe(listener);
+    unsubscribe();
+
+    const tracked = scope.track(() => operation.promise);
+    operation.resolve();
+    await tracked;
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/turbo/request-scope.ts
+++ b/frontend/src/turbo/request-scope.ts
@@ -26,47 +26,52 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import * as Turbo from '@hotwired/turbo';
+// Counts the in-flight operations of one consumer (a controller root, a
+// dialog trigger) so it can block re-entrant work and reflect busy state onto
+// whatever DOM it currently owns. Knows nothing of DOM or Angular: consumers
+// construct it synchronously, keep it across reconnects and subscribe to
+// project its state.
+export class TurboRequestScope {
+  #pending = 0;
 
-export namespace TurboHelpers {
-  let progressBarTimeout:number | undefined;
-  let pendingOperations = 0;
+  #listeners = new Set<() => void>();
 
-  function getProgressBar():Turbo.ProgressBar {
-    return (Turbo.session.adapter as Turbo.BrowserAdapter).progressBar;
+  get busy():boolean {
+    return this.#pending > 0;
   }
 
-  // Overlapping operations share the bar: it shows for the first one and
-  // hides only once the last one has finished.
-  export function showProgressBar() {
-    pendingOperations += 1;
-    if (pendingOperations > 1) {
-      return;
-    }
+  subscribe(listener:() => void):() => void {
+    this.#listeners.add(listener);
 
-    const progressBar = getProgressBar();
-    progressBar.setValue(0);
-    progressBarTimeout ??= window.setTimeout(() => {
-      progressBar.show();
-    }, Turbo.config.drive.progressBarDelay);
+    return () => {
+      this.#listeners.delete(listener);
+    };
   }
 
-  export function hideProgressBar() {
-    if (pendingOperations === 0) {
-      return;
+  async track<T>(operation:() => Promise<T>):Promise<T> {
+    this.#enter();
+    try {
+      return await operation();
+    } finally {
+      this.#leave();
     }
+  }
 
-    pendingOperations -= 1;
-    if (pendingOperations > 0) {
-      return;
+  #enter():void {
+    this.#pending += 1;
+    if (this.#pending === 1) {
+      this.#notify();
     }
+  }
 
-    const progressBar = getProgressBar();
-    progressBar.setValue(1);
-    progressBar.hide();
-    if (progressBarTimeout != null) {
-      window.clearTimeout(progressBarTimeout);
-      progressBarTimeout = undefined;
+  #leave():void {
+    this.#pending -= 1;
+    if (this.#pending === 0) {
+      this.#notify();
     }
+  }
+
+  #notify():void {
+    this.#listeners.forEach((listener) => listener());
   }
 }

--- a/frontend/src/turbo/requests.spec.ts
+++ b/frontend/src/turbo/requests.spec.ts
@@ -1,0 +1,495 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { renderStreamMessage } from '@hotwired/turbo';
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { TurboHelpers } from 'core-turbo/helpers';
+import { TurboRequestScope } from 'core-turbo/request-scope';
+import {
+  isTurboStream,
+  renderErrorStream,
+  request,
+} from './requests';
+
+const TURBO_STREAM_ACCEPT = 'text/vnd.turbo-stream.html';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200, headers:Record<string, string> = {}):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE, ...headers } });
+}
+
+function htmlResponse(status = 200):Response {
+  return new Response('<p>Plain page</p>', { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+describe('turbo/requests', () => {
+  let fetchSpy:Mock;
+  let target:HTMLElement;
+  let csrfMeta:HTMLMetaElement;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    csrfMeta = document.createElement('meta');
+    csrfMeta.name = 'csrf-token';
+    csrfMeta.content = 'token-123';
+    document.head.appendChild(csrfMeta);
+  });
+
+  afterEach(() => {
+    target.remove();
+    csrfMeta.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const lastInit = () => fetchSpy.mock.lastCall?.[1] as RequestInit & { headers:Headers };
+  const lastUrl = () => fetchSpy.mock.lastCall?.[0] as string|URL;
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  describe('rendering', () => {
+    it('renders a successful stream exactly once and resolves with the response', async () => {
+      const response = await request('/dialog');
+
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await flush();
+      expect(renderedChunks()).toBe(1);
+      expect(response.succeeded).toBe(true);
+      expect(isTurboStream(response)).toBe(true);
+      expect(await response.responseText).toBe(STREAM_HTML);
+    });
+
+    it('renders a 422 stream', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(422));
+
+      const response = await request('/form');
+
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      expect(response.statusCode).toBe(422);
+    });
+
+    it('resolves without rendering for other error streams', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(500));
+
+      const response = await request('/form');
+      await flush();
+
+      expect(response.failed).toBe(true);
+      expect(response.statusCode).toBe(500);
+      expect(renderedChunks()).toBe(0);
+    });
+
+    it('does not render or reject non-stream responses by default', async () => {
+      fetchSpy.mockResolvedValueOnce(htmlResponse());
+
+      const response = await request('/page');
+      await flush();
+
+      expect(renderedChunks()).toBe(0);
+      expect(isTurboStream(response)).toBe(false);
+      expect(await response.responseText).toBe('<p>Plain page</p>');
+    });
+
+    it.each([200, 500])('leaves HTML fallback readable with a stream preference and status %i', async (status) => {
+      fetchSpy.mockResolvedValueOnce(htmlResponse(status));
+      const init = { method: 'GET', responseKind: 'turbo-stream' as const };
+
+      const response = await request('/dialog', init);
+      await flush();
+
+      expect(response.statusCode).toBe(status);
+      expect(await response.responseText).toBe('<p>Plain page</p>');
+      expect(renderedChunks()).toBe(0);
+    });
+
+    it('treats authentication challenges as ordinary responses', async () => {
+      const href = window.location.href;
+
+      for (const challenge of ['Bearer realm="OpenProject API"', 'Basic realm="OpenProject API"']) {
+        fetchSpy.mockResolvedValueOnce(new Response('', { status: 401, headers: { 'WWW-Authenticate': challenge } }));
+
+        const response = await request('/protected');
+
+        expect(response.statusCode).toBe(401);
+        expect(response.header('WWW-Authenticate')).toBe(challenge);
+      }
+
+      expect(window.location.href).toBe(href);
+    });
+
+    it('propagates network failures', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      await expect(request('/down')).rejects.toThrow('Failed to fetch');
+    });
+  });
+
+  describe('Turbo request tracking', () => {
+    const requestIdOf = () => lastInit().headers.get('X-Turbo-Request-Id') ?? '';
+    // A stream element removes itself once its action has run; the refresh
+    // action then debounces the page refresh, so a timer started after the
+    // removal outlasts it.
+    const renderRefreshStream = async (requestId:string) => {
+      renderStreamMessage(`<turbo-stream action="refresh" request-id="${requestId}"></turbo-stream>`);
+      expect(document.querySelector('turbo-stream')).not.toBeNull();
+      await waitFor(() => { expect(document.querySelector('turbo-stream')).toBeNull(); });
+    };
+    const outlastRefreshDebounce = () => new Promise((resolve) => { setTimeout(resolve, 400); });
+    let proposedVisits:number;
+    const cancelVisit = (event:Event) => {
+      proposedVisits += 1;
+      event.preventDefault();
+    };
+
+    beforeEach(() => {
+      proposedVisits = 0;
+      document.addEventListener('turbo:before-visit', cancelVisit);
+    });
+
+    afterEach(() => {
+      document.removeEventListener('turbo:before-visit', cancelVisit);
+    });
+
+    it('tags every request with its own Turbo request id', async () => {
+      await request('/a');
+      const first = requestIdOf();
+
+      await request('/b');
+
+      expect(first).toMatch(/\S/);
+      expect(requestIdOf()).toMatch(/\S/);
+      expect(requestIdOf()).not.toBe(first);
+    });
+
+    it('lets Turbo skip a refresh stream caused by its own request', async () => {
+      await request('/a');
+      const requestId = requestIdOf();
+
+      await renderRefreshStream('some-other-request');
+      await waitFor(() => { expect(proposedVisits).toBe(1); });
+
+      await renderRefreshStream(requestId);
+      await outlastRefreshDebounce();
+      expect(proposedVisits).toBe(1);
+    });
+
+    it('reads the response body repeatedly after rendering', async () => {
+      for (const status of [200, 422, 500]) {
+        fetchSpy.mockResolvedValueOnce(streamResponse(status));
+
+        const response = await request('/form');
+
+        expect(await response.responseText).toBe(STREAM_HTML);
+        expect(await response.responseText).toBe(STREAM_HTML);
+      }
+
+      await waitFor(() => { expect(renderedChunks()).toBe(2); });
+    });
+  });
+
+  describe('renderErrorStream', () => {
+    it('renders the stream of a non-422 error response once', async () => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(403));
+      const response = await request('/forbidden');
+
+      await expect(renderErrorStream(response)).resolves.toBe(true);
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await flush();
+      expect(renderedChunks()).toBe(1);
+    });
+
+    it('leaves already rendered and non-stream responses alone', async () => {
+      const rendered = await request('/dialog');
+      await expect(renderErrorStream(rendered)).resolves.toBe(false);
+
+      fetchSpy.mockResolvedValueOnce(streamResponse(422));
+      const unprocessable = await request('/form');
+      await expect(renderErrorStream(unprocessable)).resolves.toBe(false);
+
+      fetchSpy.mockResolvedValueOnce(htmlResponse(500));
+      const html = await request('/page');
+      await expect(renderErrorStream(html)).resolves.toBe(false);
+
+      await waitFor(() => { expect(renderedChunks()).toBe(2); });
+      await flush();
+      expect(renderedChunks()).toBe(2);
+    });
+  });
+
+  describe('request shape', () => {
+    it('passes the URL through untouched', async () => {
+      const url = '/work_packages?filters[]=status%3Dopen&filters[]=type%3Dbug#details';
+
+      await request(url);
+
+      expect(lastUrl()).toBe(url);
+    });
+
+    it('passes URL objects through untouched', async () => {
+      const url = new URL('/dialog?x=1', window.location.origin);
+
+      await request(url);
+
+      expect(lastUrl()).toBe(url);
+    });
+
+    it('preserves native body encoding', async () => {
+      const params = new URLSearchParams({ query: 'a b' });
+      await request('/query', { method: 'PATCH', body: params });
+      expect(lastInit().body).toBe(params);
+
+      const formData = new FormData();
+      formData.append('name', 'x');
+      await request('/form', { method: 'POST', body: formData });
+      expect(lastInit().body).toBe(formData);
+
+      await request('/json', { method: 'POST', body: '{"a":1}', headers: { 'Content-Type': 'application/json' } });
+      expect(lastInit().body).toBe('{"a":1}');
+      expect(lastInit().headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('adds no default Accept or XHR headers', async () => {
+      await request('/legacy', { method: 'POST' });
+
+      expect(lastInit().headers.has('Accept')).toBe(false);
+      expect(lastInit().headers.has('X-Requested-With')).toBe(false);
+    });
+
+    it('keeps explicit headers from every HeadersInit shape', async () => {
+      await request('/a', { headers: { Accept: TURBO_STREAM_ACCEPT } });
+      expect(lastInit().headers.get('Accept')).toBe(TURBO_STREAM_ACCEPT);
+
+      await request('/b', { headers: [['Accept', TURBO_STREAM_ACCEPT]] });
+      expect(lastInit().headers.get('Accept')).toBe(TURBO_STREAM_ACCEPT);
+
+      await request('/c', { headers: new Headers({ Accept: TURBO_STREAM_ACCEPT }) });
+      expect(lastInit().headers.get('Accept')).toBe(TURBO_STREAM_ACCEPT);
+
+      await request('/d', { headers: { Accept: NEGOTIATED_ACCEPT, 'X-Requested-With': 'XMLHttpRequest' } });
+      expect(lastInit().headers.get('Accept')).toBe('text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+      expect(lastInit().headers.get('X-Requested-With')).toBe('XMLHttpRequest');
+    });
+
+    it('negotiates stream and HTML responses without adding XHR headers', async () => {
+      const init = { method: 'GET', responseKind: 'turbo-stream' as const };
+
+      await request('/dialog', init);
+
+      expect(lastInit().headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+      expect(lastInit().headers.has('X-Requested-With')).toBe(false);
+    });
+
+    it('overrides conflicting Accept headers from every HeadersInit shape', async () => {
+      const headerShapes:HeadersInit[] = [
+        { Accept: 'application/json', 'Content-Type': 'application/json' },
+        [['accept', 'application/json'], ['Content-Type', 'application/json']],
+        new Headers({ Accept: 'application/json', 'Content-Type': 'application/json' }),
+      ];
+
+      for (const headers of headerShapes) {
+        const init = { headers, responseKind: 'turbo-stream' as const };
+        await request('/dialog', init);
+
+        expect(lastInit().headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+        expect(lastInit().headers.get('Content-Type')).toBe('application/json');
+        expect(new Headers(headers).get('Accept')).toBe('application/json');
+      }
+    });
+
+    it('preserves native bodies with a stream preference', async () => {
+      const formData = new FormData();
+      formData.append('name', 'x');
+
+      for (const body of [new URLSearchParams({ query: 'a b' }), formData, '{"a":1}']) {
+        const init = { method: 'POST', body, responseKind: 'turbo-stream' as const };
+        await request('/form', init);
+
+        expect(lastInit().body).toBe(body);
+        expect(lastInit().headers.has('Content-Type')).toBe(false);
+      }
+    });
+
+    it('strips custom options without mutating the supplied init', async () => {
+      const scope = new TurboRequestScope();
+      const headers = new Headers({ Accept: 'application/json' });
+      const init = Object.freeze({
+        method: 'post',
+        headers,
+        responseKind: 'turbo-stream' as const,
+        progress: false,
+        scope,
+      });
+
+      await request('/form', init);
+
+      expect(lastInit()).not.toHaveProperty('responseKind');
+      expect(lastInit()).not.toHaveProperty('progress');
+      expect(lastInit()).not.toHaveProperty('scope');
+      expect(init.method).toBe('post');
+      expect(init.responseKind).toBe('turbo-stream');
+      expect(init.progress).toBe(false);
+      expect(init.scope).toBe(scope);
+      expect(init.headers).toBe(headers);
+      expect(headers.get('Accept')).toBe('application/json');
+      expect(headers.has('X-CSRF-Token')).toBe(false);
+    });
+
+    it('passes the abort signal through', async () => {
+      const controller = new AbortController();
+
+      await request('/a', { signal: controller.signal });
+
+      expect(lastInit().signal).toBe(controller.signal);
+    });
+
+    it('normalizes the method and defaults to GET', async () => {
+      await request('/a');
+      expect(lastInit().method).toBe('GET');
+
+      await request('/b', { method: 'post' });
+      expect(lastInit().method).toBe('POST');
+    });
+  });
+
+  describe('CSRF token', () => {
+    it('adds the meta token to same-origin unsafe requests', async () => {
+      for (const method of ['post', 'PUT', 'PATCH', 'DELETE']) {
+        await request('/a', { method });
+        expect(lastInit().headers.get('X-CSRF-Token')).toBe('token-123');
+      }
+
+      await request(new URL('/a', window.location.origin), { method: 'POST' });
+      expect(lastInit().headers.get('X-CSRF-Token')).toBe('token-123');
+    });
+
+    it('adds no token to safe methods', async () => {
+      for (const method of [undefined, 'GET', 'HEAD', 'OPTIONS', 'TRACE']) {
+        await request('/a', { method });
+        expect(lastInit().headers.has('X-CSRF-Token')).toBe(false);
+      }
+    });
+
+    it('keeps an explicit token', async () => {
+      await request('/a', { method: 'POST', headers: { 'X-CSRF-Token': 'explicit' } });
+
+      expect(lastInit().headers.get('X-CSRF-Token')).toBe('explicit');
+    });
+
+    it('adds no token to cross-origin requests', async () => {
+      await request('https://example.test/a', { method: 'POST' });
+
+      expect(lastInit().headers.has('X-CSRF-Token')).toBe(false);
+    });
+
+    it('adds no token when the page has none', async () => {
+      csrfMeta.remove();
+
+      await request('/a', { method: 'POST' });
+
+      expect(lastInit().headers.has('X-CSRF-Token')).toBe(false);
+    });
+  });
+
+  describe('progress', () => {
+    let showSpy:ReturnType<typeof vi.spyOn>;
+    let hideSpy:ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      showSpy = vi.spyOn(TurboHelpers, 'showProgressBar').mockImplementation(() => undefined);
+      hideSpy = vi.spyOn(TurboHelpers, 'hideProgressBar').mockImplementation(() => undefined);
+    });
+
+    it('is off by default', async () => {
+      await request('/a');
+
+      expect(showSpy).not.toHaveBeenCalled();
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+
+    it('shows the bar for the request and hides it once settled', async () => {
+      let resolveFetch!:(response:Response) => void;
+      fetchSpy.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+
+      const init = { method: 'GET', progress: true };
+      const pending = request('/a', init);
+
+      expect(showSpy).toHaveBeenCalledOnce();
+      expect(hideSpy).not.toHaveBeenCalled();
+
+      resolveFetch(htmlResponse());
+      await pending;
+
+      expect(hideSpy).toHaveBeenCalledOnce();
+    });
+
+    it('hides the bar when the request fails', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      const init = { method: 'GET', progress: true };
+      await expect(request('/a', init)).rejects.toThrow();
+
+      expect(hideSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('scope', () => {
+    it('tracks the request on the given scope until it settles', async () => {
+      const scope = new TurboRequestScope();
+      let resolveFetch!:(response:Response) => void;
+      fetchSpy.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+
+      const init = { method: 'GET', scope };
+      const pending = request('/a', init);
+
+      expect(scope.busy).toBe(true);
+
+      resolveFetch(htmlResponse());
+      await pending;
+
+      expect(scope.busy).toBe(false);
+    });
+
+    it('releases the scope when the request fails', async () => {
+      const scope = new TurboRequestScope();
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      const init = { method: 'GET', scope };
+      await expect(request('/a', init)).rejects.toThrow();
+
+      expect(scope.busy).toBe(false);
+    });
+  });
+});

--- a/frontend/src/turbo/requests.ts
+++ b/frontend/src/turbo/requests.ts
@@ -1,0 +1,125 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { FetchResponse, fetch as turboFetch, renderStreamMessage } from '@hotwired/turbo';
+import { getMetaContent } from 'core-app/core/setup/globals/global-helpers';
+import { TurboHelpers } from 'core-turbo/helpers';
+import type { TurboRequestScope } from 'core-turbo/request-scope';
+
+export interface TurboRequestInit extends RequestInit {
+  responseKind?:'turbo-stream';
+  progress?:boolean;
+  scope?:TurboRequestScope;
+}
+
+const CSRF_HEADER = 'X-CSRF-Token';
+const CSRF_SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE']);
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html';
+
+// The published typings declare no constructor for the exported class.
+const NativeFetchResponse = FetchResponse as unknown as new (response:Response) => FetchResponse;
+
+// Performs a Turbo fetch and renders a Turbo Stream response for successful
+// and 422 responses. HTTP errors resolve; the caller decides what an error
+// status means. Nothing here waits for Angular.
+export function request(url:string|URL, init:TurboRequestInit = {}):Promise<FetchResponse> {
+  const { responseKind, progress, scope, ...fetchInit } = init;
+  const operation = () => perform(url, fetchInit, responseKind, progress);
+
+  return scope ? scope.track(operation) : operation();
+}
+
+export function isTurboStream(response:FetchResponse):boolean {
+  return response.header('Content-Type')?.startsWith(STREAM_CONTENT_TYPE) ?? false;
+}
+
+export function isUnprocessableEntity(response:FetchResponse):boolean {
+  return response.statusCode === 422;
+}
+
+// Renders the stream of an error response `request` left unrendered, for
+// callers that surface server-side error streams. Resolves to whether it
+// rendered anything. Pass an already read body to avoid a second read.
+export async function renderErrorStream(response:FetchResponse, body?:string):Promise<boolean> {
+  if (!isTurboStream(response) || response.succeeded || isUnprocessableEntity(response)) {
+    return false;
+  }
+
+  renderStreamMessage(body ?? await response.responseText);
+
+  return true;
+}
+
+async function perform(
+  url:string|URL,
+  init:RequestInit,
+  responseKind:TurboRequestInit['responseKind'],
+  progress:boolean|undefined,
+):Promise<FetchResponse> {
+  if (progress) {
+    TurboHelpers.showProgressBar();
+  }
+
+  try {
+    const response = new NativeFetchResponse(await turboFetch(url, withRequestHeaders(url, init, responseKind)));
+
+    if (isTurboStream(response) && (response.succeeded || isUnprocessableEntity(response))) {
+      renderStreamMessage(await response.responseText);
+    }
+
+    return response;
+  } finally {
+    if (progress) {
+      TurboHelpers.hideProgressBar();
+    }
+  }
+}
+
+function withRequestHeaders(
+  url:string|URL,
+  init:RequestInit,
+  responseKind:TurboRequestInit['responseKind'],
+):RequestInit {
+  const method = (init.method ?? 'GET').toUpperCase();
+  const headers = new Headers(init.headers);
+  const token = getMetaContent('csrf-token', null);
+
+  if (responseKind === 'turbo-stream') {
+    headers.set('Accept', 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml');
+  }
+
+  if (token && !CSRF_SAFE_METHODS.has(method) && !headers.has(CSRF_HEADER) && isSameOrigin(url)) {
+    headers.set(CSRF_HEADER, token);
+  }
+
+  return { ...init, method, headers };
+}
+
+function isSameOrigin(url:string|URL):boolean {
+  return new URL(String(url), window.location.href).origin === window.location.origin;
+}

--- a/frontend/src/typings/hotwired-turbo.d.ts
+++ b/frontend/src/typings/hotwired-turbo.d.ts
@@ -26,47 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import * as Turbo from '@hotwired/turbo';
+// @types/hotwired__turbo 8.0.16 omits the fetch export that Turbo 8 ships.
+import '@hotwired/turbo';
 
-export namespace TurboHelpers {
-  let progressBarTimeout:number | undefined;
-  let pendingOperations = 0;
-
-  function getProgressBar():Turbo.ProgressBar {
-    return (Turbo.session.adapter as Turbo.BrowserAdapter).progressBar;
-  }
-
-  // Overlapping operations share the bar: it shows for the first one and
-  // hides only once the last one has finished.
-  export function showProgressBar() {
-    pendingOperations += 1;
-    if (pendingOperations > 1) {
-      return;
-    }
-
-    const progressBar = getProgressBar();
-    progressBar.setValue(0);
-    progressBarTimeout ??= window.setTimeout(() => {
-      progressBar.show();
-    }, Turbo.config.drive.progressBarDelay);
-  }
-
-  export function hideProgressBar() {
-    if (pendingOperations === 0) {
-      return;
-    }
-
-    pendingOperations -= 1;
-    if (pendingOperations > 0) {
-      return;
-    }
-
-    const progressBar = getProgressBar();
-    progressBar.setValue(1);
-    progressBar.hide();
-    if (progressBarTimeout != null) {
-      window.clearTimeout(progressBarTimeout);
-      progressBarTimeout = undefined;
-    }
-  }
+declare module '@hotwired/turbo' {
+  export function fetch(url:string|URL, options?:RequestInit):Promise<Response>;
 }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-20147

# What are you trying to accomplish?

Stimulus controllers and the Angular `TurboRequestsService` each carried their own copy of "fetch, check the content type, read the text, render the stream, toggle the progress bar". This PR adds one shared request module and moves the first consumers onto it. It is the foundation for [AGILE-362](https://community.openproject.org/wp/AGILE-362), which needs the request scope, and for a later sweep of the remaining raw-fetch callers.

- New `core-turbo/requests`: `request(url, init)` on Turbo's exported `fetch` and `FetchResponse`. Renders a Turbo Stream once for successful and 422 responses, adds the CSRF token to same-origin unsafe methods, preserves URL, native body and abort-signal handling while applying CSRF, Accept and Turbo request-ID headers. `responseKind: 'turbo-stream'` sets the stream-first Accept header; `progress` and `scope` wire the progress bar and in-flight tracking. `renderErrorStream()` for callers that also show server error streams; `isTurboStream()` and `isUnprocessableEntity()` are the only response predicates callers need beyond Turbo's own.
- New `TurboRequestScope`: in-flight counter with subscriptions, DOM- and Angular-free.
- `TurboHelpers` progress bar counts overlapping operations.
- `TurboRequestsService` delegates to the module, keeps its `{ html, headers }` result and `TurboRequestError`, keeps its error, toast and cancellation contract, and no longer drops a replacement request's abort controller when the replaced one settles.
- Migrated: `async-dialog`, `resource-timeline` and `non-working-times` dialogs through one strict stream check in `handleDialogResponse`; `refresh-on-form-changes`, `generic-drag-and-drop` and `sortable-lists` off Request.JS `FetchRequest`.
- `@types/hotwired__turbo` (8.0.16) omits the `fetch` export Turbo 8 ships, so `src/typings/hotwired-turbo.d.ts` declares that one function.

Follow-up work is tracked separately, with one work package per PR:

- [OP-20194](https://community.openproject.org/wp/OP-20194): PR B, migrating seven compatible raw-fetch callers.
- [OP-20195](https://community.openproject.org/wp/OP-20195): reporting and BIM model-settings migration, then removal of Request.JS and its typings.
- [OP-20193](https://community.openproject.org/wp/OP-20193): Angular HttpClient backend and shared HTTP policy.
- [AGILE-393](https://community.openproject.org/wp/AGILE-393) and [OP-13356](https://community.openproject.org/wp/OP-13356): error-response policy and useful frame/stream failure feedback. The twelve differing raw-fetch protocols remain deferred pending relevant policy decisions.

OP-20147 covers this PR only. [AGILE-362](https://community.openproject.org/wp/AGILE-362) integrates the foundation into batch destinations separately.

# What approach did you choose and why?

Turbo's `fetch` rather than Request.JS `FetchRequest.perform` or Turbo's delegate-driven `FetchRequest`: `perform` assigns `window.location` from the `WWW-Authenticate` header on a 401 (`require_login` answers turbo-stream requests that way), serialises a `URLSearchParams` body as `{}`, and adds `X-Requested-With` plus an HTML Accept to every request, which the legacy service callers must not get. Turbo's `FetchRequest` is built around a delegate and the Drive lifecycle, which plain callers do not have. Turbo's `fetch` is the thin layer underneath both: it tags every request with `X-Turbo-Request-Id`, so a refresh stream carrying a matching recent `request-id` is skipped instead of reloading the page. The former Request.JS callers already had that id; the service and dialog callers gain it. OpenProject still owns CSRF, Accept negotiation, status policy and lifecycle.

Rendering defaults to ok-or-422 with an explicit `renderErrorStream` supplement, so a 422 never renders twice and HTTP errors never enter `catch` by themselves. Turbo's responseText reads a clone, keeping the response body available to callers. The service reuses its body read for supplementary error-stream rendering; successful and 422 streams are read by both the primitive and the service.

Behaviour changes worth a look: every shared request now carries `X-Turbo-Request-Id` (see above); the two calendar dialogs now reject non-stream responses instead of rendering arbitrary text; async-dialog already validated streams and now catches/logs failures; dialogs and service.requestStream widen Accept from stream-only to stream plus HTML fallback, while dialogs retain strict response validation; the former Request.JS callers keep `X-Requested-With: XMLHttpRequest` explicitly and lose Request.JS's automatic redirect on `WWW-Authenticate`; `hideProgressBar` without a show is a no-op; async-dialog sends the CSRF token for a non-GET `data-turbo-method` (no current usage); the service no longer adds the token cross-origin.

Validation: the second review reran 218 affected Chromium tests across 24 files and the application TypeScript check successfully. The implementation pass also ran affected Firefox/WebKit specs locally. Changed-file ESLint reports only the pre-existing prefer-nullish-coalescing finding in turbo-requests.service.ts; its empty-string request-ID fallback is preserved. Sharing the progress bar with Turbo Drive remains outside this change.

# AI involvement

Collaborative

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
