### PR TITLE
[OP-20194] Migrate compatible Turbo Stream fetch callers

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/admin/jira-configuration-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/jira-configuration-form.controller.spec.ts
@@ -1,0 +1,185 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import JiraConfigurationFormController from './jira-configuration-form.controller';
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+describe('Admin JIRA configuration form controller', () => {
+  let ctx:StimulusTestContext;
+  let fetchSpy:Mock;
+  let target:HTMLElement;
+  let csrfMeta:HTMLMetaElement;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    csrfMeta = document.createElement('meta');
+    csrfMeta.name = 'csrf-token';
+    csrfMeta.content = 'token-123';
+    document.head.appendChild(csrfMeta);
+
+    ctx = await setupStimulusTest({
+      controllers: { 'admin--jira-configuration-form': JiraConfigurationFormController },
+    });
+  });
+
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
+    ctx.dispose();
+    target.remove();
+    csrfMeta.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const lastCall = () => fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers, body:FormData }];
+
+  async function mountForm({ id = '7', token = 'secret' } = {}) {
+    const idAttribute = id ? `data-admin--jira-configuration-form-id-value="${id}"` : '';
+    await ctx.mount(`
+      <form data-controller="admin--jira-configuration-form"
+            data-admin--jira-configuration-form-url-value="/admin/import/jira/test"
+            ${idAttribute}>
+        <input data-admin--jira-configuration-form-target="urlInput" value=" https://jira.example.com ">
+        <input data-admin--jira-configuration-form-target="tokenInput" value="${token}">
+        <button type="button" data-admin--jira-configuration-form-target="button"
+                data-action="click->admin--jira-configuration-form#testConnection">Test</button>
+        <button type="submit" data-admin--jira-configuration-form-target="button">Save</button>
+        <div data-admin--jira-configuration-form-target="progressBanner" hidden>Testing</div>
+      </form>
+    `);
+
+    const form = ctx.container.querySelector('form')!;
+    return {
+      test: form.querySelector<HTMLButtonElement>('button[type="button"]')!,
+      buttons: Array.from(form.querySelectorAll('button')),
+      banner: form.querySelector<HTMLElement>('[data-admin--jira-configuration-form-target="progressBanner"]')!,
+    };
+  }
+
+  it('posts the trimmed url, token and id as form data', async () => {
+    const { test } = await mountForm();
+
+    test.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = lastCall();
+    expect(url).toBe('/admin/import/jira/test');
+    expect(init.method).toBe('POST');
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.headers.get('X-CSRF-Token')).toBe('token-123');
+    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body.get('url')).toBe('https://jira.example.com');
+    expect(init.body.get('personal_access_token')).toBe('secret');
+    expect(init.body.get('id')).toBe('7');
+  });
+
+  it('omits a blank token and a missing id', async () => {
+    const { test } = await mountForm({ id: '', token: '' });
+
+    test.click();
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+    const [, init] = lastCall();
+    expect(init.body.has('personal_access_token')).toBe(false);
+    expect(init.body.has('id')).toBe(false);
+  });
+
+  it('disables the buttons and shows the banner until the request settles', async () => {
+    let resolveFetch!:(response:Response) => void;
+    fetchSpy.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+    const { test, buttons, banner } = await mountForm();
+
+    test.click();
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    expect(banner.hidden).toBe(false);
+
+    resolveFetch(streamResponse());
+
+    await waitFor(() => { expect(banner.hidden).toBe(true); });
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+  });
+
+  it.each([422, 500])('renders an HTTP %i stream exactly once', async (status) => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(status));
+    const { test, banner } = await mountForm();
+
+    test.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await flush();
+    expect(renderedChunks()).toBe(1);
+    expect(banner.hidden).toBe(true);
+  });
+
+  it('renders nothing for a non-stream response and restores the form', async () => {
+    fetchSpy.mockResolvedValueOnce(htmlResponse());
+    const { test, buttons, banner } = await mountForm();
+
+    test.click();
+
+    await waitFor(() => { expect(banner.hidden).toBe(true); });
+    expect(renderedChunks()).toBe(0);
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+  });
+
+  it('logs and restores the form when the request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const { test, buttons, banner } = await mountForm();
+
+    test.click();
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(banner.hidden).toBe(true);
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/jira-configuration-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/jira-configuration-form.controller.ts
@@ -27,8 +27,7 @@
 //++
 
 import {Controller} from '@hotwired/stimulus';
-import * as Turbo from '@hotwired/turbo';
-import {useMeta} from 'stimulus-use';
+import {renderErrorStream, request} from 'core-turbo/requests';
 
 export default class extends Controller {
     static targets = ['button', 'progressBanner', 'urlInput', 'tokenInput'];
@@ -37,9 +36,6 @@ export default class extends Controller {
     declare readonly progressBannerTarget:HTMLButtonElement;
     declare readonly urlInputTarget:HTMLInputElement;
     declare readonly tokenInputTarget:HTMLInputElement;
-
-    static metaNames = ['csrf-token'];
-    declare readonly csrfToken:string;
 
     static values = {
         url: String,
@@ -50,7 +46,6 @@ export default class extends Controller {
     declare idValue:string;
 
     connect():void {
-        useMeta(this, {suffix: false});
         document.addEventListener('turbo:before-cache', this.clearBeforeCache);
     }
 
@@ -89,16 +84,12 @@ export default class extends Controller {
                 formData.append('id', this.idValue);
             }
 
-            const response = await fetch(this.urlValue, {
+            const response = await request(this.urlValue, {
                 method: 'POST',
                 body: formData,
-                headers: {
-                    'Accept': 'text/vnd.turbo-stream.html',
-                    'X-CSRF-Token': this.csrfToken,
-                },
+                responseKind: 'turbo-stream',
             });
-
-            Turbo.renderStreamMessage(await response.text());
+            await renderErrorStream(response);
         } catch (error) {
             console.error(error);
         } finally {

--- a/frontend/src/stimulus/controllers/dynamic/admin/jira-projects.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/jira-projects.controller.spec.ts
@@ -1,0 +1,192 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import JiraProjectsController from './jira-projects.controller';
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+describe('Admin JIRA projects controller', () => {
+  let ctx:StimulusTestContext;
+  let fetchSpy:Mock;
+  let target:HTMLElement;
+  let csrfMeta:HTMLMetaElement;
+  let checkbox:HTMLInputElement;
+  let checkAll:HTMLAnchorElement;
+  let filter:HTMLInputElement;
+  let submitButton:HTMLElement;
+  let spinnerButton:HTMLElement;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    csrfMeta = document.createElement('meta');
+    csrfMeta.name = 'csrf-token';
+    csrfMeta.content = 'token-123';
+    document.head.appendChild(csrfMeta);
+
+    ctx = await setupStimulusTest({ controllers: { 'admin--jira-projects': JiraProjectsController } });
+    await ctx.mount(`
+      <div data-controller="admin--jira-projects"
+           data-admin--jira-projects-toggle-url-value="/admin/import/jira/1/run/2/select_projects/toggle?project_id=PROJECT_ID"
+           data-admin--jira-projects-filter-url-value="/admin/import/jira/1/run/2/select_projects/filter"
+           data-admin--jira-projects-debounce-value="0">
+        <input type="checkbox" value="10001" data-action="change->admin--jira-projects#toggleProject">
+        <a href="/admin/import/jira/1/run/2/select_projects/check_all" data-action="click->admin--jira-projects#checkAll">All</a>
+        <input type="text" data-action="input->admin--jira-projects#filterProjects">
+        <button type="button" data-admin--jira-projects-target="submitButton">Save</button>
+        <button type="button" data-admin--jira-projects-target="spinnerButton" hidden>Working</button>
+      </div>
+    `);
+
+    checkbox = ctx.container.querySelector('input[type="checkbox"]')!;
+    checkAll = ctx.container.querySelector('a')!;
+    filter = ctx.container.querySelector('input[type="text"]')!;
+    submitButton = ctx.container.querySelector('[data-admin--jira-projects-target="submitButton"]')!;
+    spinnerButton = ctx.container.querySelector('[data-admin--jira-projects-target="spinnerButton"]')!;
+  });
+
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
+    ctx.dispose();
+    target.remove();
+    csrfMeta.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const callAt = (index:number) => fetchSpy.mock.calls[index] as [string, RequestInit & { headers:Headers, body:FormData }];
+
+  it('toggles a project with a stream GET and renders the counter', async () => {
+    checkbox.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = callAt(0);
+    expect(url).toBe('/admin/import/jira/1/run/2/select_projects/toggle?project_id=10001');
+    expect(init.method).toBe('GET');
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.headers.has('X-CSRF-Token')).toBe(false);
+  });
+
+  it('requests the bulk action from the link href without navigating', async () => {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    checkAll.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    expect(callAt(0)[0]).toBe(checkAll.href);
+    expect(callAt(0)[1].method).toBe('GET');
+  });
+
+  it('posts the filter as form data with the CSRF token', async () => {
+    filter.value = 'crm';
+    filter.dispatchEvent(new Event('input', { bubbles: true }));
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = callAt(0);
+    expect(url).toBe('/admin/import/jira/1/run/2/select_projects/filter');
+    expect(init.method).toBe('POST');
+    expect(init.headers.get('X-CSRF-Token')).toBe('token-123');
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body.get('filter')).toBe('crm');
+  });
+
+  it('sends queued requests one at a time and toggles the spinner meanwhile', async () => {
+    const resolvers:((response:Response) => void)[] = [];
+    fetchSpy.mockImplementation(() => new Promise<Response>((resolve) => { resolvers.push(resolve); }));
+
+    checkbox.click();
+    checkbox.click();
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+    expect(submitButton.hidden).toBe(true);
+    expect(spinnerButton.hidden).toBe(false);
+
+    resolvers[0](streamResponse());
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledTimes(2); });
+    expect(spinnerButton.hidden).toBe(false);
+
+    resolvers[1](streamResponse());
+
+    await waitFor(() => { expect(spinnerButton.hidden).toBe(true); });
+    expect(submitButton.hidden).toBe(false);
+    await waitFor(() => { expect(renderedChunks()).toBe(2); });
+  });
+
+  it.each([422, 500])('renders an HTTP %i stream exactly once', async (status) => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(status));
+
+    checkbox.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await flush();
+    expect(renderedChunks()).toBe(1);
+    expect(spinnerButton.hidden).toBe(true);
+  });
+
+  it('renders nothing for a non-stream response', async () => {
+    fetchSpy.mockResolvedValueOnce(htmlResponse());
+
+    checkbox.click();
+
+    await waitFor(() => { expect(spinnerButton.hidden).toBe(true); });
+    expect(renderedChunks()).toBe(0);
+  });
+
+  it('warns when a request fails', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    checkbox.click();
+
+    await waitFor(() => { expect(consoleWarn).toHaveBeenCalledOnce(); });
+    expect(renderedChunks()).toBe(0);
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/jira-projects.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/jira-projects.controller.ts
@@ -27,9 +27,8 @@
 //++
 
 import {Controller} from '@hotwired/stimulus';
-import {renderStreamMessage} from '@hotwired/turbo';
 import {debounce, DebouncedFunc} from 'lodash-es';
-import {useMeta} from 'stimulus-use';
+import {renderErrorStream, request, type TurboRequestInit} from 'core-turbo/requests';
 
 export default class extends Controller {
     static values = {
@@ -39,9 +38,7 @@ export default class extends Controller {
     };
 
     static targets = ['submitButton', 'spinnerButton'];
-    static metaNames = ['csrf-token'];
 
-    declare readonly csrfToken:string;
     declare readonly toggleUrlValue:string;
     declare readonly filterUrlValue:string;
     declare readonly debounceValue:number;
@@ -55,7 +52,6 @@ export default class extends Controller {
     private drainingQueue = false;
 
     connect():void {
-        useMeta(this, {suffix: false});
         this.debouncedFilter = debounce(
             (filter:string) => this.submitFilter(filter),
             this.debounceValue,
@@ -72,27 +68,19 @@ export default class extends Controller {
         const projectId = checkbox.value;
         const url = this.toggleUrlValue.replace('PROJECT_ID', projectId);
 
-        this.enqueue(async () => {
-            const response = await fetch(url, {
-                headers: {
-                    Accept: 'text/vnd.turbo-stream.html',
-                },
-            });
-            const html = await response.text();
-            renderStreamMessage(html);
-        });
+        this.enqueue(() => this.submitStream(url));
     }
 
     checkAll(event:Event):void {
         event.preventDefault();
         const link = event.currentTarget as HTMLAnchorElement;
-        this.enqueue(() => this.submitBulkAction(link.href));
+        this.enqueue(() => this.submitStream(link.href));
     }
 
     uncheckAll(event:Event):void {
         event.preventDefault();
         const link = event.currentTarget as HTMLAnchorElement;
-        this.enqueue(() => this.submitBulkAction(link.href));
+        this.enqueue(() => this.submitStream(link.href));
     }
 
     filterProjects(event:Event):void {
@@ -134,31 +122,15 @@ export default class extends Controller {
         if (this.hasSpinnerButtonTarget) this.spinnerButtonTarget.hidden = !visible;
     }
 
-    private async submitBulkAction(url:string):Promise<void> {
-        const response = await fetch(url, {
-            headers: {
-                Accept: 'text/vnd.turbo-stream.html',
-            },
-        });
-        const html = await response.text();
-        renderStreamMessage(html);
-    }
-
-    private async submitFilter(filter:string):Promise<void> {
-        const url = this.filterUrlValue;
+    private submitFilter(filter:string):Promise<void> {
         const formData = new FormData();
         formData.append('filter', filter);
 
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: {
-                'Accept': 'text/vnd.turbo-stream.html',
-                'X-CSRF-Token': this.csrfToken,
-            },
-            body: formData,
-        });
+        return this.submitStream(this.filterUrlValue, {method: 'POST', body: formData});
+    }
 
-        const html = await response.text();
-        renderStreamMessage(html);
+    private async submitStream(url:string, init:TurboRequestInit = {}):Promise<void> {
+        const response = await request(url, {...init, responseKind: 'turbo-stream'});
+        await renderErrorStream(response);
     }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.spec.ts
@@ -1,0 +1,176 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import WorkflowCheckboxStateController from './workflow-checkbox-state.controller';
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+describe('Admin workflow checkbox state controller', () => {
+  let ctx:StimulusTestContext;
+  let fetchSpy:Mock;
+  let target:HTMLElement;
+  let csrfMeta:HTMLMetaElement;
+  let originalOpenProject:typeof window.OpenProject;
+  let dialog:HTMLDialogElement;
+  let saveButton:HTMLButtonElement;
+  let navigate:Mock;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    csrfMeta = document.createElement('meta');
+    csrfMeta.name = 'csrf-token';
+    csrfMeta.content = 'token-123';
+    document.head.appendChild(csrfMeta);
+
+    // isDirtyValueChanged mirrors dirtiness into window.OpenProject.pageState.
+    originalOpenProject = window.OpenProject;
+    window.OpenProject = { pageState: 'pristine' } as unknown as typeof window.OpenProject;
+
+    ctx = await setupStimulusTest({
+      controllers: { 'admin--workflow-checkbox-state': WorkflowCheckboxStateController },
+    });
+    await ctx.mount(`
+      <form>
+        <div data-controller="admin--workflow-checkbox-state"
+             data-admin--workflow-checkbox-state-save-url-value="/types/1/workflow/matrix?tab=always"
+             data-admin--workflow-checkbox-state-variant-id-value="type-1"
+             data-admin--workflow-checkbox-state-has-checkbox-changes-value="true">
+          <input type="hidden" name="role_ids[]" value="3">
+          <input type="checkbox" name="status[1][2]" value="always" data-old-status="1" data-new-status="2" checked>
+          <input type="checkbox" name="status[2][1]" value="always" data-old-status="2" data-new-status="1">
+          <dialog data-admin--workflow-checkbox-state-target="confirmationDialog">
+            <button type="button" data-admin--workflow-checkbox-state-target="ignoreButton">Ignore</button>
+            <button type="button" data-admin--workflow-checkbox-state-target="saveButton">Save</button>
+          </dialog>
+        </div>
+      </form>
+    `);
+
+    dialog = ctx.container.querySelector('dialog')!;
+    saveButton = ctx.container.querySelector('[data-admin--workflow-checkbox-state-target="saveButton"]')!;
+    navigate = vi.fn();
+  });
+
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
+    ctx.dispose();
+    sessionStorage.clear();
+    target.remove();
+    csrfMeta.remove();
+    window.OpenProject = originalOpenProject;
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const lastCall = () => fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers, body:FormData }];
+  const controller = () => ctx.getController<WorkflowCheckboxStateController>('admin--workflow-checkbox-state');
+
+  function saveFromDialog() {
+    controller().confirmNavigation(navigate);
+    expect(dialog.open).toBe(true);
+    saveButton.click();
+  }
+
+  it('patches only the checked transitions as form data', async () => {
+    saveFromDialog();
+
+    await waitFor(() => { expect(navigate).toHaveBeenCalledOnce(); });
+    const [url, init] = lastCall();
+    expect(url).toBe('/types/1/workflow/matrix?tab=always');
+    expect(init.method).toBe('PATCH');
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.headers.get('X-CSRF-Token')).toBe('token-123');
+    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body.getAll('role_ids[]')).toEqual(['3']);
+    expect(init.body.get('status[1][2]')).toBe('always');
+    expect(init.body.has('status[2][1]')).toBe(false);
+  });
+
+  it('renders the stream, closes the dialog and navigates on success', async () => {
+    saveFromDialog();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await waitFor(() => { expect(navigate).toHaveBeenCalledOnce(); });
+    expect(dialog.open).toBe(false);
+    expect(window.OpenProject.pageState).toBe('pristine');
+  });
+
+  it.each([422, 500])('renders an HTTP %i stream once and keeps the dialog open', async (status) => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(status));
+
+    saveFromDialog();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await flush();
+    expect(renderedChunks()).toBe(1);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(dialog.open).toBe(true);
+    expect(window.OpenProject.pageState).toBe('edited');
+  });
+
+  it('treats a non-stream success as stored without rendering', async () => {
+    fetchSpy.mockResolvedValueOnce(htmlResponse());
+
+    saveFromDialog();
+
+    await waitFor(() => { expect(navigate).toHaveBeenCalledOnce(); });
+    expect(renderedChunks()).toBe(0);
+    expect(dialog.open).toBe(false);
+  });
+
+  it('navigates straight away when nothing is dirty', async () => {
+    controller().hasCheckboxChangesValue = false;
+    await ctx.nextFrame();
+
+    controller().confirmNavigation(navigate);
+
+    expect(navigate).toHaveBeenCalledOnce();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -27,8 +27,7 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
-import { renderStreamMessage } from '@hotwired/turbo';
-import { useMeta } from 'stimulus-use';
+import { renderErrorStream, request } from 'core-turbo/requests';
 
 const PRISTINE_STATE_KEY = 'workflow-pristine-state';
 const STATUS_STATE_KEY = 'workflow-status-state';
@@ -73,9 +72,6 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLElem
   declare saveUrlValue:string;
   declare variantIdValue:string;
 
-  static metaNames = ['csrf-token'];
-  declare readonly csrfToken:string;
-
   private initialCheckboxState:CheckboxesState = {};
 
   // The form belongs to the host page and encloses this element. Captured on connect
@@ -84,10 +80,6 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLElem
   private form:HTMLFormElement | null = null;
 
   connect() {
-    // Populates this.csrfToken from the page's meta tag; without it the background save
-    // is rejected as a forgery and the session is reset.
-    useMeta(this, { suffix: false });
-
     this.form = this.element.closest('form');
 
     this.element.addEventListener('change', this.onCheckboxChange);
@@ -148,19 +140,14 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLElem
   private async save():Promise<boolean> {
     if (!this.saveUrlValue) return false;
 
-    const response = await fetch(this.saveUrlValue, {
+    const response = await request(this.saveUrlValue, {
       method: 'PATCH',
       body: this.matrixFormData(),
-      headers: {
-        Accept: 'text/vnd.turbo-stream.html',
-        'X-CSRF-Token': this.csrfToken,
-      },
+      responseKind: 'turbo-stream',
     });
+    await renderErrorStream(response);
 
-    const html = await response.text();
-    if (html) renderStreamMessage(html);
-
-    if (!response.ok) return false;
+    if (!response.succeeded) return false;
 
     this.markSaved();
     return true;

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.spec.ts
@@ -28,6 +28,7 @@
 
 import { waitFor } from '@testing-library/dom';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import { vi, type Mock } from 'vitest';
 import type FiltersFormControllerType from './filters-form.controller';
 
 const ASSIGNEE_FILTER_ROW = `
@@ -152,5 +153,165 @@ describe('Filters form controller - filter count badge', () => {
       expect(counter.textContent).toBe('1');
       expect(counter.hidden).toBe(false);
     });
+  });
+});
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+describe('Filters form controller - live turbo stream requests', () => {
+  let ctx:StimulusTestContext;
+  let FiltersFormController:typeof FiltersFormControllerType;
+  let fetchSpy:Mock;
+  let replaceState:Mock;
+  let target:HTMLElement;
+  let loadingIndicator:HTMLElement;
+
+  beforeAll(async () => {
+    ({ default: FiltersFormController } = await import('./filters-form.controller'));
+  });
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+    replaceState = vi.fn();
+    vi.spyOn(window.history, 'replaceState').mockImplementation(replaceState);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    loadingIndicator = document.createElement('div');
+    loadingIndicator.id = 'global-loading-indicator';
+    loadingIndicator.hidden = true;
+    document.body.appendChild(loadingIndicator);
+
+    ctx = await setupStimulusTest({
+      controllers: { 'filter--filters-form': FiltersFormController },
+    });
+    await ctx.mount(`
+      <div data-controller="filter--filters-form"
+           data-filter--filters-form-turbo-stream-request-value="true"
+           data-filter--filters-form-url-path-name-value="/projects">
+        <button data-filter--filters-form-target="filterFormToggle">Filter</button>
+        <span data-filter--filters-form-target="filterCount" hidden>0</span>
+        <select data-filter--filters-form-target="addFilterSelect">
+          <option value=""></option>
+          <option value="assignee">Assignee</option>
+        </select>
+        ${ASSIGNEE_FILTER_ROW}
+      </div>
+    `);
+    ctx.getController<FiltersFormControllerType>('filter--filters-form').addFilterByName('assignee');
+    // Revealing the row submits the filter set (empty assignee value) once; every test starts after that settled.
+    await waitFor(() => { if (!replaceState.mock.calls.length) throw new Error('waiting for initial replaceState'); });
+    await waitFor(() => { if (target.querySelectorAll('.chunk').length !== 1) throw new Error('waiting for initial chunk'); });
+    fetchSpy.mockClear();
+    replaceState.mockClear();
+    target.replaceChildren();
+  });
+
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
+    ctx.dispose();
+    target.remove();
+    loadingIndicator.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const lastCall = () => fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+
+  function enterSimpleValue(value:string) {
+    const valueInput = ctx.container.querySelector<HTMLInputElement>('[data-filter--filters-form-target="simpleValue"]')!;
+    valueInput.value = value;
+    valueInput.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  it('requests the filtered page as a stream and records the url', async () => {
+    enterSimpleValue('john');
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = lastCall();
+    expect(url.split('?')[0]).toBe('/projects');
+    expect(url).toMatch(/[?&]filters=/);
+    expect(decodeURIComponent(url)).toContain('assignee');
+    expect(init.method).toBe('GET');
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.headers.has('X-CSRF-Token')).toBe(false);
+    await waitFor(() => { expect(replaceState).toHaveBeenCalledOnce(); });
+    expect(replaceState.mock.lastCall?.[2]).toMatch(/filters=/);
+    expect(loadingIndicator.hidden).toBe(true);
+  });
+
+  it('shows the loading indicator until the request settles', async () => {
+    let resolveFetch!:(response:Response) => void;
+    fetchSpy.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+
+    enterSimpleValue('john');
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+    expect(loadingIndicator.hidden).toBe(false);
+
+    resolveFetch(streamResponse());
+
+    await waitFor(() => { expect(loadingIndicator.hidden).toBe(true); });
+  });
+
+  it('does not repeat a request for unchanged filters', async () => {
+    enterSimpleValue('john');
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+
+    ctx.getController<FiltersFormControllerType>('filter--filters-form').sendForm();
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it.each([422, 500])('renders an HTTP %i stream once and still records the url', async (status) => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(status));
+
+    enterSimpleValue('john');
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await flush();
+    expect(renderedChunks()).toBe(1);
+    expect(replaceState).toHaveBeenCalledOnce();
+    expect(loadingIndicator.hidden).toBe(true);
+  });
+
+  it('renders nothing for a non-stream response but still records the url', async () => {
+    fetchSpy.mockResolvedValueOnce(htmlResponse());
+
+    enterSimpleValue('john');
+
+    await waitFor(() => { expect(replaceState).toHaveBeenCalledOnce(); });
+    expect(renderedChunks()).toBe(0);
+    expect(loadingIndicator.hidden).toBe(true);
+  });
+
+  it('hides the indicator and allows a retry when the request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    enterSimpleValue('john');
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(loadingIndicator.hidden).toBe(true);
+    expect(replaceState).not.toHaveBeenCalled();
+
+    enterSimpleValue('john');
+
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledTimes(2); });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -27,12 +27,13 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
-import { renderStreamMessage, visit } from '@hotwired/turbo';
+import { visit } from '@hotwired/turbo';
 import { debounce } from 'lodash-es';
 import {
   hideElement,
   showElement,
 } from 'core-app/shared/helpers/dom-helpers';
+import { renderErrorStream, request } from 'core-turbo/requests';
 import { escapeFilterValue } from 'core-stimulus/helpers/filter-helpers';
 import { PrimerMultiInputElement } from '@primer/view-components/app/lib/primer/forms/primer_multi_input';
 
@@ -493,22 +494,18 @@ export default class FiltersFormController extends Controller {
       const previousFilters = this.sentFilters;
       this.sentFilters = newFilters;
 
-      fetch(url, {
-        headers: {
-          Accept: 'text/vnd.turbo-stream.html',
-        },
-      })
-        .then((response:Response) => response.text())
-        .then((html:string) => {
-          renderStreamMessage(html);
+      void request(url, { responseKind: 'turbo-stream' })
+        .then(async (response) => {
+          await renderErrorStream(response);
           if (this.sentFilters === newFilters) {
             window.history.replaceState(window.history.state, '', browserUrl);
           }
-          hideElement(loadingIndicator);
         })
         .catch((error:Error) => {
           this.sentFilters = previousFilters;
           console.error('Error:', error);
+        })
+        .finally(() => {
           hideElement(loadingIndicator);
         });
     } else {

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.spec.ts
@@ -33,12 +33,32 @@ import { vi, type Mock } from 'vitest';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type MyTimeTrackingControllerType from './time-tracking.controller';
 
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
 describe('My time tracking controller', () => {
   let ctx:StimulusTestContext;
   let MyTimeTrackingController:typeof MyTimeTrackingControllerType;
   let request:Mock;
   let myTimeTrackingRefresh:Mock;
   let originalOpenProject:typeof window.OpenProject;
+  let fetchSpy:Mock;
+  let target:HTMLElement;
+  let csrfMeta:HTMLMetaElement;
+  const pathHelperService = {
+    timeEntryDialog: () => '/time_entries/dialog',
+    timeEntryUpdate: (id:string) => `/time_entries/${id}`,
+    myTimeTrackingRefresh: undefined as unknown as Mock,
+  };
 
   beforeAll(async () => {
     ({ default: MyTimeTrackingController } = await import('./time-tracking.controller'));
@@ -47,16 +67,24 @@ describe('My time tracking controller', () => {
   beforeEach(async () => {
     request = vi.fn().mockResolvedValue({ html: '', headers: new Headers() });
     myTimeTrackingRefresh = vi.fn().mockReturnValue('/my/time_tracking/refresh?date=2026-06-01');
+    pathHelperService.myTimeTrackingRefresh = myTimeTrackingRefresh;
+
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    csrfMeta = document.createElement('meta');
+    csrfMeta.name = 'csrf-token';
+    csrfMeta.content = 'token-123';
+    document.head.appendChild(csrfMeta);
+
     originalOpenProject = window.OpenProject;
     window.OpenProject = {
       getPluginContext: () => Promise.resolve({
-        services: {
-          turboRequests: { request },
-          pathHelperService: {
-            timeEntryDialog: () => '/time_entries/dialog',
-            myTimeTrackingRefresh,
-          },
-        },
+        services: { turboRequests: { request }, pathHelperService },
       }),
     } as unknown as typeof window.OpenProject;
 
@@ -65,8 +93,13 @@ describe('My time tracking controller', () => {
     });
   });
 
-  afterEach(() => {
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
     ctx.dispose();
+    target.remove();
+    csrfMeta.remove();
     window.OpenProject = originalOpenProject;
     vi.restoreAllMocks();
   });
@@ -144,14 +177,89 @@ describe('My time tracking controller', () => {
     resolveContext({
       services: {
         turboRequests: { request },
-        pathHelperService: {
-          timeEntryDialog: () => '/time_entries/dialog',
-          myTimeTrackingRefresh,
-        },
+        pathHelperService,
       },
     });
     await ctx.nextFrame();
 
     expect(request).not.toHaveBeenCalled();
+  });
+
+  describe('updateTimeEntry', () => {
+    const renderedChunks = () => target.querySelectorAll('.chunk').length;
+    const lastCall = () => fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers, body:string }];
+
+    async function renderReadyController() {
+      const controller = await renderListView();
+      await waitFor(() => { expect(controller.pathHelperService).toBeDefined(); });
+      return controller;
+    }
+
+    it('patches the entry as JSON and renders the stream', async () => {
+      const controller = await renderReadyController();
+      const revert = vi.fn();
+
+      controller.updateTimeEntry('5', '2026-06-01', '09:00', 1.5, revert);
+
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      const [url, init] = lastCall();
+      expect(url).toBe('/time_entries/5');
+      expect(init.method).toBe('PATCH');
+      expect(init.headers.get('Content-Type')).toBe('application/json');
+      expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+      expect(init.headers.get('X-CSRF-Token')).toBe('token-123');
+      expect(JSON.parse(init.body)).toEqual({
+        time_entry: { spent_on: '2026-06-01', start_time: '09:00', hours: 1.5 },
+        no_dialog: true,
+      });
+      await flush();
+      expect(revert).not.toHaveBeenCalled();
+    });
+
+    it('sends a null start time for all-day entries', async () => {
+      const controller = await renderReadyController();
+
+      controller.updateTimeEntry('5', '2026-06-01', null, 8, vi.fn());
+
+      await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+      expect(JSON.parse(lastCall()[1].body).time_entry.start_time).toBeNull();
+    });
+
+    it.each([422, 500])('renders an HTTP %i stream once and reverts the event', async (status) => {
+      fetchSpy.mockResolvedValueOnce(streamResponse(status));
+      const controller = await renderReadyController();
+      const revert = vi.fn();
+
+      controller.updateTimeEntry('5', '2026-06-01', '09:00', 1.5, revert);
+
+      await waitFor(() => { expect(revert).toHaveBeenCalledOnce(); });
+      await waitFor(() => { expect(renderedChunks()).toBe(1); });
+      await flush();
+      expect(renderedChunks()).toBe(1);
+    });
+
+    it('renders nothing for a non-stream response and keeps the event', async () => {
+      fetchSpy.mockResolvedValueOnce(htmlResponse());
+      const controller = await renderReadyController();
+      const revert = vi.fn();
+
+      controller.updateTimeEntry('5', '2026-06-01', '09:00', 1.5, revert);
+
+      await waitFor(() => { expect(fetchSpy).toHaveBeenCalledOnce(); });
+      await flush();
+      expect(renderedChunks()).toBe(0);
+      expect(revert).not.toHaveBeenCalled();
+    });
+
+    it('reverts the event when the request fails', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const controller = await renderReadyController();
+      const revert = vi.fn();
+
+      controller.updateTimeEntry('5', '2026-06-01', '09:00', 1.5, revert);
+
+      await waitFor(() => { expect(revert).toHaveBeenCalledOnce(); });
+      expect(renderedChunks()).toBe(0);
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -37,13 +37,12 @@ import type { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.se
 import type { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import moment from 'moment';
 import allLocales from '@fullcalendar/core/locales-all';
-import { renderStreamMessage } from '@hotwired/turbo';
 import { opStopwatchStopIconData, toDOMString } from '@openproject/octicons-angular';
-import { useMeta } from 'stimulus-use';
 import { html, render, TemplateResult } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
+import { renderErrorStream, request } from 'core-turbo/requests';
 
 interface AdditionalDialogCloseData {
   spent_on?:string;
@@ -73,8 +72,6 @@ export default class MyTimeTrackingController extends Controller {
     timeZone: String,
   };
 
-  static metaNames = ['csrf-token'];
-
   declare readonly calendarTarget:HTMLElement;
   declare readonly hasCalendarTarget:boolean;
   declare readonly modeValue:string;
@@ -89,7 +86,6 @@ export default class MyTimeTrackingController extends Controller {
   declare readonly workingDaysValue:number[];
   declare readonly startOfWeekValue:number;
   declare readonly timeZoneValue:string;
-  declare readonly csrfToken:string;
 
   private calendar:Calendar;
   private DEFAULT_TIMED_EVENT_DURATION = '01:00';
@@ -97,10 +93,6 @@ export default class MyTimeTrackingController extends Controller {
 
   initialize() {
     useAngularServices(this);
-  }
-
-  connect() {
-    useMeta(this, { suffix: false });
   }
 
   servicesConnected() {
@@ -427,12 +419,9 @@ export default class MyTimeTrackingController extends Controller {
   }
 
   updateTimeEntry(timeEntryId:string, spentOn:string, startTime:string|null, hours:number, revertFunction:() => void) {
-    fetch(this.pathHelperService.timeEntryUpdate(timeEntryId), {
+    void request(this.pathHelperService.timeEntryUpdate(timeEntryId), {
       method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': this.csrfToken,
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         time_entry: {
           spent_on: spentOn,
@@ -441,20 +430,21 @@ export default class MyTimeTrackingController extends Controller {
         },
         no_dialog: true,
       }),
+      responseKind: 'turbo-stream',
     })
-      .then((response) => {
-        void response.text().then((html) => {
-          renderStreamMessage(html);
-        });
-        if (!response.ok && revertFunction) {
-          revertFunction();
-        }
-      })
-      .catch(() => {
-        if (revertFunction) {
-          revertFunction();
-        }
-      });
+      .then(
+        async (response) => {
+          if (!response.succeeded && revertFunction) {
+            revertFunction();
+          }
+          await renderErrorStream(response);
+        },
+        () => {
+          if (revertFunction) {
+            revertFunction();
+          }
+        },
+      );
   }
 
   displayDuration(duration:number):string {

--- a/frontend/src/stimulus/controllers/dynamic/resource-management/user-card.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/resource-management/user-card.controller.spec.ts
@@ -1,0 +1,128 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { waitFor } from '@testing-library/dom';
+import { vi, type Mock } from 'vitest';
+import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
+import UserCardController from './user-card.controller';
+
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse(status = 200):Response {
+  return new Response(STREAM_HTML, { status, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+describe('UserCardController', () => {
+  let ctx:StimulusTestContext;
+  let fetchSpy:Mock;
+  let target:HTMLElement;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
+
+    ctx = await setupStimulusTest({ controllers: { 'resource-management--user-card': UserCardController } });
+    await ctx.mount(`
+      <div data-controller="resource-management--user-card"
+           data-resource-management--user-card-url-value="/resource_planners/1/users/2/allocations">
+        <span class="name">Ada</span>
+        <button type="button" class="remove">Remove</button>
+      </div>
+    `);
+  });
+
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
+    ctx.dispose();
+    target.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
+  const card = () => ctx.container.querySelector<HTMLElement>('[data-controller]')!;
+  const lastCall = () => fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+
+  it('requests the details dialog as a stream when the card is clicked', async () => {
+    card().querySelector<HTMLElement>('.name')!.click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [url, init] = lastCall();
+    expect(url).toBe('/resource_planners/1/users/2/allocations');
+    expect(init.method).toBe('GET');
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.headers.has('X-CSRF-Token')).toBe(false);
+  });
+
+  it('ignores clicks on interactive elements inside the card', async () => {
+    card().querySelector<HTMLElement>('.remove')!.click();
+    await ctx.nextFrame();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([422, 500])('renders an HTTP %i stream exactly once', async (status) => {
+    fetchSpy.mockResolvedValueOnce(streamResponse(status));
+
+    card().click();
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    await flush();
+    expect(renderedChunks()).toBe(1);
+  });
+
+  it('logs instead of rendering a non-stream response', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockResolvedValueOnce(htmlResponse());
+
+    card().click();
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+    expect(renderedChunks()).toBe(0);
+  });
+
+  it('logs when the request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    card().click();
+
+    await waitFor(() => { expect(consoleError).toHaveBeenCalledOnce(); });
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/resource-management/user-card.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/resource-management/user-card.controller.ts
@@ -27,7 +27,8 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
-import { renderStreamMessage } from '@hotwired/turbo';
+import { request } from 'core-turbo/requests';
+import { handleDialogResponse } from 'core-stimulus/helpers/request-helpers';
 import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 
 export default class UserCardController extends Controller<HTMLElement> {
@@ -48,17 +49,16 @@ export default class UserCardController extends Controller<HTMLElement> {
       return;
     }
 
-    void this.openDialog();
+    this.openDialog();
   };
 
   private fromInteractiveElement(event:Event):boolean {
     return closestInteractiveElement(event.target as Element | null, this.element) !== null;
   }
 
-  private async openDialog():Promise<void> {
-    await fetch(this.urlValue, {
-      headers: { Accept: 'text/vnd.turbo-stream.html' },
-    }).then((response) => response.text())
-      .then((html) => renderStreamMessage(html));
+  private openDialog():void {
+    void request(this.urlValue, { responseKind: 'turbo-stream' })
+      .then(handleDialogResponse)
+      .catch((error) => { console.error(error); });
   }
 }

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.spec.ts
@@ -32,11 +32,24 @@ import { vi, type Mock } from 'vitest';
 import { setupStimulusTest, type StimulusTestContext } from 'core-stimulus/test-helpers';
 import type RequirePasswordConfirmationControllerType from './require-password-confirmation.controller';
 
+const STREAM_CONTENT_TYPE = 'text/vnd.turbo-stream.html; charset=utf-8';
+const NEGOTIATED_ACCEPT = 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml';
+const STREAM_HTML = '<turbo-stream action="append" target="stream-target"><template><span class="chunk"></span></template></turbo-stream>';
+
+function streamResponse():Response {
+  return new Response(STREAM_HTML, { status: 200, headers: { 'Content-Type': STREAM_CONTENT_TYPE } });
+}
+
+function htmlResponse():Response {
+  return new Response('<p>Login</p>', { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
 describe('Require password confirmation controller', () => {
   let ctx:StimulusTestContext;
   let RequirePasswordConfirmationController:typeof RequirePasswordConfirmationControllerType;
   let myPasswordConfirmationDialogPath:Mock;
   let fetchSpy:Mock;
+  let target:HTMLElement;
   let originalOpenProject:typeof window.OpenProject;
 
   beforeAll(async () => {
@@ -45,10 +58,12 @@ describe('Require password confirmation controller', () => {
 
   beforeEach(async () => {
     myPasswordConfirmationDialogPath = vi.fn().mockReturnValue('/my/password_confirmation_dialog');
-    fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
-      headers: new Headers({ 'Content-Type': 'text/vnd.turbo-stream.html' }),
-      text: () => Promise.resolve(''),
-    } as unknown as Response);
+    fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(streamResponse()));
+    vi.spyOn(window, 'fetch').mockImplementation(fetchSpy);
+
+    target = document.createElement('div');
+    target.id = 'stream-target';
+    document.body.appendChild(target);
 
     originalOpenProject = window.OpenProject;
     window.OpenProject = {
@@ -62,11 +77,17 @@ describe('Require password confirmation controller', () => {
     });
   });
 
-  afterEach(() => {
+  const flush = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+
+  afterEach(async () => {
+    await flush();
     ctx.dispose();
+    target.remove();
     window.OpenProject = originalOpenProject;
     vi.restoreAllMocks();
   });
+
+  const renderedChunks = () => target.querySelectorAll('.chunk').length;
 
   async function renderForm() {
     await ctx.mount(`
@@ -75,6 +96,12 @@ describe('Require password confirmation controller', () => {
       </form>
     `);
     return ctx.container.querySelector('form')!;
+  }
+
+  function submit(form:HTMLFormElement):SubmitEvent {
+    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
+    form.dispatchEvent(event);
+    return event;
   }
 
   it('binds the declared services after connect', async () => {
@@ -89,8 +116,7 @@ describe('Require password confirmation controller', () => {
   it('intercepts the submit and requests the confirmation dialog', async () => {
     const form = await renderForm();
 
-    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
-    form.dispatchEvent(event);
+    const event = submit(form);
 
     expect(event.defaultPrevented).toBe(true);
 
@@ -110,8 +136,7 @@ describe('Require password confirmation controller', () => {
       bubbleOrder.push(`bubble:prevented=${event.defaultPrevented}`);
     });
 
-    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
-    form.dispatchEvent(event);
+    const event = submit(form);
 
     expect(event.defaultPrevented).toBe(true);
     expect(bubbleOrder).toEqual(['bubble:prevented=true']);
@@ -122,7 +147,7 @@ describe('Require password confirmation controller', () => {
     const requestSubmit = vi.fn();
     form.requestSubmit = requestSubmit;
 
-    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    submit(form);
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -138,7 +163,7 @@ describe('Require password confirmation controller', () => {
   it('reopens the dialog after a cancelled confirmation', async () => {
     const form = await renderForm();
 
-    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    submit(form);
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
@@ -149,7 +174,7 @@ describe('Require password confirmation controller', () => {
     document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog, submitted: false } }));
 
     fetchSpy.mockClear();
-    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    submit(form);
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -159,7 +184,7 @@ describe('Require password confirmation controller', () => {
   it('ignores dialog:close events for other dialogs', async () => {
     const form = await renderForm();
 
-    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    submit(form);
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
@@ -169,7 +194,7 @@ describe('Require password confirmation controller', () => {
     document.dispatchEvent(new CustomEvent('dialog:close', { detail: { dialog: other, submitted: false } }));
 
     fetchSpy.mockClear();
-    form.dispatchEvent(new SubmitEvent('submit', { cancelable: true, bubbles: true }));
+    submit(form);
 
     await ctx.nextFrame();
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -183,8 +208,7 @@ describe('Require password confirmation controller', () => {
 
     const form = await renderForm();
 
-    const event = new SubmitEvent('submit', { cancelable: true, bubbles: true });
-    form.dispatchEvent(event);
+    const event = submit(form);
 
     expect(event.defaultPrevented).toBe(true);
 
@@ -197,5 +221,35 @@ describe('Require password confirmation controller', () => {
     await ctx.nextFrame();
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders the confirmation dialog stream', async () => {
+    const form = await renderForm();
+
+    submit(form);
+
+    await waitFor(() => { expect(renderedChunks()).toBe(1); });
+    const [, init] = fetchSpy.mock.lastCall as [string, RequestInit & { headers:Headers }];
+    expect(init.headers.get('Accept')).toBe(NEGOTIATED_ACCEPT);
+    expect(init.headers.has('X-CSRF-Token')).toBe(false);
+  });
+
+  it.each([
+    ['a non-stream response', () => Promise.resolve(htmlResponse())],
+    ['a failed request', () => Promise.reject(new TypeError('Failed to fetch'))],
+  ])('allows a new dialog request after %s', async (_label, outcome) => {
+    fetchSpy.mockImplementationOnce(outcome);
+    const form = await renderForm();
+
+    submit(form);
+    await waitFor(() => { expect(fetchSpy).toHaveBeenCalledTimes(1); });
+    expect(renderedChunks()).toBe(0);
+
+    // activeDialog is released asynchronously in the catch; resubmitting
+    // until the second request goes out avoids a fixed sleep.
+    await waitFor(() => {
+      submit(form);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
@@ -27,7 +27,8 @@
 //++
 
 import { ApplicationController } from 'stimulus-use';
-import { renderStreamMessage } from '@hotwired/turbo';
+import { request } from 'core-turbo/requests';
+import { handleDialogResponse } from 'core-stimulus/helpers/request-helpers';
 import { useAngularServices, type PickedServices, type ServiceKey } from 'core-stimulus/mixins/use-angular-services';
 import { DialogCloseDetail } from 'core-turbo/dialog-stream-action';
 
@@ -102,25 +103,11 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
     this.activeDialog = true;
 
     const { pathHelperService } = await this.services;
-    void fetch(pathHelperService.myPasswordConfirmationDialogPath(), {
-      method: 'GET',
-      headers: {
-        Accept: 'text/vnd.turbo-stream.html',
-      },
-    }).then((response) => {
-      const contentType = response.headers.get('Content-Type') ?? '';
-      const isTurboStream = contentType.includes('text/vnd.turbo-stream.html');
-
-      if (!isTurboStream) {
-        return Promise.reject(new Error('Response is not a Turbo Stream'));
-      }
-
-      return response.text();
-    }).then((html) => {
-      renderStreamMessage(html);
-    }).catch(() => {
-      this.activeDialog = false;
-    });
+    void request(pathHelperService.myPasswordConfirmationDialogPath(), { responseKind: 'turbo-stream' })
+      .then(handleDialogResponse)
+      .catch(() => {
+        this.activeDialog = false;
+      });
 
     return false;
   }


### PR DESCRIPTION

# Ticket

https://community.openproject.org/wp/OP-20194

# What are you trying to accomplish?

Follow-up to #25273 ([OP-20147](https://community.openproject.org/wp/OP-20147)). Seven Stimulus controllers still fetched Turbo Streams by hand: build a CSRF header from `useMeta`, set Accept, `response.text()`, `renderStreamMessage`. They now go through the shared `core-turbo/requests` module, which owns CSRF, Accept negotiation and the 200/422 render; each caller keeps its own status logic, ordering and cleanup.

- Dialog openers: `resource-management/user-card`, `require-password-confirmation` — `request(...).then(handleDialogResponse)`, the same strict stream check the dialogs from PR A use.
- Admin forms: `admin/jira-configuration-form` (POST form data), `admin/jira-projects` (three calls through one `submitStream`), `admin/workflow-checkbox-state` (PATCH form data) — `request` plus `renderErrorStream` for non-422 error streams; `useMeta`/`metaNames`/`csrfToken` removed.
- Page level: `filter/filters-form` (live GET reload) and `my/time-tracking` (PATCH JSON) — same shape; filters keep the `sentFilters` revert and latest-request-only `replaceState`, time tracking keeps `revert()` on failure and rejection.

Every caller has a spec covering the request contract (method, Accept, CSRF presence, body), 200/422/500 streams rendering exactly once, non-stream bodies, network failure and its cleanup (buttons, banner, spinner, loading indicator, `activeDialog`, `revert`), plus the Jira queue ordering.

Out of scope, tracked elsewhere: the twelve raw-fetch callers with a different status protocol, Request.JS retirement ([OP-20195](https://community.openproject.org/wp/OP-20195)), the Angular backend ([OP-20193](https://community.openproject.org/wp/OP-20193)) and error-policy changes ([AGILE-393](https://community.openproject.org/wp/AGILE-393), [OP-13356](https://community.openproject.org/wp/OP-13356)).

# What approach did you choose and why?

Behaviour kept: all seven endpoints answer `format.turbo_stream` only, so the stream-first Accept negotiation changes nothing server-side; 422 renders once (module) and other error streams render on the resolved path, never from `catch`; no `progress` option is used because none of these callers drove the Turbo progress bar; no `X-Requested-With` is added.

Deliberate changes worth a look:

- `user-card` now logs a non-stream response (for example a login page) instead of feeding it to `renderStreamMessage`, matching the PR A dialogs. `require-password-confirmation` already validated the stream.
- `filters-form` hides the global loading indicator in `finally`. Before, a stream that failed to render left the indicator stuck (flagged as High in the #25168 review at `filters-form.controller.ts:504`). The `window.location.href` fallback still shows the indicator before navigating.
- `time-tracking` sends the negotiated Accept header; it sent none before. `time_entries#update` only serves turbo_stream, so the response is unchanged.
- Every request now carries `X-Turbo-Request-Id`. No server code emits `turbo_stream.refresh`, so the refresh suppression that header enables is inert on these paths.

Not changed on purpose: `jira-projects` still leaves its queue and spinner stalled when a request rejects (pre-existing, only logged), and `workflow-checkbox-state` still has no rejection handler for its save. Both are error-policy questions for AGILE-393.

# AI involvement

Directed

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
