### PR TITLE
[OP-20191] WP type Project tab mentions 'Variants' even if the feature toggle is off  

### DIFF
--- a/app/components/work_package_types/projects_tab/sub_header_component.rb
+++ b/app/components/work_package_types/projects_tab/sub_header_component.rb
@@ -70,7 +70,7 @@ module WorkPackageTypes
 
       def clear_button_id = "type-projects-filters-clear-button"
 
-      def variant_filter_available? = variant.default?
+      def variant_filter_available? = variant.default? && OpenProject::FeatureDecisions.type_variants_active?
 
       def variant_filter_component
         VariantFilterComponent.new(type:, variant:, query:)

--- a/spec/requests/work_package_types/projects_tab_spec.rb
+++ b/spec/requests/work_package_types/projects_tab_spec.rb
@@ -212,6 +212,12 @@ RSpec.describe "Work package type projects tab", :skip_csrf, type: :rails_reques
       expect(page).to have_no_css("[data-test-selector='quick-filter-select-panel-button']")
     end
 
+    it "leaves it out at type level when the feature is disabled", with_flag: { type_variants: false } do
+      get edit_type_projects_path(type_id: type.id)
+
+      expect(page).to have_no_css("[data-test-selector='quick-filter-select-panel-button']")
+    end
+
     it "keeps the project name search inside a variant" do
       get edit_type_projects_path(type_id: type.id, variant_id: hardware.id)
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-20191

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
