### PR TITLE
[OP-20150] Fix forum message activity links

### DIFF
--- a/app/models/activities/message_activity_provider.rb
+++ b/app/models/activities/message_activity_provider.rb
@@ -66,11 +66,11 @@ class Activities::MessageActivityProvider < Activities::BaseActivityProvider
   end
 
   def event_path(event)
-    url_helpers.project_forum_topic_path(*url_helper_parameter(event))
+    url_helpers.project_forum_topic_path(url_helper_parameter(event))
   end
 
   def event_url(event)
-    url_helpers.project_forum_topic_url(*url_helper_parameter(event))
+    url_helpers.project_forum_topic_url(url_helper_parameter(event))
   end
 
   private
@@ -85,7 +85,7 @@ class Activities::MessageActivityProvider < Activities::BaseActivityProvider
     if is_reply
       {
         project_id: event["project_id"],
-        forum: event["forum_id"],
+        forum_id: event["forum_id"],
         id: event["parent_id"],
         r: event["journable_id"],
         anchor: "message-#{event['journable_id']}"

--- a/spec/models/activities/message_activity_provider_spec.rb
+++ b/spec/models/activities/message_activity_provider_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Activities::MessageActivityProvider do
+  let(:event_scope) { "messages" }
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
+  let(:forum) { create(:forum, project:) }
+
+  describe ".find_events" do
+    let(:events) do
+      described_class
+        .find_events(event_scope, user, Time.zone.yesterday.to_datetime, Time.zone.tomorrow.to_datetime, {})
+    end
+
+    context "for a topic" do
+      let!(:topic) { create(:message, forum:, author: user) }
+
+      it "links to the forum topic" do
+        expect(events.first.event_path)
+          .to eq("/projects/#{project.identifier}/forums/#{forum.id}/topics/#{topic.id}")
+      end
+    end
+
+    context "for a reply" do
+      let(:topic) { create(:message, forum:, author: user) }
+      let!(:reply) { create(:message, forum:, parent: topic, author: user) }
+
+      it "links to the replied message in its forum topic" do
+        expect(events.first.event_path)
+          .to eq("/projects/#{project.identifier}/forums/#{forum.id}/topics/#{topic.id}?r=#{reply.id}#message-#{reply.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
[OP-20150](https://community.openproject.org/wp/OP-20150)

# What are you trying to accomplish?
Forum message activities were passing route parameters to the project_forum_topic helpers with a splatted hash. This caused Rails to treat each key/value pair as a path segment and generated URLs such as /projects/project_id%2F1/forums/forum_id%2F1/topics/id%2F1.

Pass the route parameters as a single hash instead, and use forum_id consistently for reply links.

# AI involvement
Collaborative – AI generated a substantial part of the code; I reviewed and understand every line.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)