### PR TITLE
[MEET-299] The 'Past' page of My meetings only shows me 5 items

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -32,6 +32,7 @@ require "will_paginate"
 
 module PaginationHelper
   SHOW_MORE_DEFAULT_LIMIT = 5
+  SHOW_MORE_PAST_DEFAULT_LIMIT = 15
   SHOW_MORE_DEFAULT_INCREMENT = 20
   SHOW_MORE_MAX_LIMIT = 1000
 
@@ -107,8 +108,8 @@ module PaginationHelper
 
   ##
   # Paginate an AR relation for the "show more" pagination functionality
-  def show_more_pagination(paginator, limit: nil)
-    paginator.paginate(page: 1, per_page: show_more_limit_param(limit:))
+  def show_more_pagination(paginator, limit: nil, initial_limit: SHOW_MORE_DEFAULT_LIMIT)
+    paginator.paginate(page: 1, per_page: show_more_limit_param(limit:, initial_limit:))
   end
 
   private

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -475,7 +475,8 @@ class MeetingsController < ApplicationController
     time_filter = @query.find_active_filter(:time)
     # We group meetings into individual groups, but only for upcoming meetings
     if time_filter&.past?
-      @meetings = show_more_pagination(@query.results, limit: params[:limit])
+      @meetings = show_more_pagination(@query.results, limit: params[:limit],
+                                                       initial_limit: SHOW_MORE_PAST_DEFAULT_LIMIT)
     else
       service = ::GroupMeetingsService.new(@query.results, limit: params[:limit])
       call = service.call

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -303,7 +303,8 @@ class RecurringMeetingsController < ApplicationController
         [total, 0].max
       end
 
-    @count = [show_more_limit_param(limit: params[:limit]), @max_count].compact.min
+    initial_limit = @direction == "past" ? SHOW_MORE_PAST_DEFAULT_LIMIT : SHOW_MORE_DEFAULT_LIMIT
+    @count = [show_more_limit_param(limit: params[:limit], initial_limit:), @max_count].compact.min
   end
 
   def planned_occurrence(recurrence_start_time)

--- a/modules/meeting/spec/requests/meetings_index_spec.rb
+++ b/modules/meeting/spec/requests/meetings_index_spec.rb
@@ -299,6 +299,26 @@ RSpec.describe "Meeting index",
       expect(table).to have_no_text "meeting on next monday"
       expect(table).to have_no_text "meeting on next friday"
     end
+
+    context "with more than 15 past meetings" do
+      before do
+        20.times do |i|
+          create(:meeting,
+                 :author_participates,
+                 title: "old meeting #{i}",
+                 start_time: DateTime.parse("2025-01-2#{i % 8}T05:00:00Z"),
+                 project:,
+                 author: user)
+        end
+      end
+
+      it "shows 15 past meetings by default with a show-more footer for the rest" do
+        expect(subject).to have_http_status(:ok)
+
+        expect(page).to have_css("#meetings-table-footer-component")
+        expect(page).to have_text "There are 6 more meetings."
+      end
+    end
   end
 
   context "when the time filter is not present" do

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
@@ -451,5 +451,23 @@ RSpec.describe "Recurring meetings show",
         end
       end
     end
+
+    describe "past direction default" do
+      before do
+        (1..16).each do |i|
+          create(:meeting,
+                 recurring_meeting:,
+                 start_time: i.days.ago + 10.hours,
+                 recurrence_start_time: i.days.ago + 10.hours)
+        end
+      end
+
+      it "defaults to 15 past meetings when no limit parameter is provided" do
+        get project_recurring_meeting_path(project, recurring_meeting, direction: "past")
+
+        expect(page).to have_css(".op-border-box-table--rows [role='row']", count: 15)
+        expect(page).to have_css("#recurring-meetings-footer-component")
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-299

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
