### PR TITLE
fix order of custom field names in error from formula

### DIFF
--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -170,7 +170,7 @@ module CustomField::CalculatedValue
       surplus_cfs = formula_cfs - allowed_cfs
 
       if surplus_cfs.any?
-        custom_field_names = CustomField.where(id: surplus_cfs).pluck(:name)
+        custom_field_names = CustomField.where(id: surplus_cfs).pluck(:name).sort
         errors.add(:formula, :not_allowed_custom_fields_referenced, custom_fields: custom_field_names.join(", "))
       end
     end

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -819,7 +819,7 @@ RSpec.describe CustomField::CalculatedValue, with_ee: %i[calculated_values weigh
       current_user { user }
 
       it_behaves_like "invalid formula",
-                      "The attribute int, float cannot be used because it leads to a circular reference; " \
+                      "The attribute float, int cannot be used because it leads to a circular reference; " \
                       "one attribute depends on the other."
     end
 


### PR DESCRIPTION
Query without order leads to possibility of flaky test failure, but it seems to be simplest to order by name

https://github.com/opf/openproject/actions/runs/34623626816/job/103343311439?pr=25278
```
Failures:

  1) CustomField::CalculatedValue#validate_formula with a formula that contains custom fields that are not visible to the user behaves like invalid formula is invalid
     Failure/Error: expect(subject.errors).to be_of_kind(:formula, error_symbol_or_message)
       expected `#<ActiveModel::Errors [#<ActiveModel::Error attribute=formula, type=not_allowed_custom_fields_referenced, options={custom_fields: "float, int"}>]>.of_kind?(:formula, "The attribute int, float cannot be used because it leads to a circular reference; one attribute depends on the other.")` to be truthy, got false
     Shared Example Group: "invalid formula" called from ./spec/models/custom_field/calculated_value_spec.rb:821
     # ./spec/models/custom_field/calculated_value_spec.rb:650:in 'block (4 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.3/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/without_env.rb:52:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:60:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:219:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in 'block (2 levels) in RSpec::Retry.setup'

Finished in 4 minutes 7.7 seconds (files took 38.86 seconds to load)
52504 examples, 1 failure, 47 pending, 1 error occurred outside of examples

Failed examples:

rspec ./spec/models/custom_field/calculated_value_spec.rb:645 # CustomField::CalculatedValue#validate_formula with a formula that contains custom fields that are not visible to the user behaves like invalid formula is invalid
```